### PR TITLE
feat(bpp): Szukaj zapytaniem — interaktywny widok DjangoQL poza adminem

### DIFF
--- a/src/bpp/templates/bpp/_zapytanie_pager.html
+++ b/src/bpp/templates/bpp/_zapytanie_pager.html
@@ -1,0 +1,15 @@
+{% if results.has_other_pages %}
+    <ul class="pagination" role="navigation" aria-label="Paginacja">
+        {% if results.has_previous %}
+            <li><a href="?model={{ model_key }}&query={{ query|urlencode }}&page={{ results.previous_page_number }}">&laquo; poprzednia</a></li>
+        {% else %}
+            <li class="disabled">&laquo; poprzednia</li>
+        {% endif %}
+        <li class="current">{{ results.number }} / {{ results.paginator.num_pages }}</li>
+        {% if results.has_next %}
+            <li><a href="?model={{ model_key }}&query={{ query|urlencode }}&page={{ results.next_page_number }}">nastepna &raquo;</a></li>
+        {% else %}
+            <li class="disabled">nastepna &raquo;</li>
+        {% endif %}
+    </ul>
+{% endif %}

--- a/src/bpp/templates/bpp/zapytanie.html
+++ b/src/bpp/templates/bpp/zapytanie.html
@@ -142,6 +142,63 @@
             text-align: right;
             font-variant-numeric: tabular-nums;
         }
+        /* Klikalne przyklady w pomocy */
+        .zapytanie-help-sublevel { margin-top: 0.5rem; }
+        .zapytanie-help-sublevel summary {
+            cursor: pointer;
+            padding: 0.3rem 0;
+            font-size: 0.95rem;
+        }
+        .zapytanie-help-sublevel ul.examples {
+            list-style: none;
+            margin-left: 0;
+            padding-left: 0;
+        }
+        .zapytanie-help-sublevel ul.examples > li {
+            margin-bottom: 0.7rem;
+        }
+        .zapytanie-help-sublevel ul.examples > li > em {
+            color: #475569;
+            font-size: 0.85rem;
+        }
+        .zapytanie-help-sublevel ul.examples code {
+            display: block;
+            margin-top: 0.25rem;
+            padding: 0.5rem 0.7rem;
+            font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
+            font-size: 0.85rem;
+            background: #f1f5f9;
+            border: 1px solid #cbd5e1;
+            border-radius: 4px;
+            color: #0f172a;
+            cursor: pointer;
+            white-space: pre-wrap;
+            word-break: break-word;
+            line-height: 1.55;
+            transition: background 0.12s, border-color 0.12s, transform 0.05s;
+            user-select: text;
+        }
+        .zapytanie-help-sublevel ul.examples code:hover {
+            background: #e0f2fe;
+            border-color: #38bdf8;
+        }
+        .zapytanie-help-sublevel ul.examples code:active {
+            transform: scale(0.99);
+        }
+        .zapytanie-help-sublevel ul.examples code:focus-visible {
+            outline: 2px solid #1779ba;
+            outline-offset: 2px;
+        }
+        /* Klikalny wiersz tabeli wynikow */
+        tr[data-href] { cursor: pointer; }
+        tr[data-href]:hover { background: #f8fafc; }
+        tr[data-href] a, tr[data-href] button { cursor: auto; }
+        .rekord-id-cell {
+            font-family: 'SF Mono', Monaco, monospace;
+            font-size: 0.85rem;
+            color: #64748b;
+            white-space: nowrap;
+        }
     </style>
 {% endblock %}
 
@@ -222,231 +279,61 @@
                         <tr><td>in, not in</td><td>nalezy do listy: <code>rok in (2023, 2024)</code></td></tr>
                     </tbody>
                 </table>
-                <p style="margin-top: 0.75rem;"><strong>Przyklady &mdash; Rekord</strong> (od podstaw do mocniejszych):</p>
-                <ul>
-                    <li>
-                        <em>Po slowie w tytule:</em>
-                        <code>tytul_oryginalny ~ "nowotwor"</code>
-                    </li>
-                    <li>
-                        <em>Wysoko punktowane prace ostatnich trzech lat:</em>
-                        <code>rok &gt;= 2022 and punkty_kbn &gt;= 100</code>
-                    </li>
-                    <li>
-                        <em>Wysoki Impact Factor z zakresu lat:</em>
-                        <code>impact_factor &gt; 5 and rok in (2022, 2023, 2024)</code>
-                    </li>
-                    <li>
-                        <em>Brak DOI mimo wysokiej punktacji (do uzupelnienia):</em>
-                        <code>punkty_kbn &gt;= 70 and doi = ""</code>
-                    </li>
-                    <li>
-                        <em>Czesto cytowane, ale nierecenzowane:</em>
-                        <code>liczba_cytowan &gt; 10 and recenzowana = False</code>
-                    </li>
-                    <li>
-                        <em>Konkretny charakter formalny + zakres punktow:</em>
-                        <code>charakter_formalny.skrot = "AC" and punkty_kbn &gt;= 40 and punkty_kbn &lt;= 100</code>
-                    </li>
-                    <li>
-                        <em>Wieloautorskie prace w okresie ewaluacyjnym:</em>
-                        <code>liczba_autorow &gt; 20 and rok &gt;= 2022 and rok &lt;= 2025</code>
-                    </li>
-                    <li>
-                        <em>Konkretne zrodlo + lata:</em>
-                        <code>zrodlo.nazwa ~ "Nature" and rok &gt;= 2020</code>
-                    </li>
-                    <li>
-                        <em>Polskojezyczne artykuly:</em>
-                        <code>jezyk.skrot = "pol" and charakter_formalny.skrot = "AC"</code>
-                    </li>
-                    <li>
-                        <em>Open Access &mdash; rekordy z przypisanym trybem dostepu:</em>
-                        <code>openaccess_tryb_dostepu != None and rok &gt;= 2023</code>
-                    </li>
-                    <li>
-                        <em>Szukanie po slowach kluczowych w tytule (combo OR):</em>
-                        <code>tytul_oryginalny ~ "COVID" or tytul_oryginalny ~ "SARS-CoV"</code>
-                    </li>
-                    <li>
-                        <em>Rekordy bez WWW i bez DOI (do redakcji):</em>
-                        <code>www = "" and doi = "" and rok &gt;= 2023</code>
-                    </li>
-                </ul>
-                <p><strong>Przyklady &mdash; Autor:</strong></p>
-                <ul>
-                    <li>
-                        <em>Po fragmencie nazwiska:</em>
-                        <code>nazwisko ~ "Kowal"</code>
-                    </li>
-                    <li>
-                        <em>Profesorowie z wpisanym ORCID:</em>
-                        <code>tytul.skrot = "prof." and orcid != ""</code>
-                    </li>
-                    <li>
-                        <em>Maja ORCID ale brak go w PBN:</em>
-                        <code>orcid != "" and orcid_w_pbn = False</code>
-                    </li>
-                    <li>
-                        <em>Z konkretnej jednostki (LIKE po nazwie):</em>
-                        <code>aktualna_jednostka.nazwa ~ "Medycyny" and tytul.skrot startswith "dr"</code>
-                    </li>
-                    <li>
-                        <em>Brak emaila, ale jest ORCID (mozna spytac o adres):</em>
-                        <code>email = "" and orcid != ""</code>
-                    </li>
-                    <li>
-                        <em>Konkretna jednostka po skrocie + filtr po nazwisku:</em>
-                        <code>nazwisko startswith "Now" and aktualna_jednostka.skrot = "II WL"</code>
-                    </li>
-                    <li>
-                        <em>Doktoraty + asystenci (zbior tytulow):</em>
-                        <code>tytul.skrot in ("dr", "dr hab.", "mgr")</code>
-                    </li>
-                </ul>
                 <p style="margin-top: 1rem;">
-                    <strong>Skomplikowane zapytania &mdash; Rekord (power-user):</strong>
+                    <strong>Przyklady &mdash; rozwin wg poziomu trudnosci.
+                    Kliknij wybrane zapytanie, zeby je wstawic do edytora.</strong>
                 </p>
-                <ol>
-                    <li>
-                        <em>Audyt ewaluacyjny &mdash; tylko recenzowane, z DOI,
-                        w okresie 2022&ndash;2025, z minimum 70 punktow:</em>
-                        <code>recenzowana = True and doi != "" and rok in (2022, 2023, 2024, 2025) and punkty_kbn &gt;= 70</code>
-                    </li>
-                    <li>
-                        <em>Combo z grupowaniem (rok OR + charakter OR) &times;
-                        punktacja:</em>
-                        <code>(rok = 2024 or rok = 2025) and (charakter_formalny.skrot = "AC" or charakter_formalny.skrot = "AOR") and punkty_kbn &gt;= 100</code>
-                    </li>
-                    <li>
-                        <em>Negacja: wszystko poza artykulami z czasopism,
-                        z minimum IF=3, od 2023:</em>
-                        <code>not (charakter_formalny.skrot = "AC") and rok &gt;= 2023 and impact_factor &gt; 3</code>
-                    </li>
-                    <li>
-                        <em>Wieloklauzulowo: tytul (covid/sars) &times; jezyk
-                        (en/pl) &times; min 3 autorow &times; konkretny rok:</em>
-                        <code>(tytul_oryginalny ~ "COVID" or tytul_oryginalny ~ "SARS") and jezyk.skrot in ("ang", "pol") and liczba_autorow &gt;= 3 and rok = 2023</code>
-                    </li>
-                    <li>
-                        <em>Wydawcy Elsevier/Springer/Wiley w okresie ewaluacji
-                        z konkretnym przedzialem punktow:</em>
-                        <code>(wydawca.nazwa ~ "Elsevier" or wydawca.nazwa ~ "Springer" or wydawca.nazwa ~ "Wiley") and rok &gt;= 2022 and punkty_kbn &gt;= 70 and punkty_kbn &lt;= 200</code>
-                    </li>
-                    <li>
-                        <em>Hot &amp; trending: cytowane &gt;50 razy
-                        w&nbsp;publikacjach z&nbsp;ostatnich 5 lat z&nbsp;IF
-                        &gt; 5:</em>
-                        <code>liczba_cytowan &gt; 50 and rok &gt;= 2020 and impact_factor &gt; 5</code>
-                    </li>
-                    <li>
-                        <em>Audyt jakosci danych: artykuly z 2024+ bez DOI,
-                        bez WWW, recenzowane &mdash; wymagaja redakcji:</em>
-                        <code>charakter_formalny.skrot = "AC" and rok &gt;= 2024 and doi = "" and www = "" and recenzowana = True</code>
-                    </li>
-                    <li>
-                        <em>Top-tier prace: Nature/Cell/Science/Lancet po 2020,
-                        wszystkie OA:</em>
-                        <code>zrodlo.nazwa in ("Nature", "Cell", "Science", "The Lancet") and rok &gt; 2020 and openaccess_tryb_dostepu != None</code>
-                    </li>
-                    <li>
-                        <em>Prace z polskim wydawca + jezyk = polski +
-                        konkretny zakres lat:</em>
-                        <code>wydawca.nazwa ~ "PWN" and jezyk.skrot = "pol" and rok in (2022, 2023, 2024)</code>
-                    </li>
-                    <li>
-                        <em>Rekordy zmienione od poczatku biezacego roku
-                        z adnotacjami redaktora:</em>
-                        <code>ostatnio_zmieniony &gt;= "2025-01-01" and adnotacje != ""</code>
-                    </li>
-                    <li>
-                        <em>Granica IF + zakres punktow + minimum
-                        cytowan &mdash; do rankingu jakosciowego:</em>
-                        <code>impact_factor &gt;= 5 and impact_factor &lt;= 10 and punkty_kbn &gt;= 100 and liczba_cytowan &gt;= 5</code>
-                    </li>
-                    <li>
-                        <em>Konkretny typ KBN + waski przedzial punktow +
-                        slowo w tytule:</em>
-                        <code>typ_kbn.skrot = "PO" and punkty_kbn &gt;= 40 and punkty_kbn &lt;= 70 and (tytul_oryginalny ~ "neuro" or tytul_oryginalny ~ "kardio")</code>
-                    </li>
-                    <li>
-                        <em>Powtorzenia DOI (zapytanie do weryfikacji
-                        manualnej, lista DOI):</em>
-                        <code>doi in ("10.1038/s41586-024-XXXXX", "10.1126/science.YYYYY")</code>
-                    </li>
-                </ol>
 
-                <p style="margin-top: 1rem;">
-                    <strong>Skomplikowane zapytania &mdash; Autor (power-user):</strong>
-                </p>
-                <ol>
-                    <li>
-                        <em>Profesorowie z konkretnej jednostki, z wpisanym
-                        ORCID-em, ale nie potwierdzonym w PBN:</em>
-                        <code>tytul.skrot in ("prof.", "prof. dr hab.") and aktualna_jednostka.skrot startswith "I WL" and orcid != "" and orcid_w_pbn = False</code>
-                    </li>
-                    <li>
-                        <em>Dwie jednostki + tytul dr/dr hab. + jest orcid:</em>
-                        <code>(aktualna_jednostka.skrot = "II WL" or aktualna_jednostka.skrot = "WLS") and tytul.skrot startswith "dr" and orcid != ""</code>
-                    </li>
-                    <li>
-                        <em>Brak emaila ale jest ORCID &mdash; do uzupelnienia
-                        kontaktu z poziomu administracji:</em>
-                        <code>email = "" and orcid != "" and tytul.skrot in ("dr", "dr hab.", "prof.")</code>
-                    </li>
-                    <li>
-                        <em>Format ORCID nieprawidlowy (nie zaczyna sie od
-                        '0000-'):</em>
-                        <code>orcid != "" and not (orcid startswith "0000-")</code>
-                    </li>
-                    <li>
-                        <em>Wszystkie z aktualna jednostka, oprocz mgr/mgr inz:</em>
-                        <code>aktualna_jednostka != None and not (tytul.skrot in ("mgr", "mgr inz."))</code>
-                    </li>
-                    <li>
-                        <em>Wyszukiwanie po fragmentach imienia i nazwiska
-                        (Jan Kowalski / Janusz Kowalik / ...):</em>
-                        <code>(imiona ~ "Jan" or imiona startswith "Janusz") and nazwisko startswith "Kowal"</code>
-                    </li>
-                </ol>
+                {% for level in examples %}
+                    <details class="zapytanie-help-sublevel">
+                        <summary>
+                            <strong>{{ level.level }}. {{ level.title }}</strong>
+                            &mdash; {{ level.subtitle }}
+                        </summary>
+                        {% for group in level.groups %}
+                            <p><em>{{ group.label }}:</em></p>
+                            <ul class="examples">
+                                {% for desc, query in group.items %}
+                                    <li>
+                                        {% if desc %}<em>{{ desc }}:</em>{% endif %}
+                                        <code data-model="{{ group.model }}"
+                                              role="button"
+                                              tabindex="0"
+                                              title="Kliknij, aby wstawic do zapytania (model: {{ group.model }})">{{ query }}</code>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endfor %}
+                    </details>
+                {% endfor %}
 
