### PR TITLE
perf(ci): rozbij 116s monster-test admin-links na parametryzowane case'y

### DIFF
--- a/src/bpp/tests/test_admin/test_admin_home_links.py
+++ b/src/bpp/tests/test_admin/test_admin_home_links.py
@@ -3,16 +3,34 @@
 Łapie sytuacje typu: ktoś przemianował aplikację Django (np.
 ``dynamic_columns`` → ``dynamic_admin_columns``), a w menu / dashboardzie
 został wpisany stary URL → 404 dla superusera klikającego z home page.
+
+Podział na trzy testy (świadomy, pod CI):
+
+* ``test_admin_changelist_reachable[<url>]`` — JEDEN case na zarejestrowany
+  ModelAdmin, lista URL-i policzona w collection-time z ``admin.site._registry``
+  (bez bazy). To jest ciężki bulk (rendering changelist), a parametryzacja
+  pozwala pytest-split rozrzucić te ~N case'ów po wszystkich shardach i xdist
+  po workerach. Wcześniej całe sondowanie siedziało w jednym ``transaction=True``
+  teście (~116s wg ``.test_durations``) — pytest-split nigdy nie rozdzieli
+  pojedynczego testu, więc był on twardą podłogą swojego sharda niezależnie od
+  liczby shardów (305s na shardzie 0 przy 8 i przy 12 shardach).
+* ``test_admin_add_form_reachable[<url>]`` — analogicznie JEDEN case na model
+  dla add-formy (też potrafi być ciężka: autocomplete / inline widgety), też
+  rozłożone po shardach. Akceptuje 403 (model z wyłączonym dodawaniem).
+* ``test_admin_home_links_resolve_and_custom_reachable`` — lekki: pobiera
+  /admin/ RAZ, a każdy wyrenderowany link MUSI się resolvować do widoku (to
+  łapie stale URL po przemianowaniu aplikacji — ``resolve()`` jest in-process,
+  bez renderingu). Changelisty i add-formy pokrywają testy parametryzowane
+  powyżej, więc tu HTTP-em sondujemy tylko nieliczne linki spoza registry
+  (realnie custom admin views) — dzięki czemu test zostaje tani.
 """
 
 import re
-import threading
-from concurrent.futures import ThreadPoolExecutor
 from html.parser import HTMLParser
 
 import pytest
 from django.test import Client
-
+from django.urls import Resolver404, resolve
 
 # Linki, które celowo pomijamy w teście:
 #  * logout — wylogowuje sesję klienta, w środku przebiegu testu nie ma
@@ -50,15 +68,16 @@ class _AnchorHrefExtractor(HTMLParser):
 
 
 def _extract_links(html_bytes):
-    """Zwraca posortowaną listę unikalnych URL-i klikalnych (<a href>)."""
+    """Zwraca posortowaną listę unikalnych ścieżek klikalnych (<a href>)."""
     html = html_bytes.decode("utf-8", errors="replace")
     parser = _AnchorHrefExtractor()
     parser.feed(html)
 
     links = set()
     for href in parser.hrefs:
-        # Obetnij fragment i query — interesuje nas sam path.
-        href = href.split("#", 1)[0]
+        # Obetnij fragment i query — interesuje nas sam path (resolve()
+        # i tak nie przyjmuje query-stringa).
+        href = href.split("#", 1)[0].split("?", 1)[0]
         # Zewnętrzne URL-e, javascript:, mailto:, puste — pomijamy.
         if not href or href.startswith(
             ("http://", "https://", "javascript:", "mailto:", "tel:")
@@ -76,59 +95,136 @@ def _extract_links(html_bytes):
     return sorted(links)
 
 
-# Liczba wątków sprawdzających linki równolegle. Empirycznie 4–6 to plateau
-# na M-Mac (~45–47s end-to-end); 8 wątków ~58s, 16 wątków ~113s. Plateau jest
-# tam, bo template rendering w adminie jest w przewadze CPU-bound w Pythonie,
-# więc GIL serializuje pracę zanim conn pool PG zacznie być wąskim gardłem.
-_PARALLELISM = 4
+def _registry_urls(action):
+    """URL-e ``admin:<app>_<model>_<action>`` dla każdego zarejestrowanego
+    ModelAdmin.
 
-
-@pytest.mark.django_db(transaction=True)
-@pytest.mark.timeout(600)
-def test_admin_home_links_all_reachable(admin_user):
-    """Każdy link ze strony /admin/ otwiera się bez 404/500.
-
-    Łapie regresje typu: stale URL w menu po przemianowaniu aplikacji.
-    Nie podążamy za przekierowaniami: 3xx do widoku w admin jest OK,
-    bo to sam URL z menu sprawdzamy — nie cały graf nawigacji.
-
-    `transaction=True` jest konieczne, żeby wątki sprawdzające linki widziały
-    zacommitowanego `admin_user` przez własne połączenia do PG — przy
-    standardowym TX-wrap teście inne wątki dostają pustą bazę i 302→login.
+    Liczone w collection-time, BEZ bazy danych — ``reverse()`` potrzebuje tylko
+    załadowanego URLconf-u (pytest-django robi ``django.setup()`` + admin
+    autodiscover zanim collection ruszy), a ``admin.site._registry`` jest wtedy
+    już wypełniony. Dzięki temu pytest-split widzi N osobnych param-case'ów
+    i rozkłada je po shardach.
     """
