### PR TITLE
security: GET → POST z ekranem potwierdzenia dla 4 mutujących widoków

### DIFF
--- a/src/bpp/newsfragments/+get-post-mutations.bugfix.rst
+++ b/src/bpp/newsfragments/+get-post-mutations.bugfix.rst
@@ -1,0 +1,18 @@
+Cztery widoki wykonujące mutacje danych zostały przerobione z metody
+HTTP ``GET`` na ``POST`` z ekranem potwierdzenia. Wcześniej kliknięcie
+zwykłego linku (lub np. prefetch w przeglądarce) mogło wykonać ciężką
+operację bez świadomej akcji użytkownika i bez ochrony CSRF. Teraz
+``GET`` wyświetla ekran potwierdzenia z formularzem ``POST``,
+zabezpieczonym tokenem CSRF, a sama mutacja wykonywana jest dopiero
+po akceptacji.
+
+Dotyczy widoków:
+
+- ``komparator_pbn_udzialy:rebuild`` — przebudowa rozbieżności PBN
+  (uruchamia zadanie Celery z ``clear_existing=True``).
+- ``rozbieznosci_if:ustaw_wszystkie`` — masowe ustawienie IF
+  z punktacji źródła dla przefiltrowanych rekordów.
+- ``rozbieznosci_pk:ustaw_wszystkie`` — masowe ustawienie punktów
+  MNiSW z punktacji źródła dla przefiltrowanych rekordów.
+- ``snapshot_odpiec:nowy`` — utworzenie nowego snapshotu odpięć.
+- ``snapshot_odpiec:aplikuj`` — zaaplikowanie snapshotu na bazę.

--- a/src/komparator_pbn_udzialy/templates/komparator_pbn_udzialy/rebuild_confirm.html
+++ b/src/komparator_pbn_udzialy/templates/komparator_pbn_udzialy/rebuild_confirm.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block title %}Przebudowa rozbieżności PBN{% endblock %}
+
+{% block breadcrumbs %}
+    <li><a href="/">Strona główna</a></li>
+    <li><a href="{% url 'komparator_pbn_udzialy:list' %}">Problemy PBN</a></li>
+    <li class="active">Przebudowa</li>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="large-12 columns">
+        <h2>Przebudowa rozbieżności PBN</h2>
+
+        {% include "includes/pbn_freshness_warning.html" %}
+
+        <div class="callout warning">
+            <h4>Czy na pewno przebudować rozbieżności?</h4>
+            <p>
+                Operacja ta <strong>usunie wszystkie istniejące rozbieżności
+                dyscyplin PBN i braki autorów</strong>, a następnie wygeneruje
+                je ponownie na podstawie aktualnych danych z PBN.
+            </p>
+            <p>
+                Wszystkie ręczne oznaczenia (np. „ignoruj”, opisy) zostaną
+                utracone. Operacja wykonywana jest w tle i może potrwać kilka
+                minut.
+            </p>
+        </div>
+
+        {% if not pbn_data_fresh %}
+        <div class="callout alert">
+            <p>
+                <strong>Uwaga:</strong> {{ pbn_stale_message }}.
+                Pobierz aktualne dane z PBN przed uruchomieniem przebudowy.
+            </p>
+        </div>
+        {% endif %}
+
+        <form method="post">
+            {% csrf_token %}
+            <button type="submit" class="button alert"{% if not pbn_data_fresh %} disabled{% endif %}>
+                <span class="fi-refresh"></span> Tak, przebuduj rozbieżności
+            </button>
+            <a href="{% url 'komparator_pbn_udzialy:list' %}" class="button secondary">
+                Anuluj
+            </a>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/src/komparator_pbn_udzialy/tests/test_views.py
+++ b/src/komparator_pbn_udzialy/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.test import Client
@@ -167,3 +169,62 @@ def test_problemy_pbn_list_view_statistics(client_with_group: Client):
     assert response.context["missing_autor_count"] == 1
     assert response.context["missing_link_count"] == 1
     assert response.context["total_count"] == 2
