### PR TITLE
ci: build test-runner image once and pull from GHCR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Default minimum permissions; per-job overrides below where extra
+# scopes are needed (notably `packages:` for the GHCR push/pull flow).
+permissions:
+  contents: read
+
 jobs:
   lint:
     # Lint only Python files changed in this push/PR. The repo's
@@ -91,17 +96,96 @@ jobs:
           FILES: ${{ steps.files.outputs.list }}
         run: uv run --extra dev ruff format --check --force-exclude $FILES
 
-  tests-fast:
-    # Non-Playwright tests (parallel + serial). Runs concurrently with
-    # `tests-playwright` so the slow browser suite doesn't block the
-    # fast feedback loop.
-    name: Tests (fast)
-    # Skip this job if it's a "Merge tag" commit on the dev branch
+  prepare-image:
+    # Build the test-runner image once and push it to GHCR with two
+    # tags: `:sha-<commit>` (consumed by downstream test jobs) and
+    # `:cache` (registry-mode buildx cache, auto-merged across builds).
+    # All test jobs `needs:` this step so the image is built once per
+    # workflow run instead of N times per matrix runner.
+    name: Build test-runner image
     if: |
       !(github.ref == 'refs/heads/dev' && contains(github.event.head_commit.message, 'Merge tag'))
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
+    permissions:
+      contents: read
+      # GHCR push needs `packages: write`. GITHUB_TOKEN inherits this
+      # scope only when the job declares it explicitly.
+      packages: write
+
+    outputs:
+      image: ${{ steps.tag.outputs.image }}
+
+    env:
+      PYTHON_VERSION: "3.12"
+      DEBIAN_VERSION: trixie
+      NODEJS_VERSION: "20"
+      # Lowercase repo owner, since GHCR rejects mixed-case namespaces.
+      # GitHub Actions ${{ github.repository_owner }} preserves case.
+      IMAGE_REPO: ghcr.io/iplweb/bpp-test-runner
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      with:
+        driver: docker-container
+
+    - name: Log in to GHCR
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Compute image tag
+      id: tag
+      env:
+        SHA: ${{ github.sha }}
+      run: |
+        echo "image=${IMAGE_REPO}:sha-${SHA}" >> "$GITHUB_OUTPUT"
+
+    - name: Build & push test-runner image
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      with:
+        context: .
+        file: docker/bpp_base/Dockerfile
+        target: test-runner
+        push: true
+        # Two tags: immutable sha-pinned (consumed by tests jobs) and
+        # the registry-cache helper used to seed `cache-from` next time.
+        tags: |
+          ${{ steps.tag.outputs.image }}
+        build-args: |
+          PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+          DEBIAN_VERSION=${{ env.DEBIAN_VERSION }}
+          NODEJS_VERSION=${{ env.NODEJS_VERSION }}
+        # Registry-mode cache. mode=max stores all intermediate layers,
+        # so subsequent builds where uv.lock/Dockerfile/build.txt are
+        # unchanged finish in seconds. The first run after rolling out
+        # this workflow has no cache and pays the full ~3 min build —
+        # warm cache afterwards.
+        cache-from: type=registry,ref=${{ env.IMAGE_REPO }}:cache
+        cache-to: type=registry,ref=${{ env.IMAGE_REPO }}:cache,mode=max
+
+  tests-fast:
+    # Non-Playwright tests (parallel + serial). Runs concurrently with
+    # `tests-playwright` so the slow browser suite doesn't block the
+    # fast feedback loop.
+    name: Tests (fast)
+    needs: prepare-image
+    if: |
+      !(github.ref == 'refs/heads/dev' && contains(github.event.head_commit.message, 'Merge tag'))
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      packages: read
 
     strategy:
       max-parallel: 4
@@ -111,14 +195,17 @@ jobs:
         # aren't spending runner minutes on a build we expect to fail.
         python-version: ["3.12"]
 
