### PR TITLE
fix(channels): napraw flake test_bpp_notifications* — konfigurowalny per-worker channel-layer prefix

### DIFF
--- a/docs/CHANNELS_BROADCAST_FLAKE.md
+++ b/docs/CHANNELS_BROADCAST_FLAKE.md
@@ -1,5 +1,14 @@
 # test_bpp_notifications — diagnostyka flake'u (2026-05-13)
 
+> **AKTUALIZACJA 2026-05-31 — zidentyfikowana przyczyna i fix.**
+> Sekcja „## Przyczyna: kolizja nazw grup między workerami xdist" na końcu
+> tego dokumentu opisuje znalezioną przyczynę (współdzielony namespace
+> channel-layer w Redisie między workerami pytest-xdist) i wdrożony fix
+> (konfigurowalny, per-worker prefix przez `django_bpp.channels_prefix`).
+> Reszta dokumentu poniżej to oryginalny zapis diagnostyki z 2026-05-13,
+> zachowany dla kontekstu.
+
+
 Po migracji z lokalnej apki `src/notifications/` na zewnętrzny pakiet
 `django-channels-broadcast>=0.2.0` (commity `f6e0fa6cf` + `048c2cfa2`)
 test `src/integration_tests/test_bpp_with_notifications.py::test_bpp_notifications`
@@ -219,3 +228,79 @@ Sensowne kolejne kroki diagnostyki:
 4. Sprawdzić czy gubi się na poziomie `bzpopmin` w Daphne (`receive_loop`
    nie zdąża z polling przed expiry message-a) — `self.expiry` default
    60s, powinno wystarczyć, ale warto zweryfikować.
