### PR TITLE
perf(tests): tańsza kolekcja + szersze pokrycie testu admina

### DIFF
--- a/src/bpp/tests/test_admin/test_admin.py
+++ b/src/bpp/tests/test_admin/test_admin.py
@@ -1,10 +1,10 @@
 from unittest.mock import Mock
 
 import pytest
-from django.apps import apps
+from django.contrib import admin
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
-from django.urls import NoReverseMatch
+from django.test import RequestFactory
 from django.urls.base import reverse
 from model_bakery import baker
 
@@ -127,33 +127,31 @@ def test_zapisz_wydawnictwo_w_adminie(klass, autor_klass, name, url, admin_app):
     Autorzy.objects.all().delete()
 
 
-# Parametryzujemy WYŁĄCZNIE po modelach z aplikacji `bpp`. Wcześniej było
-# `apps.get_models()` (wszystkie modele całego projektu) + `if app_label !=
-# "bpp": return` w ciele — to generowało setki pustych no-op item-ów w raporcie
-# i niepotrzebnie obciążało kolekcję. Filtr na poziomie parametryzacji daje
-# identyczne pokrycie (modele nie-bpp i tak były pomijane), tylko bez śmieci.
-_BPP_MODELS = [m for m in apps.get_models() if m._meta.app_label == "bpp"]
+# Parametryzujemy po KAŻDYM modelu zarejestrowanym w adminie (nie tylko `bpp`).
+# Źródłem prawdy jest `admin.site._registry` — czyli dokładnie te modele, które
+# faktycznie mają strony w adminie.
+_ADMIN_MODELS = sorted(
+    admin.site._registry,
+    key=lambda m: (m._meta.app_label, m._meta.model_name),
+)
 
 
-@pytest.mark.parametrize("model", _BPP_MODELS, ids=lambda m: m.__name__)
+@pytest.mark.parametrize(
+    "model",
+    _ADMIN_MODELS,
+    ids=lambda m: f"{m._meta.app_label}.{m._meta.model_name}",
+)
 @pytest.mark.django_db
-def test_widok_admina(admin_client, model):
-    """Wejdź na podstrony admina 'changelist' oraz 'add' dla każdego modelu z aplikacji
-    'bpp' który to istnieje w adminie (został zarejestrowany) i do którego to admin_client
-    ma uprawnienia.
-
-    W ten sposób możemy wyłapać błędy z nazwami pól w adminie, których to Django nie wyłapie
-    przed uruchomieniem aplikacji.
+def test_widok_admina(admin_client, admin_user, model):
+    """Wejdź na podstrony 'changelist' oraz 'add' KAŻDEGO modelu zarejestrowanego
+    w adminie.
     """
 
     app_label = model._meta.app_label
     model_name = model._meta.model_name
+    model_admin = admin.site._registry[model]
 
-    url_name = f"admin:{app_label}_{model_name}_changelist"
-    try:
-        url = reverse(url_name)
-    except NoReverseMatch:
-        return
+    url = reverse(f"admin:{app_label}_{model_name}_changelist")
 
     res = admin_client.get(url)
     assert res.status_code == 200, f"changelist failed for {model!r}"
@@ -161,18 +159,13 @@ def test_widok_admina(admin_client, model):
     res = admin_client.get(url + "?q=fafa")
     assert res.status_code == 200, f"changelist query failed for {model!r}"
 
-    MODELS_WITHOUT_ADD = [
-        ("bpp", "bppmultiseekvisibility"),
-        ("bpp", "rzeczownik"),
-        ("bpp", "oplatypublikacjilog"),
-    ]
-    if (app_label, model_name) in MODELS_WITHOUT_ADD:
+    request = RequestFactory().get("/")
+    request.user = admin_user
+    if not model_admin.has_add_permission(request):
         return
 
-    url_name = f"admin:{app_label}_{model_name}_add"
-    url = reverse(url_name)
+    url = reverse(f"admin:{app_label}_{model_name}_add")
     res = admin_client.get(url)
-
     assert res.status_code == 200, f"add failed for {model!r}"
 
 

--- a/src/bpp/tests/test_admin/test_admin.py
+++ b/src/bpp/tests/test_admin/test_admin.py
@@ -127,7 +127,15 @@ def test_zapisz_wydawnictwo_w_adminie(klass, autor_klass, name, url, admin_app):
     Autorzy.objects.all().delete()
 
 
-@pytest.mark.parametrize("model", apps.get_models())
+# Parametryzujemy WYŁĄCZNIE po modelach z aplikacji `bpp`. Wcześniej było
+# `apps.get_models()` (wszystkie modele całego projektu) + `if app_label !=
+# "bpp": return` w ciele — to generowało setki pustych no-op item-ów w raporcie
+# i niepotrzebnie obciążało kolekcję. Filtr na poziomie parametryzacji daje
+# identyczne pokrycie (modele nie-bpp i tak były pomijane), tylko bez śmieci.
+_BPP_MODELS = [m for m in apps.get_models() if m._meta.app_label == "bpp"]
+
+
+@pytest.mark.parametrize("model", _BPP_MODELS, ids=lambda m: m.__name__)
 @pytest.mark.django_db
 def test_widok_admina(admin_client, model):
     """Wejdź na podstrony admina 'changelist' oraz 'add' dla każdego modelu z aplikacji