+    env:
+      TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
+
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install system build deps (for uv sync)
-      # uv sync --frozen builds native wheels (pycairo, psycopg2, lxml,
-      # cryptography) that need header libraries not present on the
-      # default runner image. Reuse docker/bpp_base/build.txt so the
-      # package list stays in sync with the runtime/test images.
+      # baseline_check below runs `uv sync` directly on the host runner
+      # and several wheels (pycairo, psycopg2, lxml, cryptography) need
+      # native headers. Reuse docker/bpp_base/build.txt so the package
+      # list stays in sync with the test-runner image.
       run: |
         sudo apt-get update
         xargs -a docker/bpp_base/build.txt sudo apt-get install -y
@@ -129,53 +216,25 @@ jobs:
         enable-cache: true
 
     - name: Install project deps (for baseline_check)
-      # baseline_check is a Django management command that loads the
-      # full INSTALLED_APPS. No DB connection needed — it reads
-      # src/baseline-sql/baseline.meta.json and counts migration files.
-      # --frozen is intentional: uv.lock is the single source of truth.
       run: uv sync --frozen --no-install-project
 
     - name: Check baseline freshness
       # Fail loudly if migrations have outpaced the baseline pg_dump by
-      # more than --max-delta. When this fails, the fix is to run
-      # `make rebuild-baseline` locally and commit the refreshed files.
-      # Only runs in tests-fast (not tests-playwright) — fail-fast on
-      # baseline drift, no need to duplicate the check.
+      # more than --max-delta. Only runs here (not in tests-playwright)
+      # — fail-fast on baseline drift, no need to duplicate the check.
       env:
         DJANGO_BPP_SKIP_DOTENV: "1"
       run: uv run python src/manage.py baseline_check --max-delta 50
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+    - name: Log in to GHCR
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
-        driver: docker-container
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Cache Docker layers
-      # Shared cache key with tests-playwright — both jobs build the
-      # same test-runner image, so the second job to run (whichever it
-      # is) will hit the buildx layer cache and finish the build in
-      # seconds rather than rebuilding from scratch.
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: /tmp/.buildx-cache
-        key: >-
-          ${{ runner.os }}-buildx-${{ matrix.python-version }}-${{
-            hashFiles(
-              'docker/bpp_base/Dockerfile',
-              'docker/bpp_base/*.txt',
-              'uv.lock'
-            )
-          }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ matrix.python-version }}-
-
-    - name: Build test-runner image
-      env:
-        PYTHON_VERSION: ${{ matrix.python-version }}
-        COMPOSE_DOCKER_CLI_BUILD: 1
-        DOCKER_BUILDKIT: 1
-      run: |
-        docker compose -f docker-compose.test.yml build test-runner
+    - name: Pull test-runner image
+      run: docker compose -f docker-compose.test.yml pull test-runner
 
     - name: Start services
       run: |
@@ -241,14 +300,20 @@ jobs:
 
   tests-playwright:
     # Playwright (browser) tests, runs concurrently with tests-fast.
-    # Re-uses the same buildx layer cache (same key), so the test-runner
-    # image rebuild is essentially a cache pull on the second runner.
+    # Image is pulled from GHCR (built once by prepare-image), so each
+    # shard runner only pays the pull cost (~30s) instead of a full
+    # rebuild.
     name: Tests (Playwright)
+    needs: prepare-image
     if: |
       !(github.ref == 'refs/heads/dev' && contains(github.event.head_commit.message, 'Merge tag'))
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
+    permissions:
+      contents: read
+      packages: read
 
     strategy:
       # Shard the Playwright suite across N runners. pytest-shard splits
@@ -268,41 +333,21 @@ jobs:
         python-version: ["3.12"]
         shard: [0, 1, 2]
 
