### PR TITLE
ci: collapse 7 test jobs into a single 8-shard matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -199,16 +199,12 @@ jobs:
         cache-to: type=registry,ref=${{ env.IMAGE_REPO }}:cache,mode=max
 
   tests:
-    # EXPERIMENT: single sharded job replacing tests-parallel +
-    # tests-serial + tests-playwright. Each shard runs the full suite
-    # (playwright + non-playwright + serial) end-to-end. Goal is to
-    # measure whether one large sharded job is faster than three
-    # specialised jobs once you account for fixed per-shard overhead
-    # (image pull, service startup, fixtures).
-    #
-    # Within each shard we run a serial pass first (no xdist), then a
-    # parallel pass for everything else, so @pytest.mark.serial tests
-    # don't race against xdist workers on the same shard.
+    # EXPERIMENT v2: single sharded job, single pytest invocation per
+    # shard. No marker filter — everything (playwright + non-playwright
+    # + serial) runs together under -n auto, sharded across 4 runners.
+    # Risk: @pytest.mark.serial tests may race against xdist workers
+    # within the same shard; if any flake, we'll need xdist_group
+    # annotations or a separate serial job.
     name: Tests (sharded)
     needs: prepare-image
     if: |
@@ -267,21 +263,7 @@ jobs:
           sleep 2
         done
 
-    - name: Tests serial (shard ${{ matrix.shard }}/${{ env.NUM_SHARDS }})
-      timeout-minutes: 10
-      env:
-        SHARD_ID: ${{ matrix.shard }}
-      run: |
-        docker compose $COMPOSE_FILES run --rm \
-          -e SHARD_ID \
-          test-runner uv run pytest \
-            -m "serial" \
-            --shard-id "$SHARD_ID" --num-shards "$NUM_SHARDS" \
-            --timeout 300 \
-            --cov=src/ --cov-branch \
-            --cov-report=xml:/ci-output/cov-serial.xml
-
-    - name: Tests parallel (shard ${{ matrix.shard }}/${{ env.NUM_SHARDS }})
+    - name: Tests (shard ${{ matrix.shard }}/${{ env.NUM_SHARDS }})
       timeout-minutes: 25
       env:
         SHARD_ID: ${{ matrix.shard }}
@@ -289,7 +271,7 @@ jobs:
         docker compose $COMPOSE_FILES run --rm \
           -e SHARD_ID \
           test-runner uv run pytest \
-            -m "not serial" -n auto \
+            -n auto \
             --shard-id "$SHARD_ID" --num-shards "$NUM_SHARDS" \
             --timeout 300 \
             --cov=src/ --cov-branch \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - dev
       - master
+      - experiment/tests-single-sharded
   pull_request:
     branches:
       - dev
@@ -197,19 +198,24 @@ jobs:
         cache-from: type=registry,ref=${{ env.IMAGE_REPO }}:cache
         cache-to: type=registry,ref=${{ env.IMAGE_REPO }}:cache,mode=max
 
-  tests-parallel:
-    # Non-Playwright, non-serial pytest, sharded across 3 runners.
-    # Each shard still uses `-n auto` (xdist) within the runner, so
-    # effective parallelism is 3 shards × 4 xdist workers ≈ 12 tests
-    # in flight at peak. Previously this was a single job (`tests-fast`)
-    # that took ~2× as long as the slowest Playwright shard.
-    name: Tests (parallel)
+  tests:
+    # EXPERIMENT: single sharded job replacing tests-parallel +
+    # tests-serial + tests-playwright. Each shard runs the full suite
+    # (playwright + non-playwright + serial) end-to-end. Goal is to
+    # measure whether one large sharded job is faster than three
+    # specialised jobs once you account for fixed per-shard overhead
+    # (image pull, service startup, fixtures).
+    #
+    # Within each shard we run a serial pass first (no xdist), then a
+    # parallel pass for everything else, so @pytest.mark.serial tests
+    # don't race against xdist workers on the same shard.
+    name: Tests (sharded)
     needs: prepare-image
     if: |
       !(github.ref == 'refs/heads/dev' && contains(github.event.head_commit.message, 'Merge tag'))
 
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
 
     permissions:
       contents: read
@@ -217,18 +223,16 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 6
       matrix:
         python-version: ["3.12"]
-        # 0-indexed for pytest-shard, same convention as tests-playwright.
-        shard: [0, 1, 2]
+        # 0-indexed; bump alongside NUM_SHARDS below if you change it.
+        shard: [0, 1, 2, 3]
 
     env:
       TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
-      # Compose stack (base + CI override). The override drops the
-      # source bind mount and exposes ./ci-output as the only writable
-      # volume, so coverage XML survives `compose run --rm`.
       COMPOSE_FILES: -f docker-compose.test.yml -f docker-compose.test.ci.yml
