### PR TITLE
feat(powiazania_autorow): animacja zmiany układu + szybkie generowanie powiązań (SQL)

### DIFF
--- a/src/powiazania_autorow/core.py
+++ b/src/powiazania_autorow/core.py
@@ -3,122 +3,93 @@ Core functionality for calculating author connections.
 """
 
 import logging
-from collections import defaultdict
 
-from django.db import transaction
+from django.db import connection, transaction
 
 from bpp.models import Patent_Autor, Wydawnictwo_Ciagle_Autor, Wydawnictwo_Zwarte_Autor
 
+from .models import AuthorConnection
+
 logger = logging.getLogger(__name__)
 
+# Modele autorstwa, z których liczymy współautorstwa. Każdy ma WŁASNĄ przestrzeń
+# rekord_id (Ciągłe/Zwarte/Patenty to osobne tabele), więc liczymy per-tabela i
+# sumujemy — rekord_id=5 w jednej tabeli to inna praca niż rekord_id=5 w drugiej.
+_MODELE_AUTORSTWA = (
+    Wydawnictwo_Ciagle_Autor,
+    Wydawnictwo_Zwarte_Autor,
+    Patent_Autor,
+)
 
-def calculate_author_connections():  # noqa: C901
+
+def _self_join_sql(db_table):
+    """Fragment SELECT: dla jednej tabeli *_Autor liczy, ile WSPÓLNYCH prac
+    (DISTINCT rekord_id) dzieli każda nieuporządkowana para autorów.
+
+    Self-join po rekord_id; warunek ``a1.autor_id < a2.autor_id`` daje każdą
+    parę dokładnie raz (mniejszy id jako primary) i z definicji wyklucza parę
+    autora z samym sobą — nawet gdy autor ma kilka wpisów na tej samej pracy
+    (różne typy odpowiedzialności / kolejność). NULL-owe autor_id odpadają przy
+    porównaniu ``<``. Join korzysta z istniejącego indeksu unique_together
+    ``(rekord, autor, ...)`` — bez potrzeby dodawania nowych indeksów.
     """
-    Calculate and update all author connections based on shared publications.
-    This function analyzes all publications and creates/updates AuthorConnection records.
+    return f"""
+        SELECT a1.autor_id AS p,
+               a2.autor_id AS s,
+               COUNT(DISTINCT a1.rekord_id) AS cnt
+          FROM "{db_table}" a1
+          JOIN "{db_table}" a2
+            ON a1.rekord_id = a2.rekord_id
+           AND a1.autor_id < a2.autor_id
+         GROUP BY a1.autor_id, a2.autor_id
     """
-    from .models import AuthorConnection
 
-    logger.info("Starting author connections calculation...")
 
-    # Dictionary to store connections: {(author1_id, author2_id): count}
-    connections = defaultdict(int)
+def calculate_author_connections():
+    """Przelicza od zera całą tabelę AuthorConnection z bieżących współautorstw.
 
-    # Process Wydawnictwo_Ciagle (continuous publications)
-    logger.info("Processing Wydawnictwo_Ciagle...")
-    # Bez select_related — przy .values_list selektujemy tylko kolumny FK
-    # z tabeli bazowej, więc join był martwy. .iterator() strumieniuje
-    # wiersze zamiast ładować wszystkie do RAM naraz.
-    ciagle_authors = Wydawnictwo_Ciagle_Autor.objects.values_list(
-        "rekord_id", "autor_id"
-    ).iterator(chunk_size=2000)
+    Całość liczona w SQL: ``TRUNCATE`` + ``INSERT ... SELECT`` z self-joinem per
+    tabela autorstwa (Ciągłe / Zwarte / Patenty), zsumowane po parze autorów.
+    Zero round-tripów do Pythona i zero materializacji par w pamięci — w
+    odróżnieniu od dawnej wersji, która streamowała wszystkie wiersze i budowała
+    ogromny słownik par (O(k^2) na publikację, patologia przy pracach z setkami
+    współautorów).
 
-    # Group authors by publication
-    publications_ciagle = defaultdict(list)
-    for rekord_id, autor_id in ciagle_authors:
-        if autor_id:  # Skip null authors
-            publications_ciagle[rekord_id].append(autor_id)
+    Semantyka: ``shared_publications_count`` = liczba WSPÓLNYCH publikacji
+    (DISTINCT rekord), sumowana po typach prac. Para autorów zapisywana jest raz,
+    z mniejszym id jako ``primary_author`` (spójnie z unique_together). Pary
+    autora z samym sobą nie powstają.
 