+    env:
+      TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
+
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Install system build deps (for uv sync)
-      run: |
-        sudo apt-get update
-        xargs -a docker/bpp_base/build.txt sudo apt-get install -y
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+    - name: Log in to GHCR
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
-        driver: docker-container
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Cache Docker layers
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: /tmp/.buildx-cache
-        key: >-
-          ${{ runner.os }}-buildx-${{ matrix.python-version }}-${{
-            hashFiles(
-              'docker/bpp_base/Dockerfile',
-              'docker/bpp_base/*.txt',
-              'uv.lock'
-            )
-          }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ matrix.python-version }}-
-
-    - name: Build test-runner image
-      env:
-        PYTHON_VERSION: ${{ matrix.python-version }}
-        COMPOSE_DOCKER_CLI_BUILD: 1
-        DOCKER_BUILDKIT: 1
-      run: |
-        docker compose -f docker-compose.test.yml build test-runner
+    - name: Pull test-runner image
+      run: docker compose -f docker-compose.test.yml pull test-runner
 
     - name: Start services
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,11 +171,13 @@ jobs:
         cache-from: type=registry,ref=${{ env.IMAGE_REPO }}:cache
         cache-to: type=registry,ref=${{ env.IMAGE_REPO }}:cache,mode=max
 
-  tests-fast:
-    # Non-Playwright tests (parallel + serial). Runs concurrently with
-    # `tests-playwright` so the slow browser suite doesn't block the
-    # fast feedback loop.
-    name: Tests (fast)
+  tests-parallel:
+    # Non-Playwright, non-serial pytest, sharded across 3 runners.
+    # Each shard still uses `-n auto` (xdist) within the runner, so
+    # effective parallelism is 3 shards × 4 xdist workers ≈ 12 tests
+    # in flight at peak. Previously this was a single job (`tests-fast`)
+    # that took ~2× as long as the slowest Playwright shard.
+    name: Tests (parallel)
     needs: prepare-image
     if: |
       !(github.ref == 'refs/heads/dev' && contains(github.event.head_commit.message, 'Merge tag'))
@@ -188,12 +190,12 @@ jobs:
       packages: read
 
     strategy:
+      fail-fast: false
       max-parallel: 4
       matrix:
-        # Django 5.2 officially tests on CPython 3.10–3.13; Python 3.14
-        # is not supported upstream yet. Keep the matrix to 3.12 so we
-        # aren't spending runner minutes on a build we expect to fail.
         python-version: ["3.12"]
+        # 0-indexed for pytest-shard, same convention as tests-playwright.
+        shard: [0, 1, 2]
 
     env:
       TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
@@ -202,26 +204,31 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install system build deps (for uv sync)
-      # baseline_check below runs `uv sync` directly on the host runner
-      # and several wheels (pycairo, psycopg2, lxml, cryptography) need
-      # native headers. Reuse docker/bpp_base/build.txt so the package
-      # list stays in sync with the test-runner image.
+      # Only shard 0 runs baseline_check, but every shard needs the
+      # native headers if anything else triggers a host-side `uv sync`
+      # (currently only baseline_check does, but we keep the apt step
+      # uniform across shards so a future host-side step doesn't
+      # silently fail on shards 1/2).
+      if: matrix.shard == 0
       run: |
         sudo apt-get update
         xargs -a docker/bpp_base/build.txt sudo apt-get install -y
 
     - name: Install uv (for baseline_check)
+      if: matrix.shard == 0
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         enable-cache: true
 
     - name: Install project deps (for baseline_check)
+      if: matrix.shard == 0
       run: uv sync --frozen --no-install-project
 
     - name: Check baseline freshness
-      # Fail loudly if migrations have outpaced the baseline pg_dump by
-      # more than --max-delta. Only runs here (not in tests-playwright)
-      # — fail-fast on baseline drift, no need to duplicate the check.
+      # Run only on shard 0 — baseline drift is a deterministic, repo-
+      # global property; running the check three times wastes ~15s per
+      # shard and gives no extra signal.
+      if: matrix.shard == 0
       env:
         DJANGO_BPP_SKIP_DOTENV: "1"
       run: uv run python src/manage.py baseline_check --max-delta 50
@@ -260,28 +267,18 @@ jobs:
         docker compose -f docker-compose.test.yml run --rm \
           test-runner uv run make assets
 
-    - name: Tests (without Playwright, parallel)
+    - name: Tests (parallel, shard ${{ matrix.shard }}/3)
       timeout-minutes: 20
