### PR TITLE
docs(pages): publikacja dokumentacji na GitHub Pages (iplweb.github.io/bpp)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,10 @@
 name: Docs
 
-# Buduje dokumentacje MkDocs Material w trybie --strict jako PR check.
+# Buduje dokumentacje MkDocs Material w trybie --strict jako PR check,
+# a na push do `dev` dodatkowo publikuje ja na GitHub Pages
+# (https://iplweb.github.io/bpp/). RTD (bpp.readthedocs.io) biegnie
+# rownolegle z tego samego mkdocs.yml; `site_url` wskazuje github.io,
+# wiec canonical w obu buildach kieruje na Pages (brak konkurencji SEO).
 # Workflow nie konsumuje zadnych nieZaufanych inputow (issue/PR titles,
 # commit messages), wiec wzorce z https://github.blog/security/...
 # nie maja tu zastosowania.
@@ -52,9 +56,40 @@ jobs:
       - name: Build docs (strict mode)
         run: mkdocs build --strict --verbose
 
-      - name: Upload built site as artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      # Artefakt w formacie GitHub Pages (nazwa `github-pages`) — konsumuje
+      # go job `deploy`. Na PR-ach job `deploy` nie biegnie, ale artefakt
+      # i tak da sie pobrac do podejrzenia builda.
+      - name: Upload built site as Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          name: docs-site
           path: site/
-          retention-days: 7
+
+  deploy:
+    name: Deploy to GitHub Pages
+    # Publikujemy tylko z kanonicznego brancha `dev` i tylko na push —
+    # nigdy z PR-a ani z `master` (master sluzy buildowi obrazow Docker,
+    # nie dokumentacji).
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    # Deploy potrzebuje szerszych uprawnien niz domyslne `contents: read`.
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Osobna grupa od workflow-owej: nie chcemy ubijac trwajacego deployu
+    # Pages w polowie (cancel-in-progress: false).
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/iplweb/bpp">Source on GitHub</a> •
   <a href="https://www.iplweb.pl">iplweb.pl</a> •
   <a href="https://bpp.iplweb.pl">bpp.iplweb.pl</a> •
-  <a href="https://bpp.readthedocs.io">Dokumentacja</a>
+  <a href="https://iplweb.github.io/bpp/">Dokumentacja</a>
 </p>
 
 ---