-    # Count connections
-    for authors in publications_ciagle.values():
-        if len(authors) > 1:
-            for i in range(len(authors)):
-                for j in range(i + 1, len(authors)):
-                    # Always store with smaller ID first to avoid duplicates
-                    author_pair = tuple(sorted([authors[i], authors[j]]))
-                    connections[author_pair] += 1
-
-    # Process Wydawnictwo_Zwarte (monographs)
-    logger.info("Processing Wydawnictwo_Zwarte...")
-    # Patrz wyżej — bez martwego select_related, ze strumieniowaniem.
-    zwarte_authors = Wydawnictwo_Zwarte_Autor.objects.values_list(
-        "rekord_id", "autor_id"
-    ).iterator(chunk_size=2000)
-
-    publications_zwarte = defaultdict(list)
-    for rekord_id, autor_id in zwarte_authors:
-        if autor_id:
-            publications_zwarte[rekord_id].append(autor_id)
-
-    for authors in publications_zwarte.values():
-        if len(authors) > 1:
-            for i in range(len(authors)):
-                for j in range(i + 1, len(authors)):
-                    author_pair = tuple(sorted([authors[i], authors[j]]))
-                    connections[author_pair] += 1
-
-    # Process Patents
-    logger.info("Processing Patents...")
-    # Patrz wyżej — bez martwego select_related, ze strumieniowaniem.
-    patent_authors = Patent_Autor.objects.values_list("rekord_id", "autor_id").iterator(
-        chunk_size=2000
+    Zwraca łączną liczbę utworzonych powiązań.
+    """
+    table = AuthorConnection._meta.db_table
+    union = "\n        UNION ALL\n".join(
+        _self_join_sql(m._meta.db_table) for m in _MODELE_AUTORSTWA
     )
+    insert_sql = f"""
+        INSERT INTO "{table}"
+            (primary_author_id, secondary_author_id,
+             shared_publications_count, last_updated)
+        SELECT p, s, SUM(cnt) AS shared, now()
+          FROM (
+{union}
+          ) sub
+         GROUP BY p, s
+    """
 
-    publications_patent = defaultdict(list)
-    for rekord_id, autor_id in patent_authors:
-        if autor_id:
-            publications_patent[rekord_id].append(autor_id)
-
-    for authors in publications_patent.values():
-        if len(authors) > 1:
-            for i in range(len(authors)):
-                for j in range(i + 1, len(authors)):
-                    author_pair = tuple(sorted([authors[i], authors[j]]))
-                    connections[author_pair] += 1
-
-    logger.info(f"Found {len(connections)} author connections")
-
-    # Update database
+    logger.info("Przeliczanie powiązań autorów (SQL)...")
     with transaction.atomic():
-        # Clear existing connections
-        logger.info("Clearing existing connections...")
-        AuthorConnection.objects.all().delete()
+        with connection.cursor() as cur:
+            # DELETE (nie TRUNCATE): TRUNCATE wywala się błędem ObjectInUse, gdy
+            # w tej samej transakcji były wcześniej INSERT-y do tabeli (oczekujące
+            # zdarzenia wyzwalaczy FK) — np. w testach owiniętych w transakcję lub
+            # gdy recompute leci po innej operacji na tabeli. DELETE bez WHERE to
+            # jedno zapytanie, transakcyjne i odporne na ten przypadek. Cały blok
+            # jest atomowy: przy błędzie INSERT-u DELETE też się cofa, więc tabela
+            # nigdy nie zostaje pusta.
+            cur.execute(f'DELETE FROM "{table}"')
+            cur.execute(insert_sql)
 
-        # Create new connections
-        logger.info("Creating new connections...")
-        batch_size = 1000
-        connections_to_create = []
-
-        for (author1_id, author2_id), count in connections.items():
-            if count > 0:  # Only create connections with at least 1 shared publication
-                connections_to_create.append(
-                    AuthorConnection(
-                        primary_author_id=author1_id,
-                        secondary_author_id=author2_id,
-                        shared_publications_count=count,
-                    )
-                )
-
-                if len(connections_to_create) >= batch_size:
-                    AuthorConnection.objects.bulk_create(connections_to_create)
-                    connections_to_create = []
-
-        # Create remaining connections
-        if connections_to_create:
-            AuthorConnection.objects.bulk_create(connections_to_create)
-
-    total_connections = AuthorConnection.objects.count()
-    logger.info(
-        f"Calculation complete. Created {total_connections} author connections."
-    )
-    return total_connections
+    total = AuthorConnection.objects.count()
+    logger.info("Przeliczono %s powiązań autorów.", total)
+    return total

--- a/src/powiazania_autorow/management/commands/przelicz_powiazania_autorow.py
+++ b/src/powiazania_autorow/management/commands/przelicz_powiazania_autorow.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+
+from powiazania_autorow.core import calculate_author_connections
+
+
+class Command(BaseCommand):
+    help = (
+        "Przelicza od zera tabelę powiązań autorów (współautorstwa) na podstawie "
+        "wydawnictw ciągłych, zwartych i patentów. Liczone w całości w SQL."
+    )
+
+    def handle(self, *args, **options):
+        total = calculate_author_connections()
+        self.stdout.write(self.style.SUCCESS(f"Przeliczono {total} powiązań autorów."))

--- a/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/layout.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/layout.js
@@ -119,6 +119,14 @@ export function pozycjeUkladu(ctx, centerId, children, levelOf) {
     return pozycjeRadialne(centerId, children);
 }
 
+// Delikatna "guma" na PRZEJŚCIU między układami: easing z lekkim
+// przestrzeleniem celu (drugi punkt kontrolny krzywej Béziera ma y > 1, więc
+// węzeł minimalnie wyjeżdża za pozycję docelową i wraca). W przeciwieństwie do
+// spring() jest w pełni przewidywalny — żadnego rozkołysania, tylko subtelne
+// "dociągnięcie". Strojenie: większe y2 = wyraźniejsze odbicie.
+const EASING_UKLAD = "cubic-bezier(0.34, 1.25, 0.64, 1)";
+const CZAS_UKLAD = 520; // ms — nieco dłużej niż 450, by przestrzelenie było czytelne
+
 // Ułożenie grafu wg bieżącego układu. "sila" = layout siłowy fcose
 // (organiczne skupiska); pozostałe = deterministyczne pozycje liczone
 // z drzewa ostatniej sieci. `animuj` steruje animacją przejścia.
@@ -130,7 +138,8 @@ export function ulozGraf(ctx, animuj) {
             quality: "default",
             randomize: true,
             animate: animuj,
-            animationDuration: 500,
+            animationDuration: CZAS_UKLAD,
+            animationEasing: animuj ? EASING_UKLAD : undefined,
             fit: true,
             padding: 50,
             nodeRepulsion: 9000,
@@ -149,11 +158,12 @@ export function ulozGraf(ctx, animuj) {
             const p = pozycje[n.id()];
             if (p) {
                 n.animate(
-                    { position: p }, { duration: 450, easing: "ease-out" }
+                    { position: p },
+                    { duration: CZAS_UKLAD, easing: EASING_UKLAD }
                 );
             }
         });
-        cy.animate({ fit: { eles: cy.elements(), padding: 50 }, duration: 450 });
+        cy.animate({ fit: { eles: cy.elements(), padding: 50 }, duration: CZAS_UKLAD });
     } else {
         cy.batch(function () {
             cy.nodes().forEach(function (n) {

--- a/src/powiazania_autorow/tests.py
+++ b/src/powiazania_autorow/tests.py
@@ -228,6 +228,90 @@ def test_calculate_author_connections_clears_existing():
 
 
 @pytest.mark.django_db
+def test_calculate_liczy_distinct_publikacje_i_bez_self_loop():
+    """Autor z KILKOMA wpisami na jednej pracy (różne typy odpowiedzialności)
+    nie zawyża liczby wspólnych publikacji ani nie tworzy pętli autor-do-siebie.
+
+    `shared_publications_count` = liczba WSPÓLNYCH publikacji (DISTINCT rekord),
+    a nie liczba par wierszy. Stara wersja liczyła pary wierszy (zawyżała) i
+    potrafiła stworzyć powiązanie autora z samym sobą.
+    """
+    from bpp.models import Typ_Odpowiedzialnosci
+
+    x = baker.make(Autor, imiona="X", nazwisko="Iks")
+    y = baker.make(Autor, imiona="Y", nazwisko="Igrek")
+    t1 = baker.make(Typ_Odpowiedzialnosci)
+    t2 = baker.make(Typ_Odpowiedzialnosci)
+
+    pub = baker.make(Wydawnictwo_Ciagle)
+    # X występuje DWA razy na tej samej pracy (dwa typy odpowiedzialności)
+    baker.make(
+        Wydawnictwo_Ciagle_Autor,
+        rekord=pub,
+        autor=x,
+        typ_odpowiedzialnosci=t1,
+        kolejnosc=0,
+    )
+    baker.make(
+        Wydawnictwo_Ciagle_Autor,
+        rekord=pub,
+        autor=x,
+        typ_odpowiedzialnosci=t2,
+        kolejnosc=1,
+    )
+    baker.make(
+        Wydawnictwo_Ciagle_Autor,
+        rekord=pub,
+        autor=y,
+        typ_odpowiedzialnosci=t1,
+        kolejnosc=2,
+    )
+
+    calculate_author_connections()
+
+    # tylko jedno powiązanie X<->Y; ŻADNEJ pętli X<->X
+    assert AuthorConnection.objects.count() == 1
+    conn = AuthorConnection.objects.get()
+    assert {conn.primary_author_id, conn.secondary_author_id} == {x.pk, y.pk}
+    assert conn.shared_publications_count == 1  # jedna wspólna praca, nie dwie
+    assert not AuthorConnection.objects.filter(
+        primary_author_id=x.pk, secondary_author_id=x.pk
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_calculate_zapisuje_mniejszy_id_jako_primary():
+    """Para autorów zapisywana raz, z mniejszym id jako primary_author."""
+    a = baker.make(Autor)
+    b = baker.make(Autor)
+    lo, hi = sorted([a.pk, b.pk])
+    pub = baker.make(Wydawnictwo_Ciagle)
+    baker.make(Wydawnictwo_Ciagle_Autor, rekord=pub, autor=a, kolejnosc=0)
+    baker.make(Wydawnictwo_Ciagle_Autor, rekord=pub, autor=b, kolejnosc=1)
+
+    calculate_author_connections()
+
+    conn = AuthorConnection.objects.get()
+    assert conn.primary_author_id == lo
+    assert conn.secondary_author_id == hi
+
+
+@pytest.mark.django_db
+def test_management_command_przelicza_powiazania():
+    from django.core.management import call_command
+
+    a = baker.make(Autor, imiona="A", nazwisko="Aa")
+    b = baker.make(Autor, imiona="B", nazwisko="Bb")
+    pub = baker.make(Wydawnictwo_Ciagle)
+    baker.make(Wydawnictwo_Ciagle_Autor, rekord=pub, autor=a, kolejnosc=0)
+    baker.make(Wydawnictwo_Ciagle_Autor, rekord=pub, autor=b, kolejnosc=1)
+
+    call_command("przelicz_powiazania_autorow")
+
+    assert AuthorConnection.objects.count() == 1
+
+
+@pytest.mark.django_db
 def test_calculate_author_connections_single_author_publication():
     """Test that single-author publications don't create connections."""
     # Create author


### PR DESCRIPTION
Dwie niezależne rzeczy w eksploratorze sieci współautorstwa (na bazie świeżego `dev` po #293). **Bez 3D** — to osobny temat.

## 1. Delikatna animacja zmiany układu
Przejście między układami (radialny / koncentryczny / siłowy) dostaje easing z lekkim, przewidywalnym **przestrzeleniem celu** (`cubic-bezier(0.34, 1.25, 0.64, 1)` — drugi punkt kontrolny `y>1`) zamiast `ease-out`. Subtelny efekt „gumy" bez rozkołysania, które miałby `spring()`. Stałe `EASING_UKLAD` / `CZAS_UKLAD` do strojenia; fcose dostaje to samo przez `animationEasing`. (`layout.js`)

## 2. Szybkie generowanie powiązań — całość w SQL
`calculate_author_connections()` przepisane z Pythona na **`DELETE` + `INSERT … SELECT`** z self-joinem per tabela autorstwa (Ciągłe / Zwarte / Patenty), `GROUP BY` po parze autorów.

- **Dlaczego szybciej:** stara wersja streamowała wszystkie wiersze autorstwa do Pythona i budowała ogromny słownik par — `O(k²)` na publikację, co eksploduje przy pracach z setkami współautorów (hyperauthorship). Teraz robi to baza jednym zapytaniem.
- **Indeksy:** nic nie trzeba dodawać — self-join po `rekord_id` korzysta z istniejącego indeksu `unique_together (rekord, autor, …)` na wszystkich trzech tabelach.
- **Przy okazji 2 poprawki semantyczne:**
  - `shared_publications_count` = `COUNT(DISTINCT rekord)` — faktyczna liczba wspólnych **publikacji** (stara wersja liczyła pary wierszy → zawyżała, gdy autor miał kilka typów odpowiedzialności na jednej pracy);
  - **brak pętli autor↔autor** (stara wersja potrafiła je tworzyć w tym samym przypadku).
- `DELETE` zamiast `TRUNCATE` — `TRUNCATE` wywala się `ObjectInUse`, gdy w tej samej transakcji były wcześniej zapisy do tabeli (np. w testach owiniętych w transakcję). Cały blok atomowy.
- Sygnatura bez zmian → celery task i backfill-migracja działają dalej.
- Nowa komenda: **`manage.py przelicz_powiazania_autorow`** (ręczne przeliczenie z CLI).

## Testy
+3 nowe (DISTINCT-publikacje bez self-loop, mniejszy id jako primary, management command). Stare testy parzystości przechodzą bez zmian. Cały moduł zielony: **50 passed**. ruff + `manage.py check` czyste.

> Zmiana JS jest w źródle ES modułów (`layout.js`); bundle `dist/cytoscape-bundle.js` jest gitignored i odbudowywany na buildzie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)