### PR TITLE
perf(ci): równoległy baseline-check + 8→12 shardów

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,44 @@ jobs:
           uvx pre-commit run ruff-format \
             --from-ref "$DIFF_BASE" --to-ref HEAD --show-diff-on-failure
 
+  baseline-check:
+    # Guard repo-state-only: czy baseline-sql/baseline.sql nadaza za migracjami
+    # (manage.py baseline_check). Wydzielone z prepare-image i puszczone
+    # ROWNOLEGLE — wczesniej te ~37s (apt + uv sync + check) blokowaly start
+    # builda obrazu, a wiec i wszystkich shardow, na KAZDYM runie. Drift jest
+    # rzadki: sporadyczny "zmarnowany" build przy realnym drifcie jest tanszy
+    # niz 37s na kazdym runie. Drift = ten job czerwony = caly run czerwony.
+    name: Check baseline freshness
+    if: |
+      !(github.ref == 'refs/heads/dev' && contains(github.event.head_commit.message, 'Merge tag'))
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Install system build deps (for uv sync)
+      run: |
+        sudo apt-get update
+        xargs -a docker/bpp_base/build.txt sudo apt-get install -y
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: false
+
+    - name: Install project deps
+      run: uv sync --frozen --no-install-project
+
+    - name: Check baseline freshness
+      env:
+        DJANGO_BPP_SKIP_DOTENV: "1"
+      run: uv run python src/manage.py baseline_check --max-delta 50
+
   prepare-image:
     # Build the test-runner image once and push it to GHCR with two
     # tags: `:sha-<commit>` (consumed by downstream test jobs) and
@@ -128,31 +166,11 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    # baseline_check is repo-state-only — it doesn't need the
-    # test-runner image, the database, or any baked artefacts. Running
-    # it here (instead of inside a test job) means a baseline drift
-    # fails fast and skips the expensive image build below.
-    - name: Install system build deps (for uv sync)
-      run: |
-        sudo apt-get update
-        xargs -a docker/bpp_base/build.txt sudo apt-get install -y
-
-    - name: Install uv (for baseline_check)
-      # No setup-uv cache here — this job pushes images to GHCR, and
-      # zizmor flags cache+publish combos as a poisoning vector. The
-      # cache hit would shave a few seconds off a one-shot uv sync,
-      # not worth the audit smell.
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-      with:
-        enable-cache: false
-
-    - name: Install project deps (for baseline_check)
-      run: uv sync --frozen --no-install-project
-
-    - name: Check baseline freshness
-      env:
-        DJANGO_BPP_SKIP_DOTENV: "1"
-      run: uv run python src/manage.py baseline_check --max-delta 50
+    # baseline_check przeniesiony do osobnego joba `baseline-check`, ktory
+    # biegnie ROWNOLEGLE z tym buildem (wczesniej jego ~37s apt+uv sync+check
+    # blokowaly start builda obrazu — a wiec i wszystkich shardow). Baseline
+    # drift jest rzadki, wiec sporadyczny "zmarnowany" build przy realnym
+    # drifcie jest tanszy niz 37s na kazdym runie.
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -245,16 +263,20 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 12
       matrix:
         python-version: ["3.12"]
-        # 0-indexed; bump alongside NUM_SHARDS below if you change it.
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+        # 0-indexed; MUSI byc spojne z NUM_SHARDS nizej. Duration-split
+        # (pytest-split, .test_durations) balansuje dowolne N po czasie, wiec
+        # bump jest tani: 8 -> 12 tnie czas testow najwolniejszego sharda
+        # (~220s -> ~150s). Powyzej ~12 zysk topnieje, bo czas sharda spada
+        # ponizej czasu prepare-image (to staje sie podloga krytycznej sciezki).
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
     env:
       TEST_RUNNER_IMAGE: ${{ needs.prepare-image.outputs.image }}
       COMPOSE_FILES: -f docker-compose.test.yml -f docker-compose.test.ci.yml
-      NUM_SHARDS: "8"
+      NUM_SHARDS: "12"
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Po co

Quick-winy na krytycznej sciezce CI po #286 (duration-split) + #287 (slim image).
Zmierzony profil (run na dev, post-#286):

```
prepare-image (SERIAL, gejtuje wszystkie shardy)  ~307s
  ├─ Build & push test-runner image               270s
  └─ baseline_check prelude (apt+uv sync+check)     37s   ← serial przed buildem
        +
najwolniejszy shard                               ~290s  (~70s pull + ~220s testy)
```

## Zmiany

**1. `baseline-check` → osobny job, RÓWNOLEGLE.** Wczesniej ~37s (apt + `uv sync`
+ `baseline_check`) bieglo serial PRZED buildem obrazu na kazdym runie. Baseline
drift jest rzadki, wiec sporadyczny "zmarnowany" build przy realnym drifcie jest
tanszy niz 37s × kazdy run. Drift dalej wywala caly run (czerwony job).

**2. Shardy 8 → 12.** `.test_durations` (pytest-split) balansuje dowolne N po
CZASIE, wiec bump jest tani — tnie czas testow najwolniejszego sharda
(~220s → ~150s). 12 to rozsadny pulap: powyzej czas sharda spada ponizej
prepare-image, ktore staje sie podloga.

Lacznie **~2 min** z krytycznej sciezki, niski risk.

## Bezpieczenstwo / kompatybilnosc

- Required checki `Tests (sharded) (3.12, 0..7)` dalej istnieja (teraz 0..11) →
  branch-protection nietkniete.
- `tests` dalej `needs: prepare-image`; `baseline-check` leci obok i wywala run
  niezaleznie przy drifcie.
- Koszt: 12 (zamiast 8) pullow obrazu + runnerow per run — swiadomy trade-off
  za szybkosc.

## Poza zakresem (nastepny PR)

Prawdziwa podloga to **prepare-image ~5min (serial)**. Osobny, wiekszy PR:
decoupling source od obrazu (obraz piecze tylko deps; assety jako artifact;
shardy biora source z checkout) — zeby na typowym commicie prepare-image nie
przebudowywal+pushowal obrazu. Najpierw dokladny pomiar 270s build&push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)