@@ -103,7 +103,7 @@ Pełna lista z wersjami — [bpp-deploy/docker-compose.yml](https://github.com/i
 - 💻 **Kod monorepo**: [github.com/iplweb/bpp](https://github.com/iplweb/bpp)
 - 🚀 **Wdrożenie produkcyjne**: [github.com/iplweb/bpp-deploy](https://github.com/iplweb/bpp-deploy)
 - 🐘 **dbserver (wydzielony)**: [github.com/iplweb/bpp-dbserver](https://github.com/iplweb/bpp-dbserver)
-- 📚 **Dokumentacja**: [bpp.readthedocs.io](https://bpp.readthedocs.io)
+- 📚 **Dokumentacja**: [iplweb.github.io/bpp](https://iplweb.github.io/bpp/)
 - 🌐 **Strona projektu / demo**: [bpp.iplweb.pl](https://bpp.iplweb.pl)
 - 💼 **Wsparcie komercyjne**: [iplweb.pl](https://www.iplweb.pl)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://github.com/iplweb/bpp/actions/workflows/tests.yml"><img src="https://github.com/iplweb/bpp/actions/workflows/tests.yml/badge.svg?branch=dev" alt="Testy"></a>
   <a href="https://github.com/iplweb/bpp/actions/workflows/build-docker-images.yml"><img src="https://github.com/iplweb/bpp/actions/workflows/build-docker-images.yml/badge.svg?branch=master" alt="Docker - oficjalne obrazy"></a>
-  <a href="http://bpp.readthedocs.io/pl/latest/?badge=latest"><img src="https://readthedocs.org/projects/bpp/badge/?version=latest" alt="Dokumentacja"></a>
+  <a href="https://iplweb.github.io/bpp/"><img src="https://github.com/iplweb/bpp/actions/workflows/docs.yml/badge.svg?branch=dev" alt="Dokumentacja"></a>
 </p>
 
 <p align="center">
@@ -274,7 +274,9 @@ tylko podczas trwania komendy (chyba że `--reuse`).
 ## Dokumentacja
 
 Dokumentacja dostępna jest na stronie
-[bpp.readthedocs.io](https://bpp.readthedocs.io/).
+[iplweb.github.io/bpp](https://iplweb.github.io/bpp/)
+(równolegle nadal budowana także na
+[bpp.readthedocs.io](https://bpp.readthedocs.io/)).
 
 ## Rozwój
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Bibliografia Publikacji Pracowników
 site_description: Dokumentacja systemu BPP (Bibliografia Publikacji Pracowników)
-site_url: https://bpp.readthedocs.io/
+site_url: https://iplweb.github.io/bpp/
 repo_url: https://github.com/iplweb/bpp
 repo_name: iplweb/bpp
 edit_uri: edit/dev/docs/

--- a/src/bpp_setup_wizard/PBN_INTEGRACJA.md
+++ b/src/bpp_setup_wizard/PBN_INTEGRACJA.md
@@ -63,7 +63,7 @@ Po uzyskaniu danych z PBN, wprowadź je podczas konfiguracji uczelni:
 
 ### Wsparcie
 - Oficjalna dokumentacja PBN: https://pbn.nauka.gov.pl/centrum-pomocy/
-- Dokumentacja integracji BPP z PBN: https://bpp.readthedocs.io/pl/latest/konfiguracja_pbn.html
+- Dokumentacja integracji BPP z PBN: https://iplweb.github.io/bpp/konfiguracja_pbn/
 - Przykłady i najlepsze praktyki: https://bpp.iplweb.pl/zrodla
 
 ## Często zadawane pytania


### PR DESCRIPTION
## Po co

Hostujemy dokumentację (MkDocs Material) dodatkowo na **GitHub Pages**
pod `https://iplweb.github.io/bpp/`. RTD (`bpp.readthedocs.io`) **zostaje
równolegle** z tego samego `mkdocs.yml` — to układ przejściowy.

Infrastruktura była już w 90% gotowa: workflow `docs.yml` budował `site/`
w trybie `--strict` jako PR check i wrzucał artifact. Ten PR dokłada tylko
brakujący krok **publikacji**.

## Co się zmienia

- **`.github/workflows/docs.yml`**
  - krok upload: `actions/upload-artifact` → `actions/upload-pages-artifact`
    (format Pages, artefakt `github-pages`),
  - nowy job **`deploy`** (`actions/deploy-pages`), gated na
    `push` do `dev` — **nie** na PR, **nie** na `master`,
  - minimalne uprawnienia: `pages: write` + `id-token: write`,
    osobna grupa `concurrency: pages` (`cancel-in-progress: false`).
- **`mkdocs.yml`**: `site_url` → `https://iplweb.github.io/bpp/`.
  Dzięki temu `<link rel="canonical">` w **obu** buildach (Pages i RTD)
  wskazuje github.io → brak konkurencji SEO między hostingami.
- **Linki "Dokumentacja"** (`README.md`, `DOCKERHUB.md`,
  `PBN_INTEGRACJA.md`) → github.io. Badge RTD w README zamieniony na
  badge workflow `Docs` (GitHub-native, spójny z pozostałymi badge'ami).

## ⚠️ Wymaga ręcznej akcji po merge

W **Settings → Pages → Source** ustawić **"GitHub Actions"**.
Bez tego job `deploy` padnie (Pages nieaktywne dla repo).

## Czego ten PR NIE rusza

- `.readthedocs.yaml` — RTD biegnie dalej równolegle.
- Wersjonowania docs — nie było używane na RTD, więc nic nie tracimy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)