### PR TITLE
Fix CI: install cairo system deps in refresh-baseline workflow

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
+      - name: Install system build deps
+        # uv sync builds several wheels from source (pycairo via
+        # svglib/xhtml2pdf, psycopg2, python-ldap, cryptography) that need
+        # native headers. Reuse docker/bpp_base/build.txt so the package
+        # list stays in sync with the runtime/test images and tests.yml.
+        run: |
+          sudo apt-get update
+          xargs -a docker/bpp_base/build.txt sudo apt-get install -y
+
       - name: Install Python deps (with baseline-rebuild extra)
         run: uv sync --frozen --no-install-project --extra baseline-rebuild
 


### PR DESCRIPTION
## Summary

Fixes the failing **Refresh baseline pg_dump** workflow on `dev`.

**Root cause:** The `refresh` job's *Install Python deps* step runs `uv sync`, which compiles `pycairo` 1.29.0 from source (`bpp-iplweb → xhtml2pdf → svglib → rlpycairo → pycairo`). The bare `ubuntu-latest` runner has no `cairo` C library, so `pkg-config`/CMake fail with `ERROR: Dependency "cairo" not found` and the install exits 1.

**Fix:** Add the same `Install system build deps` step that `tests.yml` already uses — installing packages from `docker/bpp_base/build.txt` (which includes `libcairo2-dev`) before the Python deps step. This keeps the workflow's native-header list in sync with the runtime/test Docker images.

**Failed run:** https://github.com/iplweb/bpp/actions/runs/26722862855

## Verification

The workflow only auto-triggers on pushes to `dev` touching `src/**/migrations/**`, so this PR's branch won't auto-run it. I'll trigger it via `workflow_dispatch` on this branch to confirm the install step reaches green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) using \`github-build-fixer\` skill