### PR TITLE
feat(run_site): manage.py run_site — szybkie uruchomienie dev w testcontainerach

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,46 @@ Instaluje przez `apt` pakiety `yarnpkg`, `python3-dev`, `libpq-dev`,
 `uv sync --all-extras`. Po nim nadal trzeba ręcznie wywołać
 `uv run playwright install` oraz `sudo playwright install-deps`.
 
+## Szybkie uruchomienie wersji deweloperskiej (`run_site`)
+
+Komenda `manage.py run_site` uruchamia kompletny lokalny stack BPP
+w **testcontainerach** (PostgreSQL + Redis na losowych portach), więc
+można mieć kilka konfiguracji obok siebie bez konfliktów portów.
+
+```bash
+# Z baseline.sql (pusta baza demo):
+uv run python src/manage.py run_site
+
+# Z dump-em produkcyjnym (autodetect formatu):
+uv run python src/manage.py run_site --from-dump ~/backups/bpp.pg_dump
+```
+
+Co robi:
+
+1. Startuje PostgreSQL + Redis w kontenerach Docker na losowych portach.
+2. Odtwarza dump (`.sql` / `.sql.gz` / `.dump` / `.pg_dump` / `.pgdump`)
+   lub baseline (jeśli `--from-dump` nie podany).
+3. Wykonuje `migrate --noinput`.
+4. Tworzy lub nadpisuje superusera `admin` / `admin` z czyszczeniem
+   wymogu zmiany hasła (świeży wpis w `password_policies.PasswordHistory`).
+5. Drukuje banner z URL-ami i otwiera przeglądarkę na `/admin/`.
+6. Odpala `runserver` na losowym wolnym porcie i blokuje.
+
+`Ctrl-C` zatrzymuje runserver i sprząta kontenery.
+
+Opcje:
+
+| Flaga | Działanie |
+|-------|-----------|
+| `--from-dump PATH` | Restore z dump-a (autodetect po extension). |
+| `--with-celery` | Dodatkowo odpala celery worker. |
+| `--no-browser` | Nie otwiera przeglądarki. |
+| `--port PORT` | Konkretny port runserver (default: losowy wolny). |
+| `--reuse` | Reusuje istniejące named containery (szybszy restart). |
+
+**Wymaganie:** działający Docker daemon. Kontenery są ulotne — żyją
+tylko podczas trwania komendy (chyba że `--reuse`).
+
 ## Technologie
 
 | | |

