### PR TITLE
fix(tests): @pytest.mark.django_db na testach WS anonimowych notyfikacji (flaky zależny od kolejności)

### DIFF
--- a/src/django_bpp/tests/test_asgi_notifications.py
+++ b/src/django_bpp/tests/test_asgi_notifications.py
@@ -12,13 +12,21 @@ pakiet zewnętrzny anonimowy front przestał się łączyć. BPP ustawia flagę 
 ``True`` (``settings/base.py``), żeby przywrócić poprzednie zachowanie — ten
 plik to przypina, żeby ktoś przypadkiem nie zdjął/odwrócił ustawienia.
 
-Test jest celowo hermetyczny: ``on_connect`` (replay z bazy) jest zamockowany,
-więc nie potrzebujemy DB ani Redisa — exerciseujemy wyłącznie bramkę
-auth + accept/close na ``InMemoryChannelLayer``. ``async_to_sync`` odpala
-asynchroniczny ``WebsocketCommunicator`` w syncowym teście (repo nie ma
-``pytest-asyncio``).
+``on_connect`` (replay z bazy) jest zamockowany, więc NIE odpytujemy tabel
+notyfikacji, a ``InMemoryChannelLayer`` trzyma Redisa z daleka — exerciseujemy
+wyłącznie bramkę auth + accept/close. Testy są jednak ``@pytest.mark.django_db``:
+channels owija sync-consumera w ``DatabaseSyncToAsync``, który woła
+``close_old_connections()`` (channels/db.py) wokół handlera. To iteruje
+zainicjalizowane połączenia i robi ``ensure_connection()``. Gdy wcześniejszy
+test w procesie zainicjalizował połączenie w współdzielonym wątku sync-executora,
+pytest-django blokuje ten dostęp dla testu bez marka → ``RuntimeError: Database
+access not allowed`` (flaky zależny od kolejności; w izolacji przechodzi, bo
+połączenie nie jest zainicjalizowane). Mark zezwala na sam cykl połączenia
+(bez realnych zapytań do tabel). ``async_to_sync`` odpala asynchroniczny
+``WebsocketCommunicator`` w syncowym teście (repo nie ma ``pytest-asyncio``).
 """
 
+import pytest
 from asgiref.sync import async_to_sync
 from channels.testing import WebsocketCommunicator
 from channels_broadcast.consumers import NotificationsConsumer
@@ -48,6 +56,7 @@ def test_bpp_enables_anonymous_notifications():
     assert settings.CHANNELS_BROADCAST_ENABLE_ANONYMOUS is True
 
 
+@pytest.mark.django_db
 def test_anonymous_user_can_connect(settings, mocker):
     """Z flagą BPP (True) anonim nawiązuje WS — handshake zaakceptowany."""
     settings.CHANNEL_LAYERS = INMEMORY_LAYER
@@ -57,6 +66,7 @@ def test_anonymous_user_can_connect(settings, mocker):
     assert _connect_as_anonymous() is True
 
 
+@pytest.mark.django_db
 def test_anonymous_rejected_when_flag_disabled(settings, mocker):
     """Objaw sprzed fixu: bez flagi anonim jest odrzucany (close przed accept)."""
     settings.CHANNEL_LAYERS = INMEMORY_LAYER


### PR DESCRIPTION
## Objaw

`test_anonymous_user_can_connect` (`src/django_bpp/tests/test_asgi_notifications.py`)
padał w sharded CI z:

```
RuntimeError: Database access not allowed, use the "django_db" mark, ...
```

…ale **przechodził w izolacji**. Klasyczny flaky zależny od kolejności testów.

## Root cause (nie tam, gdzie się wydaje)

Wbrew docstringowi, problem **nie** jest w `on_connect` (jest zamockowany).
Pełny ślad pokazuje:

```
channels/db.py:11:  close_old_connections()
django/db/__init__.py:59:  for conn in connections.all(initialized_only=True):
django/db/backends/base/base.py:600:  if self.get_autocommit() != ...
django/db/backends/base/base.py:454:  self.ensure_connection()  → RuntimeError
```

channels owija sync-consumera w `DatabaseSyncToAsync`, który **wokół handlera**
woła `close_old_connections()`. To iteruje *zainicjalizowane* połączenia i robi
`ensure_connection()`:

- **W izolacji:** współdzielony wątek sync-executora nigdy nie dotknął DB →
  brak zainicjalizowanego połączenia → `close_old_connections` to no-op → pass.
- **W pełnym suetcie:** wcześniejszy test `django_db` zainicjalizował połączenie
  w tym współdzielonym wątku; zostaje "initialized". pytest-django blokuje wtedy
  ten dostęp dla testu **bez** marka → `RuntimeError`.

To samo dotyczy `test_anonymous_rejected_when_flag_disabled` (też odpala
consumera), więc markowane są oba.

## Fix

`@pytest.mark.django_db` na obu testach exerciseujących consumera. Mark zezwala
na sam cykl połączenia (`ensure_connection`), **bez** realnych zapytań do tabel
notyfikacji (`on_connect` dalej mockowany), a `InMemoryChannelLayer` dalej
trzyma Redisa z daleka. Docstring poprawiony — błędnie twierdził „nie
potrzebujemy DB", co doprowadziło do buga.

## Weryfikacja

- Repro z całym katalogiem `django_bpp/tests/` (`-n0`): było `1 failed, 26 passed`
  → teraz **27 passed**
- Izolacja: **3 passed**
- `ruff check`: czysto

## Kontekst

Wyłapane na CI PR #270 (bump denorma). To **osobny**, wcześniej istniejący flaky
na `dev` — niezwiązany z denormem — więc trafia własnym branchem/PR-em zgodnie
z prośbą.

🤖 Generated with [Claude Code](https://claude.com/claude-code)