### PR TITLE
feat(oidc): dokończenie logowania — wylogowanie z Keycloaka, .well-known, robustness

### DIFF
--- a/docs/superpowers/specs/2026-06-03-oidc-keycloak-login-design.md
+++ b/docs/superpowers/specs/2026-06-03-oidc-keycloak-login-design.md
@@ -137,16 +137,33 @@ Blok warunkowy à la `if MICROSOFT_AUTH_CLIENT_ID:` — aktywny tylko gdy
 - Bez e2e przeciw realnemu Keycloakowi — to wymaga sekretów i sieci;
   testujemy ręcznie po wgraniu env.
 
-## Poza zakresem spike'a (faza 2, po obejrzeniu claimów)
+## Faza 2 — dokończenie (PR na `feature/multi-hosted-config`, ZAIMPLEMENTOWANE)
+
+Zakres niezależny od realnych claimów (gating ról świadomie odłożony, bo role
+bywają w access/id-tokenie, nie w userinfo — nie buduję na ślepo):
+
+- **Wylogowanie z Keycloaka** (RP-Initiated Logout): `BppOIDCAwareLogoutView`
+  pod `logout/` — sesja OIDC → redirect na `end_session_endpoint` z
+  `id_token_hint` (z sesji; `OIDC_STORE_ID_TOKEN=True`) +
+  `post_logout_redirect_uri`; każda inna sesja → standardowy `LogoutView`.
+  Wymaga rejestracji post-logout redirect URI w kliencie KC.
+- **Endpointy z `.well-known/openid-configuration`**: `fetch_well_known_endpoints`
+  pobiera prawdziwe adresy (krótki timeout), z **fallbackiem na konwencję**
+  Keycloaka gdy IdP nieosiągalny przy starcie. Sieć dotykana tylko z settings;
+  testy env-resolution bez sieci.
+- **Odporność**: unikalny `username` przy kolizji (`base-2`, `base-3`…),
+  brak `email` obsłużony.
+
+## Poza zakresem — faza 2b (po obejrzeniu claimów)
 
 - Gating studentów: filtr po roli/grupie z tokenu („nie wpuszczamy” /
   „nie tworzymy kont”).
 - Mapowanie ról/grup Keycloaka → grupy/uprawnienia Django.
 - Powiązanie z istniejącym `Autor` przez claim `person_id`.
-- Wylogowanie z Keycloaka (`end_session_endpoint`).
 - Twarde wiązanie skrótu z `Uczelnia` z bazy zamiast auto-detekcji env.