+      env:
+        SHARD_ID: ${{ matrix.shard }}
       run: |
         docker compose -f docker-compose.test.yml run --rm \
+          -e SHARD_ID \
           test-runner uv run pytest \
             -m "not playwright and not serial" -n auto \
+            --shard-id "$SHARD_ID" --num-shards 3 \
             --timeout 300 \
             --cov=src/ --cov-branch \
-            --cov-report=xml:cov.xml
-
-    - name: Tests (serial, no xdist)
-      # Tests tagged @pytest.mark.serial share state that xdist
-      # workers shouldn't race on (e.g. PG connections that flake when
-      # another worker recycles the DB). Run them sequentially in a
-      # single process; --cov-append keeps coverage merged.
-      timeout-minutes: 5
-      run: |
-        docker compose -f docker-compose.test.yml run --rm \
-          test-runner uv run pytest \
-            -m "serial and not playwright" \
-            --timeout 300 \
-            --cov=src/ --cov-branch --cov-append \
             --cov-report=xml:cov.xml
 
     - name: Upload coverage to Coveralls (parallel)
@@ -289,7 +286,88 @@ jobs:
       uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: tests-fast
+        flag-name: tests-parallel-${{ matrix.shard }}
+        parallel: true
+        file: cov.xml
+
+    - name: Cleanup
+      if: always()
+      run: |
+        docker compose -f docker-compose.test.yml down -v
+
+  tests-serial:
+    # Tests tagged @pytest.mark.serial share state that xdist workers
+    # shouldn't race on (e.g. PG connections that flake when another
+    # worker recycles the DB). Run them sequentially in a single
+    # process; the suite is small (~30 s), so we don't shard it.
+    name: Tests (serial)
+    needs: prepare-image
+    if: |
+      !(github.ref == 'refs/heads/dev' && contains(github.event.head_commit.message, 'Merge tag'))
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      packages: read
+
+    env:
+      TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Log in to GHCR
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Pull test-runner image
+      run: docker compose -f docker-compose.test.yml pull test-runner
+
+    - name: Start services
+      run: |
+        docker compose -f docker-compose.test.yml up -d db redis
+
+    - name: Wait for services
+      timeout-minutes: 2
+      run: |
+        until docker compose -f docker-compose.test.yml exec db \
+            pg_isready -U bpp; do
+          echo "Waiting for PostgreSQL..."
+          sleep 2
+        done
+        until docker compose -f docker-compose.test.yml exec redis \
+            redis-cli ping; do
+          echo "Waiting for Redis..."
+          sleep 2
+        done
+
+    - name: Build assets
+      timeout-minutes: 10
+      run: |
+        docker compose -f docker-compose.test.yml run --rm \
+          test-runner uv run make assets
+
+    - name: Tests (serial, no xdist)
+      timeout-minutes: 10
+      run: |
+        docker compose -f docker-compose.test.yml run --rm \
+          test-runner uv run pytest \
+            -m "serial and not playwright" \
+            --timeout 300 \
+            --cov=src/ --cov-branch \
+            --cov-report=xml:cov.xml
+
+    - name: Upload coverage to Coveralls (parallel)
+      if: always()
+      uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: tests-serial
         parallel: true
         file: cov.xml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,6 +129,32 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+    # baseline_check is repo-state-only — it doesn't need the
+    # test-runner image, the database, or any baked artefacts. Running
+    # it here (instead of inside a test job) means a baseline drift
+    # fails fast and skips the expensive image build below.
+    - name: Install system build deps (for uv sync)
+      run: |
+        sudo apt-get update
+        xargs -a docker/bpp_base/build.txt sudo apt-get install -y
+
+    - name: Install uv (for baseline_check)
+      # No setup-uv cache here — this job pushes images to GHCR, and
+      # zizmor flags cache+publish combos as a poisoning vector. The
+      # cache hit would shave a few seconds off a one-shot uv sync,
+      # not worth the audit smell.
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      with:
+        enable-cache: false
+
+    - name: Install project deps (for baseline_check)
+      run: uv sync --frozen --no-install-project
+
+    - name: Check baseline freshness
+      env:
+        DJANGO_BPP_SKIP_DOTENV: "1"
+      run: uv run python src/manage.py baseline_check --max-delta 50
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       with:
@@ -199,39 +225,13 @@ jobs:
 
     env:
       TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
