### PR TITLE
perf(tests): usuń martwy time.sleep w test_global_search (Playwright)

### DIFF
--- a/src/integration_tests/test_bpp_with_notifications.py
+++ b/src/integration_tests/test_bpp_with_notifications.py
@@ -147,7 +147,10 @@ def test_bpp_notifications_and_messages(preauth_asgi_page: Page):
 
     call_command("send_message", preauth_asgi_page.authorized_user.username, s)
 
-    page.wait_for_timeout(1000)  # Give time for message to be sent
+    # `wait_for_function` poll-uje az tekst sie pojawi (timeout 15 s daje
+    # zapas), wiec poprzedzajacy go staly `wait_for_timeout(1000)` byl
+    # martwym czasem — subskrypcja kanalu jest juz udowodniona w fixturze
+    # `preauth_asgi_page` (wait_for_channel_subscription).
     page.wait_for_function(
         f"() => document.body.textContent.includes('{s}')", timeout=15000
     )

--- a/src/integration_tests/test_bpp_with_notifications.py
+++ b/src/integration_tests/test_bpp_with_notifications.py
@@ -147,10 +147,7 @@ def test_bpp_notifications_and_messages(preauth_asgi_page: Page):
 
     call_command("send_message", preauth_asgi_page.authorized_user.username, s)
 
-    # `wait_for_function` poll-uje az tekst sie pojawi (timeout 15 s daje
-    # zapas), wiec poprzedzajacy go staly `wait_for_timeout(1000)` byl
-    # martwym czasem — subskrypcja kanalu jest juz udowodniona w fixturze
-    # `preauth_asgi_page` (wait_for_channel_subscription).
+    page.wait_for_timeout(1000)  # Give time for message to be sent
     page.wait_for_function(
         f"() => document.body.textContent.includes('{s}')", timeout=15000
     )

--- a/src/integration_tests/test_global_search.py
+++ b/src/integration_tests/test_global_search.py
@@ -23,12 +23,11 @@ def test_global_search_user(
         page.goto(channels_live_server.url)
         wait_for_page_load(page)
 
-        # Accept cookies if needed
+        # Accept cookies if needed. `Cookielaw.accept()` is synchronous, so
+        # the banner is gone once evaluate() returns — no fixed sleep needed
+        # before pressing "/"; `wait_for_selector(state="visible")` below
+        # poll-uje az dialog wyszukiwarki sie pojawi.
         page.evaluate("if (typeof Cookielaw !== 'undefined') { Cookielaw.accept(); }")
-
-        import time
-
-        time.sleep(0.5)
 
         # Press "/" to open the global search dialog
         page.keyboard.press("/")
@@ -94,12 +93,12 @@ def test_global_search_logged_in(
         wait_for_page_load(admin_page)
 
         # Accept cookies if needed
+        # `Cookielaw.accept()` is synchronous; banner is gone once evaluate()
+        # returns. `wait_for_selector(state="visible")` below poll-uje na
+        # dialog, wiec staly sleep przed press("/") byl martwym czasem.
         admin_page.evaluate(
             "if (typeof Cookielaw !== 'undefined') { Cookielaw.accept(); }"
         )
-        import time
-
-        time.sleep(0.5)
 
         # Press "/" to open the global search dialog
         admin_page.keyboard.press("/")


### PR DESCRIPTION
## Kontekst

Analiza listy `--durations=50` dla testów Playwright. Suite jest już mocno
zoptymalizowany (MD5 hasher, `CELERY_ALWAYS_EAGER`, DummyCache, xdist z
DB-per-worker, `--reuse-db`, session-scoped Daphne, `-n auto` w CI), a
większość `sleep`/`wait_for_timeout` ma już komentarze tłumaczące, że jest
celowa (polling, okno dla negatywnej asercji, udokumentowany bufor na flaky
race w `docs/CHANNELS_BROADCAST_FLAKE.md`).

Ten PR usuwa **tylko** opóźnienie, które jest bezspornie martwe — niskie
ryzyko, bez zmiany logiki ani stabilności.

## Zmiana

**`test_global_search.py` (×2)** — `time.sleep(0.5)` stał po
**synchronicznym** `Cookielaw.accept()`, tuż przed
`wait_for_selector(state="visible")`, który sam poll-uje na pojawienie się
dialogu wyszukiwarki. Sleep był więc czystym martwym czasem; pozostawiony
mechanizm `wait_for_selector` jest ścisłym nadzbiorem usuniętego stałego
czekania.

Efekt: ~1 s mniej łącznie, bez wpływu na stabilność.

## Zawężenie zakresu (ważne)

Pierwotnie PR dotykał też `test_bpp_with_notifications.py` (ten sam wzorzec).
Wycofano to: dokładnie ten `wait_for_timeout(1000)` jest już usuwany — i to
**lepiej** (event-driven + `@flaky(reruns=3)` na naprawę flakiness) — na
branchu `worktree-fix-notifications-test`. Tamten branch zostaje źródłem
prawdy dla tego pliku, żeby uniknąć konfliktu i podwójnej zmiany.

## Czego świadomie NIE ruszono

- Bufory na flaky race w async notyfikacjach (`docs/CHANNELS_BROADCAST_FLAKE.md`).
- Okna obserwacyjne dla negatywnych asercji (`test_podpowiedzi_dyscyplin.py`).
- Duże czasy w fazie *setup* (clarivate ~17 s, crossref ~14 s) — to koszt
  jednorazowy startu Daphne/przeglądarki/bazy na workera, nie skaluje się
  z liczbą testów.

🤖 Generated with [Claude Code](https://claude.com/claude-code)