### PR TITLE
fix(notifications): pozwól anonimom łączyć się z WS notyfikacji

### DIFF
--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -889,6 +889,19 @@ CHANNEL_LAYERS = {
     },
 }
 
+# Pozwól anonimowym użytkownikom łączyć się z WebSocketem notyfikacji
+# (/asgi/notifications/) i subskrybować globalny kanał "__all__".
+#
+# django-channels-broadcast domyślnie (CHANNELS_BROADCAST_ENABLE_ANONYMOUS=False)
+# odrzuca anonimów w NotificationsConsumer.connect() przez self.close() PRZED
+# self.accept() — uvicorn zwraca wtedy HTTP 403 na handshake, a przeglądarka
+# raportuje NS_ERROR_WEBSOCKET_CONNECTION_REFUSED. Stary lokalny src/notifications/
+# consumer akceptował połączenie bezwarunkowo, więc po przepięciu na pakiet
+# zewnętrzny (refactor f6e0fa6cf) anonimowy front przestał się łączyć. Ta flaga
+# przywraca poprzednie zachowanie. Kanał "__all__" jest globalnym broadcastem —
+# nie publikuj na nim danych wrażliwych.
+CHANNELS_BROADCAST_ENABLE_ANONYMOUS = True
+
 
 # django-compressor dla każdej wersji będzie miał swoją nazwę katalogu
 # wyjściowego, z tej prostej przyczyny, że nie wszystkie przeglądarki

--- a/src/django_bpp/tests/test_asgi_notifications.py
+++ b/src/django_bpp/tests/test_asgi_notifications.py
@@ -1,0 +1,66 @@
+"""Regresja: anonimowy klient musi móc nawiązać WebSocket /asgi/notifications/.
+
+Przejście notyfikacji z lokalnego ``src/notifications/`` na pakiet
+``django-channels-broadcast`` (refactor f6e0fa6cf) wprowadziło bramkę w
+``NotificationsConsumer.connect()``: anonim jest odrzucany (``self.close()``
+PRZED ``self.accept()``) gdy ``CHANNELS_BROADCAST_ENABLE_ANONYMOUS`` jest
+wyłączone (domyślna wartość pakietu to ``False``). uvicorn zwraca wtedy HTTP 403
+na handshake, a przeglądarka raportuje ``NS_ERROR_WEBSOCKET_CONNECTION_REFUSED``.
+
+Stary lokalny consumer akceptował połączenie bezwarunkowo, więc po przepięciu na
+pakiet zewnętrzny anonimowy front przestał się łączyć. BPP ustawia flagę na
+``True`` (``settings/base.py``), żeby przywrócić poprzednie zachowanie — ten
+plik to przypina, żeby ktoś przypadkiem nie zdjął/odwrócił ustawienia.
+
+Test jest celowo hermetyczny: ``on_connect`` (replay z bazy) jest zamockowany,
+więc nie potrzebujemy DB ani Redisa — exerciseujemy wyłącznie bramkę
+auth + accept/close na ``InMemoryChannelLayer``. ``async_to_sync`` odpala
+asynchroniczny ``WebsocketCommunicator`` w syncowym teście (repo nie ma
+``pytest-asyncio``).
+"""
+
+from asgiref.sync import async_to_sync
+from channels.testing import WebsocketCommunicator
+from channels_broadcast.consumers import NotificationsConsumer
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
+
+PATH = "/asgi/notifications/"
+INMEMORY_LAYER = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+
+
+def _connect_as_anonymous():
+    """Otwórz WS jako anonim i zwróć, czy handshake został zaakceptowany."""
+
+    async def _run():
+        communicator = WebsocketCommunicator(NotificationsConsumer.as_asgi(), PATH)
+        communicator.scope["user"] = AnonymousUser()
+        connected, _ = await communicator.connect()
+        if connected:
+            await communicator.disconnect()
+        return connected
+
+    return async_to_sync(_run)()
+
+
+def test_bpp_enables_anonymous_notifications():
+    """Kontrakt z frontem: BPP ma włączone anonimowe notyfikacje."""
+    assert settings.CHANNELS_BROADCAST_ENABLE_ANONYMOUS is True
+
+
+def test_anonymous_user_can_connect(settings, mocker):
+    """Z flagą BPP (True) anonim nawiązuje WS — handshake zaakceptowany."""
+    settings.CHANNEL_LAYERS = INMEMORY_LAYER
+    settings.CHANNELS_BROADCAST_ENABLE_ANONYMOUS = True
+    mocker.patch("channels_broadcast.models.Notification.objects.on_connect")
+
+    assert _connect_as_anonymous() is True
+
+
+def test_anonymous_rejected_when_flag_disabled(settings, mocker):
+    """Objaw sprzed fixu: bez flagi anonim jest odrzucany (close przed accept)."""
+    settings.CHANNEL_LAYERS = INMEMORY_LAYER
+    settings.CHANNELS_BROADCAST_ENABLE_ANONYMOUS = False
+    mocker.patch("channels_broadcast.models.Notification.objects.on_connect")
+
+    assert _connect_as_anonymous() is False


