### PR TITLE
fix(denorm): ON CONFLICT w triggerach autor_dyscyplina + bump django-denorm-iplweb 1.11.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "arrow>=1.3,<2",
     "numpy>=2.4.4",
     "pygad>=3.6.0",
-    "django-denorm-iplweb>=1.10.2",
+    "django-denorm-iplweb>=1.11.1",
     "django-tabular-permissions==2.9.3",
     "simplejson>=4.1.1,<5",
     "django-reversion>=6,<7",

--- a/src/bpp/migrations/0418_autor_dyscyplina_trigger_on_conflict.py
+++ b/src/bpp/migrations/0418_autor_dyscyplina_trigger_on_conflict.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from django.db import connection, migrations
+
+
+def load_sql(apps, schema_editor):
+    sql_file = Path(__file__).parent / "0418_autor_dyscyplina_trigger_on_conflict.sql"
+    with open(sql_file) as f:
+        sql = f.read()
+    # connection.cursor() zamiast schema_editor.execute() — w cqueue sa `%s`,
+    # ktore schema_editor probowalby interpretowac jako placeholdery parametrow.
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bpp", "0417_remove_uczelnia_pokazuj_raport_autorow_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(load_sql, migrations.RunPython.noop),
+    ]

--- a/src/bpp/migrations/0418_autor_dyscyplina_trigger_on_conflict.sql
+++ b/src/bpp/migrations/0418_autor_dyscyplina_trigger_on_conflict.sql
@@ -1,0 +1,134 @@
+BEGIN;
+
+-- denorm 1.11.0 dodaje UNIQUE index `denorm_dirtyinstance_unique` na
+-- (content_type_id, COALESCE(object_id, -1), COALESCE(func_name, '')).
+-- Wlasne triggery BPP (ponizej) enqueue'uja rekordy do denorm_dirtyinstance
+-- surowym INSERT-em z pominieciem maszynerii denorma, ktora swoje wlasne
+-- INSERT-y owija w `BEGIN ... EXCEPTION WHEN unique_violation THEN -- nic END`.
+-- Bez ON CONFLICT te recznie pisane INSERT-y wpadaja w UniqueViolation, gdy ten
+-- sam (content_type_id, rekord_id) jest juz w kolejce (np. powtorka miedzy
+-- iteracjami petli po tabelach / polach). Dodajemy `ON CONFLICT DO NOTHING`
+-- (bez conflict-target — lapie kazdy unique_violation), co odwzorowuje idiom
+-- denorma i jest no-opem na starym denormie bez tego indeksu.
+--
+-- NIE edytujemy 0302 (zakaz modyfikacji istniejacych migracji) — CREATE OR
+-- REPLACE podmienia tylko cialo funkcji; istniejace triggery wiaza sie po
+-- nazwie, wiec nie wymagaja odtworzenia.
+
+CREATE OR REPLACE FUNCTION bpp_autor_dyscyplina_change()
+  RETURNS TRIGGER
+  LANGUAGE plpython3u
+AS
+$$
+  # Uruchamiane w przypadku zmiany dyscypliny obiektu Autor_Dyscyplina
+  # (tabela bpp_autor_dyscyplina)
+
+  # Ta funkcja wygląda jak wygląda, bo w przypadku zmiany dwóch pól tzn dyscyplina_naukowa
+  # oraz subdyscyplina_naukowa, w najgorszym możliwym przypadku -- zamiany jednego z drugim
+  # będzie potrzebne właśnie takie przemapowanie rzeczy:
+
+  if TD['new']['rok'] != TD['old']['rok']:
+    plpy.error("Zmiana roku NIE jest obsługiwana")
+    return
+
+  if TD['new']['autor_id'] != TD['old']['autor_id']:
+    plpy.error("Zmiana ID autora nie jest obsługiwana")
+    return
+
+  rok = TD['new']['rok']
+  autor_id = TD['new']['autor_id']
+
+  f1 = 'dyscyplina_naukowa_id'
+  f2 = 'subdyscyplina_naukowa_id'
+
+  val_f1_old = TD['old'][f1]
+  val_f1_new = TD['new'][f1]
+
+  val_f2_old = TD['old'][f2]
+  val_f2_new = TD['new'][f2]
+
+  diff_f1 = val_f1_old != val_f1_new
+  diff_f2 = val_f2_old != val_f2_new
+
+  # Brak zmian dyscyplin, wróć
+  if not diff_f1 and not diff_f2:
+    return
+
+  qry = """
+    CREATE TEMP TABLE %(temp_table)s AS
+    SELECT %(table)s_autor.id, %(table)s_autor.rekord_id FROM %(table)s, %(table)s_autor
+    WHERE dyscyplina_naukowa_id = %(dyscyplina_id)s
+      AND %(table)s.rok = %(rok)i
+      AND %(table)s.id = %(table)s_autor.rekord_id
+      AND %(table)s_autor.autor_id = %(autor_id)i
+  """
+
+  cqueue = """
+  INSERT INTO denorm_dirtyinstance(content_type_id, object_id) SELECT %(content_type_id)s, rekord_id FROM %(table)s ON CONFLICT DO NOTHING
+  """
+
+  for table in ['bpp_wydawnictwo_ciagle',
+                'bpp_wydawnictwo_zwarte',
+                'bpp_patent']:
+
+    rv = plpy.execute("SELECT id FROM django_content_type WHERE app_label = 'bpp' AND model = '%s'" % table[4:], 1)
+    content_type_id = rv[0]['id']
+
+    if diff_f1 and (val_f1_old != None):
+      plpy.execute(qry % dict(temp_table="dys", table=table, dyscyplina_id=val_f1_old, rok=rok, autor_id=autor_id))
+
+    if diff_f2 and (val_f2_old != None):
+      plpy.execute(qry % dict(temp_table="subdys", table=table, dyscyplina_id=val_f2_old, rok=rok, autor_id=autor_id))
+
+    if diff_f1 and (val_f1_old != None):
+      plpy.execute("UPDATE %s_autor SET dyscyplina_naukowa_id = %s WHERE id IN (SELECT id FROM dys)" % (table, val_f1_new))
+      plpy.execute(cqueue % dict(table="dys", content_type_id=content_type_id))
+      plpy.execute("DROP TABLE dys")
+
+    if diff_f2 and (val_f2_old != None):
+      plpy.execute("UPDATE %s_autor SET dyscyplina_naukowa_id = %s WHERE id IN (SELECT id FROM subdys)" % (table, val_f2_new or "NULL"))
+      plpy.execute(cqueue % dict(table="subdys", content_type_id=content_type_id))
+      plpy.execute("DROP TABLE subdys")
+$$;
+
+
+CREATE OR REPLACE FUNCTION bpp_autor_dyscyplina_delete()
+  RETURNS TRIGGER
+  LANGUAGE plpython3u
+AS
+$$
+  # Uruchamiane w przypadku skasowania wpisu dla roku czyli obiektu Autor_Dyscyplina
+  # (tabela bpp_autor_dyscyplina)
+
+  cqueue = """
+  INSERT INTO denorm_dirtyinstance(content_type_id, object_id) SELECT %(content_type_id)s, rekord_id FROM %(table)s ON CONFLICT DO NOTHING
+  """
+
+  autor_id = TD['old']['autor_id']
+  rok = TD['old']['rok']
+
+  for field in ['dyscyplina_naukowa_id', 'subdyscyplina_naukowa_id']:
+    if TD['old'][field] is None:
+      continue
+
+    for table in ['bpp_wydawnictwo_ciagle',
+                  'bpp_wydawnictwo_zwarte',
+                  'bpp_patent']:
+      rv = plpy.execute("SELECT id FROM django_content_type WHERE app_label = 'bpp' AND model = '%s'" % table[4:], 1)
+      content_type_id = rv[0]['id']
+
+      plpy.execute("""
+      CREATE TEMP TABLE dys AS
+      SELECT %(table)s_autor.id, %(table)s_autor.rekord_id
+      FROM %(table)s, %(table)s_autor
+      WHERE %(table)s.rok = %(rok)i
+        AND %(table)s.id = %(table)s_autor.rekord_id
+        AND %(table)s_autor.autor_id = %(autor_id)i
+      """ % dict(table=table, autor_id=autor_id, rok=rok))
+      plpy.execute("UPDATE %(table)s_autor SET dyscyplina_naukowa_id = NULL WHERE id IN (SELECT id FROM dys)" % dict(table=table))
+      plpy.execute(cqueue % dict(content_type_id=content_type_id, table="dys"))
+      plpy.execute("DROP TABLE dys")
+
+$$;
+
+COMMIT;

