### PR TITLE
deps(uv): jawnie zadeklaruj indeks PyPI (dependency confusion guard)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,16 @@ push = false
 [tool.uv]
 environments = ["python_version >= '3.10' and python_version < '3.15' and platform_python_implementation != 'PyPy'"]
 
+# Jawne zadeklarowanie indeksu PyPI jako jedynego, domyslnego zrodla
+# pakietow. Chroni przed dependency confusion: gdyby kiedys pojawil sie
+# prywatny indeks, ten wpis musi pozostac jawnie default = true a nowy
+# indeks dodawany jako pierwszy z `explicit = true` aby tylko wybrane
+# pakiety byly z niego pobierane. Patrz docs/SECURITY_PRACTICES.md.
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+default = true
+
 [tool.bumpver.file_patterns]
 "pyproject.toml" = ['current_version = "{version}"',
     'version = "{pep440_version}"']

--- a/src/bpp/newsfragments/+uv-explicit-pypi-index.doc.rst
+++ b/src/bpp/newsfragments/+uv-explicit-pypi-index.doc.rst
@@ -1,0 +1,1 @@
+Jawnie zadeklarowano PyPI jako jedyny domyślny indeks ``uv`` w ``pyproject.toml``. Chroni przed dependency confusion (publikacją zlosliwego pakietu na PyPI o tej samej nazwie co przyszly prywatny pakiet).


### PR DESCRIPTION
## Podsumowanie

PR 2/12 wdrażający rekomendacje z
[lirantal/pypi-security-best-practices](https://github.com/lirantal/pypi-security-best-practices) —
praktyka **#5: Prevent Dependency Confusion**.

## Co się zmienia

Dodaje jawny `[[tool.uv.index]]` block w `pyproject.toml` deklarujący
PyPI jako jedyny domyślny indeks. Komentarz objaśnia zasadę dodawania
przyszłych prywatnych indeksów (priority + `explicit = true`).

## Dlaczego

- Bez jawnej deklaracji `uv` używa `pypi.org` jako implicit default.
- Gdy ktoś w przyszłości doda prywatny indeks, łatwo o pomyłkę kolejności
  → atakujący publikujący pakiet na PyPI o tej samej nazwie co wewnętrzny
  pakiet wygrywa resolution (klasyczne dependency confusion).
- Jawna deklaracja + komentarz wymuszają świadomą decyzję.

## Plan testowy

- [x] `uv lock` — bez zmian w `uv.lock` (pypi był juz default).
- [x] `pre-commit run --files pyproject.toml` — passed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)