--- a/docs/superpowers/plans/2026-05-01-deduplikator-autorow-general.md
+++ b/docs/superpowers/plans/2026-05-01-deduplikator-autorow-general.md
@@ -1,0 +1,3014 @@
+# Deduplikator autorów — tryb general — plan implementacji
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dodać do istniejącego modułu `src/deduplikator_autorow/` drugi tryb skanowania — `general` — znajdujący duplikaty autorów spoza `OsobaZInstytucji` (PBN). Zachowuje istniejący tryb PBN, dodaje cluster-skip dla klastrów zawierających członka PBN-instytucji, deterministyczny wybór "main" hierarchią cech.
+
+**Architecture:** Rozszerzenie aplikacji `deduplikator_autorow`. Nowe utility (`utils/meta.py`, `utils/cluster.py`, `utils/main_selection.py`, `utils/search_general.py`). Refactor `tasks.py:scan_for_duplicates` na dwie fazy w jednym tasku celery (PBN→general). Nowy status `PARTIAL_COMPLETED`. Migracje: rename `IgnoredAuthor` → `IgnoredScientist`, nowy `IgnoredAuthor` (FK→Autor), pole `phase` na `DuplicateScanRun`, `scan_mode` na `DuplicateCandidate`, replace constraint.
+
+**Tech Stack:** Django 4.x/5.x, Celery, pytest + pytest-django + pytest-xdist, model_bakery, Postgres.
+
+**Spec:** `docs/superpowers/specs/2026-05-01-deduplikator-autorow-general-design.md`
+
+---
+
+## Konwencje wykonania
+
+- **Worktree:** wszystkie zmiany w `~/Programowanie/bpp-worktrees/deduplikator-autorow-general/` (utworzony w Phase 0).
+- **Python uruchamiamy zawsze przez `uv run`** (nigdy goły `python`).
+- **pytest:** `UV_NO_SYNC=1 uv run --all-extras pytest -n auto <target> 2>&1 | tee /tmp/dedup-test.log` — output ZAWSZE do pliku, jeśli błąd → grepuj `/tmp/dedup-test.log`. Nigdy nie odpalaj testów po raz drugi „dla pewności".
+- **Migracje:** nigdy nie modyfikujemy istniejących migracji w `src/*/migrations/`. Nowe pliki numerujemy kolejno od `0009_*`.
+- **Pre-commit:** uruchamiać tylko na zmienionych plikach. Nie używać `--all-files`. Po `git add` przed commitem `pre-commit` uruchomi się sam.
+- **Commit cadence:** commit po każdym ukończonym Tasku (chyba że Task explicite mówi inaczej).
+- **Maks. 88 znaków** na linię (ruff format).
+
+---
+
+## Phase 0: Worktree i pre-flight
+
+### Task 0.1: Utworzenie worktree
+
+**Files:**
+- Brak nowych plików; operacja git.
+
+- [ ] **Step 1: Sprawdź stan repo**
+
+```bash
+cd /Users/mpasternak/Programowanie/bpp
+git status
+git fetch origin
+git log --oneline -5 dev
+```
+
+Expected: `dev` branch, ostatni commit to spec deduplikatora.
+
+- [ ] **Step 2: Utwórz worktree**
+
+```bash
+git worktree add ~/Programowanie/bpp-worktrees/deduplikator-autorow-general -b feature/deduplikator-autorow-general dev
+cd ~/Programowanie/bpp-worktrees/deduplikator-autorow-general
+```
+
+Expected: katalog utworzony, branch ustawiony.
+
+- [ ] **Step 3: Zainstaluj zależności w worktree**
+
+```bash
+uv sync --all-extras
+```
+
+Expected: `uv.lock` resolved, brak błędów.
+
+- [ ] **Step 4: Sanity-check testów**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_szukaj_kopii.py -n auto 2>&1 | tee /tmp/dedup-sanity.log
+```
+
+Expected: testy istniejące przechodzą.
+
+---
+
+## Phase 1: Modele i migracje
+
+Cel: wprowadzić wszystkie zmiany strukturalne ZANIM zaczniemy logikę. Ułatwi to debugowanie późniejsze.
+
+### Task 1.1: Rename `IgnoredAuthor` → `IgnoredScientist`
+
+**Files:**
+- Modify: `src/deduplikator_autorow/models.py`
+- Create: `src/deduplikator_autorow/migrations/0009_rename_ignoredauthor_ignoredscientist.py`
+- Modify: `src/deduplikator_autorow/admin.py`
+- Modify: `src/deduplikator_autorow/views.py`
+- Modify: `src/deduplikator_autorow/tasks.py`
+- Modify: `src/deduplikator_autorow/utils/finders.py`
+
+- [ ] **Step 1: Przemianuj klasę modelu**
+
+W `src/deduplikator_autorow/models.py`, znajdź klasę `IgnoredAuthor` (FK→Scientist) i zmień jej nazwę na `IgnoredScientist`. Zmień też verbose_names:
+
+```python
+class IgnoredScientist(models.Model):
+    """Scientists from PBN that should be completely ignored in deduplication"""
+
+    scientist = models.OneToOneField(
+        "pbn_api.Scientist",
+        on_delete=models.CASCADE,
+        db_index=True,
+        verbose_name="Scientist (PBN)",
+        help_text="Scientist record that should be ignored in deduplication",
+    )
+
+    autor = models.ForeignKey(
+        "bpp.Autor",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        verbose_name="Autor (BPP)",
+        help_text="Optional reference to BPP author",
+    )
+
+    reason = models.CharField(
+        max_length=500,
+        blank=True,
+        verbose_name="Powód ignorowania",
+    )
+
+    created_on = models.DateTimeField("Data utworzenia", default=timezone.now)
+    created_by = models.ForeignKey(
+        BppUser,
+        on_delete=models.CASCADE,
+        verbose_name="Utworzył",
+    )
+
+    class Meta:
+        verbose_name = "Ignorowany Scientist (PBN)"
+        verbose_name_plural = "Ignorowani Scientist (PBN)"
+        ordering = ["-created_on"]
+
+    def __str__(self):
+        if self.autor:
+            return f"Ignorowany: {self.autor} (Scientist #{self.scientist.pk})"
+        return f"Ignorowany: Scientist #{self.scientist.pk}"
+```
+
+- [ ] **Step 2: Zaktualizuj importy w innych plikach**
+
+W każdym z plików: `admin.py`, `views.py`, `tasks.py`, `utils/finders.py` — znajdź referencje `IgnoredAuthor` i przemianuj na `IgnoredScientist`. Konkretne miejsca:
+
+```bash
+cd ~/Programowanie/bpp-worktrees/deduplikator-autorow-general
+grep -rn "IgnoredAuthor" src/deduplikator_autorow/
+```
+
+Każde wystąpienie zamień (sed nie zadziała przez Edit; rób ręcznie). Plik `models.py` jest właścicielem klasy, ale w `admin.py` jest decorator `@admin.register(IgnoredAuthor)` i klasa `IgnoredAuthorAdmin` → przemianuj klasę na `IgnoredScientistAdmin` i decorator na `@admin.register(IgnoredScientist)`. Zmiana w `__init__.py` modułu jeśli reeksportowane.
+
+- [ ] **Step 3: Wygeneruj migrację**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras src/manage.py makemigrations deduplikator_autorow --name rename_ignoredauthor_ignoredscientist
+```
+
+Sprawdź, że plik `0009_rename_ignoredauthor_ignoredscientist.py` zawiera `migrations.RenameModel(old_name="IgnoredAuthor", new_name="IgnoredScientist")` i `AlterModelOptions`.
+
+Expected: pojedyncza migracja z RenameModel + AlterModelOptions.
+
+- [ ] **Step 4: Sprawdź że testy istniejące dalej przechodzą**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/ -n auto 2>&1 | tee /tmp/dedup-task1.log
+```
+
+Expected: wszystkie istniejące testy zielone (rename to non-breaking change wewnątrz modułu).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/deduplikator_autorow/
+git commit -m "$(cat <<'EOF'
+refactor(deduplikator): zmień nazwę IgnoredAuthor → IgnoredScientist
+
+Pierwszy krok przygotowania pod tryb general — istniejący IgnoredAuthor
+był specyficzny dla PBN (FK→Scientist) i zwalniamy nazwę pod nowy model
+ignorujący autorów BPP w trybie ogólnym.
+EOF
+)"
+```
+
+---
+
+### Task 1.2: Nowy `IgnoredAuthor` (FK→Autor)
+
+**Files:**
+- Modify: `src/deduplikator_autorow/models.py`
+- Create: `src/deduplikator_autorow/migrations/0010_add_ignored_author.py`
+- Modify: `src/deduplikator_autorow/admin.py`
+- Test: `src/deduplikator_autorow/tests/test_models_ignored.py` (nowy)
+
+- [ ] **Step 1: Napisz failing test**
+
+`src/deduplikator_autorow/tests/test_models_ignored.py`:
+
+```python
+"""Testy modelu IgnoredAuthor (general) i IgnoredScientist (PBN)."""
+
+import pytest
+from model_bakery import baker
+
+from deduplikator_autorow.models import IgnoredAuthor, IgnoredScientist
+
+
+@pytest.mark.django_db
+def test_ignored_scientist_can_be_created():
+    scientist = baker.make("pbn_api.Scientist")
+    user = baker.make("bpp.BppUser")
+    obj = IgnoredScientist.objects.create(scientist=scientist, created_by=user)
+    assert obj.pk is not None
+    assert obj.scientist == scientist
+
+
+@pytest.mark.django_db
+def test_ignored_author_can_be_created():
+    autor = baker.make("bpp.Autor")
+    user = baker.make("bpp.BppUser")
+    obj = IgnoredAuthor.objects.create(autor=autor, created_by=user, reason="test")
+    assert obj.pk is not None
+    assert obj.autor == autor
+    assert obj.reason == "test"
+
+
+@pytest.mark.django_db
+def test_ignored_author_one_to_one_constraint():
+    """Próba podwójnego dodania tego samego autora rzuca IntegrityError."""
+    from django.db import IntegrityError
+
+    autor = baker.make("bpp.Autor")
+    user = baker.make("bpp.BppUser")
+    IgnoredAuthor.objects.create(autor=autor, created_by=user)
+    with pytest.raises(IntegrityError):
+        IgnoredAuthor.objects.create(autor=autor, created_by=user)
+```
+
+- [ ] **Step 2: Uruchom test — ma fail-ować na imporcie**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_models_ignored.py -n0 2>&1 | tee /tmp/dedup-task1-2.log
+```
+
+Expected: ImportError lub `cannot import name 'IgnoredAuthor'`.
+
+- [ ] **Step 3: Dodaj klasę `IgnoredAuthor` w `models.py`**
+
+W pliku `src/deduplikator_autorow/models.py`, **po** klasie `IgnoredScientist`, dodaj:
+
+```python
+class IgnoredAuthor(models.Model):
+    """BPP authors (without PBN-Scientist link) that should be ignored in deduplication."""
+
+    autor = models.OneToOneField(
+        "bpp.Autor",
+        on_delete=models.CASCADE,
+        db_index=True,
+        verbose_name="Autor (BPP)",
+        help_text="Autor BPP do ignorowania w deduplikacji ogólnej",
+    )
+
+    reason = models.CharField(
+        max_length=500,
+        blank=True,
+        verbose_name="Powód ignorowania",
+    )
+
+    created_on = models.DateTimeField("Data utworzenia", default=timezone.now)
+    created_by = models.ForeignKey(
+        BppUser,
+        on_delete=models.CASCADE,
+        verbose_name="Utworzył",
+    )
+
+    class Meta:
+        verbose_name = "Ignorowany autor (BPP)"
+        verbose_name_plural = "Ignorowani autorzy (BPP)"
+        ordering = ["-created_on"]
+
+    def __str__(self):
+        return f"Ignorowany autor: {self.autor}"
+```
+
+- [ ] **Step 4: Wygeneruj migrację**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras src/manage.py makemigrations deduplikator_autorow --name add_ignored_author
+```
+
+Expected: `0010_add_ignored_author.py` z `CreateModel(name="IgnoredAuthor", ...)`.
+
+- [ ] **Step 5: Dodaj admin dla nowego modelu**
+
+W `src/deduplikator_autorow/admin.py`, **po** klasie `IgnoredScientistAdmin`, dodaj:
+
+```python
+@admin.register(IgnoredAuthor)
+class IgnoredAuthorAdmin(DynamicAdminFilterMixin, admin.ModelAdmin):
+    list_display = [
+        "get_autor_display",
+        "reason",
+        "created_by",
+        "created_on",
+    ]
+
+    list_filter = ["created_on", "created_by"]
+
+    search_fields = [
+        "autor__nazwisko",
+        "autor__imiona",
+        "reason",
+        "created_by__username",
+    ]
+
+    readonly_fields = ["created_on"]
+    date_hierarchy = "created_on"
+    ordering = ["-created_on"]
+
+    def get_autor_display(self, obj):
+        if obj.autor:
+            url = reverse("admin:bpp_autor_change", args=[obj.autor.pk])
+            return mark_safe(f'<a href="{url}">{obj.autor}</a>')
+        return "-"
+
+    get_autor_display.short_description = "Autor (BPP)"
+
+    def save_model(self, request, obj, form, change):
+        if not change:
+            obj.created_by = request.user
+        super().save_model(request, obj, form, change)
+```
+
+Dodaj `IgnoredAuthor` do importu na górze `admin.py`.
+
+- [ ] **Step 6: Uruchom testy — powinny przejść**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_models_ignored.py -n auto 2>&1 | tee /tmp/dedup-task1-2.log
+```
+
+Expected: 3 testy zielone.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A src/deduplikator_autorow/
+git commit -m "feat(deduplikator): nowy model IgnoredAuthor (FK→Autor) dla trybu general"
+```
+
+---
+
+### Task 1.3: `phase` na ScanRun, `scan_mode` na Candidate, status `PARTIAL_COMPLETED`, constraint
+
+**Files:**
+- Modify: `src/deduplikator_autorow/models.py`
+- Create: `src/deduplikator_autorow/migrations/0011_scan_mode_phase_partial.py`
+- Test: `src/deduplikator_autorow/tests/test_models_scan_fields.py` (nowy)
+
+- [ ] **Step 1: Failing test**
+
+`src/deduplikator_autorow/tests/test_models_scan_fields.py`:
+
+```python
+"""Testy nowych pól: phase, scan_mode, PARTIAL_COMPLETED status."""
+
+import pytest
+from model_bakery import baker
+
+from deduplikator_autorow.models import DuplicateCandidate, DuplicateScanRun
+
+
+@pytest.mark.django_db
+def test_scan_run_phase_field_default_blank():
+    scan = DuplicateScanRun.objects.create()
+    assert scan.phase == ""
+
+
+@pytest.mark.django_db
+def test_scan_run_phase_field_can_be_set():
+    scan = DuplicateScanRun.objects.create(phase="general")
+    scan.refresh_from_db()
+    assert scan.phase == "general"
+
+
+@pytest.mark.django_db
+def test_scan_run_partial_completed_status():
+    scan = DuplicateScanRun.objects.create(
+        status=DuplicateScanRun.Status.PARTIAL_COMPLETED
+    )
+    scan.refresh_from_db()
+    assert scan.status == "partial_completed"
+    assert scan.get_status_display() == "Częściowo zakończone (faza PBN OK, general anulowana)"
+
+
+@pytest.mark.django_db
+def test_candidate_scan_mode_default_pbn():
+    scan = DuplicateScanRun.objects.create()
+    autor1 = baker.make("bpp.Autor")
+    autor2 = baker.make("bpp.Autor")
+    cand = DuplicateCandidate.objects.create(
+        scan_run=scan,
+        main_autor=autor1,
+        duplicate_autor=autor2,
+        confidence_score=80,
+        confidence_percent=0.5,
+        main_autor_name="Test Main",
+        duplicate_autor_name="Test Dup",
+    )
+    cand.refresh_from_db()
+    assert cand.scan_mode == "pbn"
+
+
+@pytest.mark.django_db
+def test_candidate_scan_mode_general():
+    scan = DuplicateScanRun.objects.create()
+    autor1 = baker.make("bpp.Autor")
+    autor2 = baker.make("bpp.Autor")
+    cand = DuplicateCandidate.objects.create(
+        scan_run=scan,
+        main_autor=autor1,
+        duplicate_autor=autor2,
+        confidence_score=80,
+        confidence_percent=0.5,
+        main_autor_name="Test Main",
+        duplicate_autor_name="Test Dup",
+        scan_mode="general",
+    )
+    cand.refresh_from_db()
+    assert cand.scan_mode == "general"
+
+
+@pytest.mark.django_db
+def test_candidate_unique_constraint_includes_scan_mode():
+    """Ta sama para (main, dup) może istnieć w obu trybach, ale nie dwa razy w jednym."""
+    from django.db import IntegrityError
+
+    scan = DuplicateScanRun.objects.create()
+    autor1 = baker.make("bpp.Autor")
+    autor2 = baker.make("bpp.Autor")
+
+    DuplicateCandidate.objects.create(
+        scan_run=scan,
+        main_autor=autor1,
+        duplicate_autor=autor2,
+        confidence_score=80,
+        confidence_percent=0.5,
+        main_autor_name="A",
+        duplicate_autor_name="B",
+        scan_mode="pbn",
+    )
+    # Ta sama para w trybie general — OK
+    DuplicateCandidate.objects.create(
+        scan_run=scan,
+        main_autor=autor1,
+        duplicate_autor=autor2,
+        confidence_score=80,
+        confidence_percent=0.5,
+        main_autor_name="A",
+        duplicate_autor_name="B",
+        scan_mode="general",
+    )
+    # Drugi raz w trybie pbn — IntegrityError
+    with pytest.raises(IntegrityError):
+        DuplicateCandidate.objects.create(
+            scan_run=scan,
+            main_autor=autor1,
+            duplicate_autor=autor2,
+            confidence_score=80,
+            confidence_percent=0.5,
+            main_autor_name="A",
+            duplicate_autor_name="B",
+            scan_mode="pbn",
+        )
+```
+
+- [ ] **Step 2: Uruchom — fail**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_models_scan_fields.py -n0 2>&1 | tee /tmp/dedup-task1-3.log
+```
+
+Expected: AttributeError lub similar — pole `phase` nie istnieje, status `PARTIAL_COMPLETED` nie zdefiniowany.
+
+- [ ] **Step 3: Modyfikuj `DuplicateScanRun`**
+
+W `src/deduplikator_autorow/models.py`, klasa `DuplicateScanRun`:
+
+(a) W `Status` dodaj wartość:
+
+```python
+class Status(models.TextChoices):
+    PENDING = "pending", "Oczekuje"
+    RUNNING = "running", "W trakcie"
+    COMPLETED = "completed", "Zakończone"
+    PARTIAL_COMPLETED = (
+        "partial_completed",
+        "Częściowo zakończone (faza PBN OK, general anulowana)",
+    )
+    CANCELLED = "cancelled", "Anulowane"
+    FAILED = "failed", "Błąd"
+```
+
+(b) Dodaj pole `phase` po `celery_task_id`:
+
+```python
+phase = models.CharField(
+    "Aktualna faza",
+    max_length=20,
+    blank=True,
+    choices=[("pbn", "Faza PBN"), ("general", "Faza ogólna")],
+)
+```
+
+- [ ] **Step 4: Modyfikuj `DuplicateCandidate`**
+
+W tej samej klasie dodaj pole `scan_mode` po `priority`:
+
+```python
+scan_mode = models.CharField(
+    "Tryb skanowania",
+    max_length=20,
+    choices=[("pbn", "PBN"), ("general", "Ogólny")],
+    default="pbn",
+    db_index=True,
+)
+```
+
+W `class Meta` zamień constraint:
+
+```python
+class Meta:
+    verbose_name = "Kandydat na duplikat"
+    verbose_name_plural = "Kandydaci na duplikaty"
+    ordering = ["-priority", "-confidence_score", "main_autor__nazwisko"]
+    indexes = [
+        models.Index(fields=["scan_run", "status"]),
+        models.Index(fields=["main_autor", "status"]),
+        models.Index(fields=["priority", "confidence_score"]),
+        models.Index(fields=["scan_run", "scan_mode", "status"]),
+    ]
+    constraints = [
+        models.UniqueConstraint(
+            fields=["scan_run", "scan_mode", "main_autor", "duplicate_autor"],
+            name="unique_scan_mode_main_duplicate",
+        ),
+    ]
+```
+
+- [ ] **Step 5: Wygeneruj migrację**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras src/manage.py makemigrations deduplikator_autorow --name scan_mode_phase_partial
+```
+
+Expected: `0011_*.py` z AddField (phase, scan_mode), AlterField (status — choices), AddIndex, RemoveConstraint, AddConstraint.
+
+- [ ] **Step 6: Sprawdź że migracja jest reversible/clean (dry-run)**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras src/manage.py migrate --plan deduplikator_autorow 0011 2>&1 | tee /tmp/dedup-migrate-plan.log
+UV_NO_SYNC=1 uv run --all-extras src/manage.py migrate deduplikator_autorow 2>&1 | tee /tmp/dedup-migrate.log
+```
+
+Expected: migracja przechodzi bez ostrzeżeń.
+
+- [ ] **Step 7: Uruchom testy — powinny przejść**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_models_scan_fields.py -n auto 2>&1 | tee /tmp/dedup-task1-3.log
+```
+
+Expected: 6 testów zielonych.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A src/deduplikator_autorow/
+git commit -m "feat(deduplikator): pola phase, scan_mode, status PARTIAL_COMPLETED, constraint"
+```
+
+---
+
+## Phase 2: Engine — meta-cache, analiza, cluster, main selection
+
+Cel: zbudować in-memory komponenty pozwalające analizować duplikaty bez SQL na hot-path.
+
+### Task 2.1: `utils/cluster.py` — union-find
+
+**Files:**
+- Create: `src/deduplikator_autorow/utils/cluster.py`
+- Test: `src/deduplikator_autorow/tests/test_cluster.py` (nowy)
+
+- [ ] **Step 1: Failing test**
+
+`src/deduplikator_autorow/tests/test_cluster.py`:
+
+```python
+"""Testy union-find (connected components)."""
+
+from deduplikator_autorow.utils.cluster import find_clusters
+
+
+def test_two_disjoint_pairs():
+    pairs = [(1, 2), (3, 4)]
+    clusters = sorted(find_clusters(pairs), key=min)
+    assert clusters == [{1, 2}, {3, 4}]
+
+
+def test_transitive_cluster():
+    """A~B and B~C → cluster {A, B, C}."""
+    pairs = [(1, 2), (2, 3)]
+    clusters = list(find_clusters(pairs))
+    assert clusters == [{1, 2, 3}]
+
+
+def test_single_pair():
+    pairs = [(7, 8)]
+    clusters = list(find_clusters(pairs))
+    assert clusters == [{7, 8}]
+
+
+def test_no_pairs():
+    assert list(find_clusters([])) == []
+
+
+def test_isolated_nodes_with_pairs():
+    """Tylko węzły mające połączenia trafiają do klastrów."""
+    pairs = [(1, 2), (5, 6), (2, 3)]
+    clusters = sorted(find_clusters(pairs), key=min)
+    assert clusters == [{1, 2, 3}, {5, 6}]
+
+
+def test_duplicate_pairs_are_idempotent():
+    pairs = [(1, 2), (1, 2), (2, 1)]
+    clusters = list(find_clusters(pairs))
+    assert clusters == [{1, 2}]
+```
+
+- [ ] **Step 2: Run — ImportError**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_cluster.py -n0 2>&1 | tee /tmp/dedup-task2-1.log
+```
+
+- [ ] **Step 3: Implementacja**
+
+`src/deduplikator_autorow/utils/cluster.py`:
+
+```python
+"""Union-find (connected components) dla par autorów.
+
+Dla zbioru par (a, b) zwraca spójne komponenty grafu.
+"""
+
+
+def find_clusters(pairs):
+    """Zwraca listę zbiorów (klastrów) z par.
+
+    Args:
+        pairs: iterable krotek (pk_a, pk_b).
+
+    Returns:
+        list[set[int]]: lista klastrów (każdy klaster to set PKów).
+    """
+    parent = {}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]  # path compression
+            x = parent[x]
+        return x
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for a, b in pairs:
+        if a not in parent:
+            parent[a] = a
+        if b not in parent:
+            parent[b] = b
+        union(a, b)
+
+    clusters_by_root = {}
+    for node in parent:
+        root = find(node)
+        clusters_by_root.setdefault(root, set()).add(node)
+
+    return list(clusters_by_root.values())
+```
+
+- [ ] **Step 4: Run — pass**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_cluster.py -n auto 2>&1 | tee /tmp/dedup-task2-1.log
+```
+
+Expected: 6 zielonych.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): utils.cluster — union-find dla klastrów autorów"
+```
+
+---
+
+### Task 2.2: `utils/main_selection.py` — hierarchia B
+
+**Files:**
+- Create: `src/deduplikator_autorow/utils/main_selection.py`
+- Test: `src/deduplikator_autorow/tests/test_main_selection.py` (nowy)
+
+- [ ] **Step 1: Failing test**
+
+`src/deduplikator_autorow/tests/test_main_selection.py`:
+
+```python
+"""Testy hierarchii wyboru głównego rekordu (hierarchia B)."""
+
+from deduplikator_autorow.utils.main_selection import pick_main_pk
+
+
+def _meta(**kwargs):
+    """Helper — minimalny wpis meta."""
+    base = {
+        "ma_orcid": False,
+        "ma_pbn_uid": False,
+        "ma_tytul": False,
+        "ma_dyscypline": False,
+        "publikacje_count": 0,
+        "max_rok": 0,
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_orcid_wins_over_everything():
+    metas = {
+        1: _meta(ma_orcid=False, publikacje_count=100, max_rok=2025),
+        2: _meta(ma_orcid=True, publikacje_count=1, max_rok=2000),
+    }
+    cluster = {1, 2}
+    assert pick_main_pk(cluster, metas) == 2
+
+
+def test_pbn_uid_wins_when_orcid_tied():
+    metas = {
+        1: _meta(ma_orcid=True, ma_pbn_uid=False),
+        2: _meta(ma_orcid=True, ma_pbn_uid=True),
+    }
+    assert pick_main_pk({1, 2}, metas) == 2
+
+
+def test_tytul_wins_when_above_tied():
+    metas = {
+        1: _meta(ma_orcid=True, ma_pbn_uid=True, ma_tytul=False),
+        2: _meta(ma_orcid=True, ma_pbn_uid=True, ma_tytul=True),
+    }
+    assert pick_main_pk({1, 2}, metas) == 2
+
+
+def test_dyscyplina_wins_when_above_tied():
+    metas = {
+        1: _meta(ma_orcid=True, ma_pbn_uid=True, ma_tytul=True, ma_dyscypline=False),
+        2: _meta(ma_orcid=True, ma_pbn_uid=True, ma_tytul=True, ma_dyscypline=True),
+    }
+    assert pick_main_pk({1, 2}, metas) == 2
+
+
+def test_publikacje_count_wins_when_above_tied():
+    metas = {
+        1: _meta(publikacje_count=5),
+        2: _meta(publikacje_count=10),
+    }
+    assert pick_main_pk({1, 2}, metas) == 2
+
+
+def test_max_rok_wins_when_publikacje_tied():
+    metas = {
+        1: _meta(publikacje_count=5, max_rok=2020),
+        2: _meta(publikacje_count=5, max_rok=2025),
+    }
+    assert pick_main_pk({1, 2}, metas) == 2
+
+
+def test_pk_lowest_wins_when_all_tied():
+    metas = {
+        77: _meta(),
+        12: _meta(),
+        99: _meta(),
+    }
+    assert pick_main_pk({77, 12, 99}, metas) == 12
+```
+
+- [ ] **Step 2: Run — fail**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_main_selection.py -n0 2>&1 | tee /tmp/dedup-task2-2.log
+```
+
+- [ ] **Step 3: Implementacja**
+
+`src/deduplikator_autorow/utils/main_selection.py`:
+
+```python
+"""Wybór głównego rekordu (main) w klastrze duplikatów.
+
+Hierarchia (kolejne kryteria odpalają tylko przy remisie):
+1. ma_orcid (DESC)
+2. ma_pbn_uid (DESC)
+3. ma_tytul (DESC)
+4. ma_dyscypline (DESC)
+5. publikacje_count (DESC)
+6. max_rok (DESC)
+7. pk (ASC)
+"""
+
+
+def _selection_key(pk: int, meta: dict) -> tuple:
+    """Klucz sortowania — niższe wartości = lepszy kandydat na main."""
+    return (
+        not meta["ma_orcid"],
+        not meta["ma_pbn_uid"],
+        not meta["ma_tytul"],
+        not meta["ma_dyscypline"],
+        -meta["publikacje_count"],
+        -(meta["max_rok"] or 0),
+        pk,
+    )
+
+
+def pick_main_pk(cluster: set[int], metas: dict[int, dict]) -> int:
+    """Z klastra (set PKów) wybiera PK głównego rekordu.
+
+    Args:
+        cluster: set PKów członków klastra.
+        metas: {pk -> meta dict z polami ma_orcid, ma_pbn_uid, ma_tytul,
+                ma_dyscypline, publikacje_count, max_rok}.
+
+    Returns:
+        PK rekordu wybranego jako main.
+    """
+    return min(cluster, key=lambda pk: _selection_key(pk, metas[pk]))
+```
+
+- [ ] **Step 4: Run — pass**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_main_selection.py -n auto 2>&1 | tee /tmp/dedup-task2-2.log
+```
+
+Expected: 7 zielonych.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): utils.main_selection — hierarchia wyboru głównego"
+```
+
+---
+
+### Task 2.3: `utils/meta.py` — meta-cache builder
+
+**Files:**
+- Create: `src/deduplikator_autorow/utils/meta.py`
+- Test: `src/deduplikator_autorow/tests/test_meta.py` (nowy)
+
+- [ ] **Step 1: Failing test**
+
+`src/deduplikator_autorow/tests/test_meta.py`:
+
+```python
+"""Testy budowniczego meta-cache dla autorów."""
+
+import pytest
+from django.test.utils import CaptureQueriesContext
+from django.db import connection
+from model_bakery import baker
+
+from deduplikator_autorow.utils.meta import build_autor_meta
+
+
+@pytest.mark.django_db
+def test_meta_includes_basic_fields():
+    autor = baker.make(
+        "bpp.Autor",
+        nazwisko="Kowalski",
+        imiona="Jan",
+        orcid="0000-0001-2345-6789",
+    )
+    meta = build_autor_meta()
+    assert autor.pk in meta
+    m = meta[autor.pk]
+    assert m["nazwisko_norm"] == "kowalski"
+    assert m["imiona_norm"] == ["jan"]
+    assert m["ma_orcid"] is True
+    assert m["ma_pbn_uid"] is False
+    assert m["ma_tytul"] is False
+    assert m["publikacje_count"] == 0
+    assert m["max_rok"] == 0
+    assert m["lata_publikacji"] == set()
+
+
+@pytest.mark.django_db
+def test_meta_compound_lastname_parts():
+    autor = baker.make("bpp.Autor", nazwisko="Gal-Cisoń", imiona="Anna")
+    meta = build_autor_meta()
+    parts = meta[autor.pk]["nazwisko_parts"]
+    assert sorted(parts) == ["cisoń", "gal"]
+
+
+@pytest.mark.django_db
+def test_meta_ma_osoba_z_instytucji_true():
+    from pbn_api.models import Scientist, OsobaZInstytucji
+
+    autor = baker.make("bpp.Autor", nazwisko="X")
+    scientist = baker.make("pbn_api.Scientist", rekord_w_bpp=autor)
+    baker.make("pbn_api.OsobaZInstytucji", personId=scientist)
+
+    meta = build_autor_meta()
+    assert meta[autor.pk]["ma_osoba_z_instytucji"] is True
+
+
+@pytest.mark.django_db
+def test_meta_constant_query_count():
+    """Sanity: dodanie autorów nie zwiększa liczby zapytań (no N+1)."""
+    baker.make("bpp.Autor", _quantity=5, nazwisko="A")
+    with CaptureQueriesContext(connection) as ctx_small:
+        build_autor_meta()
+    n_small = len(ctx_small.captured_queries)
+
+    baker.make("bpp.Autor", _quantity=20, nazwisko="B")
+    with CaptureQueriesContext(connection) as ctx_big:
+        build_autor_meta()
+    n_big = len(ctx_big.captured_queries)
+
+    assert n_small == n_big, (
+        f"N+1 detected: small={n_small} queries, big={n_big} queries"
+    )
+```
+
+- [ ] **Step 2: Run — fail**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_meta.py -n0 2>&1 | tee /tmp/dedup-task2-3.log
+```
+
+- [ ] **Step 3: Implementacja**
+
+`src/deduplikator_autorow/utils/meta.py`:
+
+```python
+"""Budowniczy meta-cache dla wszystkich autorów BPP.
+
+Stała liczba zapytań SQL niezależna od N. Wynik trzymany w pamięci podczas
+fazy general — pozwala uniknąć N×k SQL queries podczas pair-generation.
+"""
+
+from collections import defaultdict
+
+from django.db.models import Count, Max
+from django.contrib.postgres.aggregates import ArrayAgg
+
+from bpp.models import Autor, Autor_Dyscyplina
+from bpp.models.cache import Rekord
+from pbn_api.models import OsobaZInstytucji
+
+
+def _normalize(s: str | None) -> str:
+    """Lowercase i strip — używamy do bucketingu."""
+    return (s or "").strip().lower()
+
+
+def _split_compound(nazwisko: str | None) -> list[str]:
+    """Rozbij nazwisko myślnikowe na części znormalizowane."""
+    if not nazwisko:
+        return []
+    return [_normalize(p) for p in nazwisko.split("-") if p.strip()]
+
+
+def build_autor_meta() -> dict[int, dict]:
+    """Buduje słownik {autor_pk -> meta} dla wszystkich autorów BPP.
+
+    Wykonuje stałą liczbę zapytań SQL (~5):
+    1. Pełna lista autorów + atrybuty bezpośrednie.
+    2. GROUP BY publikacje per autor (count, max_rok, lata).
+    3. Dyscypliny per autor (DISTINCT).
+    4. OsobaZInstytucji → autor.
+    5. (opcjonalnie) inne agregaty.
+
+    Returns:
+        {pk -> {nazwisko_norm, nazwisko_parts, imiona_norm, ma_orcid, ma_pbn_uid,
+                ma_tytul, ma_osoba_z_instytucji, ma_dyscypline, publikacje_count,
+                lata_publikacji, max_rok, obj}}
+    """
+    autorzy_meta = {}
+    for a in Autor.objects.only(
+        "pk", "nazwisko", "imiona", "orcid", "pbn_uid_id", "tytul_id"
+    ).iterator():
+        autorzy_meta[a.pk] = {
+            "obj": a,  # uwaga: Autor instance — odwołujemy się tylko do pk/nazwisko/imiona
+            "nazwisko_norm": _normalize(a.nazwisko),
+            "nazwisko_parts": _split_compound(a.nazwisko),
+            "imiona_norm": [_normalize(i) for i in (a.imiona or "").split() if i],
+            "ma_orcid": bool(a.orcid),
+            "orcid_value": a.orcid or None,
+            "ma_pbn_uid": bool(a.pbn_uid_id),
+            "ma_tytul": bool(a.tytul_id),
+            "tytul_id": a.tytul_id,
+            "ma_osoba_z_instytucji": False,
+            "ma_dyscypline": False,
+            "publikacje_count": 0,
+            "lata_publikacji": set(),
+            "max_rok": 0,
+        }
+
+    # Publikacje agregaty per autor — JEDNO globalne zapytanie GROUP BY.
+    # UWAGA: nazwa pola relacyjnego w Rekord może wymagać sprawdzenia.
+    # Sprawdź `Rekord._meta.get_fields()` lub kod `Rekord.objects.prace_autora()`
+    # by potwierdzić nazwę M2M ("autorzy" lub inna). Jeśli inna — zmień klucz
+    # w .values() i .filter() poniżej.
+    pub_agg = (
+        Rekord.objects.values("autorzy")
+        .annotate(
+            cnt=Count("id"),
+            max_rok=Max("rok"),
+            lata=ArrayAgg("rok", distinct=True),
+        )
+        .filter(autorzy__isnull=False)
+    )
+    for row in pub_agg:
+        pk = row["autorzy"]
+        if pk in autorzy_meta:
+            m = autorzy_meta[pk]
+            m["publikacje_count"] = row["cnt"] or 0
+            m["max_rok"] = row["max_rok"] or 0
+            m["lata_publikacji"] = set(filter(None, row["lata"] or []))
+
+    # Dyscypliny
+    dysc_pks = set(
+        Autor_Dyscyplina.objects.values_list("autor_id", flat=True).distinct()
+    )
+    for pk in dysc_pks:
+        if pk in autorzy_meta:
+            autorzy_meta[pk]["ma_dyscypline"] = True
+
+    # OsobaZInstytucji
+    osoba_pks = OsobaZInstytucji.objects.filter(
+        personId__rekord_w_bpp__isnull=False
+    ).values_list("personId__rekord_w_bpp__pk", flat=True)
+    for pk in osoba_pks:
+        if pk in autorzy_meta:
+            autorzy_meta[pk]["ma_osoba_z_instytucji"] = True
+
+    return autorzy_meta
+
+
+def build_buckets(meta: dict[int, dict]) -> dict[str, list[int]]:
+    """Buduje buckety {nazwisko_norm -> [pk1, pk2, ...]} z meta.
+
+    Każdy autor trafia do bucketu:
+    - swojego znormalizowanego nazwiska,
+    - każdej części składowej (compound: "Gal-Cisoń" → bucket "gal" i "cisoń"),
+    - odwróconego compound ("Gal-Cisoń" → bucket "cisoń-gal").
+    """
+    buckets: dict[str, list[int]] = defaultdict(list)
+    for pk, m in meta.items():
+        if not m["nazwisko_norm"]:
+            continue
+        buckets[m["nazwisko_norm"]].append(pk)
+        parts = m["nazwisko_parts"]
+        for part in parts:
+            if len(part) > 2 and part != m["nazwisko_norm"]:
+                buckets[part].append(pk)
+        if len(parts) == 2:
+            reversed_name = "-".join(reversed(parts))
+            if reversed_name != m["nazwisko_norm"]:
+                buckets[reversed_name].append(pk)
+    return dict(buckets)
+```
+
+- [ ] **Step 4: Run — pass**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_meta.py -n auto 2>&1 | tee /tmp/dedup-task2-3.log
+```
+
+Expected: 4 zielone. **Jeśli `test_meta_constant_query_count` zawodzi — to znak, że gdzieś jest N+1 i wymaga naprawy w `build_autor_meta`.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): utils.meta — pre-load wszystkich autorów do pamięci"
+```
+
+---
+
+### Task 2.4: `analiza_duplikatow_meta` — scoring na meta
+
+**Files:**
+- Create: `src/deduplikator_autorow/utils/analysis_meta.py`
+- Test: `src/deduplikator_autorow/tests/test_analysis_meta.py` (nowy)
+
+**Cel:** odpowiednik istniejącej `analiza_duplikatow`, ale operuje na słownikach meta zamiast obiektach DB. **Nie zastępujemy** istniejącego `analiza_duplikatow` (zostaje dla PBN-flow), tylko dokładamy nową funkcję dla general-flow.
+
+- [ ] **Step 1: Failing test**
+
+`src/deduplikator_autorow/tests/test_analysis_meta.py`:
+
+```python
+"""Testy analiza_duplikatow_meta — scoring par autorów na bazie meta."""
+
+from deduplikator_autorow.utils.analysis_meta import analiza_pary_meta
+
+
+def _meta(
+    nazwisko="kowalski",
+    imiona=("jan",),
+    orcid=None,
+    pbn_uid=False,
+    tytul=False,
+    pubs=0,
+    max_rok=0,
+    lata=None,
+    plec=None,
+):
+    return {
+        "nazwisko_norm": nazwisko,
+        "nazwisko_parts": nazwisko.split("-"),
+        "imiona_norm": list(imiona),
+        "orcid_value": orcid,
+        "ma_orcid": bool(orcid),
+        "ma_pbn_uid": pbn_uid,
+        "ma_tytul": tytul,
+        "tytul_id": 1 if tytul else None,
+        "publikacje_count": pubs,
+        "max_rok": max_rok,
+        "lata_publikacji": set(lata or []),
+        "plec_kod": plec,
+    }
+
+
+def test_identyczne_orcid_dodaje_50():
+    a = _meta(orcid="0000-0001-2345-6789")
+    b = _meta(orcid="0000-0001-2345-6789")
+    score, reasons = analiza_pary_meta(a, b)
+    assert score >= 50
+    assert any("ORCID" in r for r in reasons)
+
+
+def test_rozne_orcid_odejmuje_50():
+    a = _meta(orcid="0000-0001-1111-1111")
+    b = _meta(orcid="0000-0002-2222-2222")
+    score, reasons = analiza_pary_meta(a, b)
+    assert score <= -40  # -50 + małe plusy z innych kryteriów
+
+
+def test_identyczne_nazwisko_dodaje_40():
+    a = _meta(nazwisko="kowalski")
+    b = _meta(nazwisko="kowalski")
+    score, reasons = analiza_pary_meta(a, b)
+    assert score >= 40
+    assert any("nazwisko" in r.lower() for r in reasons)
+
+
+def test_wspolne_lata_publikacji_dodaje_20():
+    a = _meta(lata=[2020, 2021, 2022])
+    b = _meta(lata=[2021, 2022])
+    score, reasons = analiza_pary_meta(a, b)
+    assert any("wspólne lata" in r.lower() for r in reasons)
+
+
+def test_score_to_int():
+    a = _meta()
+    b = _meta()
+    score, _ = analiza_pary_meta(a, b)
+    assert isinstance(score, int)
+```
+
+- [ ] **Step 2: Run — fail**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_analysis_meta.py -n0 2>&1 | tee /tmp/dedup-task2-4.log
+```
+
+- [ ] **Step 3: Implementacja**
+
+`src/deduplikator_autorow/utils/analysis_meta.py`:
+
+```python
+"""Analiza pary autorów na podstawie wyłącznie meta-cache (bez SQL).
+
+Odpowiednik analysis.analiza_duplikatow ale dla pary (a, b) zamiast
+pivota OsobaZInstytucji. Punkty kalibrowane są zgodnie z istniejącą
+funkcją; różnica to brak płci (gender wymagałby dodatkowego inferencji
+z imienia — pomijamy w v1, bo dziś korzysta z `Autor.plec`,
+opcjonalnego pola).
+"""
+
+
+def _common_initials(imiona_a: list[str], imiona_b: list[str]) -> int:
+    """Liczba pasujących pierwszych liter."""
+    initials_a = {x[0] for x in imiona_a if x}
+    initials_b = {x[0] for x in imiona_b if x}
+    return len(initials_a & initials_b)
+
+
+def analiza_pary_meta(a: dict, b: dict) -> tuple[int, list[str]]:
+    """Zwraca (score, reasons) dla pary (a, b) na bazie meta-cache."""
+    score = 0
+    reasons: list[str] = []
+
+    # Liczba publikacji duplikatu (dla heurystyki "mało pubs = łatwiej duplikat")
+    pubs_b = b["publikacje_count"]
+    if pubs_b <= 5:
+        score += 10
+        reasons.append(f"mało publikacji ({pubs_b}) - prawdopodobny duplikat")
+    elif pubs_b <= 10:
+        score -= 10
+        reasons.append(f"średnio publikacji ({pubs_b}) - możliwy duplikat")
+    else:
+        score -= 20
+        reasons.append(f"wiele publikacji ({pubs_b}) - mało prawdopodobny duplikat")
+
+    # Tytuł
+    if not b["ma_tytul"] and a["ma_tytul"]:
+        score += 15
+        reasons.append("brak tytułu naukowego u kandydata - prawdopodobny duplikat")
+    elif b["ma_tytul"] and a["ma_tytul"]:
+        if a.get("tytul_id") == b.get("tytul_id"):
+            score += 10
+            reasons.append("identyczny tytuł naukowy")
+        else:
+            score -= 15
+            reasons.append("różny tytuł naukowy")
+
+    # ORCID
+    if not b["ma_orcid"] and a["ma_orcid"]:
+        score += 15
+        reasons.append("brak ORCID u kandydata - prawdopodobny duplikat")
+    elif b["ma_orcid"] and a["ma_orcid"]:
+        if a.get("orcid_value") == b.get("orcid_value"):
+            score += 50
+            reasons.append("identyczny ORCID - to ten sam autor")
+        else:
+            score -= 50
+            reasons.append("różny ORCID - to różni autorzy")
+
+    # Nazwisko
+    if a["nazwisko_norm"] and b["nazwisko_norm"]:
+        if a["nazwisko_norm"] == b["nazwisko_norm"]:
+            score += 40
+            reasons.append("identyczne nazwisko")
+        elif (
+            a["nazwisko_norm"] in b["nazwisko_norm"]
+            or b["nazwisko_norm"] in a["nazwisko_norm"]
+        ):
+            score += 30
+            reasons.append("podobne nazwisko (zawieranie)")
+
+    # Swap imię ↔ nazwisko (dokładny)
+    if a["nazwisko_norm"] and b["nazwisko_norm"] and a["imiona_norm"] and b["imiona_norm"]:
+        if (a["nazwisko_norm"] in b["imiona_norm"]) and (
+            b["nazwisko_norm"] in a["imiona_norm"]
+        ):
+            score += 50
+            reasons.append("wykryto pełną zamianę imienia z nazwiskiem")
+
+    # Imiona — exact matches
+    common = set(a["imiona_norm"]) & set(b["imiona_norm"])
+    if common:
+        score += 30 * len(common)
+        reasons.append(f"wspólne imię ({len(common)})")
+
+    # Imiona — prefiksy 3-znakowe
+    similar = 0
+    for ia in a["imiona_norm"]:
+        for ib in b["imiona_norm"]:
+            if len(ia) >= 3 and len(ib) >= 3 and ia != ib:
+                if ia.startswith(ib[:3]) or ib.startswith(ia[:3]):
+                    similar += 1
+    if similar:
+        score += 15 * similar
+        reasons.append(f"podobne imię ({similar})")
+
+    # Inicjały
+    init_count = _common_initials(a["imiona_norm"], b["imiona_norm"])
+    if init_count:
+        score += 5 * init_count
+        reasons.append(f"pasujące inicjały ({init_count})")
+
+    # Brak imion u kandydata
+    if not b["imiona_norm"] and a["imiona_norm"]:
+        score += 10
+        reasons.append("brak imion u kandydata")
+
+    # Lata publikacji
+    common_lata = a["lata_publikacji"] & b["lata_publikacji"]
+    if common_lata:
+        score += 20
+        reasons.append(f"wspólne lata publikacji: {sorted(common_lata)}")
+    elif a["lata_publikacji"] and b["lata_publikacji"]:
+        min_dist = min(
+            abs(ra - rb) for ra in a["lata_publikacji"] for rb in b["lata_publikacji"]
+        )
+        if min_dist <= 2:
+            score += 15
+            reasons.append(f"bliskie lata publikacji (różnica {min_dist})")
+        elif min_dist <= 7:
+            score -= 5
+            reasons.append(f"średnia odległość lat publikacji ({min_dist})")
+        else:
+            score -= 20
+            reasons.append(f"duża odległość lat publikacji ({min_dist})")
+
+    return score, reasons
+```
+
+**Uwaga:** funkcja `analiza_pary_meta` używa pól `orcid_value` i `tytul_id` z meta. Te pola są dodane w `build_autor_meta` w Task 2.3 (sprawdź że tam są przed odpaleniem testów tu).
+
+- [ ] **Step 4: Run — pass**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_analysis_meta.py -n auto 2>&1 | tee /tmp/dedup-task2-4.log
+```
+
+Expected: 5 zielonych.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): utils.analysis_meta — scoring par bez SQL"
+```
+
+---
+
+## Phase 3: Implementacja fazy `general`
+
+### Task 3.1: `utils/search_general.py` — pair generation w bucketach
+
+**Files:**
+- Create: `src/deduplikator_autorow/utils/search_general.py`
+- Test: `src/deduplikator_autorow/tests/test_search_general.py` (nowy)
+
+- [ ] **Step 1: Failing test**
+
+`src/deduplikator_autorow/tests/test_search_general.py`:
+
+```python
+"""Testy generowania par kandydatów w fazie general."""
+
+import pytest
+from model_bakery import baker
+
+from deduplikator_autorow.utils.meta import build_autor_meta, build_buckets
+from deduplikator_autorow.utils.search_general import (
+    generate_pairs,
+    BUCKET_MAX_SIZE,
+)
+
+
+@pytest.mark.django_db
+def test_simple_lastname_pair():
+    a1 = baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    a2 = baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    meta = build_autor_meta()
+    buckets = build_buckets(meta)
+    pairs = list(generate_pairs(buckets, meta, ignored_pks=set(), notadup_pks=set()))
+    pks = {(min(p, q), max(p, q)) for p, q, _, _ in pairs}
+    assert (min(a1.pk, a2.pk), max(a1.pk, a2.pk)) in pks
+
+
+@pytest.mark.django_db
+def test_compound_lastname_pair():
+    a1 = baker.make("bpp.Autor", nazwisko="Gal-Cisoń", imiona="Anna")
+    a2 = baker.make("bpp.Autor", nazwisko="Cisoń-Gal", imiona="Anna")
+    meta = build_autor_meta()
+    buckets = build_buckets(meta)
+    pairs = list(generate_pairs(buckets, meta, ignored_pks=set(), notadup_pks=set()))
+    pks = {(min(p, q), max(p, q)) for p, q, _, _ in pairs}
+    assert (min(a1.pk, a2.pk), max(a1.pk, a2.pk)) in pks
+
+
+@pytest.mark.django_db
+def test_pair_dedup():
+    a1 = baker.make("bpp.Autor", nazwisko="Smith", imiona="John")
+    a2 = baker.make("bpp.Autor", nazwisko="Smith", imiona="John")
+    meta = build_autor_meta()
+    buckets = build_buckets(meta)
+    pairs = list(generate_pairs(buckets, meta, ignored_pks=set(), notadup_pks=set()))
+    # Para (a1, a2) MUSI wystąpić tylko raz, niezależnie od ile bucketów
+    pair_set = [(p, q) for p, q, _, _ in pairs]
+    assert len(pair_set) == len(set(pair_set))
+
+
+@pytest.mark.django_db
+def test_ignored_excluded():
+    a1 = baker.make("bpp.Autor", nazwisko="Brown", imiona="Bob")
+    a2 = baker.make("bpp.Autor", nazwisko="Brown", imiona="Bob")
+    meta = build_autor_meta()
+    buckets = build_buckets(meta)
+    pairs = list(
+        generate_pairs(
+            buckets, meta, ignored_pks={a1.pk}, notadup_pks=set()
+        )
+    )
+    assert pairs == []
+
+
+@pytest.mark.django_db
+def test_below_min_confidence_excluded():
+    """Para z niskim confidence (kompletnie różne imiona, różne lata) → pominięta."""
+    a1 = baker.make("bpp.Autor", nazwisko="Davis", imiona="John")
+    a2 = baker.make(
+        "bpp.Autor",
+        nazwisko="Davis",
+        imiona="Mary-Anne Phyllis Henrietta Wilhelmina",
+    )
+    meta = build_autor_meta()
+    buckets = build_buckets(meta)
+    pairs = list(generate_pairs(buckets, meta, ignored_pks=set(), notadup_pks=set()))
+    # Zachowanie zależy od scoring; dla samego nazwiska +40, brak wspólnych imion
+    # → score = 40 + (-10/-20 z pubs) ≈ 30 < 50, więc pominięta
+    pks = {(p, q) for p, q, _, _ in pairs}
+    assert (min(a1.pk, a2.pk), max(a1.pk, a2.pk)) not in pks
+
+
+@pytest.mark.django_db
+def test_oversized_bucket_skipped():
+    """Bucket > BUCKET_MAX_SIZE jest pomijany z warningiem."""
+    baker.make("bpp.Autor", nazwisko="PopularName", _quantity=BUCKET_MAX_SIZE + 1)
+    meta = build_autor_meta()
+    buckets = build_buckets(meta)
+    pairs = list(generate_pairs(buckets, meta, ignored_pks=set(), notadup_pks=set()))
+    # Dla bucketu o tym nazwisku — nic nie powinno się wygenerować
+    assert pairs == []
+```
+
+- [ ] **Step 2: Run — fail**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_search_general.py -n0 2>&1 | tee /tmp/dedup-task3-1.log
+```
+
+- [ ] **Step 3: Implementacja**
+
+`src/deduplikator_autorow/utils/search_general.py`:
+
+```python
+"""Generator par kandydatów w fazie general — in-memory bucket comparisons."""
+
+import logging
+
+from .analysis_meta import analiza_pary_meta
+
+logger = logging.getLogger(__name__)
+
+BUCKET_MAX_SIZE = 200
+MIN_CONFIDENCE_TO_STORE = 50
+
+
+def generate_pairs(
+    buckets: dict[str, list[int]],
+    meta: dict[int, dict],
+    ignored_pks: set[int],
+    notadup_pks: set[int],
+    min_confidence: int = MIN_CONFIDENCE_TO_STORE,
+):
+    """Yield krotek (pk_a, pk_b, score, reasons) dla par przekraczających próg.
+
+    Args:
+        buckets: {nazwisko_norm -> [pk1, pk2, ...]}
+        meta: {pk -> meta dict}
+        ignored_pks: zbiór PK do całkowitego pominięcia (IgnoredAuthor).
+        notadup_pks: zbiór PK oznaczonych jako NotADuplicate (też pomijamy).
+        min_confidence: próg score-u poniżej którego para jest pomijana.
+
+    Yields:
+        (pk_a, pk_b, score, reasons) gdzie pk_a < pk_b.
+    """
+    seen_pairs: set[tuple[int, int]] = set()
+    skipped_buckets = 0
+    for bucket_name, pks in buckets.items():
+        if len(pks) > BUCKET_MAX_SIZE:
+            logger.warning(
+                "Skipping oversized bucket '%s' (%d members)", bucket_name, len(pks)
+            )
+            skipped_buckets += 1
+            continue
+        # Wykluczenia ignored
+        active = [p for p in pks if p not in ignored_pks]
+        for i, pk_a in enumerate(active):
+            for pk_b in active[i + 1 :]:
+                if pk_a == pk_b:
+                    continue
+                key = (min(pk_a, pk_b), max(pk_a, pk_b))
+                if key in seen_pairs:
+                    continue
+                # Wyklucz pary gdzie którykolwiek jest NotADuplicate
+                if key[0] in notadup_pks or key[1] in notadup_pks:
+                    seen_pairs.add(key)
+                    continue
+                score, reasons = analiza_pary_meta(meta[key[0]], meta[key[1]])
+                if score >= min_confidence:
+                    yield key[0], key[1], score, reasons
+                seen_pairs.add(key)
+    if skipped_buckets:
+        logger.info("Skipped %d oversized buckets in general phase", skipped_buckets)
+```
+
+- [ ] **Step 4: Run — pass**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_search_general.py -n auto 2>&1 | tee /tmp/dedup-task3-1.log
+```
+
+Expected: 6 zielonych.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): utils.search_general — generator par dla trybu general"
+```
+
+---
+
+### Task 3.2: Funkcja `_run_general_phase` w `tasks.py`
+
+**Files:**
+- Modify: `src/deduplikator_autorow/tasks.py`
+- Test: `src/deduplikator_autorow/tests/test_general_phase.py` (nowy)
+
+- [ ] **Step 1: Failing test**
+
+`src/deduplikator_autorow/tests/test_general_phase.py`:
+
+```python
+"""Testy fazy general w skanowaniu duplikatów."""
+
+import pytest
+from model_bakery import baker
+
+from deduplikator_autorow.models import (
+    DuplicateCandidate,
+    DuplicateScanRun,
+    IgnoredAuthor,
+    NotADuplicate,
+)
+from deduplikator_autorow.tasks import _run_general_phase
+
+
+@pytest.mark.django_db
+def test_general_finds_simple_pair():
+    """Dwóch autorów o tym samym nazwisku i imieniu, żaden nie ma OsobaZInstytucji
+    → powinna się utworzyć para w trybie general."""
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    scan = DuplicateScanRun.objects.create()
+    _run_general_phase(scan, min_confidence=50)
+    cands = DuplicateCandidate.objects.filter(scan_run=scan, scan_mode="general")
+    assert cands.count() == 1
+
+
+@pytest.mark.django_db
+def test_general_skips_cluster_with_osoba_instytucji():
+    """Klaster {A, B, C} gdzie B ma OsobaZInstytucji — klaster pominięty."""
+    a = baker.make("bpp.Autor", nazwisko="Nowak", imiona="Anna")
+    b = baker.make("bpp.Autor", nazwisko="Nowak", imiona="Anna")
+    c = baker.make("bpp.Autor", nazwisko="Nowak", imiona="Anna")
+    scientist = baker.make("pbn_api.Scientist", rekord_w_bpp=b)
+    baker.make("pbn_api.OsobaZInstytucji", personId=scientist)
+
+    scan = DuplicateScanRun.objects.create()
+    _run_general_phase(scan, min_confidence=50)
+    cands = DuplicateCandidate.objects.filter(scan_run=scan, scan_mode="general")
+    # Wszystkie trzy są w klastrze {a, b, c} — bo b ma OsobaZInstytucji,
+    # cały klaster jest pomijany.
+    assert cands.count() == 0
+    _ = (a, c)  # silence linters
+
+
+@pytest.mark.django_db
+def test_general_main_chosen_by_orcid():
+    """Z dwóch autorów ORCID-owany wygrywa jako main."""
+    a = baker.make("bpp.Autor", nazwisko="Adams", imiona="Eve", orcid=None)
+    b = baker.make(
+        "bpp.Autor", nazwisko="Adams", imiona="Eve", orcid="0000-0001-2345-6789"
+    )
+    scan = DuplicateScanRun.objects.create()
+    _run_general_phase(scan, min_confidence=50)
+    cand = DuplicateCandidate.objects.get(scan_run=scan, scan_mode="general")
+    assert cand.main_autor_id == b.pk
+    assert cand.duplicate_autor_id == a.pk
+
+
+@pytest.mark.django_db
+def test_general_pk_tiebreaker():
+    """Wszystko równe → niższy pk wygrywa jako main."""
+    a = baker.make("bpp.Autor", nazwisko="Black", imiona="Carl")
+    b = baker.make("bpp.Autor", nazwisko="Black", imiona="Carl")
+    lower_pk = min(a.pk, b.pk)
+    higher_pk = max(a.pk, b.pk)
+
+    scan = DuplicateScanRun.objects.create()
+    _run_general_phase(scan, min_confidence=50)
+    cand = DuplicateCandidate.objects.get(scan_run=scan, scan_mode="general")
+    assert cand.main_autor_id == lower_pk
+    assert cand.duplicate_autor_id == higher_pk
+
+
+@pytest.mark.django_db
+def test_general_respects_ignored_author():
+    a = baker.make("bpp.Autor", nazwisko="Yellow", imiona="Sun")
+    b = baker.make("bpp.Autor", nazwisko="Yellow", imiona="Sun")
+    user = baker.make("bpp.BppUser")
+    IgnoredAuthor.objects.create(autor=a, created_by=user)
+
+    scan = DuplicateScanRun.objects.create()
+    _run_general_phase(scan, min_confidence=50)
+    assert DuplicateCandidate.objects.filter(scan_run=scan).count() == 0
+    _ = b
+
+
+@pytest.mark.django_db
+def test_general_respects_not_a_duplicate():
+    a = baker.make("bpp.Autor", nazwisko="Green", imiona="Mike")
+    b = baker.make("bpp.Autor", nazwisko="Green", imiona="Mike")
+    user = baker.make("bpp.BppUser")
+    NotADuplicate.objects.create(autor=a, created_by=user)
+
+    scan = DuplicateScanRun.objects.create()
+    _run_general_phase(scan, min_confidence=50)
+    assert DuplicateCandidate.objects.filter(scan_run=scan).count() == 0
+    _ = b
+
+
+@pytest.mark.django_db
+def test_general_transitive_cluster():
+    """A~B and B~C ale ne A~C → klaster {A,B,C} z trzema parami pod jednym main."""
+    # Wszystkie z imieniem Jan, by zapewnić wysokie confidence
+    a = baker.make("bpp.Autor", nazwisko="Linker", imiona="Jan")
+    b = baker.make("bpp.Autor", nazwisko="Linker", imiona="Jan")
+    c = baker.make("bpp.Autor", nazwisko="Linker", imiona="Jan")
+    scan = DuplicateScanRun.objects.create()
+    _run_general_phase(scan, min_confidence=50)
+    cands = DuplicateCandidate.objects.filter(scan_run=scan, scan_mode="general")
+    # Klaster ma 3 członków → 2 par (main + 2 dup)
+    assert cands.count() == 2
+    main_pks = {c.main_autor_id for c in cands}
+    assert len(main_pks) == 1  # ten sam main dla wszystkich par
+    expected_main = min(a.pk, b.pk, c.pk)
+    assert main_pks == {expected_main}
+```
+
+- [ ] **Step 2: Run — fail**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_general_phase.py -n0 2>&1 | tee /tmp/dedup-task3-2.log
+```
+
+Expected: ImportError (`_run_general_phase` nie istnieje).
+
+- [ ] **Step 3: Dodaj funkcję `_run_general_phase` w `tasks.py`**
+
+W `src/deduplikator_autorow/tasks.py`, na dole pliku (przed `cancel_scan`), dodaj:
+
+```python
+def _run_general_phase(scan_run, min_confidence=MIN_CONFIDENCE_TO_STORE):
+    """Faza 2 skanu — duplikaty general.
+
+    Algorytm:
+    1. build_autor_meta — pre-load wszystkich autorów do pamięci.
+    2. build_buckets — grupowanie po znormalizowanym nazwisku.
+    3. generate_pairs — wszystkie pary kandydatów score-em >= min_confidence.
+    4. find_clusters — connected components z par.
+    5. cluster-skip — odrzuć klastry z OsobaZInstytucji.
+    6. pick_main_pk — hierarchia wyboru main.
+    7. emit DuplicateCandidate(scan_mode='general').
+    """
+    from .models import DuplicateCandidate, IgnoredAuthor, NotADuplicate
+    from .utils.analysis_meta import analiza_pary_meta
+    from .utils.cluster import find_clusters
+    from .utils.main_selection import pick_main_pk
+    from .utils.meta import build_autor_meta, build_buckets
+    from .utils.search_general import generate_pairs
+
+    logger.info("General phase: building meta cache...")
+    meta = build_autor_meta()
+    buckets = build_buckets(meta)
+    logger.info("General phase: %d autorów, %d bucketów", len(meta), len(buckets))
+
+    ignored_pks = set(IgnoredAuthor.objects.values_list("autor_id", flat=True))
+    notadup_pks = set(NotADuplicate.objects.values_list("autor_id", flat=True))
+
+    pairs_data: dict[tuple[int, int], tuple[int, list[str]]] = {}
+    for pk_a, pk_b, score, reasons in generate_pairs(
+        buckets, meta, ignored_pks, notadup_pks, min_confidence
+    ):
+        pairs_data[(pk_a, pk_b)] = (score, reasons)
+
+    logger.info("General phase: znaleziono %d par", len(pairs_data))
+
+    pair_keys = list(pairs_data.keys())
+    clusters = find_clusters(pair_keys)
+    logger.info("General phase: %d klastrów wstępnych", len(clusters))
+
+    skipped_count = 0
+    candidates_to_create: list[DuplicateCandidate] = []
+    for cluster in clusters:
+        # Cluster-skip jeśli ktokolwiek ma OsobaZInstytucji
+        if any(meta[pk]["ma_osoba_z_instytucji"] for pk in cluster):
+            skipped_count += 1
+            continue
+        main_pk = pick_main_pk(cluster, meta)
+        for dup_pk in cluster - {main_pk}:
+            key = (min(main_pk, dup_pk), max(main_pk, dup_pk))
+            score_reasons = pairs_data.get(key)
+            if score_reasons is None:
+                # Pair przechodnia — wylicz on-the-fly
+                score, reasons = analiza_pary_meta(meta[main_pk], meta[dup_pk])
+            else:
+                score, reasons = score_reasons
+            main_autor = meta[main_pk]["obj"]
+            dup_autor = meta[dup_pk]["obj"]
+            candidates_to_create.append(
+                DuplicateCandidate(
+                    scan_run=scan_run,
+                    main_autor=main_autor,
+                    duplicate_autor=dup_autor,
+                    confidence_score=score,
+                    confidence_percent=normalize_confidence(score),
+                    reasons=reasons,
+                    priority=calculate_author_priority(dup_autor),
+                    main_autor_name=str(main_autor),
+                    duplicate_autor_name=str(dup_autor),
+                    main_publications_count=meta[main_pk]["publikacje_count"],
+                    duplicate_publications_count=meta[dup_pk]["publikacje_count"],
+                    scan_mode="general",
+                )
+            )
+            if len(candidates_to_create) >= 1000:
+                with transaction.atomic():
+                    DuplicateCandidate.objects.bulk_create(
+                        candidates_to_create, ignore_conflicts=True
+                    )
+                candidates_to_create = []
+
+    if candidates_to_create:
+        with transaction.atomic():
+            DuplicateCandidate.objects.bulk_create(
+                candidates_to_create, ignore_conflicts=True
+            )
+
+    logger.info(
+        "General phase complete: %d klastrów pominiętych (z OsobaZInstytucji)",
+        skipped_count,
+    )
+```
+
+- [ ] **Step 4: Dodaj brakujące importy w `tasks.py`**
+
+Na górze pliku, jeśli nie ma:
+
+```python
+import logging
+logger = get_task_logger(__name__)  # już jest
+```
+
+- [ ] **Step 5: Run testy fazy general**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_general_phase.py -n auto 2>&1 | tee /tmp/dedup-task3-2.log
+```
+
+Expected: 7 zielonych.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): _run_general_phase w tasks.py — algorytm fazy general"
+```
+
+---
+
+### Task 3.3: Wyodrębnij `_run_pbn_phase`, połącz w `scan_for_duplicates` z PARTIAL_COMPLETED
+
+**Files:**
+- Modify: `src/deduplikator_autorow/tasks.py`
+- Test: `src/deduplikator_autorow/tests/test_combined_scan.py` (nowy)
+
+- [ ] **Step 1: Failing test**
+
+`src/deduplikator_autorow/tests/test_combined_scan.py`:
+
+```python
+"""Testy combined task scan_for_duplicates (PBN + general)."""
+
+from unittest import mock
+
+import pytest
+from model_bakery import baker
+
+from deduplikator_autorow.models import DuplicateCandidate, DuplicateScanRun
+from deduplikator_autorow.tasks import scan_for_duplicates
+
+
+@pytest.mark.django_db
+def test_combined_scan_runs_both_phases_status_completed():
+    """Sukces obu faz → status COMPLETED."""
+    # Pusta baza: brak OsobaZInstytucji, brak duplikatów Autor → szybko kończy
+    result = scan_for_duplicates.apply().result
+    assert result["status"] == "success"
+    scan = DuplicateScanRun.objects.get(pk=result["scan_run_id"])
+    assert scan.status == DuplicateScanRun.Status.COMPLETED
+
+
+@pytest.mark.django_db
+def test_combined_scan_general_finds_duplicates():
+    """Faza general dodaje DuplicateCandidate(scan_mode='general')."""
+    baker.make("bpp.Autor", nazwisko="Hawkins", imiona="Lee")
+    baker.make("bpp.Autor", nazwisko="Hawkins", imiona="Lee")
+    result = scan_for_duplicates.apply().result
+    scan = DuplicateScanRun.objects.get(pk=result["scan_run_id"])
+    assert (
+        DuplicateCandidate.objects.filter(scan_run=scan, scan_mode="general").count()
+        >= 1
+    )
+
+
+@pytest.mark.django_db
+def test_cancel_during_general_phase_leaves_partial_completed():
+    """Anulowanie w fazie 2 (general) → PARTIAL_COMPLETED."""
+    # Symulacja: faza PBN przechodzi (brak OsobaZInstytucji), w fazie general
+    # ustawiamy CANCELLED z innego procesu.
+    baker.make("bpp.Autor", nazwisko="Igor", imiona="Test")
+    baker.make("bpp.Autor", nazwisko="Igor", imiona="Test")
+
+    # Mock _run_general_phase żeby ustawić status na CANCELLED
+    def fake_general(scan_run, *args, **kwargs):
+        scan_run.status = DuplicateScanRun.Status.CANCELLED
+        scan_run.save(update_fields=["status"])
+
+    with mock.patch(
+        "deduplikator_autorow.tasks._run_general_phase", side_effect=fake_general
+    ):
+        result = scan_for_duplicates.apply().result
+
+    scan = DuplicateScanRun.objects.get(pk=result["scan_run_id"])
+    assert scan.status == DuplicateScanRun.Status.PARTIAL_COMPLETED
+    assert result["status"] == "partial_completed"
+
+
+@pytest.mark.django_db
+def test_cancel_during_pbn_phase_leaves_cancelled():
+    """Anulowanie w fazie 1 (PBN) → CANCELLED, faza 2 nie startuje."""
+
+    def fake_pbn(scan_run, *args, **kwargs):
+        scan_run.status = DuplicateScanRun.Status.CANCELLED
+        scan_run.save(update_fields=["status"])
+
+    with mock.patch(
+        "deduplikator_autorow.tasks._run_pbn_phase", side_effect=fake_pbn
+    ), mock.patch(
+        "deduplikator_autorow.tasks._run_general_phase"
+    ) as general_mock:
+        result = scan_for_duplicates.apply().result
+        general_mock.assert_not_called()
+
+    scan = DuplicateScanRun.objects.get(pk=result["scan_run_id"])
+    assert scan.status == DuplicateScanRun.Status.CANCELLED
+    assert result["status"] == "cancelled"
+
+
+@pytest.mark.django_db
+def test_phase_field_set_during_run():
+    """Pole phase jest ustawiane: 'pbn' przy rozpoczęciu fazy 1, 'general' fazy 2."""
+    phases_seen = []
+
+    original_pbn = None
+    original_general = None
+
+    from deduplikator_autorow import tasks
+
+    original_pbn = tasks._run_pbn_phase
+    original_general = tasks._run_general_phase
+
+    def spy_pbn(scan_run, *a, **kw):
+        scan_run.refresh_from_db()
+        phases_seen.append(("pbn", scan_run.phase))
+        return original_pbn(scan_run, *a, **kw)
+
+    def spy_general(scan_run, *a, **kw):
+        scan_run.refresh_from_db()
+        phases_seen.append(("general", scan_run.phase))
+        return original_general(scan_run, *a, **kw)
+
+    with mock.patch.object(tasks, "_run_pbn_phase", spy_pbn), mock.patch.object(
+        tasks, "_run_general_phase", spy_general
+    ):
+        scan_for_duplicates.apply()
+
+    # phase ustawiane PRZED wejściem do każdej fazy
+    assert phases_seen == [("pbn", "pbn"), ("general", "general")]
+```
+
+- [ ] **Step 2: Run — fail**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_combined_scan.py -n0 2>&1 | tee /tmp/dedup-task3-3.log
+```
+
+Expected: testy zawodzą — bo `scan_for_duplicates` jeszcze nie wykonuje fazy general / nie obsługuje PARTIAL_COMPLETED / `_run_pbn_phase` nie istnieje jako osobna funkcja.
+
+- [ ] **Step 3: Wyodrębnij `_run_pbn_phase`**
+
+W `src/deduplikator_autorow/tasks.py`, **wytnij** body istniejącego taska `scan_for_duplicates` (od `try:` do return-ów) do nowej funkcji prywatnej `_run_pbn_phase(scan_run, min_confidence)`. Sygnatura:
+
+```python
+def _run_pbn_phase(scan_run, min_confidence=MIN_CONFIDENCE_TO_STORE):
+    """Faza 1 skanu — duplikaty PBN (iteracja po OsobaZInstytucji).
+
+    To jest dotychczasowa logika scan_for_duplicates wyciągnięta do funkcji.
+    Modyfikuje scan_run in-place. Wszystkie tworzone DuplicateCandidate mają
+    scan_mode='pbn' (default).
+
+    Sprawdza scan_run.status == CANCELLED na każdej iteracji — jeśli tak,
+    przerywa wcześniej (return).
+    """
+    from pbn_api.models import OsobaZInstytucji
+
+    from .models import DuplicateCandidate, IgnoredScientist  # uwaga: rename
+    # ... (cała dotychczasowa logika)
+```
+
+**Uwaga:** zmień `IgnoredAuthor` na `IgnoredScientist` w referencjach (ten model był renamowany w Task 1.1, ale jeśli ten plik dalej zawiera starą nazwę — to bug. Sprawdź.):
+
+```bash
+grep -n "IgnoredAuthor\|IgnoredScientist" src/deduplikator_autorow/tasks.py
+```
+
+Powinien używać `IgnoredScientist` po Task 1.1.
+
+`_run_pbn_phase` powinien zachować scan_mode='pbn' implicite (default na DuplicateCandidate). Jeśli istniejąca logika tworzy `DuplicateCandidate(...)` w `_process_duplicate_info`, default `scan_mode='pbn'` wystarczy (po Task 1.3).
+
+- [ ] **Step 4: Przepisz `scan_for_duplicates`**
+
+```python
+@shared_task(bind=True, name="deduplikator_autorow.scan_for_duplicates")
+def scan_for_duplicates(self, user_id=None, min_confidence=MIN_CONFIDENCE_TO_STORE):
+    """Combined task: faza PBN + faza general w jednym przebiegu.
+
+    Statusy końcowe:
+    - COMPLETED: obie fazy ukończone.
+    - PARTIAL_COMPLETED: faza PBN OK, faza general anulowana → wyniki PBN dostępne.
+    - CANCELLED: faza PBN anulowana → brak wyników.
+    - FAILED: nieobsłużony wyjątek.
+    """
+    from .models import DuplicateCandidate, DuplicateScanRun
+
+    user = _get_user_by_id(user_id)
+    scan_run = DuplicateScanRun.objects.create(
+        status=DuplicateScanRun.Status.RUNNING,
+        created_by=user,
+        celery_task_id=self.request.id or "",
+    )
+
+    try:
+        # Replace mode — clear poprzednie kandydaci (pending wszystkich trybów)
+        DuplicateCandidate.objects.all().delete()
+
+        # FAZA 1: PBN
+        scan_run.phase = "pbn"
+        scan_run.save(update_fields=["phase"])
+        _run_pbn_phase(scan_run, min_confidence)
+        scan_run.refresh_from_db()
+        if scan_run.status == DuplicateScanRun.Status.CANCELLED:
+            scan_run.finished_at = timezone.now()
+            scan_run.save(update_fields=["finished_at"])
+            logger.info("Scan cancelled in PBN phase")
+            return {
+                "status": "cancelled",
+                "scan_run_id": scan_run.pk,
+            }
+
+        # FAZA 2: general
+        scan_run.phase = "general"
+        scan_run.save(update_fields=["phase"])
+        _run_general_phase(scan_run, min_confidence)
+        scan_run.refresh_from_db()
+        if scan_run.status == DuplicateScanRun.Status.CANCELLED:
+            scan_run.status = DuplicateScanRun.Status.PARTIAL_COMPLETED
+            scan_run.finished_at = timezone.now()
+            scan_run.save(update_fields=["status", "finished_at"])
+            logger.info("Scan cancelled in general phase → PARTIAL_COMPLETED")
+            return {
+                "status": "partial_completed",
+                "scan_run_id": scan_run.pk,
+            }
+
+        # Sukces obu faz
+        total_cands = DuplicateCandidate.objects.filter(scan_run=scan_run).count()
+        scan_run.status = DuplicateScanRun.Status.COMPLETED
+        scan_run.finished_at = timezone.now()
+        scan_run.duplicates_found = total_cands
+        scan_run.save()
+        return {
+            "status": "success",
+            "scan_run_id": scan_run.pk,
+            "duplicates_found": total_cands,
+        }
+
+    except Exception as e:
+        logger.exception("Error during duplicate scan")
+        scan_run.status = DuplicateScanRun.Status.FAILED
+        scan_run.finished_at = timezone.now()
+        scan_run.error_message = str(e)
+        scan_run.save()
+        return {
+            "status": "error",
+            "scan_run_id": scan_run.pk,
+            "error": str(e),
+        }
+```
+
+- [ ] **Step 5: Run testy combined**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_combined_scan.py -n auto 2>&1 | tee /tmp/dedup-task3-3.log
+```
+
+Expected: 5 zielonych.
+
+- [ ] **Step 6: Run wszystkie istniejące testy task-ów**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_tasks.py -n auto 2>&1 | tee /tmp/dedup-task3-3-existing.log
+```
+
+Expected: stare testy też zielone (mogą wymagać drobnych poprawek po refactorze, ale logika PBN niezmieniona).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): scan_for_duplicates dwufazowo (PBN + general) z PARTIAL_COMPLETED"
+```
+
+---
+
+## Phase 4: Views + URLs
+
+### Task 4.1: `get_latest_usable_scan` helper
+
+**Files:**
+- Modify: `src/deduplikator_autorow/utils/counters.py`
+- Modify: `src/deduplikator_autorow/views.py`
+
+- [ ] **Step 1: Dodaj helper w `counters.py`**
+
+W `src/deduplikator_autorow/utils/counters.py`, **po** `get_latest_completed_scan`, dodaj:
+
+```python
+def get_latest_usable_scan():
+    """Pobiera ostatnie skanowanie z użytecznymi wynikami.
+
+    "Użyteczne" = COMPLETED lub PARTIAL_COMPLETED (faza PBN ukończona,
+    nawet jeśli general anulowana).
+
+    Returns:
+        DuplicateScanRun lub None
+    """
+    return (
+        DuplicateScanRun.objects.filter(
+            status__in=[
+                DuplicateScanRun.Status.COMPLETED,
+                DuplicateScanRun.Status.PARTIAL_COMPLETED,
+            ]
+        )
+        .order_by("-finished_at")
+        .first()
+    )
+```
+
+- [ ] **Step 2: Zaktualizuj wszystkie odwołania w `views.py`**
+
+W `src/deduplikator_autorow/views.py`, znajdź `get_latest_completed_scan` i zamień na `get_latest_usable_scan`. Konkretnie, **lokalna definicja** `get_latest_completed_scan()` w views.py (linia ~643) — usuń ją (jest reimplementacją utils-owej), zamiast tego importuj `get_latest_usable_scan` z `.utils.counters`.
+
+- [ ] **Step 3: Run istniejące testy widoków**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_views_permissions.py -n auto 2>&1 | tee /tmp/dedup-task4-1.log
+```
+
+Expected: zielone (zmiana interfejsu, nie semantyki).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): get_latest_usable_scan — uwzględnia PARTIAL_COMPLETED"
+```
+
+---
+
+### Task 4.2: Filtr `mode` w `duplicate_authors_view`
+
+**Files:**
+- Modify: `src/deduplikator_autorow/views.py`
+- Test: `src/deduplikator_autorow/tests/test_view_mode_filter.py` (nowy)
+
+- [ ] **Step 1: Failing test**
+
+`src/deduplikator_autorow/tests/test_view_mode_filter.py`:
+
+```python
+"""Testy filtra mode w widoku duplicate_authors."""
+
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+from deduplikator_autorow.models import DuplicateCandidate, DuplicateScanRun
+
+
+@pytest.fixture
+def user_with_perms(client, db):
+    user = baker.make("bpp.BppUser", is_active=True)
+    user.set_password("xx")
+    user.save()
+    grp, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    user.groups.add(grp)
+    client.force_login(user)
+    return user
+
+
+@pytest.fixture
+def scan_with_both_modes(db):
+    from django.utils import timezone
+
+    scan = DuplicateScanRun.objects.create(
+        status=DuplicateScanRun.Status.COMPLETED,
+        finished_at=timezone.now(),
+    )
+    a1 = baker.make("bpp.Autor", nazwisko="Pbn1", imiona="Jan")
+    a2 = baker.make("bpp.Autor", nazwisko="Pbn1", imiona="Jan")
+    g1 = baker.make("bpp.Autor", nazwisko="Gen1", imiona="Anna")
+    g2 = baker.make("bpp.Autor", nazwisko="Gen1", imiona="Anna")
+    DuplicateCandidate.objects.create(
+        scan_run=scan, main_autor=a1, duplicate_autor=a2,
+        confidence_score=80, confidence_percent=0.6,
+        main_autor_name="Pbn1 Jan", duplicate_autor_name="Pbn1 Jan",
+        scan_mode="pbn",
+    )
+    DuplicateCandidate.objects.create(
+        scan_run=scan, main_autor=g1, duplicate_autor=g2,
+        confidence_score=80, confidence_percent=0.6,
+        main_autor_name="Gen1 Anna", duplicate_autor_name="Gen1 Anna",
+        scan_mode="general",
+    )
+    return scan
+
+
+def test_view_mode_filter_pbn(client, user_with_perms, scan_with_both_modes):
+    response = client.get(
+        reverse("deduplikator_autorow:duplicate_authors") + "?mode=pbn"
+    )
+    assert response.status_code == 200
+    # Powinien pokazać Pbn1, NIE Gen1
+    content = response.content.decode()
+    assert "Pbn1" in content
+    assert "Gen1" not in content
+
+
+def test_view_mode_filter_general(client, user_with_perms, scan_with_both_modes):
+    response = client.get(
+        reverse("deduplikator_autorow:duplicate_authors") + "?mode=general"
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Gen1" in content
+    assert "Pbn1" not in content
+
+
+def test_view_mode_filter_both(client, user_with_perms, scan_with_both_modes):
+    """Default 'both' lub explicit — pokazuje pierwszego (PBN preferowane jako kanoniczne)."""
+    response = client.get(
+        reverse("deduplikator_autorow:duplicate_authors") + "?mode=both"
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    # Co najmniej jeden z dwóch widoczny — najprawdopodobniej PBN
+    assert "Pbn1" in content or "Gen1" in content
+```
+
+- [ ] **Step 2: Run — fail**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_view_mode_filter.py -n0 2>&1 | tee /tmp/dedup-task4-2.log
+```
+
+- [ ] **Step 3: Modyfikuj `duplicate_authors_view`**
+
+W `src/deduplikator_autorow/views.py`:
+
+(a) Na początku funkcji `duplicate_authors_view`, po `latest_pbn_download = ...`, dodaj:
+
+```python
+mode = request.GET.get("mode", "both")
+if mode not in ("pbn", "general", "both"):
+    mode = "both"
+context["mode"] = mode
+```
+
+(b) Tam gdzie `DuplicateCandidate.objects.filter(scan_run=completed_scan, status=PENDING)` — dodaj:
+
+```python
+candidates_qs = DuplicateCandidate.objects.filter(
+    scan_run=completed_scan, status=DuplicateCandidate.Status.PENDING
+)
+if mode != "both":
+    candidates_qs = candidates_qs.filter(scan_mode=mode)
+```
+
+(c) Counters per mode:
+
+```python
+context["pending_pbn_count"] = DuplicateCandidate.objects.filter(
+    scan_run=completed_scan,
+    status=DuplicateCandidate.Status.PENDING,
+    scan_mode="pbn",
+).count()
+context["pending_general_count"] = DuplicateCandidate.objects.filter(
+    scan_run=completed_scan,
+    status=DuplicateCandidate.Status.PENDING,
+    scan_mode="general",
+).count()
+```
+
+(d) `_get_next_candidate_group` — dodaj parametr `mode`:
+
+```python
+def _get_next_candidate_group(scan_run, skip_count=0, mode="both"):
+    qs = DuplicateCandidate.objects.filter(
+        scan_run=scan_run,
+        status=DuplicateCandidate.Status.PENDING,
+    )
+    if mode != "both":
+        qs = qs.filter(scan_mode=mode)
+    distinct_main_autor_ids = (
+        qs.order_by("scan_mode", "-priority", "-confidence_score", "main_autor_id")
+        # PBN przed general (alfabetycznie 'general' < 'pbn' więc trzeba tweak):
+        # użyj Case/When albo: ordering po -scan_mode da 'pbn' przed 'general'
+        # tu używamy Case dla jasności
+        .values_list("main_autor_id", flat=True)
+        .distinct()
+    )
+    # ... reszta jak dziś
+```
+
+**Uwaga sortowania w trybie `both`:** Spec wymaga `pbn` przed `general`. Zwykła kolejność alfabetyczna ASC `general < pbn`. Trzeba odwrócić: `.order_by(... )` z polem mapującym `scan_mode='pbn'` na 0 i `'general'` na 1. Najprościej:
+
+```python
+from django.db.models import Case, IntegerField, Value, When
+
+qs = qs.annotate(
+    mode_order=Case(
+        When(scan_mode="pbn", then=Value(0)),
+        When(scan_mode="general", then=Value(1)),
+        default=Value(2),
+        output_field=IntegerField(),
+    )
+).order_by("mode_order", "-priority", "-confidence_score", "main_autor_id")
+```
+
+(e) Wywołanie `_get_next_candidate_group(completed_scan, skip_count=skip_count, mode=mode)` w widoku.
+
+- [ ] **Step 4: Run testy**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_view_mode_filter.py -n auto 2>&1 | tee /tmp/dedup-task4-2.log
+```
+
+Expected: 3 zielone.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): filtr mode (pbn/general/both) w widoku"
+```
+
+---
+
+### Task 4.3: `scal_autorow_view` — backwards-compat dla Autor PK
+
+**Files:**
+- Modify: `src/deduplikator_autorow/views.py`
+- Test: `src/deduplikator_autorow/tests/test_scal_view.py` (nowy)
+
+- [ ] **Step 1: Failing test**
+
+```python
+"""Testy backwards-compat dla scal_autorow_view."""
+
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+
+
+@pytest.fixture
+def auth_client(client, db):
+    user = baker.make("bpp.BppUser", is_active=True)
+    user.set_password("xx"); user.save()
+    grp, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    user.groups.add(grp)
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+def test_scal_autorow_accepts_main_autor_id(auth_client):
+    main = baker.make("bpp.Autor")
+    dup = baker.make("bpp.Autor")
+    response = auth_client.post(
+        reverse("deduplikator_autorow:scal_autorow"),
+        {
+            "main_autor_id": main.pk,
+            "duplicate_autor_id": dup.pk,
+            "skip_pbn": "true",
+        },
+    )
+    assert response.status_code in (200, 500)  # 500 OK gdy brak publikacji do scalania
+    # Test że view nie zwrócił 400 z "Brak parametrów"
+    assert b"Brak wymaganych" not in response.content
+
+
+@pytest.mark.django_db
+def test_scal_autorow_backwards_compat_scientist_ids(auth_client):
+    """Stare parametry main_scientist_id / duplicate_scientist_id mapują na Autor PK."""
+    main = baker.make("bpp.Autor")
+    dup = baker.make("bpp.Autor")
+    main_sci = baker.make("pbn_api.Scientist", rekord_w_bpp=main)
+    dup_sci = baker.make("pbn_api.Scientist", rekord_w_bpp=dup)
+
+    response = auth_client.post(
+        reverse("deduplikator_autorow:scal_autorow"),
+        {
+            "main_scientist_id": main_sci.pk,
+            "duplicate_scientist_id": dup_sci.pk,
+            "skip_pbn": "true",
+        },
+    )
+    assert response.status_code in (200, 500)
+    assert b"Brak wymaganych" not in response.content
+```
+
+- [ ] **Step 2: Run — fail**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_scal_view.py -n0 2>&1
+```
+
+- [ ] **Step 3: Modyfikuj `scal_autorow_view`**
+
+W `src/deduplikator_autorow/views.py`, w `scal_autorow_view`:
+
+(a) Czytaj wszystkie warianty parametrów:
+
+```python
+def _read_id(request, *names):
+    for name in names:
+        val = request.GET.get(name) or request.POST.get(name)
+        if val:
+            return val
+    return None
+
+main_autor_id = _read_id(request, "main_autor_id")
+duplicate_autor_id = _read_id(request, "duplicate_autor_id")
+
+# Backwards-compat: jeśli przyszły scientist_id, mapuj na Autor.pk
+if not main_autor_id:
+    main_scientist_id = _read_id(request, "main_scientist_id")
+    if main_scientist_id:
+        try:
+            sci = Scientist.objects.get(pk=main_scientist_id)
+            if sci.rekord_w_bpp:
+                main_autor_id = sci.rekord_w_bpp.pk
+        except Scientist.DoesNotExist:
+            pass
+
+if not duplicate_autor_id:
+    duplicate_scientist_id = _read_id(request, "duplicate_scientist_id")
+    if duplicate_scientist_id:
+        try:
+            sci = Scientist.objects.get(pk=duplicate_scientist_id)
+            if sci.rekord_w_bpp:
+                duplicate_autor_id = sci.rekord_w_bpp.pk
+        except Scientist.DoesNotExist:
+            pass
+```
+
+(b) Walidacja:
+
+```python
+if not main_autor_id or not duplicate_autor_id:
+    return JsonResponse(
+        {"success": False, "error": "Brak wymaganych parametrów: main_autor_id i duplicate_autor_id"},
+        status=400,
+    )
+```
+
+(c) Wywołanie `scal_autorow` (utility) — sprawdź jego sygnaturę. Funkcja `scal_autora` w `utils/merge.py` przyjmuje obiekty `Autor`, więc:
+
+```python
+main_autor = Autor.objects.get(pk=main_autor_id)
+duplicate_autor = Autor.objects.get(pk=duplicate_autor_id)
+result = scal_autora(
+    main_autor, duplicate_autor, request.user,
+    skip_pbn=skip_pbn,
+    auto_assign_discipline=auto_assign_discipline,
+    use_subdiscipline=use_subdiscipline,
+)
+```
+
+**Uwaga:** funkcja-wrapper `scal_autorow(main_scientist_id, duplicate_scientist_id, user, ...)` z `utils/merge.py` używała Scientist.pk. Zachowaj ją (dla backwards-compat zewnętrznych callerów), ale wewnętrznie view używa `scal_autora` bezpośrednio.
+
+- [ ] **Step 4: Run testy**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_scal_view.py -n auto
+```
+
+Expected: 2 zielone.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): scal_autorow_view akceptuje main_autor_id (backwards-compat scientist_id)"
+```
+
+---
+
+### Task 4.4: `ignore_autor` + rename `ignore_author` → `ignore_scientist`
+
+**Files:**
+- Modify: `src/deduplikator_autorow/views.py`
+- Modify: `src/deduplikator_autorow/urls.py`
+- Test: `src/deduplikator_autorow/tests/test_ignore_views.py` (nowy)
+
+- [ ] **Step 1: Failing test**
+
+`src/deduplikator_autorow/tests/test_ignore_views.py`:
+
+```python
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+from deduplikator_autorow.models import IgnoredAuthor, IgnoredScientist
+
+
+@pytest.fixture
+def auth_client(client, db):
+    user = baker.make("bpp.BppUser", is_active=True)
+    user.set_password("xx"); user.save()
+    grp, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    user.groups.add(grp)
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+def test_ignore_scientist_endpoint(auth_client):
+    sci = baker.make("pbn_api.Scientist")
+    response = auth_client.post(
+        reverse("deduplikator_autorow:ignore_scientist"),
+        {"scientist_id": sci.pk, "reason": "test"},
+    )
+    assert response.status_code == 302  # redirect
+    assert IgnoredScientist.objects.filter(scientist=sci).exists()
+
+
+@pytest.mark.django_db
+def test_ignore_autor_endpoint(auth_client):
+    autor = baker.make("bpp.Autor")
+    response = auth_client.post(
+        reverse("deduplikator_autorow:ignore_autor"),
+        {"autor_id": autor.pk, "reason": "test"},
+    )
+    assert response.status_code == 302
+    assert IgnoredAuthor.objects.filter(autor=autor).exists()
+
+
+@pytest.mark.django_db
+def test_reset_ignored_autorzy(auth_client):
+    autor = baker.make("bpp.Autor")
+    user = baker.make("bpp.BppUser")
+    IgnoredAuthor.objects.create(autor=autor, created_by=user)
+    response = auth_client.post(
+        reverse("deduplikator_autorow:reset_ignored_autorzy")
+    )
+    assert response.status_code == 302
+    assert IgnoredAuthor.objects.count() == 0
+```
+
+- [ ] **Step 2: Run — fail (URL not found)**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_ignore_views.py -n0
+```
+
+- [ ] **Step 3: Zaktualizuj `views.py`**
+
+(a) Przemianuj `ignore_author` → `ignore_scientist` (zachowuje swoją logikę, tylko zmiana nazwy + zapis do `IgnoredScientist`).
+
+(b) Zaktualizuj `reset_ignored_authors` → `reset_ignored_scientists` (kasuje `IgnoredScientist`).
+
+(c) Dodaj nową funkcję `ignore_autor`:
+
+```python
+@group_required(GR_WPROWADZANIE_DANYCH)
+@require_http_methods(["POST"])
+def ignore_autor(request):
+    autor_id = request.POST.get("autor_id")
+    reason = request.POST.get("reason", "")
+    if not autor_id:
+        messages.error(request, "Brak wymaganego parametru: autor_id")
+        return redirect("deduplikator_autorow:duplicate_authors")
+    try:
+        autor = Autor.objects.get(pk=autor_id)
+        if IgnoredAuthor.objects.filter(autor=autor).exists():
+            messages.warning(request, f"Autor {autor} jest już ignorowany.")
+        else:
+            IgnoredAuthor.objects.create(
+                autor=autor, reason=reason, created_by=request.user
+            )
+            messages.success(request, f"Autor {autor} oznaczony jako ignorowany.")
+    except Autor.DoesNotExist:
+        messages.error(request, f"Nie znaleziono autora o ID: {autor_id}")
+    return redirect("deduplikator_autorow:duplicate_authors")
+```
+
+(d) Dodaj `reset_ignored_autorzy`:
+
+```python
+@group_required(GR_WPROWADZANIE_DANYCH)
+@require_http_methods(["POST"])
+def reset_ignored_autorzy(request):
+    count = IgnoredAuthor.objects.count()
+    IgnoredAuthor.objects.all().delete()
+    messages.success(request, f"Zresetowano {count} ignorowanych autorów (BPP).")
+    return redirect("deduplikator_autorow:duplicate_authors")
+```
+
+Dodaj import `IgnoredAuthor` na górze pliku.
+
+- [ ] **Step 4: Zaktualizuj `urls.py`**
+
+W `src/deduplikator_autorow/urls.py`:
+
+```python
+urlpatterns = [
+    path("duplicate-authors/", views.duplicate_authors_view, name="duplicate_authors"),
+    path("mark-non-duplicate/", views.mark_non_duplicate, name="mark_non_duplicate"),
+    path("reset-skipped-authors/", views.reset_skipped_authors, name="reset_skipped_authors"),
+    path("reset-not-duplicates/", views.reset_not_duplicates, name="reset_not_duplicates"),
+    # Ignore PBN Scientist (rename z ignore-author)
+    path("ignore-scientist/", views.ignore_scientist, name="ignore_scientist"),
+    path("reset-ignored-scientists/", views.reset_ignored_scientists, name="reset_ignored_scientists"),
+    # Ignore Autor BPP (nowy)
+    path("ignore-autor/", views.ignore_autor, name="ignore_autor"),
+    path("reset-ignored-autorzy/", views.reset_ignored_autorzy, name="reset_ignored_autorzy"),
+    # Reszta jak dziś
+    path("delete-author/", views.delete_author, name="delete_author"),
+    path("scal-autorow/", views.scal_autorow_view, name="scal_autorow"),
+    path("download-duplicates-xlsx/", views.download_duplicates_xlsx, name="download_duplicates_xlsx"),
+    path("start-scan/", views.start_scan_view, name="start_scan"),
+    path("cancel-scan/", views.cancel_scan_view, name="cancel_scan"),
+    path("scan-status/<int:scan_id>/", views.scan_status_view, name="scan_status"),
+    path("mark-candidate-not-duplicate/", views.mark_candidate_not_duplicate, name="mark_candidate_not_duplicate"),
+]
+```
+
+- [ ] **Step 5: Run testy**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_ignore_views.py -n auto
+```
+
+Expected: 3 zielone.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): ignore_autor + ignore_scientist (rename z ignore_author)"
+```
+
+---
+
+## Phase 5: Template — radio mode + badges + banner + counters
+
+### Task 5.1: Mode radio, badges, counters, PARTIAL_COMPLETED banner
+
+**Files:**
+- Modify: `src/deduplikator_autorow/templates/deduplikator_autorow/duplicate_authors.html`
+- Modify: `src/deduplikator_autorow/static/deduplikator_autorow/scss/*.scss` (jeśli potrzeba badge styling)
+
+- [ ] **Step 1: Czytaj obecny template**
+
+```bash
+sed -n '1,50p' src/deduplikator_autorow/templates/deduplikator_autorow/duplicate_authors.html
+```
+
+- [ ] **Step 2: Dodaj radio + counters w nagłówku**
+
+W sekcji nagłówka strony, po existing scan-status box, dodaj:
+
+```html
+{# Mode filter #}
+<div class="row deduplikator-autorow__mode-filter">
+  <div class="small-12 columns">
+    <strong>Pokaż wyniki:</strong>
+    <label>
+      <input type="radio" name="mode" value="pbn"
+             {% if mode == "pbn" %}checked{% endif %}
+             onchange="location.href='?mode=pbn'">
+      PBN ({{ pending_pbn_count }})
+    </label>
+    <label>
+      <input type="radio" name="mode" value="general"
+             {% if mode == "general" %}checked{% endif %}
+             onchange="location.href='?mode=general'">
+      Ogólny ({{ pending_general_count }})
+    </label>
+    <label>
+      <input type="radio" name="mode" value="both"
+             {% if mode == "both" or not mode %}checked{% endif %}
+             onchange="location.href='?mode=both'">
+      Oba
+    </label>
+  </div>
+</div>
+```
+
+- [ ] **Step 3: Banner dla PARTIAL_COMPLETED**
+
+Po komunikatach Django messages, dodaj:
+
+```html
+{% if completed_scan and completed_scan.status == "partial_completed" %}
+  <div class="callout warning deduplikator-autorow__partial-banner">
+    <strong>Skanowanie częściowo zakończone:</strong>
+    Faza ogólna została anulowana. Wyniki PBN są dostępne, ale duplikaty
+    ogólne nie zostały przeskanowane. Uruchom skan ponownie, aby zobaczyć
+    wszystkie duplikaty.
+  </div>
+{% endif %}
+```
+
+- [ ] **Step 4: Badge per główny autor**
+
+Tam gdzie wyświetla się nagłówek głównego autora (`{{ glowny_autor }}`), dodaj badge przed lub obok:
+
+```html
+{% if first_candidate.scan_mode == "pbn" %}
+  <span class="deduplikator-autorow__badge deduplikator-autorow__badge--pbn">PBN</span>
+{% elif first_candidate.scan_mode == "general" %}
+  <span class="deduplikator-autorow__badge deduplikator-autorow__badge--general">OGÓLNY</span>
+{% endif %}
+```
+
+Trzeba przekazać `first_candidate` z `views.py` (np. pierwszy z `candidates_for_author`).
+
+W `views.py`, po `candidates_for_author = ...`:
+
+```python
+context["first_candidate"] = (
+    candidates_for_author.first() if candidates_for_author else None
+)
+```
+
+- [ ] **Step 5: Dodaj progress fazy**
+
+W bloku scan-progress (jeżeli `running_scan`):
+
+```html
+{% if running_scan %}
+<div class="deduplikator-autorow__scan-progress">
+  Faza: <strong>{{ running_scan.get_phase_display|default:"-" }}</strong>
+  ({{ running_scan.progress_percent }}%)
+</div>
+{% endif %}
+```
+
+- [ ] **Step 6: Style SCSS dla badge**
+
+W `src/deduplikator_autorow/static/deduplikator_autorow/scss/_deduplikator-autorow.scss` (lub odpowiedni partial):
+
+```scss
+.deduplikator-autorow {
+  &__badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: 0.75em;
+    font-weight: 600;
+    color: #fff;
+
+    &--pbn {
+      background-color: #2196f3;
+    }
+
+    &--general {
+      background-color: #ff9800;
+    }
+  }
+
+  &__partial-banner {
+    margin: 1em 0;
+  }
+
+  &__mode-filter {
+    margin: 1em 0;
+    label {
+      margin-right: 1.5em;
+    }
+  }
+}
+```
+
+- [ ] **Step 7: Build SCSS**
+
+```bash
+cd ~/Programowanie/bpp-worktrees/deduplikator-autorow-general
+grunt build 2>&1 | tee /tmp/dedup-grunt.log
+```
+
+Expected: build OK, brak SCSS-error.
+
+- [ ] **Step 8: Smoke-test view**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_view_mode_filter.py src/deduplikator_autorow/tests/test_views_permissions.py -n auto
+```
+
+Expected: zielone.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): UI — radio mode, badges, banner PARTIAL_COMPLETED, fazy progress"
+```
+
+---
+
+## Phase 6: XLSX z kolumną Tryb
+
+### Task 6.1: Kolumna "Tryb" w XLSX
+
+**Files:**
+- Modify: `src/deduplikator_autorow/utils/export.py`
+- Test: `src/deduplikator_autorow/tests/test_xlsx_export.py` (modify)
+
+- [ ] **Step 1: Failing test (zaktualizuj istniejący)**
+
+W `src/deduplikator_autorow/tests/test_xlsx_export.py`, dodaj:
+
+```python
+import pytest
+from io import BytesIO
+from openpyxl import load_workbook
+from model_bakery import baker
+
+from deduplikator_autorow.models import DuplicateCandidate, DuplicateScanRun
+from deduplikator_autorow.utils.export import export_duplicates_to_xlsx
+
+
+@pytest.mark.django_db
+def test_xlsx_export_includes_tryb_column():
+    scan = DuplicateScanRun.objects.create(status=DuplicateScanRun.Status.COMPLETED)
+    a1 = baker.make("bpp.Autor", nazwisko="X", imiona="A")
+    a2 = baker.make("bpp.Autor", nazwisko="X", imiona="A")
+    b1 = baker.make("bpp.Autor", nazwisko="Y", imiona="B")
+    b2 = baker.make("bpp.Autor", nazwisko="Y", imiona="B")
+    DuplicateCandidate.objects.create(
+        scan_run=scan, main_autor=a1, duplicate_autor=a2,
+        confidence_score=80, confidence_percent=0.6,
+        main_autor_name="X A", duplicate_autor_name="X A",
+        scan_mode="pbn",
+    )
+    DuplicateCandidate.objects.create(
+        scan_run=scan, main_autor=b1, duplicate_autor=b2,
+        confidence_score=80, confidence_percent=0.6,
+        main_autor_name="Y B", duplicate_autor_name="Y B",
+        scan_mode="general",
+    )
+    content = export_duplicates_to_xlsx()
+    wb = load_workbook(BytesIO(content))
+    ws = wb.active
+    headers = [c.value for c in ws[1]]
+    assert "Tryb" in headers
+
+    tryb_col_idx = headers.index("Tryb") + 1  # 1-indexed
+    tryby = [ws.cell(row=r, column=tryb_col_idx).value for r in range(2, 4)]
+    assert "PBN" in tryby
+    assert "Ogólny" in tryby
+```
+
+- [ ] **Step 2: Run — fail**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_xlsx_export.py::test_xlsx_export_includes_tryb_column -n0
+```
+
+- [ ] **Step 3: Modyfikuj `export.py`**
+
+W `_build_candidate_row`, dodaj na końcu listy:
+
+```python
+return [
+    main_name,
+    main.pk,
+    f"{site_domain}/bpp/autor/{main.pk}/",
+    main.pbn_uid_id or "",
+    _create_pbn_url(main.pbn_uid_id),
+    dup_name,
+    dup.pk,
+    f"{site_domain}/bpp/autor/{dup.pk}/",
+    dup.pbn_uid_id or "",
+    _create_pbn_url(dup.pbn_uid_id),
+    round(candidate.confidence_percent, 2),
+    duplicate_counts[candidate.main_autor_id],
+    "PBN" if candidate.scan_mode == "pbn" else "Ogólny",  # NOWA KOLUMNA
+]
+```
+
+W `headers`:
+
+```python
+headers = [
+    "Główny autor",
+    "BPP ID głównego autora",
+    "BPP URL głównego autora",
+    "PBN UID głównego autora",
+    "PBN URL głównego autora",
+    "Duplikat",
+    "BPP ID duplikatu",
+    "BPP URL duplikatu",
+    "PBN UID duplikatu",
+    "PBN URL duplikatu",
+    "Pewność podobieństwa",
+    "Ilość duplikatów",
+    "Tryb",  # NOWA
+]
+```
+
+W `export_duplicates_to_xlsx`, w queryset NIE dodawaj filtra na `scan_mode` (eksportujemy oba).
+
+- [ ] **Step 4: Run testy**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/test_xlsx_export.py -n auto
+```
+
+Expected: zielone (i nowy test też).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(deduplikator): kolumna Tryb w XLSX export"
+```
+
+---
+
+## Phase 7: Newsfragment + finalizacja
+
+### Task 7.1: Newsfragment towncrier
+
+**Files:**
+- Create: `src/bpp/newsfragments/<NUMER>.feature` (np. `1100.feature`)
+
+- [ ] **Step 1: Sprawdź istniejące numery**
+
+```bash
+ls src/bpp/newsfragments/ | grep -E '^\d+\.' | sort -n | tail -10
+```
+
+Expected: znajdź najwyższy numer, użyj kolejnego.
+
+- [ ] **Step 2: Utwórz fragment**
+
+Plik `src/bpp/newsfragments/<NUMER>.feature`:
+
+```
+Deduplikator autorów: nowy tryb "ogólny" znajdujący duplikaty wśród autorów spoza listy pracowników instytucji w PBN. Jeden przycisk "Skanuj duplikaty" uruchamia obie fazy (PBN + ogólna) sekwencyjnie. Widok pozwala filtrować wyniki radio-button-em (PBN/Ogólny/Oba), eksport XLSX zawiera kolumnę "Tryb". Anulowanie fazy ogólnej skutkuje statusem "Częściowo zakończone" — wyniki PBN pozostają dostępne.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/bpp/newsfragments/
+git commit -m "docs(newsfragment): tryb ogólny deduplikatora autorów"
+```
+
+---
+
+### Task 7.2: Finalny smoke-test
+
+- [ ] **Step 1: Pełen suite testów modułu**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest src/deduplikator_autorow/tests/ -n auto 2>&1 | tee /tmp/dedup-final.log
+```
+
+Expected: wszystkie zielone. Jeśli któryś nie — fix przed merge.
+
+- [ ] **Step 2: Smoke pełny suite (opcjonalnie, długo)**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras pytest -n auto 2>&1 | tee /tmp/dedup-fullsuite.log
+```
+
+Expected: brak nowych regresji w innych testach.
+
+- [ ] **Step 3: Sprawdź migrate na świeżej bazie**
+
+```bash
+UV_NO_SYNC=1 uv run --all-extras src/manage.py migrate deduplikator_autorow zero
+UV_NO_SYNC=1 uv run --all-extras src/manage.py migrate deduplikator_autorow
+```
+
+Expected: czysty rollback i forward.
+
+- [ ] **Step 4: Pre-commit na ostatnich zmianach**
+
+```bash
+pre-commit
+```
+
+Expected: brak nowych issue.
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git push -u origin feature/deduplikator-autorow-general
+```
+
+---
+
+## Self-review checklist (zostaw jako notatkę dla wykonawcy)
+
+Po Task 7.2 — sprawdź:
+
+- [ ] Wszystkie nowe testy w `src/deduplikator_autorow/tests/` przechodzą.
+- [ ] `migrate` od zera działa.
+- [ ] `migrate ... zero && migrate` działa (rollback OK).
+- [ ] Istniejące testy modułu nie regresują.
+- [ ] Newsfragment napisany (Task 7.1).
+- [ ] `grunt build` przeszedł bez błędów.
+- [ ] PR opisuje: rename `IgnoredAuthor`→`IgnoredScientist` (breaking change wewnątrz, brak external API), nowy `IgnoredAuthor`(FK→Autor), `scan_mode` na Candidate, `phase` + `PARTIAL_COMPLETED` na ScanRun.
+
+---
+
+## Spec coverage matrix
+
+| Wymaganie speca | Task pokrywający |
+|-----------------|------------------|
+| Rename IgnoredAuthor → IgnoredScientist | 1.1 |
+| Nowy IgnoredAuthor (FK→Autor) | 1.2 |
+| Pole scan_mode na Candidate | 1.3 |
+| Pole phase na ScanRun | 1.3 |
+| Status PARTIAL_COMPLETED | 1.3 |
+| Constraint scan_mode w unique key | 1.3 |
+| Index (scan_run, scan_mode, status) | 1.3 |
+| utils.cluster (union-find) | 2.1 |
+| utils.main_selection (hierarchia B) | 2.2 |
+| utils.meta (cache + buckets) | 2.3 |
+| utils.analysis_meta (scoring na meta) | 2.4 |
+| utils.search_general (pair generation) | 3.1 |
+| _run_general_phase (algorytm) | 3.2 |
+| Cluster-skip (OsobaZInstytucji) | 3.2 |
+| Klastry przechodnie | 3.2 |
+| _run_pbn_phase (extract) | 3.3 |
+| scan_for_duplicates (combined) | 3.3 |
+| PARTIAL_COMPLETED w cancellation logic | 3.3 |
+| get_latest_usable_scan | 4.1 |
+| Mode filter w view | 4.2 |
+| Sortowanie pbn-przed-general w mode=both | 4.2 |
+| scal_autorow_view backwards-compat | 4.3 |
+| ignore_autor + ignore_scientist | 4.4 |
+| reset_ignored_autorzy + reset_ignored_scientists | 4.4 |
+| URL renames | 4.4 |
+| Mode radio w UI | 5.1 |
+| Counters split | 5.1 |
+| Badges PBN/Ogólny | 5.1 |
+| PARTIAL_COMPLETED banner | 5.1 |
+| Phase progress display | 5.1 |
+| XLSX kolumna Tryb | 6.1 |
+| Newsfragment | 7.1 |
+
+Wszystkie wymagania speca pokryte zadaniami. **Brak placeholderów ani TBD.**

--- a/docs/superpowers/specs/2026-05-01-deduplikator-autorow-general-design.md
+++ b/docs/superpowers/specs/2026-05-01-deduplikator-autorow-general-design.md
@@ -20,10 +20,10 @@ Rozszerzenie istniejącej aplikacji `deduplikator_autorow`. **Bez nowej aplikacj
 
 ### Pojęcia
 
-- **Tryb skanowania (`scan_mode`)** — pole na `DuplicateScanRun` i `DuplicateCandidate`.
+- **Tryb skanowania (`scan_mode`)** — pole tylko na `DuplicateCandidate`.
   - `pbn` — kandydat znaleziony przez fazę PBN skanu.
   - `general` — kandydat znaleziony przez fazę general.
-  - `both` (tylko na `DuplicateScanRun`) — skan zawiera obie fazy.
+- **Faza skanu (`phase`)** — pole na `DuplicateScanRun` (`pbn` / `general`), pokazuje aktualnie wykonywaną fazę. Jeden scan zawsze robi obie fazy sekwencyjnie.
 - **Pivot (general):** `Autor` z bazy. Klaster jest emitowany tylko jeśli żaden członek nie ma `OsobaZInstytucji`.
 - **Wybór "main" w klastrze general** — hierarchia tiebreakerów (patrz sekcja "Wybór głównego").
 
@@ -43,7 +43,7 @@ Rozszerzenie istniejącej aplikacji `deduplikator_autorow`. **Bez nowej aplikacj
 - Modele:
   - `IgnoredAuthor` (FK→Scientist) **rename** na `IgnoredScientist`.
   - Nowy `IgnoredAuthor` (FK→Autor) — dla trybu general.
-  - `DuplicateScanRun` — nowe pola `scan_mode`, `phase`.
+  - `DuplicateScanRun` — nowe pole `phase`; rozszerzony `Status` o `PARTIAL_COMPLETED`.
   - `DuplicateCandidate` — nowe pole `scan_mode`; `main_osoba_z_instytucji` zostaje nullable (już jest dziś).
 - `tasks.py:scan_for_duplicates` — uruchamia OBA tryby sekwencyjnie pod jednym `DuplicateScanRun`.
 - `views.py` — filtr `mode` w GET; rozdzielone akcje dla PBN/general (ignore, reset).
@@ -55,56 +55,133 @@ Rozszerzenie istniejącej aplikacji `deduplikator_autorow`. **Bez nowej aplikacj
 
 `Autor.objects.all()` — pełen zbiór, **bez** wstępnego wyłączania osób z `OsobaZInstytucji` (potrzebne do cluster-skip).
 
-### Krok 1: generowanie par kandydatów
+### Krok 0: pre-loading do pamięci (cache meta-danych autorów)
 
-Iteracja po wszystkich `Autor`-ach w kolejności PK rosnącej. Dla każdego pivota:
+Przed jakimikolwiek pivot-pass-ami ładujemy do pamięci **per-autor metadata** dla całej bazy (potrzebne wielokrotnie podczas iteracji + analizy). Jeden zestaw zapytań SQL (zamiast N×k):
 
-1. Wywołanie `szukaj_kopii_autora(autor)` — uogólniona wersja `szukaj_kopii`. Heurystyki identyczne jak dziś:
-   - exact lastname (case insensitive),
-   - reversed compound lastname (`Gal-Cisoń` → `Cisoń-Gal`),
-   - compound parts (`Gal-Cisoń` → `Gal`, `Cisoń`),
-   - compound member match (`Woźniak` matchuje `Kowalska-Woźniak`),
-   - swap imię ↔ nazwisko,
-   - dopasowanie imion / inicjałów (`word_match_filter`, `initial_match_filter`).
-2. Filtrowanie kandydatów przez `NotADuplicate` i nowy `IgnoredAuthor` (FK→Autor).
-3. Dla każdego kandydata: `analiza_duplikatow_pary(pivot, kandydat)` → `confidence_score`, `reasons`.
-4. Filtr: `confidence_score >= MIN_CONFIDENCE_TO_STORE` (=50, jak obecnie w PBN).
+```python
+# Wszyscy autorzy z normalizowanymi kluczami bucketingu
+autorzy_meta = {
+    a.pk: {
+        "obj": a,
+        "nazwisko_norm": _normalize(a.nazwisko),
+        "nazwisko_parts": _split_compound(a.nazwisko),  # do bucketingu compound
+        "imiona_norm": [_normalize(i) for i in (a.imiona or "").split()],
+        "ma_orcid": bool(a.orcid),
+        "ma_pbn_uid": bool(a.pbn_uid_id),
+        "ma_tytul": bool(a.tytul_id),
+        "ma_osoba_z_instytucji": False,  # set below
+        "ma_dyscypline": False,  # set below
+        "publikacje_count": 0,  # set below
+        "lata_publikacji": set(),  # set below
+        "max_rok": 0,  # set below
+    }
+    for a in Autor.objects.select_related("tytul", "pbn_uid", "plec").iterator()
+}
 
-Wynik kroku 1: zbiór nieuporządkowanych par. **Deduplikacja par symetrycznych** w pamięci (`dict[frozenset({pk_a, pk_b})] -> (score, reasons)`).
+# Jeden GROUP BY zamiast N count-ów
+for row in Rekord.objects.values("autorzy__pk").annotate(
+    cnt=Count("id"), max_rok=Max("rok"), lata=ArrayAgg("rok", distinct=True)
+):
+    pk = row["autorzy__pk"]
+    if pk in autorzy_meta:
+        m = autorzy_meta[pk]
+        m["publikacje_count"] = row["cnt"]
+        m["max_rok"] = row["max_rok"] or 0
+        m["lata_publikacji"] = set(filter(None, row["lata"]))
 
-### Krok 2: grupowanie w klastry (connected components)
+# Set ma_dyscypline jednym zapytaniem
+for pk in Autor_Dyscyplina.objects.values_list("autor_id", flat=True).distinct():
+    if pk in autorzy_meta:
+        autorzy_meta[pk]["ma_dyscypline"] = True
 
-Graf nieskierowany: węzły = `Autor.pk`, krawędzie = pary z kroku 1. Algorytm union-find. Każda spójna komponenta = klaster.
+# Set ma_osoba_z_instytucji
+osoba_pks = OsobaZInstytucji.objects.values_list("personId__rekord_w_bpp__pk", flat=True)
+for pk in osoba_pks:
+    if pk in autorzy_meta:
+        autorzy_meta[pk]["ma_osoba_z_instytucji"] = True
 
-### Krok 3: cluster-skip
+# NotADuplicate / IgnoredAuthor wykluczenia
+ignored_pks = set(IgnoredAuthor.objects.values_list("autor_id", flat=True))
+notadup_pks = set(NotADuplicate.objects.values_list("autor_id", flat=True))
+```
+
+**Konkretny dokładny shape zapytań może być doprecyzowany w planie implementacji** — istotne jest że jest to **stała liczba zapytań SQL niezależna od N**, a nie N×k.
+
+Dla 50k autorów × ~10 fields × ~200 bajtów = ~100MB pamięci. Akceptowalne dla celery worker-a.
+
+### Krok 1: bucketing po nazwisku (przed pivot pass)
+
+Zamiast iterować pivot-po-pivot z wykonywaniem ILIKE-zapytań, **grupujemy autorów do bucketów** po znormalizowanym nazwisku, jednorazowo w pamięci:
+
+```python
+buckets = defaultdict(list)  # nazwisko_norm -> [pk1, pk2, ...]
+for pk, m in autorzy_meta.items():
+    if not m["nazwisko_norm"]:
+        continue  # pomijamy autorów bez nazwiska
+    buckets[m["nazwisko_norm"]].append(pk)
+    # compound names: dodaj do bucketów dla każdej części
+    for part in m["nazwisko_parts"]:
+        if len(part) > 2:
+            buckets[part].append(pk)
+    # reversed compound (np. "Gal-Cisoń" → bucket "Cisoń-Gal")
+    if len(m["nazwisko_parts"]) == 2:
+        reversed_name = "-".join(reversed(m["nazwisko_parts"]))
+        buckets[_normalize(reversed_name)].append(pk)
+```
+
+**Limit ochronny:** bucket większy niż `BUCKET_MAX_SIZE` (np. 200) pomijamy z warning-iem do logu (popularne nazwiska typu "Nowak", "Kowalski" — komparowanie 200×200 par wewnątrz nie ma sensu, raczej wskazuje że heurystyka nazwiskowa nie wystarczy). Te edge case'y obsłuży użytkownik ręcznie przez search-by-lastname.
+
+### Krok 2: pair-generation w obrębie bucketów
+
+Dla każdego bucketu, pary `(a, b)` gdzie `pk_a < pk_b`:
+
+1. Sprawdzenie wykluczeń: jeżeli `a.pk in ignored_pks` lub `b.pk in ignored_pks` lub para po którejkolwiek stronie matchuje `notadup_pks` → pomiń.
+2. **In-memory** swap-detection / imiona-matching używając `autorzy_meta[a.pk]` i `autorzy_meta[b.pk]` (BEZ zapytań SQL).
+3. Wywołanie `analiza_duplikatow_pary(meta_a, meta_b)` — **nowa funkcja** operująca na słownikach meta zamiast obiektach DB, używa cache'owanych: orcid, pbn_uid, tytul, imiona, lata, publikacje_count, max_rok. Reasons + score liczone jak dziś, ale bez SQL.
+4. Filtr: `confidence_score >= MIN_CONFIDENCE_TO_STORE` (=50).
+
+Para jest deterministycznie posortowana (`pk_a < pk_b`) → automatyczna deduplikacja par symetrycznych.
+
+Wynik kroku 2: lista par `[(pk_a, pk_b, score, reasons), ...]`.
+
+### Krok 2.5: progress reporting
+
+Bucketing + pair generation jest jednorazowe i **szybkie** (bez SQL). Progress aktualizujemy raz przed/po cluster-pass: `authors_scanned` skacze do `total_authors_to_scan` po fazie general (bo nie iterujemy realnie po autorach indywidualnie). Dla UI lepiej: progress na bazie procesowania bucketów (ile bucketów / total), aktualizowany co 100 bucketów.
+
+### Krok 3: grupowanie w klastry (connected components)
+
+Graf nieskierowany: węzły = `Autor.pk`, krawędzie = pary z kroku 2. Algorytm union-find (in-memory). Każda spójna komponenta = klaster.
+
+### Krok 4: cluster-skip
 
 Dla każdego klastra:
-- Jeżeli **którykolwiek** członek ma `OsobaZInstytucji` (`Autor.pbn_uid.osobazinstytucji` istnieje) → **odrzuć klaster**.
-- Inaczej → przekaż do kroku 4.
+- Jeżeli **którykolwiek** członek ma `ma_osoba_z_instytucji=True` (z meta-cache) → **odrzuć klaster**.
+- Inaczej → przekaż do kroku 5.
 
 Statystyki logowane: ile klastrów odrzucono, ile autorów w nich.
 
-### Krok 4: wybór "main" w klastrze (hierarchia B)
+### Krok 5: wybór "main" w klastrze (hierarchia B)
 
-Sortowanie członków klastra po kluczu złożonym (kolejne kryteria odpalają tylko przy remisie):
+Sortowanie członków klastra po kluczu złożonym (z meta-cache, **bez SQL**):
 
-| Priorytet | Kryterium | Kierunek |
+| Priorytet | Kryterium (z `autorzy_meta`) | Kierunek |
 |-----------|-----------|----------|
-| 1 | `bool(orcid)` | DESC (ma > nie ma) |
-| 2 | `bool(pbn_uid)` | DESC (ma > nie ma) |
-| 3 | `bool(tytul)` | DESC (ma > nie ma) |
-| 4 | `Autor_Dyscyplina.objects.filter(autor=...).exists()` | DESC (ma > nie ma) |
-| 5 | `Rekord.objects.prace_autora(autor).count()` | DESC (więcej > mniej) |
-| 6 | max rok publikacji (NULL→0) | DESC (nowszy > starszy) |
+| 1 | `ma_orcid` | DESC (ma > nie ma) |
+| 2 | `ma_pbn_uid` | DESC (ma > nie ma) |
+| 3 | `ma_tytul` | DESC (ma > nie ma) |
+| 4 | `ma_dyscypline` | DESC (ma > nie ma) |
+| 5 | `publikacje_count` | DESC (więcej > mniej) |
+| 6 | `max_rok` (NULL→0) | DESC (nowszy > starszy) |
 | 7 | `pk` | ASC (niższy > wyższy) |
 
 Pierwszy w posortowanej liście → `main_autor`. Reszta → `duplicate_autor`-zy.
 
-### Krok 5: emisja `DuplicateCandidate`
+### Krok 6: emisja `DuplicateCandidate`
 
 Dla klastra `{main, dup1, dup2, ..., dupN}`:
 - Dla każdego `dup_i`: zapisujemy `DuplicateCandidate(scan_mode='general', main_autor=main, duplicate_autor=dup_i, confidence_score=score(main, dup_i), reasons=..., priority=calculate_author_priority(dup_i))`.
-- Jeżeli para `(main, dup_i)` **nie była** bezpośrednio w grafie (klaster przechodni), wyliczamy score on-the-fly z `analiza_duplikatow_pary(main, dup_i)`.
+- Jeżeli para `(main, dup_i)` **nie była** bezpośrednio w grafie (klaster przechodni), wyliczamy score on-the-fly z `analiza_duplikatow_pary(meta[main], meta[dup_i])` (z meta-cache, bez SQL).
 
 ### Bulk-creation
 
@@ -112,17 +189,18 @@ Dla klastra `{main, dup1, dup2, ..., dupN}`:
 
 ### Performance / progress
 
-- Spodziewany czas dla ~50k autorów: kilka–kilkanaście minut w celery (z indeksem na `nazwisko`).
-- Progress: `authors_scanned` aktualizowany co `PROGRESS_UPDATE_INTERVAL=100` w fazie general (jak dziś dla PBN).
-- W ramach jednego `DuplicateScanRun`: total = `OsobaZInstytucji.count()` + `Autor.count()` (suma obu faz).
+- **Strategy: meta-load → bucket → in-memory analysis.** Stała liczba zapytań SQL niezależna od N (~10 globalnych zapytań w fazie meta-load). Cała iteracja po parach jest in-memory (Python dict lookups).
+- Spodziewany czas dla ~50k autorów: **rzędu minut** (meta-load to największy koszt; pair generation w bucketach jest szybkie).
+- Pamięć: ~100MB dla 50k autorów. Akceptowalne dla celery worker-a (powinno być default 512MB+).
+- Progress w fazie general: aktualizowany co 100 bucketów (z `total = len(buckets)`).
+- W ramach jednego `DuplicateScanRun`: progress sygnalizowany przez `phase` (`pbn` / `general`) i `progress_percent` per fazę. Suma progress nie ma sensu (PBN to per-osoba, general to per-bucket — różne jednostki). Frontend pokazuje "Faza X z 2: Y%" dla aktualnej fazy.
 
 ## Zmiany modelu i migracje
 
 **Kolejność wykonania migracji jest istotna:**
 1. Migracja 1 (rename `IgnoredAuthor` → `IgnoredScientist`) — **musi** wykonać się przed Migracja 2, bo Migracja 2 tworzy nową klasę `IgnoredAuthor` która zajmie zwolnioną nazwę tabeli/modelu.
 2. Migracja 2 (nowy `IgnoredAuthor` FK→Autor).
-3. Migracja 3 (pola `scan_mode`, `phase`, indexes, constraint replace).
-4. Migracja 4 (backfill — opcjonalnie razem z Migracja 3 jeśli `default='pbn'` na `AddField` wystarczy).
+3. Migracja 3 (pole `phase`, status `PARTIAL_COMPLETED`, pole `scan_mode` na `DuplicateCandidate`, index, constraint replace). `AddField(scan_mode, default='pbn')` sam wypełnia istniejące wiersze.
 
 ### Migracja 1: rename `IgnoredAuthor` → `IgnoredScientist`
 
@@ -160,20 +238,17 @@ class IgnoredAuthor(models.Model):
         ordering = ["-created_on"]
 ```
 
-### Migracja 3: pole `scan_mode` na `DuplicateScanRun` i `DuplicateCandidate`
+### Migracja 3: pole `phase` na `DuplicateScanRun`, rozszerzenie `Status`, pole `scan_mode` na `DuplicateCandidate`
 
 Na `DuplicateScanRun`:
 
 ```python
-scan_mode = models.CharField(
-    "Tryb skanowania", max_length=20,
-    choices=[("pbn", "PBN"), ("general", "Ogólny"), ("both", "Oba")],
-    default="both", db_index=True,
-)
 phase = models.CharField(
     "Aktualna faza", max_length=20, blank=True,
     choices=[("pbn", "Faza PBN"), ("general", "Faza ogólna")],
 )
+# Status: choices rozszerzony o ("partial_completed", "Częściowo zakończone")
+# To jest tylko zmiana choices — bez DB-level constraint changes (TextField).
 ```
 
 Na `DuplicateCandidate`:
@@ -203,17 +278,41 @@ class Meta:
 
 ### Migracja 4: backfill `scan_mode` na istniejących `DuplicateCandidate`
 
-`RunPython` ustawia `scan_mode='pbn'` na wszystkich istniejących wierszach (wszystkie dotychczasowe wpisy pochodzą z trybu PBN). Wykonuje się **przed** `Migracja 3 part B` w której zmieniany jest `default` z `pbn` → standalone constraint, lub jako jedna sekwencja: `AddField(default='pbn')` → `RunPython(no-op)` (default już sam wypełnia).
+Niepotrzebna jako osobna migracja. `AddField(scan_mode, default='pbn')` w Migracja 3 sam wypełnia istniejące wiersze wartością `'pbn'` (wszystkie dotychczasowe wpisy pochodzą z trybu PBN). Numer 4 zostaje pominięty — w sumie 3 migracje: rename, new `IgnoredAuthor`, new `phase`+`scan_mode`+constraint.
 
 ## Celery task: `scan_for_duplicates`
 
 Jeden task, dwie fazy. Sygnatura zostaje (`user_id`, `min_confidence`).
 
+### Statusy `DuplicateScanRun`
+
+Rozszerzamy enum `Status` o nowy stan:
+
+```python
+class Status(models.TextChoices):
+    PENDING = "pending", "Oczekuje"
+    RUNNING = "running", "W trakcie"
+    COMPLETED = "completed", "Zakończone"
+    PARTIAL_COMPLETED = "partial_completed", "Częściowo zakończone (faza PBN OK, general anulowana)"
+    CANCELLED = "cancelled", "Anulowane"
+    FAILED = "failed", "Błąd"
+```
+
+**Semantyka cancellation:**
+- Cancellation w fazie 1 (PBN) → `CANCELLED`. View nie pokazuje wyników z tego scan-runa.
+- Cancellation w fazie 2 (general) → `PARTIAL_COMPLETED`. View **pokazuje** kandydatów PBN z tego scan-runa, ale nie general (bo niedokończona).
+- Sukces obu faz → `COMPLETED`.
+
+View `duplicate_authors_view` traktuje `COMPLETED` i `PARTIAL_COMPLETED` jednakowo jako "skan jest źródłem danych", z dodatkowym banner-em ostrzeżeniem przy `PARTIAL_COMPLETED`: "Faza ogólna została anulowana — wyniki niekompletne. Uruchom skan ponownie, aby zobaczyć wszystkie duplikaty."
+
+Migracja: dodanie wartości `partial_completed` do choices (TextField — bez DB-level constraint zmian).
+
+### Pseudokod taska
+
 ```python
 @shared_task(bind=True, name="deduplikator_autorow.scan_for_duplicates")
 def scan_for_duplicates(self, user_id=None, min_confidence=MIN_CONFIDENCE_TO_STORE):
     scan_run = DuplicateScanRun.objects.create(
-        scan_mode="both",
         status=DuplicateScanRun.Status.RUNNING,
         ...
     )
@@ -222,15 +321,26 @@ def scan_for_duplicates(self, user_id=None, min_confidence=MIN_CONFIDENCE_TO_STO
     scan_run.phase = "pbn"
     scan_run.save(update_fields=["phase"])
     _run_pbn_phase(scan_run, min_confidence)
-    if scan_run.status == CANCELLED: return ...
+    scan_run.refresh_from_db()
+    if scan_run.status == DuplicateScanRun.Status.CANCELLED:
+        # Cancellation w fazie 1 = CANCELLED (już ustawione przez sygnał anulowania)
+        scan_run.finished_at = timezone.now()
+        scan_run.save(update_fields=["finished_at"])
+        return {"status": "cancelled", ...}
 
     # FAZA 2: general
     scan_run.phase = "general"
     scan_run.save(update_fields=["phase"])
     _run_general_phase(scan_run, min_confidence)
-    if scan_run.status == CANCELLED: return ...
+    scan_run.refresh_from_db()
+    if scan_run.status == DuplicateScanRun.Status.CANCELLED:
+        # Cancellation w fazie 2 = PARTIAL_COMPLETED (PBN ma wyniki, general nie)
+        scan_run.status = DuplicateScanRun.Status.PARTIAL_COMPLETED
+        scan_run.finished_at = timezone.now()
+        scan_run.save(update_fields=["status", "finished_at"])
+        return {"status": "partial_completed", ...}
 
-    scan_run.status = COMPLETED
+    scan_run.status = DuplicateScanRun.Status.COMPLETED
     scan_run.finished_at = timezone.now()
     scan_run.save()
 ```
@@ -239,7 +349,9 @@ def scan_for_duplicates(self, user_id=None, min_confidence=MIN_CONFIDENCE_TO_STO
 
 `_run_general_phase` — nowa funkcja realizująca algorytm z sekcji "Algorytm trybu general". Każdy emitowany kandydat ma `scan_mode='general'`.
 
-Total progress = sum obu faz (`total_authors_to_scan = osoby_pbn.count() + autor.count()`). `authors_scanned` rośnie monotonicznie przez obie fazy.
+### Helper: `get_latest_usable_scan()`
+
+Zastępuje `get_latest_completed_scan()`. Zwraca `DuplicateScanRun` z `status IN (COMPLETED, PARTIAL_COMPLETED)`, najnowszy. Wszystkie miejsca w `views.py` używają `get_latest_usable_scan()`.
 
 ## UI / widoki
 
@@ -261,6 +373,10 @@ Total progress = sum obu faz (`total_authors_to_scan = osoby_pbn.count() + autor
 3. **Lista pending-candidates** — filtrowana wg `mode`. Każdy nagłówek/grupa ma badge:
    - `[PBN]` (np. niebieski),
    - `[OGÓLNY]` (np. zielony/pomarańczowy).
+
+   **Sortowanie / kolejność krok-po-kroku:**
+   - W trybie `pbn` lub `general`: jak dziś — `ORDER BY priority DESC, confidence_score DESC, main_autor_id`.
+   - W trybie `both` (Oba): **najpierw wszystkie pending PBN** (w swojej kolejności), **potem wszystkie pending general** (w swojej kolejności). Tryb-po-trybie, nie interleaving po confidence. Powód: PBN-owe są kanoniczne, user powinien je dokończyć przed wzięciem się za general.
 
 4. **Counters:**
 
@@ -355,9 +471,10 @@ Lokalizacja: `src/deduplikator_autorow/tests/`.
 - `test_scan_runs_pbn_then_general_phase` — z fixturem `OsobaZInstytucji` i autorami spoza, weryfikuje że oba fazy emitują kandydaty z odpowiednimi `scan_mode`.
 - `test_scan_progress_total_is_sum_of_phases` — `total_authors_to_scan == osoby.count() + autor.count()`.
 - `test_scan_progress_reaches_100_after_both_phases` — po sukcesie, `progress_percent == 100`.
-- `test_scan_cancellation_during_pbn_phase` — anulowanie w fazie 1 → status `CANCELLED`, faza 2 nie startuje.
-- `test_scan_cancellation_during_general_phase` — anulowanie w fazie 2 → status `CANCELLED`.
+- `test_scan_cancellation_during_pbn_phase` — anulowanie w fazie 1 → status `CANCELLED`, faza 2 nie startuje, view nie pokazuje wyników.
+- `test_scan_cancellation_during_general_phase` — anulowanie w fazie 2 → status `PARTIAL_COMPLETED`, view pokazuje kandydatów PBN, banner ostrzeżenia widoczny.
 - `test_scan_skips_clusters_with_osoba_instytucji` — w fixture'ze klaster z `OsobaZInstytucji` nie ląduje w `DuplicateCandidate(scan_mode='general')`.
+- `test_scan_meta_load_constant_query_count` — używamy `assertNumQueries` lub `django_assert_num_queries`: meta-load dla N=20 autorów → ta sama liczba zapytań co dla N=200 (sanity-check że nie ma N+1).
 
 ### `test_views.py` — widoki
 
@@ -384,7 +501,7 @@ Istniejące testy PBN (jeżeli są w repo) muszą dalej przechodzić bez modyfik
   - nowy `utils/cluster.py`,
   - zaktualizowany `tasks.py`, `views.py`, `urls.py`, `models.py`, `admin.py`, `utils/export.py`,
   - zaktualizowany template `templates/deduplikator_autorow/duplicate_authors.html`.
-- 4 migracje (rename, new model, scan_mode fields + indexes, backfill).
+- 3 migracje (rename `IgnoredAuthor` → `IgnoredScientist`, nowy `IgnoredAuthor`(FK→Autor), `phase`+`scan_mode`+`PARTIAL_COMPLETED`+index+constraint).
 - Testy w `src/deduplikator_autorow/tests/`.
 - Newsfragment towncrier (`feat`).
 

--- a/docs/superpowers/specs/2026-05-01-deduplikator-autorow-general-design.md
+++ b/docs/superpowers/specs/2026-05-01-deduplikator-autorow-general-design.md
@@ -1,0 +1,396 @@
+# Deduplikator autorów — tryb ogólny (general)
+
+**Data:** 2026-05-01
+**Branch:** `feature/deduplikator-autorow-general`
+**Worktree:** `~/Programowanie/bpp-worktrees/deduplikator-autorow-general/`
+**Bazowy:** `dev`
+
+## Cel
+
+Rozszerzyć istniejący moduł `src/deduplikator_autorow/` o drugi tryb skanowania, który znajduje duplikaty autorów **niezwiązanych z `OsobaZInstytucji` (PBN)**. Obecny tryb (PBN) iteruje po `OsobaZInstytucji` i obsługuje pracowników instytucji powiązanych z PBN. Nowy tryb (`general`) obsługuje "resztę bazy" — autorów zaimportowanych z PBN jako `Scientist`, ale nie będących pracownikami instytucji, oraz autorów bez powiązania PBN.
+
+Operacyjnie:
+1. User uruchamia jeden skan, który robi oba tryby sekwencyjnie.
+2. Po skanie: w widoku radio-button-em wybiera, którego trybu wyniki ogląda (PBN / Ogólny / Oba).
+3. Dla każdego klastra duplikatów z trybu general — jeżeli **którykolwiek** członek klastra ma `OsobaZInstytucji`, klaster jest pomijany (handluje go tryb PBN).
+
+## Architektura wysokopoziomowa
+
+Rozszerzenie istniejącej aplikacji `deduplikator_autorow`. **Bez nowej aplikacji Django.**
+
+### Pojęcia
+
+- **Tryb skanowania (`scan_mode`)** — pole na `DuplicateScanRun` i `DuplicateCandidate`.
+  - `pbn` — kandydat znaleziony przez fazę PBN skanu.
+  - `general` — kandydat znaleziony przez fazę general.
+  - `both` (tylko na `DuplicateScanRun`) — skan zawiera obie fazy.
+- **Pivot (general):** `Autor` z bazy. Klaster jest emitowany tylko jeśli żaden członek nie ma `OsobaZInstytucji`.
+- **Wybór "main" w klastrze general** — hierarchia tiebreakerów (patrz sekcja "Wybór głównego").
+
+### Komponenty z reuse (bez zmian lub minimalne)
+
+- `analiza_duplikatow` (scoring) — generalizowany; przyjmuje `(glowny_autor: Autor, kandydat_autor: Autor)` zamiast `osoba_z_instytucji`. Cała logika scoringu (płeć, ORCID, tytuł, imiona, lata, swap) działa po obiektach `Autor`.
+- `scal_autora` — bez zmian, działa po `Autor`-ach.
+- `LogScalania` — bez zmian.
+- `NotADuplicate` (FK→Autor) — bez zmian; działa dla obu trybów.
+- Template `duplicate_authors.html` — drobne dodatki: radio mode, badge per-pozycja, pasek statusu fazy.
+
+### Komponenty nowe / zmieniane
+
+- `utils/search_general.py` — nowa strategia generowania kandydatów dla trybu general.
+- `utils/main_selection.py` — nowy moduł: hierarchia wyboru głównego w klastrze.
+- `utils/cluster.py` — nowy moduł: union-find / connected components nad parami.
+- Modele:
+  - `IgnoredAuthor` (FK→Scientist) **rename** na `IgnoredScientist`.
+  - Nowy `IgnoredAuthor` (FK→Autor) — dla trybu general.
+  - `DuplicateScanRun` — nowe pola `scan_mode`, `phase`.
+  - `DuplicateCandidate` — nowe pole `scan_mode`; `main_osoba_z_instytucji` zostaje nullable (już jest dziś).
+- `tasks.py:scan_for_duplicates` — uruchamia OBA tryby sekwencyjnie pod jednym `DuplicateScanRun`.
+- `views.py` — filtr `mode` w GET; rozdzielone akcje dla PBN/general (ignore, reset).
+- `utils/export.py` — XLSX z dodatkową kolumną "Tryb".
+
+## Algorytm trybu `general`
+
+### Wejście
+
+`Autor.objects.all()` — pełen zbiór, **bez** wstępnego wyłączania osób z `OsobaZInstytucji` (potrzebne do cluster-skip).
+
+### Krok 1: generowanie par kandydatów
+
+Iteracja po wszystkich `Autor`-ach w kolejności PK rosnącej. Dla każdego pivota:
+
+1. Wywołanie `szukaj_kopii_autora(autor)` — uogólniona wersja `szukaj_kopii`. Heurystyki identyczne jak dziś:
+   - exact lastname (case insensitive),
+   - reversed compound lastname (`Gal-Cisoń` → `Cisoń-Gal`),
+   - compound parts (`Gal-Cisoń` → `Gal`, `Cisoń`),
+   - compound member match (`Woźniak` matchuje `Kowalska-Woźniak`),
+   - swap imię ↔ nazwisko,
+   - dopasowanie imion / inicjałów (`word_match_filter`, `initial_match_filter`).
+2. Filtrowanie kandydatów przez `NotADuplicate` i nowy `IgnoredAuthor` (FK→Autor).
+3. Dla każdego kandydata: `analiza_duplikatow_pary(pivot, kandydat)` → `confidence_score`, `reasons`.
+4. Filtr: `confidence_score >= MIN_CONFIDENCE_TO_STORE` (=50, jak obecnie w PBN).
+
+Wynik kroku 1: zbiór nieuporządkowanych par. **Deduplikacja par symetrycznych** w pamięci (`dict[frozenset({pk_a, pk_b})] -> (score, reasons)`).
+
+### Krok 2: grupowanie w klastry (connected components)
+
+Graf nieskierowany: węzły = `Autor.pk`, krawędzie = pary z kroku 1. Algorytm union-find. Każda spójna komponenta = klaster.
+
+### Krok 3: cluster-skip
+
+Dla każdego klastra:
+- Jeżeli **którykolwiek** członek ma `OsobaZInstytucji` (`Autor.pbn_uid.osobazinstytucji` istnieje) → **odrzuć klaster**.
+- Inaczej → przekaż do kroku 4.
+
+Statystyki logowane: ile klastrów odrzucono, ile autorów w nich.
+
+### Krok 4: wybór "main" w klastrze (hierarchia B)
+
+Sortowanie członków klastra po kluczu złożonym (kolejne kryteria odpalają tylko przy remisie):
+
+| Priorytet | Kryterium | Kierunek |
+|-----------|-----------|----------|
+| 1 | `bool(orcid)` | DESC (ma > nie ma) |
+| 2 | `bool(pbn_uid)` | DESC (ma > nie ma) |
+| 3 | `bool(tytul)` | DESC (ma > nie ma) |
+| 4 | `Autor_Dyscyplina.objects.filter(autor=...).exists()` | DESC (ma > nie ma) |
+| 5 | `Rekord.objects.prace_autora(autor).count()` | DESC (więcej > mniej) |
+| 6 | max rok publikacji (NULL→0) | DESC (nowszy > starszy) |
+| 7 | `pk` | ASC (niższy > wyższy) |
+
+Pierwszy w posortowanej liście → `main_autor`. Reszta → `duplicate_autor`-zy.
+
+### Krok 5: emisja `DuplicateCandidate`
+
+Dla klastra `{main, dup1, dup2, ..., dupN}`:
+- Dla każdego `dup_i`: zapisujemy `DuplicateCandidate(scan_mode='general', main_autor=main, duplicate_autor=dup_i, confidence_score=score(main, dup_i), reasons=..., priority=calculate_author_priority(dup_i))`.
+- Jeżeli para `(main, dup_i)` **nie była** bezpośrednio w grafie (klaster przechodni), wyliczamy score on-the-fly z `analiza_duplikatow_pary(main, dup_i)`.
+
+### Bulk-creation
+
+`DuplicateCandidate` zbierany w pamięci i zapisywany przez `bulk_create(ignore_conflicts=True)` co 1000 sztuk (jak obecny PBN-skan).
+
+### Performance / progress
+
+- Spodziewany czas dla ~50k autorów: kilka–kilkanaście minut w celery (z indeksem na `nazwisko`).
+- Progress: `authors_scanned` aktualizowany co `PROGRESS_UPDATE_INTERVAL=100` w fazie general (jak dziś dla PBN).
+- W ramach jednego `DuplicateScanRun`: total = `OsobaZInstytucji.count()` + `Autor.count()` (suma obu faz).
+
+## Zmiany modelu i migracje
+
+**Kolejność wykonania migracji jest istotna:**
+1. Migracja 1 (rename `IgnoredAuthor` → `IgnoredScientist`) — **musi** wykonać się przed Migracja 2, bo Migracja 2 tworzy nową klasę `IgnoredAuthor` która zajmie zwolnioną nazwę tabeli/modelu.
+2. Migracja 2 (nowy `IgnoredAuthor` FK→Autor).
+3. Migracja 3 (pola `scan_mode`, `phase`, indexes, constraint replace).
+4. Migracja 4 (backfill — opcjonalnie razem z Migracja 3 jeśli `default='pbn'` na `AddField` wystarczy).
+
+### Migracja 1: rename `IgnoredAuthor` → `IgnoredScientist`
+
+```python
+operations = [
+    migrations.RenameModel(old_name="IgnoredAuthor", new_name="IgnoredScientist"),
+    migrations.AlterModelOptions(
+        name="ignoredscientist",
+        options={
+            "verbose_name": "Ignorowany Scientist (PBN)",
+            "verbose_name_plural": "Ignorowani Scientist (PBN)",
+            "ordering": ["-created_on"],
+        },
+    ),
+]
+```
+
+Wszystkie referencje w `tasks.py`, `views.py`, `finders.py`, `admin.py`, templates → `IgnoredAuthor` → `IgnoredScientist`.
+
+### Migracja 2: nowy `IgnoredAuthor` (FK→Autor)
+
+```python
+class IgnoredAuthor(models.Model):
+    autor = models.OneToOneField(
+        "bpp.Autor", on_delete=models.CASCADE, db_index=True,
+        verbose_name="Autor (BPP)",
+    )
+    reason = models.CharField(max_length=500, blank=True)
+    created_on = models.DateTimeField(default=timezone.now)
+    created_by = models.ForeignKey(BppUser, on_delete=models.CASCADE)
+
+    class Meta:
+        verbose_name = "Ignorowany autor (BPP)"
+        verbose_name_plural = "Ignorowani autorzy (BPP)"
+        ordering = ["-created_on"]
+```
+
+### Migracja 3: pole `scan_mode` na `DuplicateScanRun` i `DuplicateCandidate`
+
+Na `DuplicateScanRun`:
+
+```python
+scan_mode = models.CharField(
+    "Tryb skanowania", max_length=20,
+    choices=[("pbn", "PBN"), ("general", "Ogólny"), ("both", "Oba")],
+    default="both", db_index=True,
+)
+phase = models.CharField(
+    "Aktualna faza", max_length=20, blank=True,
+    choices=[("pbn", "Faza PBN"), ("general", "Faza ogólna")],
+)
+```
+
+Na `DuplicateCandidate`:
+
+```python
+scan_mode = models.CharField(
+    "Tryb", max_length=20,
+    choices=[("pbn", "PBN"), ("general", "Ogólny")],
+    default="pbn", db_index=True,
+)
+
+class Meta:
+    indexes = [
+        ...,
+        models.Index(fields=["scan_run", "scan_mode", "status"]),
+    ]
+    constraints = [
+        # Replace existing unique_scan_main_duplicate
+        models.UniqueConstraint(
+            fields=["scan_run", "scan_mode", "main_autor", "duplicate_autor"],
+            name="unique_scan_mode_main_duplicate",
+        ),
+    ]
+```
+
+`UniqueConstraint` z `scan_mode` zastępuje istniejący `unique_scan_main_duplicate` — para autorów może (defensywnie) wystąpić w obu trybach, ale nie dwa razy w tym samym trybie/skanie.
+
+### Migracja 4: backfill `scan_mode` na istniejących `DuplicateCandidate`
+
+`RunPython` ustawia `scan_mode='pbn'` na wszystkich istniejących wierszach (wszystkie dotychczasowe wpisy pochodzą z trybu PBN). Wykonuje się **przed** `Migracja 3 part B` w której zmieniany jest `default` z `pbn` → standalone constraint, lub jako jedna sekwencja: `AddField(default='pbn')` → `RunPython(no-op)` (default już sam wypełnia).
+
+## Celery task: `scan_for_duplicates`
+
+Jeden task, dwie fazy. Sygnatura zostaje (`user_id`, `min_confidence`).
+
+```python
+@shared_task(bind=True, name="deduplikator_autorow.scan_for_duplicates")
+def scan_for_duplicates(self, user_id=None, min_confidence=MIN_CONFIDENCE_TO_STORE):
+    scan_run = DuplicateScanRun.objects.create(
+        scan_mode="both",
+        status=DuplicateScanRun.Status.RUNNING,
+        ...
+    )
+
+    # FAZA 1: PBN
+    scan_run.phase = "pbn"
+    scan_run.save(update_fields=["phase"])
+    _run_pbn_phase(scan_run, min_confidence)
+    if scan_run.status == CANCELLED: return ...
+
+    # FAZA 2: general
+    scan_run.phase = "general"
+    scan_run.save(update_fields=["phase"])
+    _run_general_phase(scan_run, min_confidence)
+    if scan_run.status == CANCELLED: return ...
+
+    scan_run.status = COMPLETED
+    scan_run.finished_at = timezone.now()
+    scan_run.save()
+```
+
+`_run_pbn_phase` — istniejąca logika (wycinamy z obecnego body taska do funkcji prywatnej). Każdy emitowany kandydat ma `scan_mode='pbn'`.
+
+`_run_general_phase` — nowa funkcja realizująca algorytm z sekcji "Algorytm trybu general". Każdy emitowany kandydat ma `scan_mode='general'`.
+
+Total progress = sum obu faz (`total_authors_to_scan = osoby_pbn.count() + autor.count()`). `authors_scanned` rośnie monotonicznie przez obie fazy.
+
+## UI / widoki
+
+### Template `duplicate_authors.html`
+
+1. **Górny panel statusu skanu:**
+   - Jeden przycisk `Skanuj duplikaty` (uruchamia jeden task; oba tryby).
+   - Pasek postępu: "Faza X z 2: PBN/Ogólny — Y%" + ogólny progress 0–100%.
+   - ETA jak dziś.
+
+2. **Selector trybu (radio inline):**
+
+   ```
+   Pokaż wyniki: ( ) PBN  ( ) Ogólny  (•) Oba
+   ```
+
+   GET param: `?mode=pbn|general|both`. Domyślnie `both`.
+
+3. **Lista pending-candidates** — filtrowana wg `mode`. Każdy nagłówek/grupa ma badge:
+   - `[PBN]` (np. niebieski),
+   - `[OGÓLNY]` (np. zielony/pomarańczowy).
+
+4. **Counters:**
+
+   ```
+   PBN: 123 par do sprawdzenia
+   Ogólny: 45 par do sprawdzenia
+   ```
+
+5. **Pobierz XLSX** — pojedynczy przycisk. Plik zawiera **wszystkie** pending-candidates (oba tryby), z dodatkową kolumną `Tryb`.
+
+### `views.py`
+
+- `duplicate_authors_view(request)`:
+  - Czyta `mode` z GET (`pbn`/`general`/`both`, default `both`).
+  - Pobiera pending z `DuplicateCandidate.objects.filter(scan_run=latest_completed, status=PENDING)`. Jeśli `mode != 'both'` → `.filter(scan_mode=mode)`.
+  - `_get_next_candidate_group(scan_run, skip_count, mode)` — dokłada `scan_mode=mode` jeśli ≠ `both`.
+  - Główny autor pivota to zawsze `Autor`. W trybie general `glowny_autor.pbn_uid` może być `None` — template chroniony przez `{% if scientist %}` (już jest).
+
+- `scal_autorow_view`:
+  - **Zmiana parametrów:** wprowadzamy `main_autor_id` / `duplicate_autor_id` (PK Autor-a).
+  - Backwards-compat: jeżeli przyszły stare parametry `main_scientist_id` / `duplicate_scientist_id` (z dotychczasowego frontu PBN) — view tłumaczy je przez `Scientist.rekord_w_bpp.pk` na Autor PK i działa dalej.
+  - Frontend (template) **zawsze przekazuje nowe parametry** (Autor PK) — nie ma w nim żadnego rozróżnienia po trybie. W trybie PBN main_autor_id to po prostu `glowny_autor.pk`, niezależnie od tego, czy ma Scientist.
+
+- `ignore_author` rozdzielamy:
+  - `ignore_scientist(request)` (POST `scientist_id`) → `IgnoredScientist`.
+  - `ignore_autor(request)` (POST `autor_id`) → `IgnoredAuthor`.
+  - W template przycisk "Ignoruj autora" wybiera odpowiednią akcję na podstawie trybu.
+
+- `reset_ignored_authors` rozdzielamy:
+  - `reset_ignored_scientists` → kasuje `IgnoredScientist`.
+  - `reset_ignored_autorzy` → kasuje `IgnoredAuthor`.
+
+### `urls.py`
+
+Zmiany:
+- Istniejący path `ignore-author/` zmienia name z `ignore_author` na `ignore_scientist` (URL i nazwa w `name=` razem) — view bierze `scientist_id` jak dziś, zapisuje do `IgnoredScientist`. To wewnętrzny endpoint AJAX widoku `duplicate_authors`, brak zewnętrznych konsumentów do zachowania.
+- Istniejący path `reset-ignored-authors/` zmienia name na `reset_ignored_scientists`.
+- Nowe paths:
+  - `ignore-autor/` (name `ignore_autor`) → `views.ignore_autor` (POST `autor_id` → `IgnoredAuthor`).
+  - `reset-ignored-autorzy/` (name `reset_ignored_autorzy`) → kasuje wszystkie `IgnoredAuthor`.
+
+### `utils/export.py`
+
+`export_duplicates_to_xlsx()`:
+- Pobiera **wszystkie** pending z najnowszego completed scan run (oba tryby).
+- Dodaje kolumnę "Tryb" (PBN/Ogólny).
+- Pozostałe kolumny bez zmian (główny autor, PBN UID głównego — może być pusty w general — duplikat, PBN UID duplikatu, liczba publikacji, lata).
+
+## Edge cases
+
+1. **Kandydat w obu trybach naraz** — nie powinno się zdarzyć (general odrzuca klastry z OsobaZInstytucji), ale defensywnie unique constraint zostaje rozszerzony o `scan_mode` (patrz Migracja 3). Para `(main, dup)` może wystąpić w obu trybach, ale tylko raz w każdym.
+
+2. **Jeden autor w wielu klastrach** — możliwe gdy heurystyka przechodnia jest słaba (A∈klaster1 jako main z B, A∈klaster2 jako dup C). UI grupuje po `main_autor`, więc A pojawi się w dwóch grupach. Akceptowane w pierwszej iteracji; warning w logu skanu.
+
+3. **Pivot bez `nazwisko`** — pomijamy w pętli (jak dziś).
+
+4. **Pre-flight check świeżości danych PBN** — blokuje cały skan (oba tryby), bo faza PBN jej wymaga. Komunikat: "Pobierz świeże dane PBN, aby uruchomić skanowanie."
+
+5. **Anulowanie skanu między fazami** — `scan_run.status == CANCELLED` sprawdzane na początku każdej iteracji w obu fazach. Po fazie PBN → przed fazą general — sprawdzenie ponownie.
+
+6. **Główny autor po general jest do scalenia, ale ma wpis `NotADuplicate`** — `szukaj_kopii_autora` filtruje przez `NotADuplicate` (jak dziś `szukaj_kopii` w PBN).
+
+7. **Kasowanie wszystkich `DuplicateCandidate` na początku skanu** — bez zmian; usuwamy wszystkich pending z poprzedniego skanu (replace mode), bo nowy skan jest źródłem prawdy.
+
+## Testy
+
+Lokalizacja: `src/deduplikator_autorow/tests/`.
+
+### `test_general_scan.py` — algorytm general
+
+- `test_general_finds_simple_pair` — dwóch `Kowalski Jan` (różne PK), żaden bez OsobaZInstytucji → 1 para.
+- `test_general_skips_cluster_with_osobaz_instytucji` — klaster {A, B, C}, B ma OsobaZInstytucji → klaster pominięty.
+- `test_general_main_selection_hierarchy` — różne kombinacje ORCID/pbn_uid/tytuł/dyscyplina/pubs/PK → main wybierany zgodnie z hierarchią B.
+- `test_general_main_pk_tiebreaker` — wszystko równe → niższy PK wygrywa.
+- `test_general_swap_detection` — `Jan Kowalski` ↔ `Kowalski Jan` → para znaleziona.
+- `test_general_compound_lastname` — `Gal-Cisoń` matchuje `Cisoń-Gal`.
+- `test_general_pair_dedup` — para (A,B) i (B,A) emitowane raz.
+- `test_general_transitive_cluster` — A~B i B~C, ale A≁C → klaster {A,B,C} z trzema parami pod jednym main.
+- `test_general_respects_not_a_duplicate` — autor w `NotADuplicate` nie pojawia się jako kandydat.
+- `test_general_respects_ignored_author` — autor w `IgnoredAuthor` nie pojawia się ani jako pivot, ani jako kandydat.
+
+### `test_models.py` — modele
+
+- `test_ignored_scientist_rename_works` — `IgnoredScientist` zapisuje się i odczytuje.
+- `test_ignored_author_creates_for_autor` — `IgnoredAuthor(autor=...)` zapisuje się.
+- `test_duplicate_candidate_scan_mode_default_pbn` — domyślnie `pbn`.
+- `test_duplicate_candidate_scan_mode_general` — `general` zapisywane.
+- `test_duplicate_scan_run_phase_field` — `phase` zapisywane.
+
+### `test_tasks.py` — celery task
+
+- `test_scan_runs_pbn_then_general_phase` — z fixturem `OsobaZInstytucji` i autorami spoza, weryfikuje że oba fazy emitują kandydaty z odpowiednimi `scan_mode`.
+- `test_scan_progress_total_is_sum_of_phases` — `total_authors_to_scan == osoby.count() + autor.count()`.
+- `test_scan_progress_reaches_100_after_both_phases` — po sukcesie, `progress_percent == 100`.
+- `test_scan_cancellation_during_pbn_phase` — anulowanie w fazie 1 → status `CANCELLED`, faza 2 nie startuje.
+- `test_scan_cancellation_during_general_phase` — anulowanie w fazie 2 → status `CANCELLED`.
+- `test_scan_skips_clusters_with_osoba_instytucji` — w fixture'ze klaster z `OsobaZInstytucji` nie ląduje w `DuplicateCandidate(scan_mode='general')`.
+
+### `test_views.py` — widoki
+
+- `test_view_filter_by_mode_pbn` — `?mode=pbn` pokazuje tylko PBN.
+- `test_view_filter_by_mode_general` — `?mode=general` tylko general.
+- `test_view_filter_by_mode_both` — `?mode=both` (default) pokazuje oba.
+- `test_view_general_mode_main_without_scientist` — render działa kiedy `glowny_autor.pbn_uid is None`.
+- `test_xlsx_export_includes_mode_column` — generuje XLSX z kolumną "Tryb".
+- `test_ignore_autor_endpoint` — POST do `ignore_autor` zapisuje `IgnoredAuthor`.
+- `test_ignore_scientist_endpoint` — POST do `ignore_scientist` zapisuje `IgnoredScientist`.
+- `test_scal_autorow_uses_autor_ids` — nowe parametry `main_autor_id` / `duplicate_autor_id` działają.
+- `test_scal_autorow_backwards_compat_scientist_ids` — stare parametry dalej działają.
+- `test_counters_split_by_mode` — counters pokazują osobne liczby dla PBN i general.
+
+### Backwards-compat
+
+Istniejące testy PBN (jeżeli są w repo) muszą dalej przechodzić bez modyfikacji logiki.
+
+## Deliverables
+
+- Zaktualizowane pliki w `src/deduplikator_autorow/`:
+  - nowy `utils/search_general.py`,
+  - nowy `utils/main_selection.py`,
+  - nowy `utils/cluster.py`,
+  - zaktualizowany `tasks.py`, `views.py`, `urls.py`, `models.py`, `admin.py`, `utils/export.py`,
+  - zaktualizowany template `templates/deduplikator_autorow/duplicate_authors.html`.
+- 4 migracje (rename, new model, scan_mode fields + indexes, backfill).
+- Testy w `src/deduplikator_autorow/tests/`.
+- Newsfragment towncrier (`feat`).
+
+## Co celowo poza zakresem
+
+- Refactor heurystyki `szukaj_kopii` do nowych typów dopasowań (np. trigram similarity).
+- Detekcja duplikatów na bazie publikacji (np. wspólna tematyka, wspólne afiliacje).
+- Asynchroniczne odpalanie obu faz równolegle (sekwencyjnie wystarcza).
+- Auto-merge wysokiej-pewności klastrów (zostaje manualne).

--- a/src/bpp/management/commands/_run_site_helpers/__init__.py
+++ b/src/bpp/management/commands/_run_site_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helpery dla komendy run_site."""

--- a/src/bpp/management/commands/_run_site_helpers/banner.py
+++ b/src/bpp/management/commands/_run_site_helpers/banner.py
@@ -1,0 +1,45 @@
+"""Banner z URL-ami i statusem stack-u."""
+
+_TEMPLATE = """\
+╔════════════════════════════════════════════════════════════════╗
+║  BPP run-site — stack uruchomiony                              ║
+╠════════════════════════════════════════════════════════════════╣
+║  Appserver:  {appserver_url:<50}║
+║  Admin:      {admin_url:<50}║
+║              login: {admin_user:<10} hasło: {admin_pass:<19}║
+║                                                                ║
+║  PostgreSQL: {pg_endpoint:<50}║
+║  Redis:      {redis_endpoint:<50}║
+║                                                                ║
+║  Celery:     {celery_label:<50}║
+║  Dump:       {dump_label:<50}║
+╠════════════════════════════════════════════════════════════════╣
+║  Ctrl-C zakończy serwer i sprzątnie kontenery.                 ║
+╚════════════════════════════════════════════════════════════════╝
+"""
+
+
+def format_banner(
+    *,
+    appserver_url: str,
+    admin_url: str,
+    admin_user: str,
+    admin_pass: str,
+    pg_host: str,
+    pg_port: int,
+    redis_host: str,
+    redis_port: int,
+    with_celery: bool,
+    dump_label: str,
+) -> str:
+    """Sformatowany banner z parametrami stack-u (plain text + box-drawing chars)."""
+    return _TEMPLATE.format(
+        appserver_url=appserver_url,
+        admin_url=admin_url,
+        admin_user=admin_user,
+        admin_pass=admin_pass,
+        pg_endpoint=f"{pg_host}:{pg_port} (bpp/password)",
+        redis_endpoint=f"{redis_host}:{redis_port}",
+        celery_label="running" if with_celery else "disabled",
+        dump_label=dump_label,
+    )

--- a/src/bpp/management/commands/_run_site_helpers/processes.py
+++ b/src/bpp/management/commands/_run_site_helpers/processes.py
@@ -1,0 +1,93 @@
+"""Spawn / wait / terminate dla runserver i celery worker subprocesses."""
+
+from __future__ import annotations
+
+import logging
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def find_free_port() -> int:
+    """Pyta OS o wolny TCP port. Zwraca natychmiast (port może wciąż być wolny)."""
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _src_dir() -> Path:
+    """Zwraca katalog `src/` (parent of bpp app)."""
+    # __file__ = src/bpp/management/commands/_run_site_helpers/processes.py
+    # parents[4] = src/
+    return Path(__file__).resolve().parents[4]
+
+
+def _python_executable() -> str:
+    """Path do Python interpreter — używa sys.executable, więc subprocess
+    odziedziczą venv (uv run zachowany)."""
+    return sys.executable
+
+
+def spawn_runserver(port: int, env: dict[str, str]) -> subprocess.Popen:
+    """Spawn `manage.py runserver 127.0.0.1:port` w foreground.
+
+    Caller czeka via `proc.wait()`. NIE przekazujemy stdin.
+    """
+    src = _src_dir()
+    cmd = [
+        _python_executable(),
+        str(src / "manage.py"),
+        "runserver",
+        f"127.0.0.1:{port}",
+    ]
+    logger.info("Spawn runserver: %s", " ".join(cmd))
+    return subprocess.Popen(cmd, env=env, cwd=str(src))
+
+
+def spawn_celery(env: dict[str, str]) -> subprocess.Popen:
+    """Spawn celery worker w background (stdout/stderr → DEVNULL)."""
+    src = _src_dir()
+    cmd = [
+        _python_executable(),
+        "-m",
+        "celery",
+        "-A",
+        "django_bpp.tasks",
+        "worker",
+        "-l",
+        "info",
+    ]
+    logger.info("Spawn celery: %s", " ".join(cmd))
+    return subprocess.Popen(
+        cmd,
+        env=env,
+        cwd=str(src),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def wait_terminate(proc: subprocess.Popen, timeout: float = 5.0) -> None:
+    """Wyślij SIGTERM, poczekaj timeout, jeśli nie wyszedł — SIGKILL."""
+    if proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logger.warning("Process %s did not terminate, killing", proc.pid)
+        proc.kill()
+        proc.wait(timeout=2.0)
+
+
+def run_subprocess_blocking(
+    cmd: list[str],
+    env: dict[str, str],
+    cwd: str | None = None,
+) -> int:
+    """Uruchom subprocess i czekaj. Zwraca returncode."""
+    logger.info("Subprocess: %s", " ".join(cmd))
+    return subprocess.run(cmd, env=env, cwd=cwd).returncode

--- a/src/bpp/management/commands/_run_site_helpers/restore.py
+++ b/src/bpp/management/commands/_run_site_helpers/restore.py
@@ -59,15 +59,20 @@ def build_restore_command(
         ]
         return cmd, format == "sql.gz"
     if format == "pgdump":
+        # Brak --clean / --if-exists: zakładamy pustą bazę (caller suppressuje
+        # baseline). --clean by tu walczył z FK cascade (constraint dependencies
+        # na pbn_api_publication_pkey, bpp_autor_pkey itp.).
+        # --no-owner: ignoruje ALTER OWNER z dump-a (user "bpp" może nie
+        # mieć permission do ról istniejących na production source DB).
+        # --exit-on-error: pierwszy błąd kończy proces.
         cmd = [
             "docker",
             "exec",
             "-i",
             container_id,
             "pg_restore",
-            "--clean",
-            "--if-exists",
             "--no-owner",
+            "--exit-on-error",
             "-U",
             db_user,
             "-d",

--- a/src/bpp/management/commands/_run_site_helpers/restore.py
+++ b/src/bpp/management/commands/_run_site_helpers/restore.py
@@ -21,7 +21,7 @@ def detect_dump_format(path: Path) -> str | None:
         return "sql.gz"
     if name.endswith(".sql"):
         return "sql"
-    if name.endswith(".dump") or name.endswith(".pgdump"):
+    if name.endswith(".dump") or name.endswith(".pgdump") or name.endswith(".pg_dump"):
         return "pgdump"
     return None
 

--- a/src/bpp/management/commands/_run_site_helpers/restore.py
+++ b/src/bpp/management/commands/_run_site_helpers/restore.py
@@ -1,0 +1,100 @@
+"""Detekcja formatu dumpu i budowa komendy restore."""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def detect_dump_format(path: Path) -> str | None:
+    """Zwraca 'sql' / 'sql.gz' / 'pgdump' lub None.
+
+    Detekcja po extension (case-insensitive). Treść pliku NIE jest
+    inspekcjonowana — kompromis simplicity vs. correctness OK dla dev tool.
+    """
+    name = path.name.lower()
+    if name.endswith(".sql.gz"):
+        return "sql.gz"
+    if name.endswith(".sql"):
+        return "sql"
+    if name.endswith(".dump") or name.endswith(".pgdump"):
+        return "pgdump"
+    return None
+
+
+def build_restore_command(
+    format: str,
+    container_id: str,
+    db_user: str = "bpp",
+    db_name: str = "bpp",
+) -> tuple[list[str], bool]:
+    """Buduje komendę docker exec do restore.
+
+    Args:
+        format: 'sql' / 'sql.gz' / 'pgdump'.
+        container_id: ID/name kontenera PG.
+        db_user, db_name: parametry połączenia.
+
+    Returns:
+        (cmd, needs_decompression) — cmd to lista argów do subprocess,
+        decompress=True oznacza że caller musi wgzipsknąć stdin (sql.gz).
+    """
+    if format in ("sql", "sql.gz"):
+        cmd = [
+            "docker",
+            "exec",
+            "-i",
+            container_id,
+            "psql",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-U",
+            db_user,
+            "-d",
+            db_name,
+        ]
+        return cmd, format == "sql.gz"
+    if format == "pgdump":
+        cmd = [
+            "docker",
+            "exec",
+            "-i",
+            container_id,
+            "pg_restore",
+            "--clean",
+            "--if-exists",
+            "--no-owner",
+            "-U",
+            db_user,
+            "-d",
+            db_name,
+        ]
+        return cmd, False
+    raise ValueError(f"Nieobsługiwany format: {format!r}")
+
+
+def restore_dump(
+    dump_path: Path,
+    container_id: str,
+    db_user: str = "bpp",
+    db_name: str = "bpp",
+) -> None:
+    """Wykonuje restore dump-a do kontenera. Rzuca CalledProcessError przy błędzie."""
+    fmt = detect_dump_format(dump_path)
+    if fmt is None:
+        raise ValueError(f"Nieobsługiwany format pliku: {dump_path.name}")
+
+    cmd, needs_decompress = build_restore_command(fmt, container_id, db_user, db_name)
+    logger.info("Restore: %s (%s) → container %s", dump_path, fmt, container_id)
+
+    if needs_decompress:
+        with gzip.open(dump_path, "rb") as src:
+            subprocess.run(cmd, stdin=src, check=True)
+    else:
+        with open(dump_path, "rb") as src:
+            subprocess.run(cmd, stdin=src, check=True)
+    logger.info("Restore: ukończony")

--- a/src/bpp/management/commands/run_site.py
+++ b/src/bpp/management/commands/run_site.py
@@ -100,7 +100,12 @@ class Command(BaseCommand):
         celery_proc = None
         try:
             try:
-                containers = start_containers(reuse=opts["reuse"])
+                # Suppress baseline gdy user dał własny dump — pg_restore
+                # walczy z FK cascade gdy baseline już zaimportowany.
+                containers = start_containers(
+                    reuse=opts["reuse"],
+                    load_baseline=(dump_path is None),
+                )
             except DockerNotRunningError as exc:
                 raise CommandError(f"Docker daemon nie jest dostępny: {exc}") from exc
 

--- a/src/bpp/management/commands/run_site.py
+++ b/src/bpp/management/commands/run_site.py
@@ -159,7 +159,7 @@ class Command(BaseCommand):
         if detect_dump_format(path) is None:
             raise CommandError(
                 f"Nieobsługiwany format pliku {path.name}. "
-                f"Użyj .sql, .sql.gz, .dump lub .pgdump."
+                f"Użyj .sql, .sql.gz, .dump, .pgdump lub .pg_dump."
             )
         return path
 

--- a/src/bpp/management/commands/run_site.py
+++ b/src/bpp/management/commands/run_site.py
@@ -206,23 +206,25 @@ class Command(BaseCommand):
             raise CommandError(f"manage.py migrate failed (rc={rc})")
 
     def _create_superuser(self, env):
+        """Utwórz lub nadpisz superusera + skasuj wymóg zmiany hasła.
+
+        Idempotentne: gdy user "admin" już istnieje (np. po restore dump-a
+        z prod-u), hasło i flagi (is_active/is_staff/is_superuser) są
+        nadpisywane. Wpisy w ``password_policies.PasswordChangeRequired``
+        są kasowane, żeby admin nie dostawał propozycji zmiany hasła
+        zaraz po zalogowaniu.
+        """
         self.stdout.write(
             f"[run_site] Superuser: {_SUPERUSER_USERNAME} / {_SUPERUSER_PASSWORD}"
         )
         cmd = [
             _python_executable(),
             str(_src_dir() / "manage.py"),
-            "createsuperuser",
-            "--noinput",
+            "runsite_setup_admin",
         ]
         rc = run_subprocess_blocking(cmd, env=env, cwd=str(_src_dir()))
         if rc != 0:
-            self.stdout.write(
-                self.style.WARNING(
-                    "[run_site] createsuperuser zwrócił błąd "
-                    "(prawdopodobnie user już istnieje — kontynuuję)"
-                )
-            )
+            raise CommandError(f"runsite_setup_admin failed (rc={rc})")
 
     def _print_banner(
         self, *, appserver_url, admin_url, containers, with_celery, dump_path

--- a/src/bpp/management/commands/run_site.py
+++ b/src/bpp/management/commands/run_site.py
@@ -1,0 +1,96 @@
+"""Management command: uruchom dev stack z testcontainerami.
+
+Startuje PG+Redis na losowych portach (testcontainers), odtwarza dump,
+tworzy superusera admin/admin, odpala runserver i blokuje. Ctrl-C
+zatrzymuje runserver i sprząta kontenery.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+def _detect_dump_format(path: Path) -> str | None:
+    """Zwraca 'sql' / 'sql.gz' / 'pgdump' lub None.
+
+    Detekcja po extension, case-insensitive. Helper przeniesiony do
+    _run_site_helpers.restore w Task 2.1 — tu duplikat dla skeleton-u.
+    """
+    name = path.name.lower()
+    if name.endswith(".sql.gz"):
+        return "sql.gz"
+    if name.endswith(".sql"):
+        return "sql"
+    if name.endswith(".dump") or name.endswith(".pgdump"):
+        return "pgdump"
+    return None
+
+
+class Command(BaseCommand):
+    help = (
+        "Odpala dev stack BPP: PG+Redis (testcontainers) + runserver. "
+        "Opcjonalnie odtwarza dump i odpala celery."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--from-dump",
+            type=str,
+            default=None,
+            metavar="PATH",
+            help="Plik do odtworzenia (.sql / .sql.gz / .dump). "
+            "Domyślnie: baseline.sql z obrazu PG.",
+        )
+        parser.add_argument(
+            "--with-celery",
+            action="store_true",
+            default=False,
+            help="Dodatkowo odpal celery worker.",
+        )
+        parser.add_argument(
+            "--no-browser",
+            action="store_true",
+            default=False,
+            help="Nie otwieraj przeglądarki.",
+        )
+        parser.add_argument(
+            "--port",
+            type=int,
+            default=None,
+            help="Port runserver (default: wolny port).",
+        )
+        parser.add_argument(
+            "--reuse",
+            action="store_true",
+            default=False,
+            help="Reuse named containers zamiast tworzyć nowe.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Tylko walidacja args + exit (do testów).",
+        )
+
+    def handle(self, *args, **opts):
+        self._validate_dump_arg(opts.get("from_dump"))
+        if opts.get("dry_run"):
+            self.stdout.write(self.style.SUCCESS("dry-run OK"))
+            return
+
+        raise CommandError("Pełna implementacja w toku — na razie tylko --dry-run.")
+
+    def _validate_dump_arg(self, dump):
+        if dump is None:
+            return None
+        path = Path(dump).expanduser().resolve()
+        if not path.is_file():
+            raise CommandError(f"Plik dump-a nie istnieje: {path}")
+        if _detect_dump_format(path) is None:
+            raise CommandError(
+                f"Nieobsługiwany format pliku {path.name}. "
+                f"Użyj .sql, .sql.gz, .dump lub .pgdump."
+            )
+        return path

--- a/src/bpp/management/commands/run_site.py
+++ b/src/bpp/management/commands/run_site.py
@@ -11,21 +11,7 @@ from pathlib import Path
 
 from django.core.management.base import BaseCommand, CommandError
 
-
-def _detect_dump_format(path: Path) -> str | None:
-    """Zwraca 'sql' / 'sql.gz' / 'pgdump' lub None.
-
-    Detekcja po extension, case-insensitive. Helper przeniesiony do
-    _run_site_helpers.restore w Task 2.1 — tu duplikat dla skeleton-u.
-    """
-    name = path.name.lower()
-    if name.endswith(".sql.gz"):
-        return "sql.gz"
-    if name.endswith(".sql"):
-        return "sql"
-    if name.endswith(".dump") or name.endswith(".pgdump"):
-        return "pgdump"
-    return None
+from ._run_site_helpers.restore import detect_dump_format
 
 
 class Command(BaseCommand):
@@ -88,7 +74,7 @@ class Command(BaseCommand):
         path = Path(dump).expanduser().resolve()
         if not path.is_file():
             raise CommandError(f"Plik dump-a nie istnieje: {path}")
-        if _detect_dump_format(path) is None:
+        if detect_dump_format(path) is None:
             raise CommandError(
                 f"Nieobsługiwany format pliku {path.name}. "
                 f"Użyj .sql, .sql.gz, .dump lub .pgdump."

--- a/src/bpp/management/commands/run_site.py
+++ b/src/bpp/management/commands/run_site.py
@@ -7,11 +7,35 @@ zatrzymuje runserver i sprząta kontenery.
 
 from __future__ import annotations
 
+import logging
+import os
+import threading
+import time
+import webbrowser
 from pathlib import Path
 
 from django.core.management.base import BaseCommand, CommandError
 
-from ._run_site_helpers.restore import detect_dump_format
+from ._run_site_helpers.banner import format_banner
+from ._run_site_helpers.processes import (
+    _python_executable,
+    _src_dir,
+    find_free_port,
+    run_subprocess_blocking,
+    spawn_celery,
+    spawn_runserver,
+    wait_terminate,
+)
+from ._run_site_helpers.restore import detect_dump_format, restore_dump
+
+logger = logging.getLogger(__name__)
+
+
+_SUPERUSER_USERNAME = "admin"
+_SUPERUSER_PASSWORD = "admin"  # noqa: S105 — dev tool, intencjonalnie hardcoded
+_SUPERUSER_EMAIL = "admin@example.com"
+
+_BROWSER_OPEN_DELAY_SECONDS = 2.0
 
 
 class Command(BaseCommand):
@@ -60,13 +84,71 @@ class Command(BaseCommand):
             help="Tylko walidacja args + exit (do testów).",
         )
 
-    def handle(self, *args, **opts):
-        self._validate_dump_arg(opts.get("from_dump"))
+    def handle(self, *args, **opts):  # noqa: C901
+        dump_path = self._validate_dump_arg(opts.get("from_dump"))
         if opts.get("dry_run"):
             self.stdout.write(self.style.SUCCESS("dry-run OK"))
             return
 
-        raise CommandError("Pełna implementacja w toku — na razie tylko --dry-run.")
+        from testcontainers_bpp.containers import (
+            DockerNotRunningError,
+            start_containers,
+            stop_containers,
+        )
+
+        containers = None
+        celery_proc = None
+        try:
+            try:
+                containers = start_containers(reuse=opts["reuse"])
+            except DockerNotRunningError as exc:
+                raise CommandError(f"Docker daemon nie jest dostępny: {exc}") from exc
+
+            env = self._build_env(containers)
+            self._restore_dump_if_needed(dump_path, containers)
+            self._migrate(env)
+            self._create_superuser(env)
+
+            port = opts.get("port") or find_free_port()
+            appserver_url = f"http://127.0.0.1:{port}"
+            admin_url = f"{appserver_url}/admin/"
+
+            self._print_banner(
+                appserver_url=appserver_url,
+                admin_url=admin_url,
+                containers=containers,
+                with_celery=opts["with_celery"],
+                dump_path=dump_path,
+            )
+
+            if opts["with_celery"]:
+                celery_proc = spawn_celery(env)
+
+            if not opts["no_browser"]:
+                self._open_browser(admin_url)
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"\nrunserver: {appserver_url}/  (Ctrl-C aby zakończyć)"
+                )
+            )
+
+            runserver_proc = spawn_runserver(port, env)
+            try:
+                runserver_proc.wait()
+            except KeyboardInterrupt:
+                self.stdout.write("\n[run_site] Przerwane (Ctrl-C)")
+                wait_terminate(runserver_proc)
+        finally:
+            if celery_proc is not None:
+                wait_terminate(celery_proc)
+            if containers is not None:
+                try:
+                    stop_containers(containers)
+                except Exception:
+                    logger.exception("[run_site] Failed to stop containers")
+
+    # ── helpers ─────────────────────────────────────────────────────────
 
     def _validate_dump_arg(self, dump):
         if dump is None:
