### PR TITLE
fix(tests): wait for the / shortcut to be live, then press once (repair test_global_search)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,6 +380,26 @@ usuwajacy tagi starsze niz N dni.
 - Fixtures in `src/conftest.py` and subdirectories
 - Full suite timeout: at least 600000ms (10 minutes)
 
+### Testy Playwright (`src/integration_tests/`) lokalnie
+
+Testy przeglądarkowe (np. `test_global_search.py`) **da się** odpalić
+lokalnie — testcontainery same stawiają PostgreSQL + Redis, a fixture
+`channels_live_server` startuje Daphne. Trzeba tylko mieć zbudowany
+frontend i przeglądarki Playwright:
+
+```bash
+make assets              # zbuduj CSS/JS + .mo — BEZ tego live server
+                         # nie wyrenderuje strony i `page.goto` timeoutuje
+make playwright-install  # jednorazowo: pobierz przeglądarki Playwright
+uv run pytest src/integration_tests/test_global_search.py::test_global_search_user
+```
+
+- Pierwszy run bywa wolny (cold start testcontainerów) i `page.goto`
+  potrafi raz timeoutnąć — **ponów**, kolejne są szybkie (~2 s/test).
+- `--count=N` (pytest-repeat) powtarza test N razy — przydatne do
+  łapania timing-flake'ów Playwrighta.
+- Żeby pominąć browser-testy w ogóle: `make tests-without-playwright`.
+
 ### Testcontainers
 
 Testy używają plugin-ow `pytest-testcontainers` + `pytest-testcontainers-django`

--- a/src/integration_tests/test_global_search.py
+++ b/src/integration_tests/test_global_search.py
@@ -7,6 +7,30 @@ from bpp.models import Rekord, Wydawnictwo_Ciagle
 from django_bpp.playwright_util import select_select2_autocomplete, wait_for_page_load
 
 
+def open_global_search(page: Page) -> None:
+    """Press "/" once to open the global-search modal — after the shortcut
+    is actually live.
+
+    The "/" shortcut is a document-level ``keydown`` handler installed by
+    the modal script's IIFE, which in the same run also defines
+    ``window.openGlobalSearch``. ``wait_for_page_load`` only blocks for
+    ``domcontentloaded``, so on a slow (CI) page jQuery + that inline
+    script may not have finished when the test runs — the handler isn't
+    bound yet and a single ``press("/")`` is silently dropped. This is the
+    flakiness #254 exposed by deleting the fixed ``time.sleep`` that used
+    to wait the script out.
+
+    Waiting for ``window.openGlobalSearch`` to exist is the precise
+    readiness signal: it is defined by the same IIFE that binds the
+    keydown listener, so once it is a function the shortcut is live. Then
+    press "/" exactly once, the way a user would — the test still verifies
+    that a single keystroke opens the dialog.
+    """
+    page.wait_for_function("() => typeof window.openGlobalSearch === 'function'")
+    page.keyboard.press("/")
+    page.wait_for_selector("#globalSearchInput", state="visible", timeout=5000)
+
+
 def test_global_search_user(
     channels_live_server,
     page: Page,
@@ -23,17 +47,12 @@ def test_global_search_user(
         page.goto(channels_live_server.url)
         wait_for_page_load(page)
 
-        # Accept cookies if needed. `Cookielaw.accept()` is synchronous, so
-        # the banner is gone once evaluate() returns — no fixed sleep needed
-        # before pressing "/"; `wait_for_selector(state="visible")` below
-        # poll-uje az dialog wyszukiwarki sie pojawi.
+        # Accept cookies if needed (synchronous; banner gone once it returns).
         page.evaluate("if (typeof Cookielaw !== 'undefined') { Cookielaw.accept(); }")
 
-        # Press "/" to open the global search dialog
-        page.keyboard.press("/")
-
-        # Wait for the dialog/input to be visible
-        page.wait_for_selector("#globalSearchInput", state="visible", timeout=5000)
+        # Open the global search dialog via the "/" shortcut (resilient to
+        # the keydown handler not yet being live on a cold CI page).
+        open_global_search(page)
 
         # Type the search term directly into the input
         page.fill("#globalSearchInput", "Test")
@@ -92,21 +111,14 @@ def test_global_search_logged_in(
         admin_page.goto(channels_live_server_per_test.url)
         wait_for_page_load(admin_page)
 
-        # Accept cookies if needed
-        # `Cookielaw.accept()` is synchronous; banner is gone once evaluate()
-        # returns. `wait_for_selector(state="visible")` below poll-uje na
-        # dialog, wiec staly sleep przed press("/") byl martwym czasem.
+        # Accept cookies if needed (synchronous; banner gone once it returns).
         admin_page.evaluate(
             "if (typeof Cookielaw !== 'undefined') { Cookielaw.accept(); }"
         )
 
-        # Press "/" to open the global search dialog
-        admin_page.keyboard.press("/")
-
-        # Wait for the dialog/input to be visible
-        admin_page.wait_for_selector(
-            "#globalSearchInput", state="visible", timeout=5000
-        )
+        # Open the global search dialog via the "/" shortcut (resilient to
+        # the keydown handler not yet being live on a cold CI page).
+        open_global_search(admin_page)
 
         # Type the search term directly into the input - use the unique title
         admin_page.fill("#globalSearchInput", unique_title)


### PR DESCRIPTION
## Summary

`test_global_search_user` / `_logged_in` started failing **deterministically** on `dev` CI (`Page.wait_for_selector("#globalSearchInput") Timeout`) after #254 removed the `time.sleep(0.5)` between `Cookielaw.accept()` and `keyboard.press("/")`. (`tests.yml` is red on `origin/dev` itself; this also blocks #256.)

## Root cause (confirmed by probing the live page)

`wait_for_page_load` only blocks for `domcontentloaded`. On a slow CI page, jQuery + the inline global-search modal script haven't finished running yet, so the `/` keydown handler **isn't bound** — the single press is silently dropped and the modal never opens. (Locally the script is ready ~6 ms after load and there's **no** post-load navigation, which is exactly why it only reproduces on slow CI.) The deleted `sleep` was load-bearing: it waited that script out.

## Fix (faithful to the test's intent)

Wait for `window.openGlobalSearch` to exist — it's defined by the **same IIFE that binds the keydown listener**, so it's a precise "shortcut is live" signal — then press `/` **exactly once**, as a user would. The test still verifies that a *single keystroke* opens the dialog: no retry loop, no fixed sleep, no `evaluate`.

```python
page.wait_for_function("() => typeof window.openGlobalSearch === 'function'")
page.keyboard.press("/")
page.wait_for_selector("#globalSearchInput", state="visible", timeout=5000)
```

## Verification

- **Locally** (`make assets` + `make playwright-install`): both tests pass 3× each (6/6).
- CI on this PR (shard 6 carries both tests).

Also adds a short CLAUDE.md section documenting how to run a Playwright integration test locally (the gap that made this harder than it should've been).

Unblocks #256.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)