-                <p style="margin-top: 0.75rem;">
-                    <em>Wskazowki dla power-userow:</em>
-                </p>
-                <ul>
-                    <li>
-                        <strong>Grupowanie</strong> &mdash; uzywaj nawiasow
-                        do logicznych grup: <code>(A or B) and C</code>.
-                    </li>
-                    <li>
-                        <strong>Negacja</strong> &mdash; <code>not</code> przed
-                        wyrazeniem: <code>not (charakter_formalny.skrot = "AC")</code>.
-                    </li>
-                    <li>
-                        <strong>Pola relacji</strong> &mdash; po kropce:
-                        <code>charakter_formalny.skrot</code>,
-                        <code>zrodlo.wydawca.nazwa</code> (zagniezdzanie OK).
-                    </li>
-                    <li>
-                        <strong>Listy wartosci</strong> &mdash;
-                        <code>in (...)</code> dzieli sie przecinkami,
-                        oszczedza wielu <code>or</code>.
-                    </li>
-                    <li>
-                        <strong>Daty/datetime</strong> &mdash;
-                        ISO-string w cudzyslowie: <code>"2025-01-01"</code>.
-                    </li>
-                    <li>
-                        <strong>Pusty FK</strong> &mdash;
-                        <code>pole != None</code> / <code>pole = None</code>;
-                        dla stringa <code>pole = ""</code>.
-                    </li>
-                    <li>
-                        <strong>Granice zakresow</strong> &mdash; brak operatora
-                        <code>between</code>, zlozyć z
-                        <code>&gt;= X and &lt;= Y</code>.
-                    </li>
-                </ul>
+                <details class="zapytanie-help-sublevel">
+                    <summary><strong>Wskazowki dla power-userow</strong></summary>
+                    <ul>
+                        <li>
+                            <strong>Grupowanie</strong> &mdash; nawiasy do logicznych grup: <code>(A or B) and C</code>.
+                        </li>
+                        <li>
+                            <strong>Negacja</strong> &mdash; <code>not</code> przed wyrazeniem: <code>not (charakter_formalny.skrot = "AC")</code>.
+                        </li>
+                        <li>
+                            <strong>Pola relacji</strong> &mdash; po kropce, mozna zagniezdzac: <code>charakter_formalny.skrot</code>, <code>zrodlo.wydawca.nazwa</code>.
+                        </li>
+                        <li>
+                            <strong>Listy wartosci</strong> &mdash; <code>in (...)</code> oszczedza wielu <code>or</code>.
+                        </li>
+                        <li>
+                            <strong>Daty / datetime</strong> &mdash; ISO-string w cudzyslowie: <code>"2025-01-01"</code>.
+                        </li>
+                        <li>
+                            <strong>Pusty FK</strong> &mdash; <code>pole != None</code> / <code>pole = None</code>; dla stringa <code>pole = ""</code>.
+                        </li>
+                        <li>
+                            <strong>Granice zakresow</strong> &mdash; brak <code>between</code>, zlozyc z <code>&gt;= X and &lt;= Y</code>.
+                        </li>
+                    </ul>
+                </details>
+
             </details>
 
             <p style="margin-top: 1rem;">
@@ -508,33 +395,38 @@
                 <table class="hover stack">
                     <thead>
                         <tr>
-                            <th>ID</th>
                             <th>Reprezentacja</th>
-                            <th>Akcje</th>
+                            <th style="width: 6rem;">ID</th>
+                            <th style="width: 9rem;">Akcje</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for obj in results %}
-                            <tr>
-                                <td>{{ obj.pk }}</td>
-                                <td>
-                                    {% if model_key == "rekord" %}
-                                        {{ obj.opis_bibliograficzny_cache|safe }}
-                                    {% else %}
-                                        {{ obj }}
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if model_key == "autor" %}
+                            {% if model_key == "rekord" %}
+                                <tr data-href="{{ obj.get_absolute_url }}">
+                                    <td>{{ obj.opis_bibliograficzny_cache|safe }}</td>
+                                    <td class="rekord-id-cell">{{ obj.pk.0 }}-{{ obj.pk.1 }}</td>
+                                    <td>
+                                        <a href="{{ obj.get_absolute_url }}" target="_blank">Zobacz</a>
+                                        {% if request.user.is_staff and obj.admin_url %}
+                                            <br>
+                                            <a href="{{ obj.admin_url }}" target="_blank">Edytuj</a>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% else %}
+                                <tr data-href="{% url 'bpp:browse_autor' obj.slug %}">
+                                    <td>{{ obj }}</td>
+                                    <td class="rekord-id-cell">{{ obj.pk }}</td>
+                                    <td>
                                         <a href="{% url 'bpp:browse_autor' obj.slug %}" target="_blank">Zobacz</a>
                                         {% if request.user.is_staff %}
+                                            <br>
                                             <a href="{% url 'admin:bpp_autor_change' obj.pk %}" target="_blank">Edytuj</a>
                                         {% endif %}
-                                    {% else %}
-                                        <a href="{{ obj.get_absolute_url }}" target="_blank">Zobacz</a>
-                                    {% endif %}
-                                </td>
-                            </tr>
+                                    </td>
+                                </tr>
+                            {% endif %}
                         {% endfor %}
                     </tbody>
                 </table>
@@ -885,6 +777,104 @@
                 });
             }
         );