@@ -80,3 +162,87 @@ class Command(BaseCommand):
                 f"Użyj .sql, .sql.gz, .dump lub .pgdump."
             )
         return path
+
+    def _build_env(self, containers) -> dict[str, str]:
+        env = os.environ.copy()
+        env["DJANGO_BPP_DB_HOST"] = containers.pg_host
+        env["DJANGO_BPP_DB_PORT"] = str(containers.pg_port)
+        env["DJANGO_BPP_REDIS_HOST"] = containers.redis_host
+        env["DJANGO_BPP_REDIS_PORT"] = str(containers.redis_port)
+        env["DJANGO_BPP_SKIP_DOTENV"] = "1"
+        env["DJANGO_SUPERUSER_USERNAME"] = _SUPERUSER_USERNAME
+        env["DJANGO_SUPERUSER_PASSWORD"] = _SUPERUSER_PASSWORD
+        env["DJANGO_SUPERUSER_EMAIL"] = _SUPERUSER_EMAIL
+        return env
+
+    def _restore_dump_if_needed(self, dump_path, containers):
+        if dump_path is None:
+            return
+        if containers.pg is None:
+            raise CommandError(
+                "Reuse=True nie ma kontenera do restore — "
+                "uruchom raz bez --reuse aby zaimportować dump."
+            )
+        container_id = containers.pg.get_wrapped_container().id
+        self.stdout.write(f"[run_site] Restore: {dump_path} → PG container...")
+        restore_dump(dump_path, container_id)
+        self.stdout.write(self.style.SUCCESS("[run_site] Restore: ukończony"))
+
+    def _migrate(self, env):
+        self.stdout.write("[run_site] Migracja...")
+        cmd = [
+            _python_executable(),
+            str(_src_dir() / "manage.py"),
+            "migrate",
+            "--noinput",
+        ]
+        rc = run_subprocess_blocking(cmd, env=env, cwd=str(_src_dir()))
+        if rc != 0:
+            raise CommandError(f"manage.py migrate failed (rc={rc})")
+
+    def _create_superuser(self, env):
+        self.stdout.write(
+            f"[run_site] Superuser: {_SUPERUSER_USERNAME} / {_SUPERUSER_PASSWORD}"
+        )
+        cmd = [
+            _python_executable(),
+            str(_src_dir() / "manage.py"),
+            "createsuperuser",
+            "--noinput",
+        ]
+        rc = run_subprocess_blocking(cmd, env=env, cwd=str(_src_dir()))
+        if rc != 0:
+            self.stdout.write(
+                self.style.WARNING(
+                    "[run_site] createsuperuser zwrócił błąd "
+                    "(prawdopodobnie user już istnieje — kontynuuję)"
+                )
+            )
+
+    def _print_banner(
+        self, *, appserver_url, admin_url, containers, with_celery, dump_path
+    ):
+        text = format_banner(
+            appserver_url=appserver_url,
+            admin_url=admin_url,
+            admin_user=_SUPERUSER_USERNAME,
+            admin_pass=_SUPERUSER_PASSWORD,
+            pg_host=containers.pg_host,
+            pg_port=containers.pg_port,
+            redis_host=containers.redis_host,
+            redis_port=containers.redis_port,
+            with_celery=with_celery,
+            dump_label=str(dump_path) if dump_path else "baseline",
+        )
+        self.stdout.write("")
+        self.stdout.write(text)
+
+    def _open_browser(self, url):
+        def _delayed():
+            try:
+                time.sleep(_BROWSER_OPEN_DELAY_SECONDS)
+                webbrowser.open(url)
+            except Exception:
+                logger.exception("[run_site] Otwarcie przeglądarki nie powiodło się")
+
+        threading.Thread(target=_delayed, daemon=True).start()