### PR DESCRIPTION
## Problem

Anonimowy użytkownik dostaje w przeglądarce:

```
Firefox nie może nawiązać połączenia z serwerem wss://<host>/asgi/notifications/.
NS_ERROR_WEBSOCKET_CONNECTION_REFUSED
```

(zgłoszone na staging `bpp-test.umlub.pl`).

## Root cause

Refactor `f6e0fa6cf` (przepięcie notyfikacji z lokalnego `src/notifications/` na pakiet `django-channels-broadcast`) wprowadził regresję. Nowy `NotificationsConsumer.connect()` odrzuca anonima — woła `self.close()` **przed** `self.accept()` — gdy `CHANNELS_BROADCAST_ENABLE_ANONYMOUS` jest wyłączone, a **default pakietu to `False`**. uvicorn zwraca wtedy HTTP 403 na handshake, więc przeglądarka raportuje `NS_ERROR_WEBSOCKET_CONNECTION_REFUSED`.

Stary lokalny consumer akceptował połączenie **bezwarunkowo**, więc anonimowy front (`bundle-entry.js`) łączył się bez problemu aż do tego refaktora.

Wykluczone (nie były przyczyną):
- commit nginx `bpp-deploy@51ff86d` (WS upgrade / mapa) — dla `@proxy_to_app` zachowanie WS jest identyczne, nginx nie rozróżnia anonim/zalogowany;
- `AllowedHostsOriginValidator` — odrzuca niezależnie od logowania, a host przechodzi (strona ładuje się po HTTP, więc jest w `ALLOWED_HOSTS`).

## Fix

`CHANNELS_BROADCAST_ENABLE_ANONYMOUS = True` w `settings/base.py` — przywraca poprzednie zachowanie (anonim subskrybuje globalny kanał `__all__`).

> ⚠️ `__all__` to globalny broadcast — nie publikować na nim danych wrażliwych.

## Test

`django_bpp/tests/test_asgi_notifications.py` (3 testy, hermetyczne — bez DB/Redisa, `WebsocketCommunicator` + `InMemoryChannelLayer`, `on_connect` zmockowane, `async_to_sync` bo repo nie ma `pytest-asyncio`):

- `test_bpp_enables_anonymous_notifications` — przypina, że `base.py` trzyma `True`;
- `test_anonymous_user_can_connect` — flaga `True` → anonim się łączy;
- `test_anonymous_rejected_when_flag_disabled` — flaga `False` → odrzucony (potwierdza mechanizm objawu).

## Deploy

Zmiana w kodzie bpp wbudowanym w obraz `appserver` → wymaga rebuildu obrazu i `make pull && make up` na staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)