+
+
+@pytest.mark.django_db
+def test_rebuild_view_get_renders_confirmation(client_with_group: Client):
+    """GET wyświetla ekran potwierdzenia, NIE startuje zadania Celery."""
+    url = reverse("komparator_pbn_udzialy:rebuild")
+    with patch(
+        "komparator_pbn_udzialy.tasks.porownaj_dyscypliny_pbn_task"
+    ) as mock_task:
+        response = client_with_group.get(url)
+    assert response.status_code == 200
+    assert (
+        b"Czy na pewno przebudowa" in response.content
+        or b"przebudowa" in response.content.lower()
+    )
+    mock_task.delay.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_rebuild_view_post_starts_task(client_with_group: Client):
+    """POST uruchamia zadanie Celery i przekierowuje na stronę statusu."""
+    url = reverse("komparator_pbn_udzialy:rebuild")
+    with (
+        patch("komparator_pbn_udzialy.tasks.porownaj_dyscypliny_pbn_task") as mock_task,
+        patch(
+            "komparator_pbn_udzialy.views.is_pbn_publications_data_fresh",
+            return_value=(True, "", None),
+        ),
+    ):
+        mock_result = MagicMock()
+        mock_result.id = "test-task-id"
+        mock_task.delay.return_value = mock_result
+        response = client_with_group.post(url)
+    assert response.status_code == 302
+    mock_task.delay.assert_called_once_with(clear_existing=True)
+
+
+@pytest.mark.django_db
+def test_rebuild_view_post_blocked_when_pbn_data_stale(client_with_group: Client):
+    """POST przy nieświeżych danych PBN nie uruchamia zadania."""
+    url = reverse("komparator_pbn_udzialy:rebuild")
+    with (
+        patch("komparator_pbn_udzialy.tasks.porownaj_dyscypliny_pbn_task") as mock_task,
+        patch(
+            "komparator_pbn_udzialy.views.is_pbn_publications_data_fresh",
+            return_value=(False, "Dane są stare", None),
+        ),
+    ):
+        response = client_with_group.post(url)
+    assert response.status_code == 302  # Redirect z komunikatem błędu
+    mock_task.delay.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_rebuild_view_get_anonymous_redirected(client: Client):
+    """Anonimowy klient nie ma dostępu do widoku rebuild (login redirect)."""
+    url = reverse("komparator_pbn_udzialy:rebuild")
+    response = client.get(url)
+    assert response.status_code in (302, 403)

--- a/src/komparator_pbn_udzialy/views.py
+++ b/src/komparator_pbn_udzialy/views.py
@@ -283,12 +283,24 @@ class RozbieznoscDyscyplinPBNDetailView(GroupRequiredMixin, DetailView):
 class RebuildDiscrepanciesView(View):
     """Widok do przebudowy rozbieżności.
 
-    Kliknięcie od razu uruchamia zadanie Celery z clear_existing=True.
+    GET wyświetla ekran potwierdzenia, POST uruchamia zadanie Celery
+    z ``clear_existing=True``.
     """
 
+    template_name = "komparator_pbn_udzialy/rebuild_confirm.html"
+
     def get(self, request):
-        """Uruchamia przebudowę rozbieżności od razu."""
-        # Sprawdź świeżość danych PBN
+        pbn_data_fresh, pbn_stale_message, _ = is_pbn_publications_data_fresh()
+        return render(
+            request,
+            self.template_name,
+            {
+                "pbn_data_fresh": pbn_data_fresh,
+                "pbn_stale_message": pbn_stale_message,
+            },
+        )
+
+    def post(self, request):
         pbn_data_fresh, pbn_stale_message, _ = is_pbn_publications_data_fresh()
         if not pbn_data_fresh:
             messages.error(
@@ -298,7 +310,6 @@ class RebuildDiscrepanciesView(View):
             )
             return HttpResponseRedirect(reverse("komparator_pbn_udzialy:list"))
 
-        # Uruchom w tle z clear_existing=True
         try:
             from komparator_pbn_udzialy.tasks import porownaj_dyscypliny_pbn_task
 
@@ -319,7 +330,7 @@ class RebuildDiscrepanciesView(View):
             )
 
         except Exception as e:
