### PR TITLE
perf(docker): cache grunt build w test-runner gdy zmienił się tylko Python

### DIFF
--- a/docker/bpp_base/Dockerfile
+++ b/docker/bpp_base/Dockerfile
@@ -334,17 +334,56 @@ RUN --mount=type=cache,target=/root/.npm,id=npm-cache \
 # (~1 min × N jobs) on every invocation. Local dev keeps the bind
 # mount and rebuilds assets on demand.
 #
-# Granular COPYs (instead of `COPY . /src`) keep this layer cached
-# whenever the change is outside the listed paths — edits to
-# .github/, docker/, docker-compose*.yml, .pre-commit-config.yaml,
-# etc. don't invalidate the source layer or the grunt/compilemessages
-# steps below it. Only changes inside src/ or the listed top-level
-# config files force a rebuild of the assets.
+# Asset-source COPYs PRZED `grunt build` — dokladnie jak w stage `builder`
+# (patrz komentarz tam) — zeby warstwa grunta (~60s) byla CACHE-HIT, gdy
+# zmienil sie TYLKO kod Pythona, a nie scss/js. Wczesniej test-runner robil
+# `COPY src/` (cale drzewo) przed gruntem, wiec grunt przebudowywal sie na
+# KAZDYM commicie (a wiec i prepare-image gejtujacy wszystkie shardy). Teraz
+# grunt odpala sie tylko gdy faktycznie ruszysz scss/js. Gruntfile.js juz jest
+# w /src (skopiowany z package.json/yarn.lock wyzej). Dodajac nowy task SCSS
+# do Gruntfile.js — dopisz tu COPY (jak w builderze).
+# Theme and admin SCSS
+COPY src/bpp/static/scss/ src/bpp/static/scss/
+COPY src/bpp/static/bpp/scss/ src/bpp/static/bpp/scss/
+# JS for esbuild bundle
+COPY src/bpp/static/bpp/js/ src/bpp/static/bpp/js/
+# App-specific SCSS (keep alphabetical, mirror `builder`)
+COPY src/bpp_setup_wizard/static/bpp_setup_wizard/scss/ \
+     src/bpp_setup_wizard/static/bpp_setup_wizard/scss/
+COPY src/deduplikator_autorow/static/deduplikator_autorow/scss/ \
+     src/deduplikator_autorow/static/deduplikator_autorow/scss/
+COPY src/deduplikator_zrodel/static/deduplikator_zrodel/scss/ \
+     src/deduplikator_zrodel/static/deduplikator_zrodel/scss/
+COPY src/ewaluacja_dwudyscyplinowcy/static/ewaluacja_dwudyscyplinowcy/scss/ \
+     src/ewaluacja_dwudyscyplinowcy/static/ewaluacja_dwudyscyplinowcy/scss/
+COPY src/ewaluacja_liczba_n/static/ewaluacja_liczba_n/scss/ \
+     src/ewaluacja_liczba_n/static/ewaluacja_liczba_n/scss/
+COPY src/ewaluacja_optymalizuj_publikacje/static/ewaluacja_optymalizuj_publikacje/scss/ \
+     src/ewaluacja_optymalizuj_publikacje/static/ewaluacja_optymalizuj_publikacje/scss/
+COPY src/komparator_publikacji_pbn/static/komparator_publikacji_pbn/scss/ \
+     src/komparator_publikacji_pbn/static/komparator_publikacji_pbn/scss/
+COPY src/pbn_downloader_app/static/pbn_downloader_app/scss/ \
+     src/pbn_downloader_app/static/pbn_downloader_app/scss/
+COPY src/pbn_export_queue/static/pbn_export_queue/scss/ \
+     src/pbn_export_queue/static/pbn_export_queue/scss/
+COPY src/pbn_import/static/pbn_import/scss/ \
+     src/pbn_import/static/pbn_import/scss/
+COPY src/pbn_komparator_zrodel/static/pbn_komparator_zrodel/scss/ \
+     src/pbn_komparator_zrodel/static/pbn_komparator_zrodel/scss/
+COPY src/przemapuj_prace_autora/static/przemapuj_prace_autora/scss/ \
+     src/przemapuj_prace_autora/static/przemapuj_prace_autora/scss/
+COPY src/przemapuj_zrodla_pbn/static/przemapuj_zrodla_pbn/scss/ \
+     src/przemapuj_zrodla_pbn/static/przemapuj_zrodla_pbn/scss/
+
+RUN npx grunt build-non-interactive
+
+# Reszta zrodla PO gruncie: zmiany w kodzie Pythona nie unieważniaja warstwy
+# grunta powyzej. Skompilowane assety (gitignored, nieobecne w kontekscie
+# build) przezyja ten COPY — COPY nie kasuje plikow, ktorych nie ma w zrodle.
 COPY src/ /src/src/
 COPY baseline-sql/ /src/baseline-sql/
 COPY conftest.py pytest.ini Makefile pyproject.toml uv.lock /src/
 
