### PR TITLE
feat(static): cache-busting długiego ogona statyków przez Manifest

### DIFF
--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -232,6 +232,19 @@ STATICFILES_FINDERS = (
     #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
+# Storage backends (Django 5.x). `staticfiles` → tolerancyjny
+# ManifestStaticFilesStorage (issue #269): content-hash cache-busting całego
+# long-taila statyków; szczegóły i powód tolerancji w django_bpp/storage.py.
+# `default` (media) zostaje na domyślnym Django FileSystemStorage.
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django_bpp.storage.TolerantManifestStaticFilesStorage",
+    },
+}
+
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",

--- a/src/django_bpp/storage.py
+++ b/src/django_bpp/storage.py
@@ -1,0 +1,43 @@
+"""Tolerancyjny ManifestStaticFilesStorage dla BPP (issue #269).
+
+`ManifestStaticFilesStorage` hashuje każdy `{% static %}` z osobna
+(`name.<content-hash>.ext`) i przepisuje odwołania `url(...)` /
+`sourceMappingURL` wewnątrz CSS/JS na wersje hashowane. Dzięki temu
+cache-bustuje cały long-tail statyków — w tym to, czego `{% compress %}`
+nie umie: pliki z atrybutem `defer`/`async` (compress sklejałby je w jeden
+synchroniczny plik), dane ładowane `fetch`-em (np. `bpp/js/Polish.json`)
+oraz vendored skrypty (`multiseek/js/multiseek.js`, `djangoql`, ...).
+
+Problem z vanilla wersją: przerywa `collectstatic` przy pierwszym
+nierozwiązywalnym odwołaniu — `url(...)`/`sourceMappingURL` wskazującym na
+plik, którego nie ma w zebranych statykach. W BPP to ~132 odwołania
+(sprite'y `.png` grappelli/jqueryui w adminie + sourcemapy `.map` foundation),
+których targetów fizycznie nie da się zahashować, bo ich nie ma w STATIC_ROOT.
+`manifest_strict=False` tu NIE pomaga — dotyczy runtime'owych lookupów
+`.url()`, a crash leci na etapie build-time `post_process`, którego ta flaga
+nie obejmuje.
+
+Subklasa przechwytuje ten `ValueError` w `hashed_name` i zostawia odwołanie
+pod nazwą oryginalną (niezahashowaną) zamiast wywalać build. Te pliki serwują
+się dokładnie tak jak dziś — bez cache-bustingu, ale działają; i tak ~nigdy
+się nie zmieniają między wydaniami.
+"""
+
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+
+class TolerantManifestStaticFilesStorage(ManifestStaticFilesStorage):
+    # Runtime: brakujący wpis w manifeście → zwróć nazwę nie-hashowaną zamiast
+    # rzucać "Missing staticfiles manifest entry". Chroni dev/testy bez
+    # collectstatic (choć tam i tak działa short-circuit DEBUG w `.url()`)
+    # oraz 132 vendored-refy, które zostały niezahashowane na buildzie.
+    manifest_strict = False
+
+    def hashed_name(self, name, content=None, filename=None):
+        try:
+            return super().hashed_name(name, content, filename)
+        except ValueError:
+            # Build-time tolerancja: nierozwiązywalne odwołanie (vendored .map
+            # / sprite, którego targetu nie ma w zebranych statykach). Zostaw
+            # nazwę oryginalną zamiast przerywać collectstatic — issue #269.
+            return name