-    home_client = Client()
-    home_client.force_login(admin_user)
-    home = home_client.get("/admin/")
-    assert home.status_code == 200, "/admin/ nie zwraca 200"
+    from django.contrib import admin
+    from django.urls import NoReverseMatch, reverse
 
-    links = _extract_links(home.content)
-    assert links, (
-        "Nie znaleziono żadnych linków na stronie /admin/ — "
-        "test nic by nie sprawdził."
+    urls = set()
+    for model in admin.site._registry:
+        meta = model._meta
+        try:
+            urls.add(reverse(f"admin:{meta.app_label}_{meta.model_name}_{action}"))
+        except NoReverseMatch:
+            # ModelAdmin bez standardowego URL-a dla tej akcji (np. nadpisany
+            # get_urls) — nieosiągalny przez reverse, pomijamy.
+            continue
+    return sorted(urls)
+
+
+# Ewaluowane raz, w collection-time. Jeśli puste (teoretycznie nie powinno),
+# parametryzacja dałaby zero case'ów — guard-test niżej pilnuje, że registry
+# w ogóle coś zawiera.
+_REGISTRY_CHANGELIST_URLS = _registry_urls("changelist")
+_REGISTRY_ADD_URLS = _registry_urls("add")
+
+
+def test_registry_admin_urls_nonempty():
+    """Sanity: collection-time enumeracja faktycznie coś znalazła.
+
+    Gdyby admin autodiscover nie zadziałał, parametryzacje changelist/add
+    zwinęłyby się do zera case'ów i CI przeszłoby „zielono" nic nie
+    sprawdzając — ten guard temu zapobiega.
+    """
+    assert _REGISTRY_CHANGELIST_URLS, (
+        "admin.site._registry nie dał żadnego changelist URL — autodiscover "
+        "adminów nie zadziałał albo żaden ModelAdmin nie jest zarejestrowany."
     )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url", _REGISTRY_CHANGELIST_URLS)
+def test_admin_changelist_reachable(admin_user, url):
+    """Changelist zarejestrowanego ModelAdmin otwiera się bez 4xx/5xx.
+
+    Jeden case na model → pytest-split rozkłada renderowanie changelist po
+    shardach. ``transaction=True`` (jak w starym monolicie) jest NIEpotrzebne:
+    tu jest jeden klient w jednym wątku, więc standardowy TX-rollback testu
+    wystarcza i jest szybszy niż flush bazy per case.
+    """
+    client = Client()
+    client.force_login(admin_user)
+    response = client.get(url)
+    assert response.status_code < 400, f"{url} -> HTTP {response.status_code}"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url", _REGISTRY_ADD_URLS)
+def test_admin_add_form_reachable(admin_user, url):
+    """Add-forma zarejestrowanego ModelAdmin renderuje się (lub jest celowo
+    wyłączona).
+
+    Też rozłożone po shardach (add-formy potrafią być ciężkie: autocomplete /
+    inline widgety). Akceptujemy 403 — to znaczy, że ``has_add_permission``
+    celowo wyłącza dodawanie dla tego modelu (taki model po prostu nie pokazuje
+    linku „+ Dodaj" w menu); 404/500 to realna regresja i ma failować.
+    """
+    client = Client()
+    client.force_login(admin_user)
+    response = client.get(url)
+    assert response.status_code < 400 or response.status_code == 403, (
+        f"{url} -> HTTP {response.status_code}"
+    )
+
+
+@pytest.mark.django_db
+def test_admin_home_links_resolve_and_custom_reachable(admin_user):
+    """Każdy link ze strony /admin/ resolvuje się; custom/add-linki też 200.
+
+    Łapie regresje typu: stale URL w menu po przemianowaniu aplikacji
+    (``resolve()`` rzuca ``Resolver404`` → fail). Changelisty i add-formy
+    zarejestrowanych modeli NIE są tu ponownie sondowane HTTP-em — pokrywają je
+    rozłożone po shardach ``test_admin_changelist_reachable[...]`` i
+    ``test_admin_add_form_reachable[...]`` — więc ten test zostaje tani (jeden
+    GET /admin/ + resolve in-process + sondowanie tylko nielicznych linków
+    spoza registry, czyli realnie custom admin views).
+
+    Nie podążamy za przekierowaniami: 3xx do widoku w admin jest OK, bo to sam
+    URL z menu sprawdzamy — nie cały graf nawigacji.
+    """
+    client = Client()
+    client.force_login(admin_user)
+    home = client.get("/admin/")
+    assert home.status_code == 200, "/admin/ nie zwraca 200"
 
     # /admin/ już sprawdzone; pomiń żeby nie strzelać ponownie po linku
     # z breadcrumb logo.
-    links = [link for link in links if link != "/admin/"]
+    links = [link for link in _extract_links(home.content) if link != "/admin/"]
+    assert links, (
+        "Nie znaleziono żadnych linków na stronie /admin/ — test nic by nie sprawdził."
+    )
 
-    tls = threading.local()
-
-    def _probe(link):
-        client = getattr(tls, "client", None)
-        if client is None:
-            client = Client()
-            client.force_login(admin_user)
-            tls.client = client
-        response = client.get(link)
-        return link, response.status_code
-
+    covered = set(_REGISTRY_CHANGELIST_URLS) | set(_REGISTRY_ADD_URLS)
+    unresolvable = []
     broken = []
-    with ThreadPoolExecutor(max_workers=_PARALLELISM) as executor:
-        for link, status in executor.map(_probe, links):
+    for link in links:
+        try:
+            resolve(link)
+        except Resolver404:
+            unresolvable.append(link)
+            continue
+        # Changelisty i add-formy registry pokrywają rozłożone testy
+        # parametryzowane — tu sonduj HTTP-em tylko linki spoza tej puli
+        # (realnie custom admin views), żeby ten test został tani.
+        if link not in covered:
+            status = client.get(link).status_code
             if status >= 400:
                 broken.append((link, status))
 
+    assert not unresolvable, (
+        "Linki ze strony /admin/, które NIE resolvują się do żadnego widoku "
+        "(prawdopodobnie stale URL po przemianowaniu aplikacji):\n"
+        + "\n".join(f"  {url}" for url in unresolvable)
+    )
     assert not broken, (
-        "Linki ze strony /admin/, które zwróciły 4xx/5xx:\n"
-        + "\n".join(f"  {url} -> HTTP {code}" for url, code in broken)
+        "Linki ze strony /admin/ (spoza registry-changelist), które zwróciły "
+        "4xx/5xx:\n" + "\n".join(f"  {url} -> HTTP {code}" for url, code in broken)
     )


### PR DESCRIPTION
## Problem

Analiza timingu workflow **Tests** na `dev` pokazała, że krytyczną ścieżkę runu wyznacza **jeden test**:

```
shard 0:  305s   ← czeka na niego cały run
reszta:   ~170-190s
```

`shard 0 = 305s przy 8 shardach I przy 12 shardach` — bump 8→12 (#288) nic mu nie dał. Przyczyna: `test_admin_home_links_all_reachable` sondował wszystkie linki `/admin/` w **jednym** teście (~116s wg `.test_durations`, najcięższy w całym repo; następny ma 28s) z wewnętrznym `ThreadPoolExecutor`. **pytest-split nigdy nie rozdzieli pojedynczego testu** — był twardą podłogą swojego sharda. Pod `-n auto` na 2-rdzeniowym runnerze 4 wewnętrzne wątki + drugi xdist-worker tłoczyły się na 2 rdzeniach (CPU-bound rendering, GIL) → realne ~227s testów na shardzie 0 vs ~97s gdzie indziej.

## Rozwiązanie

Rozbicie na trzy testy, które pytest-split + xdist rozkładają po wszystkich shardach:

| test | co robi | dystrybucja |
|------|---------|-------------|
| `test_admin_changelist_reachable[<url>]` | changelist każdego ModelAdmin, lista z `admin.site._registry` + `reverse()` w **collection-time** (bez DB) | ~134 case'y |
| `test_admin_add_form_reachable[<url>]` | add-forma każdego modelu; **403 OK** (`has_add_permission` wyłączone) | ~134 case'y |
| `test_admin_home_links_resolve_and_custom_reachable` | pobiera `/admin/` raz, `resolve()` każdego linku (łapie stale URL po przemianowaniu aplikacji), HTTP-probe **tylko** custom views spoza registry | 1 test, ~14s |

**Najcięższy nierozdzielalny item spadł ze 116s do 14s.**

### Zachowane gwarancje
- **Stale URL w menu po przemianowaniu aplikacji** (deklarowany cel oryginału) — łapie `resolve()` na wszystkich wyrenderowanych linkach.
- **4xx/5xx w changelist/add** — pokrywają testy parametryzowane (ściślej niż oryginał: probują też add-formy modeli z wyłączonym dodawaniem, akceptując 403).
- **Custom admin views** — nadal HTTP-probe w lekkim teście.

### Drobiazg
`transaction=True` (oryginał potrzebował go z powodu wątków widzących zacommitowanego usera przez osobne połączenia PG) jest zbędne — pojedynczy klient w jednym wątku, standardowy TX-rollback wystarcza i jest szybszy.

## Oczekiwany efekt

shard 0: ~227s testów → poziom reszty (~97-110s) → **wall clock runu ~340s → ~215s (~37% szybciej)**.

## Weryfikacja

`270 passed` lokalnie (testcontainers). Slowest-durations: najwolniejszy item to 14s (resolve), reszta <2s.

## Uwaga (follow-up)

Nowe nazwy testów nie są jeszcze w `.test_durations` → dostaną średnią wagę do następnego `make test-durations`; stary klucz 115.8s zostaje jako martwy wpis (ignorowany przez pytest-split). Pełny efekt balansowania po refreshu durations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)