--- a/src/bpp/tests/test_cache/test_cache.py
+++ b/src/bpp/tests/test_cache/test_cache.py
@@ -27,7 +27,8 @@ from bpp.models.struktura import Jednostka
 from bpp.models.system import Charakter_Formalny, Jezyk, Typ_KBN, Typ_Odpowiedzialnosci
 from bpp.models.wydawnictwo_ciagle import Wydawnictwo_Ciagle, Wydawnictwo_Ciagle_Autor
 from bpp.models.zrodlo import Zrodlo
-from bpp.tests.helpers import autor as autor_publikacji, ciagle, zwarte
+from bpp.tests.helpers import autor as autor_publikacji
+from bpp.tests.helpers import ciagle, zwarte
 from bpp.tests.util import any_autor, any_ciagle
 
 
@@ -453,7 +454,9 @@ def test_rebuild_ciagle(
     django_assert_max_num_queries, wydawnictwo_ciagle_z_dwoma_autorami, denorms
 ):
     Wydawnictwo_Ciagle.objects.all().delete()
-    with django_assert_max_num_queries(10):
+    # denorm 1.11+ dokłada jedno zapytanie w rebuild/flush (lock-and-capture
+    # dirty PK przez SELECT ... FOR UPDATE — fix wyścigu w flush pipeline).
+    with django_assert_max_num_queries(11):
         denorms.rebuildall("Wydawnictwo_Ciagle")
 
 
