### PR TITLE
Switch django-fsm to django-fsm-2 (maintained fork)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "pypandoc>=1.13,<2",
     "django-static-sitemaps>=5.0.0",
     "django-model-utils==5.0.0",
-    "django-fsm>=3,<4",
+    "django-fsm-2>=4,<5",
     "django-mptt>=0.16,<1",
     "wosclient==0.1.5",
     "MOAI-iplweb>=2.0.2",

--- a/src/bpp/newsfragments/+django-fsm-2.feature.rst
+++ b/src/bpp/newsfragments/+django-fsm-2.feature.rst
@@ -1,0 +1,6 @@
+Zastąpiono nieutrzymywany pakiet ``django-fsm`` jego aktywnie
+rozwijanym forkiem ``django-fsm-2``. API pozostało niezmienione
+(``from django_fsm import FSMField, transition, GET_STATE``),
+więc zmiana jest przezroczysta dla kodu i migracji bazy danych.
+Dzięki temu znika ostrzeżenie ``UserWarning`` o braku wsparcia
+dla ``django-fsm``.

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ dependencies = [
     { name = "django-filter", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-flexible-reports", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-formtools", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "django-fsm", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "django-fsm-2", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-grappelli", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-group-by", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-import-export", marker = "platform_python_implementation != 'PyPy'" },
@@ -439,7 +439,7 @@ requires-dist = [
     { name = "django-filter", specifier = ">=25.2,<25.3" },
     { name = "django-flexible-reports", specifier = ">=0.2.12" },
     { name = "django-formtools", specifier = ">=2.5.1,<3" },
-    { name = "django-fsm", specifier = ">=3,<4" },
+    { name = "django-fsm-2", specifier = ">=4,<5" },
     { name = "django-grappelli", specifier = ">=4,<5" },
     { name = "django-group-by", specifier = "==0.3.1" },
     { name = "django-import-export", specifier = ">=4.4,<5" },
@@ -1850,12 +1850,17 @@ wheels = [
 ]
 
 [[package]]
-name = "django-fsm"
-version = "3.0.1"
+name = "django-fsm-2"
+version = "4.2.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/06/0b/605c646b09bcf4d49aa64fec87c732c6acbff93b945339381a6df0f78e99/django-fsm-3.0.1.tar.gz", hash = "sha256:d6436f5931e09d76e9a434781548627deab80c74cd6726adce95b31b5ddd4d1e", size = 12800, upload-time = "2025-10-07T16:33:27.398Z" }
+dependencies = [
+    { name = "django", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "django-stubs-ext", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' and platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/eb/594712952364f0b1f009b9c414940a09031d07fe95bb888e92f50aa9a550/django_fsm_2-4.2.4.tar.gz", hash = "sha256:0e395afd03ff504afd476e8568ca213aafc3324bd4e5427e5b3287f7b1e7d979", size = 21544, upload-time = "2026-03-16T20:33:33.476Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/87/ad5a38d1a8241b485835c6e6158634b29e885be78424ca42fb63df15b965/django_fsm-3.0.1-py2.py3-none-any.whl", hash = "sha256:ea07be2da221efa5cb8743cc94e0bb64fd962adff594f82269040eb4708c30c6", size = 12454, upload-time = "2025-10-07T16:33:26.218Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f6/75b74d0b631abfccfb71dda88b530ccccfba48cd6db674f7c27f027b827b/django_fsm_2-4.2.4-py3-none-any.whl", hash = "sha256:0072be359520075eee4baead3873e5eb8f1700b4f91e41208058cbea0ceae9b9", size = 23282, upload-time = "2026-03-16T20:33:31.97Z" },
 ]
 
 [[package]]
@@ -2145,6 +2150,19 @@ dependencies = [
     { name = "six", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/86/7d902fe13a60abc8601c6450a940973e2e4f9d4a409b34d6adb4f5ceaa66/django-static-sitemaps-5.0.0.tar.gz", hash = "sha256:4580bda5bbaa4dbf40bc8bbde5936e1675eac1c7b76f65286705befeeefbaa85", size = 8660, upload-time = "2024-02-18T09:04:01.556Z" }
+
+[[package]]
+name = "django-stubs-ext"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e6/5dcdaa785ec3eed5fc196c7e68fb7ad9d9fe6d5acccea4690e65f2546417/django_stubs_ext-6.0.3.tar.gz", hash = "sha256:3307d42132bc295d5744de6276bc5fdf6896efc70f891e21c0ae8bdf529d2762", size = 6663, upload-time = "2026-04-18T15:10:53.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/fa/0a3a05c29d6295dbd52fa3cb4047a95de11ba4f2696072d6f3f2c1e6f370/django_stubs_ext-6.0.3-py3-none-any.whl", hash = "sha256:9e4105955419ae310d7da9cfd808e039d4dae3092c628f021057bb4f2c237f8f", size = 10354, upload-time = "2026-04-18T15:10:52.395Z" },
+]
 
 [[package]]
 name = "django-tables2"


### PR DESCRIPTION
## Summary

- Zamiana nieutrzymywanego `django-fsm>=3,<4` na aktywnie rozwijany fork `django-fsm-2>=4,<5`.
- Drop-in replacement — ten sam import path `django_fsm` (FSMField, transition, GET_STATE), zero zmian w kodzie modeli i migracjach.
- Znika `UserWarning` od django-fsm 3.0.1 o braku wsparcia i rekomendacji migracji do `viewflow.fsm`.

## Why not viewflow.fsm?

`viewflow.fsm` nie jest drop-in — zupełnie inne API (deskryptor `State` zamiast `FSMField`, brak `GET_STATE` dla dynamicznych targetów, brak `on_error`). Pełna migracja oznacza rewrite state machine w `src/import_dyscyplin/models.py`. `django-fsm-2` daje ten sam efekt (usunięcie warninga, aktywnie utrzymywana biblioteka) bez ryzyka regresji.

## Test plan

- [x] `uv run python -c "from django_fsm import GET_STATE, FSMField, transition"` przechodzi bez warninga
- [x] `uv run pytest src/import_dyscyplin/ -n auto` — 23 passed. Pozostałe 4 failed + 8 errors to pre-existing bug na `dev` (TRUNCATE/FK w `bpp_rekord_mat` przy teardown `transactional_db` — niezwiązane z tą zmianą).
- [ ] CI