+    });
+})();
+</script>
+<script>
+(function() {
+    // === Klikalne przyklady zapytan ============================================
+    // Tagujemy <ul> w sublevel-ach (poza "Wskazowki") klasa .examples i
+    // przypisujemy data-model do kazdego <code> wg poprzedzajacego <em>Rekord:</em>
+    // / <em>Autor:</em> naglowka. Klik wstawia query do textarea + przelacza model
+    // przez change-event radio (co tryguje dql.loadIntrospections w drugim IIFE).
+    function setupExamples() {
+        document.querySelectorAll(".zapytanie-help-sublevel")
+            .forEach(function(level) {
+                var summary = level.querySelector("summary");
+                if (summary && /Wskazowki/i.test(summary.textContent)) return;
+                var currentModel = null;
+                // querySelectorAll daje elementy w kolejnosci dokumentu.
+                level.querySelectorAll("p > em, ul").forEach(function(el) {
+                    if (el.tagName === "EM") {
+                        var t = el.textContent;
+                        if (/Autor/i.test(t)) currentModel = "autor";
+                        else if (/Rekord/i.test(t)) currentModel = "rekord";
+                    } else {
+                        el.classList.add("examples");
+                        el.querySelectorAll("li > code, li > br + code, li code")
+                            .forEach(function(code) {
+                                if (!currentModel) return;
+                                if (code.dataset.model) return; // raz
+                                code.dataset.model = currentModel;
+                                code.setAttribute("role", "button");
+                                code.setAttribute("tabindex", "0");
+                                code.title =
+                                    "Kliknij, aby wstawic do zapytania " +
+                                    "(model: " + currentModel + ")";
+                            });
+                    }
+                });
+            });
+    }
+
+    function applyExample(code) {
+        var query = code.textContent.trim();
+        var model = code.dataset.model;
+        if (!query || !model) return;
+        var radio = document.querySelector(
+            'input[name="model"][value="' + model + '"]'
+        );
+        if (radio && !radio.checked) {
+            radio.checked = true;
+            // bubbling change event -> drugi IIFE robi dql.loadIntrospections
+            radio.dispatchEvent(new Event("change", {bubbles: true}));
+        }
+        var ta = document.getElementById("id_query");
+        if (ta) {
+            ta.value = query;
+            ta.focus();
+            ta.setSelectionRange(query.length, query.length);
+            // scroll do formularza zeby user widzial co sie wstawilo
+            ta.scrollIntoView({behavior: "smooth", block: "center"});
+        }
+    }
+
+    // === Klikalne wiersze tabeli wynikow ========================================
+    function setupResultRowClicks() {
+        document.addEventListener("click", function(e) {
+            var tr = e.target.closest("tr[data-href]");
+            if (!tr) return;
+            // pomin gdy klik na link/przycisk w wierszu — one maja wlasna logike
+            if (e.target.closest("a, button")) return;
+            var href = tr.dataset.href;
+            if (!href) return;
+            window.open(href, "_blank", "noopener");
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function() {
+        setupExamples();
+        setupResultRowClicks();
+
+        // Delegowany click na <code data-model> w pomocy.
+        document.addEventListener("click", function(e) {
+            var code = e.target.closest(
+                ".zapytanie-help-sublevel ul.examples code[data-model]"
+            );
+            if (!code) return;
+            e.preventDefault();
+            applyExample(code);
+        });
+        // Keyboard (Enter/Space) dla a11y.
+        document.addEventListener("keydown", function(e) {
+            if (e.key !== "Enter" && e.key !== " ") return;
+            var code = e.target.closest(
+                ".zapytanie-help-sublevel ul.examples code[data-model]"
+            );
+            if (!code) return;
+            e.preventDefault();
+            applyExample(code);
+        });
     });
 })();
 </script>

--- a/src/bpp/templates/bpp/zapytanie.html
+++ b/src/bpp/templates/bpp/zapytanie.html
@@ -1,0 +1,891 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block extratitle %}
+    Szukaj zapytaniem
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'djangoql/css/completion.css' %}">
+    <style>
+        /* Button-group jako wybor modelu — czysty CSS, bez JS */
+        .zapytanie-model-group { margin-bottom: 1rem; }
+        .zapytanie-model-group .button {
+            margin: 0;
+            cursor: pointer;
+            background: #fff;
+            color: #2c3e50;
+            border: 1px solid #cfd8dc;
+            font-weight: 500;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+        }
+        .zapytanie-model-group .button input[type="radio"] {
+            position: absolute;
+            opacity: 0;
+            pointer-events: none;
+            width: 1px;
+            height: 1px;
+        }
+        .zapytanie-model-group .button:hover {
+            background: #f1f5f9;
+        }
+        .zapytanie-model-group .button:has(input[type="radio"]:checked) {
+            background: #1779ba;
+            color: #fff;
+            border-color: #1779ba;
+            box-shadow: inset 0 1px 2px rgba(0,0,0,.15);
+        }
+        .zapytanie-model-group .button:focus-within {
+            outline: 2px solid #1779ba;
+            outline-offset: 2px;
+        }
+
+        /* Beta badge */
+        .beta-badge {
+            display: inline-block;
+            vertical-align: middle;
+            margin-left: 0.5rem;
+            padding: 2px 8px;
+            font-size: 0.7rem;
+            font-weight: 700;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            color: #fff;
+            background: linear-gradient(135deg, #f39c12 0%, #e67e22 100%);
+            border-radius: 3px;
+            box-shadow: 0 1px 2px rgba(0,0,0,.15);
+        }
+
+        /* DjangoQL completion popup — over sticky-header.
+           Wymuszamy position:fixed bo BPP body ma position:relative+min-height:100vh
+           (z gradient-background), wiec popup z position:absolute liczony przez
+           djangoql laduje POZA viewportem i pcha scrollbar. */
+        .djangoql-completion {
+            position: fixed !important;
+            z-index: 9000 !important;
+            max-width: min(90vw, 520px);
+            box-shadow: 0 6px 24px rgba(0,0,0,.15);
+            border-radius: 4px;
+        }
+        .djangoql-completion ul { max-height: min(50vh, 320px); }
+        /* Wymuszenie widocznego highlightu wybranej sugestii — djangoql daje
+           .active, ale jego default (#79aec8) bywa pokryty stylami BPP. */
+        .djangoql-completion li.active,
+        .djangoql-completion li.active b {
+            background-color: #1779ba !important;
+            color: #fff !important;
+        }
+        .djangoql-completion li {
+            transition: background-color 0.08s;
+        }
+
+        /* Textarea — kod-friendly */
+        #id_query {
+            font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
+            font-size: 0.95rem;
+            line-height: 1.45;
+        }
+
+        .zapytanie-help-card {
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            border-radius: 4px;
+            padding: 0.75rem 1rem;
+            margin-top: 0.5rem;
+        }
+        .zapytanie-help-card summary {
+            cursor: pointer;
+            font-weight: 600;
+            color: #1779ba;
+        }
+        .zapytanie-help-card kbd {
+            display: inline-block;
+            padding: 1px 6px;
+            font-family: monospace;
+            font-size: 0.85em;
+            background: #fff;
+            border: 1px solid #cbd5e0;
+            border-radius: 3px;
+        }
+        .zapytanie-help-card table { margin-top: 0.5rem; }
+        .zapytanie-help-card table td:first-child { white-space: nowrap; font-family: monospace; }
+        /* Historia zapytan */
+        .zapytanie-history-card .history-query {
+            font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
+            font-size: 0.85rem;
+            white-space: pre-wrap;
+            word-break: break-word;
+            display: block;
+            max-width: 60ch;
+        }
+        .zapytanie-history-card .history-remove {
+            background: transparent;
+            border: 1px solid #e2e8f0;
+            border-radius: 3px;
+            color: #94a3b8;
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 0.85rem;
+            line-height: 1;
+            padding: 2px 6px;
+        }
+        .zapytanie-history-card .history-remove:hover {
+            color: #dc2626;
+            border-color: #fca5a5;
+            background: #fef2f2;
+        }
+        .zapytanie-history-card td { vertical-align: top; }
+        .zapytanie-history-card .history-count-cell {
+            text-align: right;
+            font-variant-numeric: tabular-nums;
+        }
+    </style>
+{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li class="current">Szukaj zapytaniem (DjangoQL)</li>
+{% endblock %}
+
+{% block content %}
+<div class="grid-x grid-margin-x">
+    <div class="cell">
+        <h1>
+            <span class="fi-clipboard-pencil" aria-hidden="true"></span>
+            Szukaj zapytaniem
+            <span class="beta-badge" title="Funkcja w wersji beta">beta</span>
+        </h1>
+
+        <div class="callout secondary" role="note" style="border-left: 4px solid #f39c12;">
+            <p style="margin: 0;">
+                <strong>Podglad technologiczny.</strong>
+                Ta funkcja jest udostepniona w ramach <em>podgladu
+                technologicznego</em> &mdash; pozwala przeszukiwac rekordy
+                i autorow zapytaniami w jezyku
+                <a href="https://github.com/ivelum/djangoql" target="_blank" rel="noopener">DjangoQL</a>,
+                podobnie jak w panelu administracyjnym Django. Interfejs
+                i zakres dostepnych pol moga sie zmieniac. Jesli cos nie
+                dziala albo masz pomysl na ulepszenie &mdash; daj znac.
+            </p>
+        </div>
+
+        <form method="get" action="" autocomplete="off">
+            <div class="zapytanie-model-group button-group">
+                {% for radio in form.model %}
+                    <label class="button" title="Przeszukaj model {{ radio.choice_label }}">
+                        {{ radio.tag }}
+                        {% if radio.choice_value == "rekord" %}
+                            <span class="fi-page-multiple" aria-hidden="true"></span>
+                        {% else %}
+                            <span class="fi-torso" aria-hidden="true"></span>
+                        {% endif %}
+                        <span>{{ radio.choice_label }}</span>
+                    </label>
+                {% endfor %}
+            </div>
+            {% if form.model.errors %}
+                <small class="form-error is-visible">{{ form.model.errors|join:", " }}</small>
+            {% endif %}
+
+            <label for="{{ form.query.id_for_label }}">
+                {{ form.query.label }}
+            </label>
+            {{ form.query }}
+            {% if form.query.errors %}
+                <small class="form-error is-visible">{{ form.query.errors|join:", " }}</small>
+            {% endif %}
+
+            <details class="zapytanie-help-card">
+                <summary>
+                    <span class="fi-info" aria-hidden="true"></span>
+                    Skladnia DjangoQL &mdash; rozwin pomoc i przyklady
+                </summary>
+                <p style="margin-top: 0.75rem;">
+                    Zapytania pisz w postaci <code>pole operator wartosc</code>,
+                    laczone przez <kbd>and</kbd> / <kbd>or</kbd>. Stringi
+                    obejmij cudzyslowem. Edytor podpowiada nazwy pol i
+                    wartosci &mdash; uzyj klawiszy <kbd>&uarr;</kbd>
+                    <kbd>&darr;</kbd> do wyboru, <kbd>Tab</kbd> aby wstawic.
+                </p>
+                <table class="hover stack unstriped">
+                    <thead>
+                        <tr><th>Operator</th><th>Znaczenie</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td>=, !=</td><td>rowne / rozne</td></tr>
+                        <tr><td>&gt;, &gt;=, &lt;, &lt;=</td><td>porownania liczbowe / dat</td></tr>
+                        <tr><td>~, !~</td><td>zawiera / nie zawiera (tekst)</td></tr>
+                        <tr><td>startswith, endswith</td><td>zaczyna sie / konczy</td></tr>
+                        <tr><td>in, not in</td><td>nalezy do listy: <code>rok in (2023, 2024)</code></td></tr>
+                    </tbody>
+                </table>
+                <p style="margin-top: 0.75rem;"><strong>Przyklady &mdash; Rekord</strong> (od podstaw do mocniejszych):</p>
+                <ul>
+                    <li>
+                        <em>Po slowie w tytule:</em>
+                        <code>tytul_oryginalny ~ "nowotwor"</code>
+                    </li>
+                    <li>
+                        <em>Wysoko punktowane prace ostatnich trzech lat:</em>
+                        <code>rok &gt;= 2022 and punkty_kbn &gt;= 100</code>
+                    </li>
+                    <li>
+                        <em>Wysoki Impact Factor z zakresu lat:</em>
+                        <code>impact_factor &gt; 5 and rok in (2022, 2023, 2024)</code>
+                    </li>
+                    <li>
+                        <em>Brak DOI mimo wysokiej punktacji (do uzupelnienia):</em>
+                        <code>punkty_kbn &gt;= 70 and doi = ""</code>
+                    </li>
+                    <li>
+                        <em>Czesto cytowane, ale nierecenzowane:</em>
+                        <code>liczba_cytowan &gt; 10 and recenzowana = False</code>
+                    </li>
+                    <li>
+                        <em>Konkretny charakter formalny + zakres punktow:</em>
+                        <code>charakter_formalny.skrot = "AC" and punkty_kbn &gt;= 40 and punkty_kbn &lt;= 100</code>
+                    </li>
+                    <li>
+                        <em>Wieloautorskie prace w okresie ewaluacyjnym:</em>
+                        <code>liczba_autorow &gt; 20 and rok &gt;= 2022 and rok &lt;= 2025</code>
+                    </li>
+                    <li>
+                        <em>Konkretne zrodlo + lata:</em>
+                        <code>zrodlo.nazwa ~ "Nature" and rok &gt;= 2020</code>
+                    </li>
+                    <li>
+                        <em>Polskojezyczne artykuly:</em>
+                        <code>jezyk.skrot = "pol" and charakter_formalny.skrot = "AC"</code>
+                    </li>
+                    <li>
+                        <em>Open Access &mdash; rekordy z przypisanym trybem dostepu:</em>
+                        <code>openaccess_tryb_dostepu != None and rok &gt;= 2023</code>
+                    </li>
+                    <li>
+                        <em>Szukanie po slowach kluczowych w tytule (combo OR):</em>
+                        <code>tytul_oryginalny ~ "COVID" or tytul_oryginalny ~ "SARS-CoV"</code>
+                    </li>
+                    <li>
+                        <em>Rekordy bez WWW i bez DOI (do redakcji):</em>
+                        <code>www = "" and doi = "" and rok &gt;= 2023</code>
+                    </li>
+                </ul>
+                <p><strong>Przyklady &mdash; Autor:</strong></p>
+                <ul>
+                    <li>
+                        <em>Po fragmencie nazwiska:</em>
+                        <code>nazwisko ~ "Kowal"</code>
+                    </li>
+                    <li>
+                        <em>Profesorowie z wpisanym ORCID:</em>
+                        <code>tytul.skrot = "prof." and orcid != ""</code>
+                    </li>
+                    <li>
+                        <em>Maja ORCID ale brak go w PBN:</em>
+                        <code>orcid != "" and orcid_w_pbn = False</code>
+                    </li>
+                    <li>
+                        <em>Z konkretnej jednostki (LIKE po nazwie):</em>
+                        <code>aktualna_jednostka.nazwa ~ "Medycyny" and tytul.skrot startswith "dr"</code>
+                    </li>
+                    <li>
+                        <em>Brak emaila, ale jest ORCID (mozna spytac o adres):</em>
+                        <code>email = "" and orcid != ""</code>
+                    </li>
+                    <li>
+                        <em>Konkretna jednostka po skrocie + filtr po nazwisku:</em>
+                        <code>nazwisko startswith "Now" and aktualna_jednostka.skrot = "II WL"</code>
+                    </li>
+                    <li>
+                        <em>Doktoraty + asystenci (zbior tytulow):</em>
+                        <code>tytul.skrot in ("dr", "dr hab.", "mgr")</code>
+                    </li>
+                </ul>
+                <p style="margin-top: 1rem;">
+                    <strong>Skomplikowane zapytania &mdash; Rekord (power-user):</strong>
+                </p>
+                <ol>
+                    <li>
+                        <em>Audyt ewaluacyjny &mdash; tylko recenzowane, z DOI,
+                        w okresie 2022&ndash;2025, z minimum 70 punktow:</em>
+                        <code>recenzowana = True and doi != "" and rok in (2022, 2023, 2024, 2025) and punkty_kbn &gt;= 70</code>
+                    </li>
+                    <li>
+                        <em>Combo z grupowaniem (rok OR + charakter OR) &times;
+                        punktacja:</em>
+                        <code>(rok = 2024 or rok = 2025) and (charakter_formalny.skrot = "AC" or charakter_formalny.skrot = "AOR") and punkty_kbn &gt;= 100</code>
+                    </li>
+                    <li>
+                        <em>Negacja: wszystko poza artykulami z czasopism,
+                        z minimum IF=3, od 2023:</em>
+                        <code>not (charakter_formalny.skrot = "AC") and rok &gt;= 2023 and impact_factor &gt; 3</code>
+                    </li>
+                    <li>
+                        <em>Wieloklauzulowo: tytul (covid/sars) &times; jezyk
+                        (en/pl) &times; min 3 autorow &times; konkretny rok:</em>
+                        <code>(tytul_oryginalny ~ "COVID" or tytul_oryginalny ~ "SARS") and jezyk.skrot in ("ang", "pol") and liczba_autorow &gt;= 3 and rok = 2023</code>
+                    </li>
+                    <li>
+                        <em>Wydawcy Elsevier/Springer/Wiley w okresie ewaluacji
+                        z konkretnym przedzialem punktow:</em>
+                        <code>(wydawca.nazwa ~ "Elsevier" or wydawca.nazwa ~ "Springer" or wydawca.nazwa ~ "Wiley") and rok &gt;= 2022 and punkty_kbn &gt;= 70 and punkty_kbn &lt;= 200</code>
+                    </li>
+                    <li>
+                        <em>Hot &amp; trending: cytowane &gt;50 razy
+                        w&nbsp;publikacjach z&nbsp;ostatnich 5 lat z&nbsp;IF
+                        &gt; 5:</em>
+                        <code>liczba_cytowan &gt; 50 and rok &gt;= 2020 and impact_factor &gt; 5</code>
+                    </li>
+                    <li>
+                        <em>Audyt jakosci danych: artykuly z 2024+ bez DOI,
+                        bez WWW, recenzowane &mdash; wymagaja redakcji:</em>
+                        <code>charakter_formalny.skrot = "AC" and rok &gt;= 2024 and doi = "" and www = "" and recenzowana = True</code>
+                    </li>
+                    <li>
+                        <em>Top-tier prace: Nature/Cell/Science/Lancet po 2020,
+                        wszystkie OA:</em>
+                        <code>zrodlo.nazwa in ("Nature", "Cell", "Science", "The Lancet") and rok &gt; 2020 and openaccess_tryb_dostepu != None</code>
+                    </li>
+                    <li>
+                        <em>Prace z polskim wydawca + jezyk = polski +
+                        konkretny zakres lat:</em>
+                        <code>wydawca.nazwa ~ "PWN" and jezyk.skrot = "pol" and rok in (2022, 2023, 2024)</code>
+                    </li>
+                    <li>
+                        <em>Rekordy zmienione od poczatku biezacego roku
+                        z adnotacjami redaktora:</em>
+                        <code>ostatnio_zmieniony &gt;= "2025-01-01" and adnotacje != ""</code>
+                    </li>
+                    <li>
+                        <em>Granica IF + zakres punktow + minimum
+                        cytowan &mdash; do rankingu jakosciowego:</em>
+                        <code>impact_factor &gt;= 5 and impact_factor &lt;= 10 and punkty_kbn &gt;= 100 and liczba_cytowan &gt;= 5</code>
+                    </li>
+                    <li>
+                        <em>Konkretny typ KBN + waski przedzial punktow +
+                        slowo w tytule:</em>
+                        <code>typ_kbn.skrot = "PO" and punkty_kbn &gt;= 40 and punkty_kbn &lt;= 70 and (tytul_oryginalny ~ "neuro" or tytul_oryginalny ~ "kardio")</code>
+                    </li>
+                    <li>
+                        <em>Powtorzenia DOI (zapytanie do weryfikacji
+                        manualnej, lista DOI):</em>
+                        <code>doi in ("10.1038/s41586-024-XXXXX", "10.1126/science.YYYYY")</code>
+                    </li>
+                </ol>
+
+                <p style="margin-top: 1rem;">
+                    <strong>Skomplikowane zapytania &mdash; Autor (power-user):</strong>
+                </p>
+                <ol>
+                    <li>
+                        <em>Profesorowie z konkretnej jednostki, z wpisanym
+                        ORCID-em, ale nie potwierdzonym w PBN:</em>
+                        <code>tytul.skrot in ("prof.", "prof. dr hab.") and aktualna_jednostka.skrot startswith "I WL" and orcid != "" and orcid_w_pbn = False</code>
+                    </li>
+                    <li>
+                        <em>Dwie jednostki + tytul dr/dr hab. + jest orcid:</em>
+                        <code>(aktualna_jednostka.skrot = "II WL" or aktualna_jednostka.skrot = "WLS") and tytul.skrot startswith "dr" and orcid != ""</code>
+                    </li>
+                    <li>
+                        <em>Brak emaila ale jest ORCID &mdash; do uzupelnienia
+                        kontaktu z poziomu administracji:</em>
+                        <code>email = "" and orcid != "" and tytul.skrot in ("dr", "dr hab.", "prof.")</code>
+                    </li>
+                    <li>
+                        <em>Format ORCID nieprawidlowy (nie zaczyna sie od
+                        '0000-'):</em>
+                        <code>orcid != "" and not (orcid startswith "0000-")</code>
+                    </li>
+                    <li>
+                        <em>Wszystkie z aktualna jednostka, oprocz mgr/mgr inz:</em>
+                        <code>aktualna_jednostka != None and not (tytul.skrot in ("mgr", "mgr inz."))</code>
+                    </li>
+                    <li>
+                        <em>Wyszukiwanie po fragmentach imienia i nazwiska
+                        (Jan Kowalski / Janusz Kowalik / ...):</em>
+                        <code>(imiona ~ "Jan" or imiona startswith "Janusz") and nazwisko startswith "Kowal"</code>
+                    </li>
+                </ol>
+
+                <p style="margin-top: 0.75rem;">
+                    <em>Wskazowki dla power-userow:</em>
+                </p>
+                <ul>
+                    <li>
+                        <strong>Grupowanie</strong> &mdash; uzywaj nawiasow
+                        do logicznych grup: <code>(A or B) and C</code>.
+                    </li>
+                    <li>
+                        <strong>Negacja</strong> &mdash; <code>not</code> przed
+                        wyrazeniem: <code>not (charakter_formalny.skrot = "AC")</code>.
+                    </li>
+                    <li>
+                        <strong>Pola relacji</strong> &mdash; po kropce:
+                        <code>charakter_formalny.skrot</code>,
+                        <code>zrodlo.wydawca.nazwa</code> (zagniezdzanie OK).
+                    </li>
+                    <li>
+                        <strong>Listy wartosci</strong> &mdash;
+                        <code>in (...)</code> dzieli sie przecinkami,
+                        oszczedza wielu <code>or</code>.
+                    </li>
+                    <li>
+                        <strong>Daty/datetime</strong> &mdash;
+                        ISO-string w cudzyslowie: <code>"2025-01-01"</code>.
+                    </li>
+                    <li>
+                        <strong>Pusty FK</strong> &mdash;
+                        <code>pole != None</code> / <code>pole = None</code>;
+                        dla stringa <code>pole = ""</code>.
+                    </li>
+                    <li>
+                        <strong>Granice zakresow</strong> &mdash; brak operatora
+                        <code>between</code>, zlozyć z
+                        <code>&gt;= X and &lt;= Y</code>.
+                    </li>
+                </ul>
+            </details>
+
+            <p style="margin-top: 1rem;">
+                <button type="submit" class="button primary">
+                    <span class="fi-magnifying-glass" aria-hidden="true"></span> Szukaj
+                </button>
+                <a href="{% url 'bpp:zapytanie' %}" class="button secondary">
+                    Wyczysc
+                </a>
+            </p>
+        </form>
+
+        <details class="zapytanie-help-card zapytanie-history-card"
+                 id="zapytanie-history" style="display: none; margin-top: 1rem;">
+            <summary>
+                <span class="fi-clock" aria-hidden="true"></span>
+                Historia zapytan
+                (<span id="zapytanie-history-count">0</span>)
+            </summary>
+            <p style="margin-top: 0.5rem; color: #64748b; font-size: 0.85rem;">
+                <em>Historia ostatnich 20 roznych zapytan z tej przegladarki.
+                Kliknij wpis, zeby je przywrocic.</em>
+            </p>
+            <table class="hover stack unstriped" style="margin-top: 0.5rem;">
+                <thead>
+                    <tr>
+                        <th style="width: 5rem;">Model</th>
+                        <th>Zapytanie</th>
+                        <th style="text-align: right; width: 5rem;">Wynikow</th>
+                        <th style="width: 9rem;">Kiedy</th>
+                        <th style="width: 2rem;"></th>
+                    </tr>
+                </thead>
+                <tbody id="zapytanie-history-tbody"></tbody>
+            </table>
+            <p style="margin-top: 0.5rem;">
+                <button type="button"
+                        class="button tiny alert hollow"
+                        id="zapytanie-history-clear">
+                    Wyczysc cala historie
+                </button>
+            </p>
+        </details>
+
+        {% if error %}
+            <div class="callout alert" role="alert">
+                <strong>Blad zapytania:</strong>
+                <pre style="white-space: pre-wrap; word-break: break-word; margin: 0;">{{ error }}</pre>
+            </div>
+        {% endif %}
+
+        {% if results is not None %}
+            <h2>Wyniki ({{ count }} rekord{{ count|pluralize:"y,ow" }})</h2>
+            {% if query %}
+                <p><em>Zapytanie:</em> <code>{{ query }}</code> na modelu <strong>{{ model_key }}</strong></p>
+            {% endif %}
+            {% if results %}
+                {% include "bpp/_zapytanie_pager.html" %}
+                <table class="hover stack">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Reprezentacja</th>
+                            <th>Akcje</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for obj in results %}
+                            <tr>
+                                <td>{{ obj.pk }}</td>
+                                <td>
+                                    {% if model_key == "rekord" %}
+                                        {{ obj.opis_bibliograficzny_cache|safe }}
+                                    {% else %}
+                                        {{ obj }}
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if model_key == "autor" %}
+                                        <a href="{% url 'bpp:browse_autor' obj.slug %}" target="_blank">Zobacz</a>
+                                        {% if request.user.is_staff %}
+                                            <a href="{% url 'admin:bpp_autor_change' obj.pk %}" target="_blank">Edytuj</a>
+                                        {% endif %}
+                                    {% else %}
+                                        <a href="{{ obj.get_absolute_url }}" target="_blank">Zobacz</a>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {% include "bpp/_zapytanie_pager.html" %}
+            {% else %}
+                <p><em>Brak rekordow pasujacych do zapytania.</em></p>
+            {% endif %}
+        {% endif %}
+    </div>
+</div>
+
+{% if results is not None and query %}
+<script>
+    window.bppZapytanieLast = {
+        model: "{{ model_key|escapejs }}",
+        query: "{{ query|escapejs }}",
+        count: {{ count|default:0 }}
+    };
+</script>
+{% endif %}
+<script>
+(function() {
+    var KEY = "bpp:zapytanie:history";
+    var MAX = 20;
+
+    function load() {
+        try {
+            var raw = localStorage.getItem(KEY);
+            return raw ? JSON.parse(raw) : [];
+        } catch (e) {
+            return [];
+        }
+    }
+    function save(arr) {
+        try {
+            localStorage.setItem(KEY, JSON.stringify(arr));
+        } catch (e) {
+            // quota / disabled — ignore
+        }
+    }
+
+    function fmtRelative(ts) {
+        var diff = (Date.now() - ts) / 1000;
+        if (diff < 60) return "przed chwila";
+        if (diff < 3600) return Math.floor(diff / 60) + " min temu";
+        if (diff < 86400) return Math.floor(diff / 3600) + " godz. temu";
+        if (diff < 7 * 86400) return Math.floor(diff / 86400) + " dni temu";
+        var d = new Date(ts);
+        return d.toLocaleDateString("pl-PL");
+    }
+
+    function fmtCount(n) {
+        if (typeof n !== "number") return "—";
+        return n.toLocaleString("pl-PL");
+    }
+
+    function recordCurrent() {
+        if (!window.bppZapytanieLast) return;
+        var L = window.bppZapytanieLast;
+        if (!L.query) return;
+        var arr = load();
+        arr = arr.filter(function(x) {
+            return !(x.model === L.model && x.query === L.query);
+        });
+        arr.unshift({
+            model: L.model,
+            query: L.query,
+            count: L.count,
+            ts: Date.now()
+        });
+        if (arr.length > MAX) arr.length = MAX;
+        save(arr);
+    }
+
+    function buildRow(item) {
+        var tr = document.createElement("tr");
+
+        var modelTd = document.createElement("td");
+        modelTd.textContent = item.model;
+
+        var queryTd = document.createElement("td");
+        var link = document.createElement("a");
+        link.href = "?model=" + encodeURIComponent(item.model) +
+            "&query=" + encodeURIComponent(item.query);
+        link.className = "history-query";
+        link.title = "Kliknij, aby przywrocic to zapytanie";
+        link.textContent = item.query;
+        queryTd.appendChild(link);
+
+        var countTd = document.createElement("td");
+        countTd.className = "history-count-cell";
+        countTd.textContent = fmtCount(item.count);
+
+        var timeTd = document.createElement("td");
+        timeTd.title = new Date(item.ts).toLocaleString("pl-PL");
+        timeTd.textContent = fmtRelative(item.ts);
+
+        var actionsTd = document.createElement("td");
+        var rm = document.createElement("button");
+        rm.type = "button";
+        rm.className = "history-remove";
+        rm.title = "Usun ten wpis z historii";
+        rm.setAttribute("aria-label", "Usun wpis");
+        rm.textContent = "✕"; // ✕
+        rm.dataset.ts = String(item.ts);
+        rm.addEventListener("click", function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            var ts = Number(this.dataset.ts);
+            save(load().filter(function(x) { return x.ts !== ts; }));
+            render();
+        });
+        actionsTd.appendChild(rm);
+
+        tr.appendChild(modelTd);
+        tr.appendChild(queryTd);
+        tr.appendChild(countTd);
+        tr.appendChild(timeTd);
+        tr.appendChild(actionsTd);
+        return tr;
+    }
+
+    function render() {
+        var arr = load();
+        var container = document.getElementById("zapytanie-history");
+        var tbody = document.getElementById("zapytanie-history-tbody");
+        var counter = document.getElementById("zapytanie-history-count");
+        if (!container || !tbody || !counter) return;
+
+        counter.textContent = arr.length;
+        tbody.replaceChildren();
+        if (arr.length === 0) {
+            container.style.display = "none";
+            return;
+        }
+        container.style.display = "";
+        arr.forEach(function(item) {
+            tbody.appendChild(buildRow(item));
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function() {
+        recordCurrent();
+        render();
+
+        var clearBtn = document.getElementById("zapytanie-history-clear");
+        if (clearBtn) {
+            clearBtn.addEventListener("click", function() {
+                if (window.confirm("Wyczyscic cala historie zapytan?")) {
+                    save([]);
+                    render();
+                }
+            });
+        }
+    });
+})();
+</script>
+<script src="{% static 'djangoql/js/completion.js' %}"></script>
+<script>
+(function() {
+    var INTROSPECT_URLS = {
+        "rekord": "{% url 'bpp:zapytanie_introspect' 'rekord' %}",
+        "autor": "{% url 'bpp:zapytanie_introspect' 'autor' %}"
+    };
+
+    function currentModelKey() {
+        var checked = document.querySelector(
+            'input[name="model"]:checked'
+        );
+        return checked ? checked.value : "rekord";
+    }
+
+    DjangoQL.DOMReady(function() {
+        var textarea = document.getElementById("id_query");
+        var dql = null;
+
+        // Tab-completion shim. DOM Level 3: listenery w fazie AT_TARGET sa
+        // wywolywane w kolejnosci REJESTRACJI (nie w kolejnosci faz). djangoql
+        // rejestruje swoj keydown w konstruktorze (DjangoQL.init), wiec
+        // rejestrujemy NASZ listener PIERWSZY — ustawia selected=0 zanim
+        // handler djangoql go sprawdzi i wykona selectCompletion+preventDefault.
+        textarea.addEventListener("keydown", function(e) {
+            if (!dql) return;
+            if (e.keyCode !== 9 || e.shiftKey) return;
+            if (!dql.completionEnabled) return;
+            if (!dql.suggestions || dql.suggestions.length === 0) return;
+            if (dql.selected === null) {
+                dql.selected = 0;
+            }
+        });
+
+        dql = DjangoQL.init({
+            introspections: INTROSPECT_URLS[currentModelKey()],
+            selector: textarea,
+            autoResize: false
+        });
+
+        // BPP-owe body ma position:relative + min-height:100vh
+        // (gradient-background). djangoql doczepia popup do <body> z
+        // position:absolute i wpisuje top w document-coords — wskutek czego
+        // popup laduje POZA viewportem (rozciaga body i daje scrollbar po
+        // prawej). Repozycjonujemy popup na position:fixed (viewport coords).
+        // "Mirror div" technika: zeby policzyc pixel-position kursora w
+        // textarea, kopiujemy styl tekstu do niewidocznego diva z
+        // white-space:pre-wrap, wkladamy tam pierwsze N znakow + <span>
+        // markerze, czytamy offset spana. Standardowy trick.
+        var CARET_MIRROR_PROPS = [
+            "boxSizing", "width", "height",
+            "overflowX", "overflowY",
+            "borderTopWidth", "borderRightWidth",
+            "borderBottomWidth", "borderLeftWidth",
+            "borderTopStyle", "borderRightStyle",
+            "borderBottomStyle", "borderLeftStyle",
+            "paddingTop", "paddingRight", "paddingBottom", "paddingLeft",
+            "fontStyle", "fontVariant", "fontWeight", "fontStretch",
+            "fontSize", "fontSizeAdjust", "lineHeight", "fontFamily",
+            "textAlign", "textTransform", "textIndent", "textDecoration",
+            "letterSpacing", "wordSpacing", "tabSize"
+        ];
+
+        function getCaretViewportCoords(ta) {
+            var style = window.getComputedStyle(ta);
+            var mirror = document.createElement("div");
+            CARET_MIRROR_PROPS.forEach(function(p) {
+                mirror.style[p] = style[p];
+            });
+            mirror.style.position = "absolute";
+            mirror.style.visibility = "hidden";
+            mirror.style.whiteSpace = "pre-wrap";
+            mirror.style.wordWrap = "break-word";
+            mirror.style.overflow = "hidden";
+            mirror.style.top = "0";
+            mirror.style.left = "-9999px";
+            document.body.appendChild(mirror);
+
+            // Clamp na wszelki wypadek (po clear textarea Safari/Firefox
+            // bywaja niespojne ze selectionStart).
+            var pos = Math.min(ta.selectionStart || 0, ta.value.length);
+            mirror.textContent = ta.value.substring(0, pos);
+            var marker = document.createElement("span");
+            marker.textContent = ta.value.substring(pos) || ".";
+            mirror.appendChild(marker);
+
+            var borderTop = parseFloat(style.borderTopWidth) || 0;
+            var borderLeft = parseFloat(style.borderLeftWidth) || 0;
+            // standard textarea-caret-position: offsetTop liczone od padding
+            // edge offsetParenta, wiec trzeba dodac borderTopWidth zeby
+            // zsynchronizowac z getBoundingClientRect() (border-outer-edge).
+            var caretLeft = marker.offsetLeft + borderLeft;
+            var caretTop = marker.offsetTop + borderTop;
+            var lineHeight = parseFloat(style.lineHeight);
+            if (isNaN(lineHeight)) {
+                lineHeight = parseFloat(style.fontSize) * 1.2;
+            }
+
+            document.body.removeChild(mirror);
+
+            var rect = ta.getBoundingClientRect();
+            return {
+                x: rect.left + caretLeft - ta.scrollLeft,
+                y: rect.top + caretTop - ta.scrollTop,
+                lineHeight: lineHeight,
+                taRect: rect
+            };
+        }
+
+        function computeTargetPosition() {
+            var caret = getCaretViewportCoords(dql.textarea);
+            var popupHeight = dql.completion.offsetHeight || 240;
+            var popupWidth = dql.completion.offsetWidth || 320;
+            var caretBottom = caret.y + caret.lineHeight;
+            var roomBelow = window.innerHeight - caretBottom;
+            var roomAbove = caret.y;
+
+            var top;
+            if (roomBelow < popupHeight && roomAbove > roomBelow) {
+                top = Math.max(4, caret.y - popupHeight);
+            } else {
+                top = caretBottom + 2;
+            }
+            var left = Math.max(
+                4,
+                Math.min(caret.x, window.innerWidth - popupWidth - 4)
+            );
+            return {
+                top: top + "px",
+                left: left + "px",
+                maxWidth:
+                    "min(90vw, " + Math.max(320, caret.taRect.width) + "px)"
+            };
+        }
+
+        var repositionPending = false;
+        function repositionCompletion() {
+            if (!dql.completion) return;
+            if (dql.completion.style.display === "none") return;
+            var s = dql.completion.style;
+            var target = computeTargetPosition();
+            // Guard: jezeli style sie pokrywa, nie pisz — w przeciwnym razie
+            // MutationObserver zapetli sie z naszym zapisem.
+            if (
+                s.position === "fixed" &&
+                s.top === target.top &&
+                s.left === target.left &&
+                s.maxWidth === target.maxWidth
+            ) {
+                return;
+            }
+            s.position = "fixed";
+            s.top = target.top;
+            s.left = target.left;
+            s.maxWidth = target.maxWidth;
+        }
+
+        function scheduleReposition() {
+            if (repositionPending) return;
+            repositionPending = true;
+            requestAnimationFrame(function() {
+                repositionPending = false;
+                repositionCompletion();
+            });
+        }
+
+        var origRender = dql.renderCompletion.bind(dql);
+        dql.renderCompletion = function(t) {
+            origRender(t);
+            repositionCompletion();
+        };
+
+        // Pas bezpieczenstwa: niektore listenery djangoql (np. click,
+        // zarejestrowany w konstruktorze) trzymaja bound-original reference
+        // do popupCompletion, ktora moze ominac nasz wrapper renderCompletion.
+        // MutationObserver łapie KAZDA zmiane style popupu — dopinamy pozycje
+        // bez wzgledu na sciezke wywolania.
+        new MutationObserver(scheduleReposition).observe(dql.completion, {
+            attributes: true,
+            attributeFilter: ["style"]
+        });
+
+        window.addEventListener("scroll", scheduleReposition, {passive: true});
+        window.addEventListener("resize", scheduleReposition);
+
+        document.querySelectorAll('input[name="model"]').forEach(
+            function(radio) {
+                radio.addEventListener("change", function() {
+                    if (!this.checked) return;
+                    dql.loadIntrospections(INTROSPECT_URLS[this.value]);
+                });
+            }
+        );
+    });
+})();
+</script>
+{% endblock %}

--- a/src/bpp/tests/test_zapytanie.py
+++ b/src/bpp/tests/test_zapytanie.py
@@ -1,0 +1,156 @@
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+
+URL = "bpp:zapytanie"
+
+
+@pytest.fixture
+def wprowadzanie_user(test_user):
+    group, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    test_user.groups.add(group)
+    test_user.is_staff = True
+    test_user.save()
+    return test_user
+
+
+@pytest.fixture
+def wprowadzanie_client(client, wprowadzanie_user):
+    client.force_login(wprowadzanie_user)
+    return client
+
+
+@pytest.mark.django_db
+def test_zapytanie_view_anonymous_redirected(client):
+    response = client.get(reverse(URL))
+    assert response.status_code in (302, 403)
+
+
+@pytest.mark.django_db
+def test_zapytanie_view_logged_in_non_staff_forbidden(client, test_user):
+    client.force_login(test_user)
+    response = client.get(reverse(URL))
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_zapytanie_view_staff_without_group_forbidden(client, test_user):
+    test_user.is_staff = True
+    test_user.save()
+    client.force_login(test_user)
+    response = client.get(reverse(URL))
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_zapytanie_view_group_without_staff_forbidden(client, test_user):
+    """Staff jest wymagany oprocz przynaleznosci do grupy."""
+    group, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    test_user.groups.add(group)
+    client.force_login(test_user)
+    response = client.get(reverse(URL))
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_zapytanie_view_wprowadzanie_user_allowed(wprowadzanie_client):
+    response = wprowadzanie_client.get(reverse(URL))
+    assert response.status_code == 200
+    assert "form" in response.context
+
+
+@pytest.mark.django_db
+def test_zapytanie_view_superuser_allowed(superuser_client):
+    response = superuser_client.get(reverse(URL))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_zapytanie_view_renders_radio_buttons(superuser_client):
+    response = superuser_client.get(reverse(URL))
+    html = response.content.decode("utf-8")
+    assert 'type="radio"' in html
+    assert 'value="rekord"' in html
+    assert 'value="autor"' in html
+
+
+@pytest.mark.django_db
+def test_zapytanie_query_autor_matches(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    baker.make("bpp.Autor", nazwisko="Nowak", imiona="Anna")
+
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "autor", "query": 'nazwisko = "Kowalski"'},
+    )
+    assert response.status_code == 200
+    assert response.context["count"] == 1
+    assert response.context["error"] is None
+    results = list(response.context["results"])
+    assert len(results) == 1
+    assert results[0].nazwisko == "Kowalski"
+
+
+@pytest.mark.django_db
+def test_zapytanie_query_autor_no_matches(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski")
+
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "autor", "query": 'nazwisko = "Nieistnieje"'},
+    )
+    assert response.status_code == 200
+    assert response.context["count"] == 0
+    assert response.context["error"] is None
+
+
+@pytest.mark.django_db
+def test_zapytanie_query_invalid_syntax_shows_error(superuser_client):
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "autor", "query": "this is not valid djangoql !!!"},
+    )
+    assert response.status_code == 200
+    assert response.context["error"]
+    assert response.context["count"] is None
+
+
+@pytest.mark.django_db
+def test_zapytanie_query_unknown_field_shows_error(superuser_client):
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "autor", "query": 'nieistniejace_pole = "x"'},
+    )
+    assert response.status_code == 200
+    assert response.context["error"]
+
+
+@pytest.mark.django_db
+def test_zapytanie_empty_query_renders_form_without_results(superuser_client):
+    response = superuser_client.get(reverse(URL), {"model": "autor", "query": ""})
+    assert response.status_code == 200
+    assert response.context.get("results") is None
+
+
+@pytest.mark.django_db
+def test_zapytanie_query_rekord_uses_correct_model(superuser_client):
+    """Radio 'rekord' przelacza queryset na model Rekord, nie Autor."""
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "rekord", "query": "rok = 1900"},
+    )
+    assert response.status_code == 200
+    assert response.context["error"] is None
+    assert response.context["model_key"] == "rekord"
+    assert response.context["count"] == 0
+
+
+@pytest.mark.django_db
+def test_zapytanie_default_model_is_rekord(superuser_client):
+    response = superuser_client.get(reverse(URL))
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert form.fields["model"].initial == "rekord"

