### PR TITLE
feat(nowe_raporty): przyjazny komunikat zamiast 404 przy braku definicji raportu

### DIFF
--- a/docs/superpowers/specs/2026-05-31-raport-brak-definicji-design.md
+++ b/docs/superpowers/specs/2026-05-31-raport-brak-definicji-design.md
@@ -1,0 +1,120 @@
+# Przyjazny komunikat przy braku definicji raportu
+
+Data: 2026-05-31
+Status: zatwierdzony, do implementacji
+Branch/worktree: `feat/nowe-raporty-brak-definicji` / `~/Programowanie/bpp-raport-brak-definicji`
+
+## Problem
+
+Raporty w `nowe_raporty` to definicje `flexible_reports.Report` identyfikowane
+przez `slug` (`raport-autorow`, `raport-jednostek`, `raport-uczelni`,
+`raport-wydzialow`). Gdy definicja raportu nie istnieje w bazie (świeża
+instalacja, nieskonfigurowany moduł redagowania), strona formularza raportu
+zwraca **twardy błąd 404**:
+
+```python
+# src/nowe_raporty/views.py – BaseFormView.get_context_data
+kwargs["report"] = get_object_or_404(Report, slug=self.report_slug)
+```
+
+Użytkownik (a zwłaszcza redaktor) nie dostaje żadnej informacji, **gdzie** ten
+raport skonfigurować.
+
+Stan obecny jest też niespójny między trzema ścieżkami:
+
+| Ścieżka | Plik | Zachowanie przy braku `Report` |
+|---|---|---|
+| Strona formularza | `BaseFormView` | **404** (`get_object_or_404`) |
+| Strona wyniku | `GenerujRaportBase` | grzeczny tekst „skontaktuj się z administratorem" (`report=None`) |
+| Eksport docx/xlsx | `GenerujRaportBase.render_to_response` | **500** (`as_docx_response(None, …)`) |
+
+## Zakres
+
+**Wyłącznie strona formularza** (punkt wejścia użytkownika). Strona wyniku już
+ma komunikat; eksport 500 jest świadomie poza zakresem (patrz „Znane, poza
+zakresem").
+
+## Rozwiązanie
+
+### 1. `src/nowe_raporty/views.py` — `BaseFormView.get_context_data`
+
+Zamiana `get_object_or_404` na łagodne pobranie (taki sam wzorzec jak
+`GenerujRaportBase`):
+
+```python
+def get_context_data(self, **kwargs):
+    kwargs["title"] = self.title
+    try:
+        kwargs["report"] = Report.objects.get(slug=self.report_slug)
+    except Report.DoesNotExist:
+        kwargs["report"] = None
+    kwargs["report_slug"] = self.report_slug
+    kwargs["report_title"] = self.title
+    return super().get_context_data(**kwargs)
+```
+
+`report_slug` i `report_title` trafiają do kontekstu, żeby szablon mógł zbudować
+link do admina z prefillowanym tytułem i slugiem.
+
+### 2. `src/nowe_raporty/templates/nowe_raporty/formularz.html`
+
+- Osłonić istniejący blok „otwórz do edycji" przez `{% if report %}` — bez tego
+  `{% url ... report.pk %}` wybuchłoby na `report == None` i fix wprowadziłby
+  nowy błąd.
+- Gdy `not report` → zamiast `{% crispy form %}` wyrenderować nowy partial
+  `nowe_raporty/_brak_definicji_raportu.html`.
+
+### 3. `src/nowe_raporty/templates/nowe_raporty/_brak_definicji_raportu.html` (nowy)
+
+Callout (Foundation, monochromatyczne `fi-*` ikony — to frontend publiczny):
+
+- **Redaktor** (`request.user.is_superuser` lub grupa `raporty` — ten sam
+  warunek co reszta szablonu): komunikat „Raport «{{ report_title }}» nie jest
+  jeszcze skonfigurowany w systemie." + przycisk **„Skonfiguruj w module
+  redagowania"** linkujący do:
+  ```
+  {% url 'admin:flexible_reports_report_add' %}?title={{ report_title|urlencode }}&slug={{ report_slug|urlencode }}
+  ```
+  Admin `ReportAdmin` ma `prepopulated_fields = {"slug": ("title",)}`, więc
+  prefill tytułu + sluga daje redaktorowi gotowy formularz dodawania.
+- **Pozostali**: ten sam komunikat + „Skontaktuj się z administratorem lub
+  redaktorem systemu." (bez linku do panelu admina — nie zdradzamy ścieżki
+  panelu osobom bez uprawnień).
+
+## Obsługa błędów
+
+Brak definicji raportu przestaje być błędem HTTP — staje się normalnym stanem
+strony 200 z komunikatem. Żadna inna ścieżka błędów się nie zmienia.
+
+## Testy
+
+W `src/nowe_raporty/tests/test_nowe_raporty.py`, dla każdej z 4 form-view
+(autor / jednostka / wydział / uczelnia):
+
+1. **Brak `Report` → 200, nie 404.** Wejście zalogowanego usera z odpowiednią
+   grupą na URL formularza bez utworzonego `Report` zwraca 200 i zawiera tekst
+   komunikatu.
+2. **Redaktor widzi link.** Superuser dostaje w treści URL
+   `admin/.../flexible_reports/report/add` z prefillowanym slugiem.
+3. **Zwykły user nie widzi linku.** Użytkownik z grupą `raporty` ale bez
+   `is_staff`/uprawnień do admina dostaje tekst „skontaktuj się", bez linku do
+   `report_add`.
+
+Konwencje: pytest, `@pytest.mark.django_db`, `model_bakery.baker`, brak klas
+testowych. Wykorzystać istniejące fixtures z `src/nowe_raporty/tests/conftest.py`
+(uwaga: domyślnie tworzą `Report` — testy braku definicji muszą działać bez tego
+fixture albo go usuwać).
+
+## Reuse
+
+Nowy partial `_brak_definicji_raportu.html` jest samowystarczalny. Gdyby zakres
+się rozszerzył, da się go wpiąć też w `generuj.html` (zastępując obecny generyczny
+tekst), ale to poza zakresem tej zmiany.
+
+## Znane, poza zakresem (świadoma decyzja użytkownika)
+
+- **Bug 500 w eksporcie** docx/xlsx: `GenerujRaportBase.render_to_response` przy
+  `?_export=docx|xlsx` woła `as_*_response(context["report"], …)` gdy
+  `report is None`. Latentny, do rozważenia przy temacie 2 (konfigurowalne
+  raporty) lub osobno.
+- **Strona wyniku** (`generuj.html`) — już ma komunikat, nie ruszamy.

