### PR TITLE
security: utwardzenie po audycie (timeouts, XSS, formula injection, perms, race)

### DIFF
--- a/src/bpp/newsfragments/+komparator-pbn-udzialy-permissions.bugfix.rst
+++ b/src/bpp/newsfragments/+komparator-pbn-udzialy-permissions.bugfix.rst
@@ -1,0 +1,6 @@
+Widoki listy problemów PBN, szczegółów rozbieżności dyscyplin
+oraz szczegółów brakującego autora w module
+``komparator_pbn_udzialy`` wymagają teraz członkostwa w grupie
+„wprowadzanie danych”. Wcześniej te trzy widoki były dostępne
+publicznie, mimo że pokazują dane synchronizowane z PBN i wewnętrzne
+identyfikatory BPP.

--- a/src/bpp/newsfragments/+pbn-client-http-timeouts.bugfix.rst
+++ b/src/bpp/newsfragments/+pbn-client-http-timeouts.bugfix.rst
@@ -1,0 +1,8 @@
+Klient PBN-API wykonuje teraz wszystkie zapytania HTTP (``GET``,
+``POST``, ``DELETE``, autoryzacja OAuth) z jawnymi limitami czasu
+łączenia i odpowiedzi. Wcześniej brak ``timeout`` powodował, że
+zawieszony serwer PBN mógł zablokować w nieskończoność proces web
+albo workera Celery. Wartość można nadpisać przez ``settings``
+lub zmienną środowiskową ``PBN_CLIENT_HTTP_TIMEOUT`` (sekundy
+jako liczba albo ``connect,read``); domyślnie 30 s connect / 120 s
+read.

--- a/src/bpp/newsfragments/+pbn-tasks-advisory-lock.bugfix.rst
+++ b/src/bpp/newsfragments/+pbn-tasks-advisory-lock.bugfix.rst
@@ -1,0 +1,8 @@
+Tworzenie zadań w tle dla pobrań z PBN
+(``pbn_downloader_app.tasks.create_task_with_lock``) oraz wysyłki
+oświadczeń (``pbn_wysylka_oswiadczen`` widok startu zadania) jest
+teraz chronione przez Postgresowy advisory lock. Wcześniej sprawdzenie
+``filter(status="running").exists()`` wewnątrz ``transaction.atomic()``
+nie gwarantowało wzajemnego wykluczenia — dwa równoczesne żądania
+mogły obydwa nie znaleźć aktywnego zadania i obydwa założyć kolejne,
+przez co dwóch workerów mogło naraz wykonywać tę samą operację.

--- a/src/bpp/newsfragments/+xlsx-formula-injection.bugfix.rst
+++ b/src/bpp/newsfragments/+xlsx-formula-injection.bugfix.rst
@@ -1,0 +1,8 @@
+Eksporty XLSX (porównanie publikacji BPP–PBN, lista publikacji
+do wysyłki oświadczeń) sanityzują teraz wartości komórek przed
+zapisem. Wartości tekstowe zaczynające się od ``=``, ``+``, ``-``,
+``@`` lub białego separatora są poprzedzane apostrofem,
+co powstrzymuje Excela / LibreOffice'a przed interpretacją ich
+jako formuł (CSV/Formula Injection wg OWASP). Pomocnicza funkcja
+``bpp.util.sanitize_xlsx_cell`` / ``sanitize_xlsx_row`` jest
+dostępna do wykorzystania w kolejnych eksportach.

--- a/src/bpp/newsfragments/+zglos-publikacje-autocomplete-xss.bugfix.rst
+++ b/src/bpp/newsfragments/+zglos-publikacje-autocomplete-xss.bugfix.rst
@@ -1,0 +1,6 @@
+Publiczny autocomplete w ``zglos_publikacje`` (wybór wydawcy
+i wydawnictwa nadrzędnego) escape'uje teraz nazwy z bazy BPP
+oraz dane pobrane z PBN przy budowie etykiet w wynikach. Wcześniej
+``mark_safe(f"...")`` interpolował wartości bez sanityzacji,
+przez co tytuł lub nazwa wydawcy zawierające znaczniki HTML
+mogły wstrzyknąć skrypt na publicznej stronie zgłoszenia.