+
+## Przyczyna: kolizja nazw grup między workerami xdist (2026-05-31)
+
+Po dalszej analizie zidentyfikowano przyczynę, której poprzednia sesja nie
+sprawdziła: **współdzielony namespace channel-layer w Redisie między
+workerami pytest-xdist.**
+
+### Mechanizm
+
+1. Nazwa grupy per-user to `md5(str(pk) + username)`
+   (`channels_broadcast/core.py::get_channel_name_for_user`).
+2. Username testowy jest stały (`fixtures/const.py::NORMAL_DJANGO_USER_LOGIN
+   = "test_login_bpp"`), a `transactional_db` robi
+   `TRUNCATE ... RESTART IDENTITY` → user testowy dostaje `pk=1` w **każdym**
+   workerze.
+3. Skutek: `md5("1" + "test_login_bpp")` = `ce13ba84…` — **identyczna** nazwa
+   grupy w gw0, gw1, …, gw15.
+4. `channels_redis` namespace'uje klucze grup jako `{prefix}:group:{name}`
+   (domyślny prefix `"asgi"`). Bez własnego prefixu wszystkie workery
+   współdzielące jeden Redis testcontainera lądują w **tej samej** grupie
+   `asgi:group:ce13ba84…`. `group_send` jednego workera fan-outuje do
+   konsumentów innych workerów → cross-talk i probabilistyczny zgub/przeplot
+   wiadomości WebSocket.
+
+Diagnostyka pkt 1 (na górze tego dokumentu) sprawdziła, że Daphne i proces
+testowy używają tego samego **portu** Redisa — ale przeoczyła, że pod
+`-n auto` *wszystkie* workery dzielą ten jeden Redis z **kolidującymi**
+nazwami grup. Asymetria solo-PASS / pełny-plik-FAIL i fakt, że fail z CI był
+na `gw8` (9. worker, czyli `-n auto` na wielordzeniowej maszynie), pasują do
+pollution stanu współdzielonego, nie do buga send/receive.
+
+### Fix: konfigurowalny per-worker prefix
+
+`src/django_bpp/channels_prefix.py` (single source of truth) liczy prefix:
+
+1. `DJANGO_BPP_CHANNELS_PREFIX` — jawny override (każde środowisko),
+2. `asgi-test-<worker>` pod xdist (`PYTEST_XDIST_WORKER` ustawione),
+3. `"asgi"` — domyślny `channels_redis` (produkcja / brak xdist).
+
+Dwa kooperujące procesy muszą zgadzać się co do prefixu **bajt w bajt**:
+
+- subprocess Daphne — przez `CHANNEL_LAYERS["default"]["CONFIG"]["prefix"]`
+  w `settings/base.py`,
+- test-side poller `wait_for_channel_subscription`
+  (`django_bpp/playwright_util.py`), który czyta klucz grupy wprost z Redisa.
+
+Daphne jest forkowany z workera xdist (`channels_live_server::_spawn_daphne`),
+więc dziedziczy `PYTEST_XDIST_WORKER`; oba procesy importują ten sam
+`channels_prefix.py` → liczą identyczny prefix. To naprawia błąd
+wcześniejszego (porzuconego) podejścia, gdzie prefix zmieniono tylko w
+`CHANNEL_LAYERS`, a poller dalej pollował hardcoded `asgi:group:…` →
+`TimeoutError` (poll złego klucza).
+
+Produkcyjnie **no-op**: `PYTEST_XDIST_WORKER` istnieje tylko pod xdist;
+zweryfikowano, że w env prod-like prefix = `"asgi"` (zgodny z domyślnym
+`channels_redis`, więc żadnej zmiany zachowania w produkcji).
+
+### Status weryfikacji — uczciwie
+
+- ✅ **Sound-by-construction**: prefix izoluje namespace per worker; obie
+  strony (Daphne + poller) liczą go z jednego źródła. Kolizja z mechanizmu
+  jest niemożliwa, gdy każdy worker ma własny namespace.
+- ✅ **Brak regresji**: pełny plik `test_bpp_with_notifications.py` z fixem,
+  `-n 8` oraz `-n 12 --count=8` → wszystko pass, zero rerunów; poller nie
+  timeout'uje (czyli prefix jest spójny między procesami).
+- ⚠️ **Nie zreprodukowano flake'u lokalnie**: na maszynie 10-rdzeniowej,
+  nawet wymuszając współdzielony namespace (`DJANGO_BPP_CHANNELS_PREFIX=asgi`)
+  pod `-n 12 --count=8` (192 egz./iterację × 3 iteracje) — 0 rerunów. Flake
+  potrzebuje wyższej równoległości (CI fail był na `gw8` = ~16 workerów pod
+  `-n auto`), której lokalny sprzęt nie wygeneruje. A/B nie był więc w stanie
+  empirycznie *udowodnić* fixu na tym sprzęcie — opieramy się na argumencie
+  konstrukcyjnym + braku regresji.
+- Mitygacja testu (`@pytest.mark.flaky(reruns=3)` + bufor) zostaje jako
+  defense-in-depth (tania, chroni przed ewentualnym rezydualnym
+  within-worker pollution session-scoped Daphne między testami tego samego
+  workera).

