### PR TITLE
deps(uv): make uv-lock-cooldown (manual lock z 3-dniowym cooldownem)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,30 @@ uv-lock: ## uv lock + commit uv.lock
 	uv lock
 	-git commit -m "Update lockfile" uv.lock
 
+# Defense-in-depth do Dependabot cooldown (.github/dependabot.yml). Gdy
+# manualnie odpalasz `uv lock` (np. po dodaniu nowej dep) - ten target
+# wymusza wykluczenie pakietow opublikowanych w ostatnich 3 dniach.
+# Chroni przed atakami typu LiteLLM (zlosliwa wersja przez ~2.5h zanim
+# PyPI quarantine zadziala). Praktyka #2 z pypi-security-best-practices.
+#
+# Wyjatki (--exclude-newer-package <pkg>=<future date>): pakiety in-house
+# *-iplweb publikowane przez ten sam team co BPP. Cooldown na nie nie ma
+# sensu (jakby konto bylo skompromitowane, atakujacy uderzylby tez tutaj),
+# a swieze releasy sa czesto load-bearing.
+#
+# Override cutoff przez env var: make uv-lock-cooldown CUTOFF=2026-04-20T00:00:00Z
+uv-lock-cooldown: ## uv lock z 3-dniowym cooldownem (defense-in-depth)
+	@CUTOFF=$${CUTOFF:-$$(date -u -v-3d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '3 days ago' +%Y-%m-%dT%H:%M:%SZ)}; \
+	FAR=2099-01-01T00:00:00Z; \
+	echo "Excluding packages newer than $$CUTOFF (in-house *-iplweb exempt)"; \
+	uv lock --exclude-newer "$$CUTOFF" \
+		--exclude-newer-package "django-denorm-iplweb=$$FAR" \
+		--exclude-newer-package "django-password-policies-iplweb=$$FAR" \
+		--exclude-newer-package "MOAI-iplweb=$$FAR" \
+		--exclude-newer-package "django_redis_iplweb=$$FAR" \
+		--exclude-newer-package "pymed-iplweb=$$FAR" \
+		--exclude-newer-package "django-dbtemplates-iplweb=$$FAR"
+
 ##@ GitHub Actions
 
 gh-run-watch: ## `gh run watch` — obserwuj najnowszy run CI

--- a/src/bpp/newsfragments/+uv-lock-cooldown.feature.rst
+++ b/src/bpp/newsfragments/+uv-lock-cooldown.feature.rst
@@ -1,0 +1,1 @@
+Dodano ``make uv-lock-cooldown`` jako defense-in-depth do Dependabot cooldown — ręczne wywołanie ``uv lock`` z 3-dniowym oknem ostygania (pakiety opublikowane w ostatnich 3 dniach są wykluczane). Pakiety in-house (``*-iplweb``) zwolnione z cooldownu (atak na konto teamu uderzylby je tak czy tak). Override ``CUTOFF`` przez env var.


### PR DESCRIPTION
## Podsumowanie

PR 6/12 z serii pypi-security-best-practices — praktyka **#2: Install with Cooldown**.
Defense-in-depth do Dependabot cooldown z PR #175.

## Co się zmienia

`Makefile`:
- Nowy target `uv-lock-cooldown` — uruchamia `uv lock --exclude-newer <today-3d>`.
- Pakiety in-house `*-iplweb` zwolnione z cooldownu via `--exclude-newer-package`.
- Override przez env var: `make uv-lock-cooldown CUTOFF=2026-04-20T00:00:00Z`.

## Dlaczego osobny target a nie globalna konfiguracja

uv 0.9.x nie wspiera ISO 8601 duration syntax w `[tool.uv] exclude-newer` —
trzeba absolutną datę. Globalny `exclude-newer = "2026-04-20"` w pyproject
musiałby być rotowany ręcznie, co po tygodniu staje się bezsensowne.

Target z dynamicznym obliczaniem daty przez `date` (GNU + BSD compatible) to
najczystsze rozwiązanie póki uv nie wspiera duration.

## Pakiety in-house exempt

`*-iplweb` to pakiety publikowane przez ten sam team co BPP. Cooldown na
nie nie ma sensu (atak na konto teamu uderzyłby je tak czy tak), a świeże
releasy są często load-bearing (`django-redis-iplweb>=6.0.1,<6.1` testowo
falował resolution bez exempta).

## Plan testowy

- [x] `make uv-lock-cooldown` — passes (uv lock z cutoff działa).
- [x] BSD `date -v-3d` na macOS, GNU `date -d '3 days ago'` na Linux — oba
      branche pokryte.
- [ ] Manual: po dodaniu nowej dep, dev wybiera `make uv-lock` (no cooldown,
      np. dla emergency hotfix) lub `make uv-lock-cooldown` (default).

## Następne kroki

Gdy uv >=1.x doda duration syntax w `exclude-newer`, zamigrujemy globalnie
do `[tool.uv]` i usuniemy target z Makefile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)