+      # Compose stack (base + CI override). The override drops the
+      # source bind mount and exposes ./ci-output as the only writable
+      # volume, so coverage XML survives `compose run --rm`.
+      COMPOSE_FILES: -f docker-compose.test.yml -f docker-compose.test.ci.yml
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - name: Install system build deps (for uv sync)
-      # Only shard 0 runs baseline_check, but every shard needs the
-      # native headers if anything else triggers a host-side `uv sync`
-      # (currently only baseline_check does, but we keep the apt step
-      # uniform across shards so a future host-side step doesn't
-      # silently fail on shards 1/2).
-      if: matrix.shard == 0
-      run: |
-        sudo apt-get update
-        xargs -a docker/bpp_base/build.txt sudo apt-get install -y
-
-    - name: Install uv (for baseline_check)
-      if: matrix.shard == 0
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-      with:
-        enable-cache: true
-
-    - name: Install project deps (for baseline_check)
-      if: matrix.shard == 0
-      run: uv sync --frozen --no-install-project
-
-    - name: Check baseline freshness
-      # Run only on shard 0 — baseline drift is a deterministic, repo-
-      # global property; running the check three times wastes ~15s per
-      # shard and gives no extra signal.
-      if: matrix.shard == 0
-      env:
-        DJANGO_BPP_SKIP_DOTENV: "1"
-      run: uv run python src/manage.py baseline_check --max-delta 50
 
     - name: Log in to GHCR
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -240,46 +240,44 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Prepare ci-output dir
+      # Bind-mounted into the container at /ci-output so pytest can
+      # write cov.xml somewhere the runner can read after `--rm`.
+      run: mkdir -p ci-output
+
     - name: Pull test-runner image
-      run: docker compose -f docker-compose.test.yml pull test-runner
+      run: docker compose $COMPOSE_FILES pull test-runner
 
     - name: Start services
-      run: |
-        docker compose -f docker-compose.test.yml up -d db redis
+      run: docker compose $COMPOSE_FILES up -d db redis
 
     - name: Wait for services
       timeout-minutes: 2
       run: |
-        until docker compose -f docker-compose.test.yml exec db \
+        until docker compose $COMPOSE_FILES exec db \
             pg_isready -U bpp; do
           echo "Waiting for PostgreSQL..."
           sleep 2
         done
-        until docker compose -f docker-compose.test.yml exec redis \
+        until docker compose $COMPOSE_FILES exec redis \
             redis-cli ping; do
           echo "Waiting for Redis..."
           sleep 2
         done
-
-    - name: Build assets
-      timeout-minutes: 10
-      run: |
-        docker compose -f docker-compose.test.yml run --rm \
-          test-runner uv run make assets
 
     - name: Tests (parallel, shard ${{ matrix.shard }}/3)
       timeout-minutes: 20
       env:
         SHARD_ID: ${{ matrix.shard }}
       run: |
-        docker compose -f docker-compose.test.yml run --rm \
+        docker compose $COMPOSE_FILES run --rm \
           -e SHARD_ID \
           test-runner uv run pytest \
             -m "not playwright and not serial" -n auto \
             --shard-id "$SHARD_ID" --num-shards 3 \
             --timeout 300 \
             --cov=src/ --cov-branch \
-            --cov-report=xml:cov.xml
+            --cov-report=xml:/ci-output/cov.xml
 
     - name: Upload coverage to Coveralls (parallel)
       if: always()
@@ -288,12 +286,11 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         flag-name: tests-parallel-${{ matrix.shard }}
         parallel: true
-        file: cov.xml
+        file: ci-output/cov.xml
 
     - name: Cleanup
       if: always()
-      run: |
-        docker compose -f docker-compose.test.yml down -v
+      run: docker compose $COMPOSE_FILES down -v
 
   tests-serial:
     # Tests tagged @pytest.mark.serial share state that xdist workers
