### PR TITLE
fix(tests): pbn_api/wydawnictwa jako pytest pluginy — koniec AppRegistryNotReady w preloadzie conftesta

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -67,6 +67,15 @@ pytest_plugins = [
     "fixtures.conftest_disciplines",
 ]
 
+# UWAGA: tu wolno importować WYŁĄCZNIE symbole z modułów wolnych od Django
+# (czyli `fixtures.const`). `pytest-testcontainers-django` preloaduje ten
+# rootdir-owy conftest w hooku `pytest_load_initial_conftests` (tryfirst),
+# ZANIM `pytest-django` zrobi `django.setup()`. Każdy top-levelowy import
+# modelu w łańcuchu `from fixtures import *` wybucha wtedy
+# `AppRegistryNotReady`. Moduły z fiksturami importującymi modele
+# (`pbn_api`, `wydawnictwa`) są zarejestrowane jako pytest pluginy w
+# `src/conftest.py` (ładowane PO `django.setup()`).
+# Regresja-guard: src/bpp/tests/test_conftest_preload_safety.py.
 from fixtures import *  # noqa
 
 

--- a/src/bpp/tests/test_autocomplete/test_autocomplete_publications.py
+++ b/src/bpp/tests/test_autocomplete/test_autocomplete_publications.py
@@ -22,7 +22,7 @@ from bpp.views.autocomplete.pbn_api import (
     PublicationAutocomplete,
     PublisherPBNAutocomplete,
 )
