### PR TITLE
ci(docker): gate Docker image builds on .docker-build flag + workflow_dispatch

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -7,13 +7,57 @@ on:
       - 'feature/**'
       - 'fix/**'
       - 'hotfix/**'
+  workflow_dispatch:
+    # Ręczne wywołanie z GUI GitHub lub przez
+    # `gh workflow run build-docker-images.yml --ref <branch>`.
+    # Zawsze buduje, niezależnie od obecności .docker-build.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check-flag:
+    # Guard job oszczędzający Docker Cloud Build minuty.
+    # - master         : buduj zawsze (release flow)
+    # - workflow_dispatch: buduj zawsze (świadomy trigger ręczny)
+    # - feature/fix/hotfix: buduj tylko gdy w root repo jest plik
+    #                      `.docker-build` (pusty, commitowany do
+    #                      gałęzi wymagającej obrazów pre-prod).
+    #
+    # Aby włączyć budowanie obrazów na branchu:
+    #   touch .docker-build && git add .docker-build && git commit
+    # Aby wyłączyć:
+    #   git rm .docker-build && git commit
+    # Budowanie ad-hoc bez commitowania flagi:
+    #   gh workflow run build-docker-images.yml --ref <branch>
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: check
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Docker build — trigger ręczny (workflow_dispatch)"
+          elif [ "$REF_NAME" = "master" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Docker build — push na master (release)"
+          elif [ -f ".docker-build" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Docker build włączone przez obecność .docker-build w root"
+          else
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Pomijam Docker build — brak .docker-build w root repo"
+          fi
+
   docker:
+    needs: check-flag
+    if: needs.check-flag.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Log in to Docker Hub

--- a/src/bpp/newsfragments/+docker-build-flag-guard.doc.rst
+++ b/src/bpp/newsfragments/+docker-build-flag-guard.doc.rst
@@ -1,0 +1,18 @@
+Workflow ``Docker - oficjalne obrazy``
+(``.github/workflows/build-docker-images.yml``) buduje i publikuje
+obrazy docker automatycznie tylko przy pushu na ``master``. Dla
+branchy ``feature/**``, ``fix/**``, ``hotfix/**`` build odpala się
+tylko wtedy, gdy w root repo istnieje pusty plik flaga
+``.docker-build`` — zmiana oszczędza Docker Cloud Build minuty
+zużywane przez każdy push na długie feature-branche. Ręczne
+uruchomienie niezależnie od flagi: ``gh workflow run
+build-docker-images.yml --ref <branch>`` (lub GUI GitHub Actions).
+
+Aby włączyć auto-build na branchu::
+
+    touch .docker-build
+    git add .docker-build && git commit -m "ci: enable docker auto-build"
+
+Aby wyłączyć::
+
+    git rm .docker-build && git commit -m "ci: disable docker auto-build"


### PR DESCRIPTION
## Summary

Workflow `build-docker-images.yml` do tej pory budował i publikował **6 obrazów** (base, appserver, workerserver, beatserver, authserver, denorm-queue) dla każdego pusha na `master`, `feature/**`, `fix/**`, `hotfix/**`. Aktywne feature-branche (np. `feature/django-5.2`, `feature/multi-hosted-config`) i świeże fixy wyczerpały limit Docker Cloud Build (575 minut), przez co ostatnie pushe failowały z `prepaid build minutes limit reached`.

## Zmiana

- Nowy guard job `check-flag` (lekki ubuntu-latest, poza Docker Cloud) decyduje czy odpalić właściwy build.
- **master**: buduj zawsze (release flow).
- **workflow_dispatch**: buduj zawsze (świadomy trigger ręczny — `gh workflow run build-docker-images.yml --ref <branch>` albo GUI).
- **feature/fix/hotfix**: buduj tylko gdy w root repo istnieje plik-flaga `.docker-build` (pusty plik, commitowany na branchu wymagającym obrazów pre-prod).
- Istniejący job `docker` ma teraz `needs: check-flag` + `if: should_build == 'true'` — pełny stack buildu odpala się dopiero po przejściu przez guard.

## Użycie

Aby włączyć auto-build na branchu:
```
touch .docker-build && git add .docker-build && git commit -m "ci: enable docker auto-build"
```

Aby wyłączyć:
```
git rm .docker-build && git commit
```

Ad-hoc bez commitowania flagi:
```
gh workflow run build-docker-images.yml --ref feature/moja-galaz
```

## Efekt na minuty Docker Cloud

- **Worst case** (master/dispatch/flaga): 1 dodatkowy job guard (~10-20s ubuntu-latest, **zero** Docker Cloud Build).
- **Typowy case** (push feature bez flagi): tylko guard. Docker Cloud Build = 0 minut zamiast N× pełny stack.

## Test plan

- [x] YAML linter: `Lint GitHub Actions workflow files` pass (pre-commit).
- [ ] Po merge: push na `ci/docker-build-flag-guard` (bez `.docker-build`) — guard powinien pominąć docker job i oznaczyć pipeline zielono.
- [ ] Push na master: powinien odpalić build normalnie.
- [ ] `gh workflow run build-docker-images.yml --ref <branch>`: powinien odpalić build ad-hoc niezależnie od flagi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)