--- a/src/django_bpp/channels_prefix.py
+++ b/src/django_bpp/channels_prefix.py
@@ -1,0 +1,58 @@
+"""Single source of truth for the ``channels_redis`` key prefix.
+
+``channels_redis`` namespaces every group key as ``{prefix}:group:{name}``
+(default prefix ``"asgi"`` — see ``RedisChannelLayer._group_key``). Under
+``pytest -n auto`` all xdist workers share one Redis testcontainer, and the
+per-user group name is ``md5(pk + username)`` — which collides across workers
+because ``transactional_db`` resets PK sequences (``TRUNCATE ... RESTART
+IDENTITY``) and the test username is constant. Without a per-worker prefix,
+consumers spawned by different workers land in the *same* Redis group, so one
+worker's ``group_send`` fans out to another worker's channels and the
+WebSocket message is probabilistically lost (see
+``docs/CHANNELS_BROADCAST_FLAKE.md``).
+
+Two cooperating processes must agree on the prefix byte-for-byte:
+
+- the Daphne subprocess, via ``CHANNEL_LAYERS`` in settings, and
+- the test-side subscription poller ``wait_for_channel_subscription``
+  (``django_bpp.playwright_util``), which reads the group key directly from
+  Redis.
+
+If they disagree, the poller watches the wrong key and times out. This module
+is that single source of truth — keep it dependency-light (stdlib only) so it
+is safe to import from Django settings.
+"""
+
+import os
+
+#: The upstream ``channels_redis`` default prefix; also the production value.
+DEFAULT_CHANNELS_PREFIX = "asgi"
+
+#: Explicit override env var, honoured in any environment.
+CHANNELS_PREFIX_ENV = "DJANGO_BPP_CHANNELS_PREFIX"
+
+
+def get_channels_prefix() -> str:
+    """Return the ``channels_redis`` key prefix for the current process.
+
+    Resolution order:
+
+    1. ``DJANGO_BPP_CHANNELS_PREFIX`` — explicit override (any environment).
+    2. ``asgi-test-<worker>`` when running under pytest-xdist
+       (``PYTEST_XDIST_WORKER`` is set) — isolates each worker's namespace so
+       colliding per-user group names cannot cross-talk between workers.
+    3. ``"asgi"`` — the ``channels_redis`` default (production / non-xdist).
+
+    Both the Daphne subprocess (spawned from the xdist worker, inheriting its
+    environment) and the pytest worker import this module, so they compute the
+    identical prefix.
+    """
+    explicit = os.environ.get(CHANNELS_PREFIX_ENV)
+    if explicit:
+        return explicit
+
+    worker = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker:
+        return f"{DEFAULT_CHANNELS_PREFIX}-test-{worker}"
+
+    return DEFAULT_CHANNELS_PREFIX

--- a/src/django_bpp/playwright_util.py
+++ b/src/django_bpp/playwright_util.py
@@ -58,12 +58,16 @@ def wait_for_channel_subscription(
 
     import redis
 
+    from django_bpp.channels_prefix import get_channels_prefix
+
     deadline = time.monotonic() + timeout
     r = redis.Redis(
         host=os.environ.get("DJANGO_BPP_REDIS_HOST", "localhost"),
         port=int(os.environ.get("DJANGO_BPP_REDIS_PORT", 6379)),
     )
-    group_key = f"asgi:group:{channel_name}".encode()
+    # Must match the prefix Daphne uses in CHANNEL_LAYERS, or we poll the wrong
+    # Redis key. channels_redis stores groups as ``{prefix}:group:{name}``.
+    group_key = f"{get_channels_prefix()}:group:{channel_name}".encode()
     while time.monotonic() < deadline:
         if r.zcount(group_key, since, "+inf") > 0:
             return

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -14,6 +14,7 @@ from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
 
 from bpp.util import slugify_function
+from django_bpp.channels_prefix import get_channels_prefix
 from django_bpp.version import VERSION
 
 logger = logging.getLogger(__name__)
@@ -864,11 +865,16 @@ BPP_WALIDUJ_AFILIACJE_AUTOROW = (
 # ASGI_APPLICATION = "django_bpp.routing.application"
 ASGI_APPLICATION = "django_bpp.asgi.application"
 
+# Channel-layer key prefix (get_channels_prefix imported at top). Production:
+# "asgi" (channels_redis default). Under pytest-xdist: "asgi-test-<worker>" so
+# colliding per-user group names cannot cross-talk between workers sharing one
+# Redis. See django_bpp.channels_prefix and docs/CHANNELS_BROADCAST_FLAKE.md.
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [(REDIS_HOST, REDIS_PORT)],
+            "prefix": get_channels_prefix(),
         },
     },
 }