-from fixtures import (
+from fixtures.pbn_api import (
     pbn_journal_json,
     pbn_pageable_json,
     pbn_publication_json,

--- a/src/bpp/tests/test_conftest_preload_safety.py
+++ b/src/bpp/tests/test_conftest_preload_safety.py
@@ -1,0 +1,70 @@
+"""Regression guard for the ``pytest-testcontainers-django`` conftest preload.
+
+The plugin preloads the rootdir ``conftest.py`` from a ``tryfirst``
+``pytest_load_initial_conftests`` hook — i.e. *before* ``pytest-django``
+runs ``django.setup()``.  At that moment Django settings may already be
+configured (``DJANGO_SETTINGS_MODULE`` is set via ``--ds``) but the app
+registry is **not** populated yet.
+
+If any module reachable from the rootdir conftest's ``from fixtures import *``
+imports or defines a Django model at top level, executing that class body
+calls ``apps.get_containing_app_config()`` → ``AppRegistryNotReady:
+Apps aren't loaded yet`` — and the plugin logs a full, alarming traceback
+("preloading rootdir conftest.py raised; continuing") at the end of every run.
+
+Model-bearing fixture modules therefore belong in ``pytest_plugins`` (loaded
+*after* ``django.setup()``), never in the eager ``from fixtures import *``
+chain.  This test reproduces the exact bootstrap state in a clean subprocess
+and asserts the rootdir conftest imports without touching the app registry.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Mimics the plugin's preload: configure settings (read DJANGO_SETTINGS_MODULE)
+# WITHOUT calling django.setup(), then import the rootdir conftest exactly the
+# way the preload does.  A top-level model import anywhere in the
+# `from fixtures import *` chain blows up here with AppRegistryNotReady.
+_PRELOAD_SNIPPET = """
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_bpp.settings.local")
+
+from django.conf import settings
+
+settings.INSTALLED_APPS  # force lazy settings load; does NOT populate apps
+
+import django.apps
+
+assert django.apps.apps.ready is False, (
+    "precondition failed: app registry is already populated; this test must "
+    "run the import BEFORE django.setup() to mirror the plugin preload"
+)
+
+import conftest  # noqa: F401  -- the rootdir conftest the plugin preloads
+"""
+
+
+def test_rootdir_conftest_imports_before_django_setup():
+    env = {
+        **os.environ,
+        # Match pytest.ini's `pythonpath = src` plus the rootdir for `conftest`.
+        "PYTHONPATH": os.pathsep.join([str(REPO_ROOT), str(REPO_ROOT / "src")]),
+        "DJANGO_BPP_TESTING": "1",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", _PRELOAD_SNIPPET],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "Importing the rootdir conftest before django.setup() failed — a "
+        "top-level Django model import leaked into the `from fixtures import *` "
+        "preload chain. Move it into a pytest_plugins module instead.\n\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )

--- a/src/bpp/tests/test_views/test_api.py
+++ b/src/bpp/tests/test_views/test_api.py
@@ -16,8 +16,7 @@ from bpp.views.api import (
 )
 from bpp.views.api.pbn_get_by_parameter import GetPBNPublicationsByISBN
 from bpp.views.api.pubmed import GetPubmedIDView, get_data_from_ncbi
-from fixtures import pbn_publication_json
-from fixtures.pbn_api import pbn_pageable_json
+from fixtures.pbn_api import pbn_pageable_json, pbn_publication_json
 
 
 def test_get_data_from_ncbi(mocker):

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -50,6 +50,13 @@ pytest_plugins = [
     "fixtures.conftest_system",
     "fixtures.conftest_browser",
     "fixtures.conftest_disciplines",
+    # ``pbn_api`` i ``wydawnictwa`` importują modele Django na top-levelu,
+    # więc MUSZĄ być rejestrowane tutaj (plugin ładowany po ``django.setup()``),
+    # a NIE przez ``from fixtures import *`` w rootdir-owym ``conftest.py`` —
+    # ten jest preloadowany ZANIM apps Django są ready i wybucha
+    # ``AppRegistryNotReady``. Guard: bpp/tests/test_conftest_preload_safety.py.
+    "fixtures.pbn_api",
+    "fixtures.wydawnictwa",
 ]
 
 # Baseline test-DB monkey-patch is installed by

--- a/src/fixtures/__init__.py
+++ b/src/fixtures/__init__.py
@@ -1,15 +1,25 @@
 """Public symbols re-eksportowane z ``fixtures`` do użycia w testach.
 
-Nie importujemy tu ``conftest_*`` — zostały zarejestrowane jako
-pytest plugins w ``src/conftest.py`` (``pytest_plugins = [...]``),
-a eager import pociągałby je PRZED rejestracją przez pytest,
-skutkując ``PytestAssertRewriteWarning: Module already imported so
-cannot be rewritten``.
+Tu wolno importować WYŁĄCZNIE moduły wolne od Django. Rootdir-owy
+``conftest.py`` robi ``from fixtures import *``, a ``pytest-testcontainers-
+django`` preloaduje ten conftest ZANIM ``django.setup()`` się wykona
+(hook ``pytest_load_initial_conftests``, tryfirst). Każdy top-levelowy
+import modelu w tym łańcuchu wybucha ``AppRegistryNotReady`` i psuje
+preload (regresja patch'owana wielokrotnie — patrz
+``src/bpp/tests/test_conftest_preload_safety.py``).
+
+Dlatego moduły z fiksturami, które importują modele (``pbn_api``,
+``wydawnictwa``, ``conftest_*``) NIE są tu importowane — rejestrujemy je
+jako pytest plugins w ``conftest.py`` (``pytest_plugins = [...]``),
+ładowane DOPIERO po ``django.setup()``. Eager import pociągałby je też
+PRZED rejestracją przez pytest, skutkując ``PytestAssertRewriteWarning:
+Module already imported so cannot be rewritten``.
+
+Niefiksturowe symbole tych modułów (helpery ``pbn_*_json``, stałe
+``MOCK_*``) importuj wprost: ``from fixtures.pbn_api import ...``.
 
 Stałe (``NORMAL_DJANGO_USER_*``, ``JEDNOSTKA_*``) trzymamy w
-``fixtures.const`` — oddzielonym od modułów-pluginów.
+``fixtures.const`` — wolnym od Django.
 """
 
 from .const import *  # noqa
-from .pbn_api import *  # noqa
-from .wydawnictwa import *  # noqa

--- a/src/fixtures/pbn_api.py
+++ b/src/fixtures/pbn_api.py
@@ -2,15 +2,8 @@ from http.server import HTTPServer
 from uuid import uuid4
 
 import pytest
+from model_bakery import baker
 
-# UWAGA: `from model_bakery import baker` jest robione lokalnie w funkcjach,
-# nie na top-levelu. Powod: rootdir-owy `conftest.py` robi `from fixtures
-# import *`, ktore preloaduje ten modul. `pytest-testcontainers-django`
-# preloaduje conftest ZANIM apps Django sa ready. `model_bakery` >= 1.20
-# wola `apps.is_installed("django.contrib.contenttypes")` w czasie importu
-# (model_bakery/content_types.py), co wybucha ImproperlyConfigured i
-# psuje preload (warning "preloading rootdir conftest.py raised").
-# Lazy import wewnatrz fikstur omija ten lancuch.
 from bpp import const
 from bpp.const import RODZAJ_PBN_KSIAZKA
 from bpp.models import Charakter_Formalny, Jezyk, Uczelnia, Wydawnictwo_Ciagle
@@ -91,8 +84,6 @@ def pbn_language():
 
 
 def _zrob_autora_pbn(autor):
-    from model_bakery import baker
-
     autor.pbn_uid = baker.make(Scientist)
     autor.save()
     return autor
@@ -105,8 +96,6 @@ def pbn_autor(autor_jan_nowak):
 
 @pytest.fixture
 def pbn_jednostka(jednostka):
-    from model_bakery import baker
-
     jednostka.pbn_uid = baker.make(Institution)
     jednostka.save()
     return jednostka
@@ -187,8 +176,6 @@ def pbn_rozdzial_z_autorem_z_dyscyplina(
 
 @pytest.fixture
 def pbn_charakter_formalny() -> Charakter_Formalny:
-    from model_bakery import baker
-
     return baker.make(Charakter_Formalny, rodzaj_pbn=RODZAJ_PBN_KSIAZKA)
 
 
@@ -240,8 +227,6 @@ def pbn_wydawnictwo_zwarte_z_charakterem(
 
 @pytest.fixture
 def pbn_uczelnia(pbn_client) -> Uczelnia:
-    from model_bakery import baker
-
     uczelnia = Uczelnia.objects.get_default()
     if uczelnia is None:
         uczelnia = baker.make(

--- a/src/fixtures/wydawnictwa.py
+++ b/src/fixtures/wydawnictwa.py
@@ -1,4 +1,5 @@
 import pytest
+from model_bakery import baker
 
 from bpp.models import Wydawnictwo_Zwarte
 
@@ -6,11 +7,6 @@ from bpp.models import Wydawnictwo_Zwarte
 @pytest.fixture
 def wydawnictwo_nadrzedne(wydawnictwo_zwarte):
     """Zwraca nowe wydawnictwo, bedace nadrzednym dla domyslnej fikstury wydawnictwa zwartego."""
-    # Lazy import baker — patrz fixtures/pbn_api.py po pelne uzasadnienie.
-    # TL;DR: model_bakery wola apps.is_installed() w czasie importu, co
-    # psuje preload conftesta przez pytest-testcontainers-django.
-    from model_bakery import baker
-
     wn = baker.make(Wydawnictwo_Zwarte)
     wydawnictwo_zwarte.wydawnictwo_nadrzedne_id = wn.pk
     wydawnictwo_zwarte.save(update_fields=["wydawnictwo_nadrzedne_id"])

--- a/src/pbn_api/tests/test_bpp_admin_helpers.py
+++ b/src/pbn_api/tests/test_bpp_admin_helpers.py
@@ -4,8 +4,12 @@ from model_bakery import baker
 
 from bpp.admin.helpers.pbn_api.gui import sprobuj_wyslac_do_pbn_gui
 from bpp.models import Charakter_Formalny, Wydawnictwo_Ciagle
-from fixtures import MOCK_MONGO_ID, MOCK_RETURNED_INSTITUTION_PUBLICATION_V2_DATA
-from fixtures.pbn_api import MOCK_RETURNED_MONGODB_DATA, pbn_pageable_json
+from fixtures.pbn_api import (
+    MOCK_MONGO_ID,
+    MOCK_RETURNED_INSTITUTION_PUBLICATION_V2_DATA,
+    MOCK_RETURNED_MONGODB_DATA,
+    pbn_pageable_json,
+)
 from pbn_api.adapters.wydawnictwo import WydawnictwoPBNAdapter
 from pbn_api.client import (
     PBN_GET_INSTITUTION_STATEMENTS,

--- a/src/pbn_api/tests/test_client_helpers.py
+++ b/src/pbn_api/tests/test_client_helpers.py
@@ -11,8 +11,11 @@ from django.contrib.messages import get_messages
 from model_bakery import baker
 
 from bpp.admin.helpers.pbn_api.gui import sprobuj_wyslac_do_pbn_gui
-from fixtures import MOCK_RETURNED_INSTITUTION_PUBLICATION_V2_DATA
-from fixtures.pbn_api import MOCK_RETURNED_MONGODB_DATA, pbn_pageable_json
+from fixtures.pbn_api import (
+    MOCK_RETURNED_INSTITUTION_PUBLICATION_V2_DATA,
+    MOCK_RETURNED_MONGODB_DATA,
+    pbn_pageable_json,
+)
 from pbn_api.client import (
     PBN_GET_INSTITUTION_STATEMENTS,
     PBN_GET_PUBLICATION_BY_ID_URL,

--- a/src/pbn_api/tests/test_client_sync.py
+++ b/src/pbn_api/tests/test_client_sync.py
@@ -9,8 +9,11 @@ For helper/GUI tests, see test_client_helpers.py
 import pytest
 
 from bpp.decorators import json
-from fixtures import MOCK_RETURNED_INSTITUTION_PUBLICATION_V2_DATA
-from fixtures.pbn_api import MOCK_RETURNED_MONGODB_DATA, pbn_pageable_json
+from fixtures.pbn_api import (
+    MOCK_RETURNED_INSTITUTION_PUBLICATION_V2_DATA,
+    MOCK_RETURNED_MONGODB_DATA,
+    pbn_pageable_json,
+)
 from pbn_api.client import (
     PBN_DELETE_PUBLICATION_STATEMENT,
     PBN_GET_INSTITUTION_STATEMENTS,


### PR DESCRIPTION
## Problem

Po przebiegu pytesta (najczęściej `make tests-only-playwright`, czyli `-n auto`) na końcu wyskakiwał alarmujący traceback:

```
preloading rootdir conftest.py raised; continuing
...
File "src/fixtures/pbn_api.py", line 16, in <module>
    from bpp.models import Charakter_Formalny, Jezyk, Uczelnia, Wydawnictwo_Ciagle
...
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```

## Przyczyna źródłowa

`pytest-testcontainers-django` preloaduje rootdir-owy `conftest.py` w hooku `pytest_load_initial_conftests` (`tryfirst`), **ZANIM** `pytest-django` zrobi `django.setup()`. Rootdir conftest robi `from fixtures import *`, które przez `fixtures/__init__.py` eager-importowało `fixtures.pbn_api` i `fixtures.wydawnictwa`. Te moduły importują modele Django na top-levelu — a wykonanie ciała klasy modelu woła `apps.get_containing_app_config()`, co przy niezaludnionym rejestrze apps wybucha `AppRegistryNotReady`.

Plugin łapie wyjątek i kontynuuje (traceback jest **kosmetyczny** — testy i tak się wykonują; `make ... Error 1` to osobny wynik testów), ale szum jest mylący.

To **regresja**: commit `0688508bf` załatał tę samą klasę błędu, ale tylko dla `model_bakery` (wtedy `ImproperlyConfigured`). `from bpp.models import` / `from pbn_api.models import` zostały eager i znów psują preload — tym razem jako `AppRegistryNotReady` (bo `--ds` ustawia `DJANGO_SETTINGS_MODULE`, więc settings są skonfigurowane, ale `apps.populate()` jeszcze nie ruszyło). Dlatego bije pod `-n auto`, gdzie kolejność rejestracji pluginów daje wygraną `tryfirst` preloadu nad `django.setup()`.

## Rozwiązanie (trwałe, nie kolejny lazy-import)

`pbn_api` i `wydawnictwa` rejestrowane jako pytest pluginy w `src/conftest.py` (ładowane **PO** `django.setup()`, dokładnie jak siostrzane `conftest_*`), i usunięte z eager `from fixtures import *`. Dzięki temu mogą swobodnie importować modele na top-levelu jak każdy `conftest_*`.

- Niefiksturowe symbole (`pbn_*_json`, `MOCK_*`) importowane wprost z `fixtures.pbn_api` w 5 miejscach (zgodnie z istniejącym wzorcem).
- Zbędne już lazy-importy `model_bakery` w obu modułach usunięte (czysty top-level import).
- Komentarze w obu conftestach + `fixtures/__init__.py` wyjaśniają kontrakt: w łańcuchu `from fixtures import *` wolno tylko moduły **wolne od Django**.

## Regresja-guard

`src/bpp/tests/test_conftest_preload_safety.py` — w subprocessie odtwarza dokładny stan preloadu (settings skonfigurowane, apps **nie** zaludnione) i asertuje, że rootdir conftest importuje się bez `AppRegistryNotReady`. Łapie każdy przyszły top-levelowy import modelu, który wpadnie do `from fixtures import *`.

## Weryfikacja

- ✅ Nowy guard: RED na starym kodzie (odtwarza dokładny traceback usera), GREEN po fixie (0.3 s, bez DB).
- ✅ `--fixtures` pokazuje `pbn_uczelnia`, `pbn_client`, `wydawnictwo_nadrzedne`; **brak** `PytestAssertRewriteWarning`.
- ✅ Slice z prawdziwą bazą (testcontainers), pokrywający wszystkie 5 zmienionych plików + konsumentów obu przeniesionych modułów fikstur: **74 passed** (wcześniej 30 errors `fixture not found` w trakcie iteracji — naprawione przez rejestrację w `src/conftest.py`).
- ✅ `ruff check` / `ruff format` czyste; pre-commit przechodzi (poza `trufflehog`, który lokalnie nie jest zainstalowany — `command not found`, bez związku ze zmianą).

🤖 Generated with [Claude Code](https://claude.com/claude-code)