### PR TITLE
feat(powiazania_autorow): tytuły na etykietach 2D + odzysk końcówki #300 (fix etykiet 3D, animacje rozmiaru, elastyczny układ)

### DIFF
--- a/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/controls.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/controls.js
@@ -8,7 +8,7 @@ import {
     pokazTooltipAutor,
     pokazTooltipKrawedz
 } from "./panel.js";
-import { przeliczRozmiary } from "./sizing.js";
+import { przeliczRozmiaryAnim } from "./sizing.js";
 import { szukaj } from "./search.js";
 import { odswiezKrawedzieWewn } from "./group-edges.js";
 import { ulozGraf } from "./layout.js";
@@ -299,7 +299,8 @@ export function podepnijZdarzenia(ctx) {
     if (ctx.selMetryka) {
         ctx.selMetryka.addEventListener("change", function () {
             ctx.metryka = ctx.selMetryka.value;
-            przeliczRozmiary(ctx);
+            // płynne przejście rozmiarów kół (~1 s) zamiast skoku
+            przeliczRozmiaryAnim(ctx, 1000);
         });
     }
 

--- a/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/cy.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/cy.js
@@ -9,7 +9,7 @@ const STYLE = [
     {
         selector: "node",
         style: {
-            "label": "data(label)",
+            "label": "data(etykieta)",
             "background-color": "#4A90E2",
             "width": "data(rozmiar)",
             "height": "data(rozmiar)",

--- a/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/graph.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/graph.js
@@ -23,6 +23,10 @@ export function dodajWezel(ctx, id, info, isCentrum, seedPos) {
         data: {
             id: id,
             label: info.label,
+            // etykieta renderowana na węźle: tytuł naukowy przed nazwiskiem
+            // (np. "prof. dr hab. Jan Kowalski"). `label` zostaje samym
+            // nazwiskiem — używają go wyszukiwarka i tooltip.
+            etykieta: (info.tytul ? info.tytul + " " : "") + (info.label || ""),
             url: info.url,
             works: info.total_works || 0,
             if_sum: info.if_sum || 0,

--- a/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/layout.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/layout.js
@@ -119,13 +119,13 @@ export function pozycjeUkladu(ctx, centerId, children, levelOf) {
     return pozycjeRadialne(centerId, children);
 }
 
-// Delikatna "guma" na PRZEJŚCIU między układami: easing z lekkim
-// przestrzeleniem celu (drugi punkt kontrolny krzywej Béziera ma y > 1, więc
-// węzeł minimalnie wyjeżdża za pozycję docelową i wraca). W przeciwieństwie do
-// spring() jest w pełni przewidywalny — żadnego rozkołysania, tylko subtelne
-// "dociągnięcie". Strojenie: większe y2 = wyraźniejsze odbicie.
-const EASING_UKLAD = "cubic-bezier(0.34, 1.25, 0.64, 1)";
-const CZAS_UKLAD = 520; // ms — nieco dłużej niż 450, by przestrzelenie było czytelne
+// "Guma" na PRZEJŚCIU między układami: easing z przestrzeleniem celu (drugi
+// punkt kontrolny krzywej Béziera ma y > 1, więc węzeł wyjeżdża za pozycję
+// docelową i sprężyście wraca). W przeciwieństwie do spring() jest w pełni
+// przewidywalny. Strojenie: większe y2 = wyraźniejsze, bardziej "gumowate"
+// odbicie; dłuższy CZAS_UKLAD = wolniejsze, bardziej elastyczne dojście.
+const EASING_UKLAD = "cubic-bezier(0.34, 1.55, 0.5, 1)";
+const CZAS_UKLAD = 650; // ms — dłużej, by sprężyste odbicie było wyraźne
 
 // Ułożenie grafu wg bieżącego układu. "sila" = layout siłowy fcose
 // (organiczne skupiska); pozostałe = deterministyczne pozycje liczone

--- a/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/sizing.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/powiazania/sizing.js
@@ -25,3 +25,51 @@ export function przeliczRozmiary(ctx) {
         });
     });
 }
+
+// Jak przeliczRozmiary, ale PŁYNNIE: interpoluje "rozmiar" każdego węzła od
+// bieżącej do docelowej wartości w pętli rAF (easeInOutCubic). Używane przy
+// zmianie metryki, żeby kółka nie skakały, tylko urosły/zmalały przez ~`czas`
+// ms. Znacznik czasu z rAF (bez Date.now). Uchwyt animacji trzymamy na ctx,
+// żeby kolejna zmiana metryki anulowała poprzednią.
+export function przeliczRozmiaryAnim(ctx, czas) {
+    const cy = ctx.cy;
+    let maxV = 1;
+    cy.nodes().forEach(function (n) {
+        const v = wartoscMetryki(ctx, n);
+        if (v > maxV) { maxV = v; }
+    });
+    const cel = {};
+    const start = {};
+    cy.nodes().forEach(function (n) {
+        const d = 12 + 34 * Math.sqrt(wartoscMetryki(ctx, n) / maxV);
+        cel[n.id()] = Math.max(12, Math.min(46, d));
+        start[n.id()] = n.data("rozmiar") || 20;
+    });
+
+    if (ctx._rozmiarRaf) {
+        cancelAnimationFrame(ctx._rozmiarRaf);
+        ctx._rozmiarRaf = null;
+    }
+    let t0 = null;
+    function krok(teraz) {
+        if (t0 === null) { t0 = teraz; }
+        const t = Math.min(1, (teraz - t0) / czas);
+        const e = t < 0.5
+            ? 4 * t * t * t
+            : 1 - Math.pow(-2 * t + 2, 3) / 2; // easeInOutCubic
+        cy.batch(function () {
+            cy.nodes().forEach(function (n) {
+                const a = start[n.id()];
+                const b = cel[n.id()];
+                if (a === undefined || b === undefined) { return; }
+                n.data("rozmiar", a + (b - a) * e);
+            });
+        });
+        if (t < 1) {
+            ctx._rozmiarRaf = requestAnimationFrame(krok);
+        } else {
+            ctx._rozmiarRaf = null;
+        }
+    }
+    ctx._rozmiarRaf = requestAnimationFrame(krok);
+}

--- a/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
@@ -26,6 +26,9 @@ const PALETA = [
 // Ile najważniejszych (wg bieżącej metryki) węzłów dostaje stałą etykietę.
 const TOP_ETYKIETY = 25;
 
+// Czas płynnej animacji rozmiaru kół przy zmianie metryki (ms).
+const ANIM_METRYKA_MS = 1200;
+
 function kolorPoziomu(level) {
     return PALETA[Math.min(level || 0, PALETA.length - 1)];
 }
@@ -94,6 +97,7 @@ export function init(ForceGraph3D) {
 
     let metryka = selMetryka ? selMetryka.value : "works";
     let etykietyOn = chkEtykiety ? chkEtykiety.checked : false;
+    let tweenRaf = null; // uchwyt animacji rozmiaru kół (zmiana metryki)
     // ostatnio pobrana sieć (raw siec.json) — do klienckiego przebudowania
     // linków przy zmianie opcji "powiązania w grupie" bez ponownego fetcha.
     let rawData = { nodes: [], edges: [], extra_edges: [] };
@@ -131,10 +135,17 @@ export function init(ForceGraph3D) {
         if (!etykietyOn || !n._top) { return null; }
         const s = new SpriteText(n.label || "");
         s.color = "#fff";
-        s.textHeight = 5;
-        s.backgroundColor = "rgba(11,16,32,0.65)";
-        s.padding = 1.5;
-        s.position.set(0, 9, 0); // unieś nad kulę
+        s.textHeight = 6;
+        s.backgroundColor = "rgba(11,16,32,0.72)";
+        s.padding = 2;
+        // Unieś etykietę NAD kulę: promień kuli ≈ nodeRelSize * cbrt(metryka),
+        // inaczej przy dużych węzłach tekst ląduje w środku kuli.
+        const promien = 4 * Math.cbrt(Math.max(1, wartoscMetryki(n, metryka)));
+        s.position.set(0, promien + 6, 0);
+        // Rysuj PONAD geometrią — nie chowaj za/wewnątrz kul (zawsze czytelne).
+        s.material.depthTest = false;
+        s.material.depthWrite = false;
+        s.renderOrder = 999;
         return s;
     }
     // Re-assign przez świeży wrapper => 3d-force-graph regeneruje obiekty
@@ -199,6 +210,35 @@ export function init(ForceGraph3D) {
             })
             .slice(0, TOP_ETYKIETY)
             .forEach(function (n) { n._top = true; });
+    }
+
+    // Płynna animacja rozmiaru kół przy zmianie metryki: co klatkę ustawiamy
+    // nodeVal na wartość interpolowaną `stara→nowa` (easeInOutCubic). Po końcu
+    // przypinamy zwykły akcesor i odświeżamy top-N/etykiety.
+    function animujMetryke(stara, nowa) {
+        if (tweenRaf) { cancelAnimationFrame(tweenRaf); tweenRaf = null; }
+        let t0 = null;
+        function krok(teraz) {
+            if (t0 === null) { t0 = teraz; }
+            const t = Math.min(1, (teraz - t0) / ANIM_METRYKA_MS);
+            const e = t < 0.5
+                ? 4 * t * t * t
+                : 1 - Math.pow(-2 * t + 2, 3) / 2; // easeInOutCubic
+            Graph.nodeVal(function (n) {
+                const a = wartoscMetryki(n, stara);
+                const b = wartoscMetryki(n, nowa);
+                return a + (b - a) * e;
+            });
+            if (t < 1) {
+                tweenRaf = requestAnimationFrame(krok);
+            } else {
+                tweenRaf = null;
+                Graph.nodeVal(function (n) { return wartoscMetryki(n, nowa); });
+                oznaczTop(Graph.graphData().nodes);
+                odswiezEtykiety();
+            }
+        }
+        tweenRaf = requestAnimationFrame(krok);
     }
 
     // Linki dla bieżącego układu: krawędzie drzewa zawsze; powiązania w grupie
@@ -358,11 +398,12 @@ export function init(ForceGraph3D) {
     }
     if (selMetryka) {
         selMetryka.addEventListener("change", function () {
-            metryka = selMetryka.value;
-            Graph.nodeVal(function (n) { return wartoscMetryki(n, metryka); });
-            // top-N (a więc i etykiety) zależy od metryki
-            oznaczTop(Graph.graphData().nodes);
-            odswiezEtykiety();
+            const stara = metryka;
+            const nowa = selMetryka.value;
+            if (nowa === stara) { return; }
+            metryka = nowa;
+            // płynne przejście rozmiarów; top-N/etykiety odświeżą się na końcu
+            animujMetryke(stara, nowa);
         });
     }
     if (ukladEl) {

--- a/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
@@ -133,7 +133,9 @@ export function init(ForceGraph3D) {
     // Etykieta węzła (SpriteText) — tylko dla top-N i gdy włączone.
     function budujEtykiete(n) {
         if (!etykietyOn || !n._top) { return null; }
-        const s = new SpriteText(n.label || "");
+        // tytuł naukowy przed nazwiskiem, np. "prof. dr hab. Jan Kowalski"
+        const txt = (n.tytul ? n.tytul + " " : "") + (n.label || "");
+        const s = new SpriteText(txt);
         s.color = "#fff";
         s.textHeight = 6;
         s.backgroundColor = "rgba(11,16,32,0.72)";


### PR DESCRIPTION
## Nowe
- **Tytuły naukowe na etykietach węzłów w widoku 2D** — etykieta na węźle pokazuje tytuł przed nazwiskiem (np. „prof. dr hab. Jan Kowalski"). Nowe `data('etykieta')`, styl Cytoscape mapuje `label` na nie; `data('label')` zostaje samym nazwiskiem, więc wyszukiwarka i tooltip działają bez zmian.

## Odzysk z #300 ⚠️
`#300` zostało zmergowane (squash) na stanie **sprzed dwóch ostatnich commitów**, więc do `dev` NIE trafiły poniższe zmiany. Ten PR je przywraca (cherry-pick):

- **Naprawa etykiet 3D** — wcześniej tekst chował się **wewnątrz kul** (offset < promień dużych węzłów). Teraz unoszony nad kulę o jej realny promień + rysowany ponad geometrią (`material.depthTest=false`) → zawsze czytelny.
- **Płynna animacja rozmiaru kół w 3D** przy zmianie metryki (~1,2 s, interpolacja `nodeVal` w rAF).
- **Tytuły naukowe na etykietach 3D** (tytuł przed nazwiskiem).
- **Płynna animacja rozmiaru kół w 2D** przy zmianie metryki (~1 s, `przeliczRozmiaryAnim`).
- **Bardziej „gumowate" przejście układu w 2D** — większe przestrzelenie easingu (`cubic-bezier y2` 1.25 → 1.55) i dłuższy czas (520 → 650 ms).

## Uwaga
Czysto front-end (JS + szablon). Bundle (`dist/*.js`) gitignored, odbudowywane na buildzie. Oba bundle kompilują się lokalnie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)