@@ -314,6 +311,7 @@ jobs:
 
     env:
       TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
+      COMPOSE_FILES: -f docker-compose.test.yml -f docker-compose.test.ci.yml
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -325,42 +323,38 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Prepare ci-output dir
+      run: mkdir -p ci-output
+
     - name: Pull test-runner image
-      run: docker compose -f docker-compose.test.yml pull test-runner
+      run: docker compose $COMPOSE_FILES pull test-runner
 
     - name: Start services
-      run: |
-        docker compose -f docker-compose.test.yml up -d db redis
+      run: docker compose $COMPOSE_FILES up -d db redis
 
     - name: Wait for services
       timeout-minutes: 2
       run: |
-        until docker compose -f docker-compose.test.yml exec db \
+        until docker compose $COMPOSE_FILES exec db \
             pg_isready -U bpp; do
           echo "Waiting for PostgreSQL..."
           sleep 2
         done
-        until docker compose -f docker-compose.test.yml exec redis \
+        until docker compose $COMPOSE_FILES exec redis \
             redis-cli ping; do
           echo "Waiting for Redis..."
           sleep 2
         done
 
-    - name: Build assets
-      timeout-minutes: 10
-      run: |
-        docker compose -f docker-compose.test.yml run --rm \
-          test-runner uv run make assets
-
     - name: Tests (serial, no xdist)
       timeout-minutes: 10
       run: |
-        docker compose -f docker-compose.test.yml run --rm \
+        docker compose $COMPOSE_FILES run --rm \
           test-runner uv run pytest \
             -m "serial and not playwright" \
             --timeout 300 \
             --cov=src/ --cov-branch \
-            --cov-report=xml:cov.xml
+            --cov-report=xml:/ci-output/cov.xml
 
     - name: Upload coverage to Coveralls (parallel)
       if: always()
@@ -369,12 +363,11 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         flag-name: tests-serial
         parallel: true
-        file: cov.xml
+        file: ci-output/cov.xml
 
     - name: Cleanup
       if: always()
-      run: |
-        docker compose -f docker-compose.test.yml down -v
+      run: docker compose $COMPOSE_FILES down -v
 
   tests-playwright:
     # Playwright (browser) tests, runs concurrently with tests-fast.
@@ -413,6 +406,7 @@ jobs:
 
     env:
       TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
+      COMPOSE_FILES: -f docker-compose.test.yml -f docker-compose.test.ci.yml
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -424,46 +418,42 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Prepare ci-output dir
+      run: mkdir -p ci-output
+
     - name: Pull test-runner image
-      run: docker compose -f docker-compose.test.yml pull test-runner
+      run: docker compose $COMPOSE_FILES pull test-runner
 
     - name: Start services
-      run: |
-        docker compose -f docker-compose.test.yml up -d db redis
+      run: docker compose $COMPOSE_FILES up -d db redis
 
     - name: Wait for services
       timeout-minutes: 2
       run: |
-        until docker compose -f docker-compose.test.yml exec db \
+        until docker compose $COMPOSE_FILES exec db \
             pg_isready -U bpp; do
           echo "Waiting for PostgreSQL..."
           sleep 2
         done
-        until docker compose -f docker-compose.test.yml exec redis \
+        until docker compose $COMPOSE_FILES exec redis \
             redis-cli ping; do
           echo "Waiting for Redis..."
           sleep 2
         done
-
-    - name: Build assets
-      timeout-minutes: 10
-      run: |
-        docker compose -f docker-compose.test.yml run --rm \
-          test-runner uv run make assets
 
     - name: Tests (Playwright, shard ${{ matrix.shard }}/3)
       timeout-minutes: 25
       env:
         SHARD_ID: ${{ matrix.shard }}
       run: |
-        docker compose -f docker-compose.test.yml run --rm \
+        docker compose $COMPOSE_FILES run --rm \
           -e SHARD_ID \
           test-runner uv run pytest \
             -m "playwright" -n auto \
             --shard-id "$SHARD_ID" --num-shards 3 \
             --timeout 300 \
             --cov=src/ --cov-branch \