--- a/docs/superpowers/specs/2026-05-31-raporty-konfigurowalne-NOTES.md
+++ b/docs/superpowers/specs/2026-05-31-raporty-konfigurowalne-NOTES.md
@@ -1,0 +1,75 @@
+# Konfigurowalna lista raportów — NOTATKI (jeszcze nie zaprojektowane)
+
+Data: 2026-05-31
+Status: **surowe wymagania, do osobnego brainstormingu** — NIE zaczynać
+implementacji przed designem.
+
+To temat 2, świadomie odłożony do osobnego cyklu po dowiezieniu tematu 1
+(przyjazny komunikat przy braku definicji raportu).
+
+## Cel
+
+Zachować obecną listę raportów (raport autorów, jednostek, uczelni, wydziałów),
+ale **uczynić ją konfigurowalną** — żeby dało się dodawać/edytować pozycje
+(tytuł, slug, itp.) bez zmian w kodzie.
+
+## Wymagania zebrane od użytkownika
+
+1. **Konfigurowalna lista raportów.** Wpisujemy tytuł raportu, slug, itp.
+   Dziś jest 4 zahardkodowane warianty: każdy ma własny `*FormView`,
+   `*FormForm`, mixin autoryzacji, URL pattern i `report_slug` w
+   `src/nowe_raporty/views.py`. Docelowo lista ma być danymi, nie kodem.
+
+2. **Dynamiczne, cache'owane menu.** Menu w `top_bar.html` jest budowane
+   dynamicznie i **cache'owane**; ma się przebudowywać przy edycji listy
+   raportów (inwalidacja cache na zapis konfiguracji raportu).
+
+3. **Przeprojektowanie uprawnień pod multi-tenant.** Dziś część logiki widoczności
+   siedzi na obiekcie `Uczelnia` jako flagi `pokazuj_raport_*`
+   (`pokazuj_raport_autorow`, `pokazuj_raport_jednostek`, `pokazuj_raport_uczelni`,
+   `pokazuj_raport_wydzialow`) + `OpcjaWyswietlaniaField`
+   (POKAZUJ_ZAWSZE / POKAZUJ_NIGDY / POKAZUJ_ZALOGOWANYM / POKAZUJ_GDY_W_ZESPOLE)
+   oraz grupa `GR_RAPORTY_WYSWIETLANIE`. To, że uprawnienia są na uczelni, jest
+   OK jako kierunek, ale:
+   - Plan: **kilka uczelni na jednej instalacji** (multi-tenant).
+   - Trzeba rozsądnie ubrać przypadki:
+     - jeden raport widoczny **tylko na jednej uczelni**,
+     - jeden raport widoczny **na wszystkich uczelniach DLA ZALOGOWANYCH**,
+     - i analogiczne kombinacje (per-uczelnia × poziom dostępu).
+
+## Obszary kodu do przejrzenia przy brainstormingu
+
+- `src/nowe_raporty/views.py` — 4 zahardkodowane view/form/mixin + `report_slug`.
+- `src/nowe_raporty/urls.py` — URL patterns per raport.
+- `src/nowe_raporty/forms.py` — formularze per raport.
+- `src/bpp/views/mixins.py` — `UczelniaSettingRequiredMixin`
+  (`OpcjaWyswietlaniaField`, `group_required`).
+- `Uczelnia.pokazuj_raport_*` — flagi widoczności na modelu uczelni.
+- `top_bar.html` — dynamiczne, cache'owane menu raportów (znaleźć mechanizm
+  cache + punkt inwalidacji).
+- `flexible_reports.Report` — istniejący model definicji raportu (slug, title,
+  elementy). Pytanie projektowe: czy konfiguracja BPP-owa (widoczność, powiązanie
+  z typem obiektu autor/jednostka/wydział/uczelnia, uprawnienia per-uczelnia)
+  ma być nowym modelem BPP wskazującym na `Report`, czy rozszerzeniem `Report`.
+
+## Otwarte pytania projektowe (na brainstorming)
+
+- Model danych: nowy `KonfiguracjaRaportu`/`PozycjaMenuRaportu` (BPP) ↔ FK do
+  `flexible_reports.Report`? Jak powiązać z typem obiektu bazowego
+  (autor/jednostka/wydział/uczelnia) i `get_base_queryset`?
+- Jak generycznie zastąpić 4 zahardkodowane `get_base_queryset` /
+  `form_valid` (różne sygnatury URL — uczelnia nie ma `obiekt.pk` w URL)?
+- Multi-tenant: czy widoczność to M2M `Raport`↔`Uczelnia` z poziomem dostępu na
+  relacji, czy osobny model reguł? Jak to wpina się w obecny
+  `get_for_request(request)` / rozpoznawanie uczelni.
+- Cache menu: gdzie żyje, czym keyowany (per-uczelnia? per-user-auth?), gdzie
+  inwalidować.
+- Migracja danych: zachować istniejące 4 raporty i ich obecne flagi
+  `pokazuj_raport_*` → nowy model (data migration).
+
+## Powiązanie z tematem 1
+
+Temat 1 dorzuca przyjazny komunikat „raport nieskonfigurowany". Gdy temat 2
+uczyni listę w pełni konfigurowalną, partial `_brak_definicji_raportu.html`
+i tak zostaje użyteczny (pozycja menu istnieje, ale `Report` jeszcze nie
+wypełniony). Latentny bug 500 w eksporcie najlepiej domknąć w temacie 2.