-RUN npx grunt build-non-interactive
 RUN /opt/venv/bin/python src/manage.py compilemessages -v0 -l pl --traceback
 
 ##############################################################################


### PR DESCRIPTION
## Po co (to jest #1, ale lepiej)

Pierwotny plan #1 = decoupling source od obrazu przez artifact. Przy implementacji
okazalo sie, ze stage **`builder` (produkcja) JUZ** robi dokladnie to, o co
chodzilo — granular COPY scss/js PRZED `grunt build`, z komentarzem *"so grunt
build is cached when only Python code changes (saves ~1-2 min on hotfixes)"*.
`test-runner` tego nie mirrorowal: robil `COPY src/` (cale drzewo) → `grunt`,
wiec grunt (~60s) przebudowywal sie na KAZDYM commicie. A `prepare-image`
gejtuje wszystkie shardy → te ~60s siedzialo na krytycznej sciezce za kazdym
razem.

Ten PR przenosi sprawdzony wzorzec z `builder` do `test-runner`. **Wiekszy zysk,
zerowe ryzyko** vs artifact-decouple (zero artifactow, zero zmian w
`tests.yml`/`.ci.yml`/shardach — assety dalej zapieczone).

## Zmiana (tylko Dockerfile)

```
# przed:  COPY src/ (cale) → grunt → compilemessages
# po:     COPY scss/js (mirror buildera) → grunt → COPY src/ (reszta) → compilemessages
```
Skompilowane assety (gitignored, nieobecne w kontekscie build) przezywaja
pozniejszy `COPY src/` — COPY nie kasuje plikow spoza zrodla.

## Dowod (lokalnie, arm64)

Build B po dotknieciu pliku **.py**:
```
#56 RUN npx grunt build-non-interactive   → CACHED        ✅ (60s pominiete)
#57 COPY src/ /src/src/                    → DONE 0.7s
#60 RUN ... compilemessages                → DONE 3.4s
```
- assety zapieczone: `app-blue.css` ~305K, `app-green/mwsl.css`, `*.mo` obecne,
- 3 testy zielone w obrazie, w tym **Playwright render** (`test_anonymous_smoke_crawl`).

## Efekt na CI

Na typowym (python-only) commicie `grunt build` = cache-hit →
**prepare-image ~140s → ~40s (~100s z krytycznej sciezki)**. Grunt odpala sie
tylko gdy faktycznie ruszysz scss/js (rzadziej). Stack pomiarow:

| build | kiedy | przed | po |
|-------|-------|-------|-----|
| nic nie zmienione | — | ~24s | ~24s |
| **tylko Python** (typowo) | **co commit** | **~140s** | **~40s** |
| scss/js | rzadko | ~140s | ~140s |
| deps | rzadko | ~290s | ~290s |

## Bezpieczenstwo

- `builder`, `testserver`, `runtime` nietkniete; tylko reorder w `test-runner`.
- Obraz dalej piecze source+assety → shardy i `.ci.yml` bez zmian.
- Walidacja na CI: pelny suite na x86_64 (zwlaszcza Playwright render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)