### PR TITLE
chore(make): add baseline-update target (in-place baseline refresh)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,10 +362,26 @@ tests-fresh: destroy-test-databases tests ## Jak `tests`, ale od zera (destroy-t
 # Regenerate baseline-sql/baseline.sql by spinning up an isolated
 # postgres (via testcontainers), running migrate, dumping, and writing
 # baseline.meta.json. Commit the refreshed files to git.
-rebuild-baseline: ## Regeneruj baseline.sql do przyspieszenia testów (commit efektu!)
+rebuild-baseline: ## Regeneruj baseline.sql OD ZERA (pełny reset; duży diff)
 	DJANGO_BPP_SKIP_DOTENV=1 uv run python src/manage.py baseline_rebuild
 	@echo ""
 	@echo "Baseline regenerated. Files:"
+	@ls -lh baseline-sql/baseline.sql baseline-sql/baseline.meta.json
+	@echo ""
+	@echo "Don't forget to commit:"
+	@echo "    git add baseline-sql/baseline.sql baseline-sql/baseline.meta.json"
+
+# Update baseline-sql/baseline.sql IN PLACE: load the existing baseline
+# into an isolated postgres, apply pending migrations, dump back. Preserves
+# auto-increment IDs and the existing dump representation, so the diff is
+# just the delta of the new migrations -- no full auth/* table churn (column
+# reordering, IDENTITY-vs-serial) that the from-scratch `rebuild-baseline`
+# produces. This is the usual way to refresh the baseline after adding
+# migrations; reach for `rebuild-baseline` only for a full reset.
+baseline-update: ## Zaktualizuj baseline.sql IN-PLACE (load+migrate+dump; mały diff)
+	DJANGO_BPP_SKIP_DOTENV=1 uv run python src/manage.py baseline_update
+	@echo ""
+	@echo "Baseline updated in place. Files:"
 	@ls -lh baseline-sql/baseline.sql baseline-sql/baseline.meta.json
 	@echo ""
 	@echo "Don't forget to commit:"


### PR DESCRIPTION
## Summary

Adds a `make baseline-update` target wrapping the `baseline_update` management command, for the common case of refreshing `baseline.sql` after adding migrations.

**Why:** `make rebuild-baseline` runs `baseline_rebuild` — a from-scratch rebuild on an empty DB + full re-dump. Even for a one-migration change that produces a huge diff: `auth/*` and other tables get re-emitted with reordered columns, `IDENTITY`-vs-`serial`, fresh sequences. `baseline_update` instead **loads the existing baseline, applies pending migrations, and dumps back in place**, preserving auto-increment IDs and the existing representation — so the diff is just the delta.

## Verification

Ran `make baseline-update` against the current dev baseline: it touched **2/17 lines** of `baseline.sql` (`django_migrations` + one data table), with **no auth-table churn** — vs the ~1960-line rewrite `rebuild-baseline` produces. `make help` lists both targets; recipe dry-run is clean.

Also clarifies the `rebuild-baseline` help text as the from-scratch (big-diff, full-reset) option.

```
rebuild-baseline   Regeneruj baseline.sql OD ZERA (pełny reset; duży diff)
baseline-update    Zaktualizuj baseline.sql IN-PLACE (load+migrate+dump; mały diff)
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)