### PR TITLE
feat: automatyczne sprawdzanie duplikatów w PBN (#318)

### DIFF
--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
@@ -22,6 +22,40 @@
         </div>
     {% endif %}
 
+    {% if pbn_result %}
+        {% if pbn_result.pbn_mongo_id %}
+            <div class="callout warning">
+                <span class="fi-alert"></span>
+                <strong>Znaleziono rekord w PBN:</strong>
+                Publikacja o tym DOI istnieje już
+                w Polskiej Bibliografii Naukowej.
+                <br>
+                PBN UID:
+                <code>{{ pbn_result.pbn_mongo_id }}</code>
+                {% if pbn_result.pbn_url %}
+                    &mdash;
+                    <a href="{{ pbn_result.pbn_url }}"
+                       target="_blank"
+                       rel="noopener">
+                        Otwórz w PBN
+                    </a>
+                {% endif %}
+            </div>
+        {% elif pbn_result.pbn_needs_auth %}
+            <div class="callout secondary">
+                <span class="fi-info"></span>
+                Nie można sprawdzić duplikatu
+                w PBN &mdash; wymagana autoryzacja.
+                Zaloguj się do PBN w menu głównym.
+            </div>
+        {% elif pbn_result.pbn_error %}
+            <div class="callout secondary">
+                <span class="fi-info"></span>
+                {{ pbn_result.pbn_error }}
+            </div>
+        {% endif %}
+    {% endif %}
+
     {% if suggest_crossref %}
         <div class="callout warning">
             <span class="fi-info"></span>

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
@@ -24,12 +24,9 @@
 
     {% if pbn_result %}
         {% if pbn_result.pbn_mongo_id %}
-            <div class="callout warning">
-                <span class="fi-alert"></span>
-                <strong>Znaleziono rekord w PBN:</strong>
-                Publikacja o tym DOI istnieje już
-                w Polskiej Bibliografii Naukowej.
-                <br>
+            <div class="callout success">
+                <span class="fi-check"></span>
+                <strong>Znaleziono odpowiednik w PBN.</strong>
                 PBN UID:
                 <code>{{ pbn_result.pbn_mongo_id }}</code>
                 {% if pbn_result.pbn_url %}
@@ -44,7 +41,7 @@
         {% elif pbn_result.pbn_needs_auth %}
             <div class="callout secondary">
                 <span class="fi-info"></span>
-                Nie można sprawdzić duplikatu
+                Nie można sprawdzić odpowiednika
                 w PBN &mdash; wymagana autoryzacja.
                 Zaloguj się do PBN w menu głównym.
             </div>

--- a/src/importer_publikacji/tests/test_pbn_check.py
+++ b/src/importer_publikacji/tests/test_pbn_check.py
@@ -1,0 +1,171 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from importer_publikacji.views import (
+    _check_pbn_by_doi,
+    _empty_pbn_result,
+    _get_pbn_publication_by_doi,
+    _link_pbn_uid,
+    _populate_pbn_result,
+)
+from pbn_api.exceptions import (
+    AccessDeniedException,
+    HttpException,
+    NeedsPBNAuthorisationException,
+    PraceSerwisoweException,
+)
+
+
+def _make_session(
+    provider_name="CrossRef",
+    doi="10.1234/test",
+    matched_data=None,
+):
+    session = MagicMock()
+    session.provider_name = provider_name
+    session.normalized_data = {"doi": doi} if doi else {}
+    session.matched_data = matched_data or {}
+    return session
+
+
+def test_check_pbn_skip_when_provider_is_pbn():
+    session = _make_session(provider_name="PBN")
+    assert _check_pbn_by_doi(session) is None
+
+
+def test_check_pbn_skip_when_no_doi():
+    session = _make_session(doi=None)
+    assert _check_pbn_by_doi(session) is None
+
+
+def test_check_pbn_skip_when_empty_doi():
+    session = _make_session(doi="")
+    assert _check_pbn_by_doi(session) is None
+
+
+@patch("importer_publikacji.views._get_pbn_client")
+def test_check_pbn_skip_when_client_fails(mock_import):
+    mock_import.side_effect = ValueError("Brak konfiguracji")
+    with patch(
+        "importer_publikacji.views._get_pbn_client",
+        side_effect=ValueError("Brak konfiguracji"),
+    ):
+        with patch(
+            "importer_publikacji.providers.pbn._get_pbn_client",
+            side_effect=ValueError("Brak konfiguracji"),
+        ):
+            session = _make_session()
+            assert _check_pbn_by_doi(session) is None
+
+
+def test_get_pbn_publication_by_doi_success():
+    client = MagicMock()
+    client.get_publication_by_doi.return_value = {
+        "mongoId": "abc123def456",
+        "status": "ACTIVE",
+    }
+    data, error = _get_pbn_publication_by_doi(client, "10.1234/test")
+    assert data == {"mongoId": "abc123def456", "status": "ACTIVE"}
+    assert error is None
+
+
+def test_get_pbn_publication_by_doi_404():
+    client = MagicMock()
+    client.get_publication_by_doi.side_effect = HttpException(
+        404, "/api/v1/publications/doi/", "Not found"
+    )
+    data, error = _get_pbn_publication_by_doi(client, "10.1234/test")
+    assert data is None
+    assert error is not None
+    assert error["pbn_error"] is None
+    assert error["pbn_needs_auth"] is False
+
+
+def test_get_pbn_publication_by_doi_access_denied():
+    client = MagicMock()
+    client.get_publication_by_doi.side_effect = AccessDeniedException(
+        "/api/v1/", "Forbidden"
+    )
+    data, error = _get_pbn_publication_by_doi(client, "10.1234/test")
+    assert data is None
+    assert error["pbn_needs_auth"] is True
+
+
+def test_get_pbn_publication_by_doi_needs_auth():
+    client = MagicMock()
+    client.get_publication_by_doi.side_effect = NeedsPBNAuthorisationException(
+        403, "/api/", "Auth"
+    )
+    data, error = _get_pbn_publication_by_doi(client, "10.1234/test")
+    assert data is None
+    assert error["pbn_needs_auth"] is True
+
+
+def test_get_pbn_publication_by_doi_prace_serwisowe():
+    client = MagicMock()
+    client.get_publication_by_doi.side_effect = PraceSerwisoweException()
+    data, error = _get_pbn_publication_by_doi(client, "10.1234/test")
+    assert data is None
+    assert error["pbn_error"] == "PBN w trakcie prac serwisowych"
+
+
+def test_get_pbn_publication_by_doi_http_500():
+    client = MagicMock()
+    client.get_publication_by_doi.side_effect = HttpException(
+        500, "/api/", "Server Error"
+    )
+    data, error = _get_pbn_publication_by_doi(client, "10.1234/test")
+    assert data is None
+    assert "Błąd komunikacji z PBN" in error["pbn_error"]
+
+
+def test_empty_pbn_result():
+    result = _empty_pbn_result()
+    assert result["pbn_mongo_id"] is None
+    assert result["pbn_url"] is None
+    assert result["pbn_error"] is None
+    assert result["pbn_needs_auth"] is False
+
+
+@pytest.mark.django_db
+def test_populate_pbn_result_with_data():
+    session = _make_session()
+    result = _empty_pbn_result()
+    data = {"mongoId": "abc123def456", "status": "ACTIVE"}
+
+    _populate_pbn_result(result, data, session)
+
+    assert result["pbn_mongo_id"] == "abc123def456"
+    assert session.matched_data["pbn_mongo_id"] == "abc123def456"
+    session.save.assert_called_once()
+
+
+def test_populate_pbn_result_with_empty_data():
+    session = _make_session()
+    result = _empty_pbn_result()
+    _populate_pbn_result(result, None, session)
+    assert result["pbn_mongo_id"] is None
+
+
+def test_populate_pbn_result_no_mongo_id():
+    session = _make_session()
+    result = _empty_pbn_result()
+    _populate_pbn_result(result, {"status": "ACTIVE"}, session)
+    assert result["pbn_mongo_id"] is None
+
+
+@pytest.mark.django_db
+def test_link_pbn_uid_no_mongo_id():
+    session = _make_session(matched_data={})
+    record = MagicMock()
+    _link_pbn_uid(session, record)
+    record.save.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_link_pbn_uid_publication_not_found():
+    session = _make_session(matched_data={"pbn_mongo_id": "nonexistent123456789012"})
+    record = MagicMock()
+    _link_pbn_uid(session, record)
+    record.save.assert_not_called()

--- a/src/importer_publikacji/tests/test_pbn_check.py
+++ b/src/importer_publikacji/tests/test_pbn_check.py
@@ -5,6 +5,7 @@ import pytest
 from importer_publikacji.views import (
     _check_pbn_by_doi,
     _empty_pbn_result,
+    _ensure_pbn_publication_local,
     _get_pbn_publication_by_doi,
     _link_pbn_uid,
     _populate_pbn_result,
@@ -129,7 +130,8 @@ def test_empty_pbn_result():
 
 
 @pytest.mark.django_db
-def test_populate_pbn_result_with_data():
+@patch("importer_publikacji.views._ensure_pbn_publication_local")
+def test_populate_pbn_result_with_data(mock_ensure):
     session = _make_session()
     result = _empty_pbn_result()
     data = {"mongoId": "abc123def456", "status": "ACTIVE"}
@@ -139,6 +141,7 @@ def test_populate_pbn_result_with_data():
     assert result["pbn_mongo_id"] == "abc123def456"
     assert session.matched_data["pbn_mongo_id"] == "abc123def456"
     session.save.assert_called_once()
+    mock_ensure.assert_called_once_with(data)
 
 
 def test_populate_pbn_result_with_empty_data():
@@ -153,6 +156,30 @@ def test_populate_pbn_result_no_mongo_id():
     result = _empty_pbn_result()
     _populate_pbn_result(result, {"status": "ACTIVE"}, session)
     assert result["pbn_mongo_id"] is None
+
+
+@patch("pbn_integrator.utils.zapisz_mongodb")
+def test_ensure_pbn_publication_local_calls_zapisz(
+    mock_zapisz,
+):
+    data = {
+        "mongoId": "abc123",
+        "status": "ACTIVE",
+        "verificationLevel": "MODERATOR",
+        "verified": True,
+        "versions": [],
+    }
+    _ensure_pbn_publication_local(data)
+    mock_zapisz.assert_called_once()
+
+
+@patch("pbn_integrator.utils.zapisz_mongodb")
+def test_ensure_pbn_publication_local_handles_error(
+    mock_zapisz,
+):
+    mock_zapisz.side_effect = Exception("DB error")
+    # Nie powinno rzucić wyjątku
+    _ensure_pbn_publication_local({"mongoId": "abc123"})
 
 
 @pytest.mark.django_db

--- a/src/importer_publikacji/views.py
+++ b/src/importer_publikacji/views.py
@@ -822,7 +822,11 @@ def _empty_pbn_result():
 
 
 def _populate_pbn_result(result, data, session):
-    """Wypełnij result danymi z odpowiedzi PBN API."""
+    """Wypełnij result danymi z odpowiedzi PBN API.
+
+    Jeśli znaleziono odpowiednik, zapisz/zaktualizuj
+    lokalny rekord pbn_api.Publication.
+    """
     if not (data and isinstance(data, dict)):
         return
 
@@ -839,8 +843,26 @@ def _populate_pbn_result(result, data, session):
             pbn_api_root=uczelnia.pbn_api_root,
             pbn_uid_id=mongo_id,
         )
+
+    # Zaciągnij/zaktualizuj lokalny rekord Publication
+    _ensure_pbn_publication_local(data)
+
     session.matched_data["pbn_mongo_id"] = mongo_id
     session.save(update_fields=["matched_data"])
+
+
+def _ensure_pbn_publication_local(data):
+    """Zapisz dane z PBN API jako lokalny rekord Publication."""
+    try:
+        from pbn_api.models import Publication
+        from pbn_integrator.utils import zapisz_mongodb
+
+        zapisz_mongodb(data, Publication)
+    except Exception as e:
+        logger.warning(
+            "Nie udało się zapisać rekordu PBN lokalnie: %s",
+            e,
+        )
 
 
 def _check_pbn_by_doi(session):

--- a/src/importer_publikacji/views.py
+++ b/src/importer_publikacji/views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import traceback
 
 from django.contrib.contenttypes.models import ContentType
@@ -45,6 +46,8 @@ from .providers import (
     get_provider,
     get_providers_metadata,
 )
+
+logger = logging.getLogger(__name__)
 
 _POLISH_DIACRITICS = set("ąćęłńóśźżĄĆĘŁŃÓŚŹŻ")
 
@@ -768,6 +771,113 @@ def _find_duplicates(session):
     return results
 
 
+def _get_pbn_publication_by_doi(client, doi):
+    """Wywołaj API PBN i zwróć (data, result) lub result przy błędzie.
+
+    Zwraca krotkę (data, None) przy sukcesie lub
+    (None, result_dict) przy błędzie wymagającym
+    natychmiastowego zwrotu.
+    """
+    from pbn_api.exceptions import (
+        AccessDeniedException,
+        HttpException,
+        NeedsPBNAuthorisationException,
+        PraceSerwisoweException,
+    )
+
+    result = _empty_pbn_result()
+
+    try:
+        data = client.get_publication_by_doi(doi)
+    except (
+        AccessDeniedException,
+        NeedsPBNAuthorisationException,
+    ):
+        result["pbn_needs_auth"] = True
+        return None, result
+    except PraceSerwisoweException:
+        result["pbn_error"] = "PBN w trakcie prac serwisowych"
+        return None, result
+    except HttpException as e:
+        if getattr(e, "status_code", None) == 404:
+            return None, result
+        result["pbn_error"] = f"Błąd komunikacji z PBN: {e}"
+        return None, result
+    except Exception as e:
+        logger.warning("Błąd sprawdzania PBN: %s", e)
+        result["pbn_error"] = f"Błąd sprawdzania PBN: {e}"
+        return None, result
+
+    return data, None
+
+
+def _empty_pbn_result():
+    """Zwróć pusty słownik wyniku sprawdzenia PBN."""
+    return {
+        "pbn_mongo_id": None,
+        "pbn_url": None,
+        "pbn_error": None,
+        "pbn_needs_auth": False,
+    }
+
+
+def _populate_pbn_result(result, data, session):
+    """Wypełnij result danymi z odpowiedzi PBN API."""
+    if not (data and isinstance(data, dict)):
+        return
+
+    mongo_id = data.get("mongoId")
+    if not mongo_id:
+        return
+
+    result["pbn_mongo_id"] = mongo_id
+    uczelnia = Uczelnia.objects.get_default()
+    if uczelnia and uczelnia.pbn_api_root:
+        from bpp.const import LINK_PBN_DO_PUBLIKACJI
+
+        result["pbn_url"] = LINK_PBN_DO_PUBLIKACJI.format(
+            pbn_api_root=uczelnia.pbn_api_root,
+            pbn_uid_id=mongo_id,
+        )
+    session.matched_data["pbn_mongo_id"] = mongo_id
+    session.save(update_fields=["matched_data"])
+
+
+def _check_pbn_by_doi(session):
+    """Sprawdź czy publikacja z danym DOI istnieje w PBN.
+
+    Zwraca dict z kluczami pbn_mongo_id, pbn_url,
+    pbn_error, pbn_needs_auth — lub None jeśli sprawdzenie
+    nie dotyczy (brak DOI, provider PBN, brak konfiguracji).
+    """
+    if session.provider_name == "PBN":
+        return None
+
+    doi = session.normalized_data.get("doi")
+    if not doi:
+        return None
+
+    normalized = normalize_doi(doi)
+    if not normalized:
+        return None
+
+    try:
+        from .providers.pbn import _get_pbn_client
+
+        client = _get_pbn_client()
+    except Exception as e:
+        logger.warning("Nie można utworzyć klienta PBN: %s", e)
+        return None
+
+    data, error_result = _get_pbn_publication_by_doi(client, normalized)
+    if error_result is not None:
+        return error_result
+
+    result = _empty_pbn_result()
+    _populate_pbn_result(result, data, session)
+    return result
+
+
 def _is_crossref_data(raw_data):
     """Heurystyka: czy raw_data to JSON z CrossRef API."""
     if not raw_data or not isinstance(raw_data, dict):
@@ -795,6 +905,7 @@ def _verify_context(request, session, form=None):
         form = VerifyForm(initial=initial)
 
     existing = _find_duplicates(session)
+    pbn_result = _check_pbn_by_doi(session)
 
     doi = session.normalized_data.get("doi")
     suggest_crossref = bool(doi and session.provider_name != "CrossRef")
@@ -827,6 +938,7 @@ def _verify_context(request, session, form=None):
         "auto_zwarte": (mapper.jest_wydawnictwem_zwartym if mapper else None),
         "suggest_crossref": suggest_crossref,
         "crossref_doi": doi if suggest_crossref else None,
+        "pbn_result": pbn_result,
         "field_categories": field_categories,
         "raw_json_pretty": raw_json_pretty,
     }