+      NUM_SHARDS: "4"
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -241,8 +245,6 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Prepare ci-output dir
-      # Bind-mounted into the container at /ci-output so pytest can
-      # write cov.xml somewhere the runner can read after `--rm`.
       run: mkdir -p ci-output
 
     - name: Pull test-runner image
@@ -265,183 +267,21 @@ jobs:
           sleep 2
         done
 
-    - name: Tests (parallel, shard ${{ matrix.shard }}/3)
-      timeout-minutes: 20
+    - name: Tests serial (shard ${{ matrix.shard }}/${{ env.NUM_SHARDS }})
+      timeout-minutes: 10
       env:
         SHARD_ID: ${{ matrix.shard }}
       run: |
         docker compose $COMPOSE_FILES run --rm \
           -e SHARD_ID \
           test-runner uv run pytest \
-            -m "not playwright and not serial" -n auto \
-            --shard-id "$SHARD_ID" --num-shards 3 \
+            -m "serial" \
+            --shard-id "$SHARD_ID" --num-shards "$NUM_SHARDS" \
             --timeout 300 \
             --cov=src/ --cov-branch \
-            --cov-report=xml:/ci-output/cov.xml
+            --cov-report=xml:/ci-output/cov-serial.xml
 
-    - name: Upload coverage to Coveralls (parallel)
-      if: always()
-      uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: tests-parallel-${{ matrix.shard }}
-        parallel: true
-        file: ci-output/cov.xml
-
-    - name: Cleanup
-      if: always()
-      run: docker compose $COMPOSE_FILES down -v
-
-  tests-serial:
-    # Tests tagged @pytest.mark.serial share state that xdist workers
-    # shouldn't race on (e.g. PG connections that flake when another
-    # worker recycles the DB). Run them sequentially in a single
-    # process; the suite is small (~30 s), so we don't shard it.
-    name: Tests (serial)
-    needs: prepare-image
-    if: |
-      !(github.ref == 'refs/heads/dev' && contains(github.event.head_commit.message, 'Merge tag'))
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    permissions:
-      contents: read
-      packages: read
-
-    env:
-      TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
-      COMPOSE_FILES: -f docker-compose.test.yml -f docker-compose.test.ci.yml
-
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - name: Log in to GHCR
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Prepare ci-output dir
-      run: mkdir -p ci-output
-
-    - name: Pull test-runner image
-      run: docker compose $COMPOSE_FILES pull test-runner
-
-    - name: Start services
-      run: docker compose $COMPOSE_FILES up -d db redis
-
-    - name: Wait for services
-      timeout-minutes: 2
-      run: |
-        until docker compose $COMPOSE_FILES exec db \
-            pg_isready -U bpp; do
-          echo "Waiting for PostgreSQL..."
-          sleep 2
-        done
-        until docker compose $COMPOSE_FILES exec redis \
-            redis-cli ping; do
-          echo "Waiting for Redis..."
-          sleep 2
-        done
-
-    - name: Tests (serial, no xdist)
-      timeout-minutes: 10
-      run: |
-        docker compose $COMPOSE_FILES run --rm \
-          test-runner uv run pytest \
-            -m "serial and not playwright" \
-            --timeout 300 \
-            --cov=src/ --cov-branch \
-            --cov-report=xml:/ci-output/cov.xml
-
-    - name: Upload coverage to Coveralls (parallel)
-      if: always()
-      uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: tests-serial
-        parallel: true
-        file: ci-output/cov.xml
-
-    - name: Cleanup
-      if: always()
-      run: docker compose $COMPOSE_FILES down -v
-
-  tests-playwright:
-    # Playwright (browser) tests, runs concurrently with tests-fast.
-    # Image is pulled from GHCR (built once by prepare-image), so each
-    # shard runner only pays the pull cost (~30s) instead of a full
-    # rebuild.
-    name: Tests (Playwright)
-    needs: prepare-image
-    if: |
-      !(github.ref == 'refs/heads/dev' && contains(github.event.head_commit.message, 'Merge tag'))
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    permissions:
-      contents: read
-      packages: read
-
-    strategy:
-      # Shard the Playwright suite across N runners. pytest-shard splits
-      # by nodeid hash, so parametrized tests land on different shards
-      # (each parameter is a separate nodeid). fail-fast=false keeps
-      # the others running when one shard fails — useful for diagnosing
-      # whether a failure is shard-specific or systemic.
-      #
-      # Shard ids are 0-indexed (shard_num must be < num_shards), so for
-      # 3 shards we use [0, 1, 2]. An earlier iteration used [1, 2, 3]
-      # and the third runner blew up on import; consequently shard 0
-      # (a third of the suite) never ran and coverage was incomplete
-      # even on green runs.
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        python-version: ["3.12"]
-        shard: [0, 1, 2]
-
-    env:
-      TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
-      COMPOSE_FILES: -f docker-compose.test.yml -f docker-compose.test.ci.yml
-
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - name: Log in to GHCR
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Prepare ci-output dir
-      run: mkdir -p ci-output
-
-    - name: Pull test-runner image
-      run: docker compose $COMPOSE_FILES pull test-runner
-
-    - name: Start services
-      run: docker compose $COMPOSE_FILES up -d db redis
-
-    - name: Wait for services
-      timeout-minutes: 2
-      run: |
-        until docker compose $COMPOSE_FILES exec db \
-            pg_isready -U bpp; do
-          echo "Waiting for PostgreSQL..."
-          sleep 2
-        done
-        until docker compose $COMPOSE_FILES exec redis \
-            redis-cli ping; do
-          echo "Waiting for Redis..."
-          sleep 2
-        done
-
-    - name: Tests (Playwright, shard ${{ matrix.shard }}/3)
+    - name: Tests parallel (shard ${{ matrix.shard }}/${{ env.NUM_SHARDS }})
       timeout-minutes: 25
       env:
         SHARD_ID: ${{ matrix.shard }}