-            logger.error(f"Błąd podczas uruchamiania zadania Celery: {e}")
+            logger.exception("Błąd podczas uruchamiania zadania Celery")
             messages.error(
                 request,
                 f"Nie można uruchomić zadania w tle: {str(e)}",

--- a/src/rozbieznosci_if/conftest.py
+++ b/src/rozbieznosci_if/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from django.contrib.auth.models import Group
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+
+
+@pytest.fixture
+def wprowadzanie_danych_group(db):
+    group, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    return group
+
+
+@pytest.fixture
+def client_with_group(client, admin_user, wprowadzanie_danych_group):
+    admin_user.groups.add(wprowadzanie_danych_group)
+    client.force_login(admin_user)
+    return client

--- a/src/rozbieznosci_if/templates/rozbieznosci_if/index.html
+++ b/src/rozbieznosci_if/templates/rozbieznosci_if/index.html
@@ -56,8 +56,7 @@
                                 <span class="fi-download"></span> Eksport XLSX
                             </a>
                             <a href="{% url 'rozbieznosci_if:ustaw_wszystkie' %}?{{ filter_query_string }}"
-                               class="button warning"
-                               data-confirm="Czy na pewno chcesz zaktualizować {{ field_label }} dla wszystkich {{ page_obj.paginator.count }} rekordów?">
+                               class="button warning">
                                 <span class="fi-check"></span> Ustaw wszystkie wg źródła
                             </a>
                         {% else %}
@@ -66,8 +65,7 @@
                                 <span class="fi-download"></span> Eksport XLSX
                             </a>
                             <a href="{% url 'rozbieznosci_if:ustaw_wszystkie' %}"
-                               class="button warning"
-                               data-confirm="Czy na pewno chcesz zaktualizować {{ field_label }} dla wszystkich {{ page_obj.paginator.count }} rekordów?">
+                               class="button warning">
                                 <span class="fi-check"></span> Ustaw wszystkie wg źródła
                             </a>
                         {% endif %}

--- a/src/rozbieznosci_if/templates/rozbieznosci_if/ustaw_wszystkie_confirm.html
+++ b/src/rozbieznosci_if/templates/rozbieznosci_if/ustaw_wszystkie_confirm.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block title %}Potwierdź aktualizację {{ field_label }}{% endblock %}
+
+{% block breadcrumbs %}
+    <li><a href="/">Strona główna</a></li>
+    <li><a href="{% url app_name|add:':index' %}">Rozbieżności {{ field_label }}</a></li>
+    <li class="active">Potwierdzenie</li>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="medium-12 columns">
+        <h2>Potwierdź aktualizację {{ field_label }}</h2>
+
+        <div class="callout warning">
+            <p>
+                Operacja zaktualizuje wartość <strong>{{ field_label }}</strong>
+                w <strong>{{ count }}</strong>
+                {% if count == 1 %}rekordzie{% else %}rekordach{% endif %}
+                wydawnictw ciągłych — wartością ze źródła
+                (<em>Punktacja Źródła</em>).
+            </p>
+            <p>
+                Filtry: rok od <strong>{{ rok_od }}</strong> do
+                <strong>{{ rok_do }}</strong>{% if tytul %},
+                tytuł zawiera „<strong>{{ tytul }}</strong>”{% endif %}.
+            </p>
+            {% if use_celery %}
+            <p>
+                Operacja będzie wykonana w tle (Celery), zostaniesz przekierowany
+                na stronę statusu zadania.
+            </p>
+            {% else %}
+            <p>
+                Operacja zostanie wykonana synchronicznie.
+            </p>
+            {% endif %}
+        </div>
+
+        <form method="post">
+            {% csrf_token %}
+            <input type="hidden" name="rok_od" value="{{ rok_od }}">
+            <input type="hidden" name="rok_do" value="{{ rok_do }}">
+            <input type="hidden" name="tytul" value="{{ tytul }}">
+            <button type="submit" class="button warning">
+                <span class="fi-check"></span> Tak, zaktualizuj {{ count }}
+                {% if count == 1 %}rekord{% else %}rekordów{% endif %}
+            </button>
+            <a href="{% url app_name|add:':index' %}?rok_od={{ rok_od }}&rok_do={{ rok_do }}{% if tytul %}&tytul={{ tytul }}{% endif %}"
+               class="button secondary">Anuluj</a>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/src/rozbieznosci_if/tests.py
+++ b/src/rozbieznosci_if/tests.py
@@ -339,19 +339,34 @@ def test_ustaw_if_ze_zrodla_nonexistent():
 
 
 @pytest.mark.django_db
