### PR TITLE
feat(powiazania_autorow): widok 3D sieci powiązań (Three.js / WebGL)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -234,6 +234,15 @@ module.exports = function (grunt) {
                          '--outfile=src/powiazania_autorow/static/powiazania_autorow/js/dist/cytoscape-bundle.js ' +
                          '--format=iife --target=es2018'
             },
+            // Osobny lazy bundle Three.js + 3d-force-graph dla widoku 3D sieci
+            // powiązań (ładowany tylko na stronie 3D, nie globalnie).
+            esbuildThree: {
+                command: 'npx esbuild ' +
+                         'src/powiazania_autorow/static/powiazania_autorow/js/three-entry.js ' +
+                         '--bundle --minify-syntax --minify-whitespace --sourcemap ' +
+                         '--outfile=src/powiazania_autorow/static/powiazania_autorow/js/dist/three-bundle.js ' +
+                         '--format=iife --target=es2018'
+            },
             // Post-process bundle to fix IIFE scope issues
             // django-autocomplete-light: yl namespace (esbuild renames to yl2)
             patchBundle: {
@@ -259,6 +268,7 @@ module.exports = function (grunt) {
         'shell:linkSitePackages',
         'shell:esbuild',
         'shell:esbuildCytoscape',
+        'shell:esbuildThree',
         'shell:patchBundle',
         'shell:collectstatic'
     ]);