@@ -138,12 +146,8 @@ def test_widok_admina(admin_client, model):
     przed uruchomieniem aplikacji.
     """
 
-    # for model in apps.get_models():
     app_label = model._meta.app_label
     model_name = model._meta.model_name
-
-    if app_label != "bpp":
-        return
 
     url_name = f"admin:{app_label}_{model_name}_changelist"
     try:

--- a/src/nowe_raporty/tests/test_docx_export.py
+++ b/src/nowe_raporty/tests/test_docx_export.py
@@ -257,11 +257,28 @@ def test_convert_using_docker_image_custom_docker_image(monkeypatch, tmp_path):
     assert output_path.exists()
 
 
-@pytest.mark.skipif(
-    subprocess.run(["docker", "info"], capture_output=True, check=False).returncode
-    != 0,
-    reason="Docker is not available",
-)
+def _docker_available():
+    """Sprawdza dostępność Docker daemona LENIWIE (przy uruchomieniu testu).
+
+    Nie wołaj tego w `@pytest.mark.skipif(...)` — argumenty dekoratora liczą
+    się w momencie *importu* modułu (czyli przy każdej kolekcji pytest, także
+    `pytest -k cos_innego`), więc `docker info` startowałby na każdym przebiegu
+    i niepotrzebnie wiązał całą sesję z demonem Dockera. Wywołane wewnątrz
+    ciała testu odpala się tylko wtedy, gdy ten test naprawdę jest zbierany
+    do uruchomienia.
+    """
+    try:
+        return (
+            subprocess.run(
+                ["docker", "info"], capture_output=True, check=False
+            ).returncode
+            == 0
+        )
+    except FileNotFoundError:
+        return False
+
+
+@pytest.mark.slow
 def test_convert_using_docker_image_integration(tmp_path):
     """Integration test: actual Docker conversion with real html2docx container.
 
@@ -289,6 +306,9 @@ def test_convert_using_docker_image_integration(tmp_path):
     </body>
     </html>
     """
+
+    if not _docker_available():
+        pytest.skip("Docker is not available")
 
     output_path = tmp_path / "integration_test.docx"
 


### PR DESCRIPTION
## Co i dlaczego

Dwa usprawnienia testów wynikłe z analizy `--durations`. **Żadne nie obniża pokrycia** — przeciwnie, drugie je zwiększa.

### 1. `test_docx_export`: koniec z `docker info` przy każdej kolekcji
Test integracyjny był ogated przez `@pytest.mark.skipif(subprocess.run(["docker","info"]...))`. Argument `skipif` liczy się w momencie **importu modułu**, więc `docker info` odpalał się przy **każdym** uruchomieniu pytest (także `pytest -k cos_innego`), wiążąc całą sesję z demonem Dockera. Przeniesione do leniwego `_docker_available()` w ciele testu + `@pytest.mark.slow`.

Na Dockerze test działa **tak samo jak wcześniej** (zweryfikowane: 1 passed). Zmienia się tylko to, że niezwiązane przebiegi nie odpalają już subprocessu przy kolekcji.

### 2. `test_widok_admina`: po CAŁYM rejestrze admina (45 → 133 modele)
Było: parametryzacja po `apps.get_models()` (wszystkie modele projektu) + `if app_label != "bpp": return` → setki pustych no-op item-ów, a realnie testowane tylko 45 modeli `bpp`.

Jest: parametryzacja wprost po `admin.site._registry` → **wszystkie 133 zarejestrowane modele** (pbn_api, ewaluacja_*, deduplikator_*, flexible_reports, third-party adminy...). Strona `add` testowana tylko gdy `ModelAdmin.has_add_permission()` na to pozwala (zastępuje ręczną listę `MODELS_WITHOUT_ADD`).

## Weryfikacja
- `test_widok_admina`: **133/133 PASSED dwukrotnie** w izolacji (124s, 136s).
- `test_docx_export` unit: 11 passed; integracyjny na Dockerze: 1 passed.
- collect-only: bez wywołania `docker info`.
- ruff check + format: czysto.

> Uwaga dla reviewera: przy pierwszym przebiegu widać było 16 "failures" w `test_widok_admina` — to był artefakt równoległego odpalenia kilku procesów pytest z `PYTEST_TESTCONTAINERS_REUSE=1` (współdzielony jeden kontener PG, procesy nadpisywały sobie rollbackowany stan). W izolacji test jest stabilnie zielony; xdist (per-worker DB) tego problemu nie ma.

## Świadomie NIE ruszone
- `test_raport_ewaluacja_no_queries` (N=100) i `test_jednostka_...` (MAX+1 autorów) — zmniejszanie N obniżyłoby realne pokrycie (N=100 jest load-bearing dla `max_num_queries`). Zostają.
- `test_admin_home_links_all_reachable` (97s) — realny smoke-test wszystkich stron admina. Zostaje.

🤖 Generated with [Claude Code](https://claude.com/claude-code)