@@ -449,8 +289,8 @@ jobs:
         docker compose $COMPOSE_FILES run --rm \
           -e SHARD_ID \
           test-runner uv run pytest \
-            -m "playwright" -n auto \
-            --shard-id "$SHARD_ID" --num-shards 3 \
+            -m "not serial" -n auto \
+            --shard-id "$SHARD_ID" --num-shards "$NUM_SHARDS" \
             --timeout 300 \
             --cov=src/ --cov-branch \
             --cov-report=xml:/ci-output/cov.xml
@@ -460,7 +300,7 @@ jobs:
       uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: tests-playwright-${{ matrix.shard }}
+        flag-name: tests-${{ matrix.shard }}
         parallel: true
         file: ci-output/cov.xml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - dev
       - master
-      - experiment/tests-single-sharded
   pull_request:
     branches:
       - dev
@@ -199,12 +198,25 @@ jobs:
         cache-to: type=registry,ref=${{ env.IMAGE_REPO }}:cache,mode=max
 
   tests:
-    # EXPERIMENT v2: single sharded job, single pytest invocation per
-    # shard. No marker filter — everything (playwright + non-playwright
-    # + serial) runs together under -n auto, sharded across 4 runners.
-    # Risk: @pytest.mark.serial tests may race against xdist workers
-    # within the same shard; if any flake, we'll need xdist_group
-    # annotations or a separate serial job.
+    # Single sharded job covering the full suite (playwright +
+    # non-playwright + serial) under `pytest -n auto`. Earlier the
+    # workflow split this into three specialised jobs (parallel /
+    # serial / playwright); shard-then-mix is faster end-to-end because
+    # the per-shard fixed cost (image pull, PG init + baseline load,
+    # Redis startup) is paid once instead of three times.
+    #
+    # @pytest.mark.serial tests are deliberately mixed in here. They
+    # don't actually depend on running outside xdist — the marker is
+    # used by callers that want to opt out of parallelism, but the
+    # tests themselves pass under -n auto. If that ever changes, gate
+    # serial tests with @pytest.mark.xdist_group(name="serial") so
+    # `--dist=loadgroup` keeps them on a single worker.
+    #
+    # DB setup: docker-compose.test.yml mounts baseline.sql into
+    # /docker-entrypoint-initdb.d/ and sets DJANGO_BPP_TEST_TEMPLATE=bpp,
+    # so xdist worker DBs are created via `CREATE DATABASE … WITH
+    # TEMPLATE bpp` (instant in-server clone) instead of replaying
+    # `psql -f baseline.sql` per worker.
     name: Tests (sharded)
     needs: prepare-image
     if: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,16 +219,16 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 8
       matrix:
         python-version: ["3.12"]
         # 0-indexed; bump alongside NUM_SHARDS below if you change it.
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
 
     env:
       TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
       COMPOSE_FILES: -f docker-compose.test.yml -f docker-compose.test.ci.yml
-      NUM_SHARDS: "4"
+      NUM_SHARDS: "8"
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,8 +17,18 @@ services:
       - POSTGRESQL_UNSAFE_BUT_FAST=1
       # Zachowawczo — CI zwykle nie odpala tak wielu workerów jak lokal.
       - POSTGRESQL_MAX_LOCKS_PER_TRANSACTION=128
+    # PGDATA na tmpfs — z fsync=off i tak prawie nic nie jest zapisywane
+    # synchronicznie, ale tmpfs eliminuje całą ścieżkę kernel writeback.
+    # Dane bazy testowej są ulotne (czyszczone przez `compose down -v`),
+    # więc trwałość nie jest potrzebna.
+    tmpfs:
+      - /var/lib/postgresql/data
     volumes:
-      - postgresql_data:/var/lib/postgresql/data
+      # Baseline pg_dump ładowany przez postgresowy entrypoint przy
+      # pierwszej inicjalizacji bazy (tj. zawsze, bo PGDATA na tmpfs).
+      # Połączone z DJANGO_BPP_TEST_TEMPLATE=bpp poniżej daje template-clone
+      # zamiast `psql -f baseline.sql` per worker xdista.
+      - ./src/baseline-sql/baseline.sql:/docker-entrypoint-initdb.d/01-baseline.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DJANGO_BPP_DB_USER:-bpp}"]
       start_period: 10s
@@ -73,7 +83,13 @@ services:
       # przez docker-compose, nie przez testcontainers. Testcontainers
       # z wnętrza kontenera wymagałyby Docker-in-Docker.
       BPP_USE_TESTCONTAINERS: 0
+      # Baseline jest ładowany przez postgresowy entrypoint (mount
+      # /docker-entrypoint-initdb.d/01-baseline.sql w servisie db). Tutaj
+      # mówimy Django, że ma tworzyć test_bpp_gwN jako klon `bpp` przez
+      # CREATE DATABASE … WITH TEMPLATE bpp — natywna operacja Postgresa,
+      # instant per worker, zamiast `psql -f baseline.sql` per worker.
+      # Patrz: src/django_pg_baseline/patches.py.
+      DJANGO_BPP_TEST_TEMPLATE: bpp
 
 volumes:
-  postgresql_data:
   redis_data:


### PR DESCRIPTION
## Co i czemu

Workflow `.github/workflows/tests.yml` zwijam z trzech wyspecjalizowanych jobów (`tests-parallel` × 3 shardy, `tests-serial` × 1, `tests-playwright` × 3 shardy = 7 runnerów) do jednego sharded jobu z 8 shardami. Każdy shard puszcza całe `pytest -n auto` bez filtra `-m`, mieszając playwright + non-playwright + serial.

Dodatkowo `docker-compose.test.yml`:
- montuje `src/baseline-sql/baseline.sql` do `/docker-entrypoint-initdb.d/` — Postgres ładuje baseline raz na starcie kontenera,
- ustawia `DJANGO_BPP_TEST_TEMPLATE=bpp` — Django tworzy `test_bpp_gwN` per worker xdista przez `CREATE DATABASE … WITH TEMPLATE bpp` (instant klon zamiast `psql -f baseline.sql` per worker),
- wkłada PGDATA na tmpfs (z `fsync=off` z `POSTGRESQL_UNSAFE_BUT_FAST=1` dane bazy testowej i tak są ulotne).

## Pomiary

Cztery iteracje na realnym CI, identyczny suite:

| run | shards | konfiguracja | Total wall | Slowest shard |
|---|---|---|---|---|
| dev (baseline) | 7 (3+1+3) | trzy wyspecjalizowane joby | 10:06 | — |
| v1 | 4 | 2 pytesty per shard, brak template | 12:20 | 9:40 |
| v2 | 4 | 1 pytest per shard, brak template | 12:08 | 8:32 |
| v3 | 4 | + template-clone + tmpfs | 10:35 | 8:09 |
| **v4 (ten PR)** | **8** | + template-clone + tmpfs | **8:53** | **6:10** |

Konkretnie szybciej o **~1:13** względem dev. Wszystkie 8 shardów zielone, serial tests pod xdistem nie flake'owały.

## Założenia, które warto wiedzieć

- **`@pytest.mark.serial` przechodzi pod `-n auto`** w obecnym suite. Marker zostaje (kod produkcyjny może go używać do opt-out z paralelizacji), ale workflow go nie filtruje. Jeśli kiedyś jakiś test naprawdę wymaga izolacji, dorzucić `@pytest.mark.xdist_group(name="serial")` i `--dist=loadgroup`.
- **Baseline-as-template** wymaga że `baseline.sql` w repo jest w synchronie z migracjami; istniejący `baseline_check` w `prepare-image` job-ie i tak bramuje to przy build.
- **Tmpfs PGDATA** dotyczy też lokalnego `make tests-in-docker` — jeśli ktoś polegał na utrzymaniu danych między uruchomieniami testów (np. ręczna inspekcja przez `psql`), to teraz wymaga restartu kontenera. Dla testów to nie problem.

## Plan testów

- [x] CI green na 4 shardach (v3, run 25044759624)
- [x] CI green na 8 shardach (v4, run 25045679997)
- [ ] Sprawdzić że `make tests-in-docker` lokalnie też działa (template-clone + tmpfs to zmiana po stronie compose'a, lokalnie)