### PR TITLE
fix(tests): deterministyczny wybór w Select2 helperze (klik zamiast Enter)

### DIFF
--- a/src/django_bpp/playwright_util.py
+++ b/src/django_bpp/playwright_util.py
@@ -153,8 +153,29 @@ def select_select2_autocomplete(
         timeout=timeout,
     )
 
-    # Press Enter to select the first/highlighted result
-    search_input.press("Enter")
+    # Select the result deterministically. Pressing Enter blindly picks the
+    # FIRST highlighted option, which under CI timing can be a stale/broader
+    # intermediate AJAX result: typing "Aut2…" character-by-character may, when
+    # press_sequentially runs slower than Select2's debounce, momentarily show
+    # the results for "Aut…" — which also contain a *different* author sharing
+    # the prefix. Enter then silently selects that wrong author; the mistake
+    # only surfaces later as a unique-constraint violation on submit (two
+    # formset rows pointing at the same autor_id). So: prefer clicking the
+    # specific option whose visible text contains the full search term. Only if
+    # no such option exists — fields where the search term is not a substring
+    # of the rendered label, e.g. generated "zapisany jako" name variants — do
+    # we fall back to Enter-on-first-highlight.
+    option_selector = (
+        ".select2-results__option:not(.loading-results):not(.select2-results__message)"
+    )
+    matching_option = page.locator(option_selector).filter(has_text=value).first
+    try:
+        matching_option.wait_for(state="visible", timeout=2000)
+        matching_option.click()
+    except Exception:
+        # No option literally containing the search term — fall back to
+        # selecting the first/highlighted result via Enter.
+        search_input.press("Enter")
 
     # Wait for the actual signals that selection propagated:
     # (1) Select2 closes the dropdown after Enter, (2) underlying <select>


### PR DESCRIPTION
## Problem

Flake na CI (PR #189, shard 5/8): `test_procent_odpowiedzialnosci_baseModel_AutorFormset_dwoch_autorow[chromium-wydawnictwo_zwarte]` wywalał się Playwright `TimeoutError` na `wait_for_function`. To był jednak tylko **wtórny** objaw — na serwerze leciał HTTP 500:

```
psycopg2.errors.UniqueViolation: ... "bpp_wydawnictwo_zwarte_a_rekord_id_autor_id_typ_o_efb01db8_uniq"
DETAIL: Klucz (rekord_id, autor_id, typ_odpowiedzialnosci_id)=(37, 38, 15) już istnieje.
```

Oba wiersze formsetu autorów wylądowały z **tym samym** `autor_id`, choć test wybierał dwóch różnych autorów. Strona nigdy nie pokazała „dodany pomyślnie" → timeout Playwrighta.

## Root cause

`select_select2_autocomplete` (`src/django_bpp/playwright_util.py`) wciskał **Enter**, wybierając PIERWSZĄ podświetloną pozycję wyników — bez weryfikacji, że to faktycznie szukany rekord.

Testowi autorzy dzielą prefiks nazwiska: `Aut1<suffix>` / `Aut2<suffix>`. Pod obciążeniem CI `press_sequentially` wpisuje znaki wolniej niż debounce Select2 (~250 ms), więc dla zapytania `"Aut2…"` w oknie czasowym widoczne bywają jeszcze wyniki dla `"Aut…"` — zawierające autora **pierwszego**. Warunek oczekiwania (`!isLoading && hasResults`) spełniają te nieświeże, szersze wyniki, a Enter wybiera złego autora. Oba wiersze → ten sam `autor_id` → `UniqueViolation` przy zapisie.

To **nie** jest regresja PR #189 — jedyna zmiana tego PR-a w `admin/core.py` to klucz cache w `filter_count_view` (inna ścieżka niż `save_related`). Pre-existing timing-flake Select2. Dodatkowo: w `pytest.ini` jest `--only-rerun TimeoutError`, ale brak `--reruns N` → realnie 0 retry, więc jeden błędny strzał wywala cały shard.

## Fix

Helper klika teraz **konkretną pozycję, której widoczny tekst zawiera pełną szukaną wartość**, zamiast wciskać Enter na pierwszej podświetlonej. Tylko gdy takiej pozycji nie ma (pola, gdzie szukany tekst nie jest podłańcuchem etykiety — np. generowane warianty „zapisany jako" typu `Kopara1`) helper spada do dawnego Enter-na-pierwszej.

Naprawia całą klasę tych flake'ów, nie tylko ten jeden test.

## Weryfikacja

Lokalnie, na zbudowanych assetach + testcontainers:

```
test_..._dwoch_autorow × {wydawnictwo_ciagle, wydawnictwo_zwarte, patent} × 3 powtórki = 9/9 passed
```

Happy-path bez regresji; ścieżka fallback (Enter dla `zapisany_jako`) zweryfikowana, bo `Kopara1/2` nie są podłańcuchem etykiety. Timing-flake reprodukuje się głównie pod obciążeniem CI — ostateczna walidacja na zielonym CI tego PR-a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)