@@ -1254,6 +1366,34 @@ def _create_streszczenia(session, record):
         )
 
 
+def _link_pbn_uid(session, record):
+    """Powiąż PBN UID z rekordem publikacji, jeśli znaleziono."""
+    pbn_mongo_id = session.matched_data.get("pbn_mongo_id")
+    if not pbn_mongo_id:
+        return
+
+    from django.db import IntegrityError
+
+    from pbn_api.models import Publication
+
+    try:
+        pbn_pub = Publication.objects.get(
+            mongoId=pbn_mongo_id,
+        )
+        record.pbn_uid = pbn_pub
+        record.save(update_fields=["pbn_uid_id"])
+    except Publication.DoesNotExist:
+        logger.info(
+            "Rekord PBN %s nie istnieje lokalnie — pominięto linkowanie",
+            pbn_mongo_id,
+        )
+    except IntegrityError:
+        logger.warning(
+            "PBN UID %s jest już powiązany z innym rekordem BPP",
+            pbn_mongo_id,
+        )
+
+
 @transaction.atomic
 def _create_publication(session):
     """Utwórz rekord publikacji na podstawie sesji."""
@@ -1297,9 +1437,13 @@ def _create_publication(session):
     _create_streszczenia(session, record)
 
     if session.zrodlo and normalized_data.get("year"):
-        from bpp.models.zrodlo import uzupelnij_punktacje_z_zrodla
+        from bpp.models.zrodlo import (
+            uzupelnij_punktacje_z_zrodla,
+        )
 
         uzupelnij_punktacje_z_zrodla(record, session.zrodlo, normalized_data["year"])
+
+    _link_pbn_uid(session, record)
 
     return record
 


### PR DESCRIPTION
## Summary
- Przy imporcie publikacji z CrossRef/BibTeX/DSpace/WWW system automatycznie sprawdza PBN API po DOI
- W kroku weryfikacji wyświetla PBN UID z linkiem do PBN, komunikat o braku autoryzacji lub błąd serwisu
- Przy tworzeniu rekordu próbuje powiązać go z istniejącym PBN UID

## Test plan
- [ ] `uv run pytest src/importer_publikacji/tests/test_pbn_check.py -x` — testy jednostkowe nowej funkcjonalności
- [ ] `uv run pytest src/importer_publikacji/ -x` — pełne testy modułu
- [ ] Zaimportować publikację z CrossRef z DOI istniejącym w PBN → w kroku weryfikacji powinien pojawić się komunikat z PBN UID i linkiem

🤖 Generated with [Claude Code](https://claude.com/claude-code)