### PR TITLE
fix(ci): lint via pre-commit so CI and local ruff can't diverge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,12 @@ permissions:
 
 jobs:
   lint:
-    # Lint only Python files changed in this push/PR. The repo's
-    # convention is that ruff runs on changed files only (see
-    # pre-commit config); historic drift in unchanged files is
-    # deliberately left alone, so CI must match that scope.
+    # Lint only Python files changed in this push/PR by running the
+    # pre-commit ruff hooks THEMSELVES (see .pre-commit-config.yaml)
+    # against the changed range. The ruff version + args live in one
+    # place, so local pre-commit and CI can never disagree. The repo's
+    # convention is changed-files-only; pre-commit's --from-ref/--to-ref
+    # reproduces that scope and historic drift is left alone.
     name: Lint changed files
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -33,15 +35,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install system build deps
-        # uv run triggers a full project sync, and several wheels (pycairo
-        # via svglib/xhtml2pdf, psycopg2, python-ldap, cryptography) need
-        # native headers to build. Reuse docker/bpp_base/build.txt so the
-        # package list stays in sync with the runtime/test images.
-        run: |
-          sudo apt-get update
-          xargs -a docker/bpp_base/build.txt sudo apt-get install -y
-
+      # No apt build deps / project sync here: pre-commit builds an
+      # isolated ruff env from a prebuilt wheel (no native compilation),
+      # so the heavy toolchain the test jobs need is unnecessary for
+      # linting. uv is only a fast launcher for pre-commit (via uvx).
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -66,36 +63,37 @@ jobs:
             echo "ref=origin/dev" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Collect changed Python files
-        id: files
+      - name: Ruff + ruff-format (via pre-commit — single source of truth)
+        # Runs the SAME `ruff` and `ruff-format` hooks declared in
+        # .pre-commit-config.yaml (pinned rev) over the changed range, so
+        # CI and a local `pre-commit run` execute the byte-identical ruff
+        # binary + args (--fix --exit-non-zero-on-fix). "passes locally,
+        # fails CI" becomes impossible — there is one ruff, one config.
+        # Bumping the ruff `rev` in .pre-commit-config.yaml updates CI
+        # automatically; no edit here is ever needed for a ruff upgrade.
+        #
+        # pre-commit derives the file scope ITSELF from --from-ref/
+        # --to-ref; we deliberately do NOT hand it a file list. A
+        # hand-rolled `git diff | tr '\n' ' '` list carries a trailing
+        # space, and `pre-commit run --files "<path> "` matches no real
+        # file → "(no files to check) Skipped" → exit 0 → the gate
+        # silently passes broken code. --from-ref/--to-ref sidesteps that
+        # entirely. --show-diff-on-failure prints the exact reformat diff
+        # so the fix is obvious straight from the CI log.
+        #
+        # `uvx` runs pre-commit as an isolated tool, so no `uv sync` / apt
+        # build toolchain is needed merely to lint (pre-commit builds ruff
+        # from a prebuilt wheel — no native code). pre-commit is left
+        # UNPINNED on purpose: it is just the runner, and only the ruff
+        # `rev` in .pre-commit-config.yaml affects results — so there is
+        # no third version to babysit alongside the ruff rev + pin.
         env:
           DIFF_BASE: ${{ steps.base.outputs.ref }}
         run: |
