### PR TITLE
feat(nowe_raporty): zwarty układ zakresów od–do w "Opcjach zaawansowanych"

### DIFF
--- a/src/nowe_raporty/forms.py
+++ b/src/nowe_raporty/forms.py
@@ -52,16 +52,14 @@ class BaseRaportForm(forms.Form):
     )
 
     # Opcje zaawansowane (schowane domyślnie, filtrują cały raport).
-    punkty_mnisw_od = forms.FloatField(required=False, label="Punkty MNiSW od")
-    punkty_mnisw_do = forms.FloatField(required=False, label="Punkty MNiSW do")
-    if_od = forms.FloatField(required=False, label="Impact Factor od")
-    if_do = forms.FloatField(required=False, label="Impact Factor do")
-    punktacja_wewnetrzna_od = forms.FloatField(
-        required=False, label="Punktacja wewnętrzna od"
-    )
-    punktacja_wewnetrzna_do = forms.FloatField(
-        required=False, label="Punktacja wewnętrzna do"
-    )
+    # Labele są krótkie ("od"/"do"), bo nazwę metryki niesie nagłówek grupy
+    # renderowany w _grupa_zakres() — patrz układ "Opcje zaawansowane".
+    punkty_mnisw_od = forms.FloatField(required=False, label="od")
+    punkty_mnisw_do = forms.FloatField(required=False, label="do")
+    if_od = forms.FloatField(required=False, label="od")
+    if_do = forms.FloatField(required=False, label="do")
+    punktacja_wewnetrzna_od = forms.FloatField(required=False, label="od")
+    punktacja_wewnetrzna_do = forms.FloatField(required=False, label="do")
     tylko_punktowane = forms.BooleanField(
         required=False, label="Tylko prace punktowane (pkt MNiSW > 0)"
     )
@@ -136,32 +134,38 @@ class BaseRaportForm(forms.Form):
             if lata["rok__max"] is not None:
                 field.field.validators.append(MaxValueValidator(lata["rok__max"]))
 
-    def _wiersze_zaawansowane(self):
-        wiersze = [
-            Row(
-                Column("punkty_mnisw_od", css_class="large-6 medium-6 small-12"),
-                Column("punkty_mnisw_do", css_class="large-6 medium-6 small-12"),
+    @staticmethod
+    def _grupa_zakres(naglowek, pole_od, pole_do):
+        """Nagłówek metryki + para pól od/do obok siebie (Opcje zaawansowane).
+
+        Inputy zostają w jednym wierszu także na małych ekranach (small-6),
+        bo zakres "od–do" czyta się jako jedna całość.
+        """
+        return [
+            HTML(
+                '<div class="zaawansowane-grupa-naglowek" '
+                'style="font-weight:600;margin:0.75rem 0 0.25rem;">'
+                f"{naglowek}</div>"
             ),
             Row(
-                Column("if_od", css_class="large-6 medium-6 small-12"),
-                Column("if_do", css_class="large-6 medium-6 small-12"),
+                Column(pole_od, css_class="large-6 medium-6 small-6"),
+                Column(pole_do, css_class="large-6 medium-6 small-6"),
             ),
         ]
+
+    def _wiersze_zaawansowane(self):
+        elementy = [
+            *self._grupa_zakres("Punkty MNiSW", "punkty_mnisw_od", "punkty_mnisw_do"),
+            *self._grupa_zakres("Impact Factor", "if_od", "if_do"),
+        ]
         if "punktacja_wewnetrzna_od" in self.fields:
-            wiersze.append(
-                Row(
-                    Column(
-                        "punktacja_wewnetrzna_od",
-                        css_class="large-6 medium-6 small-12",
-                    ),
-                    Column(
-                        "punktacja_wewnetrzna_do",
-                        css_class="large-6 medium-6 small-12",
-                    ),
-                )
+            elementy += self._grupa_zakres(
+                "Punktacja wewnętrzna",
+                "punktacja_wewnetrzna_od",
+                "punktacja_wewnetrzna_do",
             )
-        wiersze.append(Row(Column("tylko_punktowane")))
-        return wiersze
+        elementy.append(Row(Column("tylko_punktowane")))
+        return elementy
 
 
 def form_class_dla(definicja):


### PR DESCRIPTION
## Co

W formularzach raportów (`/nowe_raporty/raport-*`) sekcja **„Opcje zaawansowane"** renderowała każde pole zakresu jako osobną kolumnę crispy z labelem nad inputem — cztery pola „jedno pod drugim":

```
Punkty MNiSW od          Punkty MNiSW do
[___________]            [___________]
Impact Factor od         Impact Factor do
[___________]            [___________]
```

Teraz każda metryka ma **nagłówek**, a pod nim **parę pól od/do obok siebie** (krótkie labele „od"/„do", `small-6` także na mobile):

```
Punkty MNiSW
[od ____]   [do ____]

Impact Factor
[od ____]   [do ____]

Punktacja wewnętrzna
[od ____]   [do ____]
```

## Jak

- `forms.py`: nowy helper `_grupa_zakres(naglowek, pole_od, pole_do)` (nagłówek `HTML()` + `Row`/`Column`), `_wiersze_zaawansowane()` składa z niego grupy.
- labele pól skrócone do „od"/„do" (nazwę metryki niesie nagłówek grupy).
- **Nazwy pól i `POLA_ZAAWANSOWANE` bez zmian** → kontrakt z `views.zastosuj_filtry_zaawansowane` nietknięty, logika filtrowania i testy działają bez zmian.

## Weryfikacja

- **60/60** testów `nowe_raporty` przechodzi (w tym render widoków).
- render sekcji potwierdzony: nagłówki `zaawansowane-grupa-naglowek`, pary `<label for=id_*_od>od</label>` / `do`, trzy grupy.
- `ruff` + `ruff-format`: Passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)