--- a/src/bpp/tests/test_zapytanie.py
+++ b/src/bpp/tests/test_zapytanie.py
@@ -1,11 +1,22 @@
 import pytest
 from django.contrib.auth.models import Group
 from django.urls import reverse
+from djangoql.exceptions import DjangoQLParserError
+from djangoql.parser import DjangoQLParser
 from model_bakery import baker
 
 from bpp.const import GR_WPROWADZANIE_DANYCH
+from bpp.views.zapytanie import EXAMPLES
 
 URL = "bpp:zapytanie"
+
+
+def _all_examples():
+    """Splaszcza EXAMPLES do listy (level, model, desc, query)."""
+    for level in EXAMPLES:
+        for group in level["groups"]:
+            for desc, query in group["items"]:
+                yield (level["level"], group["model"], desc, query)
 
 
 @pytest.fixture
@@ -154,3 +165,51 @@ def test_zapytanie_default_model_is_rekord(superuser_client):
     assert response.status_code == 200
     form = response.context["form"]
     assert form.fields["model"].initial == "rekord"
+
+
+@pytest.mark.parametrize(
+    "level,model,desc,query",
+    list(_all_examples()),
+    ids=lambda v: str(v)[:50] if isinstance(v, str) else str(v),
+)
+def test_zapytanie_examples_are_valid_djangoql(level, model, desc, query):
+    """Kazdy przyklad w EXAMPLES MUSI byc poprawnym DjangoQL.
+
+    DjangoQL grammar (parser.py) nie wspiera unary `not (expr)`; do negacji
+    uzywaj `!=`, `!~`, `not in`, `not startswith`, `not endswith`.
+    Ten test parsuje skladniowo (bez resolvowania pol — to dziedzina schemy).
+    """
+    parser = DjangoQLParser()
+    try:
+        parser.parse(query)
+    except DjangoQLParserError as exc:
+        pytest.fail(
+            f"Bledna skladnia DjangoQL w przykladzie "
+            f"(level={level}, model={model}, desc={desc!r}): "
+            f"{query!r}\n -> {exc}"
+        )
+
+
+def test_zapytanie_examples_cover_both_models():
+    """Sanity check: kazdy poziom ma przyklady dla obu modeli."""
+    for level in EXAMPLES:
+        models = {g["model"] for g in level["groups"]}
+        assert models == {"rekord", "autor"}, (
+            f"Level {level['level']} ma niekompletne pokrycie: {models}"
+        )
+        for group in level["groups"]:
+            assert group["items"], (
+                f"Level {level['level']} {group['model']}: brak przykladow"
+            )
+
+
+def test_zapytanie_examples_no_unary_not():
+    """DjangoQL NIE WSPIERA unary `not (expr)` — wykryjmy regresje."""
+    import re
+
+    pattern = re.compile(r"\bnot\s*\(")
+    for level, model, desc, query in _all_examples():
+        assert not pattern.search(query), (
+            f"Unary 'not (...)' znaleziono w przykladzie "
+            f"(level={level}, model={model}, desc={desc!r}): {query!r}"
+        )

