### PR TITLE
ci(dependabot): dodaj cooldown 3d/7d dla wszystkich ekosystemów

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    # Cooldown: GitHub Actions tag-promotion attacks (np. malicious tag
+    # nadpisany na popularnej akcji) sa wykrywane szybko - daj 3 dni
+    # community na zauwazenie problemu zanim wystawimy PR.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
 
   - package-ecosystem: "uv"
     directory: "/"
@@ -25,6 +31,16 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    # Cooldown: czekaj az pakiet "ostygnie" przed otwarciem PR-a.
+    # Chroni przed atakami typu LiteLLM (atak trwal 2.5h zanim PyPI
+    # quarantine zadzialalo - 119k pobran zlosliwego pakietu). Dependabot
+    # automatycznie omija cooldown dla aktualizacji security (CVE).
+    # Praktyka #2 z lirantal/pypi-security-best-practices.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 3
     groups:
       python-minor-and-patch:
         update-types:
@@ -50,6 +66,11 @@ updates:
     commit-message:
       prefix: "docker"
       include: "scope"
+    # Cooldown: 3 dni na bazowe obrazy. Tag promotion attacks na obrazach
+    # bazowych (np. python:3.13-slim) sa rzadkie ale mozliwe.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     groups:
       docker-base-images:
         patterns:

--- a/src/bpp/newsfragments/+dependabot-cooldown.feature.rst
+++ b/src/bpp/newsfragments/+dependabot-cooldown.feature.rst
@@ -1,0 +1,1 @@
+Dodano ``cooldown`` do ``.github/dependabot.yml`` dla wszystkich trzech ekosystemów (Python/uv, GitHub Actions, Docker). Aktualizacje czekają 3 dni (major: 7) zanim Dependabot otworzy PR — chroni przed wciąganiem swieżo skompromitowanych wersji (np. atak typu LiteLLM 2.5h przed quarantine). Aktualizacje security (CVE) automatycznie omijają cooldown.


### PR DESCRIPTION
## Podsumowanie

PR 3/12 z serii pypi-security-best-practices — praktyka **#2: Install with Cooldown**.

## Co się zmienia

`.github/dependabot.yml` — dodaje `cooldown:` block dla wszystkich trzech
ekosystemów (Python/uv, GitHub Actions, Docker). Default 3 dni, major 7 dni.

## Dlaczego

Dependabot do tej pory otwierał PR-y natychmiast po publikacji nowej wersji.
W praktyce każdy compromise typu supply-chain trafiał do nas w pierwszych
godzinach życia złośliwego pakietu — zanim community / PyPI quarantine
zdołały zareagować.

Konkretny przykład z dokumentu źródłowego: atak LiteLLM trwał **2.5h**, 119k
pobrań złośliwego pakietu zanim PyPI go zaquaranteinowało. Z 3-dniowym
cooldownem ten attack window jest praktycznie zamknięty.

**Aktualizacje security (CVE) automatycznie omijają cooldown** — Dependabot
ma to wbudowane, więc patche bezpieczeństwa nadal trafiają do nas
natychmiast.

## Plan testowy

- [x] YAML lint pre-commit — passed.
- [ ] Następny tygodniowy run Dependabot (poniedziałek) wystawi PR-y
      respektujące cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)