--- a/src/bpp/management/commands/runsite_setup_admin.py
+++ b/src/bpp/management/commands/runsite_setup_admin.py
@@ -1,0 +1,65 @@
+"""Internal management command — wywoływana przez ``run_site``.
+
+Tworzy LUB nadpisuje superusera ``admin/admin`` i czyści wymóg zmiany hasła
+z password_policies (jeśli zainstalowane). NIE należy uruchamiać tego ręcznie
+poza dev workflow.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Wewnętrzna komenda używana przez run_site — tworzy/nadpisuje "
+        "superusera admin/admin i kasuje wymóg zmiany hasła."
+    )
+
+    requires_migrations_checks = False
+
+    def handle(self, *args, **opts):
+        username = os.environ.get("DJANGO_SUPERUSER_USERNAME", "admin")
+        password = os.environ.get("DJANGO_SUPERUSER_PASSWORD", "admin")
+        email = os.environ.get("DJANGO_SUPERUSER_EMAIL", "admin@example.com")
+
+        User = get_user_model()
+        user, created = User.objects.get_or_create(
+            username=username, defaults={"email": email}
+        )
+        user.email = email
+        user.set_password(password)
+        user.is_active = True
+        user.is_staff = True
+        user.is_superuser = True
+        user.save()
+
+        if created:
+            self.stdout.write(self.style.SUCCESS(f"Superuser {username!r} utworzony."))
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Superuser {username!r} istnieje — hasło i flagi nadpisane."
+                )
+            )
+
+        self._clear_password_change_required(user)
+
+    def _clear_password_change_required(self, user):
+        """Usuń wymóg zmiany hasła z django-password-policies, jeśli istnieje."""
+        try:
+            from password_policies.models import PasswordChangeRequired
+        except ImportError:
+            return  # password_policies nie jest zainstalowane — nic do robienia
+
+        deleted, _ = PasswordChangeRequired.objects.filter(user=user).delete()
+        if deleted:
+            self.stdout.write(
+                f"Usunięto {deleted} wpisów PasswordChangeRequired dla {user}."
+            )

--- a/src/bpp/management/commands/runsite_setup_admin.py
+++ b/src/bpp/management/commands/runsite_setup_admin.py
@@ -50,6 +50,7 @@ class Command(BaseCommand):
             )
 
         self._clear_password_change_required(user)
+        self._refresh_password_history(user)
 
     def _clear_password_change_required(self, user):
         """Usuń wymóg zmiany hasła z django-password-policies, jeśli istnieje."""
@@ -63,3 +64,26 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"Usunięto {deleted} wpisów PasswordChangeRequired dla {user}."
             )
+
+    def _refresh_password_history(self, user):
+        """Dodaj świeży wpis PasswordHistory żeby middleware nie wymuszał zmiany.
+
+        ``password_policies.middleware.PasswordChangeMiddleware`` sprawdza wiek
+        ostatniego ``PasswordHistory`` (lub ``date_joined`` jako fallback)
+        względem ``PASSWORD_DURATION_SECONDS``. Po restore dump-a wpisy
+        admina są stare → hasło uznawane za przeterminowane.
+
+        Dodajemy świeży wpis z ``auto_now_add=True`` (=teraz), więc
+        ``get_newest(user)`` zwraca aktualny timestamp i ekspiracja nie
+        triggeruje. Stare wpisy zostają — szkody nie robią.
+        """
+        try:
+            from password_policies.models import PasswordHistory
+        except ImportError:
+            return
+
+        PasswordHistory.objects.create(user=user, password=user.password)
+        self.stdout.write(
+            f"Dodano świeży wpis PasswordHistory dla {user} "
+            "(zapobiega wymuszeniu zmiany hasła)."
+        )

--- a/src/bpp/newsfragments/+run-site-command.feature.rst
+++ b/src/bpp/newsfragments/+run-site-command.feature.rst
@@ -1,0 +1,5 @@
+Nowa komenda ``manage.py run_site`` — uruchamia dev stack BPP w testcontainerach
+na losowych portach (PG + Redis), opcjonalnie odtwarza dump bazy
+(``--from-dump path``, autodetect ``.sql`` / ``.sql.gz`` / ``.dump``), tworzy
+superusera ``admin/admin``, odpala ``runserver`` i otwiera przeglądarkę.
+Eliminuje konflikty portów przy wielu konfiguracjach BPP na jednym serwerze.

--- a/src/bpp/tests/test_run_site_command.py
+++ b/src/bpp/tests/test_run_site_command.py
@@ -1,0 +1,51 @@
+"""Testy command-line interface komendy run_site (no Docker required)."""
+
+import contextlib
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+
+def test_run_site_help_does_not_crash():
+    """Sanity check że komenda jest zarejestrowana."""
+    # Django's argparse `--help` writes via sys.stdout (nie self.stdout),
+    # więc trzeba przejąć sys.stdout — `stdout=out` w call_command nie
+    # zadziała dla `--help`.
+    out = StringIO()
+    with pytest.raises(SystemExit) as exc_info:
+        with contextlib.redirect_stdout(out):
+            call_command("run_site", "--help", stdout=out)
+    assert exc_info.value.code == 0
+    text = out.getvalue()
+    assert "--from-dump" in text
+    assert "--with-celery" in text
+    assert "--no-browser" in text
+    assert "--port" in text
+    assert "--reuse" in text
+
+
+def test_run_site_invalid_dump_path_raises(tmp_path):
+    """Nieistniejący --from-dump rzuca CommandError od razu."""
+    from django.core.management.base import CommandError
+
+    nonexistent = tmp_path / "no-such-file.sql"
+    with pytest.raises(CommandError, match="nie istnieje"):
+        call_command("run_site", "--from-dump", str(nonexistent), "--dry-run")
+
+
+def test_run_site_unsupported_format_raises(tmp_path):
+    """Plik o nieobsługiwanym rozszerzeniu rzuca CommandError."""
+    from django.core.management.base import CommandError
+
+    bad = tmp_path / "dump.tar"
+    bad.write_text("x")
+    with pytest.raises(CommandError, match="format"):
+        call_command("run_site", "--from-dump", str(bad), "--dry-run")
+
+
+def test_run_site_dry_run_with_valid_sql_succeeds(tmp_path):
+    """Dry-run z poprawnym .sql kończy się bez błędów."""
+    sql = tmp_path / "valid.sql"
+    sql.write_text("SELECT 1;")
+    call_command("run_site", "--from-dump", str(sql), "--dry-run")

--- a/src/bpp/tests/test_run_site_helpers.py
+++ b/src/bpp/tests/test_run_site_helpers.py
@@ -146,3 +146,46 @@ def test_banner_dump_label_path():
         dump_label="/path/to/dump.sql.gz",
     )
     assert "/path/to/dump.sql.gz" in text
+
+
+def test_find_free_port_returns_int_in_range():
+    from bpp.management.commands._run_site_helpers.processes import find_free_port
+
+    port = find_free_port()
+    assert isinstance(port, int)
+    assert 1024 <= port <= 65535
+
+
+def test_find_free_port_unique_calls():
+    """Dwa wywołania zwracają różne porty (statystycznie pewne)."""
+    from bpp.management.commands._run_site_helpers.processes import find_free_port
+
+    ports = {find_free_port() for _ in range(5)}
+    assert len(ports) >= 3
+
+
+def test_python_executable_is_path():
+    from bpp.management.commands._run_site_helpers.processes import _python_executable
+
+    exe = _python_executable()
+    assert exe  # non-empty
+    assert "python" in exe.lower()
+
+
+def test_src_dir_resolves_to_src():
+    from bpp.management.commands._run_site_helpers.processes import _src_dir
+
+    p = _src_dir()
+    assert p.name == "src"
+    assert (p / "manage.py").exists()
+
+
+def test_wait_terminate_already_exited():
+    """wait_terminate na już-zakończonym procesie nie crashuje."""
+    import subprocess
+    from bpp.management.commands._run_site_helpers.processes import wait_terminate
+
+    proc = subprocess.Popen(["python", "-c", "pass"])
+    proc.wait()
+    # Nie powinno rzucić — proc.poll() zwraca returncode
+    wait_terminate(proc)

--- a/src/bpp/tests/test_run_site_helpers.py
+++ b/src/bpp/tests/test_run_site_helpers.py
@@ -34,6 +34,13 @@ def test_detect_format_pgdump_alt(tmp_path):
     assert detect_dump_format(p) == "pgdump"
 
 
+def test_detect_format_pg_dump_underscore(tmp_path):
+    """pg_dump produkuje też pliki z extension .pg_dump (z underscore)."""
+    p = tmp_path / "db-backup.pg_dump"
+    p.write_bytes(b"")
+    assert detect_dump_format(p) == "pgdump"
+
+
 def test_detect_format_uppercase_extension(tmp_path):
     p = tmp_path / "X.SQL.GZ"
     p.write_bytes(b"")

--- a/src/bpp/tests/test_run_site_helpers.py
+++ b/src/bpp/tests/test_run_site_helpers.py
@@ -1,0 +1,82 @@
+"""Testy helperów run_site (bez Dockera)."""
+
+from pathlib import Path
+
+import pytest
+
+from bpp.management.commands._run_site_helpers.restore import (
+    detect_dump_format,
+    build_restore_command,
+)
+
+
+def test_detect_format_sql(tmp_path):
+    p = tmp_path / "x.sql"
+    p.write_text("")
+    assert detect_dump_format(p) == "sql"
+
+
+def test_detect_format_sql_gz(tmp_path):
+    p = tmp_path / "x.sql.gz"
+    p.write_bytes(b"")
+    assert detect_dump_format(p) == "sql.gz"
+
+
+def test_detect_format_pgdump(tmp_path):
+    p = tmp_path / "x.dump"
+    p.write_bytes(b"")
+    assert detect_dump_format(p) == "pgdump"
+
+
+def test_detect_format_pgdump_alt(tmp_path):
+    p = tmp_path / "x.pgdump"
+    p.write_bytes(b"")
+    assert detect_dump_format(p) == "pgdump"
+
+
+def test_detect_format_uppercase_extension(tmp_path):
+    p = tmp_path / "X.SQL.GZ"
+    p.write_bytes(b"")
+    assert detect_dump_format(p) == "sql.gz"
+
+
+def test_detect_format_unknown(tmp_path):
+    p = tmp_path / "x.tar"
+    p.write_bytes(b"")
+    assert detect_dump_format(p) is None
+
+
+def test_build_restore_command_sql():
+    cmd, decompress = build_restore_command(
+        format="sql", container_id="abc123", db_user="bpp", db_name="bpp"
+    )
+    assert decompress is False
+    assert cmd[:4] == ["docker", "exec", "-i", "abc123"]
+    assert "psql" in cmd
+    assert "-U" in cmd and "bpp" in cmd
+    assert "-d" in cmd
+
+
+def test_build_restore_command_sql_gz_decompresses():
+    cmd, decompress = build_restore_command(
+        format="sql.gz", container_id="abc123", db_user="bpp", db_name="bpp"
+    )
+    assert decompress is True  # caller pipes through gunzip
+    assert "psql" in cmd
+
+
+def test_build_restore_command_pgdump_uses_pg_restore():
+    cmd, decompress = build_restore_command(
+        format="pgdump", container_id="abc123", db_user="bpp", db_name="bpp"
+    )
+    assert decompress is False
+    assert "pg_restore" in cmd
+    assert "--clean" in cmd
+    assert "--if-exists" in cmd
+
+
+def test_build_restore_command_unknown_raises():
+    with pytest.raises(ValueError):
+        build_restore_command(
+            format="tar", container_id="x", db_user="bpp", db_name="bpp"
+        )

--- a/src/bpp/tests/test_run_site_helpers.py
+++ b/src/bpp/tests/test_run_site_helpers.py
@@ -78,8 +78,11 @@ def test_build_restore_command_pgdump_uses_pg_restore():
     )
     assert decompress is False
     assert "pg_restore" in cmd
-    assert "--clean" in cmd
-    assert "--if-exists" in cmd
+    # Brak --clean / --if-exists — zakładamy pustą bazę (caller suppressuje baseline).
+    assert "--clean" not in cmd
+    assert "--if-exists" not in cmd
+    assert "--no-owner" in cmd
+    assert "--exit-on-error" in cmd
 
 
 def test_build_restore_command_unknown_raises():

--- a/src/bpp/tests/test_run_site_helpers.py
+++ b/src/bpp/tests/test_run_site_helpers.py
@@ -80,3 +80,69 @@ def test_build_restore_command_unknown_raises():
         build_restore_command(
             format="tar", container_id="x", db_user="bpp", db_name="bpp"
         )
+
+
+def test_banner_includes_all_endpoints():
+    from bpp.management.commands._run_site_helpers.banner import format_banner
+
+    text = format_banner(
+        appserver_url="http://localhost:54321",
+        admin_url="http://localhost:54321/admin/",
+        admin_user="admin",
+        admin_pass="admin",
+        pg_host="127.0.0.1",
+        pg_port=54322,
+        redis_host="127.0.0.1",
+        redis_port=54323,
+        with_celery=False,
+        dump_label="baseline",
+    )
+    assert "http://localhost:54321" in text
+    assert "/admin/" in text
+    assert "admin" in text
+    assert "127.0.0.1:54322" in text
+    assert "127.0.0.1:54323" in text
+    assert "baseline" in text
+
+
+def test_banner_celery_running_label():
+    from bpp.management.commands._run_site_helpers.banner import format_banner
+
+    text = format_banner(
+        appserver_url="http://localhost:1",
+        admin_url="http://localhost:1/admin/",
+        admin_user="admin",
+        admin_pass="admin",
+        pg_host="x", pg_port=1, redis_host="x", redis_port=2,
+        with_celery=True,
+        dump_label="baseline",
+    )
+    assert "running" in text.lower()
+
+
+def test_banner_celery_disabled_label():
+    from bpp.management.commands._run_site_helpers.banner import format_banner
+
+    text = format_banner(
+        appserver_url="http://localhost:1",
+        admin_url="http://localhost:1/admin/",
+        admin_user="admin",
+        admin_pass="admin",
+        pg_host="x", pg_port=1, redis_host="x", redis_port=2,
+        with_celery=False,
+        dump_label="baseline",
+    )
+    assert "disabled" in text.lower() or "wyłączone" in text.lower()
+
+
+def test_banner_dump_label_path():
+    from bpp.management.commands._run_site_helpers.banner import format_banner
+
+    text = format_banner(
+        appserver_url="x", admin_url="y",
+        admin_user="a", admin_pass="b",
+        pg_host="x", pg_port=1, redis_host="y", redis_port=2,
+        with_celery=False,
+        dump_label="/path/to/dump.sql.gz",
+    )
+    assert "/path/to/dump.sql.gz" in text

--- a/src/bpp/tests/test_run_site_setup_admin.py
+++ b/src/bpp/tests/test_run_site_setup_admin.py
@@ -68,6 +68,36 @@ def test_clears_password_change_required(superuser_env):
 
 
 @pytest.mark.django_db
+def test_adds_fresh_password_history_entry(superuser_env):
+    """Świeży PasswordHistory zapobiega wymuszeniu zmiany przez middleware."""
+    User = get_user_model()
+    User.objects.create_user(username="admin", password="x")
+
+    try:
+        from password_policies.models import PasswordHistory
+    except ImportError:
+        pytest.skip("password_policies nie zainstalowane")
+
+    # Przed komendą: brak wpisów PasswordHistory dla admina
+    user = User.objects.get(username="admin")
+    assert not PasswordHistory.objects.filter(user=user).exists()
+
+    call_command("runsite_setup_admin")
+
+    user.refresh_from_db()
+    entries = PasswordHistory.objects.filter(user=user)
+    assert entries.count() == 1
+    # newest jest świeży (młodszy niż 1 minuta)
+    from django.utils import timezone
+    from datetime import timedelta
+
+    newest = entries.latest("created")
+    assert (timezone.now() - newest.created) < timedelta(minutes=1)
+    # password to faktyczny hash (zaczyna się od pbkdf2 / argon2 / etc.)
+    assert "$" in newest.password
+
+
+@pytest.mark.django_db
 def test_uses_default_credentials_when_env_missing(monkeypatch):
     """Bez env vars używa default admin/admin/admin@example.com."""
     monkeypatch.delenv("DJANGO_SUPERUSER_USERNAME", raising=False)

--- a/src/bpp/tests/test_run_site_setup_admin.py
+++ b/src/bpp/tests/test_run_site_setup_admin.py
@@ -1,0 +1,84 @@
+"""Testy komendy runsite_setup_admin."""
+
+import os
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+
+@pytest.fixture
+def superuser_env(monkeypatch):
+    monkeypatch.setenv("DJANGO_SUPERUSER_USERNAME", "admin")
+    monkeypatch.setenv("DJANGO_SUPERUSER_PASSWORD", "admin")
+    monkeypatch.setenv("DJANGO_SUPERUSER_EMAIL", "admin@example.com")
+
+
+@pytest.mark.django_db
+def test_creates_admin_when_missing(superuser_env):
+    User = get_user_model()
+    assert not User.objects.filter(username="admin").exists()
+    call_command("runsite_setup_admin")
+    user = User.objects.get(username="admin")
+    assert user.is_superuser
+    assert user.is_staff
+    assert user.is_active
+    assert user.check_password("admin")
+
+
+@pytest.mark.django_db
+def test_overwrites_password_and_flags_when_exists(superuser_env):
+    """Gdy admin już istnieje (np. po restore dump-a) — hasło i flagi nadpisane."""
+    User = get_user_model()
+    existing = User.objects.create_user(
+        username="admin",
+        password="old-secret",
+        email="old@example.com",
+        is_active=False,
+        is_staff=False,
+        is_superuser=False,
+    )
+    call_command("runsite_setup_admin")
+    existing.refresh_from_db()
+    assert existing.is_superuser
+    assert existing.is_staff
+    assert existing.is_active
+    assert existing.check_password("admin")
+    assert not existing.check_password("old-secret")
+    assert existing.email == "admin@example.com"
+
+
+@pytest.mark.django_db
+def test_clears_password_change_required(superuser_env):
+    """PasswordChangeRequired dla admina jest skasowane → brak propozycji zmiany hasła."""
+    User = get_user_model()
+    user = User.objects.create_user(username="admin", password="x")
+
+    try:
+        from password_policies.models import PasswordChangeRequired
+    except ImportError:
+        pytest.skip("password_policies nie zainstalowane")
+
+    PasswordChangeRequired.objects.create(user=user)
+    assert PasswordChangeRequired.objects.filter(user=user).exists()
+
+    call_command("runsite_setup_admin")
+
+    assert not PasswordChangeRequired.objects.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_uses_default_credentials_when_env_missing(monkeypatch):
+    """Bez env vars używa default admin/admin/admin@example.com."""
+    monkeypatch.delenv("DJANGO_SUPERUSER_USERNAME", raising=False)
+    monkeypatch.delenv("DJANGO_SUPERUSER_PASSWORD", raising=False)
+    monkeypatch.delenv("DJANGO_SUPERUSER_EMAIL", raising=False)
+
+    User = get_user_model()
+    call_command("runsite_setup_admin")
+    user = User.objects.get(username="admin")
+    assert user.check_password("admin")
+    assert user.email == "admin@example.com"
+
+
+_ = os  # silence unused import warning if not needed

--- a/src/testcontainers_bpp/containers.py
+++ b/src/testcontainers_bpp/containers.py
@@ -117,8 +117,19 @@ def _get_host_port(
     return host, int(binding["HostPort"])
 
 
-def _start_pg(reuse: bool) -> tuple[PostgresContainer | None, str, int]:
-    """Start PostgreSQL container or reuse an existing one."""
+def _start_pg(
+    reuse: bool, load_baseline: bool = True
+) -> tuple[PostgresContainer | None, str, int]:
+    """Start PostgreSQL container or reuse an existing one.
+
+    Args:
+        reuse: jeśli True, próbuje znaleźć istniejący named container.
+        load_baseline: jeśli True (default), montuje ``baseline.sql``
+            do init scripts. Ustaw False gdy zamierzasz zrobić własny
+            restore na pustej bazie (np. ``pg_restore`` z user-dump-a) —
+            inaczej masz zaimportowany baseline przed restore-em i
+            ``--clean`` walczy z istniejącymi FK.
+    """
     if reuse:
         existing = _find_running_container(_PG_NAME)
         if existing:
@@ -153,20 +164,23 @@ def _start_pg(reuse: bool) -> tuple[PostgresContainer | None, str, int]:
         }
     )
 
-    baseline_sql = find_baseline_sql()
-    if baseline_sql is not None:
-        # Postgres' entrypoint (docker-entrypoint.sh) replays every
-        # ``*.sql`` in /docker-entrypoint-initdb.d/ on first cluster
-        # init, before TCP starts accepting connections. testcontainers
-        # waits for ``psql -c 'select version()'`` on TCP (see
-        # PostgresContainer._connect / ExecWaitStrategy), so by the time
-        # pg.start() returns the dump is already loaded.
-        pg.with_volume_mapping(
-            str(baseline_sql),
-            "/docker-entrypoint-initdb.d/01-baseline.sql",
-            "ro",
-        )
-        logger.info("Mounting baseline %s into PG init scripts", baseline_sql)
+    if load_baseline:
+        baseline_sql = find_baseline_sql()
+        if baseline_sql is not None:
+            # Postgres' entrypoint (docker-entrypoint.sh) replays every
+            # ``*.sql`` in /docker-entrypoint-initdb.d/ on first cluster
+            # init, before TCP starts accepting connections. testcontainers
+            # waits for ``psql -c 'select version()'`` on TCP (see
+            # PostgresContainer._connect / ExecWaitStrategy), so by the time
+            # pg.start() returns the dump is already loaded.
+            pg.with_volume_mapping(
+                str(baseline_sql),
+                "/docker-entrypoint-initdb.d/01-baseline.sql",
+                "ro",
+            )
+            logger.info("Mounting baseline %s into PG init scripts", baseline_sql)
+    else:
+        logger.info("Skipping baseline (load_baseline=False)")
 
     pg.start()
 
@@ -200,19 +214,24 @@ def _start_redis(reuse: bool) -> tuple[DockerContainer | None, str, int]:
     return redis, host, port
 
 
-def start_containers(reuse: bool = False) -> BppContainers:
+def start_containers(reuse: bool = False, load_baseline: bool = True) -> BppContainers:
     """Start all service containers.
 
     When *reuse* is True, containers get fixed names and are kept running
     after pytest exits.  On the next run they are detected and reused
     instead of being recreated.
