### PR TITLE
fix(setup-wizard): ruff format + BPP-styled admin_user + ukryj skip-link

### DIFF
--- a/src/bpp_setup_wizard/templates/bpp_setup_wizard/uczelnia_setup.html
+++ b/src/bpp_setup_wizard/templates/bpp_setup_wizard/uczelnia_setup.html
@@ -1,6 +1,8 @@
 {% extends "bare.html" %}
 {% load static crispy_forms_tags %}
 
+{% block skip_link %}{% endblock %}
+
 {% block title %}{{ title }} - Konfiguracja uczelni{% endblock %}
 
 {% block extrahead %}

--- a/src/bpp_setup_wizard/templates/first_run_wizard/admin_user.html
+++ b/src/bpp_setup_wizard/templates/first_run_wizard/admin_user.html
@@ -1,0 +1,137 @@
+{# Override pakietowego first_run_wizard/admin_user.html — BPP-styled,
+   spójny wizualnie z bpp_setup_wizard/uczelnia_setup.html (drugi krok). #}
+{% extends "bare.html" %}
+{% load static %}
+
+{% block skip_link %}{% endblock %}
+
+{% block title %}{{ title }} - Konfiguracja administratora{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <link rel="stylesheet"
+          href="{% static 'bpp_setup_wizard/css/bpp_setup_wizard.css' %}">
+{% endblock %}
+
+{% block body %}
+    <div class="bpp-setup-wizard">
+        <div class="bpp-setup-wizard__header">
+            <div class="bpp-setup-wizard__icon">
+                <span class="fi-torso"></span>
+            </div>
+            <h1 class="bpp-setup-wizard__header-title">{{ title }}</h1>
+            <p class="bpp-setup-wizard__header-subtitle">
+                Konfiguracja początkowa systemu
+            </p>
+        </div>
+
+        <div class="bpp-setup-wizard__info">
+            <h3 class="bpp-setup-wizard__info-title">
+                <span class="fi-info"></span> Informacja
+            </h3>
+            <p class="bpp-setup-wizard__info-text">
+                Baza danych BPP jest pusta. Aby kontynuować, utwórz konto
+                administratora systemu.
+            </p>
+            <p class="bpp-setup-wizard__info-text">
+                Konto administratora otrzyma pełne uprawnienia
+                (<code>is_staff</code>, <code>is_superuser</code>) i zostanie
+                automatycznie zalogowane po utworzeniu.
+            </p>
+        </div>
+
+        <form method="post" novalidate>
+            {% csrf_token %}
+
+            {% if form.non_field_errors %}
+                <div class="bpp-setup-wizard__form-errors">
+                    {{ form.non_field_errors }}
+                </div>
+            {% endif %}
+
+            <div class="bpp-setup-wizard__form-section">
+                <h4 class="bpp-setup-wizard__form-section-title">
+                    Dane konta
+                </h4>
+
+                <div class="bpp-setup-wizard__form-group">
+                    {{ form.username.label_tag }}
+                    {{ form.username }}
+                    {% if form.username.help_text %}
+                        <span class="bpp-setup-wizard__help-text">
+                            {{ form.username.help_text }}
+                        </span>
+                    {% endif %}
+                    {% if form.username.errors %}
+                        <div class="bpp-setup-wizard__error-message">
+                            {{ form.username.errors }}
+                        </div>
+                    {% endif %}
+                </div>
+
+                <div class="bpp-setup-wizard__form-group">
+                    {{ form.email.label_tag }}
+                    {{ form.email }}
+                    {% if form.email.help_text %}
+                        <span class="bpp-setup-wizard__help-text">
+                            {{ form.email.help_text }}
+                        </span>
+                    {% endif %}
+                    {% if form.email.errors %}
+                        <div class="bpp-setup-wizard__error-message">
+                            {{ form.email.errors }}
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="bpp-setup-wizard__form-section">
+                <h4 class="bpp-setup-wizard__form-section-title">
+                    Hasło
+                </h4>
+
+                <div class="bpp-setup-wizard__form-group">
+                    {{ form.password1.label_tag }}
+                    {{ form.password1 }}
+                    {% if form.password1.help_text %}
+                        <span class="bpp-setup-wizard__help-text">
+                            {{ form.password1.help_text }}
+                        </span>
+                    {% endif %}
+                    {% if form.password1.errors %}
+                        <div class="bpp-setup-wizard__error-message">
+                            {{ form.password1.errors }}
+                        </div>
+                    {% endif %}
+                </div>
+
+                <div class="bpp-setup-wizard__form-group">
+                    {{ form.password2.label_tag }}
+                    {{ form.password2 }}
+                    {% if form.password2.help_text %}
+                        <span class="bpp-setup-wizard__help-text">
+                            {{ form.password2.help_text }}
+                        </span>
+                    {% endif %}
+                    {% if form.password2.errors %}
+                        <div class="bpp-setup-wizard__error-message">
+                            {{ form.password2.errors }}
+                        </div>
+                    {% endif %}
+                </div>
+
+                <div class="bpp-setup-wizard__pbn-note">
+                    <span class="fi-alert"></span>
+                    <strong>Wskazówka:</strong> Wybierz silne hasło — to konto
+                    będzie mieć pełną kontrolę nad systemem. Walidatory
+                    wymuszają minimum 8 znaków, brak podobieństwa do nazwy
+                    użytkownika i odporność na słownikowe ataki.
+                </div>
+            </div>
+
+            <button type="submit" class="bpp-setup-wizard__submit-btn">
+                <span class="fi-save"></span> Utwórz administratora i zaloguj
+            </button>
+        </form>
+    </div>
+{% endblock %}

--- a/src/bpp_setup_wizard/tests.py
+++ b/src/bpp_setup_wizard/tests.py
@@ -190,3 +190,126 @@ def test_middleware_redirects_logged_in_admin_to_uczelnia_setup(admin_user):
     response = client.get("/")
     assert response.status_code == 302
     assert response.url == reverse("first_run_wizard:step", kwargs={"name": "uczelnia"})
+
+
+@pytest.mark.django_db
+def test_admin_user_post_via_bpp_override_creates_superuser():
+    """POST na admin_user step gdy renderuje się BPP override.
+
+    Pakiet testuje POST swojego vendor-neutral template-u. Tu sprawdzamy
+    że BPP-styled override nie zepsuł HTML form attrs (`name=`, csrf,
+    submit button) — POST faktycznie wpływa do AdminUserCreationForm
+    z pakietu i tworzy superusera.
+    """
+    User = get_user_model()
+    User.objects.all().delete()
+    Uczelnia.objects.all().delete()
+
+    client = Client()
+    url = reverse("first_run_wizard:step", kwargs={"name": "admin_user"})
+    response = client.post(
+        url,
+        {
+            "username": "bppadmin",
+            "email": "admin@bpp.test",
+            "password1": "StrongBppPwd456!",
+            "password2": "StrongBppPwd456!",
+        },
+    )
+
+    assert response.status_code == 302, response.content.decode("utf-8")[:500]
+    assert response.url == "/"
+
+    assert User.objects.count() == 1
+    user = User.objects.get(username="bppadmin")
+    assert user.email == "admin@bpp.test"
+    assert user.is_staff is True
+    assert user.is_superuser is True
+    assert user.is_active is True
+    assert user.check_password("StrongBppPwd456!")
+
+
+@pytest.mark.django_db
+def test_full_happy_path_empty_db_to_live_site():
+    """E2E na pustej bazie: anonimowy GET / → admin_user form → POST →
+    middleware → uczelnia form → POST → site live (brak redirectu setup).
+
+    Jeden Django test Client utrzymuje session przez całą ścieżkę,
+    weryfikujemy że wszystkie redirecty i obie strony BPP-styled formularzy
+    łączą się w spójny flow.
+    """
+    User = get_user_model()
+    User.objects.all().delete()
+    Uczelnia.objects.all().delete()
+
+    client = Client()
+    admin_url = reverse("first_run_wizard:step", kwargs={"name": "admin_user"})
+    uczelnia_url = reverse("first_run_wizard:step", kwargs={"name": "uczelnia"})
+
+    # 1) Pusta DB → / przekierowuje do admin_user (anon, ale admin step
+    # nie requires_superuser, więc accessible).
+    response = client.get("/")
+    assert response.status_code == 302
+    assert response.url == admin_url
+
+    # 2) GET admin_user renderuje BPP-styled formularz.
+    response = client.get(admin_url)
+    assert response.status_code == 200
+    body = response.content.decode("utf-8")
+    assert "bpp-setup-wizard" in body
+    assert 'name="username"' in body
+    assert 'name="password1"' in body
+
+    # 3) POST admin_user → tworzy admina + auto-login + redirect na /.
+    response = client.post(
+        admin_url,
+        {
+            "username": "e2eadmin",
+            "email": "e2e@bpp.test",
+            "password1": "E2EStrongPwd987!",
+            "password2": "E2EStrongPwd987!",
+        },
+    )
+    assert response.status_code == 302
+    assert response.url == "/"
+    assert User.objects.filter(username="e2eadmin", is_superuser=True).exists()
+
+    # 4) Po stworzeniu admina + automatycznym loginie, GET / przekierowuje
+    # do uczelnia (admin jest superuser, więc ma access do tego stepu).
+    response = client.get("/")
+    assert response.status_code == 302
+    assert response.url == uczelnia_url
+
+    # 5) GET uczelnia renderuje BPP-styled formularz.
+    response = client.get(uczelnia_url)
+    assert response.status_code == 200
+    body = response.content.decode("utf-8")
+    assert "Konfiguracja uczelni" in body
+    assert 'name="nazwa"' in body
+    assert 'name="pbn_api_root"' in body
+
+    # 6) POST uczelnia → tworzy Uczelnia z PBN flags + redirect na /.
+    response = client.post(
+        uczelnia_url,
+        {
+            "nazwa": "Uniwersytet E2E",
+            "nazwa_dopelniacz_field": "Uniwersytetu E2E",
+            "skrot": "UE2E",
+            "pbn_api_root": "https://pbn-micro-alpha.opi.org.pl",
+            "uzywaj_wydzialow": True,
+        },
+    )
+    assert response.status_code == 302
+    assert response.url == "/"
+    uczelnia = Uczelnia.objects.get()
+    assert uczelnia.nazwa == "Uniwersytet E2E"
+    assert uczelnia.pbn_integracja is True
+
+    # 7) GET / nie przekierowuje już do setup — site live. Może być 200 albo
+    # inny redirect zależnie od głównej routy BPP, ale NIE może być redirect
+    # do /setup/ (oba kroki ukończone).
+    response = client.get("/")
+    if response.status_code in (301, 302):
+        assert "/setup/" not in response.url, (
+            f"unexpected redirect to setup wizard after both steps done: {response.url}"
+        )

--- a/src/bpp_setup_wizard/tests.py
+++ b/src/bpp_setup_wizard/tests.py
@@ -6,6 +6,8 @@ BPP-side glue.
 """
 
 import pytest
+from django.contrib.auth import get_user_model
+from django.template.loader import get_template
 from django.test import Client
 from django.urls import reverse
 
@@ -134,6 +136,47 @@ def test_uczelnia_setup_not_accessible_when_exists(admin_user, uczelnia):
     # Step is_complete()==True → WizardStepView redirects to '/'.
     assert response.status_code == 302
     assert response.url == "/"
+
+
+@pytest.mark.django_db
+def test_admin_user_template_loaded_from_bpp_override():
+    """INSTALLED_APPS puts bpp_setup_wizard before first_run_wizard so that
+    BPP's own first_run_wizard/admin_user.html (BPP-styled, extends bare.html)
+    wins over the package's vendor-neutral default. Regression guard for
+    accidental reordering."""
+    t = get_template("first_run_wizard/admin_user.html")
+    assert "bpp_setup_wizard" in t.origin.name, (
+        f"loaded from {t.origin.name!r} — expected BPP override "
+        f"in src/bpp_setup_wizard/templates/first_run_wizard/"
+    )
+
+
+@pytest.mark.django_db
+def test_admin_user_page_is_bpp_branded_and_hides_skip_link():
+    """The first-wizard page renders with the BPP wrapper class and the
+    accessibility skip-link from bare.html is suppressed (block override)."""
+    get_user_model().objects.all().delete()
+    response = Client().get(
+        reverse("first_run_wizard:step", kwargs={"name": "admin_user"})
+    )
+    assert response.status_code == 200
+    body = response.content.decode("utf-8")
+    assert "bpp-setup-wizard" in body, "expected BPP-styled wrapper class"
+    assert "Przejdź do głównej zawartości" not in body, (
+        "skip-link from bare.html should be suppressed on wizard pages "
+        "(empty {% block skip_link %}{% endblock %} override)"
+    )
+
+
+@pytest.mark.django_db
+def test_uczelnia_setup_page_hides_skip_link(admin_user):
+    """Same skip-link suppression for the BPP-specific Uczelnia step."""
+    Uczelnia.objects.all().delete()
+    client = Client()
+    client.force_login(admin_user)
+    response = client.get(reverse("first_run_wizard:step", kwargs={"name": "uczelnia"}))
+    assert response.status_code == 200
+    assert "Przejdź do głównej zawartości" not in response.content.decode("utf-8")
 
 
 @pytest.mark.django_db

--- a/src/bpp_setup_wizard/tests.py
+++ b/src/bpp_setup_wizard/tests.py
@@ -14,6 +14,12 @@ from django.urls import reverse
 from bpp.models import Uczelnia
 from bpp_setup_wizard.steps import UczelniaSetupStep
 
+# Test password used by HTTP tests that submit AdminUserCreationForm.
+# Must satisfy Django's default AUTH_PASSWORD_VALIDATORS (length ≥ 8,
+# not similar to username, not in common-password list, not all numeric).
+# Not a real credential.
+_TEST_PASSWORD = "wizard-test-pass-min8"  # pragma: allowlist secret  # noqa: S105
+
 
 @pytest.fixture(autouse=True)
 def enable_first_run_wizard_middleware(settings):
@@ -212,8 +218,8 @@ def test_admin_user_post_via_bpp_override_creates_superuser():
         {
             "username": "bppadmin",
             "email": "admin@bpp.test",
-            "password1": "StrongBppPwd456!",
-            "password2": "StrongBppPwd456!",
+            "password1": _TEST_PASSWORD,
+            "password2": _TEST_PASSWORD,
         },
     )
 
@@ -226,7 +232,7 @@ def test_admin_user_post_via_bpp_override_creates_superuser():
     assert user.is_staff is True
     assert user.is_superuser is True
     assert user.is_active is True
-    assert user.check_password("StrongBppPwd456!")
+    assert user.check_password(_TEST_PASSWORD)
 
 
 @pytest.mark.django_db
@@ -266,8 +272,8 @@ def test_full_happy_path_empty_db_to_live_site():
         {
             "username": "e2eadmin",
             "email": "e2e@bpp.test",
-            "password1": "E2EStrongPwd987!",
-            "password2": "E2EStrongPwd987!",
+            "password1": _TEST_PASSWORD,
+            "password2": _TEST_PASSWORD,
         },
     )
     assert response.status_code == 302

--- a/src/bpp_setup_wizard/tests.py
+++ b/src/bpp_setup_wizard/tests.py
@@ -31,9 +31,7 @@ def enable_first_run_wizard_middleware(settings):
                 "first_run_wizard.middleware.FirstRunWizardMiddleware",
             )
         except ValueError:
-            middleware.insert(
-                0, "first_run_wizard.middleware.FirstRunWizardMiddleware"
-            )
+            middleware.insert(0, "first_run_wizard.middleware.FirstRunWizardMiddleware")
         settings.MIDDLEWARE = middleware
 
 
@@ -59,9 +57,7 @@ def test_uczelnia_step_requires_superuser():
 def test_uczelnia_setup_requires_login():
     Uczelnia.objects.all().delete()
     client = Client()
-    response = client.get(
-        reverse("first_run_wizard:step", kwargs={"name": "uczelnia"})
-    )
+    response = client.get(reverse("first_run_wizard:step", kwargs={"name": "uczelnia"}))
     # WizardStepView checks is_accessible() and redirects anonymous users
     # to '/' (since uczelnia step requires_superuser=True).
     assert response.status_code == 302
@@ -74,9 +70,7 @@ def test_uczelnia_setup_form_display(admin_user):
     client = Client()
     client.force_login(admin_user)
 
-    response = client.get(
-        reverse("first_run_wizard:step", kwargs={"name": "uczelnia"})
-    )
+    response = client.get(reverse("first_run_wizard:step", kwargs={"name": "uczelnia"}))
 
     assert response.status_code == 200
     content = response.content.decode("utf-8")
@@ -135,9 +129,7 @@ def test_uczelnia_setup_not_accessible_when_exists(admin_user, uczelnia):
     client = Client()
     client.force_login(admin_user)
 
-    response = client.get(
-        reverse("first_run_wizard:step", kwargs={"name": "uczelnia"})
-    )
+    response = client.get(reverse("first_run_wizard:step", kwargs={"name": "uczelnia"}))
 
     # Step is_complete()==True → WizardStepView redirects to '/'.
     assert response.status_code == 302
@@ -154,6 +146,4 @@ def test_middleware_redirects_logged_in_admin_to_uczelnia_setup(admin_user):
 
     response = client.get("/")
     assert response.status_code == 302
-    assert response.url == reverse(
-        "first_run_wizard:step", kwargs={"name": "uczelnia"}
-    )
+    assert response.url == reverse("first_run_wizard:step", kwargs={"name": "uczelnia"})

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -337,8 +337,11 @@ if TESTING:
 
 INSTALLED_APPS = [
     # "django_werkzeug",
+    # bpp_setup_wizard BEFORE first_run_wizard so BPP-side templates
+    # (first_run_wizard/admin_user.html in bpp_setup_wizard.templates)
+    # override the vendor-neutral defaults shipped by the package.
+    "bpp_setup_wizard",  # BPP-specific step + BPP-styled templates
     "first_run_wizard",  # Pluggable first-run wizard engine (PyPI)
-    "bpp_setup_wizard",  # BPP-specific step (Uczelnia + PBN); registers in apps.ready()
     "daphne",
     "tinymce",
     "formtools",

--- a/src/django_bpp/templates/bare.html
+++ b/src/django_bpp/templates/bare.html
@@ -72,7 +72,7 @@
     {% endcache %}
 </head>
 <body class="fouc-hidden">
-<a href="#main-content" class="skip-link">Przejdź do głównej zawartości</a>
+{% block skip_link %}<a href="#main-content" class="skip-link">Przejdź do głównej zawartości</a>{% endblock %}
 {% block body %}
 {% endblock %}
 <script type="text/javascript">


### PR DESCRIPTION
## Summary

Trzy powiązane zmiany kosmetyczne dla flow `/setup/*` (after-cleanup PR #poprzedniego refactoru):

### Commit 1 — `a05d145c8` style: ruff format fixup
- CI `Lint changed files` na `dev` failował na `ruff format --check` dla `src/bpp_setup_wizard/tests.py`.
- 5 wywołań `reverse("first_run_wizard:step", ...)` było rozwiniętych na 3 linie — ruff chce 1 linię.
- Zero zmian semantycznych.

### Commit 2 — `d4c11f972` feat: BPP-styled admin_user + skip-link block

**BPP-styled admin_user step.** Pakietowy `first_run_wizard/admin_user.html` (z PyPI) jest vendor-neutral (minimal inline CSS, brak BPP nawigacji). Dorzucam BPP-side override `src/bpp_setup_wizard/templates/first_run_wizard/admin_user.html` extends `bare.html` używając tych samych `.bpp-setup-wizard__*` klas co `uczelnia_setup.html`. **Wizualnie spójne:** oba kroki wyglądają identycznie.

Wymaga: `INSTALLED_APPS` — `bpp_setup_wizard` PRZED `first_run_wizard` (Django template loader bierze pierwszy match).

**Skip-link block override.** `bare.html:75` ma a11y skip-link (WCAG SC 2.4.1, visible-on-focus). Na stronach setup wizard wyciekał poza header. Owinąłem w `{% block skip_link %}` żeby step templates mogły go pustym blokiem zlikwidować. Reszta BPP UI nadal ma skip-link.

**+ 3 regression testy:**
- Template loader wybiera BPP override
- admin_user page ma `.bpp-setup-wizard` wrapper, brak skip-linka
- uczelnia_setup page — to samo

## Test plan

- [x] `uv run pytest src/bpp_setup_wizard/` — 11/11 passed
- [x] `uv run ruff check src/bpp_setup_wizard/ src/django_bpp/settings/base.py` — clean
- [x] `uv run ruff format --check src/bpp_setup_wizard/tests.py` — clean
- [ ] CI `Tests` workflow — green
- [ ] CI `Lint changed files` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)