@@ -267,6 +277,7 @@ module.exports = function (grunt) {
         'shell:linkSitePackages',
         'shell:esbuild',
         'shell:esbuildCytoscape',
+        'shell:esbuildThree',
         'shell:patchBundle'
     ]);
 

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,8 @@ SCSS_SOURCES := $(wildcard src/bpp/static/scss/*.scss) \
 # wygenerowane bundle nie stają się własną zależnością (brak pętli rebuildu).
 JS_SOURCES := $(wildcard src/bpp/static/bpp/js/*.js) \
               $(wildcard src/powiazania_autorow/static/powiazania_autorow/js/*.js) \
-              $(wildcard src/powiazania_autorow/static/powiazania_autorow/js/powiazania/*.js)
+              $(wildcard src/powiazania_autorow/static/powiazania_autorow/js/powiazania/*.js) \
+              $(wildcard src/powiazania_autorow/static/powiazania_autorow/js/siec3d/*.js)
 
 # Node modules dependency
 NODE_MODULES := node_modules/.installed

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "sass": "~1.99.0"
     },
     "dependencies": {
+        "3d-force-graph": "^1.80.0",
         "basic-ftp": "5.3.1",
         "cytoscape": "^3.34.0",
         "cytoscape-fcose": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "select2": "^4.1.0-rc.0",
         "select2-foundation-theme": "https://github.com/mpasternak/select2-foundation.git#modernize-foundation-6.9",
         "sigma": "^3.0.2",
+        "three-spritetext": "^1.10.0",
         "tone": "^15.1.22",
         "what-input": "^5.0.5"
     },

--- a/src/bpp/urls.py
+++ b/src/bpp/urls.py
@@ -96,6 +96,7 @@ from bpp.views.zapytanie import (
     ZapytanieView,
 )
 from powiazania_autorow.views import (
+    GrafPowiazan3DView,
     GrafPowiazanDaneView,
     GrafPowiazanSiecView,
     GrafPowiazanView,
@@ -251,6 +252,11 @@ urlpatterns = [
         r"^autor/(?P<pk>\d+)/powiazania/$",
         GrafPowiazanView.as_view(),
         name="browse_autor_powiazania",
+    ),
+    url(
+        r"^autor/(?P<pk>\d+)/powiazania/3d/$",
+        GrafPowiazan3DView.as_view(),
+        name="browse_autor_powiazania_3d",
     ),
     url(
         r"^autor/(?P<pk>\d+)/powiazania/dane\.json$",

--- a/src/bpp/views/browse.py
+++ b/src/bpp/views/browse.py
@@ -152,7 +152,9 @@ class AutorView(DetailView):
         # Link do sieci pokazujemy tylko gdy (a) są jakieś powiązania ORAZ
         # (b) sieć jest włączona dla tego autora (per-autor nadpisuje
         # per-uczelnia). Ten sam warunek twardo bramkuje widoki sieci (404).
-        uczelnia = Uczelnia.objects.get_for_request(self.request)
+        # getattr — get_context_data bywa wołane w testach jednostkowych bez
+        # request; get_for_request(None) degraduje do uczelni domyślnej.
+        uczelnia = Uczelnia.objects.get_for_request(getattr(self, "request", None))
         ma_powiazania = (
             self.object.czy_pokazywac_siec_powiazan(uczelnia)
             and AuthorConnection.objects.filter(

--- a/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
@@ -75,6 +75,7 @@ export function init(ForceGraph3D) {
     const glebLabel = document.getElementById("siec3d-glebokosc-label");
     const topnLabel = document.getElementById("siec3d-topn-label");
     const info = document.getElementById("siec3d-info");
+    const ukladEl = document.getElementById("siec3d-uklad");
 
     // --- opcje zaawansowane ---
     const rokOdEl = document.getElementById("siec3d-rok-od");
@@ -101,6 +102,14 @@ export function init(ForceGraph3D) {
         .linkColor(function () { return "rgba(255,255,255,0.16)"; })
         .linkWidth(function (l) { return Math.max(0.4, Math.log2(l.shared + 1)); })
         .linkOpacity(0.45)
+        // Płynące cząsteczki = "przepływ" współpracy. Tylko na silniejszych
+        // powiązaniach (shared >= 2) i z twardym capem, żeby nie mnożyć
+        // obiektów Three.js przy gęstych sieciach.
+        .linkDirectionalParticles(function (l) {
+            return l.shared >= 2 ? Math.min(2, l.shared - 1) : 0;
+        })
+        .linkDirectionalParticleSpeed(0.006)
+        .linkDirectionalParticleWidth(1.1)
         .onNodeClick(function (n) {
             // Dolot kamery do węzła (klasyczny recipe 3d-force-graph).
             const dist = 140;
@@ -156,6 +165,56 @@ export function init(ForceGraph3D) {
         };
     }
 
+    // "Sferyczne powłoki": każdy poziom BFS na własnej sferze (promień ∝ poziom),
+    // węzły rozłożone równomiernie metodą Fibonacciego. Centrum w środku.
+    // Ustawia fx/fy/fz (pozycje zamrożone).
+    function ustawSfery(nodes, R) {
+        const wgPoziomu = {};
+        nodes.forEach(function (n) {
+            const l = n.level || 0;
+            (wgPoziomu[l] = wgPoziomu[l] || []).push(n);
+        });
+        const GA = Math.PI * (3 - Math.sqrt(5)); // złoty kąt
+        Object.keys(wgPoziomu).forEach(function (lk) {
+            const grupa = wgPoziomu[lk];
+            const promien = Number(lk) * R;
+            const k = grupa.length;
+            grupa.forEach(function (n, i) {
+                if (promien === 0) { n.fx = 0; n.fy = 0; n.fz = 0; return; }
+                const y = k === 1 ? 0 : 1 - (i / (k - 1)) * 2;
+                const r = Math.sqrt(Math.max(0, 1 - y * y));
+                const theta = i * GA;
+                n.fx = promien * Math.cos(theta) * r;
+                n.fy = promien * y;
+                n.fz = promien * Math.sin(theta) * r;
+            });
+        });
+    }
+
+    // Przełączanie formy układu. Drzewo = wbudowany dagMode (radialny, używa
+    // kierunku krawędzi rodzic→dziecko; cykliczne extra_edges ignorujemy przez
+    // onDagError(null)). Warstwy = poziom→oś Z, X/Y swobodne (siła). Sfery =
+    // pozycje zamrożone. Siłowy = brak ograniczeń (domyślna chmura).
+    function zastosujUklad(uklad) {
+        const nodes = Graph.graphData().nodes;
+        if (uklad === "drzewo") {
+            nodes.forEach(function (n) { n.fx = n.fy = n.fz = undefined; });
+            Graph.dagMode("radialout").dagLevelDistance(70).onDagError(null);
+        } else if (uklad === "warstwy") {
+            Graph.dagMode(null);
+            nodes.forEach(function (n) {
+                n.fx = undefined; n.fy = undefined; n.fz = (n.level || 0) * 80;
+            });
+        } else if (uklad === "sfery") {
+            Graph.dagMode(null);
+            ustawSfery(nodes, 95);
+        } else { // siłowy
+            Graph.dagMode(null);
+            nodes.forEach(function (n) { n.fx = n.fy = n.fz = undefined; });
+        }
+        Graph.d3ReheatSimulation();
+    }
+
     // Buduje graphData z rawData. Krawędzie drzewa (edges) zawsze; poprzeczne
     // (extra_edges) tylko gdy włączone "powiązania w grupie", z progiem
     // "od N wspólnych prac" — filtr po stronie klienta (bez fetcha).
@@ -182,6 +241,8 @@ export function init(ForceGraph3D) {
             });
         }
         Graph.graphData({ nodes: nodes, links: links });
+        // utrzymaj wybraną formę układu po przebudowie danych
+        zastosujUklad(ukladEl ? ukladEl.value : "sila");
     }
 
     function dopasujRozmiar() {
@@ -249,6 +310,11 @@ export function init(ForceGraph3D) {
         selMetryka.addEventListener("change", function () {
             metryka = selMetryka.value;
             Graph.nodeVal(function (n) { return wartoscMetryki(n, metryka); });
+        });
+    }
+    if (ukladEl) {
+        ukladEl.addEventListener("change", function () {
+            zastosujUklad(ukladEl.value);
         });
     }
 

--- a/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
@@ -6,10 +6,15 @@
 //              kolor = poziom BFS (centrum -> liście),
 //   * krawędź -> linia; grubość = liczba wspólnych publikacji.
 // Interakcja (gratis z 3d-force-graph): obrót orbitalny i zoom myszą,
-// klik = dolot kamery + panel z linkiem do autora, przeciąganie węzła =
-// sprężysta reakcja układu siłowego (efekt "gumy" w 3D).
+// klik = dolot kamery + panel akcji jak w 2D, przeciąganie węzła = sprężysta
+// reakcja układu siłowego (efekt "gumy" w 3D).
+//
+// Opcje zaawansowane (te same parametry co 2D): rok od-do i "tylko aktualnie
+// zatrudnieni" idą do siec.json (przeładowanie z serwera); "powiązania w
+// grupie" (extra_edges) z progiem filtrujemy po stronie klienta z ostatnio
+// pobranych danych; "odśwież układ" rozgrzewa symulację i dopasowuje kamerę.
 
-// Kolory wg poziomu: centrum złote, dalej chłodna paleta.
+// Kolory wg poziomu: centrum złote, dalej chłodna paleta (dobre na ciemnym tle).
 const PALETA = [
     "#ffd54a", "#4ea1ff", "#36c9c0", "#7ed957",
     "#c792ea", "#ff8a65", "#9aa7b2"
@@ -19,8 +24,8 @@ function kolorPoziomu(level) {
     return PALETA[Math.min(level || 0, PALETA.length - 1)];
 }
 
-// Escape do HTML — etykiety to nazwiska autorów z bazy (mogą teoretycznie
-// zawierać znaki specjalne), a nodeLabel renderuje się jako HTML tooltipa.
+// Escape do HTML — etykiety to nazwiska autorów z bazy; nodeLabel renderuje
+// się jako HTML tooltipa.
 function esc(s) {
     return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
         return {
@@ -30,38 +35,27 @@ function esc(s) {
     });
 }
 
-// nodeVal steruje OBJĘTOŚCIĄ kuli; metryki bywają duże (sumy IF/PK), więc
-// 3d-force-graph i tak skaluje promień ~cbrt(val). Pilnujemy minimum, by
-// węzły bez prac nie znikały.
+// nodeVal steruje OBJĘTOŚCIĄ kuli; metryki bywają duże (sumy IF/PK), a
+// 3d-force-graph i tak skaluje promień ~cbrt(val). Pilnujemy minimum.
 function wartoscMetryki(n, metryka) {
     if (metryka === "if") { return Math.max(0.2, n.if_sum || 0); }
     if (metryka === "pk") { return Math.max(0.2, n.pk_sum || 0); }
     return Math.max(1, n.total_works || 1);
 }
 
-// siec.json -> {nodes, links}. Krawędzie drzewa (edges) i poprzeczne
-// (extra_edges) łączymy w jeden zbiór linków.
-function budujDane(data) {
-    const nodes = (data.nodes || []).map(function (n) {
-        return {
-            id: String(n.id),
-            label: n.label,
-            url: n.url,
-            level: n.level || 0,
-            total_works: n.total_works || 0,
-            if_sum: n.if_sum || 0,
-            pk_sum: n.pk_sum || 0
-        };
-    });
-    const krawedzie = [].concat(data.edges || [], data.extra_edges || []);
-    const links = krawedzie.map(function (e) {
-        return {
-            source: String(e.source),
-            target: String(e.target),
-            shared: e.shared || 1
-        };
-    });
-    return { nodes: nodes, links: links };
+// Link akcji jak w panelu 2D (panel.js/dom.js) — odtworzony lokalnie, bo
+// widok 3D to osobny bundle i nie importuje modułów widoku 2D.
+function linkAkcja(href, text, zewnetrzny) {
+    const a = document.createElement("a");
+    a.href = href;
+    a.textContent = text;
+    a.style.display = "block";
+    a.style.marginTop = "4px";
+    if (zewnetrzny) {
+        a.target = "_blank";
+        a.rel = "noopener";
+    }
+    return a;
 }
 
 export function init(ForceGraph3D) {
@@ -72,7 +66,9 @@ export function init(ForceGraph3D) {
 
     const autorId = String(el.dataset.autorId);
     const siecTpl = el.dataset.siecUrlTemplate;
+    const graf3dTpl = el.dataset.graf3dUrlTemplate;
 
+    // --- kontrolki podstawowe ---
     const sliderGleb = document.getElementById("siec3d-glebokosc");
     const sliderTopn = document.getElementById("siec3d-topn");
     const selMetryka = document.getElementById("siec3d-metryka");
@@ -80,7 +76,18 @@ export function init(ForceGraph3D) {
     const topnLabel = document.getElementById("siec3d-topn-label");
     const info = document.getElementById("siec3d-info");
 
+    // --- opcje zaawansowane ---
+    const rokOdEl = document.getElementById("siec3d-rok-od");
+    const rokDoEl = document.getElementById("siec3d-rok-do");
+    const chkZatr = document.getElementById("siec3d-zatrudnieni-chk");
+    const chkWewn = document.getElementById("siec3d-wewnetrzne-chk");
+    const progWewn = document.getElementById("siec3d-wewn-prog");
+    const progWewnLabel = document.getElementById("siec3d-wewn-prog-label");
+
     let metryka = selMetryka ? selMetryka.value : "works";
+    // ostatnio pobrana sieć (raw siec.json) — do klienckiego przebudowania
+    // linków przy zmianie opcji "powiązania w grupie" bez ponownego fetcha.
+    let rawData = { nodes: [], edges: [], extra_edges: [] };
 
     const Graph = ForceGraph3D()(el)
         .backgroundColor("#0b1020")
@@ -95,34 +102,87 @@ export function init(ForceGraph3D) {
         .linkWidth(function (l) { return Math.max(0.4, Math.log2(l.shared + 1)); })
         .linkOpacity(0.45)
         .onNodeClick(function (n) {
-            // Dolot kamery do węzła (klasyczny recipe 3d-force-graph): kamera
-            // ustawia się na osi środek–węzeł w stałej odległości i patrzy nań.
+            // Dolot kamery do węzła (klasyczny recipe 3d-force-graph).
             const dist = 140;
             const r = 1 + dist / Math.max(1, Math.hypot(n.x, n.y, n.z));
             Graph.cameraPosition(
                 { x: n.x * r, y: n.y * r, z: n.z * r }, n, 1000
             );
-            if (info) {
-                // Budujemy panel przez DOM (textContent + createElement),
-                // bez innerHTML z danymi autora — zero ryzyka XSS.
-                info.textContent = "";
-                const b = document.createElement("b");
-                b.textContent = n.label || "";
-                info.appendChild(b);
-                info.appendChild(document.createElement("br"));
-                info.appendChild(
-                    document.createTextNode("prace: " + (n.total_works | 0))
-                );
-                if (n.url) {
-                    info.appendChild(document.createTextNode(" · "));
-                    const a = document.createElement("a");
-                    a.href = n.url; // ścieżka z reverse(); a.href nie wykonuje JS
-                    a.textContent = "strona autora →";
-                    info.appendChild(a);
-                }
-                info.style.display = "block";
-            }
+            pokazPanel(n);
         });
+
+    // Panel akcji jak w 2D: nagłówek (nazwisko + tytuł), ORCID i linki
+    // kontekstowe. Budowany przez DOM (textContent/createElement) — zero XSS.
+    function pokazPanel(n) {
+        if (!info) { return; }
+        info.textContent = "";
+        const strong = document.createElement("strong");
+        strong.textContent = (n.label || "") + (n.tytul ? ", " + n.tytul : "");
+        info.appendChild(strong);
+
+        if (n.orcid) {
+            const o = document.createElement("div");
+            o.textContent = "ORCID: " + n.orcid;
+            o.style.fontSize = "11px";
+            o.style.color = "#666";
+            o.style.marginTop = "2px";
+            info.appendChild(o);
+        }
+        if (n.url) {
+            info.appendChild(linkAkcja(n.url, "Pokaż prace", false));
+        }
+        if (graf3dTpl) {
+            info.appendChild(linkAkcja(
+                graf3dTpl.replace("/0/", "/" + n.id + "/"),
+                "Pokaż sieć powiązań (3D)", false
+            ));
+        }
+        if (n.pbn_url) {
+            info.appendChild(linkAkcja(n.pbn_url, "Zobacz w PBN", true));
+        }
+        if (n.orcid) {
+            info.appendChild(linkAkcja(
+                "https://orcid.org/" + n.orcid, "Zobacz w ORCID", true
+            ));
+        }
+        info.style.display = "block";
+    }
+
+    function mapLink(e) {
+        return {
+            source: String(e.source),
+            target: String(e.target),
+            shared: e.shared || 1
+        };
+    }
+
+    // Buduje graphData z rawData. Krawędzie drzewa (edges) zawsze; poprzeczne
+    // (extra_edges) tylko gdy włączone "powiązania w grupie", z progiem
+    // "od N wspólnych prac" — filtr po stronie klienta (bez fetcha).
+    function render() {
+        const nodes = (rawData.nodes || []).map(function (n) {
+            return {
+                id: String(n.id),
+                label: n.label,
+                url: n.url,
+                tytul: n.tytul,
+                orcid: n.orcid,
+                pbn_url: n.pbn_url,
+                level: n.level || 0,
+                total_works: n.total_works || 0,
+                if_sum: n.if_sum || 0,
+                pk_sum: n.pk_sum || 0
+            };
+        });
+        const links = (rawData.edges || []).map(mapLink);
+        if (!chkWewn || chkWewn.checked) {
+            const prog = progWewn ? (parseInt(progWewn.value, 10) || 1) : 1;
+            (rawData.extra_edges || []).forEach(function (e) {
+                if ((e.shared || 1) >= prog) { links.push(mapLink(e)); }
+            });
+        }
+        Graph.graphData({ nodes: nodes, links: links });
+    }
 
     function dopasujRozmiar() {
         Graph.width(el.clientWidth).height(el.clientHeight);
@@ -130,14 +190,23 @@ export function init(ForceGraph3D) {
     dopasujRozmiar();
     window.addEventListener("resize", dopasujRozmiar);
 
-    // Token sekwencji — szybkie ruchy suwaków odpalają kilka fetchy; render
-    // aplikujemy tylko, gdy odpowiedź jest wciąż bieżąca.
+    // Token sekwencji — szybkie ruchy suwaków/filtrów odpalają kilka fetchy;
+    // render aplikujemy tylko dla wciąż bieżącej odpowiedzi.
     let seq = 0;
     function zaladuj() {
         const depth = sliderGleb ? parseInt(sliderGleb.value, 10) : 2;
         const topn = sliderTopn ? parseInt(sliderTopn.value, 10) : 10;
-        const url = siecTpl.replace("/0/", "/" + autorId + "/")
-            + "?depth=" + depth + "&topn=" + topn;
+        let p = "depth=" + depth + "&topn=" + topn;
+        if (rokOdEl && rokOdEl.value) {
+            p += "&rok_od=" + encodeURIComponent(rokOdEl.value);
+        }
+        if (rokDoEl && rokDoEl.value) {
+            p += "&rok_do=" + encodeURIComponent(rokDoEl.value);
+        }
+        if (chkZatr && chkZatr.checked) {
+            p += "&tylko_zatrudnieni=1";
+        }
+        const url = siecTpl.replace("/0/", "/" + autorId + "/") + "?" + p;
         const moj = ++seq;
         fetch(url)
             .then(function (r) {
@@ -146,7 +215,8 @@ export function init(ForceGraph3D) {
             })
             .then(function (data) {
                 if (moj !== seq) { return; }
-                Graph.graphData(budujDane(data));
+                rawData = data;
+                render();
             })
             .catch(function (e) {
                 if (info) {
@@ -159,9 +229,10 @@ export function init(ForceGraph3D) {
     let deb = null;
     function zaladujZwloka() {
         if (deb) { clearTimeout(deb); }
-        deb = setTimeout(zaladuj, 250);
+        deb = setTimeout(zaladuj, 300);
     }
 
+    // --- podstawowe ---
     if (sliderGleb) {
         sliderGleb.addEventListener("input", function () {
             if (glebLabel) { glebLabel.textContent = sliderGleb.value; }
@@ -177,8 +248,46 @@ export function init(ForceGraph3D) {
     if (selMetryka) {
         selMetryka.addEventListener("change", function () {
             metryka = selMetryka.value;
-            // przestawienie akcesora wymusza ponowne policzenie rozmiarów kul
             Graph.nodeVal(function (n) { return wartoscMetryki(n, metryka); });
+        });
+    }
+
+    // --- zaawansowane: rok / zatrudnieni -> przeładuj sieć ---
+    if (rokOdEl) { rokOdEl.addEventListener("input", zaladujZwloka); }
+    if (rokDoEl) { rokDoEl.addEventListener("input", zaladujZwloka); }
+    if (chkZatr) { chkZatr.addEventListener("change", zaladuj); }
+
+    // --- zaawansowane: powiązania w grupie -> przebuduj linki (bez fetcha) ---
+    if (chkWewn) { chkWewn.addEventListener("change", render); }
+    if (progWewn) {
+        progWewn.addEventListener("input", function () {
+            if (progWewnLabel) { progWewnLabel.textContent = progWewn.value; }
+            render();
+        });
+    }
+
+    // --- odśwież układ: rozgrzej symulację i dopasuj kamerę ---
+    const btnOdswiez = document.getElementById("siec3d-odswiez");
+    if (btnOdswiez) {
+        btnOdswiez.addEventListener("click", function () {
+            Graph.d3ReheatSimulation();
+            Graph.zoomToFit(700, 40);
+        });
+    }
+
+    // --- rozwijane "Opcje zaawansowane" (jak w 2D) ---
+    const btnZaaw = document.getElementById("siec3d-zaawansowane-toggle");
+    const panelZaaw = document.getElementById("siec3d-zaawansowane");
+    if (btnZaaw && panelZaaw) {
+        btnZaaw.addEventListener("click", function () {
+            const widoczne = panelZaaw.style.display !== "none";
+            panelZaaw.style.display = widoczne ? "none" : "flex";
+            const t = btnZaaw.lastChild;
+            if (t && t.nodeType === 3) {
+                t.textContent = widoczne
+                    ? " Opcje zaawansowane ▾"
+                    : " Opcje zaawansowane ▴";
+            }
         });
     }
 

--- a/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
@@ -9,16 +9,22 @@
 // klik = dolot kamery + panel akcji jak w 2D, przeciąganie węzła = sprężysta
 // reakcja układu siłowego (efekt "gumy" w 3D).
 //
-// Opcje zaawansowane (te same parametry co 2D): rok od-do i "tylko aktualnie
-// zatrudnieni" idą do siec.json (przeładowanie z serwera); "powiązania w
-// grupie" (extra_edges) z progiem filtrujemy po stronie klienta z ostatnio
-// pobranych danych; "odśwież układ" rozgrzewa symulację i dopasowuje kamerę.
+// Opcje: rok od-do i "tylko aktualnie zatrudnieni" idą do siec.json
+// (przeładowanie z serwera); "powiązania w grupie" (extra_edges, domyślnie
+// WYŁĄCZONE) z progiem dorysowujemy po stronie klienta w innym kolorze, bez
+// przerysowywania układu; "pokaż etykiety" rysuje nazwiska top-N węzłów;
+// "odśwież układ" rozgrzewa symulację i dopasowuje kamerę.
+
+import SpriteText from "three-spritetext";
 
 // Kolory wg poziomu: centrum złote, dalej chłodna paleta (dobre na ciemnym tle).
 const PALETA = [
     "#ffd54a", "#4ea1ff", "#36c9c0", "#7ed957",
     "#c792ea", "#ff8a65", "#9aa7b2"
 ];
+
+// Ile najważniejszych (wg bieżącej metryki) węzłów dostaje stałą etykietę.
+const TOP_ETYKIETY = 25;
 
 function kolorPoziomu(level) {
     return PALETA[Math.min(level || 0, PALETA.length - 1)];
@@ -76,6 +82,7 @@ export function init(ForceGraph3D) {
     const topnLabel = document.getElementById("siec3d-topn-label");
     const info = document.getElementById("siec3d-info");
     const ukladEl = document.getElementById("siec3d-uklad");
+    const chkEtykiety = document.getElementById("siec3d-etykiety-chk");
 
     // --- opcje zaawansowane ---
     const rokOdEl = document.getElementById("siec3d-rok-od");
@@ -86,6 +93,7 @@ export function init(ForceGraph3D) {
     const progWewnLabel = document.getElementById("siec3d-wewn-prog-label");
 
     let metryka = selMetryka ? selMetryka.value : "works";
+    let etykietyOn = chkEtykiety ? chkEtykiety.checked : false;
     // ostatnio pobrana sieć (raw siec.json) — do klienckiego przebudowania
     // linków przy zmianie opcji "powiązania w grupie" bez ponownego fetcha.
     let rawData = { nodes: [], edges: [], extra_edges: [] };
@@ -99,9 +107,15 @@ export function init(ForceGraph3D) {
         .nodeLabel(function (n) {
             return "<b>" + esc(n.label) + "</b><br>prace: " + (n.total_works | 0);
         })
-        .linkColor(function () { return "rgba(255,255,255,0.16)"; })
+        // etykieta jako sprite obok kuli (extend = nie zastępuje kuli);
+        // tylko dla top-N i gdy włączone "pokaż etykiety"
+        .nodeThreeObjectExtend(true)
+        .linkColor(function (l) {
+            // powiązania w grupie wyróżnione kolorem (bursztyn), drzewo białe
+            return l.grupa ? "rgba(255,179,71,0.55)" : "rgba(255,255,255,0.16)";
+        })
         .linkWidth(function (l) { return Math.max(0.4, Math.log2(l.shared + 1)); })
-        .linkOpacity(0.45)
+        .linkOpacity(0.5)
         .onNodeClick(function (n) {
             // Dolot kamery do węzła (klasyczny recipe 3d-force-graph).
             const dist = 140;
@@ -111,6 +125,24 @@ export function init(ForceGraph3D) {
             );
             pokazPanel(n);
         });
+
+    // Etykieta węzła (SpriteText) — tylko dla top-N i gdy włączone.
+    function budujEtykiete(n) {
+        if (!etykietyOn || !n._top) { return null; }
+        const s = new SpriteText(n.label || "");
+        s.color = "#fff";
+        s.textHeight = 5;
+        s.backgroundColor = "rgba(11,16,32,0.65)";
+        s.padding = 1.5;
+        s.position.set(0, 9, 0); // unieś nad kulę
+        return s;
+    }
+    // Re-assign przez świeży wrapper => 3d-force-graph regeneruje obiekty
+    // węzłów (np. po przełączeniu etykiet albo zmianie listy top-N).
+    function odswiezEtykiety() {
+        Graph.nodeThreeObject(function (n) { return budujEtykiete(n); });
+    }
+    odswiezEtykiety();
 
     // Panel akcji jak w 2D: nagłówek (nazwisko + tytuł), ORCID i linki
     // kontekstowe. Budowany przez DOM (textContent/createElement) — zero XSS.
@@ -149,17 +181,43 @@ export function init(ForceGraph3D) {
         info.style.display = "block";
     }
 
-    function mapLink(e) {
+    function mapLink(e, grupa) {
         return {
             source: String(e.source),
             target: String(e.target),
-            shared: e.shared || 1
+            shared: e.shared || 1,
+            grupa: !!grupa
         };
+    }
+
+    // Ustaw flagę _top na top-N węzłach wg bieżącej metryki (do etykiet).
+    function oznaczTop(nodes) {
+        nodes.forEach(function (n) { n._top = false; });
+        nodes.slice()
+            .sort(function (a, b) {
+                return wartoscMetryki(b, metryka) - wartoscMetryki(a, metryka);
+            })
+            .slice(0, TOP_ETYKIETY)
+            .forEach(function (n) { n._top = true; });
+    }
+
+    // Linki dla bieżącego układu: krawędzie drzewa zawsze; powiązania w grupie
+    // (extra_edges) tylko gdy włączone i poza układem "drzewo" (cykle psują DAG).
+    function zbudujLinki(uklad) {
+        const links = (rawData.edges || []).map(function (e) {
+            return mapLink(e, false);
+        });
+        if (uklad !== "drzewo" && chkWewn && chkWewn.checked) {
+            const prog = progWewn ? (parseInt(progWewn.value, 10) || 1) : 1;
+            (rawData.extra_edges || []).forEach(function (e) {
+                if ((e.shared || 1) >= prog) { links.push(mapLink(e, true)); }
+            });
+        }
+        return links;
     }
 
     // "Sferyczne powłoki": każdy poziom BFS na własnej sferze (promień ∝ poziom),
     // węzły rozłożone równomiernie metodą Fibonacciego. Centrum w środku.
-    // Ustawia fx/fy/fz (pozycje zamrożone).
     function ustawSfery(nodes, R) {
         const wgPoziomu = {};
         nodes.forEach(function (n) {
@@ -183,10 +241,9 @@ export function init(ForceGraph3D) {
         });
     }
 
-    // Przełączanie formy układu. Drzewo = wbudowany dagMode (radialny, używa
-    // kierunku krawędzi rodzic→dziecko; cykliczne extra_edges ignorujemy przez
-    // onDagError(null)). Warstwy = poziom→oś Z, X/Y swobodne (siła). Sfery =
-    // pozycje zamrożone. Siłowy = brak ograniczeń (domyślna chmura).
+    // Przełączanie formy układu. Drzewo = dagMode radialny (krawędzie drzewa są
+    // acykliczne). Warstwy = poziom→oś Z, X/Y swobodne. Sfery = pozycje
+    // zamrożone. Siłowy = brak ograniczeń (domyślna chmura).
     function zastosujUklad(uklad) {
         const nodes = Graph.graphData().nodes;
         if (uklad === "drzewo") {
@@ -208,10 +265,9 @@ export function init(ForceGraph3D) {
         Graph.d3ReheatSimulation();
     }
 
-    // Buduje graphData z rawData. Krawędzie drzewa (edges) zawsze; poprzeczne
-    // (extra_edges) tylko gdy włączone "powiązania w grupie", z progiem
-    // "od N wspólnych prac" — filtr po stronie klienta (bez fetcha).
+    // Pełna przebudowa (świeże węzły) — przy pobraniu danych i zmianie układu.
     function render() {
+        const uklad = ukladEl ? ukladEl.value : "sila";
         const nodes = (rawData.nodes || []).map(function (n) {
             return {
                 id: String(n.id),
@@ -226,19 +282,17 @@ export function init(ForceGraph3D) {
                 pk_sum: n.pk_sum || 0
             };
         });
-        const uklad = ukladEl ? ukladEl.value : "sila";
-        const links = (rawData.edges || []).map(mapLink);
-        // W "drzewie" pokazujemy TYLKO krawędzie drzewa — extra_edges tworzą
-        // cykle, które psują układ DAG (radialout); w pozostałych formach
-        // dokładamy powiązania w grupie wg progu.
-        if (uklad !== "drzewo" && (!chkWewn || chkWewn.checked)) {
-            const prog = progWewn ? (parseInt(progWewn.value, 10) || 1) : 1;
-            (rawData.extra_edges || []).forEach(function (e) {
-                if ((e.shared || 1) >= prog) { links.push(mapLink(e)); }
-            });
-        }
-        Graph.graphData({ nodes: nodes, links: links });
+        oznaczTop(nodes);
+        Graph.graphData({ nodes: nodes, links: zbudujLinki(uklad) });
         zastosujUklad(uklad);
+    }
+
+    // Przebudowa SAMYCH krawędzi z zachowaniem węzłów (i ich pozycji) — dla
+    // przełącznika/progu "powiązań w grupie", żeby nie przerzucać układu.
+    function przebudujKrawedzie() {
+        const uklad = ukladEl ? ukladEl.value : "sila";
+        const nodes = Graph.graphData().nodes;
+        Graph.graphData({ nodes: nodes, links: zbudujLinki(uklad) });
     }
 
     function dopasujRozmiar() {
@@ -306,6 +360,9 @@ export function init(ForceGraph3D) {
         selMetryka.addEventListener("change", function () {
             metryka = selMetryka.value;
             Graph.nodeVal(function (n) { return wartoscMetryki(n, metryka); });
+            // top-N (a więc i etykiety) zależy od metryki
+            oznaczTop(Graph.graphData().nodes);
+            odswiezEtykiety();
         });
     }
     if (ukladEl) {
@@ -313,18 +370,24 @@ export function init(ForceGraph3D) {
         // samego drzewa (potem zastosujUklad nada formę)
         ukladEl.addEventListener("change", render);
     }
+    if (chkEtykiety) {
+        chkEtykiety.addEventListener("change", function () {
+            etykietyOn = chkEtykiety.checked;
+            odswiezEtykiety();
+        });
+    }
 
     // --- zaawansowane: rok / zatrudnieni -> przeładuj sieć ---
     if (rokOdEl) { rokOdEl.addEventListener("input", zaladujZwloka); }
     if (rokDoEl) { rokDoEl.addEventListener("input", zaladujZwloka); }
     if (chkZatr) { chkZatr.addEventListener("change", zaladuj); }
 
-    // --- zaawansowane: powiązania w grupie -> przebuduj linki (bez fetcha) ---
-    if (chkWewn) { chkWewn.addEventListener("change", render); }
+    // --- zaawansowane: powiązania w grupie -> przebuduj SAME linki ---
+    if (chkWewn) { chkWewn.addEventListener("change", przebudujKrawedzie); }
     if (progWewn) {
         progWewn.addEventListener("input", function () {
             if (progWewnLabel) { progWewnLabel.textContent = progWewn.value; }
-            render();
+            przebudujKrawedzie();
         });
     }
 

--- a/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
@@ -1,0 +1,186 @@
+// Widok 3D sieci współautorstwa (3d-force-graph → Three.js → WebGL).
+//
+// Czyta DOKŁADNIE ten sam endpoint co widok 2D (siec.json) — żadnych zmian po
+// stronie backendu. Mapowanie:
+//   * węzeł  -> kula; rozmiar = wybrana metryka (prace / IF / PK),
+//              kolor = poziom BFS (centrum -> liście),
+//   * krawędź -> linia; grubość = liczba wspólnych publikacji.
+// Interakcja (gratis z 3d-force-graph): obrót orbitalny i zoom myszą,
+// klik = dolot kamery + panel z linkiem do autora, przeciąganie węzła =
+// sprężysta reakcja układu siłowego (efekt "gumy" w 3D).
+
+// Kolory wg poziomu: centrum złote, dalej chłodna paleta.
+const PALETA = [
+    "#ffd54a", "#4ea1ff", "#36c9c0", "#7ed957",
+    "#c792ea", "#ff8a65", "#9aa7b2"
+];
+
+function kolorPoziomu(level) {
+    return PALETA[Math.min(level || 0, PALETA.length - 1)];
+}
+
+// Escape do HTML — etykiety to nazwiska autorów z bazy (mogą teoretycznie
+// zawierać znaki specjalne), a nodeLabel renderuje się jako HTML tooltipa.
+function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+        return {
+            "&": "&amp;", "<": "&lt;", ">": "&gt;",
+            '"': "&quot;", "'": "&#39;"
+        }[c];
+    });
+}
+
+// nodeVal steruje OBJĘTOŚCIĄ kuli; metryki bywają duże (sumy IF/PK), więc
+// 3d-force-graph i tak skaluje promień ~cbrt(val). Pilnujemy minimum, by
+// węzły bez prac nie znikały.
+function wartoscMetryki(n, metryka) {
+    if (metryka === "if") { return Math.max(0.2, n.if_sum || 0); }
+    if (metryka === "pk") { return Math.max(0.2, n.pk_sum || 0); }
+    return Math.max(1, n.total_works || 1);
+}
+
+// siec.json -> {nodes, links}. Krawędzie drzewa (edges) i poprzeczne
+// (extra_edges) łączymy w jeden zbiór linków.
+function budujDane(data) {
+    const nodes = (data.nodes || []).map(function (n) {
+        return {
+            id: String(n.id),
+            label: n.label,
+            url: n.url,
+            level: n.level || 0,
+            total_works: n.total_works || 0,
+            if_sum: n.if_sum || 0,
+            pk_sum: n.pk_sum || 0
+        };
+    });
+    const krawedzie = [].concat(data.edges || [], data.extra_edges || []);
+    const links = krawedzie.map(function (e) {
+        return {
+            source: String(e.source),
+            target: String(e.target),
+            shared: e.shared || 1
+        };
+    });
+    return { nodes: nodes, links: links };
+}
+
+export function init(ForceGraph3D) {
+    const el = document.getElementById("siec3d-container");
+    if (!el || typeof ForceGraph3D !== "function") {
+        return; // brak kontenera lub biblioteki — nic nie robimy
+    }
+
+    const autorId = String(el.dataset.autorId);
+    const siecTpl = el.dataset.siecUrlTemplate;
+
+    const sliderGleb = document.getElementById("siec3d-glebokosc");
+    const sliderTopn = document.getElementById("siec3d-topn");
+    const selMetryka = document.getElementById("siec3d-metryka");
+    const glebLabel = document.getElementById("siec3d-glebokosc-label");
+    const topnLabel = document.getElementById("siec3d-topn-label");
+    const info = document.getElementById("siec3d-info");
+
+    let metryka = selMetryka ? selMetryka.value : "works";
+
+    const Graph = ForceGraph3D()(el)
+        .backgroundColor("#0b1020")
+        .nodeRelSize(4)
+        .nodeVal(function (n) { return wartoscMetryki(n, metryka); })
+        .nodeColor(function (n) { return kolorPoziomu(n.level); })
+        .nodeOpacity(0.95)
+        .nodeLabel(function (n) {
+            return "<b>" + esc(n.label) + "</b><br>prace: " + (n.total_works | 0);
+        })
+        .linkColor(function () { return "rgba(255,255,255,0.16)"; })
+        .linkWidth(function (l) { return Math.max(0.4, Math.log2(l.shared + 1)); })
+        .linkOpacity(0.45)
+        .onNodeClick(function (n) {
+            // Dolot kamery do węzła (klasyczny recipe 3d-force-graph): kamera
+            // ustawia się na osi środek–węzeł w stałej odległości i patrzy nań.
+            const dist = 140;
+            const r = 1 + dist / Math.max(1, Math.hypot(n.x, n.y, n.z));
+            Graph.cameraPosition(
+                { x: n.x * r, y: n.y * r, z: n.z * r }, n, 1000
+            );
+            if (info) {
+                // Budujemy panel przez DOM (textContent + createElement),
+                // bez innerHTML z danymi autora — zero ryzyka XSS.
+                info.textContent = "";
+                const b = document.createElement("b");
+                b.textContent = n.label || "";
+                info.appendChild(b);
+                info.appendChild(document.createElement("br"));
+                info.appendChild(
+                    document.createTextNode("prace: " + (n.total_works | 0))
+                );
+                if (n.url) {
+                    info.appendChild(document.createTextNode(" · "));
+                    const a = document.createElement("a");
+                    a.href = n.url; // ścieżka z reverse(); a.href nie wykonuje JS
+                    a.textContent = "strona autora →";
+                    info.appendChild(a);
+                }
+                info.style.display = "block";
+            }
+        });
+
+    function dopasujRozmiar() {
+        Graph.width(el.clientWidth).height(el.clientHeight);
+    }
+    dopasujRozmiar();
+    window.addEventListener("resize", dopasujRozmiar);
+
+    // Token sekwencji — szybkie ruchy suwaków odpalają kilka fetchy; render
+    // aplikujemy tylko, gdy odpowiedź jest wciąż bieżąca.
+    let seq = 0;
+    function zaladuj() {
+        const depth = sliderGleb ? parseInt(sliderGleb.value, 10) : 2;
+        const topn = sliderTopn ? parseInt(sliderTopn.value, 10) : 10;
+        const url = siecTpl.replace("/0/", "/" + autorId + "/")
+            + "?depth=" + depth + "&topn=" + topn;
+        const moj = ++seq;
+        fetch(url)
+            .then(function (r) {
+                if (!r.ok) { throw new Error("HTTP " + r.status); }
+                return r.json();
+            })
+            .then(function (data) {
+                if (moj !== seq) { return; }
+                Graph.graphData(budujDane(data));
+            })
+            .catch(function (e) {
+                if (info) {
+                    info.textContent = "Błąd: " + e.message;
+                    info.style.display = "block";
+                }
+            });
+    }
+
+    let deb = null;
+    function zaladujZwloka() {
+        if (deb) { clearTimeout(deb); }
+        deb = setTimeout(zaladuj, 250);
+    }
+
+    if (sliderGleb) {
+        sliderGleb.addEventListener("input", function () {
+            if (glebLabel) { glebLabel.textContent = sliderGleb.value; }
+            zaladujZwloka();
+        });
+    }
+    if (sliderTopn) {
+        sliderTopn.addEventListener("input", function () {
+            if (topnLabel) { topnLabel.textContent = sliderTopn.value; }
+            zaladujZwloka();
+        });
+    }
+    if (selMetryka) {
+        selMetryka.addEventListener("change", function () {
+            metryka = selMetryka.value;
+            // przestawienie akcesora wymusza ponowne policzenie rozmiarów kul
+            Graph.nodeVal(function (n) { return wartoscMetryki(n, metryka); });
+        });
+    }
+
+    zaladuj();
+}

--- a/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
@@ -102,14 +102,6 @@ export function init(ForceGraph3D) {
         .linkColor(function () { return "rgba(255,255,255,0.16)"; })
         .linkWidth(function (l) { return Math.max(0.4, Math.log2(l.shared + 1)); })
         .linkOpacity(0.45)
-        // Płynące cząsteczki = "przepływ" współpracy. Tylko na silniejszych
-        // powiązaniach (shared >= 2) i z twardym capem, żeby nie mnożyć
-        // obiektów Three.js przy gęstych sieciach.
-        .linkDirectionalParticles(function (l) {
-            return l.shared >= 2 ? Math.min(2, l.shared - 1) : 0;
-        })
-        .linkDirectionalParticleSpeed(0.006)
-        .linkDirectionalParticleWidth(1.1)
         .onNodeClick(function (n) {
             // Dolot kamery do węzła (klasyczny recipe 3d-force-graph).
             const dist = 140;
@@ -199,7 +191,8 @@ export function init(ForceGraph3D) {
         const nodes = Graph.graphData().nodes;
         if (uklad === "drzewo") {
             nodes.forEach(function (n) { n.fx = n.fy = n.fz = undefined; });
-            Graph.dagMode("radialout").dagLevelDistance(70).onDagError(null);
+            Graph.dagMode("radialout").dagLevelDistance(70)
+                .onDagError(function () {});
         } else if (uklad === "warstwy") {
             Graph.dagMode(null);
             nodes.forEach(function (n) {
@@ -233,16 +226,19 @@ export function init(ForceGraph3D) {
                 pk_sum: n.pk_sum || 0
             };
         });
+        const uklad = ukladEl ? ukladEl.value : "sila";
         const links = (rawData.edges || []).map(mapLink);
-        if (!chkWewn || chkWewn.checked) {
+        // W "drzewie" pokazujemy TYLKO krawędzie drzewa — extra_edges tworzą
+        // cykle, które psują układ DAG (radialout); w pozostałych formach
+        // dokładamy powiązania w grupie wg progu.
+        if (uklad !== "drzewo" && (!chkWewn || chkWewn.checked)) {
             const prog = progWewn ? (parseInt(progWewn.value, 10) || 1) : 1;
             (rawData.extra_edges || []).forEach(function (e) {
                 if ((e.shared || 1) >= prog) { links.push(mapLink(e)); }
             });
         }
         Graph.graphData({ nodes: nodes, links: links });
-        // utrzymaj wybraną formę układu po przebudowie danych
-        zastosujUklad(ukladEl ? ukladEl.value : "sila");
+        zastosujUklad(uklad);
     }
 
     function dopasujRozmiar() {
@@ -313,9 +309,9 @@ export function init(ForceGraph3D) {
         });
     }
     if (ukladEl) {
-        ukladEl.addEventListener("change", function () {
-            zastosujUklad(ukladEl.value);
-        });
+        // przez render(), bo "drzewo" wymaga przefiltrowania krawędzi do
+        // samego drzewa (potem zastosujUklad nada formę)
+        ukladEl.addEventListener("change", render);
     }
 
     // --- zaawansowane: rok / zatrudnieni -> przeładuj sieć ---

--- a/src/powiazania_autorow/static/powiazania_autorow/js/three-entry.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/three-entry.js
@@ -1,0 +1,15 @@
+// Entry esbuild dla widoku 3D sieci powiązań. Buduje OSOBNY bundle
+// (dist/three-bundle.js) ładowany TYLKO na stronie 3D — Three.js +
+// 3d-force-graph to spory ciężar (~150 kB gzip), nie ma go na domyślnej
+// (2D) stronie ani w globalnym bundlu.
+import ForceGraph3D from "3d-force-graph";
+
+import { init } from "./siec3d/index.js";
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", function () {
+        init(ForceGraph3D);
+    });
+} else {
+    init(ForceGraph3D);
+}

--- a/src/powiazania_autorow/templates/powiazania_autorow/graf.html
+++ b/src/powiazania_autorow/templates/powiazania_autorow/graf.html
@@ -58,6 +58,11 @@
                 class="button small secondary" style="margin: 0; height: 2.4rem;">
             <span class="fi-widget"></span> Opcje zaawansowane ▾
         </button>
+        <a href="{% url 'bpp:browse_autor_powiazania_3d' autor.pk %}"
+           class="button small secondary" style="margin: 0; height: 2.4rem;"
+           title="Zobacz sieć w 3D (obracana scena WebGL)">
+            <span class="fi-play"></span> Widok 3D
+        </a>
     </div>
 
     {# --- opcje zaawansowane (domyślnie schowane) --- #}

--- a/src/powiazania_autorow/templates/powiazania_autorow/graf3d.html
+++ b/src/powiazania_autorow/templates/powiazania_autorow/graf3d.html
@@ -33,6 +33,18 @@
                    min="1" max="10" value="2" step="1">
         </div>
         <div>
+            <label for="siec3d-uklad" style="display: block;">
+                Układ 3D
+            </label>
+            <select id="siec3d-uklad" autocomplete="off"
+                    style="margin: 0; height: 2.4rem;">
+                <option value="sila">Siłowy (chmura)</option>
+                <option value="drzewo">Drzewo (radialne)</option>
+                <option value="warstwy">Warstwy (poziomy)</option>
+                <option value="sfery">Sferyczne powłoki</option>
+            </select>
+        </div>
+        <div>
             <label for="siec3d-metryka" style="display: block;">
                 Wielkość koła wg
             </label>

--- a/src/powiazania_autorow/templates/powiazania_autorow/graf3d.html
+++ b/src/powiazania_autorow/templates/powiazania_autorow/graf3d.html
@@ -43,10 +43,58 @@
                 <option value="pk">Sumarycznego PK</option>
             </select>
         </div>
+        <button type="button" id="siec3d-zaawansowane-toggle"
+                class="button small secondary" style="margin: 0; height: 2.4rem;">
+            <span class="fi-widget"></span> Opcje zaawansowane ▾
+        </button>
         <a href="{% url 'bpp:browse_autor_powiazania' autor.pk %}"
            class="button small secondary" style="margin: 0; height: 2.4rem;">
             <span class="fi-arrow-left"></span> Widok 2D
         </a>
+    </div>
+
+    {# --- opcje zaawansowane (domyślnie schowane) --- #}
+    <div id="siec3d-zaawansowane"
+         style="display: none; flex-wrap: wrap; align-items: flex-end;
+                gap: 8px 24px; margin-top: 8px; padding: 10px;
+                background: #f7f7f7; border: 1px solid #e3e3e3;
+                border-radius: 4px;">
+        <div>
+            <label style="display: block;">Rok (od–do)</label>
+            <input type="number" id="siec3d-rok-od" autocomplete="off"
+                   placeholder="od"
+                   style="margin: 0; height: 2.4rem; width: 104px;">
+            <input type="number" id="siec3d-rok-do" autocomplete="off"
+                   placeholder="do"
+                   style="margin: 0; height: 2.4rem; width: 104px;">
+        </div>
+        <div title="Pokaż tylko współautorów z aktualną jednostką w tej uczelni">
+            <label style="display: block; margin: 0;">
+                <input type="checkbox" id="siec3d-zatrudnieni-chk" autocomplete="off"
+                       style="margin: 0 4px 0 0;">
+                Tylko aktualnie zatrudnieni
+            </label>
+            <span style="display: block; font-size: 12px; color: #666;">
+                współautorzy z bieżącej uczelni
+            </span>
+        </div>
+        <div title="Pokaż powiązania między widocznymi autorami (poza drzewem)">
+            <label style="display: block; margin: 0;">
+                <input type="checkbox" id="siec3d-wewnetrzne-chk" autocomplete="off"
+                       checked style="margin: 0 4px 0 0;">
+                Powiązania w grupie
+            </label>
+            <label for="siec3d-wewn-prog"
+                   style="display: block; font-size: 12px; color: #666;">
+                od <span id="siec3d-wewn-prog-label">1</span> wspólnych prac
+            </label>
+            <input type="range" id="siec3d-wewn-prog" autocomplete="off"
+                   min="1" max="10" value="1" step="1">
+        </div>
+        <button type="button" id="siec3d-odswiez" class="button small"
+                style="margin: 0;">
+            <span class="fi-refresh"></span> Odśwież układ
+        </button>
     </div>
     <small style="display: block; color: #666; margin: 6px 0 12px;">
         Obracaj scenę przeciągając tło, przybliżaj kółkiem myszy. Najedź na
@@ -60,6 +108,7 @@
         <div id="siec3d-container"
              data-autor-id="{{ autor.pk }}"
              data-siec-url-template="{% url 'bpp:browse_autor_powiazania_siec' 0 %}"
+             data-graf3d-url-template="{% url 'bpp:browse_autor_powiazania_3d' 0 %}"
              style="width: 100%; height: 78vh; border: 1px solid #ccc;
                     background: #0b1020;"></div>
         <div id="siec3d-info"

--- a/src/powiazania_autorow/templates/powiazania_autorow/graf3d.html
+++ b/src/powiazania_autorow/templates/powiazania_autorow/graf3d.html
@@ -55,6 +55,15 @@
                 <option value="pk">Sumarycznego PK</option>
             </select>
         </div>
+        <div title="Pokaż nazwiska najważniejszych autorów (top 25 wg metryki)">
+            <label style="display: block;">Etykiety</label>
+            <label style="display: block; margin: 0; height: 2.4rem;
+                          line-height: 2.4rem;">
+                <input type="checkbox" id="siec3d-etykiety-chk" autocomplete="off"
+                       style="margin: 0 4px 0 0;">
+                Pokaż nazwiska
+            </label>
+        </div>
         <button type="button" id="siec3d-zaawansowane-toggle"
                 class="button small secondary" style="margin: 0; height: 2.4rem;">
             <span class="fi-widget"></span> Opcje zaawansowane ▾
@@ -93,7 +102,7 @@
         <div title="Pokaż powiązania między widocznymi autorami (poza drzewem)">
             <label style="display: block; margin: 0;">
                 <input type="checkbox" id="siec3d-wewnetrzne-chk" autocomplete="off"
-                       checked style="margin: 0 4px 0 0;">
+                       style="margin: 0 4px 0 0;">
                 Powiązania w grupie
             </label>
             <label for="siec3d-wewn-prog"

--- a/src/powiazania_autorow/templates/powiazania_autorow/graf3d.html
+++ b/src/powiazania_autorow/templates/powiazania_autorow/graf3d.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block extratitle %}Sieć powiązań 3D — {{ autor }}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="{% url "bpp:browse_autorzy" %}">Autorzy</a></li>
+    <li><a href="{{ autor.get_absolute_url }}">{{ autor }}</a></li>
+    <li><a href="{% url "bpp:browse_autor_powiazania" autor.pk %}">Sieć powiązań</a></li>
+    <li class="current">3D</li>
+{% endblock %}
+
+{% block content %}
+    <h1>Sieć powiązań 3D — {{ autor }}</h1>
+
+    {# --- kontrolki (kompaktowe) --- #}
+    <div class="graf-controls"
+         style="display: flex; flex-wrap: wrap; align-items: flex-end;
+                gap: 8px 24px;">
+        <div>
+            <label for="siec3d-topn" style="display: block;">
+                Maks. współautorów na węzeł: <span id="siec3d-topn-label">10</span>
+            </label>
+            <input type="range" id="siec3d-topn" autocomplete="off"
+                   min="3" max="20" value="10" step="1">
+        </div>
+        <div>
+            <label for="siec3d-glebokosc" style="display: block;">
+                Głębokość sieci: <span id="siec3d-glebokosc-label">2</span>
+            </label>
+            <input type="range" id="siec3d-glebokosc" autocomplete="off"
+                   min="1" max="10" value="2" step="1">
+        </div>
+        <div>
+            <label for="siec3d-metryka" style="display: block;">
+                Wielkość koła wg
+            </label>
+            <select id="siec3d-metryka" autocomplete="off"
+                    style="margin: 0; height: 2.4rem;">
+                <option value="works">Liczby prac</option>
+                <option value="if">Sumarycznego IF</option>
+                <option value="pk">Sumarycznego PK</option>
+            </select>
+        </div>
+        <a href="{% url 'bpp:browse_autor_powiazania' autor.pk %}"
+           class="button small secondary" style="margin: 0; height: 2.4rem;">
+            <span class="fi-arrow-left"></span> Widok 2D
+        </a>
+    </div>
+    <small style="display: block; color: #666; margin: 6px 0 12px;">
+        Obracaj scenę przeciągając tło, przybliżaj kółkiem myszy. Najedź na
+        węzeł, aby zobaczyć autora; kliknij, aby dolecieć kamerą i otworzyć
+        link do jego strony. Złapany węzeł można przeciągać — układ reaguje
+        sprężyście. Kolor węzła odpowiada poziomowi sieci, wielkość — wybranej
+        metryce, grubość linii — liczbie wspólnych publikacji.
+    </small>
+
+    <div id="siec3d-wrapper" style="position: relative;">
+        <div id="siec3d-container"
+             data-autor-id="{{ autor.pk }}"
+             data-siec-url-template="{% url 'bpp:browse_autor_powiazania_siec' 0 %}"
+             style="width: 100%; height: 78vh; border: 1px solid #ccc;
+                    background: #0b1020;"></div>
+        <div id="siec3d-info"
+             style="position: absolute; top: 10px; left: 10px; display: none;
+                    background: rgba(255,255,255,.95); border: 1px solid #ddd;
+                    border-radius: 4px; padding: 8px 10px; font-size: 13px;
+                    max-width: 280px; z-index: 1001;"></div>
+    </div>
+
+    <script src="{% static 'powiazania_autorow/js/dist/three-bundle.js' %}"></script>
+{% endblock %}

--- a/src/powiazania_autorow/test_views.py
+++ b/src/powiazania_autorow/test_views.py
@@ -450,6 +450,34 @@ def test_strona_grafu_404_dla_nieistniejacego_autora(client):
 
 
 @pytest.mark.django_db
+def test_strona_grafu_3d_renderuje_kontener(client):
+    autor = baker.make(Autor, imiona="Jan", nazwisko="Kowalski", pokazuj=True)
+    url = reverse("bpp:browse_autor_powiazania_3d", args=[autor.pk])
+    resp = client.get(url)
+    assert resp.status_code == 200
+    tresc = resp.content.decode("utf-8")
+    assert 'id="siec3d-container"' in tresc
+    assert f'data-autor-id="{autor.pk}"' in tresc
+    # lazy bundle 3D (nazwa może być zahashowana przez ManifestStaticFiles)
+    assert "three-bundle" in tresc
+
+
+@pytest.mark.django_db
+def test_strona_grafu_3d_404_gdy_siec_wylaczona(client, uczelnia):
+    uczelnia.pokazuj_siec_powiazan = False
+    uczelnia.save()
+    autor = baker.make(Autor, pokazuj=True, pokazuj_siec_powiazan=None)
+    url = reverse("bpp:browse_autor_powiazania_3d", args=[autor.pk])
+    assert client.get(url).status_code == 404
+
+
+@pytest.mark.django_db
+def test_strona_grafu_3d_404_dla_nieistniejacego_autora(client):
+    url = reverse("bpp:browse_autor_powiazania_3d", args=[99999])
+    assert client.get(url).status_code == 404
+
+
+@pytest.mark.django_db
 def test_strona_autora_ma_flage_powiazan_true(client):
     centrum = baker.make(Autor, pokazuj=True)
     sasiad = baker.make(Autor, pokazuj=True)

--- a/src/powiazania_autorow/views.py
+++ b/src/powiazania_autorow/views.py
@@ -42,6 +42,25 @@ class GrafPowiazanView(TemplateView):
         return context
 
 
+class GrafPowiazan3DView(TemplateView):
+    """Widok 3D sieci powiązań (Three.js / WebGL) — alternatywa dla 2D.
+
+    Czyta ten sam endpoint danych (siec.json) co widok 2D; różni się tylko
+    rendererem po stronie klienta. Bramkowany tym samym ustawieniem
+    "pokazuj sieć powiązań" (404 gdy wyłączone).
+    """
+
+    template_name = "powiazania_autorow/graf3d.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        autor = get_object_or_404(Autor, pk=kwargs["pk"])
+        if not siec_powiazan_wlaczona(autor, self.request):
+            raise Http404("Sieć powiązań jest wyłączona dla tego autora.")
+        context["autor"] = autor
+        return context
+
+
 class GrafPowiazanDaneView(View):
     """JSON z sąsiadami (współautorami) danego autora.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"3d-force-graph@^1.80.0":
+  version "1.80.0"
+  resolved "https://registry.yarnpkg.com/3d-force-graph/-/3d-force-graph-1.80.0.tgz#295d84b44b8df7f416c2f2b838b5c441989a0d13"
+  integrity sha512-tzI353gW1nXPpnC7VTa3JjMg+3cp77qOLUFO0vucPTfF+q5R6sQsNsIqVTbRIb7RSypn14nBa4yfkOe9ThxASw==
+  dependencies:
+    accessor-fn "1"
+    kapsule "^1.16"
+    three ">=0.179 <1"
+    three-forcegraph "1"
+    three-render-objects "^1.41"
+
 "@babel/code-frame@^7.0.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
@@ -15,6 +26,11 @@
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+
+"@babel/runtime@^7.17.8":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
 "@babel/runtime@^7.25.6", "@babel/runtime@^7.29.2":
   version "7.29.2"
@@ -480,6 +496,11 @@
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 
+"@tweenjs/tween.js@18 - 25":
+  version "25.0.0"
+  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-25.0.0.tgz#7266baebcc3affe62a3a54318a3ea82d904cd0b9"
+  integrity sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==
+
 "@types/geojson-vt@3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@types/geojson-vt/-/geojson-vt-3.2.5.tgz#b6c356874991d9ab4207533476dfbcdb21e38408"
@@ -548,6 +569,11 @@ abs-svg-path@^0.1.1, abs-svg-path@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/abs-svg-path/-/abs-svg-path-0.1.1.tgz#df601c8e8d2ba10d4a76d625e236a9a39c2723bf"
   integrity sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==
+
+accessor-fn@1:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/accessor-fn/-/accessor-fn-1.5.3.tgz#5e2549d291d4ac022f532da9a554358dc525b0f7"
+  integrity sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==
 
 acorn@^7.1.1:
   version "7.4.1"
@@ -1098,6 +1124,18 @@ d3-array@1, d3-array@^1.2.1:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
+"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+d3-binarytree@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d3-binarytree/-/d3-binarytree-1.0.2.tgz#ed43ebc13c70fbabfdd62df17480bc5a425753cc"
+  integrity sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==
+
 d3-collection@1, d3-collection@^1.0.4:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
@@ -1113,6 +1151,22 @@ d3-dispatch@1:
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
   integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
 
+"d3-dispatch@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+"d3-force-3d@2 - 3":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/d3-force-3d/-/d3-force-3d-3.0.6.tgz#7ea4c26d7937b82993bd9444f570ed52f661d4aa"
+  integrity sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==
+  dependencies:
+    d3-binarytree "1"
+    d3-dispatch "1 - 3"
+    d3-octree "1"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
 d3-force@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.2.1.tgz#fd29a5d1ff181c9e7f0669e4bd72bdb0e914ec0b"
@@ -1122,6 +1176,11 @@ d3-force@^1.2.1:
     d3-dispatch "1"
     d3-quadtree "1"
     d3-timer "1"
+
+"d3-format@1 - 3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
 
 d3-format@^1.4.5:
   version "1.4.5"
@@ -1150,12 +1209,17 @@ d3-hierarchy@^1.1.9:
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz#2f6bee24caaea43f8dc37545fa01628559647a83"
   integrity sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==
 
-d3-interpolate@^3.0.1:
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
   dependencies:
     d3-color "1 - 3"
+
+d3-octree@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-octree/-/d3-octree-1.1.0.tgz#f07e353b76df872644e7130ab1a74c5ef2f4287e"
+  integrity sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==
 
 d3-path@1:
   version "1.0.9"
@@ -1167,12 +1231,48 @@ d3-quadtree@1:
   resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.7.tgz#ca8b84df7bb53763fe3c2f24bd435137f4e53135"
   integrity sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==
 
+"d3-quadtree@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+"d3-scale-chromatic@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#34c39da298b23c20e02f1a4b239bd0f22e7f1314"
+  integrity sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+"d3-scale@1 - 4":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+"d3-selection@2 - 3":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
 d3-shape@^1.2.0:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
   integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
   dependencies:
     d3-path "1"
+
+"d3-time-format@2 - 4":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
 
 d3-time-format@^2.2.3:
   version "2.3.0"
@@ -1186,10 +1286,22 @@ d3-time@1, d3-time@^1.1.0:
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
+"d3-time@1 - 3", "d3-time@2.1.1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
 d3-timer@1:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
   integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
+
+"d3-timer@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
 d@1, d@^1.0.1, d@^1.0.2:
   version "1.0.2"
@@ -1198,6 +1310,13 @@ d@1, d@^1.0.1, d@^1.0.2:
   dependencies:
     es5-ext "^0.10.64"
     type "^2.7.2"
+
+data-bind-mapper@1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/data-bind-mapper/-/data-bind-mapper-1.0.3.tgz#275e55fd170331b1146479f3c7eb4256b8239481"
+  integrity sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==
+  dependencies:
+    accessor-fn "1"
 
 data-uri-to-buffer@^6.0.2:
   version "6.0.2"
@@ -1662,6 +1781,15 @@ flatten-vertex-data@^1.0.2:
   integrity sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==
   dependencies:
     dtype "^2.0.0"
+
+float-tooltip@^1.7:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/float-tooltip/-/float-tooltip-1.7.5.tgz#7083bf78f0de5a97f9c2d6aa8e90d2139f34047f"
+  integrity sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==
+  dependencies:
+    d3-selection "2 - 3"
+    kapsule "^1.16"
+    preact "10"
 
 font-atlas@^2.1.0:
   version "2.1.0"
@@ -2300,6 +2428,11 @@ ini@^4.1.3:
   resolved "https://registry.yarnpkg.com/ini/-/ini-4.1.3.tgz#4c359675a6071a46985eb39b14e4a2c0ec98a795"
   integrity sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==
 
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+
 interpret@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
@@ -2517,6 +2650,13 @@ json-stringify-pretty-compact@^4.0.0:
   resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz#cf4844770bddee3cb89a6170fe4b00eee5dbf1d4"
   integrity sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==
 
+kapsule@^1.16:
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/kapsule/-/kapsule-1.16.3.tgz#5684ed89838b6658b30d0f2cc056dffc3ba68c30"
+  integrity sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==
+  dependencies:
+    lodash-es "4"
+
 kdbush@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-3.0.0.tgz#f8484794d47004cc2d85ed3a79353dbe0abc2bf0"
@@ -2560,6 +2700,11 @@ livereload-js@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/livereload-js/-/livereload-js-2.4.0.tgz#447c31cf1ea9ab52fc20db615c5ddf678f78009c"
   integrity sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==
+
+lodash-es@4:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -2738,6 +2883,37 @@ next-tick@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
+
+ngraph.events@^1.0.0, ngraph.events@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ngraph.events/-/ngraph.events-1.4.0.tgz#3153c0a5760172c744f7b2dbc5a3d8a72703e357"
+  integrity sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw==
+
+ngraph.forcelayout@3:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/ngraph.forcelayout/-/ngraph.forcelayout-3.3.1.tgz#981e1baee5e0593c490bc27219169f9cedfa4f8b"
+  integrity sha512-MKBuEh1wujyQHFTW57y5vd/uuEOK0XfXYxm3lC7kktjJLRdt/KEKEknyOlc6tjXflqBKEuYBBcu7Ax5VY+S6aw==
+  dependencies:
+    ngraph.events "^1.0.0"
+    ngraph.merge "^1.0.0"
+    ngraph.random "^1.0.0"
+
+ngraph.graph@20:
+  version "20.1.2"
+  resolved "https://registry.yarnpkg.com/ngraph.graph/-/ngraph.graph-20.1.2.tgz#903389a5370a864cb1a47c522f54994b38cb3923"
+  integrity sha512-W/G3GBR3Y5UxMLHTUCPP9v+pbtpzwuAEIqP5oZV+9IwgxAIEZwh+Foc60iPc1idlnK7Zxu0p3puxAyNmDvBd0Q==
+  dependencies:
+    ngraph.events "^1.4.0"
+
+ngraph.merge@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ngraph.merge/-/ngraph.merge-1.0.0.tgz#d763cdfa48b1bbd4270ea246f06c9c8ff5d3477c"
+  integrity sha512-5J8YjGITUJeapsomtTALYsw7rFveYkM+lBj3QiYZ79EymQcuri65Nw3knQtFxQBU1r5iOaVRXrSwMENUPK62Vg==
+
+ngraph.random@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ngraph.random/-/ngraph.random-1.2.0.tgz#3864ffbb9971e920db6c5f33ce5abc3d2439e3d2"
+  integrity sha512-4EUeAGbB2HWX9njd6bP6tciN6ByJfoaAvmVL9QTaZSeXrW46eNGA9GajiXiPBbvFqxUWFkEbyo6x5qsACUuVfA==
 
 node-addon-api@^7.0.0:
   version "7.1.1"
@@ -3043,6 +3219,13 @@ point-in-polygon@^1.1.0:
   resolved "https://registry.yarnpkg.com/point-in-polygon/-/point-in-polygon-1.1.0.tgz#b0af2616c01bdee341cbf2894df643387ca03357"
   integrity sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==
 
+polished@4:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.3.1.tgz#5a00ae32715609f83d89f6f31d0f0261c6170548"
+  integrity sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==
+  dependencies:
+    "@babel/runtime" "^7.17.8"
+
 polybooljs@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/polybooljs/-/polybooljs-1.2.2.tgz#c7127b014a63e1d00c70608abbd8dc0967ffeea3"
@@ -3107,6 +3290,11 @@ potpack@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/potpack/-/potpack-2.1.0.tgz#fe548e2f9061e9937f17191c1ab6dd98ca30e02f"
   integrity sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==
+
+preact@10:
+  version "10.29.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.29.2.tgz#3e6069c471718b8d124d1cd67565114532e88d70"
+  integrity sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==
 
 probe-image-size@^7.2.3:
   version "7.2.3"
@@ -3748,6 +3936,38 @@ text-decoder@^1.1.0:
   dependencies:
     b4a "^1.6.4"
 
+three-forcegraph@1:
+  version "1.43.4"
+  resolved "https://registry.yarnpkg.com/three-forcegraph/-/three-forcegraph-1.43.4.tgz#9e85a75e729af143440d4a05edf3b197d717310e"
+  integrity sha512-FtmiZP/T16ZQaHza3JDaDn0YTXFtg9e7pGnTeU8nzu0NNkx7MpWbF/GvmpbQsWHx3rukHtkRv1fTorLPB3FDEA==
+  dependencies:
+    accessor-fn "1"
+    d3-array "1 - 3"
+    d3-force-3d "2 - 3"
+    d3-scale "1 - 4"
+    d3-scale-chromatic "1 - 3"
+    data-bind-mapper "1"
+    kapsule "^1.16"
+    ngraph.forcelayout "3"
+    ngraph.graph "20"
+    tinycolor2 "1"
+
+three-render-objects@^1.41:
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/three-render-objects/-/three-render-objects-1.42.0.tgz#32ad1a6f83ecb92ec67573c79f7865b44d491aa6"
+  integrity sha512-KYfkPrYGEbIK8ChFocWqOF1aAN80FBUBWVYB8mB2oBpVuVN+52FvvngVYB5ieFANQu7Rt21rPYZ/xKaAgVWWRQ==
+  dependencies:
+    "@tweenjs/tween.js" "18 - 25"
+    accessor-fn "1"
+    float-tooltip "^1.7"
+    kapsule "^1.16"
+    polished "4"
+
+"three@>=0.179 <1":
+  version "0.184.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.184.0.tgz#5bca0a3851eea5345e4c205567b40dfa49b791b5"
+  integrity sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==
+
 through2@^0.6.3:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
@@ -3784,7 +4004,7 @@ tiny-lr@^1.1.1:
     object-assign "^4.1.0"
     qs "^6.4.0"
 
-tinycolor2@^1.4.2:
+tinycolor2@1, tinycolor2@^1.4.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.6.0.tgz#f98007460169b0263b97072c5ae92484ce02d09e"
   integrity sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3963,6 +3963,11 @@ three-render-objects@^1.41:
     kapsule "^1.16"
     polished "4"
 
+three-spritetext@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/three-spritetext/-/three-spritetext-1.10.0.tgz#479717cbf7ea64ee2e5879952bb5e15f608bf13d"
+  integrity sha512-t08iP1FCU1lQh8T5MmCpdijKgas8GDHJE0LqMGBuVu3xqMMpFnEZhTlih7FlxLPQizHIGoumUSpfOlY1GO/Tgg==
+
 "three@>=0.179 <1":
   version "0.184.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.184.0.tgz#5bca0a3851eea5345e4c205567b40dfa49b791b5"


### PR DESCRIPTION
Alternatywny, **obracalny widok 3D** sieci współautorstwa — obok istniejącego 2D (Cytoscape), nie zamiast niego.

## Najważniejsze: backend bez zmian merytorycznych
Widok 3D czyta **dokładnie ten sam endpoint `siec.json`** co 2D. Dochodzi tylko nowa strona-render:
- route `/autor/<pk>/powiazania/3d/` (`browse_autor_powiazania_3d`),
- `GrafPowiazan3DView` bramkowana tym samym ustawieniem **„pokazuj sieć powiązań"** (404 gdy wyłączone, jak 2D).

## Renderer i interakcja
- **`3d-force-graph`** (Three.js + d3-force-3d), WebGL.
- Węzeł = kula: **rozmiar** wg metryki (prace / IF / PK), **kolor** wg poziomu BFS (centrum→liście). Krawędź = linia: **grubość** wg liczby wspólnych publikacji.
- **Obrót orbitalny + zoom** myszą, **hover** → tooltip (autor + liczba prac), **klik** → dolot kamery do węzła + panel z linkiem do strony autora, **drag węzła** → sprężysta reakcja układu siłowego (efekt „gumy" w 3D).
- Suwaki głębokość / liczba współautorów + wybór metryki (re-fetch `siec.json`).

## Bundling (zgodnie z wymogiem: wszystko bundlowane, nie CDN)
- Osobny **lazy** `dist/three-bundle.js`, ładowany **tylko** na stronie 3D (~1.8 MB / ~400–500 kB gzip) — domyślna strona 2D i globalny bundle nietknięte.
- Nowy task gruntowy `esbuildThree` (w `build` i `build-non-interactive`); `Makefile JS_SOURCES` rozszerzony o `siec3d/*.js`.
- **Dockerfile bez zmian** — kopiuje cały katalog `powiazania_autorow/.../js/`, a `grunt build` bake'uje bundle (kontrakt static-files).
- Zależność `3d-force-graph` (+ three, d3-force-3d) w `package.json` / `yarn.lock`.

## Bezpieczeństwo
Etykiety i panel info budowane przez **escape + DOM** (`textContent`/`createElement`), bez `innerHTML` z danymi autora → brak ryzyka XSS na nazwiskach.

## UX
Link **„Widok 3D"** w kontrolkach 2D; w 3D link powrotny do 2D.

## Testy
Render kontenera 3D + bramka 404 (uczelnia wyłącza / nieistniejący autor). Cały moduł zielony: **53 passed**. ruff + `manage.py check` czyste.

> Bundle `dist/three-bundle.js` jest gitignored i odbudowywany na buildzie (jak cytoscape). Źródła: `three-entry.js` + `siec3d/index.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)