--- a/src/bpp/urls.py
+++ b/src/bpp/urls.py
@@ -90,9 +90,29 @@ from bpp.views.microsoft_auth_redirect import MicrosoftAuthRedirectView
 from bpp.views.oai import OAIView
 from bpp.views.profile import ProfilUzytkownikaView
 from bpp.views.xlsx_issn_chunks import xlsx_issn_chunks
+from bpp.views.zapytanie import (
+    ZapytanieIntrospectView,
+    ZapytanieSuggestionsView,
+    ZapytanieView,
+)
 from ranking_autorow.views import RankingAutorow, RankingAutorowFormularz
 
 urlpatterns = [
+    path(
+        "zapytanie/",
+        ZapytanieView.as_view(),
+        name="zapytanie",
+    ),
+    path(
+        "zapytanie/introspect/<str:model_key>/",
+        ZapytanieIntrospectView.as_view(),
+        name="zapytanie_introspect",
+    ),
+    path(
+        "zapytanie/suggestions/<str:model_key>/",
+        ZapytanieSuggestionsView.as_view(),
+        name="zapytanie_suggestions",
+    ),
     path(
         "profil/",
         ProfilUzytkownikaView.as_view(),

--- a/src/bpp/views/zapytanie.py
+++ b/src/bpp/views/zapytanie.py
@@ -1,0 +1,159 @@
+import json
+
+from django import forms
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.core.exceptions import FieldError, ValidationError
+from django.core.paginator import Paginator
+from django.http import Http404, HttpResponse
+from django.urls import reverse
+from django.views.generic import FormView, View
+from djangoql.exceptions import DjangoQLError
+from djangoql.queryset import apply_search
+from djangoql.schema import DjangoQLSchema
+from djangoql.serializers import SuggestionsAPISerializer
+from djangoql.views import SuggestionsAPIView
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+from bpp.models import Autor
+from bpp.models.cache import Rekord
+
+MODEL_REKORD = "rekord"
+MODEL_AUTOR = "autor"
+
+MODEL_CHOICES = (
+    (MODEL_REKORD, "Rekord"),
+    (MODEL_AUTOR, "Autor"),
+)
+
+MODELS = {
+    MODEL_REKORD: Rekord,
+    MODEL_AUTOR: Autor,
+}
+
+
+class WprowadzanieDanychOrSuperuserMixin(LoginRequiredMixin, UserPassesTestMixin):
+    """Dostep dla superuserow lub uzytkownikow w grupie 'wprowadzanie danych'
+    bedacych jednoczesnie w staffie."""
+
+    raise_exception = True
+
+    def test_func(self):
+        user = self.request.user
+        if user.is_superuser:
+            return True
+        return (
+            user.is_staff and user.groups.filter(name=GR_WPROWADZANIE_DANYCH).exists()
+        )
+
+
+class ZapytanieForm(forms.Form):
+    model = forms.ChoiceField(
+        choices=MODEL_CHOICES,
+        widget=forms.RadioSelect,
+        initial=MODEL_REKORD,
+        label="Model do przeszukania",
+    )
+    query = forms.CharField(
+        label="Zapytanie DjangoQL",
+        widget=forms.Textarea(
+            attrs={
+                "rows": 4,
+                "placeholder": ('tytul_oryginalny ~ "nowotwor" and rok >= 2020'),
+                "spellcheck": "false",
+                "autocomplete": "off",
+            }
+        ),
+        required=False,
+        help_text=(
+            "Skladnia DjangoQL: pole operator wartosc, laczone przez "
+            "<code>and</code> / <code>or</code>. "
+            "Operatory: <code>=</code>, <code>!=</code>, <code>&gt;</code>, "
+            "<code>&gt;=</code>, <code>&lt;</code>, <code>&lt;=</code>, "
+            "<code>~</code> (zawiera), <code>!~</code> (nie zawiera), "
+            "<code>in</code>, <code>not in</code>. "
+            "Stringi w cudzyslowach. "
+            'Przyklady: <code>tytul_oryginalny ~ "rak"</code>, '
+            '<code>rok = 2024 and charakter_formalny.skrot = "AC"</code>, '
+            '<code>nazwisko ~ "Kowal" or imiona ~ "Jan"</code>.'
+        ),
+    )
+
+
+class ZapytanieView(WprowadzanieDanychOrSuperuserMixin, FormView):
+    template_name = "bpp/zapytanie.html"
+    form_class = ZapytanieForm
+    paginate_by = 25
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        if self.request.method == "GET" and "model" in self.request.GET:
+            kwargs["data"] = self.request.GET
+        return kwargs
+
+    def get(self, request, *args, **kwargs):
+        form = self.get_form()
+        if "query" in request.GET and form.is_valid() and form.cleaned_data["query"]:
+            return self.render_results(form)
+        return self.render_to_response(self.get_context_data(form=form))
+
+    def render_results(self, form):
+        model_key = form.cleaned_data["model"]
+        query = form.cleaned_data["query"].strip()
+        model = MODELS[model_key]
+        queryset = model.objects.all()
+        error = None
+        results_page = None
+        count = None
+
+        try:
+            queryset = apply_search(queryset, query)
+            count = queryset.count()
+            paginator = Paginator(queryset, self.paginate_by)
+            page_number = self.request.GET.get("page") or 1
+            results_page = paginator.get_page(page_number)
+        except (DjangoQLError, FieldError, ValidationError, ValueError) as exc:
+            error = self._format_error(exc)
+
+        context = self.get_context_data(
+            form=form,
+            results=results_page,
+            count=count,
+            error=error,
+            model_key=model_key,
+            query=query,
+        )
+        return self.render_to_response(context)
+
+    @staticmethod
+    def _format_error(exc):
+        if isinstance(exc, ValidationError):
+            return "; ".join(exc.messages)
+        return str(exc)
+
+
+def _resolve_model_or_404(model_key):
+    try:
+        return MODELS[model_key]
+    except KeyError:
+        raise Http404(f"Nieznany model: {model_key}")
+
+
+class ZapytanieIntrospectView(WprowadzanieDanychOrSuperuserMixin, View):
+    def get(self, request, model_key):
+        model = _resolve_model_or_404(model_key)
+        suggestions_url = reverse(
+            "bpp:zapytanie_suggestions", kwargs={"model_key": model_key}
+        )
+        schema = DjangoQLSchema(model)
+        payload = SuggestionsAPISerializer(suggestions_url).serialize(schema)
+        return HttpResponse(
+            content=json.dumps(payload),
+            content_type="application/json; charset=utf-8",
+        )
+
+
+class ZapytanieSuggestionsView(WprowadzanieDanychOrSuperuserMixin, View):
+    def get(self, request, model_key):
+        model = _resolve_model_or_404(model_key)
+        view = SuggestionsAPIView.as_view(schema=DjangoQLSchema(model))
+        return view(request)

--- a/src/bpp/views/zapytanie.py
+++ b/src/bpp/views/zapytanie.py
@@ -135,7 +135,7 @@ def _resolve_model_or_404(model_key):
     try:
         return MODELS[model_key]
     except KeyError:
-        raise Http404(f"Nieznany model: {model_key}")
+        raise Http404(f"Nieznany model: {model_key}") from None
 
 
 class ZapytanieIntrospectView(WprowadzanieDanychOrSuperuserMixin, View):

--- a/src/bpp/views/zapytanie.py
+++ b/src/bpp/views/zapytanie.py
@@ -2,10 +2,11 @@ import json
 
 from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldError, ValidationError
 from django.core.paginator import Paginator
 from django.http import Http404, HttpResponse
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.views.generic import FormView, View
 from djangoql.exceptions import DjangoQLError
 from djangoql.queryset import apply_search
@@ -29,6 +30,231 @@ MODELS = {
     MODEL_REKORD: Rekord,
     MODEL_AUTOR: Autor,
 }
+
+# Przyklady zapytan renderowane w sekcji pomocy. Wszystkie SA testowane na
+# poprawnosc skladniowa przez DjangoQLParser (test_zapytanie_examples_parseable).
+# UWAGA: DjangoQL grammar NIE WSPIERA unary `not (expression)` — `NOT` jest
+# tylko modyfikatorem dla `NOT STARTSWITH`, `NOT ENDSWITH`, `NOT IN`. Do negacji
+# uzywaj `!=`, `!~`, `not startswith`, `not endswith`, `not in`.
+EXAMPLES = [
+    {
+        "level": 1,
+        "title": "Podstawowe",
+        "subtitle": "jeden, dwa warunki",
+        "groups": [
+            {
+                "model": MODEL_REKORD,
+                "label": "Rekord",
+                "items": [
+                    ("", 'tytul_oryginalny ~ "nowotwor"'),
+                    ("", "rok = 2024"),
+                    ("", "rok >= 2022 and rok <= 2024"),
+                    ("", 'charakter_formalny.skrot = "AC"'),
+                    ("", 'tytul_oryginalny ~ "covid" and rok = 2023'),
+                    ("", 'doi != ""'),
+                ],
+            },
+            {
+                "model": MODEL_AUTOR,
+                "label": "Autor",
+                "items": [
+                    ("", 'nazwisko ~ "Kowal"'),
+                    ("", 'tytul.skrot = "prof."'),
+                    ("", 'nazwisko = "Kowalski" and imiona = "Jan"'),
+                    ("", 'orcid != ""'),
+                    ("", 'aktualna_jednostka.nazwa ~ "Medycyny"'),
+                ],
+            },
+        ],
+    },
+    {
+        "level": 2,
+        "title": "Srednie",
+        "subtitle": "wiele warunkow, relacje, listy in (...)",
+        "groups": [
+            {
+                "model": MODEL_REKORD,
+                "label": "Rekord",
+                "items": [
+                    (
+                        "Wysoko punktowane prace ostatnich trzech lat",
+                        "rok >= 2022 and punkty_kbn >= 100",
+                    ),
+                    (
+                        "Wysoki Impact Factor z zakresu lat",
+                        "impact_factor > 5 and rok in (2022, 2023, 2024)",
+                    ),
+                    (
+                        "Brak DOI mimo wysokiej punktacji (do uzupelnienia)",
+                        'punkty_kbn >= 70 and doi = ""',
+                    ),
+                    (
+                        "Czesto cytowane, ale nierecenzowane",
+                        "liczba_cytowan > 10 and recenzowana = False",
+                    ),
+                    (
+                        "Konkretny charakter + zakres punktow",
+                        'charakter_formalny.skrot = "AC" and punkty_kbn >= 40 '
+                        "and punkty_kbn <= 100",
+                    ),
+                    (
+                        "Konkretne zrodlo + lata",
+                        'zrodlo.nazwa ~ "Nature" and rok >= 2020',
+                    ),
+                    (
+                        "Polskojezyczne artykuly",
+                        'jezyk.skrot = "pol" and charakter_formalny.skrot = "AC"',
+                    ),
+                    (
+                        "Open Access z ostatnich lat",
+                        "openaccess_tryb_dostepu != None and rok >= 2023",
+                    ),
+                    (
+                        "Slowa kluczowe w tytule (combo OR)",
+                        'tytul_oryginalny ~ "COVID" or tytul_oryginalny ~ "SARS-CoV"',
+                    ),
+                    (
+                        "Rekordy bez WWW i bez DOI (do redakcji)",
+                        'www = "" and doi = "" and rok >= 2023',
+                    ),
+                ],
+            },
+            {
+                "model": MODEL_AUTOR,
+                "label": "Autor",
+                "items": [
+                    (
+                        "Profesorowie z wpisanym ORCID",
+                        'tytul.skrot = "prof." and orcid != ""',
+                    ),
+                    (
+                        "Maja ORCID ale brak go w PBN",
+                        'orcid != "" and orcid_w_pbn = False',
+                    ),
+                    (
+                        "Z konkretnej jednostki (LIKE po nazwie)",
+                        'aktualna_jednostka.nazwa ~ "Medycyny" and '
+                        'tytul.skrot startswith "dr"',
+                    ),
+                    (
+                        "Brak emaila, ale jest ORCID",
+                        'email = "" and orcid != ""',
+                    ),
+                    (
+                        "Konkretna jednostka po skrocie + filtr po nazwisku",
+                        'nazwisko startswith "Now" and '
+                        'aktualna_jednostka.skrot = "II WL"',
+                    ),
+                    (
+                        "Doktoraty + asystenci (zbior tytulow)",
+                        'tytul.skrot in ("dr", "dr hab.", "mgr")',
+                    ),
+                ],
+            },
+        ],
+    },
+    {
+        "level": 3,
+        "title": "Zaawansowane",
+        "subtitle": "grupowanie nawiasami, negacja, zlozone audyty",
+        "groups": [
+            {
+                "model": MODEL_REKORD,
+                "label": "Rekord",
+                "items": [
+                    (
+                        "Audyt ewaluacyjny — tylko recenzowane, z DOI, "
+                        "w okresie 2022–2025, min. 70 pkt",
+                        'recenzowana = True and doi != "" and '
+                        "rok in (2022, 2023, 2024, 2025) and punkty_kbn >= 70",
+                    ),
+                    (
+                        "Grupowanie (rok OR + charakter OR) × punktacja",
+                        "(rok = 2024 or rok = 2025) and "
+                        '(charakter_formalny.skrot = "AC" or '
+                        'charakter_formalny.skrot = "AOR") and punkty_kbn >= 100',
+                    ),
+                    (
+                        "Negacja: wszystko poza artykulami z czasopism, "
+                        "IF>=3, od 2023",
+                        'charakter_formalny.skrot != "AC" and rok >= 2023 '
+                        "and impact_factor > 3",
+                    ),
+                    (
+                        "Wieloklauzulowo: tytul × jezyk × liczba autorow × rok",
+                        '(tytul_oryginalny ~ "COVID" or tytul_oryginalny ~ "SARS") '
+                        'and jezyk.skrot in ("ang", "pol") and '
+                        "liczba_autorow >= 3 and rok = 2023",
+                    ),
+                    (
+                        "Wydawcy Elsevier/Springer/Wiley + przedzial punktow",
+                        '(wydawca.nazwa ~ "Elsevier" or wydawca.nazwa ~ "Springer" '
+                        'or wydawca.nazwa ~ "Wiley") and rok >= 2022 '
+                        "and punkty_kbn >= 70 and punkty_kbn <= 200",
+                    ),
+                    (
+                        "Hot & trending: cytowane >50 razy w okresie, IF>5",
+                        "liczba_cytowan > 50 and rok >= 2020 and "
+                        "impact_factor > 5",
+                    ),
+                    (
+                        "Audyt jakosci danych — artykuly 2024+ bez DOI/WWW",
+                        'charakter_formalny.skrot = "AC" and rok >= 2024 '
+                        'and doi = "" and www = "" and recenzowana = True',
+                    ),
+                    (
+                        "Top-tier OA z Nature/Cell/Science/Lancet",
+                        'zrodlo.nazwa in ("Nature", "Cell", "Science", '
+                        '"The Lancet") and rok > 2020 and '
+                        "openaccess_tryb_dostepu != None",
+                    ),
+                    (
+                        "Zmienione od poczatku roku z adnotacjami",
+                        'ostatnio_zmieniony >= "2025-01-01" and adnotacje != ""',
+                    ),
+                    (
+                        "Wielowarunkowa granica IF + zakres punktow + "
+                        "minimum cytowan",
+                        "impact_factor >= 5 and impact_factor <= 10 and "
+                        "punkty_kbn >= 100 and liczba_cytowan >= 5",
+                    ),
+                ],
+            },
+            {
+                "model": MODEL_AUTOR,
+                "label": "Autor",
+                "items": [
+                    (
+                        "Profesorowie z jednostki + ORCID + brak w PBN",
+                        'tytul.skrot in ("prof.", "prof. dr hab.") and '
+                        'aktualna_jednostka.skrot startswith "I WL" and '
+                        'orcid != "" and orcid_w_pbn = False',
+                    ),
+                    (
+                        "Dwie jednostki + tytul dr/dr hab. + jest orcid",
+                        '(aktualna_jednostka.skrot = "II WL" or '
+                        'aktualna_jednostka.skrot = "WLS") and '
+                        'tytul.skrot startswith "dr" and orcid != ""',
+                    ),
+                    (
+                        "Brak emaila ale jest ORCID (do uzupelnienia kontaktu)",
+                        'email = "" and orcid != "" and '
+                        'tytul.skrot in ("dr", "dr hab.", "prof.")',
+                    ),
+                    (
+                        "Format ORCID nieprawidlowy (nie zaczyna sie od '0000-')",
+                        'orcid != "" and orcid not startswith "0000-"',
+                    ),
+                    (
+                        "Wszystkie z aktualna jednostka, oprocz mgr/mgr inz.",
+                        "aktualna_jednostka != None and "
+                        'tytul.skrot not in ("mgr", "mgr inz.")',
+                    ),
+                ],
+            },
+        ],
+    },
+]
 
 
 class WprowadzanieDanychOrSuperuserMixin(LoginRequiredMixin, UserPassesTestMixin):
@@ -90,6 +316,11 @@ class ZapytanieView(WprowadzanieDanychOrSuperuserMixin, FormView):
             kwargs["data"] = self.request.GET
         return kwargs
 
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx.setdefault("examples", EXAMPLES)
+        return ctx
+
     def get(self, request, *args, **kwargs):
         form = self.get_form()
         if "query" in request.GET and form.is_valid() and form.cleaned_data["query"]:
@@ -114,6 +345,9 @@ class ZapytanieView(WprowadzanieDanychOrSuperuserMixin, FormView):
         except (DjangoQLError, FieldError, ValidationError, ValueError) as exc:
             error = self._format_error(exc)
 
+        if results_page is not None and model_key == MODEL_REKORD:
+            self._attach_admin_urls(results_page)
+
         context = self.get_context_data(
             form=form,
             results=results_page,
@@ -129,6 +363,26 @@ class ZapytanieView(WprowadzanieDanychOrSuperuserMixin, FormView):
         if isinstance(exc, ValidationError):
             return "; ".join(exc.messages)
         return str(exc)
+
+    @staticmethod
+    def _attach_admin_urls(results_page):
+        """Dla kazdego Rekord-u w wynikach prebuiluje obj.admin_url.
+
+        rekord.pk to tuple (content_type_id, object_id) — odsylamy do
+        admina konkretnego podtypu (Wydawnictwo_Ciagle, Patent itd.).
+        ContentType.objects.get_for_id jest cached w pamieci procesu,
+        wiec narzut na strone = 0 DB queries po pierwszym uzyciu danego
+        ct_id.
+        """
+        for obj in results_page:
+            try:
+                ct = ContentType.objects.get_for_id(obj.pk[0])
+                obj.admin_url = reverse(
+                    f"admin:{ct.app_label}_{ct.model}_change",
+                    args=[obj.pk[1]],
+                )
+            except (ContentType.DoesNotExist, NoReverseMatch):
+                obj.admin_url = None
 
 
 def _resolve_model_or_404(model_key):

--- a/src/django_bpp/templates/top_bar.html
+++ b/src/django_bpp/templates/top_bar.html
@@ -1,4 +1,4 @@
-
+{% load user_in_group %}
 <nav role="navigation" aria-label="Główna nawigacja" class="sticky-header">
 <div class="title-bar" data-responsive-toggle="example-menu" data-hide-for="medium">
     <button class="menu-icon" type="button" data-toggle="example-menu"
@@ -31,6 +31,14 @@
                             precyzyjnie
                         </a>
                     </li>
+                    {% if request.user.is_superuser or request.user.is_staff and request.user|has_group:"wprowadzanie danych" %}
+                        <li role="menuitem">
+                            <a href="{% url "bpp:zapytanie" %}">
+                                <i class="fi-database" aria-hidden="true"></i>
+                                zapytaniem
+                            </a>
+                        </li>
+                    {% endif %}
                 </ul>
             </li>
             <li>


### PR DESCRIPTION
## Summary
- Nowy widok `/zapytanie/` dla superuserów i grupy `wprowadzanie danych` — pełny DjangoQL nad modelami `Rekord` i `Autor` poza Django adminem.
- Autocomplete podpięty pod publiczne endpointy `zapytanie/introspect/<model>/` + `zapytanie/suggestions/<model>/` (delegacja do `djangoql.DjangoQLSchema` / `SuggestionsAPIView`).
- Popup pozycjonowany u stóp kursora tekstowego (mirror-div + MutationObserver, `position: fixed` wymuszone bo BPP body ma `position:relative + min-height:100vh`).
- TAB-completion (capture-listener zarejestrowany **przed** `DjangoQL.init` — kolejność rejestracji w fazie AT_TARGET decyduje).
- Historia 20 różnych zapytań w `localStorage` z licznikiem wyników i restore'em po kliknięciu.

## UI
- Badge **beta** + callout "podgląd technologiczny".
- Button-group wyboru modelu (CSS-only `:has(input:checked)`).
- Pager nad **i** pod tabelą wyników (`{% include _zapytanie_pager.html %}`).
- Reprezentacja rekordu w wynikach: `obj.opis_bibliograficzny_cache|safe` (kursywy, linki).
- 13 power-user przykładów dla Rekord + 6 dla Autor z grupowaniem/negacją/`in (...)`.
- Wpis "zapytaniem" w menu **szukaj** z ikoną `fi-database`.

## Test plan
- [ ] CI: `pytest src/bpp/tests/test_zapytanie.py` (14 testów — lokalnie green).
- [ ] CI: pełen suite — nic nie psuje się w testach naokoło.
- [ ] Manualnie: zapytanie `tytul_oryginalny ~ "rak"` na Rekord — wyniki + opis bibliograficzny z formatowaniem.
- [ ] Manualnie: TAB-completion w pustym textarea — wstawia pierwszą sugestię.
- [ ] Manualnie: przełączenie Rekord ↔ Autor — popup z innym schemą.
- [ ] Manualnie: błąd składni — komunikat zawija się czytelnie.
- [ ] Manualnie: historia zapytań — wpisy po restore, dedup po `model+query`, "Wyczyść" działa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)