### PR TITLE
feat(powiazania_autorow): tytuł naukowy na tooltipie hover w 3D

### DIFF
--- a/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
@@ -109,7 +109,10 @@ export function init(ForceGraph3D) {
         .nodeColor(function (n) { return kolorPoziomu(n.level); })
         .nodeOpacity(0.95)
         .nodeLabel(function (n) {
-            return "<b>" + esc(n.label) + "</b><br>prace: " + (n.total_works | 0);
+            // tytuł naukowy przed nazwiskiem, np. "prof. dr hab. Jan Kowalski"
+            const tyt = n.tytul ? esc(n.tytul) + " " : "";
+            return "<b>" + tyt + esc(n.label) + "</b><br>prace: "
+                + (n.total_works | 0);
         })
         // etykieta jako sprite obok kuli (extend = nie zastępuje kuli);
         // tylko dla top-N i gdy włączone "pokaż etykiety"


### PR DESCRIPTION
Tooltip po najechaniu na węzeł w widoku 3D pokazuje teraz **tytuł naukowy przed nazwiskiem** (np. „prof. dr hab. Jan Kowalski") — spójnie z etykietami top-N i panelem po kliknięciu. Dane `tytul` są już w `siec.json`. Escape XSS-safe na tytule i nazwisku.

Czysto front-end (jedna zmiana w `siec3d/index.js`, `nodeLabel`); bundle gitignored, odbudowywany na buildzie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)