### PR TITLE
fix(static): cache-bust bundle.js + admin JS przez {% compress js %}

### DIFF
--- a/src/django_bpp/templates/admin/base.html
+++ b/src/django_bpp/templates/admin/base.html
@@ -111,7 +111,10 @@
         {% include 'session_security/dialog.html' %}
 
         {# Load SessionSecurity javascript 'class', jquery should be loaded - by you - at this point #}
-        <script type="text/javascript" src="{% static 'bpp/session_security/script_patched.js' %}"></script>
+        {# compress => content-hashed nazwa (cache-bust); musi byc PRZED inline-initem yourlabs.SessionSecurity nizej #}
+        {% compress js %}
+            <script type="text/javascript" src="{% static 'bpp/session_security/script_patched.js' %}"></script>
+        {% endcompress %}
 
         {# Bootstrap a SessionSecurity instance as the sessionSecurity global variable #}
         {% localize off %}

--- a/src/django_bpp/templates/admin/change_form.html
+++ b/src/django_bpp/templates/admin/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls static admin_modify %}
+{% load i18n admin_urls static admin_modify compress %}
 
 <!-- BREADCRUMBS -->
 {% block breadcrumbs %}
@@ -18,7 +18,10 @@
 
 {% block javascripts %}
     {{ block.super }}
-    <script src="{% static 'bpp/js/select2-autofocus.js' %}" type="text/javascript"></script>
+    {# compress => nazwa z content-hashem (cache-bust); inaczej stala nazwa zalega w cache nginxa #}
+    {% compress js %}
+        <script src="{% static 'bpp/js/select2-autofocus.js' %}" type="text/javascript"></script>
+    {% endcompress %}
     <script type="text/javascript">
         (function($) {
             $(document).ready(function() {

--- a/src/django_bpp/templates/bare.html
+++ b/src/django_bpp/templates/bare.html
@@ -57,10 +57,16 @@
         <link rel="stylesheet" href="{% static "datatables.net-zf/css/dataTables.foundation.css" %}"/>
     {% endcompress %}
 
-    {# JavaScript bundle - built with esbuild, includes jQuery and all JS dependencies #}
-    <script src="{% static 'bpp/js/dist/bundle.js' %}"></script>
-    {# Centralized event handlers for data-confirm, data-submit-on-change, data-open-url #}
-    <script src="{% static 'bpp/js/event-handlers.js' %}"></script>
+    {# JavaScript bundle - built with esbuild, includes jQuery and all JS deps. #}
+    {# Owinięte w {% compress js %}, żeby django-compressor wyemitował plik z #}
+    {# content-hashem (CACHE-<VERSION>/js/output.<hash>.js) — cache-busted tak #}
+    {# samo jak output.<hash>.css. Bez tego nginx serwuje wieczny stary #}
+    {# bundle.js spod stałej nazwy (brak hasha => agresywny cache). #}
+    {% compress js %}
+        <script src="{% static 'bpp/js/dist/bundle.js' %}"></script>
+        {# Centralized event handlers: data-confirm, data-submit-on-change, data-open-url #}
+        <script src="{% static 'bpp/js/event-handlers.js' %}"></script>
+    {% endcompress %}
     {% block extrahead_js %}{% endblock %}
 
     {% block extrahead %}


### PR DESCRIPTION
## Problem

`bundle.js` (i kilka innych BPP-owych skryptów) był ładowany **gołym `{% static %}` poza blokiem `{% compress %}`**, więc serwowany pod **stałą nazwą** `/static/bpp/js/dist/bundle.js`. nginx cache'uje `/static/` agresywnie (bez content-hasha w nazwie nie ma jak wymusić refetcha), więc po deployu klienci dostawali **stary `bundle.js`**.

Konkretny objaw zgłoszony przez użytkownika na `bpp-test`:
```
Uncaught ReferenceError: channelsBroadcast is not defined  (index):16
```
Stary bundle nie zawierał globala `channelsBroadcast` (paczka `django-channels-broadcast` **nie** była usunięta — to był stale static), więc wyjątek w `$(document).ready()` w `base.html` ubijał łańcuch ready jQuery → widgety **DAL/select2 się nie inicjalizowały** → puste, nieklikalne pola `jednostka`/`wydzial`/`autor` na `/nowe_raporty/raport-*`.

CSS tego problemu nie miał, bo jest w `{% compress css %}` → `output.<content-hash>.css`.

## Fix

Owinięcie skryptów w `{% compress js %}` — django-compressor emituje `CACHE-<VERSION>/js/output.<content-hash>.js`. Nazwa zmienia się wraz z treścią → **cache busti się sam, identycznie jak CSS**.

| Plik | Skrypt | Kto |
|---|---|---|
| `bare.html` | `bundle.js` + `event-handlers.js` | wszyscy |
| `admin/change_form.html` | `select2-autofocus.js` | admin (add/edit) |
| `admin/base.html` | `session_security/script_patched.js` | admin |

## Weryfikacja

- nazwa pliku `output.<hash>.js` **== `get_hexdigest(treści)`** (compressor `base.py:146`) — udowodnione: render → odczyt serwowanego pliku → przeliczony hash zgadza się z nazwą; inna treść ⇒ inny hash; ta sama treść ⇒ ta sama nazwa.
- kompresja **online** (`COMPRESS_OFFLINE=False`) — ta sama, sprawdzona w produkcji ścieżka co CSS; entrypoint `compress --force` nie wywala się na nowych blokach.
- `rjsmin` na realnym 1.5 MB bundlu: ~0 s, `channelsBroadcast` zachowany.
- szablony parsują się; `{% compress js %}` każdego z 4 skryptów produkuje `output.<hash>.js`.

> **Uwaga deploymentowa:** to zadziała po wdrożeniu obrazu (`COMPRESS_ENABLED = not DEBUG`). Nowy, hashowany URL nie jest w żadnym cache → przy okazji omija zalegający stary `bundle.js` na bpp-test.

## Dług (świadomie poza tym PR)

Audyt pokazał, że pozostałe gołe `{% static %}` (vendored: multiseek, djangoql, grappelli/jqueryui; oraz `defer`-y `formdefaults/modal.js`, `column-picker.js`; data `Polish.json`) też nie są bustowane, ale zmieniają się rzadko. Kompletny fix klasy to `ManifestStaticFilesStorage` — spike pokazał, że współistnieje z compressorem (`COMPRESS_ROOT=STATIC_ROOT`), ale wymaga tolerancyjnej subklasy (vanilla wywala `collectstatic` na sourcemapie `foundation.min.css.map`) — osobny temat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)