--- a/src/django_bpp/tests/test_channels_prefix.py
+++ b/src/django_bpp/tests/test_channels_prefix.py
@@ -1,0 +1,42 @@
+"""Tests for the channel-layer prefix resolver.
+
+The resolver is the single source of truth that keeps the Daphne subprocess
+(via ``CHANNEL_LAYERS``) and the test-side subscription poller agreeing on the
+``channels_redis`` key prefix. See ``django_bpp.channels_prefix``.
+"""
+
+from django_bpp.channels_prefix import (
+    DEFAULT_CHANNELS_PREFIX,
+    get_channels_prefix,
+)
+
+
+def test_default_prefix_when_no_xdist_and_no_override(monkeypatch):
+    """Production / single-process: the channels_redis default ``asgi``."""
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    monkeypatch.delenv("DJANGO_BPP_CHANNELS_PREFIX", raising=False)
+    assert get_channels_prefix() == DEFAULT_CHANNELS_PREFIX == "asgi"
+
+
+def test_per_worker_prefix_under_xdist(monkeypatch):
+    """Each xdist worker gets an isolated ``asgi-test-<worker>`` namespace."""
+    monkeypatch.delenv("DJANGO_BPP_CHANNELS_PREFIX", raising=False)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw8")
+    assert get_channels_prefix() == "asgi-test-gw8"
+
+
+def test_explicit_override_wins_over_xdist(monkeypatch):
+    """An explicit override takes precedence even under xdist."""
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+    monkeypatch.setenv("DJANGO_BPP_CHANNELS_PREFIX", "custom-ns")
+    assert get_channels_prefix() == "custom-ns"
+
+
+def test_two_workers_get_distinct_prefixes(monkeypatch):
+    """The whole point: different workers must not collide."""
+    monkeypatch.delenv("DJANGO_BPP_CHANNELS_PREFIX", raising=False)
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    first = get_channels_prefix()
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw1")
+    second = get_channels_prefix()
+    assert first != second

--- a/src/integration_tests/test_bpp_with_notifications.py
+++ b/src/integration_tests/test_bpp_with_notifications.py
@@ -138,13 +138,23 @@ def test_bpp_notifications(preauth_asgi_page_per_test: Page):
     expect(page.locator("body")).to_contain_text(s, timeout=15000)
 
 
+@pytest.mark.flaky(reruns=3)
 def test_bpp_notifications_and_messages(preauth_asgi_page: Page):
     """Sprawdz, czy notyfikacje dochodza."""
-
+    # Ten sam probabilistyczny flake co `test_bpp_notifications`: pierwszy
+    # `wait_for_function` czeka na live-push wiadomosci przez WebSocket, ktory
+    # ginie gdzies miedzy `group_send` a `chat_message` handlerem consumera w
+    # Daphne (mimo udowodnionej subskrypcji w fixture). 2-sekundowy bufor PRZED
+    # wyslaniem obniza miss-rate, `@flaky(reruns=3)` lapie reszte. Drugi
+    # assertion (po `page.reload()`) renderuje wiadomosc server-side z bazy,
+    # wiec nie podlega temu zgubowi. Patrz docs/CHANNELS_BROADCAST_FLAKE.md.
+    # (transactional_db dostarcza fixture `preauth_asgi_page`, wiec osobny
+    # marker @pytest.mark.django_db jest zbedny.)
     s = "test notyfikacji 123 456 902309093209092"
     page = preauth_asgi_page
     expect(page.locator("body")).not_to_contain_text(s)
 
+    page.wait_for_timeout(2000)  # Pozwol subskrypcji WS sie ustabilizowac
     call_command("send_message", preauth_asgi_page.authorized_user.username, s)
 
     page.wait_for_timeout(1000)  # Give time for message to be sent


### PR DESCRIPTION
## Problem

`test_bpp_notifications_and_messages[chromium]` (i cała rodzina
`test_bpp_notifications*`) failuje sporadycznie z:

```
playwright._impl._errors.TimeoutError: Page.wait_for_function: Timeout 15000ms exceeded.
```

Fail z CI był na `gw8` — przebieg równoległy `pytest -n auto`.

## Przyczyna