-          files=$(git diff --name-only --diff-filter=AM \
-            "$DIFF_BASE"...HEAD -- '*.py' | tr '\n' ' ')
-          echo "list=$files" >> "$GITHUB_OUTPUT"
-          if [ -n "$files" ]; then
-            echo "Changed Python files:"
-            printf '  %s\n' $files
-          else
-            echo "No Python files changed."
-          fi
-
-      - name: Ruff check
-        # `ruff` siedzi w [dependency-groups].dev (PEP 735); `uv run`
-        # aktywuje grupe `dev` defaultowo, wiec nie ma `--group dev`
-        # / `--extra dev`. $FILES jest env-bounded ponizej (a nie
-        # ${{ ... }} inline), wiec nie ma command injection.
-        if: steps.files.outputs.list != ''
-        env:
-          FILES: ${{ steps.files.outputs.list }}
-        run: uv run ruff check --force-exclude $FILES
-
-      - name: Ruff format --check
-        if: steps.files.outputs.list != ''
-        env:
-          FILES: ${{ steps.files.outputs.list }}
-        run: uv run ruff format --check --force-exclude $FILES
+          uvx pre-commit run ruff \
+            --from-ref "$DIFF_BASE" --to-ref HEAD --show-diff-on-failure
+          uvx pre-commit run ruff-format \
+            --from-ref "$DIFF_BASE" --to-ref HEAD --show-diff-on-failure
 
   prepare-image:
     # Build the test-runner image once and push it to GHCR with two

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -432,7 +432,11 @@ dev = [
     "pytest-shard>=0.1.2",
     "pytest-timeout>=2.1.0",
     "pyparsing>=3.3.2",
-    "ruff>=0.15.12",
+    # Pinned exact, kept in sync with the `ruff-pre-commit` rev in
+    # .pre-commit-config.yaml. CI lints via pre-commit (that rev is the
+    # source of truth); this `==` pin only keeps ad-hoc `uv run ruff`
+    # producing identical output. Bump both together, never one alone.
+    "ruff==0.15.12",
     "djlint>=1.36,<2",
     "pre-commit>=4.6.0",
     "twine>=5.1.0",

--- a/src/importer_publikacji/views/authors.py
+++ b/src/importer_publikacji/views/authors.py
@@ -102,8 +102,7 @@ def _auto_match_single_author(session, author_data, order, year):
     if result.status == StatusPorownania.DOKLADNE and bpp_autor:
         imported.match_status = ImportedAuthor.MatchStatus.AUTO_EXACT
     elif (
-        result.status
-        in (StatusPorownania.LUZNE, StatusPorownania.WYMAGA_INGERENCJI)
+        result.status in (StatusPorownania.LUZNE, StatusPorownania.WYMAGA_INGERENCJI)
         and bpp_autor
     ):
         imported.match_status = ImportedAuthor.MatchStatus.AUTO_LOOSE

--- a/uv.lock
+++ b/uv.lock
@@ -530,7 +530,7 @@ dev = [
     { name = "pytest-testcontainers-django", specifier = ">=0.2.2" },
     { name = "pytest-timeout", specifier = ">=2.1.0" },
     { name = "pytest-xdist", specifier = ">=2.3.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
+    { name = "ruff", specifier = "==0.15.12" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.14.2" },
     { name = "towncrier", specifier = ">=22.8.0" },
     { name = "twine", specifier = ">=5.1.0" },


### PR DESCRIPTION
## Problem

CI `Lint changed files` failed `ruff format --check` on `authors.py` ([failed run](https://github.com/iplweb/bpp/actions/runs/26722862869/job/78752985578)). The recurring "passes locally, fails CI" pain — addressed structurally, not with another version bump.

## Root cause

CI re-implemented linting with `uv run ruff check/format`, taking ruff from `pyproject.toml` — a **second, independent** ruff declaration that can drift from the `rev` pinned in `.pre-commit-config.yaml`. `authors.py` landed via #240 with pre-commit bypassed, so the drift surfaced as a red `dev`.

## Fix

CI now runs the pre-commit **`ruff` + `ruff-format` hooks themselves** (`uvx pre-commit run … --from-ref/--to-ref`). `.pre-commit-config.yaml` is the single source of truth for the gate — local `pre-commit` and CI execute the byte-identical ruff. **Bumping the ruff `rev` there updates CI automatically**; `tests.yml` needs no edit for a ruff upgrade.

### Notes
- **`--from-ref/--to-ref`, not a hand-rolled file list.** `git diff | tr '\n' ' '` leaves a trailing space; `pre-commit run --files "<path> "` matches no real file → `(no files to check) Skipped` → exit 0 → the gate **silently passes broken code**. The ref-range form avoids that trap. Verified locally: a committed format violation fails the gate; a clean tree passes and actually checks the changed file.
- **pre-commit left unpinned** (`uvx pre-commit`): it's only the runner; only the ruff rev affects results — no third version to babysit.
- **Lint job no longer needs apt build deps / `uv sync`** (pre-commit builds ruff from a prebuilt wheel) → faster.
- `pyproject` keeps `ruff==0.15.12` (synced with the hook rev) **only** so the documented `uv run ruff format .` matches the gate; CI doesn't consume it.
- Also formatted `authors.py` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code) using `github-build-fixer` skill