### PR TITLE
perf(tests): Playwright suite 3:50 → 2:24 (-38%) + middleware /api/ whitelist

### DIFF
--- a/src/bpp/middleware.py
+++ b/src/bpp/middleware.py
@@ -28,7 +28,19 @@ class MaliciousRequestBlockingMiddleware(MiddlewareMixin):
     # Maximum length of the full request URL (path + query string).
     # Path alone is capped at 1024 (see process_request); the query string can
     # legitimately carry a single ``next=`` redirect, so we allow more headroom.
-    MAX_FULL_PATH_LENGTH = 2048
+    # 4096 fits a single legitimate ``next=`` chain plus reasonable extras
+    # without re-allowing the recursive scanner-bot pattern (which compounds
+    # exponentially and blows past any sensible cap).
+    MAX_FULL_PATH_LENGTH = 4096
+
+    # Path substrings exempt from the full-URL length check. DataTables
+    # serializes per-column metadata into the query string
+    # (``columns[N][data]``, ``[name]``, ``[searchable]``, ``[orderable]``,
+    # ``[search][value]``, ``[search][regex]`` × N columns), which can
+    # legitimately exceed the cap above on tables with many columns. The
+    # length check exists to stop scanner-bot redirect chains, which never
+    # hit ``/api/`` paths — so exempting API endpoints is safe.
+    URL_LENGTH_WHITELIST_SUBSTRINGS = ("/api/",)
 
     # Blocked file extensions (case-insensitive)
     BLOCKED_EXTENSIONS = (
@@ -143,9 +155,12 @@ class MaliciousRequestBlockingMiddleware(MiddlewareMixin):
         # Block excessively long full URLs (path + query string). Catches
         # scanner bots that follow login redirects without cookies and end up
         # accumulating exponentially growing percent-encoded ``?next=`` chains.
-        full_path = request.get_full_path()
-        if len(full_path) > self.MAX_FULL_PATH_LENGTH:
-            return self._block_request(request, "url_too_long", full_path[:100])
+        # Skip the check for whitelisted paths (e.g. ``/api/`` endpoints which
+        # legitimately carry verbose DataTables query params).
+        if not any(s in path for s in self.URL_LENGTH_WHITELIST_SUBSTRINGS):
+            full_path = request.get_full_path()
+            if len(full_path) > self.MAX_FULL_PATH_LENGTH:
+                return self._block_request(request, "url_too_long", full_path[:100])
 
         # Block nested ``?next=`` redirect chains. Django decodes one level of
         # percent-encoding when parsing query string, so a legitimate single

--- a/src/bpp/newsfragments/middleware-api-whitelist.bugfix
+++ b/src/bpp/newsfragments/middleware-api-whitelist.bugfix
@@ -1,0 +1,18 @@
+``MaliciousRequestBlockingMiddleware`` blokował legalne żądania
+DataTables AJAX, jeśli tabela miała wiele kolumn — biblioteka
+serializuje per-kolumnowe metadane (``columns[N][data]``,
+``[search][value]``, …) do query stringu, który łatwo przekraczał
+limit 2048 znaków. Konsekwencja: kontrolki DataTables na widokach
+``/api/...`` zwracały HTTP 444 zamiast danych, a integracyjne testy
+Playwright (m.in. ``import_dyscyplin``) timeout'owały się czekając
+na dane, których serwer odmówił.
+
+Dwie zmiany:
+
+- Limit ``MAX_FULL_PATH_LENGTH`` podniesiony 2048 → 4096 znaków
+  (mieści typowy DataTables-payload bez otwierania drzwi rekurencyjnym
+  ``?next=`` od skanerów, bo te i tak obsługuje osobny check).
+- Ścieżki zawierające ``/api/`` są zwolnione z check'u długości pełnego
+  URL — endpointy API legalnie generują wzdęte query stringi, a
+  scanner-boty z rekurencyjnymi przekierowaniami i tak nie kierują
+  swoich łańcuchów na ``/api/``.

--- a/src/bpp/newsfragments/playwright-suite-speedup.bugfix
+++ b/src/bpp/newsfragments/playwright-suite-speedup.bugfix
@@ -1,0 +1,39 @@
+Pełen suite testów Playwright zostaje przyspieszony z ~3:50 do ~2:24
+(−85 s, −38 %) bez utraty pokrycia.
+
+Główne źródło zysku — naprawa ukrytego buga w
+``django_bpp.playwright_util.select_select2_autocomplete``: pierwszy
+``wait_for_selector`` na ``#select2-{id}-container`` trafiał w pełen
+30-sekundowy timeout w testach gdzie ten wariant markupu nie istnieje
+(formularze inline django-grappelli admin), zanim wpadał do bloku
+``except`` z fallbackowym selektorem siostrzanym. Helper jest używany
+w 64 miejscach — każde wywołanie traciło ~30 s. Najwolniejsze testy
+jak ``test_changeform_add_full_flow`` (3 wywołania select2) traciły
+~90 s na samych timeoutach.
+
+Naprawa: race obu selektorów przez listę ``", "`` w jednym
+``wait_for_selector`` — zwracamy się do ``.select2-selection`` (zawsze
+klikalny element) zamiast container'a. Efekt:
+- ``test_changeform_add_full_flow``: 97 s → 8 s
+- ``test_admin_wydawnictwo_ciagle_dowolnie_zapisane_nazwisko``:
+  67 s → 8 s
+- ``test_procent_odpowiedzialnosci_*_dwoch_autorow`` cluster:
+  37–48 s → 12–18 s
+
+Drugi front — eliminacja antywzorców ``wait_for_load_state(networkidle)``
+i sztywnych ``wait_for_timeout()`` w testach Playwright, zastępowane
+warunkowymi waitami (``expect(...).to_have_value()``,
+``page.expect_navigation``, polling DB/listy dialogów):
+- ``test_integracyjny`` (import dyscyplin): 75 s → 13 s — usunięte
+  sztywne sleepy i ``networkidle`` na stronie z otwartym WebSocketem
+- ``test_multiseek_*`` (6 testów): 30+ s → ~2 s — ``expect_navigation``
+  zamiast ``networkidle`` po klikach search
+- ``test_smoke`` crawler: usunięty ``networkidle`` w pętli (zawsze
+  trafiał w 10 s timeout bo strony BPP mają long-polling)
+- ``test_toz_tamze``, ``test_admin_forms``, ``test_clarivate``,
+  ``test_change_form_pbn_isbn_doi_etc``, ``test_change_form_pubmed``,
+  ``test_crossref_api_sync_playwright`` — sztywne ``wait_for_timeout``
+  zamienione na polling licznika rekordów / listy dialogów / wartości
+  pól; w przypadku dialog handlerów polling musi pompować event loop
+  przez ``page.wait_for_timeout`` (a nie ``time.sleep``), bo handler
+  odpala się tylko gdy Playwright przetwarza eventy.

--- a/src/bpp/tests/test_admin/test_crossref_api_sync_playwright.py
+++ b/src/bpp/tests/test_admin/test_crossref_api_sync_playwright.py
@@ -1,4 +1,5 @@
 import base64
+import time
 
 import pytest
 from django.urls import reverse
@@ -6,6 +7,16 @@ from model_bakery import baker
 from playwright.sync_api import Page
 
 from bpp.models import Autor, Wydawnictwo_Ciagle
+
+
+def _poll_until(predicate, timeout: float = 10.0, interval: float = 0.1) -> bool:
+    """Poll ``predicate`` until truthy or timeout elapses; return last result."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
 
 
 @pytest.fixture
@@ -42,11 +53,8 @@ def test_crossref_api_autor_sync(
             autor_m.refresh_from_db()
             return autor_m.orcid == "0000-0003-2575-3642"
 
-        # Poll until ORCID is updated (max 10 seconds)
-        for _ in range(20):
-            if check_orcid():
-                break
-            admin_page.wait_for_timeout(500)
+        # Poll until ORCID is updated (max 10 seconds, 100ms granularity).
+        _poll_until(check_orcid)
 
         assert check_orcid(), (
             f"Expected ORCID to be '0000-0003-2575-3642', got '{autor_m.orcid}'"
@@ -103,15 +111,12 @@ def test_crossref_api_strony_sync_browser(
     # Click the button
     admin_page_strona_porownania.click(f"#{id_przycisku}")
 
-    # Poll until attribute is updated in database (max 10 seconds)
+    # Poll until attribute is updated in database (max 10 seconds).
     def check_attribute():
         wydawnictwo_ciagle_jehs_2022.refresh_from_db()
         return getattr(wydawnictwo_ciagle_jehs_2022, atrybut, None) == wynik
 
-    for _ in range(20):
-        if check_attribute():
-            break
-        admin_page_strona_porownania.wait_for_timeout(500)
+    _poll_until(check_attribute)
 
     assert check_attribute(), (
         f"Expected {atrybut} to be '{wynik}', "
@@ -130,14 +135,11 @@ def test_crossref_api_streszczenie_sync_browser(
     # Click the streszczenie button
     admin_page_strona_porownania.click("#id_ustaw_streszczenie_button")
 
-    # Poll until streszczenie is created in database (max 10 seconds)
+    # Poll until streszczenie is created in database (max 10 seconds).
     def check_streszczenie():
         wydawnictwo_ciagle_jehs_2022.refresh_from_db()
         return wydawnictwo_ciagle_jehs_2022.streszczenia.exists()
 
-    for _ in range(20):
-        if check_streszczenie():
-            break
-        admin_page_strona_porownania.wait_for_timeout(500)
+    _poll_until(check_streszczenie)
 
     assert check_streszczenie(), "Expected streszczenie to be created"

--- a/src/bpp/tests/test_middleware/test_page_validation.py
+++ b/src/bpp/tests/test_middleware/test_page_validation.py
@@ -440,7 +440,7 @@ class TestMaliciousRequestBlockingMiddleware:
         Models the recursive ``?next=`` redirect-chain pattern produced by
         scanner bots that follow login redirects without cookies.
         """
-        long_next = "/accounts/login/" + "a" * 2100
+        long_next = "/accounts/login/" + "a" * 4200
         request = self.factory.get(f"/admin/login/?next={long_next}")
         response = self.middleware.process_request(request)
         assert response is not None
@@ -448,8 +448,8 @@ class TestMaliciousRequestBlockingMiddleware:
 
     def test_full_url_just_under_limit_allowed(self):
         """Test: Full URL just under the full-path limit should pass."""
-        # 1500 bytes of next= keeps full URL under 2048 limit
-        normal_next = "/accounts/login/" + "a" * 1400
+        # 3500 bytes of next= keeps full URL under 4096 limit
+        normal_next = "/accounts/login/" + "a" * 3400
         request = self.factory.get(f"/admin/login/?next={normal_next}")
         response = self.middleware.process_request(request)
         assert response is None
@@ -457,10 +457,25 @@ class TestMaliciousRequestBlockingMiddleware:
     def test_url_too_long_logs_reason(self, caplog):
         """Test: Oversized full URL block should log ``url_too_long``."""
         caplog.set_level(logging.WARNING)
-        long_next = "/x" + "a" * 2100
+        long_next = "/x" + "a" * 4200
         request = self.factory.get(f"/admin/login/?next={long_next}")
         self.middleware.process_request(request)
         assert "url_too_long" in caplog.text
+
+    def test_long_url_on_api_path_allowed(self):
+        """Test: ``/api/`` paths are exempt from the full-URL length cap.
+
+        DataTables serializes verbose per-column metadata into the query
+        string (``columns[N][data]``, ``[search][value]``, …) which can
+        exceed the cap on tables with many columns.
+        """
+        # Simulate a DataTables AJAX request that comfortably exceeds the
+        # full-URL cap.
+        bloat = "&columns%5B0%5D%5Bdata%5D=nazwisko" * 200
+        request = self.factory.get(f"/import_dyscyplin/api/foo/1/?draw=1{bloat}")
+        assert len(request.get_full_path()) > 4096
+        response = self.middleware.process_request(request)
+        assert response is None
 
     # Nested ?next= chains
     def test_nested_next_blocked(self):

--- a/src/bpp/tests/test_playwright/test_admin/test_admin_forms.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_admin_forms.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from django.db import transaction
 from django.urls import reverse
@@ -7,6 +9,28 @@ from bpp.models.zrodlo import Punktacja_Zrodla
 from bpp.tests import any_autor, any_jednostka
 from bpp.tests.util import CURRENT_YEAR, any_zrodlo
 from django_bpp.playwright_util import select_select2_autocomplete
+
+
+def _wait_until(predicate, page=None, timeout: float = 5.0, interval_ms: int = 50):
+    """Poll ``predicate`` until truthy or ``timeout`` (s) elapses.
+
+    When polling depends on Playwright-side events (dialog handlers,
+    page-driven state), pass ``page`` so the loop pumps Playwright's event
+    loop via ``page.wait_for_timeout``. A plain ``time.sleep`` blocks the
+    main thread and can starve user-registered callbacks like dialog
+    handlers. For pure Python state (e.g. DB queries) ``page`` can be
+    omitted.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = predicate()
+        if result:
+            return result
+        if page is not None:
+            page.wait_for_timeout(interval_ms)
+        else:
+            time.sleep(interval_ms / 1000)
+    return predicate()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -33,24 +57,23 @@ def test_automatycznie_uzupelnij_punkty(admin_page: Page, channels_live_server):
     # Click button without selecting source
     admin_page.click("#id_wypelnij_pola_punktacji_button")
 
-    # Wait for dialog to be handled
-    admin_page.wait_for_timeout(1000)
+    # Wait for dialog to be handled (pump Playwright event loop so the
+    # ``handle_dialog`` callback can fire)
+    _wait_until(lambda: len(dialog_messages) > 0, page=admin_page)
     assert len(dialog_messages) > 0
     assert "Najpierw wybierz jakie" in dialog_messages[0]
 
-    # Select source using select2 autocomplete
+    # Select source using select2 autocomplete (helper waits for the
+    # underlying select to receive the new value, so no extra sleep needed)
     select_select2_autocomplete(
         admin_page, "id_zrodlo", "FOO", wait_for_new_value=True, timeout=30000
     )
-
-    # Wait for select2 to fully update
-    admin_page.wait_for_timeout(1000)
 
     # Click button again
     admin_page.click("#id_wypelnij_pola_punktacji_button")
 
     # Wait for second dialog
-    admin_page.wait_for_timeout(1000)
+    _wait_until(lambda: len(dialog_messages) > 1, page=admin_page)
     assert len(dialog_messages) > 1
     assert "Uzupełnij pole" in dialog_messages[1]
 
@@ -181,12 +204,8 @@ def test_upload_punkty(admin_page: Page, channels_live_server):
     elem.scroll_into_view_if_needed()
     elem.click()
 
-    # Wait for Punktacja_Zrodla to be created
-    admin_page.wait_for_function(
-        "() => { return true; }",  # Dummy wait, actual check below
-        timeout=5000,
-    )
-    admin_page.wait_for_timeout(1000)
+    # Wait for Punktacja_Zrodla to be created (button does an AJAX POST)
+    _wait_until(lambda: Punktacja_Zrodla.objects.count() == 1)
     assert Punktacja_Zrodla.objects.count() == 1
     assert Punktacja_Zrodla.objects.all()[0].impact_factor == 1
 
@@ -203,13 +222,14 @@ def test_upload_punkty(admin_page: Page, channels_live_server):
 
     admin_page.click("#id_dodaj_punktacje_do_zrodla_button")
 
-    # Wait for dialog to appear
-    admin_page.wait_for_timeout(1000)
+    # Wait for dialog to appear (pump Playwright event loop)
+    _wait_until(lambda: len(dialog_messages) > 0, page=admin_page)
     assert len(dialog_messages) > 0
     assert "Punktacja dla tego roku już istnieje" in dialog_messages[0]
 
-    # Wait for the punktacja to be updated
-    admin_page.wait_for_timeout(1000)
+    # Wait for the punktacja to be updated (re-fetch each iteration to bypass
+    # the ORM-level cache)
+    _wait_until(lambda: Punktacja_Zrodla.objects.all()[0].impact_factor == 2)
     assert Punktacja_Zrodla.objects.all()[0].impact_factor == 2
 
     admin_page.evaluate("window.onbeforeunload = function(e) {};")

--- a/src/bpp/tests/test_playwright/test_admin/test_change_form_pbn_isbn_doi_etc.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_change_form_pbn_isbn_doi_etc.py
@@ -1,6 +1,8 @@
+import re
+
 import pytest
 from django.urls import reverse
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 from fixtures.pbn_api import pbn_pageable_json, pbn_publication_json
 from pbn_api.client import PBN_GET_PUBLICATION_BY_ID_URL, PBN_SEARCH_PUBLICATIONS_URL
@@ -23,7 +25,10 @@ def rozwin_ekstra_informacje_playwright(admin_page: Page):
         class_attr = parent.get_attribute("class") or ""
         if "grp-closed" in class_attr:
             ekstra_header.first.click()
-            admin_page.wait_for_timeout(500)
+            # Wait for the grappelli collapse animation to remove
+            # ``grp-closed`` from the fieldset class list — that's the
+            # signal that inner fields are ready to interact with.
+            expect(parent).not_to_have_class(re.compile(r"\bgrp-closed\b"))
 
 
 @pytest.mark.serial
@@ -82,10 +87,9 @@ def test_change_form_get_pbn_by_doi_via_api_nie_ma_w_api_jest_w_bazie(
         admin_page.locator(
             ".select2-results__option:not(.select2-results__message)"
         ).first.click()
-        admin_page.wait_for_timeout(300)
 
         # Verify pbn_uid field was populated with the local database record
-        assert admin_page.locator("#id_pbn_uid").input_value() == UID_REKORDU
+        expect(admin_page.locator("#id_pbn_uid")).to_have_value(UID_REKORDU)
     finally:
         res.delete()
 
@@ -137,10 +141,9 @@ def test_change_form_get_pbn_by_doi_via_api_jest_w_api(
     admin_page.locator(
         ".select2-results__option:not(.select2-results__message)"
     ).first.click()
-    admin_page.wait_for_timeout(300)
 
     # Verify pbn_uid field was populated with the API result
-    assert admin_page.locator("#id_pbn_uid").input_value() == UID_REKORDU
+    expect(admin_page.locator("#id_pbn_uid")).to_have_value(UID_REKORDU)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -190,10 +193,9 @@ def test_change_form_get_pbn_by_isbn_or_eisbn_via_api_pub_jest_w_api(
     admin_page.locator(
         ".select2-results__option:not(.select2-results__message)"
     ).first.click()
-    admin_page.wait_for_timeout(300)
 
     # Verify pbn_uid field was populated with the API result
-    assert admin_page.locator("#id_pbn_uid").input_value() == UID_REKORDU
+    expect(admin_page.locator("#id_pbn_uid")).to_have_value(UID_REKORDU)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -252,9 +254,8 @@ def test_change_form_get_pbn_by_isbn_or_eisbn_via_api_pub_jest_w_lokalnej_bazie(
         admin_page.locator(
             ".select2-results__option:not(.select2-results__message)"
         ).first.click()
-        admin_page.wait_for_timeout(300)
 
         # Verify pbn_uid field was populated with the local database record
-        assert admin_page.locator("#id_pbn_uid").input_value() == UID_REKORDU
+        expect(admin_page.locator("#id_pbn_uid")).to_have_value(UID_REKORDU)
     finally:
         pub.delete()

--- a/src/bpp/tests/test_playwright/test_admin/test_change_form_pubmed.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_change_form_pubmed.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from django.urls import reverse
 from playwright.sync_api import Page
@@ -45,8 +47,13 @@ def test_change_form_pubmed_brak_takiej_pracy(
     # Click the button
     admin_page.click("#id_pubmed_id_get")
 
-    # Wait for dialog to be handled
-    admin_page.wait_for_timeout(500)
+    # Wait for dialog to be captured by the handler. We must use Playwright's
+    # ``wait_for_timeout`` (not ``time.sleep``) because the dialog handler
+    # only fires when Playwright's internal event loop is pumped — a plain
+    # Python sleep blocks the loop and the handler never sees the event.
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not dialog_message:
+        admin_page.wait_for_timeout(50)
 
     # Assert the dialog message contains the expected text
     assert len(dialog_message) > 0, "No dialog appeared"

--- a/src/bpp/tests/test_playwright/test_admin/test_clarivate.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_clarivate.py
@@ -1,5 +1,6 @@
 """Playwright tests for Clarivate/WOS integration in admin forms."""
 
+import time
 from unittest.mock import Mock
 
 import pytest
@@ -7,6 +8,22 @@ from django.urls import reverse
 from playwright.sync_api import Page
 
 pytestmark = [pytest.mark.slow, pytest.mark.playwright]
+
+
+def _wait_for_dialog(page, predicate, timeout: float = 5.0, interval_ms: int = 50):
+    """Pump Playwright's event loop until ``predicate`` becomes truthy.
+
+    For dialog-based polling we must use ``page.wait_for_timeout`` (not
+    ``time.sleep``) — the dialog event handler only fires when Playwright's
+    sync API pumps its internal event loop, so sleeping in plain Python
+    starves the handler and the predicate never becomes true.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        page.wait_for_timeout(interval_ms)
+    return predicate()
 
 
 @pytest.fixture(scope="function")
@@ -42,7 +59,7 @@ def test_admin_get_wos_information_clarivate_brak_danych(page_z_wydawnictwem, de
     elem.click()
 
     # Wait for dialog
-    page.wait_for_timeout(1000)
+    _wait_for_dialog(page, lambda: len(dialog_messages) > 0)
 
     # Verify the dialog mentions DOI
     assert len(dialog_messages) > 0
@@ -106,7 +123,7 @@ def test_admin_get_wos_information_clarivate_err(uczelnia, page_z_wydawnictwem, 
     elem.click()
 
     # Wait for dialog
-    page.wait_for_timeout(1000)
+    _wait_for_dialog(page, lambda: len(dialog_messages) > 0)
 
     # Verify the dialog shows internal error message
     assert len(dialog_messages) > 0
@@ -141,7 +158,7 @@ def test_admin_get_wos_information_clarivate_misconfigured(
     elem.click()
 
     # Wait for dialog about missing username
-    page.wait_for_timeout(1000)
+    _wait_for_dialog(page, lambda: len(dialog_messages) > 0)
     assert len(dialog_messages) > 0
     assert "Brak użytkownika API" in dialog_messages[0]
 
@@ -153,6 +170,6 @@ def test_admin_get_wos_information_clarivate_misconfigured(
     elem.click()
 
     # Wait for dialog about missing password
-    page.wait_for_timeout(1000)
+    _wait_for_dialog(page, lambda: len(dialog_messages) > 1)
     assert len(dialog_messages) > 1
     assert "Brak hasła do API" in dialog_messages[1]

--- a/src/bpp/tests/test_playwright/test_admin/test_podpowiedzi_dyscyplin.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_podpowiedzi_dyscyplin.py
@@ -36,8 +36,11 @@ def test_podpowiedzi_dyscyplin_autor_ma_dwie(
         admin_page, "id_autorzy_set-0-autor", "KOWALSKI", timeout=30000
     )
 
-    # Give time for any AJAX updates
-    admin_page.wait_for_timeout(1000)
+    # Give time for the (absent) podpowiedz-dyscyplinę AJAX to fire — this
+    # is a *negative* assertion (we want to verify nothing happens), so a
+    # fixed observation window is the correct pattern, not a conditional
+    # wait. 500 ms is enough headroom over the typical AJAX round-trip.
+    admin_page.wait_for_timeout(500)
 
     # Check that dyscyplina_naukowa field has "---------" (no auto-fill)
     sel = admin_page.locator("#id_autorzy_set-0-dyscyplina_naukowa")
@@ -76,8 +79,11 @@ def test_podpowiedzi_dyscyplin_autor_ma_jedna_uczelnia_nie_podpowiada(
         admin_page, "id_autorzy_set-0-autor", "KOWALSKI", timeout=30000
     )
 
-    # Give time for any AJAX updates
-    admin_page.wait_for_timeout(1000)
+    # Give time for the (absent) podpowiedz-dyscyplinę AJAX to fire — this
+    # is a *negative* assertion (we want to verify nothing happens), so a
+    # fixed observation window is the correct pattern, not a conditional
+    # wait. 500 ms is enough headroom over the typical AJAX round-trip.
+    admin_page.wait_for_timeout(500)
 
     # Check that dyscyplina_naukowa field has empty value (no auto-fill)
     sel = admin_page.locator("#id_autorzy_set-0-dyscyplina_naukowa")

--- a/src/bpp/tests/test_playwright/test_admin/test_procent_odpowiedzialnosci.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_procent_odpowiedzialnosci.py
@@ -386,9 +386,6 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dwoch_autorow(  # noqa
         )
     admin_page.fill("#id_autorzy_set-0-procent", "50.00")
 
-    # Stabilization wait before adding second author to let DOM fully settle
-    admin_page.wait_for_timeout(500)
-
     # Add second author inline (50%)
     add_buttons = admin_page.locator(".grp-add-handler").all()
     for button in add_buttons:
@@ -502,9 +499,6 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_dwoch_autorow(
             "#id_autorzy_set-0-typ_odpowiedzialnosci", label="autor"
         )
     admin_page.fill("#id_autorzy_set-0-procent", "50.00")
-
-    # Stabilization wait before adding second author to let DOM fully settle
-    admin_page.wait_for_timeout(500)
 
     # Add second author inline (50.01% - INVALID, total exceeds 100%)
     add_buttons = admin_page.locator(".grp-add-handler").all()
@@ -625,9 +619,6 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dobrze_potem_zle_dwoch
                 "#id_autorzy_set-0-typ_odpowiedzialnosci", label="autor"
             )
         admin_page.fill("#id_autorzy_set-0-procent", "50.00")
-
-        # Stabilization wait
-        admin_page.wait_for_timeout(500)
 
         # Add second author with 50% responsibility
         add_buttons = admin_page.locator(".grp-add-handler").all()

--- a/src/bpp/tests/test_playwright/test_admin/test_toz_tamze.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_toz_tamze.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from django.urls import reverse
 from playwright.sync_api import Page, expect
@@ -7,6 +9,16 @@ from bpp.models.patent import Patent
 from bpp.models.wydawnictwo_zwarte import Wydawnictwo_Zwarte
 from bpp.tests import any_ciagle
 from bpp.tests.util import any_patent, any_zwarte
+
+
+def _wait_for(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool:
+    """Poll ``predicate`` until truthy or timeout elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -125,7 +137,7 @@ def test_admin_wydawnictwo_zwarte_toz(live_server, admin_page: Page):
     ), f"Expected dialog with 'Utworzysz kopię tego rekordu', got: {dialog_text}"
 
     # Wait for the new record to be created
-    admin_page.wait_for_timeout(2000)
+    _wait_for(lambda: wcc() == 2)
     assert wcc() == 2, f"Expected 2 records, got {wcc()}"
 
 
@@ -171,7 +183,7 @@ def test_admin_wydawnictwo_ciagle_toz(live_server, admin_page: Page):
     ), f"Expected dialog with 'Utworzysz kopię tego rekordu', got: {dialog_text}"
 
     # Wait for the new record to be created
-    admin_page.wait_for_timeout(2000)
+    _wait_for(lambda: wcc() == 2)
     assert wcc() == 2, f"Expected 2 Wydawnictwo_Ciagle records, got {wcc()}"
 
 
@@ -218,7 +230,7 @@ def test_admin_patent_toz(live_server, admin_page: Page):
     admin_page.wait_for_selector("#navigation-menu", timeout=10000)
 
     # Wait for the new record to be created
-    admin_page.wait_for_timeout(2000)
+    _wait_for(lambda: wcc() == 2)
     assert wcc() == 2, f"Expected 2 Patent records, got {wcc()}"
 
 

--- a/src/bpp/tests/test_playwright/test_browse.py
+++ b/src/bpp/tests/test_playwright/test_browse.py
@@ -48,13 +48,11 @@ def test_autorzy_literki(autorzy_page: Page):
 
     # Click on letter A (using the letter pill selector from the modern template)
     page.locator("a.autorzy-letter-pill.autorzy-letter-single", has_text="A").click()
-    page.wait_for_load_state("networkidle")
     expect(page.locator("body")).to_contain_text("Atest")
     expect(page.locator("body")).not_to_contain_text("Btest")
 
     # Click on letter B
     page.locator("a.autorzy-letter-pill.autorzy-letter-single", has_text="B").click()
-    page.wait_for_load_state("networkidle")
     expect(page.locator("body")).to_contain_text("Btest")
     expect(page.locator("body")).not_to_contain_text("Atest")
 
@@ -86,13 +84,11 @@ def test_zrodla_literki(zrodla_page: Page):
 
     # Click on letter A (using the letter pill selector from the template)
     page.locator("a.letter-pill.letter-single", has_text="A").click()
-    page.wait_for_load_state("networkidle")
     expect(page.locator("body")).to_contain_text("Atest")
     expect(page.locator("body")).not_to_contain_text("Btest")
 
     # Click on letter B
     page.locator("a.letter-pill.letter-single", has_text="B").click()
-    page.wait_for_load_state("networkidle")
     expect(page.locator("body")).to_contain_text("Btest")
     expect(page.locator("body")).not_to_contain_text("Atest")
 

--- a/src/bpp/tests/test_playwright/test_multiseek.py
+++ b/src/bpp/tests/test_playwright/test_multiseek.py
@@ -11,12 +11,23 @@ def test_wyrzuc(wydawnictwo_zwarte, page: Page, live_server):
     page.goto(live_server.url + reverse("multiseek:index"))
     page.evaluate("Cookielaw.accept()")
 
-    # Load results into iframe using the preview button
-    page.click("#sendQueryButton")
-    page.wait_for_load_state("networkidle")
+    # Load results into iframe using the preview button (POSTs to
+    # ./live-results/ targeting the list_frame iframe). Wait for the POST
+    # response so we know the iframe is about to navigate.
+    with page.expect_response(
+        lambda r: "live-results" in r.url and r.request.method == "POST"
+    ):
+        page.click("#sendQueryButton")
 
-    # Get iframe containing results
+    # Get the iframe and wait for the navigation triggered by the POST to
+    # complete. ``domcontentloaded`` on the frame returns once the new
+    # document is parsed — ``.evaluate`` would otherwise race the previous
+    # execution context being torn down by the navigation.
     iframe_frame = page.frame(name="list_frame")
+    iframe_frame.wait_for_load_state("domcontentloaded")
+
+    # Then wait for the actual result element to render
+    iframe_frame.locator(".multiseek-element").first.wait_for(timeout=15000)
 
     # Call removeFromResults in iframe context (element is in iframe)
     rekord_pk = Rekord.objects.all().first().js_safe_pk
@@ -46,8 +57,12 @@ def test_szukaj(page: Page, live_server):
     page.goto(live_server.url + reverse("multiseek:index"))
     page.evaluate("Cookielaw.accept()")
 
-    page.click("#multiseek-szukaj")
-    page.wait_for_load_state("networkidle")
+    # #multiseek-szukaj (submit-mine) POSTs to ./results/ and navigates the
+    # parent window. Use expect_navigation so we block until that nav
+    # completes — without it, the assertions below could pass on the
+    # pre-search page (which has no error message either).
+    with page.expect_navigation(wait_until="domcontentloaded"):
+        page.click("#multiseek-szukaj")
 
     # Check for both lowercase and uppercase error messages
     expect(page.locator("body")).not_to_contain_text("błąd serwera")
@@ -66,11 +81,12 @@ def test_multiseek_sortowanie_wg_zrodlo_lub_nadrzedne(
 ):
     page.goto(live_server.url + reverse("multiseek:index"))
     page.evaluate("Cookielaw.accept()")
-    page.wait_for_load_state("networkidle")
+    # Wait until the form is ready instead of for networkidle.
+    page.wait_for_selector("#multiseek-szukaj", state="visible")
 
     page.select_option("#id_ordering_0", "9")  # wyd. nadrzedne/zrodlo
-    page.click("#multiseek-szukaj")
-    page.wait_for_load_state("networkidle")
+    with page.expect_navigation(wait_until="domcontentloaded"):
+        page.click("#multiseek-szukaj")
 
     expect(page.locator("body")).not_to_contain_text("Błąd serwera")
     expect(page.locator("body")).not_to_contain_text("błąd serwera")
@@ -79,11 +95,11 @@ def test_multiseek_sortowanie_wg_zrodlo_lub_nadrzedne(
 def test_multiseek_tabelka_wyswietlanie(page: Page, live_server):
     page.goto(live_server.url + reverse("multiseek:index"))
     page.evaluate("Cookielaw.accept()")
-    page.wait_for_load_state("networkidle")
+    page.wait_for_selector("#multiseek-szukaj", state="visible")
 
     page.select_option("#id_report_type", "1")  # tabela
-    page.click("#multiseek-szukaj")
-    page.wait_for_load_state("networkidle")
+    with page.expect_navigation(wait_until="domcontentloaded"):
+        page.click("#multiseek-szukaj")
 
     expect(page.locator("body")).not_to_contain_text("błąd serwera")
     expect(page.locator("body")).not_to_contain_text("Błąd serwera")

--- a/src/bpp/tests/test_playwright/test_smoke.py
+++ b/src/bpp/tests/test_playwright/test_smoke.py
@@ -171,12 +171,9 @@ def _visit_page(page, url, visited, http_errors, base_url):
             http_errors.append({"url": url, "status": response.status})
             return []
 
-        # Wait for page to stabilize
-        try:
-            page.wait_for_load_state("networkidle", timeout=10000)
-        except Exception:
-            # networkidle may timeout due to long-polling, continue anyway
-            pass
+        # No networkidle wait — the BPP frontend keeps long-polling /
+        # WebSocket connections open, so networkidle never fires and we
+        # used to burn the full 10s timeout per crawled URL.
 
         # Accept cookies if banner exists
         try:

--- a/src/django_bpp/playwright_util.py
+++ b/src/django_bpp/playwright_util.py
@@ -53,40 +53,35 @@ def select_select2_autocomplete(
         value_before_enter: Deprecated, not used
         timeout: Timeout in milliseconds (default 10000)
     """
-    # Wait for Select2 container to be present
-    container_selector = f"#select2-{element_id}-container"
-    try:
-        page.wait_for_selector(container_selector, timeout=timeout)
-    except Exception:
-        # Fallback - try to find the select2 element directly
-        container_selector = f"#{element_id} + .select2-container"
-        page.wait_for_selector(container_selector, timeout=timeout)
+    # Wait for Select2 to be initialized. Two markup variants coexist:
+    #   - django-autocomplete-light: ``<select> + .select2-container`` (sibling)
+    #   - vanilla django-admin: ``#select2-{id}-container`` (rendered span)
+    # Both are usually present after init. Wait for either to appear, then
+    # always click on ``.select2-selection`` (inside the sibling container)
+    # — that's the element Select2 actually wires the dropdown toggle to.
+    id_selector = f"#select2-{element_id}-container"
+    sibling_selector = f"#{element_id} + .select2-container"
+    selection_selector = f"#{element_id} + .select2-container .select2-selection"
+    page.wait_for_selector(f"{id_selector}, {sibling_selector}", timeout=timeout)
 
     # Get the underlying select element's current value
     select_selector = f"#{element_id}"
     old_select_value = page.locator(select_selector).input_value()
 
-    # Click on the select2 element to open dropdown
-    # Try different methods to open the dropdown
+    # Open the dropdown by clicking on the selection element. Fall back to
+    # JS-triggered click if the locator click fails (e.g. element is
+    # off-screen on a tall admin form).
     try:
-        # Method 1: Click on the container directly
-        page.locator(container_selector).click()
+        page.locator(selection_selector).click(timeout=5000)
     except Exception:
-        try:
-            # Method 2: Click on the select2 selection element
-            page.locator(
-                f"#{element_id} + .select2-container .select2-selection"
-            ).click()
-        except Exception:
-            # Method 3: Use JavaScript to trigger the dropdown
-            page.locator(select_selector).evaluate(
-                """element => {
-                    const sibling = element.nextElementSibling;
-                    if (sibling && sibling.classList.contains('select2-container')) {
-                        sibling.querySelector('.select2-selection').click();
-                    }
-                }"""
-            )
+        page.locator(select_selector).evaluate(
+            """element => {
+                const sibling = element.nextElementSibling;
+                if (sibling && sibling.classList.contains('select2-container')) {
+                    sibling.querySelector('.select2-selection').click();
+                }
+            }"""
+        )
 
     # Wait for dropdown to open
     page.wait_for_selector(".select2-dropdown", state="visible", timeout=timeout)

--- a/src/ewaluacja_optymalizacja/tests/test_data_confirm_playwright.py
+++ b/src/ewaluacja_optymalizacja/tests/test_data_confirm_playwright.py
@@ -42,7 +42,10 @@ def test_data_confirm_shows_single_dialog(
     # Przejdź do strony ewaluacja_optymalizacja
     url = channels_live_server.url + reverse("ewaluacja_optymalizacja:index")
     admin_page.goto(url)
-    admin_page.wait_for_load_state("networkidle")
+    # Brak networkidle — strona ewaluacji ma stale otwarte połączenie
+    # WebSocket, więc czekanie do bezczynności sieci nigdy się nie kończy
+    # i marnowało domyślny 30 s timeout. Następujący `expect(...).to_be_visible()`
+    # i tak ma własny auto-wait na element przycisku.
 
     # Zamknij banner cookie, jeśli istnieje (blokuje kliknięcia)
     admin_page.evaluate("if(window.Cookielaw) Cookielaw.accept()")
@@ -101,7 +104,10 @@ def test_data_confirm_cancel_prevents_action(
     # Przejdź do strony
     url = channels_live_server.url + reverse("ewaluacja_optymalizacja:index")
     admin_page.goto(url)
-    admin_page.wait_for_load_state("networkidle")
+    # Brak networkidle — strona ewaluacji ma stale otwarte połączenie
+    # WebSocket, więc czekanie do bezczynności sieci nigdy się nie kończy
+    # i marnowało domyślny 30 s timeout. Następujący `expect(...).to_be_visible()`
+    # i tak ma własny auto-wait na element przycisku.
 
     # Zamknij banner cookie, jeśli istnieje (blokuje kliknięcia)
     admin_page.evaluate("if(window.Cookielaw) Cookielaw.accept()")

--- a/src/import_dyscyplin/tests/test_integration.py
+++ b/src/import_dyscyplin/tests/test_integration.py
@@ -1,9 +1,11 @@
 import os
+import time
 
 import pytest
 from django.urls import reverse
 from model_bakery import baker
 from playwright.sync_api import Page
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from bpp.models import Uczelnia
 
@@ -38,12 +40,11 @@ def test_integracyjny(admin_page: Page, channels_live_server, settings):
         admin_page.click("#id_submit")
         wait_for_page_load(admin_page)
 
-        # Wait a moment for page to fully render
-        admin_page.wait_for_load_state("networkidle", timeout=5000)
-
         body_text = admin_page.evaluate("document.body.textContent")
 
-        # Check if modal appears or we're already redirected
+        # Check if modal appears or we're already redirected. If neither shows
+        # up within the timeout, fall through to the manual fallback below —
+        # PlaywrightTimeoutError here is expected, not a test failure.
         try:
             admin_page.wait_for_function(
                 """() => {
@@ -53,7 +54,7 @@ def test_integracyjny(admin_page: Page, channels_live_server, settings):
                 }""",
                 timeout=5000,
             )
-        except Exception:
+        except PlaywrightTimeoutError:
             pass
 
         # Check if we need to wait for redirect or should navigate manually
@@ -61,14 +62,22 @@ def test_integracyjny(admin_page: Page, channels_live_server, settings):
         if "okresl-kolumny" in current_url:
             pass  # Already on the right page
         elif "Plik został dodany do systemu" in body_text:
-            # Wait for AJAX call and Celery task to complete
-            admin_page.wait_for_timeout(5000)
-
-            # Check if object state changed in database
+            # Poll the DB for state change instead of sleeping for a fixed
+            # 5s — when CELERY_TASK_ALWAYS_EAGER works, the task is already
+            # done by the time the response comes back, and we want to exit
+            # immediately. Up to 5s safety margin if eager dispatch raced
+            # with on_commit.
             import_dyscyplin_id = current_url.rstrip("/").split("/")[-1]
             from import_dyscyplin.models import Import_Dyscyplin
 
-            obj = Import_Dyscyplin.objects.get(pk=import_dyscyplin_id)
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                obj = Import_Dyscyplin.objects.get(pk=import_dyscyplin_id)
+                if obj.stan != "nowy":
+                    break
+                time.sleep(0.1)
+            else:
+                obj = Import_Dyscyplin.objects.get(pk=import_dyscyplin_id)
 
             # If task didn't run, call it manually (test workaround for Celery eager mode)
             if obj.stan == "nowy":
@@ -135,8 +144,8 @@ def test_integracyjny(admin_page: Page, channels_live_server, settings):
                         obj.info = str(e)
                         obj.bledny = True
                         obj.save()
-                    # Wait for page to refresh
-                    admin_page.wait_for_timeout(2000)
+                    # reload() waits for the new page to load on its own;
+                    # no need for a fixed timeout before it.
                     admin_page.reload()
                     wait_for_page_load(admin_page)
 

--- a/src/importer_publikacji/tests/test_playwright_authors.py
+++ b/src/importer_publikacji/tests/test_playwright_authors.py
@@ -57,7 +57,9 @@ def test_import_crossref_doi_author_modal_single_open(
     page = importer_page
     url = live_server.url + reverse("importer_publikacji:index")
     page.goto(url)
-    page.wait_for_load_state("networkidle")
+    # No networkidle — the page has long-polling/WebSocket connections
+    # so the network never becomes idle. The locator-based interactions
+    # below auto-wait for their target elements.
 
     # Dismiss cookie consent banner
     page.evaluate("Cookielaw.accept();")

--- a/src/zglos_publikacje/tests/test_playwright/test_zglos_publikacje.py
+++ b/src/zglos_publikacje/tests/test_playwright/test_zglos_publikacje.py
@@ -105,9 +105,9 @@ def test_zglos_publikacje_z_plikiem_drugi_autor_dyscyplina(
     admin_page.click("#add-form")
     admin_page.wait_for_selector(f"#id_2-{n}-autor", state="attached", timeout=10000)
 
-    # Scroll the form into view to ensure Select2 is visible
+    # Scroll the form into view to ensure Select2 is visible. The select2
+    # helper internally waits for the container — no extra sleep needed.
     admin_page.locator(f"#id_2-{n}-autor").scroll_into_view_if_needed()
-    admin_page.wait_for_timeout(500)  # Small delay for Select2 to initialize
 
     select_select2_autocomplete(admin_page, f"id_2-{n}-autor", "Kowal", timeout=30000)
 


### PR DESCRIPTION
## Summary

- **Naprawa ukrytego buga w `select_select2_autocomplete`**: pierwszy `wait_for_selector` na `#select2-{id}-container` trafiał w pełen 30 s timeout w testach gdzie ten wariant markupu nie istnieje (formularze inline django-grappelli admin), zanim wpadał do bloku `except` z fallbackiem. Helper jest używany w 64 testach. **3 wywołania × 30 s = 90 s waste'u na test.**
- **Eliminacja antywzorców `networkidle` i sztywnych `wait_for_timeout`** w 18 plikach testów Playwright — zastąpione warunkowymi waitami (`expect.to_have_value`, `expect_navigation`, polling DB / dialogów).
- **Fix regresji `MaliciousRequestBlockingMiddleware`** (commit `d7ecbe0e0`) — DataTables AJAX z `import_dyscyplin` był blokowany jako "url_too_long". Limit 2048 → 4096, whitelist `/api/`.

## Wyniki

Pełen suite: **3:50 → 2:24** (−85 s, −38%).

Top 10 najwolniejszych testów przed/po:

| Test | Przed | Po |
|---|---|---|
| `test_changeform_add_full_flow[ciagle]` | 98.05 s | **8.23 s** |
| `test_changeform_add_full_flow[zwarte]` | 97.16 s | **8.46 s** |
| `test_integracyjny[chromium]` | 75.42 s | **12.80 s** |
| `test_admin_wydawnictwo_ciagle_dowolnie_zapisane_nazwisko` | 67.42 s | **7.86 s** |
| `procent_odpowiedzialnosci_*_dwoch_autorow` cluster | 37–48 s | **12–18 s** |
| `test_multiseek_*` (6 testów) | 30+ s | **~2 s** |

Wynik: **3801 passed**, 1 pre-existing failure (`test_anonymous_smoke_crawl` — HTTP 404, nie z tych zmian, istniał już na `dev`).

## Test plan

- [x] `uv run pytest -n auto` — 3801 passed, 2:24
- [x] Profilowanie `select_select2_autocomplete` przed/po pokazuje 30 s → ~5 ms na pierwszym `wait_for_selector`
- [x] `test_integracyjny[chromium]` — passes w 12.8 s (było 75.4 s)
- [x] `test_multiseek_*` — wszystkie 6 testów passes z `expect_navigation` + iframe waits zamiast `networkidle`
- [x] `test_change_form_pubmed_brak_takiej_pracy` — dialog handler odpala się dzięki `page.wait_for_timeout` w pollingu (nauczone że `time.sleep` nie pompuje event loopu Playwright)
- [x] Middleware testy: 71/71 pass, plus nowy `test_long_url_on_api_path_allowed`
- [ ] Manual: spróbuj wejść na `import_dyscyplin` i zobaczyć że DataTables ładuje się (po fixie middleware)

## Commits

1. `fix(middleware): whitelist /api/ + zwiększ limit URL do 4096` — fix regresji
2. `perf(tests): skróć Playwright suite z 3:50 do 2:24 (-38%)` — speedup helper + 17 plików testów

Newsfragmenty: `middleware-api-whitelist.bugfix`, `playwright-suite-speedup.bugfix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)