### PR TITLE
build(i18n): kompiluj .po→.mo Babelem zamiast systemowego msgfmt (bez apt gettext)

### DIFF
--- a/docker/bpp_base/Dockerfile
+++ b/docker/bpp_base/Dockerfile
@@ -276,16 +276,19 @@ RUN sed -i s/http/https/g /etc/apt/sources.list.d/debian.sources
 # test.txt: redis-tools. Dodatkowo wzgledem `base`/produkcji:
 #  - libldap2/libsasl2-2: python-ldap (z extras `ldap`) linkuje sie z nimi;
 #    na pelnym trixie dawal je libldap2-dev/libsasl2-dev (build.txt), tu nie ma,
-#  - gettext: msgfmt do compilemessages (bake nizej),
 #  - ca-certificates/curl/gnupg: repo NodeSource + Dockera,
 #  - git: `yarn install` ma zaleznosci po URL-u git (pelny trixie mial git
 #    w buildpacku; slim nie ma) — bez tego `yarn install` pada.
+# UWAGA: `gettext` (msgfmt) NIE jest tu potrzebny — projektowy override
+# `compilemessages` (src/bpp/management/commands/) kompiluje .po→.mo Babelem
+# w czystym Pythonie. xgettext/makemessages to operacja dev-only, nieobecna
+# w buildzie/CI.
 COPY docker/bpp_base/runtime.txt docker/bpp_base/test.txt /tmp/packages/
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=apt-lists \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg gettext git libldap2 libsasl2-2 && \
+        ca-certificates curl gnupg git libldap2 libsasl2-2 && \
     cat /tmp/packages/*.txt | xargs apt-get install -y
 
 # Node (grunt build + yarn install dla `make assets`) + yarn/grunt globalnie.

--- a/docker/bpp_base/build.txt
+++ b/docker/bpp_base/build.txt
@@ -5,7 +5,6 @@ libldap2-dev
 libssl-dev
 libcairo2-dev
 python-dev-is-python3
-gettext
 curl
 gnupg
 git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ dependencies = [
     "django-site-blog>=0.2.1",
     "django-first-run-wizard>=0.1.1",
     "uvicorn-worker>=0.4.0",
+    "babel>=2.17",
 ]
 
 [project.optional-dependencies]

--- a/src/bpp/management/commands/compilemessages.py
+++ b/src/bpp/management/commands/compilemessages.py
@@ -1,0 +1,83 @@
+"""``compilemessages`` kompilujący .po → .mo w czystym Pythonie (Babel).
+
+Override komendy ``django.core`` o tej samej nazwie — aplikacja ``bpp`` jest
+w ``INSTALLED_APPS``, więc ``get_commands()`` wybiera tę implementację zamiast
+wbudowanej. Dzięki temu wszystkie istniejące wywołania (``manage.py
+compilemessages -l pl ...`` w Makefile i Dockerfile) działają bez zmian.
+
+Cel: usunąć zależność od systemowego pakietu apt ``gettext`` (binarka
+``msgfmt``), którą wbudowany ``compilemessages`` woła przez ``subprocess``.
+Babel kompiluje katalog w czystym Pythonie, więc obraz Dockera nie musi już
+instalować ``gettext`` (oszczędność apt-a; binarki C → mały wheel).
+
+Ponownie używamy CAŁEJ logiki wykrywania plików ``.po`` + parsowania flag
+(``--locale``, ``--ignore``, ``--exclude``) z klasy bazowej — nadpisujemy
+tylko (a) sondowanie obecności binarki ``msgfmt`` i (b) sam krok kompilacji.
+
+Uwaga: ``makemessages`` (xgettext/msgmerge) NIE jest tu ruszany — to operacja
+dev-only, nieobecna w buildzie/CI. Deweloper regenerujący ``.po`` ze źródeł
+nadal potrzebuje lokalnie GNU gettext (albo ``pybabel extract``).
+"""
+
+from pathlib import Path
+
+from babel.messages.mofile import write_mo
+from babel.messages.pofile import read_po
+from django.core.management.commands import compilemessages as dj_compilemessages
+
+
+class Command(dj_compilemessages.Command):
+    help = "Kompiluje pliki .po do .mo w czystym Pythonie (Babel, bez msgfmt)."
+
+    def handle(self, **options):
+        # Bazowe ``handle()`` przerywa z CommandError, jeśli binarki ``msgfmt``
+        # nie ma na PATH. Kompilujemy Babelem, więc neutralizujemy tę sondę na
+        # czas wywołania — zamiast kopiować ~50 linii logiki wykrywania locale
+        # (którą chcemy reużyć w całości, łącznie z ``--ignore``/``--locale``).
+        original_find_command = dj_compilemessages.find_command
+        dj_compilemessages.find_command = lambda program: program  # zawsze „jest"
+        try:
+            super().handle(**options)
+        finally:
+            dj_compilemessages.find_command = original_find_command
+
+    def compile_messages(self, locations):
+        """Kompiluje listę krotek ``[(katalog, plik.po), ...]`` Babelem.
+
+        Zachowuje semantykę bazową: pomija ``.mo`` świeższe niż ``.po`` oraz
+        honoruje ``--use-fuzzy`` (bazowa klasa dokleja ``-f`` do
+        ``program_options``).
+        """
+        use_fuzzy = "-f" in self.program_options
+        for dirpath, filename in locations:
+            po_path = Path(dirpath) / filename
+            mo_path = po_path.with_suffix(".mo")
+
+            try:
+                if mo_path.stat().st_mtime >= po_path.stat().st_mtime:
+                    if self.verbosity > 0:
+                        self.stdout.write(
+                            f'File "{po_path}" is already compiled and up to date.'
+                        )
+                    continue
+            except FileNotFoundError:
+                pass
+
+            if self.verbosity > 0:
+                self.stdout.write(f"processing file {filename} in {dirpath}")
+
+            with po_path.open("rb") as po_file:
+                catalog = read_po(po_file)
+
+            # Autorytatywne locale katalogu to nazwa katalogu w ścieżce
+            # ``locale/<locale>/LC_MESSAGES/`` — nie nagłówek ``Language:``,
+            # który Django generuje pusty. Babel emituje nagłówek
+            # ``Plural-Forms`` do .mo TYLKO gdy ``catalog.locale`` jest
+            # ustawione; bez tego cicho degraduje do germańskich 2 form i
+            # polskie liczebniki (4 formy) renderują się błędnie. Ustawiamy
+            # je więc jawnie ze ścieżki, odtwarzając zachowanie ``msgfmt``
+            # (który nagłówek Plural-Forms kopiuje dosłownie).
+            catalog.locale = po_path.parent.parent.name
+
+            with mo_path.open("wb") as mo_file:
+                write_mo(mo_file, catalog, use_fuzzy=use_fuzzy)

--- a/src/bpp/tests/test_compilemessages_babel.py
+++ b/src/bpp/tests/test_compilemessages_babel.py
@@ -1,0 +1,132 @@
+"""Projektowa komenda ``compilemessages`` kompiluje .po → .mo w czystym
+Pythonie (Babel), BEZ systemowej binarki ``msgfmt`` z pakietu apt ``gettext``.
+
+To jest kontrakt buildu: obraz Dockera nie instaluje już ``gettext``, więc
+``manage.py compilemessages`` nie może wołać ``msgfmt`` przez subprocess.
+Wszystkie call-site'y (Makefile, Dockerfile) wołają ``compilemessages``
+tak jak dotąd — override w aplikacji ``bpp`` wygrywa nad ``django.core``.
+"""
+
+import gettext as gettext_module
+from pathlib import Path
+
+from django.core.management import call_command
+from django.core.management.commands import compilemessages as dj_compilemessages
+from django.test import override_settings
+
+# Nagłówek z polskim Plural-Forms (3 formy) + treści z UTF-8 oraz jednym
+# wpisem ``msgid_plural``, żeby sprawdzić, że liczby mnogie przeżyją kompilację.
+PO_CONTENT = """\
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Language: pl\\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && \
+(n%100<12 || n%100>14) ? 1 : 2);\\n"
+
+msgid "Cancel"
+msgstr "Anuluj"
+
+msgid "Yes, I'm sure"
+msgstr "Tak, jestem pewny"
+
+msgid "%(count)d record"
+msgid_plural "%(count)d records"
+msgstr[0] "%(count)d rekord"
+msgstr[1] "%(count)d rekordy"
+msgstr[2] "%(count)d rekordów"
+"""
+
+
+# Realny przypadek z repo: ``django_bpp/django.po`` ma PUSTY nagłówek
+# ``Language:`` (Django generuje go takim). Autorytatywne locale katalogu
+# pochodzi wtedy WYŁĄCZNIE ze ścieżki (``locale/pl/LC_MESSAGES``), nie z
+# nagłówka. Pilnujemy, że 4-formowa polska reguła liczby mnogiej przeżyje
+# kompilację mimo pustego ``Language:`` — inaczej Babel cicho degraduje do
+# germańskich 2 form i polskie liczebniki renderują się błędnie.
+PO_EMPTY_LANGUAGE = """\
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Language: \\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && \
+(n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || \
+(n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\\n"
+
+msgid "%(count)d file"
+msgid_plural "%(count)d files"
+msgstr[0] "%(count)d plik"
+msgstr[1] "%(count)d pliki"
+msgstr[2] "%(count)d plików"
+msgstr[3] "%(count)d pliku"
+"""
+
+
+def _make_locale_tree(tmp_path: Path, content: str = PO_CONTENT) -> Path:
+    lc = tmp_path / "locale" / "pl" / "LC_MESSAGES"
+    lc.mkdir(parents=True)
+    (lc / "django.po").write_text(content, encoding="utf-8")
+    return lc
+
+
+def test_compilemessages_without_system_msgfmt(tmp_path, monkeypatch):
+    """Kompilacja działa nawet gdy binarki ``msgfmt`` nie ma na PATH."""
+    lc = _make_locale_tree(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    # Symuluj brak GNU gettext: gdyby komenda wołała msgfmt, padłaby z
+    # CommandError("Can't find msgfmt..."). Nasz override kompiluje Babelem.
+    monkeypatch.setattr(dj_compilemessages, "find_command", lambda program: None)
+
+    with override_settings(LOCALE_PATHS=[str(tmp_path / "locale")]):
+        call_command("compilemessages", "-l", "pl", verbosity=0)
+
+    assert (lc / "django.mo").exists(), "Nie powstał plik .mo"
+
+
+def test_compiled_mo_translations_and_plurals(tmp_path, monkeypatch):
+    """Skompilowany .mo zwraca poprawne tłumaczenia (UTF-8) i liczby mnogie."""
+    lc = _make_locale_tree(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(dj_compilemessages, "find_command", lambda program: None)
+
+    with override_settings(LOCALE_PATHS=[str(tmp_path / "locale")]):
+        call_command("compilemessages", "-l", "pl", verbosity=0)
+
+    with (lc / "django.mo").open("rb") as fp:
+        tr = gettext_module.GNUTranslations(fp)
+
+    assert tr.gettext("Cancel") == "Anuluj"
+    assert tr.gettext("Yes, I'm sure") == "Tak, jestem pewny"
+    # Plural-Forms z nagłówka muszą przetrwać kompilację (ngettext):
+    plural = ("%(count)d record", "%(count)d records")
+    assert tr.ngettext(*plural, 1) == "%(count)d rekord"
+    assert tr.ngettext(*plural, 3) == "%(count)d rekordy"
+    assert tr.ngettext(*plural, 5) == "%(count)d rekordów"
+
+
+def test_plural_forms_survive_empty_language_header(tmp_path, monkeypatch):
+    """4-formowa polska reguła przeżywa kompilację mimo pustego ``Language:``.
+
+    Locale katalogu (``pl``) pochodzi ze ścieżki, nie z nagłówka — kompilator
+    musi to uszanować, inaczej Babel degraduje do germańskich 2 form.
+    """
+    lc = _make_locale_tree(tmp_path, content=PO_EMPTY_LANGUAGE)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(dj_compilemessages, "find_command", lambda program: None)
+
+    with override_settings(LOCALE_PATHS=[str(tmp_path / "locale")]):
+        call_command("compilemessages", "-l", "pl", verbosity=0)
+
+    with (lc / "django.mo").open("rb") as fp:
+        tr = gettext_module.GNUTranslations(fp)
+
+    plural = ("%(count)d file", "%(count)d files")
+    # Polskie formy: 1=plik(0), 2-4=pliki(1), 5+=plików(2), 22=pliki(1).
+    assert tr.ngettext(*plural, 1) == "%(count)d plik"
+    assert tr.ngettext(*plural, 2) == "%(count)d pliki"
+    assert tr.ngettext(*plural, 5) == "%(count)d plików"
+    assert tr.ngettext(*plural, 22) == "%(count)d pliki"

--- a/src/bpp/tests/test_polskie_liczby_mnogie.py
+++ b/src/bpp/tests/test_polskie_liczby_mnogie.py
@@ -1,0 +1,34 @@
+"""Polska odmiana liczebnikowa w komunikatach admina (``bpp/admin/actions.py``).
+
+Komunikaty typu „Wybrano N rekord(y/ów)" używają
+``ngettext("rekord", "rekordów", n)``. Polszczyzna wymaga dla liczebników
+całkowitych 3 form (1 / 2–4 / 5+), więc 2-formowy fallback gettext-a daje
+błędne „2 rekordów". Poprawne formy dostarcza wpis ``msgid_plural`` z 4
+formami (msgstr[0..3]) w ``django_bpp/locale/pl/LC_MESSAGES/django.po``,
+kompilowany do ``.mo`` (sesyjny fixture ``make assets`` w ``conftest.py``).
+
+Forma 4. (CLDR „other") dotyczy ułamków i przy zliczaniu rekordów nigdy nie
+pada — testujemy całkowite n pokrywające one/few/many oraz wyjątek 12–14.
+"""
+
+from django.utils.translation import ngettext, override
+
+REKORD = ("rekord", "rekordów")
+
+
+def test_rekord_formy_one_few_many():
+    """1→rekord, 2–4→rekordy, 5+→rekordów (z wyjątkiem 12–14→rekordów)."""
+    with override("pl"):
+        assert ngettext(*REKORD, 1) == "rekord"
+        assert ngettext(*REKORD, 2) == "rekordy"
+        assert ngettext(*REKORD, 3) == "rekordy"
+        assert ngettext(*REKORD, 4) == "rekordy"
+        assert ngettext(*REKORD, 5) == "rekordów"
+        assert ngettext(*REKORD, 11) == "rekordów"
+        # 12–14 to wyjątek: mimo końcówki 2–4 idą do formy „many".
+        assert ngettext(*REKORD, 12) == "rekordów"
+        assert ngettext(*REKORD, 13) == "rekordów"
+        assert ngettext(*REKORD, 14) == "rekordów"
+        # …ale 22–24 (końcówka 2–4, setki ≠ 12–14) znów „few".
+        assert ngettext(*REKORD, 22) == "rekordy"
+        assert ngettext(*REKORD, 25) == "rekordów"

--- a/src/django_bpp/locale/pl/LC_MESSAGES/django.po
+++ b/src/django_bpp/locale/pl/LC_MESSAGES/django.po
@@ -50,3 +50,13 @@ msgstr "Kliknij lub wciśnij dowolny klawisz, aby wydłużyć czas trwania Twoje
 #: session_security/templates/session_security/all.html:33
 msgid "You have unsaved changes in a form of this page."
 msgstr "Na tej stronie znajduje się formularz, w którym zmiany mogły jeszcze nie zostać zapisane."
+
+#. Komunikaty admina „Wybrano/Zakolejkowano N rekord(y/ów)" — bpp/admin/actions.py.
+#. Polski wymaga 3 form dla liczb całkowitych (1 / 2–4 / 5+); forma [3]
+#. (CLDR „other") dotyczy ułamków i przy zliczaniu rekordów nigdy nie pada.
+msgid "rekord"
+msgid_plural "rekordów"
+msgstr[0] "rekord"
+msgstr[1] "rekordy"
+msgstr[2] "rekordów"
+msgstr[3] "rekordów"

--- a/uv.lock
+++ b/uv.lock
@@ -146,6 +146,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -206,6 +215,7 @@ version = "202606.1377"
 source = { editable = "." }
 dependencies = [
     { name = "arrow", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "babel", marker = "platform_python_implementation != 'PyPy'" },
     { name = "beautifulsoup4", marker = "platform_python_implementation != 'PyPy'" },
     { name = "bibtexparser", marker = "platform_python_implementation != 'PyPy'" },
     { name = "celery", marker = "platform_python_implementation != 'PyPy'" },
@@ -380,6 +390,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "arrow", specifier = ">=1.3,<2" },
+    { name = "babel", specifier = ">=2.17" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "bibtexparser", specifier = ">=2.0.0b7" },
     { name = "celery", specifier = ">=5.6.3" },


### PR DESCRIPTION
## Cel

Usunięcie zależności od systemowego pakietu apt **`gettext`** (binarka
`msgfmt`), którą wbudowany Django `compilemessages` woła przez `subprocess`.
Kompilacja `.po`→`.mo` odbywa się teraz w **czystym Pythonie (Babel)**.

Cały projekt ma dokładnie **2** własne pliki `.po` (`django_bpp`, `miniblog`),
więc całe apt-owe `gettext` istniało po to, by skompilować garstkę stringów.
Wymiana: binarki C + warstwa apt → jeden mały pure-python wheel.

## Zmiany

- **`src/bpp/management/commands/compilemessages.py`** *(nowy)* — override
  komendy Django (aplikacja `bpp` wygrywa nad `django.core` w
  `get_commands()`). Reużywa CAŁEJ logiki wykrywania `.po` i flag
  (`--locale`, `--ignore`, `--exclude`); podmienia tylko (a) sondę binarki
  `msgfmt` i (b) krok kompilacji → Babel. **Wszystkie call-site'y bez zmian**
  (`Makefile`, `Dockerfile`, `manage.py compilemessages -l pl`).
- **`docker/bpp_base/{build.txt,Dockerfile}`** — usunięto `gettext` z apt.
- **`pyproject.toml` / `uv.lock`** — `babel>=2.17` jako **główna** zależność
  (builder produkcyjny robi `uv sync --no-dev`, więc dev-group by nie wystarczył).
- **`src/bpp/tests/test_compilemessages_babel.py`** *(nowy)* — 3 testy (TDD).

## Subtelność: Plural-Forms a pusty `Language:`

Babel's `write_mo` emituje nagłówek `Plural-Forms` **tylko gdy `catalog.locale`
jest ustawione**, a Django generuje `.po` z pustym `Language:`. Bez tego Babel
cicho degradował do germańskich 2 form i polska 4-formowa reguła ginęła.
Naprawa: `catalog.locale` brane ze **ścieżki** (`locale/<lang>/LC_MESSAGES/`) —
autorytatywne źródło locale w gettext. Wynik: **parytet z `msgfmt`**
(identyczne tłumaczenia ORAZ identyczny nagłówek `Plural-Forms`).

## Weryfikacja

- 3/3 testy GREEN, w tym edge-case pustego `Language:` z `msgid_plural`.
- Parytet z `msgfmt` potwierdzony na realnym `django_bpp/django.po`.
- Oba projektowe `.po` kompilują się; `--ignore=site-packages` nadal pomija venv.
- Oba call-site'y działają (`manage.py`, `make compilemessages`).
- Istniejący `test_djangoql_i18n.py` nadal zielony; ruff + pre-commit czyste.
- Produkcyjny runtime i tak nigdy nie miał `gettext` (shipuje baked `.mo`) —
  zmiana dotyczy stage'y build/test.

> Uwaga: `makemessages` (xgettext) to operacja dev-only, nieobecna w
> buildzie/CI — usunięcie apt-`gettext` jej nie dotyka w obrazie.

---

## Bonus: poprawna polska odmiana w komunikatach admina (commit 2)

`bpp/admin/actions.py` używa `ngettext("rekord","rekordów",n)` w komunikatach
„Wybrano/Zakolejkowano N rekord…". Polski wymaga **3 form** dla liczb
całkowitych (1 / 2–4 / 5+), a 2-formowy fallback gettext-a dawał błędne
**„2 rekordów"** zamiast **„2 rekordy"**.

Naprawa wprost wykorzystuje 4-formową regułę `Plural-Forms` naprawioną w tym
PR-ze: dodano wpis `msgid_plural` z 4 formami (`msgstr[0..3]`) do
`django_bpp/django.po`. **Wywołania `ngettext` bez zmian** — zaczynają trafiać
do katalogu.

| n | przed | po |
|---|---|---|
| 1 | rekord | rekord |
| 2–4 | rekord**ów** ❌ | rekord**y** ✅ |
| 5+ | rekordów | rekordów |
| 22 | rekordów ❌ | rekordy ✅ |

Pozostałe wywołania (`rekordu`/`rekordów` po „dla" → dopełniacz;
`autora`/`autorów` → biernik męskoosobowy) są **już poprawne** jako 2-formowy
fallback i pozostają nietknięte (brak kolizji kluczy katalogu). Test:
`src/bpp/tests/test_polskie_liczby_mnogie.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