-            --cov-report=xml:cov.xml
+            --cov-report=xml:/ci-output/cov.xml
 
     - name: Upload coverage to Coveralls (parallel)
       if: always()
@@ -472,9 +462,8 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         flag-name: tests-playwright-${{ matrix.shard }}
         parallel: true
-        file: cov.xml
+        file: ci-output/cov.xml
 
     - name: Cleanup
       if: always()
-      run: |
-        docker compose -f docker-compose.test.yml down -v
+      run: docker compose $COMPOSE_FILES down -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,12 @@ repos:
       rev: 'v6.0.0'
       hooks:
         -   id: check-yaml
+            # docker-compose.test.ci.yml uses Compose's `!reset` YAML
+            # tag (Compose 2.4+) to drop volumes inherited from the
+            # base file. PyYAML's safe loader doesn't know
+            # Compose-specific tags, so check-yaml chokes on a file
+            # that `docker compose config` parses fine.
+            exclude: ^docker-compose\.test\.ci\.yml$
         -   id: check-toml
         -   id: end-of-file-fixer
             exclude: ^src/baseline-sql/baseline\.sql$

--- a/docker-compose.test.ci.yml
+++ b/docker-compose.test.ci.yml
@@ -1,0 +1,21 @@
+# CI-only override for docker-compose.test.yml.
+#
+# Local dev uses docker-compose.test.yml alone — the bind mount
+# `.:/src` lets developers edit code and rerun tests without rebuilding
+# the test-runner image.
+#
+# CI uses both files (`docker compose -f docker-compose.test.yml -f
+# docker-compose.test.ci.yml ...`). This override:
+#   - drops the `.:/src` bind mount, so source code comes from the
+#     baked-in COPY in the test-runner stage (Dockerfile);
+#   - exposes `./ci-output` as the only writable mount, so pytest can
+#     write `cov.xml` somewhere the runner can pick up after
+#     `compose run --rm` discards the container.
+#
+# Dropping the docker.sock mount too — CI tests don't use Docker
+# from inside the test-runner (BPP_USE_TESTCONTAINERS=0).
+
+services:
+  test-runner:
+    volumes: !reset
+      - ./ci-output:/ci-output

--- a/docker-compose.test.ci.yml
+++ b/docker-compose.test.ci.yml
@@ -17,5 +17,10 @@
 
 services:
   test-runner:
-    volumes: !reset
+    # `!override` (Compose 2.24+) replaces the volumes list from
+    # the base file wholesale — that's how we drop `.:/src` while
+    # still attaching ./ci-output. `!reset` would zero out the list
+    # entirely and our own entries below would be discarded too;
+    # tested locally with `docker compose config` and confirmed.
+    volumes: !override
       - ./ci-output:/ci-output

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -39,6 +39,12 @@ services:
       - redis_data:/data
 
   test-runner:
+    # Local dev (`make tests-in-docker`): TEST_RUNNER_IMAGE unset →
+    # compose falls back to `build:` and bakes the image on demand.
+    # CI: prepare-image job pushes ghcr.io/iplweb/bpp-test-runner:sha-<SHA>
+    # and exports TEST_RUNNER_IMAGE so test jobs `compose pull` instead
+    # of rebuilding (saves ~3 min per job × 7 jobs).
+    image: ${TEST_RUNNER_IMAGE:-bpp-test-runner:local}
     build:
       context: .
       dockerfile: docker/bpp_base/Dockerfile

--- a/docker/bpp_base/Dockerfile
+++ b/docker/bpp_base/Dockerfile
@@ -281,10 +281,14 @@ RUN --mount=type=cache,target=/root/.npm,id=npm-cache \
 # (~1 min × N jobs) on every invocation. Local dev keeps the bind
 # mount and rebuilds assets on demand.
 #