+
+    When *load_baseline* is False, baseline.sql NIE jest montowane do
+    init scripts. Use case: caller chce zrobić własny restore (np.
+    ``pg_restore`` z user-supplied dump-a) na pustej bazie.
     """
     _check_docker_daemon()
     print(  # noqa: T201
-        f"[testcontainers-bpp] Starting containers (reuse={reuse}) ...",
+        f"[testcontainers-bpp] Starting containers "
+        f"(reuse={reuse}, load_baseline={load_baseline}) ...",
         file=sys.stderr,
     )
-    pg, pg_host, pg_port = _start_pg(reuse)
+    pg, pg_host, pg_port = _start_pg(reuse, load_baseline=load_baseline)
     redis, redis_host, redis_port = _start_redis(reuse)
 
     reused = pg is None and redis is None


### PR DESCRIPTION
## Summary

Nowa komenda `manage.py run_site` pozwala szybko uruchomić lokalny dev stack BPP — PostgreSQL + Redis w testcontainerach na losowych portach (eliminuje konflikty portów przy wielu konfiguracjach BPP na jednym hoście).

- Restore dump bazy z autodetect formatu (`.sql` / `.sql.gz` / `.dump` / `.pg_dump` / `.pgdump`).
- Idempotentne tworzenie superusera `admin/admin` z nadpisywaniem hasła i czyszczeniem `password_policies` (zarówno `PasswordChangeRequired` jak i wiek `PasswordHistory`).
- Banner z URL-ami stack-u, automatyczne otwieranie przeglądarki, opcjonalny celery worker.
- Bez `--from-dump`: ładowany baseline.sql jak w testach. Z `--from-dump`: pusta baza + restore (pg_restore bez `--clean` żeby uniknąć FK cascade conflicts).

## Test plan

- [x] `pytest src/bpp/tests/test_run_site_command.py` (4 tests) — CLI args
- [x] `pytest src/bpp/tests/test_run_site_helpers.py` (15 tests) — helpery: format detection, banner, processes
- [x] `pytest src/bpp/tests/test_run_site_setup_admin.py` (5 tests) — overwrite admina, czyszczenie password_policies
- [x] Manual smoke test: `uv run python src/manage.py run_site --from-dump prod.pg_dump` — restore działa, admin loguje się bez wymuszania zmiany hasła
- [x] README zaktualizowany sekcją "Szybkie uruchomienie wersji deweloperskiej"

🤖 Generated with [Claude Code](https://claude.com/claude-code)