--- a/src/nowe_raporty/templates/nowe_raporty/_brak_definicji_raportu.html
+++ b/src/nowe_raporty/templates/nowe_raporty/_brak_definicji_raportu.html
@@ -1,0 +1,29 @@
+{% load user_in_group %}
+{# Komunikat o braku definicji raportu (flexible_reports.Report). #}
+{# Redaktor (superuser / grupa "raporty") dostaje link do modulu redagowania #}
+{# z prefillowanym tytulem i slugiem; pozostali - prosbe o kontakt. #}
+<div class="callout warning" data-brak-definicji-raportu>
+    <h4>
+        <i class="fi-alert" aria-hidden="true" style="margin-right: 6px;"></i>
+        Raport „{{ report_title }}" nie został jeszcze skonfigurowany
+    </h4>
+    {% if request.user.is_superuser or request.user|has_group:"raporty" %}
+        <p>
+            Definicja tego raportu nie istnieje w module redagowania.
+            Aby raport zaczął działać, utwórz go w module redagowania —
+            tytuł i slug (<code>{{ report_slug }}</code>) są już wstępnie
+            wypełnione.
+        </p>
+        <a class="button primary"
+           target="_blank"
+           href="{% url 'admin:flexible_reports_report_add' %}?title={{ report_title|urlencode }}&slug={{ report_slug|urlencode }}">
+            <i class="fi-page-edit" aria-hidden="true" style="margin-right: 4px;"></i>
+            Skonfiguruj w module redagowania
+        </a>
+    {% else %}
+        <p>
+            Ten raport nie jest jeszcze dostępny.
+            Skontaktuj się z administratorem lub redaktorem systemu.
+        </p>
+    {% endif %}
+</div>

--- a/src/nowe_raporty/templates/nowe_raporty/formularz.html
+++ b/src/nowe_raporty/templates/nowe_raporty/formularz.html
@@ -11,19 +11,23 @@
 
 {% block content %}
     <h2>{{ title }}</h2>
-    {# go_to_admin_change.html #}
-    {% load user_in_group %}{% if request.user.is_superuser or request.user|has_group:"raporty" %}
-        <div class="hide-for-print" style="margin-top: 10px; margin-bottom: 15px;">
-            <a target="_blank" href="{% url "admin:flexible_reports_report_change" report.pk %}" class="edit-button">
-                <i class="fi-page-edit" style="margin-right: 4px; font-size: 0.8rem;"></i>{{ text|default:"otwórz do edycji" }}
-            </a>
+    {% if not report %}
+        {% include "nowe_raporty/_brak_definicji_raportu.html" %}
+    {% else %}
+        {# go_to_admin_change.html #}
+        {% load user_in_group %}{% if request.user.is_superuser or request.user|has_group:"raporty" %}
+            <div class="hide-for-print" style="margin-top: 10px; margin-bottom: 15px;">
+                <a target="_blank" href="{% url "admin:flexible_reports_report_change" report.pk %}" class="edit-button">
+                    <i class="fi-page-edit" style="margin-right: 4px; font-size: 0.8rem;"></i>{{ text|default:"otwórz do edycji" }}
+                </a>
+            </div>
+        {% endif %}
+        <div class="grid-x">
+            <div class="large-8 medium-12 small-12 cell">
+                {% load crispy_forms_tags bpp_formdefaults %}
+                <div class="formdefaults-wrap">{% bpp_formdefaults_button form %}</div>
+                {% crispy form %}
+            </div>
         </div>
     {% endif %}
-    <div class="grid-x">
-        <div class="large-8 medium-12 small-12 cell">
-            {% load crispy_forms_tags bpp_formdefaults %}
-            <div class="formdefaults-wrap">{% bpp_formdefaults_button form %}</div>
-            {% crispy form %}
-        </div>
-    </div>
 {% endblock %}

--- a/src/nowe_raporty/tests/test_nowe_raporty.py
+++ b/src/nowe_raporty/tests/test_nowe_raporty.py
@@ -2,6 +2,8 @@ from unittest.mock import patch
 
 import openpyxl
 import pytest
+from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from flexible_reports.models import (
     DATA_FROM_DATASOURCE,
@@ -11,10 +13,15 @@ from flexible_reports.models import (
     Table,
 )
 from flexible_reports.models.report import Report
+from formdefaults.models import FormRepresentation
 from model_bakery import baker
 from six import BytesIO
 
-from formdefaults.models import FormRepresentation
+from bpp.models import OpcjaWyswietlaniaField
+from bpp.models.autor import Autor
+from bpp.models.cache import Rekord
+from bpp.models.struktura import Jednostka, Wydzial
+from bpp.models.wydawnictwo_ciagle import Wydawnictwo_Ciagle
 from nowe_raporty.views import (
     AutorRaportFormView,
     GenerujRaportDlaAutora,
@@ -23,15 +30,6 @@ from nowe_raporty.views import (
     JednostkaRaportFormView,
     WydzialRaportFormView,
 )
-
-from django.contrib.contenttypes.models import ContentType
-
-from bpp.models import OpcjaWyswietlaniaField
-from bpp.models.autor import Autor
-from bpp.models.cache import Rekord
-from bpp.models.struktura import Jednostka, Wydzial
-from bpp.models.wydawnictwo_ciagle import Wydawnictwo_Ciagle
-
 
 
 @pytest.mark.django_db
@@ -49,6 +47,55 @@ def test_view_raport_nie_zdefiniowany(generuj_raporty_app, view, klass):
     res = generuj_raporty_app.get(v)
 
     assert "Nie znaleziono definicji" in res.text
+
+
+# Brak definicji raportu (flexible_reports.Report) na stronie FORMULARZA nie moze
+# konczyc sie twardym 404 - zamiast tego przyjazny komunikat + (dla redaktora)
+# link do modulu redagowania.
+
+FORM_BRAK_DEFINICJI = [
+    ("nowe_raporty:autor_form", "raport-autorow"),
+    ("nowe_raporty:jednostka_form", "raport-jednostek"),
+    ("nowe_raporty:wydzial_form", "raport-wydzialow"),
+    ("nowe_raporty:uczelnia_form", "raport-uczelni"),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_name,slug", FORM_BRAK_DEFINICJI)
+def test_form_brak_definicji_nie_404(generuj_raporty_app, url_name, slug):
+    # Bez utworzonego Report strona formularza musi zwrocic 200 z komunikatem,
+    # a nie 404.
+    res = generuj_raporty_app.get(reverse(url_name))
+    assert res.status_code == 200
+    assert "nie został jeszcze skonfigurowany" in res.text
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_name,slug", FORM_BRAK_DEFINICJI)
+def test_form_brak_definicji_redaktor_widzi_link(
+    generuj_raporty_app, normal_django_user, url_name, slug
+):
+    # Redaktor (grupa "raporty") dostaje link do modulu redagowania z
+    # prefillowanym slugiem.
+    normal_django_user.groups.add(Group.objects.get_or_create(name="raporty")[0])
+    res = generuj_raporty_app.get(reverse(url_name))
+    assert res.status_code == 200
+    assert "report/add" in res.text
+    assert slug in res.text
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_name,slug", FORM_BRAK_DEFINICJI)
+def test_form_brak_definicji_zwykly_user_widzi_kontakt(
+    generuj_raporty_app, url_name, slug
+):
+    # Uzytkownik bez uprawnien redakcyjnych widzi prosbe o kontakt, bez linku
+    # do panelu admina.
+    res = generuj_raporty_app.get(reverse(url_name))
+    assert res.status_code == 200
+    assert "Skontaktuj się z administratorem" in res.text
+    assert "report/add" not in res.text
 
 
 @pytest.mark.django_db

--- a/src/nowe_raporty/views.py
+++ b/src/nowe_raporty/views.py
@@ -2,13 +2,13 @@ import os
 
 from django.conf import settings
 from django.http.response import FileResponse, HttpResponse, HttpResponseRedirect
-from django.shortcuts import get_object_or_404
 from django.template.context import RequestContext
 from django.views.generic import FormView, TemplateView
 from django.views.generic.detail import DetailView
 from django_tables2.export.export import TableExport
 from flexible_reports.adapters.django_tables2 import as_tablib_databook
 from flexible_reports.models.report import Report
+from formdefaults.helpers import FormDefaultsMixin
 
 from bpp.const import GR_RAPORTY_WYSWIETLANIE
 from bpp.models import Uczelnia
@@ -16,7 +16,6 @@ from bpp.models.autor import Autor
 from bpp.models.cache import Rekord
 from bpp.models.struktura import Jednostka, Wydzial
 from bpp.views.mixins import UczelniaSettingRequiredMixin
-from formdefaults.helpers import FormDefaultsMixin
 
 from .docx_export import as_docx
 from .forms import (
@@ -34,14 +33,21 @@ class BaseFormView(FormDefaultsMixin, FormView):
     def form_valid(self, form):
         d = form.cleaned_data
         return HttpResponseRedirect(
-            f"./{ d['obiekt'].pk }/{ d['od_roku'] }/{ d['do_roku'] }/?"
-            f"_export={ d['_export'] }&"
+            f"./{d['obiekt'].pk}/{d['od_roku']}/{d['do_roku']}/?"
+            f"_export={d['_export']}&"
             f"_tzju={d['tylko_z_jednostek_uczelni']}"
         )
 
     def get_context_data(self, **kwargs):
         kwargs["title"] = self.title
-        kwargs["report"] = get_object_or_404(Report, slug=self.report_slug)
+        try:
+            kwargs["report"] = Report.objects.get(slug=self.report_slug)
+        except Report.DoesNotExist:
+            # Brak definicji raportu nie jest bledem HTTP - szablon pokaze
+            # przyjazny komunikat (a redaktorowi link do modulu redagowania).
+            kwargs["report"] = None
+        kwargs["report_slug"] = self.report_slug
+        kwargs["report_title"] = self.title
         return super().get_context_data(**kwargs)
 
 
@@ -80,9 +86,9 @@ class AutorRaportFormView(AutorRaportAuthMixin, BaseFormView):
     def form_valid(self, form):
         d = form.cleaned_data
         return HttpResponseRedirect(
-            f"./{ d['obiekt'].pk }/{ d['od_roku'] }/{ d['do_roku'] }/?"
-            f"_export={ d['_export'] }&"
-            f"_tzju={ d['tylko_z_jednostek_uczelni'] }"
+            f"./{d['obiekt'].pk}/{d['od_roku']}/{d['do_roku']}/?"
+            f"_export={d['_export']}&"
+            f"_tzju={d['tylko_z_jednostek_uczelni']}"
         )
 
 
@@ -100,8 +106,8 @@ class UczelniaRaportFormView(UczelniaRaportAuthMixin, BaseFormView):
     def form_valid(self, form):
         d = form.cleaned_data
         return HttpResponseRedirect(
-            f"./{ d['od_roku'] }/{ d['do_roku'] }/?"
-            f"_export={ d['_export'] }&"
+            f"./{d['od_roku']}/{d['do_roku']}/?"
+            f"_export={d['_export']}&"
             f"_tzju={d['tylko_z_jednostek_uczelni']}"
         )
 
@@ -129,7 +135,7 @@ class GenerujRaportBase(DetailView):
 
     @property
     def title(self):
-        return f"Raport dla { self.object } za { self.okres }"
+        return f"Raport dla {self.object} za {self.okres}"
 
     def get_context_data(self, **kwargs):
         from flexible_reports.models import Report


### PR DESCRIPTION
## Problem

Strona **formularza** raportu (autor / jednostka / wydział / uczelnia) robiła
`get_object_or_404(Report, slug=...)`. Gdy definicja raportu
(`flexible_reports.Report`) nie istniała w module redagowania — np. na świeżej
instalacji — użytkownik dostawał **twardy 404** bez żadnej wskazówki, gdzie ten
raport skonfigurować.

Stan był też niespójny między ścieżkami: formularz → 404, strona wyniku →
grzeczny tekst, eksport docx/xlsx → 500.

## Zmiana (zakres: strona formularza)

- `BaseFormView.get_context_data` łapie `Report.DoesNotExist` → `report=None`
  (zamiast `get_object_or_404`), dokłada `report_slug` i `report_title` do
  kontekstu.
- Nowy partial `_brak_definicji_raportu.html` z callout-em:
  - **redaktor** (`is_superuser` lub grupa `raporty`) — przycisk *„Skonfiguruj w
    module redagowania"* linkujący do `admin:flexible_reports_report_add`
    z prefillowanym tytułem i slugiem,
  - **pozostali** — prośba o kontakt z administratorem (bez linku do panelu).
- `formularz.html` — gdy `not report` pokazuje partial zamiast bezużytecznego
  formularza; blok „otwórz do edycji" osłonięty `{% if report %}` (inaczej
  `report.pk` na `None` byłby nowym bugiem).

## Testy

12 nowych testów (3 scenariusze × 4 formularze): 200 zamiast 404, redaktor widzi
link z prefillowanym slugiem, zwykły użytkownik widzi prośbę o kontakt bez linku.
Cały moduł `nowe_raporty`: **61 passed**. ruff + ruff-format + djLint zielone.

## Poza zakresem (świadomie)

- Latentny **bug 500 w eksporcie** docx/xlsx przy braku `Report`
  (`render_to_response` → `as_*_response(None, …)`) — udokumentowany w spec, do
  domknięcia przy temacie „konfigurowalna lista raportów".
- Strona wyniku (`generuj.html`) — już ma komunikat, nietknięta.

Spec: `docs/superpowers/specs/2026-05-31-raport-brak-definicji-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