@@ -462,7 +465,9 @@ def test_rebuild_zwarte(
     django_assert_max_num_queries, wydawnictwo_zwarte_z_autorem, denorms
 ):
     Wydawnictwo_Zwarte.objects.all().delete()
-    with django_assert_max_num_queries(10):
+    # denorm 1.11+ dokłada jedno zapytanie w rebuild/flush (lock-and-capture
+    # dirty PK przez SELECT ... FOR UPDATE — fix wyścigu w flush pipeline).
+    with django_assert_max_num_queries(11):
         denorms.rebuildall("Wydawnictwo_Zwarte")
 
 

--- a/src/bpp/tests/test_models/test_autor_dyscyplina.py
+++ b/src/bpp/tests/test_models/test_autor_dyscyplina.py
@@ -372,7 +372,10 @@ def test_autor_dyscyplina_cacher_zmiana(
 
     wca.refresh_from_db()
     assert wca.dyscyplina_naukowa == dyscyplina2
-    assert DirtyInstance.objects.count() == 3
+    # denorm 1.11+ dedupuje powtorzone enqueue przez UNIQUE
+    # denorm_dirtyinstance_unique — identyczny (content_type_id, object_id,
+    # func_name) jest wstawiany raz. Wczesniej duplikat dawal 3 wiersze.
+    assert DirtyInstance.objects.count() == 2
 
 
 def test_autor_dyscyplina_cacher_skasowanie(
@@ -397,4 +400,7 @@ def test_autor_dyscyplina_cacher_skasowanie(
 
     wca.refresh_from_db()
     assert wca.dyscyplina_naukowa is None
-    assert DirtyInstance.objects.count() == 3
+    # denorm 1.11+ dedupuje powtorzone enqueue przez UNIQUE
+    # denorm_dirtyinstance_unique — identyczny (content_type_id, object_id,
+    # func_name) jest wstawiany raz. Wczesniej duplikat dawal 3 wiersze.
+    assert DirtyInstance.objects.count() == 2

--- a/src/bpp/tests/test_models/test_wydawca.py
+++ b/src/bpp/tests/test_models/test_wydawca.py
@@ -1,5 +1,6 @@
 import pytest
 from denorm.models import DirtyInstance
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError
 from model_bakery import baker
@@ -57,7 +58,12 @@ def test_wydawnictwo_zwarte_wydawca_change_alias_dla(
     wydawca.alias_dla = wydawca2
     wydawca.save()
 
-    assert DirtyInstance.objects.all().count() == 5
+    # denorm 1.11+ dedupuje powtorzone enqueue przez UNIQUE
+    # denorm_dirtyinstance_unique. Pozostaja 4 odrebne markery: dwa rekordy
+    # Wydawca (calymi instancjami) + dwa cache'owane pola wyd. zwartego
+    # (cached_punkty_dyscyplin, opis_bibliograficzny_cache). Wczesniej jeden
+    # z nich byl wstawiany dwukrotnie, co dawalo 5.
+    assert DirtyInstance.objects.all().count() == 4
 
 
 @pytest.mark.django_db
@@ -81,9 +87,21 @@ def test_wydawnictwo_zwarte_wydawca_change_poziom_ten_sam_rok(
     # Tu przebuduje wydawce + liste poziomow na wydawcy
     denorms.flush(run_once=True)
 
-    # ... a teraz bedzie przebudowywał wyd. zwrate
-    assert DirtyInstance.objects.all().count() == 1
-    assert DirtyInstance.objects.first().object_id == wydawnictwo_zwarte.pk
+    # ... a teraz bedzie przebudowywał wyd. zwrate.
+    #
+    # denorm 1.11+ przy przebudowie Wydawcy re-dirty'uje rowniez sam rekord
+    # Wydawcy (marker calej instancji, func_name=None), wiec po jednym
+    # run_once w kolejce sa 2 markery: downstream wyd. zwarte
+    # (cached_punkty_dyscyplin) + Wydawca. Indeks denorm_dirtyinstance_unique
+    # ich NIE scala — to rozne content_type. Istotne behawioralnie jest, ze
+    # wyd. zwarte zostalo zaplanowane do przeliczenia, a kolejka domyka sie
+    # do zera po pelnym flushu (sprawdzona konwergencja, bez petli).
+    zwarte_ct = ContentType.objects.get_for_model(wydawnictwo_zwarte)
+    assert DirtyInstance.objects.filter(
+        content_type=zwarte_ct, object_id=wydawnictwo_zwarte.pk
+    ).exists()
+    denorms.flush()
+    assert DirtyInstance.objects.all().count() == 0
 
 
 @pytest.mark.django_db

--- a/uv.lock
+++ b/uv.lock
@@ -412,7 +412,7 @@ requires-dist = [
     { name = "django-countdown", specifier = ">=0.2.0" },
     { name = "django-crispy-forms", specifier = ">=2.6,<3" },
     { name = "django-dbtemplates-iplweb", specifier = ">=4.3.2" },
-    { name = "django-denorm-iplweb", specifier = ">=1.10.2" },
+    { name = "django-denorm-iplweb", specifier = ">=1.11.1" },
     { name = "django-dirtyfields", specifier = "==1.9.9" },
     { name = "django-dsl", specifier = ">=0.1.14" },
     { name = "django-dynamic-admin-columns", specifier = ">=0.5.0" },
@@ -1616,7 +1616,7 @@ wheels = [
 
 [[package]]
 name = "django-denorm-iplweb"
-version = "1.10.2"
+version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery", marker = "platform_python_implementation != 'PyPy'" },
@@ -1624,9 +1624,9 @@ dependencies = [
     { name = "django", marker = "platform_python_implementation != 'PyPy'" },
     { name = "tqdm", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/dc/0fc06068da69f49e441816076cfb3624cb992ee462c2b4253f29cee9f90c/django_denorm_iplweb-1.10.2.tar.gz", hash = "sha256:adf61edc4108e4d9c1fa866cc74176f8cf26a197e3270c7067888a46d1a2b8fa", size = 53737, upload-time = "2026-04-19T18:41:35.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/69/c3271537dc2941e62818bbf9344bd779c9048e4c3b8e3f646bdc73a05a6b/django_denorm_iplweb-1.11.1.tar.gz", hash = "sha256:ba950e2e79804350829390a6498f39b19fd40484ebc3bfc55782557e48084e8c", size = 47915, upload-time = "2026-05-13T13:07:18.821Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/3c/767728cb91747501733318fff8de0fa78839904ca5e26e021a9c8d616041/django_denorm_iplweb-1.10.2-py3-none-any.whl", hash = "sha256:71fffc8e5e198fe5484c59f806bb3f2eed804bc05ed9d9d466f7f8ab7a062535", size = 43595, upload-time = "2026-04-19T18:41:31.785Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/74/55f754b832ef72d2b8c674d7354eb02bb31df72e828fedf505d47b443da9/django_denorm_iplweb-1.11.1-py3-none-any.whl", hash = "sha256:b700f393687803b815b433a76dbbed92649679aec2322e23490f53c45f3319a4", size = 49952, upload-time = "2026-05-13T13:07:20.304Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Dlaczego

Bump `django-denorm-iplweb` 1.10.2 → 1.11.1 (część grupowego PR #264) wywalał
12 testów. Bisekcja w izolowanym worktree (bump **tylko** denorma) wskazała
denorm jako jedyną przyczynę, ale głębsze śledztwo pokazało, że **denorm działa
zgodnie z projektem** — to BPP musi dostosować się do nowego kontraktu dedupu.

denorm 1.11.0 dodaje UNIQUE index `denorm_dirtyinstance_unique` na
`(content_type_id, COALESCE(object_id,-1), COALESCE(func_name,''))`, żeby jego
własny handler `EXCEPTION WHEN unique_violation` realnie dedupował kolejkę
dirty-markerów. Ręcznie pisane triggery BPP (`bpp_autor_dyscyplina_change/delete`
z migracji 0302) robią **surowy** `INSERT INTO denorm_dirtyinstance` z pominięciem
maszynerii denorma i bez `ON CONFLICT` — więc przy powtórzonym `(ct, rekord_id)`
wpadały w `UniqueViolation`.

## Co zmienia

**Mode A — realny bug (6 testów):** migracja `0418` robi `CREATE OR REPLACE` obu
funkcji triggerów, dodając do `cqueue` `ON CONFLICT DO NOTHING` (bez
conflict-target → łapie każdy unique_violation, odwzorowuje idiom denorma, no-op
na starym denormie bez indeksu). Migracja `0302` nietknięta (zakaz edycji
istniejących migracji); `CREATE OR REPLACE` podmienia tylko ciało funkcji,
triggery wiążą się po nazwie.

**Mode B — nieaktualne oczekiwania liczby markerów (4 testy):** zaktualizowane do
nowego, dedupującego zachowania — każdy przypadek zweryfikowany empirycznie przez
zrzut wierszy `DirtyInstance`:
- `autor_dyscyplina` cacher_zmiana/skasowanie: 3 → **2** (kolaps exact-duplicate;
  asercja funkcjonalna cache bez zmian)
- `wydawca` alias_dla: 5 → **4** (4 odrębne klucze, 5. był duplikatem)
- `wydawca` poziom_ten_sam_rok (`2 vs 1`): asercja **behawioralna** — wyd. zwarte
  zaplanowane do przeliczenia + **konwergencja kolejki do zera** (zamiast liczby
  markerów po `run_once`, którą zmienił rework flush pipeline w 1.11; to *więcej*
  markerów, nie efekt indeksu)

**Mode C — strażnik liczby zapytań (2 testy):** `rebuild_ciagle/zwarte`
`max_num_queries(10)→11` — denorm 1.11 dokłada jedno zapytanie (lock-and-capture
`SELECT ... FOR UPDATE` dirty PK, fix wyścigu we flush pipeline).

## Weryfikacja

- 12 pierwotnie czerwonych testów + ich pliki: **81 passed** na denorm 1.11.1
- Szerszy sweep `test_models/` + `test_cache/`: **346 passed**
- `makemigrations --check`: brak driftu modeli
- `ruff check` na wszystkich ruszanych plikach: czysto

## Poza zakresem

3 padające testy `test_multiseek` (Playwright) w #264 to **inny** pakiet —
`django-multiseek` 0.9.49→0.10.1 — i wymagają osobnej bisekcji. Ten PR bumpuje
**tylko** denorma + naprawia jego skutki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)