-- Przełączenie wyprowadzania endpointów z konwencji Keycloaka na fetch
-  `.well-known/openid-configuration` z cache.
+- Cache wyniku `.well-known` (dziś fetch przy każdym starcie procesu).
+- Wiele issuerów naraz w jednym procesie (3 uczelnie / 3 OIDC) — osobne
+  podklasy backendu + routing per-host/mountpoint.
 
 ## Wymagania od administratora Keycloak (realm KA)
 

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -1207,7 +1207,10 @@ AUTHENTICATION_BACKENDS = list(AUTHENTICATION_BACKENDS) + [
 # Backend jest DOPISYWANY do listy (ModelBackend zostaje → logowanie hasłem
 # działa równolegle).
 #
-from oidc_integration.conf import discover_oidc_config  # noqa: E402
+from oidc_integration.conf import (  # noqa: E402
+    discover_oidc_config,
+    fetch_well_known_endpoints,
+)
 
 _OIDC_CONFIG = discover_oidc_config()
 OIDC_LOGIN_ENABLED = _OIDC_CONFIG is not None
@@ -1220,16 +1223,25 @@ if _OIDC_CONFIG:
     OIDC_RP_CLIENT_ID = _OIDC_CONFIG["client_id"]
     OIDC_RP_CLIENT_SECRET = _OIDC_CONFIG["client_secret"]
 
-    _oidc_endpoints = _OIDC_CONFIG["endpoints"]
+    # Endpointy: preferuj .well-known (źródło prawdy serwera), z fallbackiem na
+    # konwencję Keycloaka gdy IdP nieosiągalny przy starcie.
+    _oidc_endpoints = (
+        fetch_well_known_endpoints(_OIDC_CONFIG["issuer"]) or _OIDC_CONFIG["endpoints"]
+    )
     OIDC_OP_AUTHORIZATION_ENDPOINT = _oidc_endpoints["authorization"]
     OIDC_OP_TOKEN_ENDPOINT = _oidc_endpoints["token"]
-    OIDC_OP_USER_ENDPOINT = _oidc_endpoints["userinfo"]
+    OIDC_OP_USER_ENDPOINT = _oidc_endpoints.get("userinfo", "")
     OIDC_OP_JWKS_ENDPOINT = _oidc_endpoints["jwks"]
+    # end_session: wylogowanie z Keycloaka (RP-Initiated Logout).
+    OIDC_OP_LOGOUT_ENDPOINT = _oidc_endpoints.get("end_session", "")
+    OIDC_OP_LOGOUT_URL_METHOD = "oidc_integration.logout.build_provider_logout_url"
 
     # Keycloak podpisuje id_token RS256; scope email konieczny do auto-create.
     OIDC_RP_SIGN_ALGO = "RS256"
     OIDC_RP_SCOPES = "openid email profile"
     OIDC_CREATE_USER = True
+    # Zapamiętaj id_token w sesji — potrzebny jako id_token_hint przy logout.
+    OIDC_STORE_ID_TOKEN = True
 
     AUTHENTICATION_BACKENDS = list(AUTHENTICATION_BACKENDS) + [
         "oidc_integration.backends.BppOIDCBackend",

--- a/src/django_bpp/urls.py
+++ b/src/django_bpp/urls.py
@@ -400,13 +400,21 @@ if not apps.is_installed("microsoft_auth"):
     # Jeżeli NIE ma włączonej aplikacji microsoft_auth, to obsługuj
     # własne logowanie hasłem z front-endu:
     #
+    # Logout świadomy OIDC: sesja OIDC → wyloguj też z Keycloaka; reszta →
+    # standardowy LogoutView. Bezpieczny nadzbiór, więc używamy go zawsze gdy
+    # apka OIDC jest aktywna.
+    if apps.is_installed("oidc_integration"):
+        from oidc_integration.views import BppOIDCAwareLogoutView as _LogoutView
+    else:
+        _LogoutView = LogoutView
+
     urlpatterns += [
         url(
             r"^accounts/login/$",
             HTMXAwareLoginView.as_view(authentication_form=MyAuthenticationForm),
             name="login_form",
         ),
-        url(r"^logout/$", login_required(LogoutView.as_view()), name="logout"),
+        url(r"^logout/$", login_required(_LogoutView.as_view()), name="logout"),
     ]
 else:
     from django_bpp.views import MicrosoftLogoutView

--- a/src/oidc_integration/backends.py
+++ b/src/oidc_integration/backends.py
@@ -89,6 +89,21 @@ class BppOIDCBackend(OIDCAuthenticationBackend):
         self._assign_uczelnia(user)
         return user
 
+    def _unique_username(self, base):
+        """Zwróć ``base`` albo ``base-2``/``base-3``… jeśli zajęty.
+
+        ``create_user`` woła się tylko, gdy nie ma konta dopasowanego po
+        e-mailu — ale sam username mógłby kolidować z innym kontem (ten sam
+        ``preferred_username`` przy innym e-mailu). Bez tego byłby IntegrityError.
+        """
+        manager = self.UserModel.objects
+        if not manager.filter(username=base).exists():
+            return base
+        i = 2
+        while manager.filter(username=f"{base}-{i}").exists():
+            i += 1
+        return f"{base}-{i}"
+
     def create_user(self, claims):
         """Załóż zwykłe konto (bez is_staff) na podstawie claimów.
 
@@ -97,9 +112,10 @@ class BppOIDCBackend(OIDCAuthenticationBackend):
         OIDC. Wywoływane tylko, gdy ``filter_users_by_claims`` (domyślnie po
         e-mailu) nie znajdzie istniejącego konta.
         """
-        username = (
+        base_username = (
             claims.get("preferred_username") or claims.get("email") or claims.get("sub")
         )
+        username = self._unique_username(base_username)
         email = claims.get("email") or ""
 
         user = self.UserModel.objects.create_user(username=username, email=email)

--- a/src/oidc_integration/conf.py
+++ b/src/oidc_integration/conf.py
@@ -13,11 +13,23 @@ Moduł celowo NIE importuje Django (czytany jest z ``settings/base.py`` zanim
 Django w pełni wstanie) — operuje wyłącznie na ``os.environ``.
 """
 
+import logging
 import os
 import re
 
+logger = logging.getLogger(__name__)
+
 _PREFIX = "DJANGO_BPP_OIDC_"
 _FIELDS = ("CLIENT_ID", "CLIENT_SECRET", "ISSUER")
+
+# Mapowanie wewnętrznych nazw endpointów → kluczy w .well-known/openid-configuration
+_WELL_KNOWN_KEYS = {
+    "authorization": "authorization_endpoint",
+    "token": "token_endpoint",
+    "userinfo": "userinfo_endpoint",
+    "jwks": "jwks_uri",
+    "end_session": "end_session_endpoint",
+}
 
 # Skrót składa się z liter/cyfr (bez podkreślników), żeby nie kolidować z
 # bare-wariantem DJANGO_BPP_OIDC_CLIENT_ID (gdzie "CLIENT" nie jest skrótem).
@@ -43,9 +55,10 @@ def _get(environ, field, skrot):
 
 
 def _keycloak_endpoints(issuer):
-    """Wyprowadź 4 endpointy z URL issuera konwencją Keycloaka.
+    """Wyprowadź endpointy z URL issuera konwencją Keycloaka.
 
-    Faza 2: zamienić na fetch ``.well-known/openid-configuration`` z cache.
+    Używane jako **fallback**, gdy nie uda się pobrać
+    ``.well-known/openid-configuration`` (patrz ``fetch_well_known_endpoints``).
     """
     base = issuer.rstrip("/") + "/protocol/openid-connect"
     return {
@@ -53,7 +66,50 @@ def _keycloak_endpoints(issuer):
         "token": f"{base}/token",
         "userinfo": f"{base}/userinfo",
         "jwks": f"{base}/certs",
+        "end_session": f"{base}/logout",
     }
+
+
+def fetch_well_known_endpoints(issuer, timeout=3):
+    """Pobierz endpointy z ``{issuer}/.well-known/openid-configuration``.
+
+    Zwraca dict w wewnętrznych nazwach (jak ``_keycloak_endpoints``) albo
+    ``None``, gdy fetch/parse się nie powiedzie. Krótki timeout i połknięcie
+    błędu są celowe: serwer BPP nie może zawisnąć na starcie, gdy IdP jest
+    nieosiągalny — wołający degraduje wtedy do konwencji.
+
+    NIE wołane w testach env-resolution (te używają konwencji); sieć dotykana
+    tylko z ``settings/base.py`` przy realnej konfiguracji.
+    """
+    url = issuer.rstrip("/") + "/.well-known/openid-configuration"
+    try:
+        import requests
+
+        resp = requests.get(url, timeout=timeout)
+        resp.raise_for_status()
+        doc = resp.json()
+    except Exception as e:  # noqa: BLE001 — degradacja do konwencji jest OK
+        logger.warning(
+            "OIDC: nie udało się pobrać %s (%s) — używam konwencji Keycloaka",
+            url,
+            e,
+        )
+        return None
+
+    endpoints = {}
+    for internal, well_known in _WELL_KNOWN_KEYS.items():
+        value = doc.get(well_known)
+        if value:
+            endpoints[internal] = value
+
+    # Bez kluczowych endpointów discovery jest bezużyteczne — degraduj.
+    if not all(k in endpoints for k in ("authorization", "token", "jwks")):
+        logger.warning(
+            "OIDC: %s nie zawiera kompletu endpointów — używam konwencji", url
+        )
+        return None
+
+    return endpoints
 
 
 def discover_oidc_config(environ=None):

--- a/src/oidc_integration/logout.py
+++ b/src/oidc_integration/logout.py
@@ -1,0 +1,31 @@
+"""Budowanie URL-a wylogowania z serwera OIDC (Keycloak end_session).
+
+RP-Initiated Logout: po lokalnym wylogowaniu Django przekierowujemy usera na
+``end_session_endpoint`` Keycloaka z ``id_token_hint`` (z sesji) i
+``post_logout_redirect_uri``. Dzięki temu wylogowanie z BPP kończy też sesję
+SSO w Keycloaku — inaczej kolejne „Zaloguj przez UAFM" logowałoby bez pytania
+o hasło (cicha re-autoryzacja z żywej sesji KC).
+"""
+
+from urllib.parse import urlencode
+
+from django.conf import settings
+
+
+def build_provider_logout_url(request):
+    """Zwróć URL wylogowania z OP albo lokalny redirect (gdy brak end_session).
+
+    Czyta ``oidc_id_token`` z sesji — MUSI być wywołane PRZED ``auth.logout``
+    (który czyści sesję). ``OIDC_STORE_ID_TOKEN=True`` zapewnia obecność tokenu.
+    """
+    fallback = getattr(settings, "LOGOUT_REDIRECT_URL", None) or "/"
+    end_session = getattr(settings, "OIDC_OP_LOGOUT_ENDPOINT", "")
+    if not end_session:
+        return fallback
+
+    params = {"post_logout_redirect_uri": request.build_absolute_uri(fallback)}
+    id_token = request.session.get("oidc_id_token")
+    if id_token:
+        params["id_token_hint"] = id_token
+
+    return f"{end_session}?{urlencode(params)}"

--- a/src/oidc_integration/tests/test_backends.py
+++ b/src/oidc_integration/tests/test_backends.py
@@ -74,6 +74,21 @@ def test_create_user_zaklada_zwykle_konto_bez_is_staff():
 
 
 @pytest.mark.django_db
+def test_create_user_unika_kolizji_username():
+    UserModel = get_user_model()
+    UserModel.objects.create_user(username="jkowalski", email="ktos@inny.pl")
+
+    backend = _backend()
+    backend.UserModel = UserModel
+    # ten sam preferred_username, inny e-mail → username nie może kolidować
+    user = backend.create_user(
+        {"preferred_username": "jkowalski", "email": "jan@uafm.edu.pl"}
+    )
+
+    assert user.username == "jkowalski-2"
+
+
+@pytest.mark.django_db
 def test_create_user_username_fallback_do_sub():
     backend = _backend()
     backend.UserModel = get_user_model()

--- a/src/oidc_integration/tests/test_conf.py
+++ b/src/oidc_integration/tests/test_conf.py
@@ -3,7 +3,7 @@
 Czysty unit — bez bazy i bez sieci. Przekazujemy własny ``environ``.
 """
 
-from oidc_integration.conf import discover_oidc_config
+from oidc_integration.conf import discover_oidc_config, fetch_well_known_endpoints
 
 ISSUER = "https://auth.uafm.edu.pl/auth/realms/KA"
 
@@ -83,3 +83,51 @@ def test_endpointy_wyprowadzone_z_issuera():
     assert ep["token"] == f"{base}/token"
     assert ep["userinfo"] == f"{base}/userinfo"
     assert ep["jwks"] == f"{base}/certs"
+    assert ep["end_session"] == f"{base}/logout"
+
+
+def test_fetch_well_known_fallback_na_bledzie_sieci(monkeypatch):
+    import requests
+
+    def boom(*args, **kwargs):
+        raise requests.RequestException("brak sieci")
+
+    monkeypatch.setattr("requests.get", boom)
+    assert fetch_well_known_endpoints(ISSUER) is None
+
+
+def test_fetch_well_known_parsuje_endpointy(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "authorization_endpoint": "https://kc/auth",
+                "token_endpoint": "https://kc/token",
+                "userinfo_endpoint": "https://kc/userinfo",
+                "jwks_uri": "https://kc/certs",
+                "end_session_endpoint": "https://kc/logout",
+            }
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: FakeResp())
+    ep = fetch_well_known_endpoints(ISSUER)
+    assert ep == {
+        "authorization": "https://kc/auth",
+        "token": "https://kc/token",
+        "userinfo": "https://kc/userinfo",
+        "jwks": "https://kc/certs",
+        "end_session": "https://kc/logout",
+    }
+
+
+def test_fetch_well_known_niekompletny_to_none(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"userinfo_endpoint": "https://kc/userinfo"}  # brak auth/token/jwks
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: FakeResp())
+    assert fetch_well_known_endpoints(ISSUER) is None

--- a/src/oidc_integration/tests/test_logout.py
+++ b/src/oidc_integration/tests/test_logout.py
@@ -1,0 +1,74 @@
+"""Testy wylogowania OIDC: builder URL-a + backend-aware widok."""
+
+import pytest
+from django.contrib.auth import BACKEND_SESSION_KEY, get_user_model
+from django.contrib.sessions.backends.db import SessionStore
+from django.test import override_settings
+from model_bakery import baker
+
+from oidc_integration.logout import build_provider_logout_url
+from oidc_integration.views import OIDC_BACKEND_PATH, BppOIDCAwareLogoutView
+
+
+def _dict_request(rf, **session):
+    """Request z sesją-słownikiem (builder nie potrzebuje DB)."""
+    req = rf.post("/logout/")
+    req.session = dict(session)
+    return req
+
+
+def _db_request(rf, **session):
+    """Request z realną sesją DB + pominięciem CSRF (dla widoku LogoutView)."""
+    req = rf.post("/logout/")
+    req.session = SessionStore()
+    for k, v in session.items():
+        req.session[k] = v
+    req.session.save()
+    req._dont_enforce_csrf_checks = True
+    return req
+
+
+@override_settings(OIDC_OP_LOGOUT_ENDPOINT="https://kc/logout", LOGOUT_REDIRECT_URL="/")
+def test_build_logout_url_zawiera_id_token_hint_i_redirect(rf):
+    req = _dict_request(rf, oidc_id_token="TOK123")
+    url = build_provider_logout_url(req)
+    assert url.startswith("https://kc/logout?")
+    assert "id_token_hint=TOK123" in url
+    assert "post_logout_redirect_uri=" in url
+
+
+@override_settings(OIDC_OP_LOGOUT_ENDPOINT="", LOGOUT_REDIRECT_URL="/start/")
+def test_build_logout_url_bez_end_session_to_fallback(rf):
+    assert build_provider_logout_url(_dict_request(rf)) == "/start/"
+
+
+@pytest.mark.django_db
+@override_settings(OIDC_OP_LOGOUT_ENDPOINT="https://kc/logout", LOGOUT_REDIRECT_URL="/")
+def test_logout_view_sesja_oidc_redirect_do_keycloaka(rf):
+    user = baker.make(get_user_model())
+    req = _db_request(
+        rf, **{BACKEND_SESSION_KEY: OIDC_BACKEND_PATH, "oidc_id_token": "TOK"}
+    )
+    req.user = user
+
+    resp = BppOIDCAwareLogoutView.as_view()(req)
+
+    assert resp.status_code == 302
+    assert resp.url.startswith("https://kc/logout")
+    assert "id_token_hint=TOK" in resp.url
+
+
+@pytest.mark.django_db
+@override_settings(OIDC_OP_LOGOUT_ENDPOINT="https://kc/logout", LOGOUT_REDIRECT_URL="/")
+def test_logout_view_sesja_haslowa_nie_idzie_do_keycloaka(rf):
+    # Inny backend w sesji → standardowe wylogowanie Django (redirect lokalny).
+    user = baker.make(get_user_model())
+    req = _db_request(
+        rf, **{BACKEND_SESSION_KEY: "django.contrib.auth.backends.ModelBackend"}
+    )
+    req.user = user
+
+    resp = BppOIDCAwareLogoutView.as_view()(req)
+
+    assert resp.status_code == 302
+    assert "kc/logout" not in resp.url

--- a/src/oidc_integration/views.py
+++ b/src/oidc_integration/views.py
@@ -1,0 +1,33 @@
+"""Widoki OIDC dla BPP — na razie tylko backend-aware wylogowanie."""
+
+from django.contrib.auth import BACKEND_SESSION_KEY
+from django.contrib.auth import logout as auth_logout
+from django.contrib.auth.views import LogoutView
+from django.http import HttpResponseRedirect
+
+from oidc_integration.logout import build_provider_logout_url
+
+OIDC_BACKEND_PATH = "oidc_integration.backends.BppOIDCBackend"
+
+
+class BppOIDCAwareLogoutView(LogoutView):
+    """Wylogowanie świadome backendu logowania.
+
+    Sesja zalogowana przez OIDC → wyloguj też z Keycloaka (RP-Initiated
+    Logout). Każda inna sesja (hasło, ORCID) → standardowe wylogowanie Django.
+    Bezpieczny nadzbiór ``LogoutView`` — gdy OIDC nieużyte, zachowuje się
+    identycznie jak oryginał.
+    """
+
+    def post(self, request, *args, **kwargs):
+        is_oidc_session = (
+            request.user.is_authenticated
+            and request.session.get(BACKEND_SESSION_KEY) == OIDC_BACKEND_PATH
+        )
+        if is_oidc_session:
+            # URL musi powstać PRZED auth_logout (czyta id_token z sesji).
+            logout_url = build_provider_logout_url(request)
+            auth_logout(request)
+            return HttpResponseRedirect(logout_url)
+
+        return super().post(request, *args, **kwargs)


### PR DESCRIPTION
Kontynuacja OIDC (po zmergowaniu spike'a #295 do `feature/multi-hosted-config`).
**Baza: `feature/multi-hosted-config` (PR #189), NIE `dev`.**

## Zakres (uzgodniony: bezpieczne, bez gatingu ról)

Świadomie **bez** gatingu po rolach — role w Keycloaku bywają w access/id-tokenie,
a `verify_claims` dostaje userinfo; budowanie na ślepo groziłoby blokadą
wszystkich albo nikogo. To czeka na zrzut realnych claimów (`[OIDC]` na stderr).

### 1. Wylogowanie z Keycloaka (RP-Initiated Logout)
- `BppOIDCAwareLogoutView` pod `logout/`: sesja OIDC → redirect na
  `end_session_endpoint` z `id_token_hint` (z sesji; `OIDC_STORE_ID_TOKEN=True`)
  + `post_logout_redirect_uri`. Każda inna sesja (hasło/ORCID) → standardowy
  `LogoutView` (bezpieczny nadzbiór).
- Bez tego wylogowanie z BPP zostawiało żywą sesję SSO w KC → kolejne logowanie
  bez pytania o hasło.

### 2. Endpointy z `.well-known/openid-configuration`
- `fetch_well_known_endpoints` pobiera prawdziwe adresy (krótki timeout),
  z **fallbackiem na konwencję Keycloaka** gdy IdP nieosiągalny przy starcie.
- Sieć dotykana tylko z `settings`; testy env-resolution bez sieci.

### 3. Odporność
- Unikalny `username` przy kolizji (`base-2`, `base-3`…) — brak IntegrityError
  gdy ten sam `preferred_username` przy innym e-mailu.

## Wymaganie od admina KC (dla wylogowania)
Zarejestrować **Valid Post Logout Redirect URI** w kliencie (np.
`https://bpp.<domena>/`).

## Weryfikacja
- 24 testy `oidc_integration` zielone (logout builder+widok, well-known
  parse/fallback/niekompletny, kolizja username, + wcześniejsze).
- settings ON/OFF sprawdzone ręcznie; `manage.py check` OK; pre-commit czysty.

## Poza zakresem (faza 2b — po claimach)
Gating ról/`person_id`, mapowanie ról→grupy, cache `.well-known`, wiele issuerów
naraz (3 uczelnie/3 OIDC = podklasy backendu + routing per-host).

Spec: `docs/superpowers/specs/2026-06-03-oidc-keycloak-login-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)