### PR TITLE
Usuń pozostałości po Selenium i splinter z projektu

### DIFF
--- a/.github/workflows/coveralls-finish.yml
+++ b/.github/workflows/coveralls-finish.yml
@@ -2,7 +2,7 @@ name: Coveralls - Finish Parallel Build
 
 on:
   workflow_run:
-    workflows: ["Testy - Django, Playwright", "Testy - Selenium"]
+    workflows: ["Testy - Django, Playwright"]
     types:
       - completed
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,6 @@ src/django_bpp/components/bower_components/
 src/django_bpp/node_modules/
 src/django_bpp/wheelhouse/
 node_modules/
-splintershots/
 
 .DS_Store
 \#*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,8 @@ bin/ustaw-domyslne-haslo-admina.sh
 - `uv run pytest --ds=django_bpp.settings.local` - Run tests with specific Django settings (rarely needed)
 
 **Alternative make commands (these internally use `uv run pytest`):**
-- `make tests-without-selenium` - Run tests excluding Selenium tests with parallelization (fast)
-- `make tests-with-selenium` - Run only Selenium tests with parallelization (slow)
+- `make tests-without-playwright` - Run tests excluding Playwright tests with parallelization (fast)
+- `make tests-only-playwright` - Run only Playwright tests with parallelization (slow)
 - `make tests` - Run full test suite
 - `make full-tests` - Run complete test suite
 
@@ -389,7 +389,7 @@ class MyModelAdmin(ConstanceScoringFieldsMixin, admin.ModelAdmin):
 
 ### Development Notes
 - Uses UV for Python dependency management (pyproject.toml and uv.lock)
-- Extensive test suite with pytest and Selenium integration
+- Extensive test suite with pytest and Playwright integration
 - Pre-commit hooks for code quality
 - Celery for background task processing
 - Django Channels for WebSocket support

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ distclean: clean
 	rm -rf src/django_bpp/staticroot
 	rm -rf *backup .pytest-cache
 	rm -rf node_modules src/node_modules src/django_bpp/staticroot
-	rm -rf .vagrant splintershots src/components/bower_components src/media
+	rm -rf .vagrant src/components/bower_components src/media
 	rm -rf dist
 	rm src/bpp/static/scss/*.css
 	rm src/bpp/static/scss/*.map

--- a/README.rst
+++ b/README.rst
@@ -11,13 +11,6 @@
    :target: https://github.com/iplweb/bpp/actions/workflows/build-docker-images.yml
    :alt: Docker - oficjalne obrazy
 
-.. image:: https://github.com/iplweb/bpp/actions/workflows/tests-no-selenium.yml/badge.svg?branch=master
-   :target: https://github.com/iplweb/bpp/actions/workflows/tests-no-selenium.yml
-   :alt: Testy - Django, Playwright
-
-.. image:: https://github.com/iplweb/bpp/actions/workflows/tests-selenium.yml/badge.svg?branch=master
-   :target: https://github.com/iplweb/bpp/actions/workflows/tests-selenium.yml
-   :alt: Testy - Selenium
 
 .. image:: https://readthedocs.org/projects/bpp/badge/?version=latest
    :target: http://bpp.readthedocs.io/pl/latest/?badge=latest

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -360,7 +360,7 @@ sequenceDiagram
 ### Testing
 - **Framework**: pytest with Django plugin
 - **Data Generation**: model_bakery (`baker.make()`)
-- **Selenium**: Firefox driver for browser tests
+- **Playwright**: Browser tests
 - **Convention**: Standalone functions, no unittest.TestCase
 
 ---

--- a/pytest.ini
+++ b/pytest.ini
@@ -31,6 +31,5 @@ filterwarnings = ignore
 norecursedirs = src/bpp/media/
 
 markers =
-    selenium: test uzywa selenium (czyli zajmuje duzo czasu)
     serial: test musi byc wykonany sekwencyjnie (nie moze byc uruchomiony rownolegle z innymi testami)
     xdist_group: grupuje testy do wykonania na tym samym workerze w pytest-xdist (uzywa pytest-xdist)

--- a/src/bpp/tests/test_admin/test_crossref_api_sync.py
+++ b/src/bpp/tests/test_admin/test_crossref_api_sync.py
@@ -22,7 +22,7 @@ def autor_m():
 @pytest.mark.vcr(
     match_on=("method", "scheme", "path", "query")
 )
-def test_crossref_api_autor_wo_selenium(admin_app, autor_m):
+def test_crossref_api_autor(admin_app, autor_m):
     url = "/admin/bpp/wydawnictwo_ciagle/pobierz-z-crossref/"
     page = admin_app.get(url)
     page.forms["crossref_form"]["identyfikator_doi"] = "10.12775/jehs.2022.12.07.045"

--- a/src/django_bpp/settings/local.py
+++ b/src/django_bpp/settings/local.py
@@ -28,8 +28,6 @@ DEBUG = True
 
 SENDFILE_BACKEND = "django_sendfile.backends.simple"
 
-SELENIUM_DRIVER = "Firefox"
-
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
 

--- a/src/django_bpp/settings/test.py
+++ b/src/django_bpp/settings/test.py
@@ -11,9 +11,6 @@ DEBUG_TOOLBAR = False
 
 SENDFILE_BACKEND = "django_sendfile.backends.simple"
 
-SELENIUM_DRIVER = "Firefox"
-
-
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
 MEDIA_ROOT = os.path.abspath(

--- a/src/fixtures/conftest.py
+++ b/src/fixtures/conftest.py
@@ -6,7 +6,7 @@ Fixtures are loaded from submodules:
 - conftest_models: Core model fixtures (uczelnia, wydzial, jednostka, autor)
 - conftest_publications: Publication fixtures (wydawnictwo_ciagle, wydawnictwo_zwarte, etc.)
 - conftest_system: System data fixtures (typy_odpowiedzialnosci, jezyki, etc.)
-- conftest_browser: Browser/Selenium fixtures
+- conftest_browser: Browser/webtest fixtures
 - conftest_disciplines: PBN discipline fixtures
 """
 

--- a/src/fixtures/conftest_browser.py
+++ b/src/fixtures/conftest_browser.py
@@ -1,4 +1,4 @@
-"""Browser and Selenium fixtures."""
+"""Browser and webtest fixtures."""
 
 import pytest
 from django.apps import apps


### PR DESCRIPTION
- Zmień nazwę testu test_crossref_api_autor_wo_selenium na test_crossref_api_autor
- Usuń SELENIUM_DRIVER z settings/local.py i settings/test.py
- Usuń marker selenium z pytest.ini
- Usuń splintershots/ z .gitignore i Makefile distclean
- Zaktualizuj docstringi conftest (Selenium -> webtest)
- Zaktualizuj CLAUDE.md (make targets, opis testów)
- Zaktualizuj docs/CODEBASE_MAP.md (Selenium -> Playwright)
- Usuń nieistniejące workflow badges z README.rst
- Usuń referencję do "Testy - Selenium" z coveralls-finish.yml

https://claude.ai/code/session_01FkpvdZ3kPVy1QrMX8y55pw