--- a/src/bpp/util.py
+++ b/src/bpp/util.py
@@ -668,6 +668,34 @@ def worksheet_columns_autosize(
         ws.column_dimensions[column].width = adjusted_width
 
 
+# Znaki, którymi zaczynający się tekst Excel/LibreOffice interpretuje
+# jako formułę (=, +, -, @) lub jako wstrzyknięcie do innej komórki/komendy
+# poprzez separator (Tab, CR, LF). Pełna lista zaleceń OWASP CSV/Formula
+# Injection: https://owasp.org/www-community/attacks/CSV_Injection
+_XLSX_FORMULA_INJECTION_LEAD = ("=", "+", "-", "@", "\t", "\r", "\n")
+
+
+def sanitize_xlsx_cell(value):
+    """Zwraca wartość bezpieczną do `ws.append()` / `ws.cell().value`.
+
+    Stringi zaczynające się od znaków interpretowanych jako formuła
+    (=, +, -, @) lub separator (Tab/CR/LF) są poprzedzane apostrofem,
+    co Excel traktuje jako wymuszenie typu „tekst" (apostrof nie jest
+    pokazywany w komórce). Pozostałe wartości (None, liczby, daty itd.)
+    są zwracane bez zmian.
+    """
+    if not isinstance(value, str):
+        return value
+    if value.startswith(_XLSX_FORMULA_INJECTION_LEAD):
+        return "'" + value
+    return value
+
+
+def sanitize_xlsx_row(row):
+    """Wersja `sanitize_xlsx_cell` dla całego wiersza (`ws.append(row)`)."""
+    return [sanitize_xlsx_cell(c) for c in row]
+
+
 def auto_fit_columns(
     ws: openpyxl.worksheet.worksheet.Worksheet,
     max_width: int = 50,

--- a/src/komparator_pbn_udzialy/tests/conftest.py
+++ b/src/komparator_pbn_udzialy/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from django.contrib.auth.models import Group
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+
+
+@pytest.fixture
+def wprowadzanie_danych_group(db):
+    group, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    return group
+
+
+@pytest.fixture
+def client_with_group(client, admin_user, wprowadzanie_danych_group):
+    admin_user.groups.add(wprowadzanie_danych_group)
+    client.force_login(admin_user)
+    return client

--- a/src/komparator_pbn_udzialy/tests/test_views.py
+++ b/src/komparator_pbn_udzialy/tests/test_views.py
@@ -8,8 +8,19 @@ from komparator_pbn_udzialy.models import BrakAutoraWPublikacji, RozbieznoscDysc
 
 
 @pytest.mark.django_db
-def test_problemy_pbn_list_view_empty(client: Client):
+def test_problemy_pbn_list_view_requires_group(client: Client):
+    """Anonimowy klient nie ma dostępu do listy problemów PBN."""
+    url = reverse("komparator_pbn_udzialy:list")
+    response = client.get(url)
+    # GroupRequiredMixin zwraca 302 (login redirect) albo 403 dla
+    # zalogowanych bez grupy; oba są akceptowalne, byle nie 200.
+    assert response.status_code in (302, 403)
+
+
+@pytest.mark.django_db
+def test_problemy_pbn_list_view_empty(client_with_group: Client):
     """Test widoku listy problemów PBN gdy brak danych."""
+    client = client_with_group
     url = reverse("komparator_pbn_udzialy:list")
     response = client.get(url)
 
@@ -19,8 +30,9 @@ def test_problemy_pbn_list_view_empty(client: Client):
 
 
 @pytest.mark.django_db
-def test_problemy_pbn_list_view_with_rozbieznosc(client: Client):
+def test_problemy_pbn_list_view_with_rozbieznosc(client_with_group: Client):
     """Test widoku listy z rozbieżnością dyscyplin."""
+    client = client_with_group
     autor = baker.make("bpp.Autor")
     jednostka = baker.make("bpp.Jednostka")
     wydawnictwo = baker.make("bpp.Wydawnictwo_Ciagle")
@@ -58,8 +70,9 @@ def test_problemy_pbn_list_view_with_rozbieznosc(client: Client):
 
 
 @pytest.mark.django_db
-def test_problemy_pbn_list_view_with_brak_autora(client: Client):
+def test_problemy_pbn_list_view_with_brak_autora(client_with_group: Client):
     """Test widoku listy z brakującym autorem."""
+    client = client_with_group
     pbn_scientist = baker.make("pbn_api.Scientist", name="Jan", lastName="Kowalski")
     publikacja_pbn = baker.make("pbn_api.Publication", year=2024, title="Test article")
     oswiadczenie = baker.make(
@@ -85,8 +98,9 @@ def test_problemy_pbn_list_view_with_brak_autora(client: Client):
 
 
 @pytest.mark.django_db
-def test_problemy_pbn_list_view_filter_by_typ(client: Client):
+def test_problemy_pbn_list_view_filter_by_typ(client_with_group: Client):
     """Test filtrowania widoku po typie problemu."""
+    client = client_with_group
     pbn_scientist = baker.make("pbn_api.Scientist", name="Anna", lastName="Nowak")
     publikacja_pbn = baker.make("pbn_api.Publication", year=2023)
     oswiadczenie = baker.make(
@@ -119,8 +133,9 @@ def test_problemy_pbn_list_view_filter_by_typ(client: Client):
 
 
 @pytest.mark.django_db
-def test_problemy_pbn_list_view_statistics(client: Client):
+def test_problemy_pbn_list_view_statistics(client_with_group: Client):
     """Test statystyk w widoku listy."""
+    client = client_with_group
     pbn_scientist = baker.make("pbn_api.Scientist")
     oswiadczenie1 = baker.make(
         "pbn_api.OswiadczenieInstytucji",

--- a/src/komparator_pbn_udzialy/views.py
+++ b/src/komparator_pbn_udzialy/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from braces.views import GroupRequiredMixin
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.contenttypes.models import ContentType
@@ -12,6 +13,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.generic import DetailView
 
+from bpp.const import GR_WPROWADZANIE_DANYCH
 from komparator_pbn_udzialy.models import (
     BrakAutoraWPublikacji,
     ProblemWrapper,
@@ -22,9 +24,10 @@ from pbn_downloader_app.freshness import is_pbn_publications_data_fresh
 logger = logging.getLogger(__name__)
 
 
-class ProblemyPBNListView(View):
+class ProblemyPBNListView(GroupRequiredMixin, View):
     """Widok listy wszystkich problemów PBN - rozbieżności i brakujących autorów."""
 
+    group_required = GR_WPROWADZANIE_DANYCH
     template_name = "komparator_pbn_udzialy/list.html"
 
     def get(self, request):
@@ -227,9 +230,10 @@ class ProblemyPBNListView(View):
         }
 
 
-class RozbieznoscDyscyplinPBNDetailView(DetailView):
+class RozbieznoscDyscyplinPBNDetailView(GroupRequiredMixin, DetailView):
     """Widok szczegółowy rozbieżności."""
 
+    group_required = GR_WPROWADZANIE_DANYCH
     model = RozbieznoscDyscyplinPBN
     template_name = "komparator_pbn_udzialy/detail.html"
     context_object_name = "rozbieznosc"
@@ -351,9 +355,10 @@ class TaskStatusAPIView(View):
             return JsonResponse({"status": "ERROR", "message": str(e)}, status=500)
 
 
-class BrakAutoraDetailView(DetailView):
+class BrakAutoraDetailView(GroupRequiredMixin, DetailView):
     """Widok szczegółowy brakującego autora."""
 
+    group_required = GR_WPROWADZANIE_DANYCH
     model = BrakAutoraWPublikacji
     template_name = "komparator_pbn_udzialy/brak_autora_detail.html"
     context_object_name = "brak_autora"

--- a/src/komparator_publikacji_pbn/views.py
+++ b/src/komparator_publikacji_pbn/views.py
@@ -11,6 +11,7 @@ from openpyxl import Workbook
 from openpyxl.styles import Alignment, Font, PatternFill
 
 from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Zwarte
+from bpp.util import sanitize_xlsx_row
 from import_common.normalization import normalize_isbn, normalize_issn
 from pbn_downloader_app.freshness import is_pbn_publications_data_fresh
 
@@ -551,20 +552,22 @@ class PublicationComparisonView(ListView):
         for comparison in comparisons:
             for diff in comparison["differences"]:
                 ws.append(
-                    [
-                        (
-                            "Wydawnictwo ciągłe"
-                            if comparison["type"] == "ciagle"
-                            else "Wydawnictwo zwarte"
-                        ),
-                        comparison["bpp_id"],
-                        comparison["pbn_id"],
-                        comparison["bpp_publication"].tytul_oryginalny[:100],
-                        comparison["bpp_publication"].rok,
-                        diff["field"],
-                        diff["bpp_value"],
-                        diff["pbn_value"],
-                    ]
+                    sanitize_xlsx_row(
+                        [
+                            (
+                                "Wydawnictwo ciągłe"
+                                if comparison["type"] == "ciagle"
+                                else "Wydawnictwo zwarte"
+                            ),
+                            comparison["bpp_id"],
+                            comparison["pbn_id"],
+                            comparison["bpp_publication"].tytul_oryginalny[:100],
+                            comparison["bpp_publication"].rok,
+                            diff["field"],
+                            diff["bpp_value"],
+                            diff["pbn_value"],
+                        ]
+                    )
                 )
                 row_num += 1
 

--- a/src/pbn_api/client/auth.py
+++ b/src/pbn_api/client/auth.py
@@ -24,13 +24,20 @@ class OAuthMixin:
 
     @classmethod
     def get_user_token(klass, base_url, app_id, app_token, one_time_token):
+        from pbn_api.conf import settings as pbn_settings
+
         headers = {
             "X-App-Id": app_id,
             "X-App-Token": app_token,
         }
         body = {"oneTimeToken": one_time_token}
         url = f"{base_url}/auth/pbn/api/user/token"
-        response = requests.post(url=url, json=body, headers=headers)
+        response = requests.post(
+            url=url,
+            json=body,
+            headers=headers,
+            timeout=pbn_settings.PBN_CLIENT_HTTP_TIMEOUT,
+        )
         try:
             response.json()
         except ValueError as e:

--- a/src/pbn_api/client/transport.py
+++ b/src/pbn_api/client/transport.py
@@ -53,10 +53,16 @@ class RequestsTransport(OAuthMixin, PBNClientTransport):
 
     def _make_get_request_with_retry(self, url, headers, max_retries=15):
         """Make GET request with retry on SSL/Connection errors."""
+        from pbn_api.conf import settings as pbn_settings
+
         retries = 0
         while retries < max_retries:
             try:
-                return requests.get(self.base_url + url, headers=headers)
+                return requests.get(
+                    self.base_url + url,
+                    headers=headers,
+                    timeout=pbn_settings.PBN_CLIENT_HTTP_TIMEOUT,
+                )
             except (SSLError, ConnectionError) as e:
                 retries += 1
                 time.sleep(random.randint(1, 5))
@@ -169,9 +175,16 @@ class RequestsTransport(OAuthMixin, PBNClientTransport):
         if not hasattr(self, "access_token"):
             return self.post(url, headers=headers, body=body, delete=delete)
 
+        from pbn_api.conf import settings as pbn_settings
+
         sent_headers = self._build_post_headers(headers)
         method = self._get_request_method(delete)
-        ret = method(self.base_url + url, headers=sent_headers, json=body)
+        ret = method(
+            self.base_url + url,
+            headers=sent_headers,
+            json=body,
+            timeout=pbn_settings.PBN_CLIENT_HTTP_TIMEOUT,
+        )
 
         if ret.status_code == 403:
             ret_json = self._parse_403_response(ret, url)

--- a/src/pbn_api/conf/settings.py
+++ b/src/pbn_api/conf/settings.py
@@ -24,3 +24,28 @@ PBN_CLIENT_BASE_URL = getattr(
 PBN_CLIENT_USER_TOKEN = getattr(
     settings, "PBN_CLIENT_USER_TOKEN", os.getenv("PBN_CLIENT_USER_TOKEN")
 )
+
+
+def _parse_timeout(raw, default):
+    if raw is None:
+        return default
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, (tuple, list)):
+        return tuple(float(x) for x in raw)
+    parts = [p.strip() for p in str(raw).split(",") if p.strip()]
+    if len(parts) == 1:
+        return float(parts[0])
+    if len(parts) == 2:
+        return (float(parts[0]), float(parts[1]))
+    return default
+
+
+PBN_CLIENT_HTTP_TIMEOUT = _parse_timeout(
+    getattr(
+        settings,
+        "PBN_CLIENT_HTTP_TIMEOUT",
+        os.getenv("PBN_CLIENT_HTTP_TIMEOUT"),
+    ),
+    default=(30.0, 120.0),
+)

--- a/src/pbn_downloader_app/tasks.py
+++ b/src/pbn_downloader_app/tasks.py
@@ -182,16 +182,28 @@ def create_task_with_lock(task_model, user, initial_step):
     """
     Create a task record with atomic transaction to prevent race conditions.
 
+    Wymusza wzajemne wykluczanie przez Postgresowy advisory lock kluczowany
+    nazwą modelu. Sam `filter(status="running").exists()` w `transaction.atomic()`
+    nie wystarczy: dwie równoległe transakcje mogłyby równocześnie nie znaleźć
+    żadnego wiersza i obie utworzyć aktywne zadanie. Advisory lock blokuje
+    cały odcinek krytyczny do końca transakcji.
+
     Returns:
         task_record: The created task record
 
     Raises:
         ValueError: If another task is already running
     """
-    from django.db import transaction
+    from django.db import connection, transaction
     from django.utils import timezone
 
+    # 32-bit signed int dla pg_advisory_xact_lock(int)
+    lock_key = abs(hash(task_model.__name__)) % (2**31)
+
     with transaction.atomic():
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_xact_lock(%s)", [lock_key])
+
         if task_model.objects.filter(status="running").exists():
             raise ValueError(
                 "Another download task is already running. Please wait for it to complete."

--- a/src/pbn_wysylka_oswiadczen/views.py
+++ b/src/pbn_wysylka_oswiadczen/views.py
@@ -12,6 +12,7 @@ from openpyxl.styles import Font
 from queryset_sequence import QuerySetSequence
 
 from bpp.const import GR_WPROWADZANIE_DANYCH
+from bpp.util import sanitize_xlsx_row
 from pbn_wysylka_oswiadczen.models import PbnWysylkaLog, PbnWysylkaOswiadczenTask
 from pbn_wysylka_oswiadczen.queries import get_publications_queryset
 from pbn_wysylka_oswiadczen.tasks import wysylka_oswiadczen_task
@@ -212,32 +213,43 @@ class StartTaskView(View):
         # Clean up stale running tasks
         PbnWysylkaOswiadczenTask.cleanup_stale_running_tasks()
 
-        # Check if task is already running
-        running_task = PbnWysylkaOswiadczenTask.objects.filter(status="running").first()
-        if running_task:
-            return JsonResponse(
-                {
-                    "success": False,
-                    "error": "Zadanie wysylki jest juz uruchomione. "
-                    "Prosze poczekac na jego zakonczenie.",
-                }
-            )
-
         # Get parameters
         rok_od = int(request.POST.get("rok_od", 2022))
         rok_do = int(request.POST.get("rok_do", 2025))
         tytul = request.POST.get("tytul", "").strip()
         resume_mode = request.POST.get("resume_mode", "false").lower() == "true"
 
-        # Create task record
-        task = PbnWysylkaOswiadczenTask.objects.create(
-            user=user,
-            status="pending",
-            rok_od=rok_od,
-            rok_do=rok_do,
-            tytul=tytul,
-            resume_mode=resume_mode,
-        )
+        # Sprawdzenie wykluczenia + utworzenie rekordu pod jednym
+        # Postgresowym advisory lockiem — bez tego dwa równoległe
+        # POST-y mogą równocześnie nie znaleźć aktywnego zadania
+        # i obydwa założyć nowe (pending), co skończy się dwoma
+        # workerami wysyłającymi oświadczenia naraz.
+        from django.db import connection, transaction
+
+        lock_key = abs(hash("PbnWysylkaOswiadczenTask")) % (2**31)
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT pg_advisory_xact_lock(%s)", [lock_key])
+
+            if PbnWysylkaOswiadczenTask.objects.filter(
+                status__in=("pending", "running")
+            ).exists():
+                return JsonResponse(
+                    {
+                        "success": False,
+                        "error": "Zadanie wysylki jest juz uruchomione. "
+                        "Prosze poczekac na jego zakonczenie.",
+                    }
+                )
+
+            task = PbnWysylkaOswiadczenTask.objects.create(
+                user=user,
+                status="pending",
+                rok_od=rok_od,
+                rok_do=rok_do,
+                tytul=tytul,
+                resume_mode=resume_mode,
+            )
 
         # Start Celery task
         try:
@@ -388,15 +400,17 @@ class ExcelExportView(View):
             pbn_uid = publication.pbn_uid_id if publication.pbn_uid_id else ""
 
             ws.append(
-                [
-                    publication.pk,
-                    pub_type,
-                    publication.tytul_oryginalny,
-                    publication.rok,
-                    pbn_uid,
-                    publication.liczba_oswiadczen,
-                    publication.liczba_przypietych,
-                ]
+                sanitize_xlsx_row(
+                    [
+                        publication.pk,
+                        pub_type,
+                        publication.tytul_oryginalny,
+                        publication.rok,
+                        pbn_uid,
+                        publication.liczba_oswiadczen,
+                        publication.liczba_przypietych,
+                    ]
+                )
             )
 
         # Adjust column widths

--- a/src/zglos_publikacje/autocomplete.py
+++ b/src/zglos_publikacje/autocomplete.py
@@ -7,7 +7,7 @@ from dal_select2_queryset_sequence.views import (
     Select2QuerySetSequenceView,
 )
 from django.contrib.postgres.search import TrigramSimilarity
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from queryset_sequence import QuerySetSequence
 
 from bpp.const import CHARAKTER_OGOLNY_KSIAZKA
@@ -59,8 +59,8 @@ class PublicWydawcaAutocomplete(
 
     def get_result_label(self, result):
         if isinstance(result, Wydawca):
-            return mark_safe(f"{result.nazwa} <small>[BPP]</small>")
-        return mark_safe(f"{result.publisherName} <small>[PBN]</small>")
+            return format_html("{} <small>[BPP]</small>", result.nazwa)
+        return format_html("{} <small>[PBN]</small>", result.publisherName)
 
     # NIE nadpisuj `get_result_value` — domyślna implementacja
     # `dal_queryset_sequence.views` zwraca `<ct_pk>-<obj_pk>`, czego
@@ -103,13 +103,13 @@ class PublicWydawnictwoNadrzedneAutocomplete(
             label = str(result.tytul_oryginalny)
             if result.rok:
                 label += f" ({result.rok})"
-            return mark_safe(f"{label} <small>[BPP]</small>")
+            return format_html("{} <small>[BPP]</small>", label)
 
         # PBN_Publication
         label = str(result.title or "")
         if result.year:
             label += f" ({result.year})"
-        return mark_safe(f"{label} <small>[PBN]</small>")
+        return format_html("{} <small>[PBN]</small>", label)
 
     # j.w. — nie nadpisujemy `get_result_value`. Patrz komentarz
     # w `PublicWydawcaAutocomplete`.


### PR DESCRIPTION
## Summary

Reakcja na audyt bezpieczeństwa — pięć defensywnych poprawek bez zmiany
zachowania użytkownika końcowego (poza tym, że trzy widoki, które
nie powinny były być publiczne, teraz wymagają zalogowania w grupie
„wprowadzanie danych").

## Co się zmienia

- **PBN client — HTTP timeouts.** `pbn_api.client.transport`
  (GET/POST/DELETE) oraz OAuth `get_user_token` używają jawnego
  ``timeout=`` przekazanego do ``requests``. Wcześniej zawieszony
  serwer PBN mógł zablokować w nieskończoność proces web albo
  workera Celery. Konfigurowalne przez ``PBN_CLIENT_HTTP_TIMEOUT``
  (settings lub env, sekundy lub ``connect,read``); domyślnie
  30 s connect / 120 s read.
- **XSS w publicznym autocomplete (`zglos_publikacje`).**
  ``mark_safe(f"{result.nazwa} <small>[BPP]</small>")`` → ``format_html``.
  Etykiety w `PublicWydawcaAutocomplete` i
  `PublicWydawnictwoNadrzedneAutocomplete` interpolowały dane
  z BPP/PBN bez escapingu — strona zgłoszenia jest publiczna.
- **Excel formula injection** w eksportach XLSX. Nowy helper
  ``bpp.util.sanitize_xlsx_cell`` / ``sanitize_xlsx_row`` prefiksuje
  apostrofem stringi zaczynające się od ``=``, ``+``, ``-``, ``@``,
  Tab/CR/LF (OWASP CSV Injection). Zastosowany w
  ``pbn_wysylka_oswiadczen`` i ``komparator_publikacji_pbn``.
- **Permissions na `komparator_pbn_udzialy`.** Trzy widoki
  (`ProblemyPBNListView`, `RozbieznoscDyscyplinPBNDetailView`,
  `BrakAutoraDetailView`) były dostępne publicznie, mimo że
  pokazują dane synchronizowane z PBN i wewnętrzne ID BPP.
  Dorzucony `GroupRequiredMixin("wprowadzanie danych")` + nowy
  test autoryzacji.
- **Race condition na lockach zadań.** ``filter(status="running").exists()``
  wewnątrz ``transaction.atomic()`` w
  `pbn_downloader_app.tasks.create_task_with_lock` i
  `pbn_wysylka_oswiadczen.views.StartTaskView` nie wykluczał
  równoczesnych żądań. Dodany Postgresowy ``pg_advisory_xact_lock``
  kluczowany nazwą modelu; w `pbn_wysylka_oswiadczen` także
  zaostrzony check (`pending` + `running` zamiast samego `running`).

## Świadomie pominięte (do osobnego PR)

- **GET → POST dla mutujących widoków** (`rebuild`, `ustaw_wszystkie`,
  `snapshot apply/create`) — wymaga ekranów potwierdzenia + update
  wszystkich szablonów linkujących do tych URL-i. Lepsza osobna iteracja
  z UX.
- **Autoryzacja `extraChannels`** w WebSocket consumer. Zmiana protokołu
  bez audytu, jak frontend tego używa, ryzykuje urwaniem powiadomień —
  do osobnego wątku.

## Test plan

- [x] `pytest -n auto` na zmienionych modułach: 196 passed (w tym
  nowy `test_problemy_pbn_list_view_requires_group`)
- [x] `pre-commit` czysto na zmienionych plikach
- [x] `towncrier build --draft` renderuje 5 fragmentów bugfix
- [ ] Manualna weryfikacja `/komparator_pbn_udzialy/` jako anon
      (powinien być redirect/403) i jako user w grupie (200)
- [ ] Smoke test eksportu XLSX z tytułem zaczynającym się od ``=``

🤖 Generated with [Claude Code](https://claude.com/claude-code)