-def test_UstawWszystkieView_small_batch(
+def test_UstawWszystkieView_get_renders_confirmation(
+    wydawnictwo_z_rozbieznoscia_rok_2023, client_with_group
+):
+    """GET wyświetla stronę potwierdzenia, NIE mutuje danych."""
+    response = client_with_group.get(
+        "/rozbieznosci_if/ustaw-wszystkie/?rok_od=2022&rok_do=2025"
+    )
+
+    wydawnictwo_z_rozbieznoscia_rok_2023.refresh_from_db()
+
+    assert response.status_code == 200
+    assert wydawnictwo_z_rozbieznoscia_rok_2023.impact_factor != 75
+
+
+@pytest.mark.django_db
+def test_UstawWszystkieView_post_small_batch(
     wydawnictwo_z_rozbieznoscia_rok_2023, rf, admin_user
 ):
-    """Test bulk update with small batch (direct execution)."""
+    """POST z małą paczką wykonuje update synchronicznie."""
     from rozbieznosci_if.views import UstawWszystkieView
 
-    req = rf.get("/", data={"rok_od": "2022", "rok_do": "2025"})
+    req = rf.post("/", data={"rok_od": "2022", "rok_do": "2025"})
     req.user = admin_user
     req._messages = Mock()
 
     view = UstawWszystkieView()
     view.request = req
-    response = view.get(req)
+    response = view.post(req)
 
     wydawnictwo_z_rozbieznoscia_rok_2023.refresh_from_db()
 
@@ -360,20 +375,19 @@ def test_UstawWszystkieView_small_batch(
 
 
 @pytest.mark.django_db
-def test_UstawWszystkieView_large_batch_triggers_celery(rf, admin_user):
-    """Test bulk update with large batch (Celery task)."""
+def test_UstawWszystkieView_post_large_batch_triggers_celery(rf, admin_user):
+    """POST z dużą paczką uruchamia zadanie Celery."""
     from rozbieznosci_if.views import (
         OFFLOAD_TASKS_WITH_THIS_ELEMENTS_OR_MORE,
         UstawWszystkieView,
     )
 
-    # Create many records to trigger Celery
     for i in range(OFFLOAD_TASKS_WITH_THIS_ELEMENTS_OR_MORE + 5):
         zrodlo = baker.make(Zrodlo)
         zrodlo.punktacja_zrodla_set.create(rok=2023, impact_factor=100 + i)
         baker.make(Wydawnictwo_Ciagle, impact_factor=10 + i, rok=2023, zrodlo=zrodlo)
 
-    req = rf.get("/", data={"rok_od": "2022", "rok_do": "2025"})
+    req = rf.post("/", data={"rok_od": "2022", "rok_do": "2025"})
     req.user = admin_user
     req._messages = Mock()
 
@@ -384,16 +398,16 @@ def test_UstawWszystkieView_large_batch_triggers_celery(rf, admin_user):
         mock_task_result = MagicMock()
         mock_task_result.id = "test-task-id"
         mock_task.delay.return_value = mock_task_result
-        response = view.get(req)
+        response = view.post(req)
 
-    assert response.status_code == 302  # Redirect to status page
+    assert response.status_code == 302
     assert "task-status" in response.url
     mock_task.delay.assert_called_once()
 
 
 @pytest.mark.django_db
-def test_UstawWszystkieView_no_records(rf, admin_user):
-    """Test bulk update with no matching records."""
+def test_UstawWszystkieView_get_no_records_redirects(rf, admin_user):
+    """GET przy braku rekordów przekierowuje od razu z komunikatem."""
     from rozbieznosci_if.views import UstawWszystkieView
 
     req = rf.get("/", data={"rok_od": "1900", "rok_do": "1901"})
@@ -646,19 +660,18 @@ def test_TaskStatusView_failed_shows_error(client, admin_user):
 
 @pytest.mark.django_db
 def test_UstawWszystkieView_large_batch_redirects_to_status(rf, admin_user):
-    """Test that large batch redirects to task status page."""
+    """Test that large batch (POST) redirects to task status page."""
     from rozbieznosci_if.views import (
         OFFLOAD_TASKS_WITH_THIS_ELEMENTS_OR_MORE,
         UstawWszystkieView,
     )
 
-    # Create many records to trigger Celery
     for i in range(OFFLOAD_TASKS_WITH_THIS_ELEMENTS_OR_MORE + 5):
         zrodlo = baker.make(Zrodlo)
         zrodlo.punktacja_zrodla_set.create(rok=2023, impact_factor=100 + i)
         baker.make(Wydawnictwo_Ciagle, impact_factor=10 + i, rok=2023, zrodlo=zrodlo)
 
-    req = rf.get("/", data={"rok_od": "2022", "rok_do": "2025"})
+    req = rf.post("/", data={"rok_od": "2022", "rok_do": "2025"})
     req.user = admin_user
     req._messages = Mock()
 
@@ -669,7 +682,7 @@ def test_UstawWszystkieView_large_batch_redirects_to_status(rf, admin_user):
         mock_task_result = MagicMock()
         mock_task_result.id = "test-task-123"
         mock_task.delay.return_value = mock_task_result
-        response = view.get(req)
+        response = view.post(req)
 
     assert response.status_code == 302
     assert "task-status" in response.url

--- a/src/rozbieznosci_if/views.py
+++ b/src/rozbieznosci_if/views.py
@@ -504,7 +504,11 @@ def ustaw_if_ze_zrodla(pks, user_id=None):
 
 
 class BaseUstawWszystkieView(GroupRequiredMixin, View):
-    """Base class for bulk update views."""
+    """Base class for bulk update views.
+
+    GET wyświetla ekran potwierdzenia (z filtrami przeniesionymi do
+    ukrytych pól formularza), POST wykonuje aktualizację.
+    """
 
     group_required = "wprowadzanie danych"
 
@@ -516,13 +520,14 @@ class BaseUstawWszystkieView(GroupRequiredMixin, View):
     log_before_field = None
     log_after_field = None
     app_name = None
+    confirm_template_name = None
     celery_task = (
         None  # String path like "rozbieznosci_if.tasks.task_ustaw_if_ze_zrodla"
     )
 
-    def get_filter_params(self):
-        """Get filter parameters from request."""
-        form = FilterForm(self.request.GET)
+    def get_filter_params(self, source):
+        """Get filter parameters from a QueryDict (request.GET or request.POST)."""
+        form = FilterForm(source)
         if form.is_valid():
             rok_od = form.cleaned_data["rok_od"]
             rok_do = form.cleaned_data["rok_do"]
@@ -539,7 +544,37 @@ class BaseUstawWszystkieView(GroupRequiredMixin, View):
         raise NotImplementedError("Subclasses must implement get_celery_task")
 
     def get(self, request):
-        rok_od, rok_do, tytul = self.get_filter_params()
+        rok_od, rok_do, tytul = self.get_filter_params(request.GET)
+
+        queryset = get_base_queryset_for_field(self.field_name, self.ignore_model)
+        queryset = apply_filters(queryset, rok_od, rok_do, tytul)
+
+        count = queryset.count()
+
+        if count == 0:
+            messages.warning(
+                request,
+                f"Nie znaleziono rekordów z rozbieżnymi wartościami "
+                f"{self.field_label} do aktualizacji.",
+            )
+            return self._redirect_back(rok_od, rok_do, tytul)
+
+        return render(
+            request,
+            self.confirm_template_name,
+            {
+                "rok_od": rok_od,
+                "rok_do": rok_do,
+                "tytul": tytul,
+                "count": count,
+                "field_label": self.field_label,
+                "use_celery": count >= OFFLOAD_TASKS_WITH_THIS_ELEMENTS_OR_MORE,
+                "app_name": self.app_name,
+            },
+        )
+
+    def post(self, request):
+        rok_od, rok_do, tytul = self.get_filter_params(request.POST)
 
         queryset = get_base_queryset_for_field(self.field_name, self.ignore_model)
         queryset = apply_filters(queryset, rok_od, rok_do, tytul)
@@ -550,32 +585,33 @@ class BaseUstawWszystkieView(GroupRequiredMixin, View):
         if count == 0:
             messages.warning(
                 request,
-                f"Nie znaleziono rekordów z rozbieżnymi wartościami {self.field_label} "
-                f"do aktualizacji.",
+                f"Nie znaleziono rekordów z rozbieżnymi wartościami "
+                f"{self.field_label} do aktualizacji.",
             )
             return self._redirect_back(rok_od, rok_do, tytul)
 
         if count >= OFFLOAD_TASKS_WITH_THIS_ELEMENTS_OR_MORE:
             task = self.get_celery_task().delay(pks, user_id=request.user.id)
             return redirect(f"{self.app_name}:task_status", task_id=task.id)
-        else:
-            updated, errors = ustaw_pole_ze_zrodla(
-                pks,
-                self.field_name,
-                self.log_model,
-                self.log_before_field,
-                self.log_after_field,
-                user_id=request.user.id,
-            )
-            if errors:
-                messages.warning(
-                    request,
-                    f"Zaktualizowano {updated} rekordów. Wystąpiły błędy dla {errors} rekordów.",
-                )
-            else:
-                messages.success(request, f"Zaktualizowano {updated} rekordów.")
 
-            return self._redirect_back(rok_od, rok_do, tytul)
+        updated, errors = ustaw_pole_ze_zrodla(
+            pks,
+            self.field_name,
+            self.log_model,
+            self.log_before_field,
+            self.log_after_field,
+            user_id=request.user.id,
+        )
+        if errors:
+            messages.warning(
+                request,
+                f"Zaktualizowano {updated} rekordów. "
+                f"Wystąpiły błędy dla {errors} rekordów.",
+            )
+        else:
+            messages.success(request, f"Zaktualizowano {updated} rekordów.")
+
+        return self._redirect_back(rok_od, rok_do, tytul)
 
     def _redirect_back(self, rok_od, rok_do, tytul=""):
         return build_redirect_url(f"{self.app_name}:index", rok_od, rok_do, tytul)
@@ -591,6 +627,7 @@ class UstawWszystkieView(BaseUstawWszystkieView):
     log_before_field = "if_before"
     log_after_field = "if_after"
     app_name = "rozbieznosci_if"
+    confirm_template_name = "rozbieznosci_if/ustaw_wszystkie_confirm.html"
 
     def get_celery_task(self):
         from rozbieznosci_if.tasks import task_ustaw_if_ze_zrodla

--- a/src/rozbieznosci_pk/templates/rozbieznosci_pk/index.html
+++ b/src/rozbieznosci_pk/templates/rozbieznosci_pk/index.html
@@ -56,8 +56,7 @@
                                 <span class="fi-download"></span> Eksport XLSX
                             </a>
                             <a href="{% url 'rozbieznosci_pk:ustaw_wszystkie' %}?{{ filter_query_string }}"
-                               class="button warning"
-                               data-confirm="Czy na pewno chcesz zaktualizować {{ field_label }} dla wszystkich {{ page_obj.paginator.count }} rekordów?">
+                               class="button warning">
                                 <span class="fi-check"></span> Ustaw wszystkie wg źródła
                             </a>
                         {% else %}
@@ -66,8 +65,7 @@
                                 <span class="fi-download"></span> Eksport XLSX
                             </a>
                             <a href="{% url 'rozbieznosci_pk:ustaw_wszystkie' %}"
-                               class="button warning"
-                               data-confirm="Czy na pewno chcesz zaktualizować {{ field_label }} dla wszystkich {{ page_obj.paginator.count }} rekordów?">
+                               class="button warning">
                                 <span class="fi-check"></span> Ustaw wszystkie wg źródła
                             </a>
                         {% endif %}

--- a/src/rozbieznosci_pk/templates/rozbieznosci_pk/ustaw_wszystkie_confirm.html
+++ b/src/rozbieznosci_pk/templates/rozbieznosci_pk/ustaw_wszystkie_confirm.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block title %}Potwierdź aktualizację {{ field_label }}{% endblock %}
+
+{% block breadcrumbs %}
+    <li><a href="/">Strona główna</a></li>
+    <li><a href="{% url app_name|add:':index' %}">Rozbieżności {{ field_label }}</a></li>
+    <li class="active">Potwierdzenie</li>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="medium-12 columns">
+        <h2>Potwierdź aktualizację {{ field_label }}</h2>
+
+        <div class="callout warning">
+            <p>
+                Operacja zaktualizuje wartość <strong>{{ field_label }}</strong>
+                w <strong>{{ count }}</strong>
+                {% if count == 1 %}rekordzie{% else %}rekordach{% endif %}
+                wydawnictw ciągłych — wartością ze źródła
+                (<em>Punktacja Źródła</em>).
+            </p>
+            <p>
+                Filtry: rok od <strong>{{ rok_od }}</strong> do
+                <strong>{{ rok_do }}</strong>{% if tytul %},
+                tytuł zawiera „<strong>{{ tytul }}</strong>”{% endif %}.
+            </p>
+            {% if use_celery %}
+            <p>
+                Operacja będzie wykonana w tle (Celery), zostaniesz przekierowany
+                na stronę statusu zadania.
+            </p>
+            {% else %}
+            <p>
+                Operacja zostanie wykonana synchronicznie.
+            </p>
+            {% endif %}
+        </div>
+
+        <form method="post">
+            {% csrf_token %}
+            <input type="hidden" name="rok_od" value="{{ rok_od }}">
+            <input type="hidden" name="rok_do" value="{{ rok_do }}">
+            <input type="hidden" name="tytul" value="{{ tytul }}">
+            <button type="submit" class="button warning">
+                <span class="fi-check"></span> Tak, zaktualizuj {{ count }}
+                {% if count == 1 %}rekord{% else %}rekordów{% endif %}
+            </button>
+            <a href="{% url app_name|add:':index' %}?rok_od={{ rok_od }}&rok_do={{ rok_do }}{% if tytul %}&tytul={{ tytul }}{% endif %}"
+               class="button secondary">Anuluj</a>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/src/rozbieznosci_pk/views.py
+++ b/src/rozbieznosci_pk/views.py
@@ -45,6 +45,7 @@ class UstawWszystkiePkView(BaseUstawWszystkieView):
     log_before_field = "pk_before"
     log_after_field = "pk_after"
     app_name = "rozbieznosci_pk"
+    confirm_template_name = "rozbieznosci_pk/ustaw_wszystkie_confirm.html"
 
     def get_celery_task(self):
         from rozbieznosci_pk.tasks import task_ustaw_pk_ze_zrodla

--- a/src/snapshot_odpiec/templates/snapshot_odpiec/aplikuj_confirm.html
+++ b/src/snapshot_odpiec/templates/snapshot_odpiec/aplikuj_confirm.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}{% load humanize %}
+
+{% block title %}Zaaplikuj snapshot odpięć nr {{ object.pk }}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="{% url 'snapshot_odpiec:index' %}">Snapshoty odpiętych dyscyplin</a></li>
+    <li class="current">Aplikuj snapshot {{ object.pk }}</li>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="medium-12 columns">
+        <h2>Zaaplikuj snapshot odpięć nr {{ object.pk }}</h2>
+
+        <div class="callout warning">
+            <p>
+                Operacja przywróci stan przypięć dyscyplin
+                z wybranego snapshotu. <strong>Wszystkie aktualne ręczne
+                przypięcia/odpięcia zostaną nadpisane</strong> wartościami
+                ze snapshotu.
+            </p>
+            <ul>
+                <li>Snapshot nr: <strong>{{ object.pk }}</strong></li>
+                <li>Utworzony: <strong>{{ object.created_on }}</strong>
+                    ({{ object.created_on|naturaltime }})</li>
+                {% if object.comment %}
+                <li>Adnotacja: <em>{{ object.comment }}</em></li>
+                {% endif %}
+                <li>Przypiętych: <strong>{{ object.przypiete }}</strong></li>
+                <li>Odpiętych: <strong>{{ object.odpiete }}</strong></li>
+            </ul>
+        </div>
+
+        <form method="post" id="aplikuj-confirm">
+            {% csrf_token %}
+            <button type="submit" class="button warning">
+                <span class="fi-check"></span> Tak, zaaplikuj snapshot
+            </button>
+            <a href="{% url 'snapshot_odpiec:index' %}" class="button secondary">
+                Anuluj
+            </a>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/src/snapshot_odpiec/templates/snapshot_odpiec/nowy_confirm.html
+++ b/src/snapshot_odpiec/templates/snapshot_odpiec/nowy_confirm.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title %}Utwórz nowy snapshot odpięć{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="{% url 'snapshot_odpiec:index' %}">Snapshoty odpiętych dyscyplin</a></li>
+    <li class="current">Nowy snapshot</li>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="medium-12 columns">
+        <h2>Utwórz nowy snapshot odpięć</h2>
+
+        <div class="callout primary">
+            <p>
+                Operacja zapisze aktualny stan przypięć/odpięć dyscyplin
+                wszystkich publikacji w postaci snapshotu, który będzie
+                można później zaaplikować, aby przywrócić ten stan.
+            </p>
+            <p>
+                Snapshot zostanie oznaczony adnotacją „utworzony ręcznie”
+                i przypisany do bieżącego użytkownika.
+            </p>
+        </div>
+
+        <form method="post" id="nowy-confirm">
+            {% csrf_token %}
+            <button type="submit" class="button warning">
+                <span class="fi-camera"></span> Tak, utwórz snapshot
+            </button>
+            <a href="{% url 'snapshot_odpiec:index' %}" class="button secondary">
+                Anuluj
+            </a>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/src/snapshot_odpiec/templates/snapshot_odpiec/snapshotodpiec_list.html
+++ b/src/snapshot_odpiec/templates/snapshot_odpiec/snapshotodpiec_list.html
@@ -168,8 +168,7 @@
         {% for elem in object_list %}
             <tr>
                 <td>
-                    <a data-confirm="Czy na pewno chcesz zaaplikować snapshot odpięć nr {{ elem.pk }}?"
-                       href="{% url "snapshot_odpiec:aplikuj" elem.pk %}">snapshot {{ elem.pk }}</a>
+                    <a href="{% url "snapshot_odpiec:aplikuj" elem.pk %}">snapshot {{ elem.pk }}</a>
                 </td>
                 <td>{{ elem.created_on }}<br><small>{{ elem.created_on|naturaltime }}</td>
                 <td>{{ elem.comment|capfirst }}</td>

--- a/src/snapshot_odpiec/tests.py
+++ b/src/snapshot_odpiec/tests.py
@@ -55,27 +55,55 @@ def test_snapshot_odpiec_index_one_time(admin_client, admin_user):
 
 
 @pytest.mark.django_db
-def test_snapshot_odpiec_nowy(admin_app):
+def test_snapshot_odpiec_nowy_get_shows_confirmation(admin_app):
+    """GET wyświetla ekran potwierdzenia, NIE tworzy snapshotu."""
     url = reverse("snapshot_odpiec:nowy")
-    res = admin_app.get(url).maybe_follow()
+    res = admin_app.get(url)
+    assert res.status_code == 200
+    assert SnapshotOdpiec.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_snapshot_odpiec_nowy_post_creates(admin_app):
+    """POST tworzy snapshot."""
+    url = reverse("snapshot_odpiec:nowy")
+    form = admin_app.get(url).forms["nowy-confirm"]
+    res = form.submit().maybe_follow()
     assert b"Utworzono snapshot" in res.content
     assert SnapshotOdpiec.objects.count() == 1
 
 
 @pytest.mark.django_db
-def test_snapshot_odpiec_aplikuj(
+def test_snapshot_odpiec_aplikuj_get_shows_confirmation(
     admin_app, admin_user, pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina
 ):
+    """GET wyświetla potwierdzenie, NIE aplikuje snapshotu."""
     pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina.autorzy_set.update(przypieta=False)
     so = SnapshotOdpiec.objects.create(owner=admin_user)
-
     pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina.autorzy_set.update(przypieta=True)
+
+    url = reverse("snapshot_odpiec:aplikuj", args=(so.pk,))
+    res = admin_app.get(url)
+    assert res.status_code == 200
+
+    # GET nie zmienił stanu przypięć
     x = pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina.autorzy_set.first()
     x.refresh_from_db()
     assert x.przypieta is True
 
+
+@pytest.mark.django_db
+def test_snapshot_odpiec_aplikuj_post_applies(
+    admin_app, admin_user, pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina
+):
+    """POST aplikuje snapshot na bazę."""
+    pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina.autorzy_set.update(przypieta=False)
+    so = SnapshotOdpiec.objects.create(owner=admin_user)
+    pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina.autorzy_set.update(przypieta=True)
+
     url = reverse("snapshot_odpiec:aplikuj", args=(so.pk,))
-    res = admin_app.get(url).maybe_follow()
+    form = admin_app.get(url).forms["aplikuj-confirm"]
+    res = form.submit().maybe_follow()
     assert res.status_code == 200
     assert b"Zaaplikowano snapshot" in res.content
     x = pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina.autorzy_set.first()

--- a/src/snapshot_odpiec/views.py
+++ b/src/snapshot_odpiec/views.py
@@ -1,6 +1,7 @@
 from braces.views import GroupRequiredMixin
 from django.contrib import messages
 from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.views import View
 from django.views.generic import DetailView, ListView
 
@@ -9,7 +10,6 @@ from snapshot_odpiec.tasks import suma_odpietych_dyscyplin, suma_przypietych_dys
 from .models import SnapshotOdpiec
 
 
-# Create your views here.
 class ListaSnapshotow(GroupRequiredMixin, ListView):
     group_required = "raporty"
     model = SnapshotOdpiec
@@ -25,24 +25,33 @@ class ListaSnapshotow(GroupRequiredMixin, ListView):
 
 
 class AplikujSnapshot(GroupRequiredMixin, DetailView):
+    """GET wyświetla potwierdzenie, POST aplikuje snapshot na bazę."""
+
     model = SnapshotOdpiec
     group_required = "raporty"
+    template_name = "snapshot_odpiec/aplikuj_confirm.html"
 
-    def get(self, *args, **kw):
+    def post(self, *args, **kw):
         self.object: SnapshotOdpiec = self.get_object()
         self.object.apply()
         messages.info(
             self.request, f"Zaaplikowano snapshot odpięć nr {self.object.pk}."
         )
-        return HttpResponseRedirect("../../")
+        return HttpResponseRedirect(reverse("snapshot_odpiec:index"))
 
 
 class NowySnapshot(GroupRequiredMixin, View):
-    group_required = "raporty"
+    """GET wyświetla potwierdzenie, POST tworzy nowy snapshot."""
 
-    def get(self, *args, **kw):
-        SnapshotOdpiec.objects.create(
-            owner=self.request.user, comment="utworzony ręcznie"
-        )
-        messages.info(self.request, "Utworzono snapshot odpięć")
-        return HttpResponseRedirect("..")
+    group_required = "raporty"
+    template_name = "snapshot_odpiec/nowy_confirm.html"
+
+    def get(self, request, *args, **kw):
+        from django.shortcuts import render
+
+        return render(request, self.template_name)
+
+    def post(self, request, *args, **kw):
+        SnapshotOdpiec.objects.create(owner=request.user, comment="utworzony ręcznie")
+        messages.info(request, "Utworzono snapshot odpięć")
+        return HttpResponseRedirect(reverse("snapshot_odpiec:index"))


### PR DESCRIPTION
## Streszczenie

Druga część poprawek po audycie bezpieczeństwa (osobny PR z wątkiem UX, jak ustaliliśmy w #203).

Cztery widoki wykonujące mutacje danych były wcześniej dostępne przez ``GET`` — kliknięcie zwykłego linku, prefetch w przeglądarce, albo CSRF-attack mogły uruchomić ciężką operację bez świadomej akcji użytkownika i bez ochrony tokenem CSRF. Tym PR-em ``GET`` zaczyna wyświetlać ekran potwierdzenia z formularzem ``POST``+CSRF, a sama mutacja wykonywana jest dopiero po akceptacji.

## Dotknięte widoki

| Widok | URL | Co mutuje |
|---|---|---|
| ``komparator_pbn_udzialy.RebuildDiscrepanciesView`` | ``komparator_pbn_udzialy:rebuild`` | Celery task z ``clear_existing=True`` (kasuje + odbudowuje rozbieżności) |
| ``rozbieznosci_if.UstawWszystkieView`` | ``rozbieznosci_if:ustaw_wszystkie`` | masowy update IF z punktacji źródła (sync albo Celery od ≥20 rekordów) |
| ``rozbieznosci_pk.UstawWszystkiePkView`` | ``rozbieznosci_pk:ustaw_wszystkie`` | masowy update punktów MNiSW (sync/Celery analogicznie) |
| ``snapshot_odpiec.NowySnapshot`` | ``snapshot_odpiec:nowy`` | tworzenie nowego snapshotu odpięć |
| ``snapshot_odpiec.AplikujSnapshot`` | ``snapshot_odpiec:aplikuj`` | nadpisanie stanu przypięć z snapshotu |

## Wzorzec UX

Wszystkie 4 widoki dostały ``def get`` (renderuje ``*_confirm.html`` z opisem operacji + przyciskiem POST) i ``def post`` (wykonuje mutację). Filtry w ``ustaw_wszystkie`` są przenoszone z GET → hidden inputs → POST, więc submit zachowuje rok_od/rok_do/tytul.

W szablonach ``index.html`` usunięte zostało ``data-confirm`` (JS confirm dialog) — pełny ekran potwierdzenia z liczbą rekordów + filtrami zastępuje ten mechanizm.

## Testy

- 4 nowe testy ``rebuild_view`` w ``komparator_pbn_udzialy``: GET nie startuje zadania, POST startuje, POST z stale data nie startuje, anonim → 302/403.
- Testy ``UstawWszystkieView`` przerobione: rendering GET (z ``client_with_group``) + POST small batch + POST large batch + GET no-records.
- ``snapshot_odpiec`` testy podzielone na warianty: GET pokazuje confirmation (nie mutuje), POST mutuje. Formularzom potwierdzenia nadane id (``aplikuj-confirm``, ``nowy-confirm``) żeby django-webtest mógł je wskazać po nazwie.
- Razem 58/58 testów dotkniętych modułów przechodzi.

## Test plan

- [ ] Smoke test po deploy: każdy z 5 widoków → GET pokazuje ekran potwierdzenia (nie startuje zadania), POST z ekranu wykonuje akcję.
- [ ] ``rozbieznosci_if/pk:ustaw_wszystkie`` z filtrami w URL: filtry zachowane na ekranie potwierdzenia i przekazane do POST.
- [ ] ``komparator_pbn_udzialy:rebuild`` przy nieświeżych danych PBN: POST pokazuje błąd, nie startuje zadania.

## Uwagi

- Pre-commit djlint zgłasza pre-existujące ostrzeżenia (H020/H025) w ``index.html`` / ``snapshotodpiec_list.html`` (pagination ``<a>`` wewnątrz ``{% if %}`` + ``<p></p>``). Nie powiązane z tym PR-em — pominięte przez ``SKIP=djlint-django`` żeby nie mieszać scope-u; do osobnej drive-by sprzątań.