--- a/src/django_bpp/tests/test_storage.py
+++ b/src/django_bpp/tests/test_storage.py
@@ -1,0 +1,66 @@
+"""Testy tolerancyjnego ManifestStaticFilesStorage (issue #269).
+
+`ManifestStaticFilesStorage` hashuje każdy `{% static %}` z osobna
+(`name.<content-hash>.ext`) i przepisuje odwołania `url(...)` /
+`sourceMappingURL` wewnątrz CSS/JS na wersje hashowane — cache-bustuje cały
+long-tail statyków. Vanilla wersja jednak przerywa `collectstatic` na
+pierwszym nierozwiązywalnym odwołaniu (target, którego nie ma w zebranych
+statykach — vendored sprite'y grappelli/jqueryui, sourcemapy foundation).
+Tolerancyjna subklasa łapie ten `ValueError` i zostawia odwołanie pod nazwą
+oryginalną zamiast wywalać build.
+"""
+
+import pytest
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+from django.core.files.base import ContentFile
+from django.test import override_settings
+
+from django_bpp.storage import TolerantManifestStaticFilesStorage
+
+
+def test_manifest_strict_is_disabled():
+    # Runtime: brakujący wpis w manifeście ma zwracać nazwę nie-hashowaną
+    # zamiast rzucać "Missing staticfiles manifest entry" (chroni dev/testy
+    # bez collectstatic oraz 132 vendored-refy serwowane pod starą nazwą).
+    assert TolerantManifestStaticFilesStorage.manifest_strict is False
+
+
+def test_unresolvable_reference_keeps_original_name():
+    # hashed_name() z content=None sprawdza istnienie pliku; gdy targetu nie
+    # ma, vanilla rzuca ValueError i przerywa collectstatic. Subklasa zwraca
+    # nazwę oryginalną (build-time tolerancja — to jest sedno issue #269).
+    storage = TolerantManifestStaticFilesStorage()
+    missing = "django_bpp/__tdd_nonexistent_probe__.map"
+    assert storage.hashed_name(missing) == missing
+
+
+def test_resolvable_content_is_still_hashed():
+    # Happy-path: gdy treść jest dostępna, hashed_name deleguje do super i
+    # zwraca nazwę z content-hashem (sanity — nie zepsuliśmy hashowania).
+    storage = TolerantManifestStaticFilesStorage()
+    hashed = storage.hashed_name("app.js", content=ContentFile(b"console.log(1);"))
+    assert hashed != "app.js"
+    assert hashed.startswith("app.")
+    assert hashed.endswith(".js")
+
+
+@override_settings(DEBUG=False)
+def test_missing_manifest_entry_falls_back_instead_of_raising():
+    # Runtime safety (DEBUG=False, hashing aktywne): wpis spoza manifestu.
+    # Vanilla (manifest_strict=True) rzuca "Missing staticfiles manifest
+    # entry" — to był objaw, którego baliśmy się w produkcji/testach. Nasza
+    # subklasa (manifest_strict=False) zwraca URL nie-hashowany. Kontrast z
+    # vanilla dowodzi, że test nie jest pusty (manifest_strict naprawdę działa).
+    probe = "bpp/js/__nonexistent_runtime_probe__.js"
+    with pytest.raises(ValueError):
+        ManifestStaticFilesStorage().url(probe)
+    assert TolerantManifestStaticFilesStorage().url(probe) == "/static/" + probe
+
+
+@override_settings(DEBUG=True)
+def test_url_in_debug_returns_unhashed_without_manifest():
+    # Keystone "jedna klasa storage wszędzie": w DEBUG `HashedFilesMixin.url()`
+    # robi short-circuit i zwraca nazwę nie-hashowaną BEZ zaglądania do
+    # manifestu — dlatego dev/runserver działa bez collectstatic i bez crasha.
+    probe = "bpp/js/__nonexistent_debug_probe__.js"
+    assert TolerantManifestStaticFilesStorage().url(probe) == "/static/" + probe


### PR DESCRIPTION
## Co i po co

Follow-up do #267 — realizuje ustalenia spike'u z #269.

#267 (`{% compress js %}`) cache-bustuje hot-path przez **bundling**, ale nie jest kompletnym fixem klasy: gubi `defer`/`async`, nie dotyka danych ładowanych `fetch`-em ani vendored ogona. `ManifestStaticFilesStorage` hashuje **każdy** `{% static %}` z osobna (`name.<hash>.ext`) → pokrywa dokładnie to, czego compress nie umie. Oba mechanizmy się **uzupełniają**: compress dalej bundluje hot-path, Manifest cache-bustuje long-tail.

## Zmiana (Additive only)

- `src/django_bpp/storage.py` *(new)* — `TolerantManifestStaticFilesStorage`: `manifest_strict=False` + override `hashed_name()` łapiący `ValueError` na nierozwiązywalnych odwołaniach.
- `src/django_bpp/settings/base.py` — `STORAGES`: `staticfiles` → ta subklasa; `default` (media) bez zmian (Django `FileSystemStorage`).
- `src/django_bpp/tests/test_storage.py` *(new)* — 5 testów.

Zero zmian w blokach `{% compress %}`, szablonach, entrypoincie.

## Dlaczego tolerancyjna subklasa

Vanilla `ManifestStaticFilesStorage` **wywala `collectstatic`** na pierwszym nierozwiązywalnym `url()`/`sourceMappingURL` (~132 vendored-refy: sprite'y `.png` grappelli/jqueryui + sourcemapy `.map` foundation — targetów nie ma w `STATIC_ROOT`). `manifest_strict=False` tu nie pomaga (dotyczy runtime'owych lookupów `.url()`; crash leci na build-time `post_process`). Subklasa łapie `ValueError` w `hashed_name` i zostawia odwołanie pod nazwą oryginalną — te pliki serwują się jak dziś, tylko bez cache-bustingu (i tak ~nigdy się nie zmieniają).

## Weryfikacja lokalna

- `collectstatic` z nową klasą: **1627 plików post-processed**, `staticfiles.json` zbudowany, long-tail zahashowany (`Polish.json`, `modal.js`[defer], `select2-autofocus.js`, `event-handlers.js`).
- ten sam input na **vanilla** Manifest: **crash** na `bundle.js.map` — dowód, że tolerancja jest load-bearing i wiernie odtwarza blocker z #269.
- **5 testów** zielonych: build-time tolerancja, happy-path hashing, runtime `manifest_strict` (z kontrastem `pytest.raises` na vanilla), short-circuit DEBUG.
- pakiet `django_bpp` bez regresji — jedyny fail (`test_anonymous_user_can_connect`) to **pre-existing xdist flake**, identyczny na nietkniętym `dev`.
- `ruff format` + `ruff check` czyste.

## Kontrakt staticów (Docker)

Entrypoint `cp -rf /app/staticroot.baked/.` kopiuje **cały** `.baked`, więc `staticfiles.json` jedzie razem — **bez zmian w entrypoincie**. Pełna weryfikacja `build → .baked → serwowanie hashowanych nazw` (DEBUG=False) oraz suite Playwright: w CI/deploy.

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