Pod `pytest -n auto` **wszystkie** workery xdist dzielą jeden Redis
testcontainera. Nazwa grupy WebSocket per-user to `md5(pk + username)`
(`channels_broadcast/core.py`). Username testowy jest stały
(`test_login_bpp`), a `transactional_db` robi `TRUNCATE … RESTART IDENTITY`,
więc user testowy dostaje `pk=1` w **każdym** workerze → **identyczna** nazwa
grupy we wszystkich workerach.

Bez `prefix` w `CHANNEL_LAYERS` channels_redis używa domyślnego namespace
`asgi:` (`{prefix}:group:{name}`), więc konsumenci z różnych workerów lądowali
w **tej samej** grupie Redis. `group_send` jednego workera fan-outował do
cudzych kanałów → cross-talk i probabilistyczny zgub wiadomości → pusty
`document.body` → timeout.

## Fix — konfigurowalny per-worker prefix

Single source of truth: `django_bpp/channels_prefix.py::get_channels_prefix()`

1. `DJANGO_BPP_CHANNELS_PREFIX` — jawny override (każde środowisko),
2. `asgi-test-<worker>` pod xdist (`PYTEST_XDIST_WORKER` ustawione),
3. `"asgi"` — domyślny channels_redis (produkcja / brak xdist).

Oba kooperujące procesy liczą prefix z tego samego modułu:
- subprocess Daphne — przez `CHANNEL_LAYERS` w `settings/base.py`,
- test-side poller `wait_for_channel_subscription` w `playwright_util.py`
  (wcześniej hardcoded `asgi:group:` — co psuło naiwne podejście
  zmieniające tylko `CHANNEL_LAYERS`: poller pollował zły klucz → TimeoutError).

Daphne jest forkowany z workera xdist, więc dziedziczy `PYTEST_XDIST_WORKER`;
oba procesy liczą identyczny prefix i nadal się „widzą" w Redisie, ale w
namespace izolowanym od innych workerów.

**Produkcyjnie no-op**: `PYTEST_XDIST_WORKER` istnieje tylko pod xdist;
zweryfikowano, że w env prod-like prefix = `"asgi"` (zgodny z domyślnym
channels_redis, więc żadnej zmiany zachowania w produkcji).

## Weryfikacja — uczciwie

- ✅ `manage.py check` OK, `ruff` OK, 4 unit testy resolvera prefixu OK.
- ✅ **Brak regresji**: pełny plik `test_bpp_with_notifications.py` z fixem,
  `-n 8` oraz `-n 12 --count=8` → wszystko pass, zero rerunów; poller nie
  timeout'uje (prefix spójny między procesami).
- ⚠️ **Flake NIE zreprodukowany lokalnie**: na maszynie 10-rdzeniowej, nawet
  wymuszając współdzielony namespace (`DJANGO_BPP_CHANNELS_PREFIX=asgi`) pod
  `-n 12 --count=8` (192 egz./iterację × 3 iteracje) → 0 rerunów. Flake
  potrzebuje wyższej równoległości (CI fail był na `gw8` = ~16 workerów pod
  `-n auto`), której lokalny sprzęt nie generuje. A/B nie był więc w stanie
  empirycznie *udowodnić* fixu na tym sprzęcie — opieramy się na argumencie
  konstrukcyjnym (per-worker namespace = kolizja niemożliwa) + braku regresji.

## Zmiany

1. **`django_bpp/channels_prefix.py`** (nowy) — single source of truth dla prefixu.
2. **`settings/base.py`** — `CHANNEL_LAYERS[...]["prefix"] = get_channels_prefix()`.
3. **`playwright_util.py`** — `wait_for_channel_subscription` używa tego samego prefixu.
4. **`tests/test_channels_prefix.py`** (nowy) — 4 unit testy resolvera.
5. **`test_bpp_with_notifications.py`** — mitygacja `@pytest.mark.flaky(reruns=3)`
   + 2s bufor (defense-in-depth, chroni przed rezydualnym within-worker pollution).
6. **`docs/CHANNELS_BROADCAST_FLAKE.md`** — udokumentowana przyczyna + fix + status weryfikacji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)