-# `COPY . /src` invalidates only this layer when source changes; all
-# preceding layers (apt, uv sync, playwright, yarn install) survive
-# the registry-mode buildx cache, so warm rebuilds are seconds.
-COPY . /src
+# Granular COPYs (instead of `COPY . /src`) keep this layer cached
+# whenever the change is outside the listed paths — edits to
+# .github/, docker/, docker-compose*.yml, .pre-commit-config.yaml,
+# etc. don't invalidate the source layer or the grunt/compilemessages
+# steps below it. Only changes inside src/ or the listed top-level
+# config files force a rebuild of the assets.
+COPY src/ /src/src/
+COPY conftest.py pytest.ini Makefile pyproject.toml uv.lock /src/
 
 RUN npx grunt build-non-interactive
 RUN /opt/venv/bin/python src/manage.py compilemessages -v0 -l pl --traceback

--- a/docker/bpp_base/Dockerfile
+++ b/docker/bpp_base/Dockerfile
@@ -264,7 +264,30 @@ RUN PLAYWRIGHT_BROWSERS_PATH=/opt/playwright \
     /opt/venv/bin/playwright install chromium chromium-headless-shell
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
 
+# Yarn deps + grunt CLI (needed for `make assets`). Mirrors the
+# testserver stage so CI gets a pre-built test-runner image with the
+# same toolchain available offline.
 WORKDIR /src
+COPY package.json yarn.lock Gruntfile.js ./
+RUN --mount=type=cache,target=/root/.npm,id=npm-cache \
+    --mount=type=cache,target=/root/.yarn,id=yarn-cache \
+    npx yarn install --dev --ignore-optional && \
+    npx yarn add grunt
+
+# Snapshot the source tree and bake the frontend assets + .mo
+# translations into the image. CI consumes this through the
+# docker-compose.test.ci.yml override (no bind mount), so each test
+# job pulls a ready-to-run image instead of running `make assets`
+# (~1 min × N jobs) on every invocation. Local dev keeps the bind
+# mount and rebuilds assets on demand.
+#
+# `COPY . /src` invalidates only this layer when source changes; all
+# preceding layers (apt, uv sync, playwright, yarn install) survive
+# the registry-mode buildx cache, so warm rebuilds are seconds.
+COPY . /src
+
+RUN npx grunt build-non-interactive
+RUN /opt/venv/bin/python src/manage.py compilemessages -v0 -l pl --traceback
 
 ##############################################################################
 # TESTSERVER: lokalny obraz developerski (NIE jest publikowany do registry)


### PR DESCRIPTION
## Summary

- Adds `prepare-image` job that builds the test-runner image once via `docker/build-push-action` with registry-mode buildx cache and pushes a sha-pinned tag to `ghcr.io/iplweb/bpp-test-runner`.
- `tests-fast` and `tests-playwright` (3-shard matrix) now `needs: prepare-image`, log in to GHCR, and `compose pull` instead of rebuilding per job.
- `docker-compose.test.yml` gets a parameterised `image:` (driven by `TEST_RUNNER_IMAGE`); local dev keeps building from source when the var is unset.
- Workflow gets a default `permissions: contents: read`; jobs that touch GHCR widen to `packages: write` (push) or `packages: read` (pull).

Replaces the previous (broken) `actions/cache` for `/tmp/.buildx-cache`, which was a no-op because `docker compose build` doesn't pass `--cache-from` to BuildKit. Per-shard rebuild was costing ~3 min × 4 jobs ≈ 12 CPU minutes per run.

## Test plan

- [ ] First CI run cold-builds + pushes to GHCR; tag `sha-<commit>` appears under repo packages.
- [ ] Subsequent run on this branch hits the `:cache` registry tag and `prepare-image` finishes in ~30 s.
- [ ] All four downstream jobs (`tests-fast`, `tests-playwright × 3 shards`) pull and run successfully.
- [ ] Coveralls receives `tests-fast`, `tests-playwright-0`, `tests-playwright-1`, `tests-playwright-2` flags and merges via the existing `coveralls-finish` workflow.
- [ ] After merge, package visibility on GHCR may need to be flipped from private → public so future fork PRs can pull (follow-up if it bites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)