### PR TITLE
fix(deps): bump django-multiseek 0.9.49 → 0.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "django-minify-html>=1.14,<2",
     "Pillow>=12.2,<14",
     "django-grappelli>=5.0.0,<6",
-    "django-multiseek==0.9.49",
+    "django-multiseek==0.10.2",
     "django-braces>=1.15.0",
     "django-loginas==0.3.14",
     "django-webmaster-verification==0.4.3",

--- a/uv.lock
+++ b/uv.lock
@@ -435,7 +435,7 @@ requires-dist = [
     { name = "django-minify-html", specifier = ">=1.14,<2" },
     { name = "django-model-utils", specifier = "==5.0.0" },
     { name = "django-mptt", specifier = ">=0.16,<1" },
-    { name = "django-multiseek", specifier = "==0.9.49" },
+    { name = "django-multiseek", specifier = "==0.10.2" },
     { name = "django-password-policies-iplweb", specifier = "==0.9.0" },
     { name = "django-pg-baseline", specifier = ">=0.3.0" },
     { name = "django-prometheus", specifier = ">=2.4.1" },
@@ -1932,16 +1932,16 @@ wheels = [
 
 [[package]]
 name = "django-multiseek"
-version = "0.9.49"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-autocomplete-light", marker = "platform_python_implementation != 'PyPy'" },
     { name = "python-dateutil", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/33/0179cf1ce1bf22a774321d54aacb6fa387c83f24dc8b289e8c7089d510af/django_multiseek-0.9.49.tar.gz", hash = "sha256:46616cb4fffd575b850db4a612dff641f4370c0ca5dd51e093cc5a372d2621b5", size = 34741, upload-time = "2026-04-16T15:50:26.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/8b/d41fad5c84a8e5f99a64825c3786d78312559f8ac9cd24fb63275331d5f0/django_multiseek-0.10.2.tar.gz", hash = "sha256:e85ba2ea95452b171899d72c97a64a4755044aed1cb29a8cd5617f9756323545", size = 39406, upload-time = "2026-06-01T09:57:57.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/38/399225b265f57c27f25131496c8550c51215b6e64bc646ea627e0c382e78/django_multiseek-0.9.49-py3-none-any.whl", hash = "sha256:7eb7da79225e2191edae7434ebf23eec363897447386a86d30f9a8cf97b53514", size = 45897, upload-time = "2026-04-16T15:50:24.833Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f3/eddf25d93e5df856c37f3aec71e8d081055fb2b8a85a077947356bddc933/django_multiseek-0.10.2-py3-none-any.whl", hash = "sha256:67d2fd82dae05841a98084b5b39ac2cbca5d16de73c191c0acf5e30c2bc6c91f", size = 51150, upload-time = "2026-06-01T09:57:56.627Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Co

Bumpuje `django-multiseek` `0.9.49 → 0.10.2` (sam multiseek, nic innego).

## Dlaczego

W grupowym bumpie Dependabota (#264) multiseek szedł do **0.10.1**, co wywalało testy Playwright (`test_playwright/test_multiseek.py`). Root cause: **0.10.1 zbudował wheel BEZ katalogu `static/`**.

Globy `package-data` w multiseeku były nierekurencyjne:

```toml
"static/multiseek/*.js"    # NIE matchuje static/multiseek/js/multiseek.js
"static/multiseek/*.css"   # NIE matchuje static/multiseek/css/style.css
```

Pliki leżą o katalog głębiej (`js/`, `css/`), a pojedynczy `*` nie rekuruje w nowym setuptools. Efekt u konsumenta:

- `GET /static/multiseek/js/multiseek.js` → **HTTP 500**
- `formAsJSON` / `multiseekFrame` niezdefiniowane → formularz wyszukiwania martwy
- objawiało się jako **30s navigation timeout** w testach przeglądarkowych (nie jako błąd serwera na `live-results`)

**0.10.2** naprawia pakowanie upstream (rekurencyjne globy `static/**/*`, `templates/**/*`); opublikowany wheel znów wozi assety. Zweryfikowane: pobrany z PyPI wheel 0.10.2 zawiera `static/multiseek/{js,css}`.

Hardening CSRF z 0.10.x jest bez zmian i nie był przyczyną — własne widoki BPP `live-results`/`results` i tak są `csrf_exempt`.

## Weryfikacja

Lokalnie na tej gałęzi (na szczycie aktualnego `dev` → `denorm 1.11.1` + ON CONFLICT z #270):

```
src/bpp/tests/test_playwright/test_multiseek.py … 6 passed in 14.73s
```

## Relacja do #264

To jest **multiseekowa część** #264, wydzielona i naprawiona. Denorm 1.11.1 (drugi winowajca w #264) jest już osobno załatwiony na `dev` przez #270. Po zmergowaniu tego, multiseekowy bump z #264 jest zbędny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)