### PR TITLE
feat(zapytanie): pickery __rel (autocomplete) + wyjaśnienie 0 wyników

### DIFF
--- a/docs/superpowers/plans/2026-06-04-zapytanie-autocomplete-rel.md
+++ b/docs/superpowers/plans/2026-06-04-zapytanie-autocomplete-rel.md
@@ -1,0 +1,995 @@
+# Zapytanie: pickery `__rel` + wyjaśnienie „0 wyników" — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dodać w djangoql-iplweb addytywny kwarg `AutocompleteField(lookup_name=…)` + idiom `<fk>__rel` (PR 1), a w BPP użyć go w widoku „Szukaj zapytaniem": pickery autocomplete `autorzy.autor__rel`, `autorzy.jednostka__rel`, `tytul__rel`, `aktualna_jednostka__rel` obok zachowanej trawersacji z kropką, plus rozbicie `explain_empty()` „dlaczego 0 wyników" (PR 2).
+
+**Architecture:** Dwie nazwy: kropka = domyślna trawersacja FK (bez zmian), `<fk>__rel` = picker (leaf `AutocompleteField`) filtrujący realny FK przez nowy `lookup_name`. Schemat BPP (`BppZapytanieSchema(ExtrasSchema)`) dorzuca syntetyczne nazwy `*__rel` w `get_fields` i mapuje je w `autocomplete`. „0 wyników" liczy `explain_empty()` raz, gdy `count == 0`.
+
+**Tech Stack:** Django, djangoql-iplweb (0.22 → 0.23), pytest + model_bakery (bpp), Django `TestCase` + pytest-django (djangoql `test_project`), Foundation CSS (frontend).
+
+**Repozytoria / gałęzie:**
+- djangoql-iplweb: `~/Programowanie/djangoql-iplweb`, gałąź `feat/autocomplete-lookup-name` (już istnieje, ma commit specu `d4b7990`).
+- bpp: `~/Programowanie/bpp`, gałąź `bpp-zapytanie-autocomplete-rel` (już istnieje, ma commit specu `0cc3cd473`).
+
+**Kolejność / zależność (decyzja użytkownika):** Najpierw djangoql → release na PyPI → bpp pinuje wersję. Oba PR-y otwiera Claude (`gh pr create`); tag/PyPI-release djangoql jest po stronie użytkownika. Faza B implementowana lokalnie przeciw editable-checkoutowi djangoql (krok B0), a `pyproject` bumpuje się do wydanej wersji dopiero w B7.
+
+**Uwaga o repo djangoql:** `master` ma niezacommitowany WIP (refactor tłumaczeń). Pracujemy WYŁĄCZNIE na gałęzi `feat/autocomplete-lookup-name`, commitujemy TYLKO swoje pliki (pathspec), nie ruszamy WIP.
+
+---
+
+## FAZA A — djangoql-iplweb (PR 1)
+
+Komendy uruchamiać **z** `~/Programowanie/djangoql-iplweb`, z jawnym
+`DJANGO_SETTINGS_MODULE=test_project.settings` (zmienna z profilu bpp potrafi
+wyciekać do środowiska).
+
+### Task A1: kwarg `lookup_name` + remap lookupu na realny FK
+
+**Files:**
+- Modify: `~/Programowanie/djangoql-iplweb/djangoql/extras.py` (klasa `AutocompleteField`, `__init__` ok. linii 523–555)
+- Test: `~/Programowanie/djangoql-iplweb/test_project/core/tests/test_autocomplete.py`
+
+- [ ] **Step 1: Dopisz testy (na koniec pliku testowego)**
+
+```python
+class RelAndPickerSchema(AutocompleteSchemaMixin, DjangoQLSchema):
+    """`author` zostaje relacją (trawersacja z kropką), a `author__rel` to
+    picker filtrujący realny FK `author` przez lookup_name."""
+
+    include = (Book, User)
+    autocomplete = {
+        Book: {
+            'author__rel': {
+                'lookup_name': 'author',
+                'queryset': lambda s: User.objects.filter(
+                    username__icontains=s
+                ).order_by('username'),
+                'search_fields': ['username'],
+                'label': lambda u: u.username,
+            },
+        },
+    }
+
+    def get_fields(self, model):
+        fields = list(super().get_fields(model))
+        if model is Book:
+            fields.append('author__rel')
+        return fields
+
+
+class LookupNameTest(TestCase):
+    def test_lookup_name_defaults_to_field_name(self):
+        field = AutocompleteField(model=Book, name='author__rel')
+        self.assertEqual(field.get_lookup_name(), 'author__rel')
+
+    def test_lookup_name_overrides_lookup(self):
+        field = AutocompleteField(
+            model=Book, name='author__rel', lookup_name='author'
+        )
+        self.assertEqual(field.get_lookup_name(), 'author')
+
+
+class RelAndPickerCoexistTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.kow = User.objects.create(username='Jan Kowalski')
+        cls.nowak = User.objects.create(username='Anna Nowak')
+        cls.b1 = Book.objects.create(name='b1', author=cls.kow)
+        cls.b2 = Book.objects.create(name='b2', author=cls.nowak)
+
+    def _search(self, q):
+        return apply_search(Book.objects.all(), q, schema=RelAndPickerSchema)
+
+    def test_picker_filters_real_fk_by_pk(self):
+        qs = self._search('author__rel = "Jan Kowalski [%d]"' % self.kow.pk)
+        sql = str(qs.query)
+        self.assertIn('author_id', sql)
+        self.assertNotIn('author__rel', sql)
+        self.assertEqual(list(qs), [self.b1])
+
+    def test_picker_in_filters_by_pks(self):
+        qs = self._search(
+            'author__rel in ("Jan Kowalski [%d]", "Anna Nowak [%d]")'
+            % (self.kow.pk, self.nowak.pk)
+        )
+        self.assertEqual(sorted(b.pk for b in qs), [self.b1.pk, self.b2.pk])
+
+    def test_picker_free_text_fallback_targets_real_fk(self):
+        qs = self._search('author__rel = "kowal"')
+        sql = str(qs.query).lower()
+        self.assertIn('username', sql)
+        self.assertIn('like', sql)
+        self.assertEqual(list(qs), [self.b1])
+
+    def test_dot_traversal_still_works(self):
+        qs = self._search('author.username = "Jan Kowalski"')
+        self.assertEqual(list(qs), [self.b1])
+
+    def test_both_idioms_in_one_query(self):
+        qs = self._search(
+            'author.username = "Jan Kowalski" '
+            'and author__rel = "Jan Kowalski [%d]"' % self.kow.pk
+        )
+        self.assertEqual(list(qs), [self.b1])
+
+    def test_picker_is_value_field_relation_is_relation(self):
+        schema = RelAndPickerSchema(Book)
+        fields = schema.models['core.book']
+        self.assertIsInstance(fields['author__rel'], AutocompleteField)
+        self.assertIsInstance(fields['author'], RelationField)
+        self.assertEqual(fields['author'].type, 'relation')
+```
+
+- [ ] **Step 2: Uruchom testy — muszą paść (RED)**
+
+Run: `cd ~/Programowanie/djangoql-iplweb && DJANGO_SETTINGS_MODULE=test_project.settings uv run pytest test_project/core/tests/test_autocomplete.py -k "LookupName or RelAndPicker" -v 2>&1 | tee /tmp/dq_a1.log`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'lookup_name'` (w testach budujących `AutocompleteField(... lookup_name=...)` i w `RelAndPickerSchema`).
+
+- [ ] **Step 3: Dodaj kwarg `lookup_name` w `AutocompleteField.__init__`**
+
+W `djangoql/extras.py`, w sygnaturze `__init__` dodaj parametr po `id_of=None,`:
+
+```python
+        id_of=None,
+        lookup_name=None,
+        search_param='q',
+```
+
+i w ciele `__init__`, po `self.id_of = id_of`:
+
+```python
+        self.id_of = id_of
+        self._lookup_name = lookup_name
+```
+
+- [ ] **Step 4: Dodaj metodę `get_lookup_name` (w sekcji „lookup / filtering")**
+
+W `AutocompleteField`, tuż przed `get_lookup_value` (albo zaraz po komentarzu
+`# -- lookup / filtering`), dodaj:
+
+```python
+    def get_lookup_name(self):
+        # `<fk>__rel` (alt-nazwa pickera) filtruje realny FK podany w
+        # lookup_name; bez niego zachowanie = self.name (non-breaking).
+        return self._lookup_name or self.name
+```
+
+- [ ] **Step 5: Uruchom testy — muszą przejść (GREEN)**
+
+Run: `cd ~/Programowanie/djangoql-iplweb && DJANGO_SETTINGS_MODULE=test_project.settings uv run pytest test_project/core/tests/test_autocomplete.py -v 2>&1 | tee /tmp/dq_a1.log`
+Expected: PASS (wszystkie, łącznie z istniejącymi — regresja zachowana).
+
+- [ ] **Step 6: Commit (tylko swoje pliki)**
+
+```bash
+cd ~/Programowanie/djangoql-iplweb
+git add djangoql/extras.py test_project/core/tests/test_autocomplete.py
+git commit -m "feat(extras): AutocompleteField lookup_name (picker pod alt-nazwą filtruje realny FK)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" -- djangoql/extras.py test_project/core/tests/test_autocomplete.py
+```
+
+### Task A2: dokumentacja idiomu `<fk>__rel` + CHANGES
+
+**Files:**
+- Modify: `~/Programowanie/djangoql-iplweb/docs/integrating-django-autocomplete-light.md`
+- Modify: `~/Programowanie/djangoql-iplweb/CHANGES.rst`
+
+- [ ] **Step 1: Dopisz `lookup_name` do tabeli „Configuration reference"**
+
+W `docs/integrating-django-autocomplete-light.md`, w tabeli pod
+`## Configuration reference`, po wierszu `id_of`, dodaj wiersz:
+
+```markdown
+| `lookup_name` | `None` | real model field to filter on (default: the field's own name); lets a picker live under a second name like `<fk>__rel` |
+```
+
+- [ ] **Step 2: Dodaj sekcję o idiomie (przed `## Limitations`)**
+
+```markdown
+## Exposing a FK as both a navigable relation and a value picker
+
+By default a FK is a **navigable relation** — you traverse into it
+(`author.last_name`, `author.country.code`). The picker above instead exposes it
+as a **value field** under the *same* name, which removes traversal. To keep
+**both**, expose the picker under a *second* name and point it back at the real
+FK with `lookup_name`. The recommended convention is `<fk>__rel` (double
+underscore, consistent with the derived-field family `__count` / `__sum` / …):
+
+```python
+from django.contrib.auth.models import User
+from djangoql.extras import AutocompleteSchemaMixin
+from djangoql.schema import DjangoQLSchema
+
+from .models import Book
+
+
+class BookSchema(AutocompleteSchemaMixin, DjangoQLSchema):
+    include = (Book, User)
+    autocomplete = {
+        Book: {
+            # picker; `author` itself stays a navigable relation
+            'author__rel': {
+                'lookup_name': 'author',           # filters the real FK
+                'url': 'user-autocomplete',
+                'search_fields': ['username'],
+            },
+        },
+    }
+
+    def get_fields(self, model):
+        # `author__rel` is synthetic (not a real model field), so it must be
+        # added explicitly or it won't be introspected / suggested.
+        fields = list(super().get_fields(model))
+        if model is Book:
+            fields.append('author__rel')
+        return fields
+```
+
+Now both work side by side:
+
+- `author.username = "kowalski"` — traversal into the related model (unchanged);
+- `author__rel = "Jan Kowalski [42]"` — picker, filters `author_id = 42`
+  (with the usual `icontains` free-text fallback over `search_fields`).
+```
+
+(Uwaga: w docu komentarze i fence-bloki jak wyżej; zachowaj istniejący styl.)
+
+- [ ] **Step 3: Dodaj wpis w `CHANGES.rst` (na górze, nad `0.22.1`)**
+
+```rst
+0.23.0 (unreleased)
+-------------------
+
+* Add an additive, non-breaking ``lookup_name`` kwarg to
+  ``djangoql.extras.AutocompleteField``. It overrides ``get_lookup_name()`` so a
+  picker can live under a second field name (e.g. ``<fk>__rel``) while still
+  filtering the **real** foreign key — letting a FK be exposed *both* as a
+  navigable relation (dot traversal) *and* as a value picker. Default ``None``
+  preserves current behavior. New docs section "Exposing a FK as both a
+  navigable relation and a value picker" documents the ``<fk>__rel`` idiom.
+
+```
+
+- [ ] **Step 4: (opcjonalnie) zbuduj docs lokalnie dla sanity**
+
+Run: `cd ~/Programowanie/djangoql-iplweb && uv run mkdocs build -q 2>&1 | tail -5`
+Expected: brak błędów (lub pomiń, jeśli mkdocs nie jest w dev-deps).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Programowanie/djangoql-iplweb
+git add docs/integrating-django-autocomplete-light.md CHANGES.rst
+git commit -m "docs(extras): document <fk>__rel idiom (relation + picker side by side)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" -- docs/integrating-django-autocomplete-light.md CHANGES.rst
+```
+
+### Task A3: pełny test djangoql + push + PR 1
+
+- [ ] **Step 1: Pełny zestaw testów autocomplete (GREEN)**
+
+Run: `cd ~/Programowanie/djangoql-iplweb && DJANGO_SETTINGS_MODULE=test_project.settings uv run pytest test_project/core/tests/test_autocomplete.py -v 2>&1 | tee /tmp/dq_full.log`
+Expected: PASS (wszystkie).
+
+- [ ] **Step 2: Push gałęzi**
+
+```bash
+cd ~/Programowanie/djangoql-iplweb
+git push -u origin feat/autocomplete-lookup-name
+```
+
+- [ ] **Step 3: Otwórz PR 1**
+
+```bash
+cd ~/Programowanie/djangoql-iplweb
+gh pr create --base master --head feat/autocomplete-lookup-name \
+  --title "feat(extras): AutocompleteField lookup_name + idiom <fk>__rel" \
+  --body "$(cat <<'EOF'
+Addytywny, non-breaking kwarg `lookup_name` na `AutocompleteField` (domyślnie
+`None` = bez zmian). Pozwala wystawić picker pod drugą nazwą `<fk>__rel`
+filtrujący realny FK, obok relacji z kropką do trawersacji. Plus sekcja w docach
+dokumentująca idiom.
+
+Spec: `docs/superpowers/specs/2026-06-04-autocomplete-lookup-name-rel-idiom-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: ⛳ CHECKPOINT — release djangoql**
+
+Po zmergowaniu PR 1 użytkownik (lub osobny proces) taguje i publikuje
+djangoql-iplweb **0.23.0** na PyPI. Faza B implementowana jest równolegle
+przeciw editable-checkoutowi (B0); finalny pin (`B7`) i PR 2 idą po publikacji.
+
+---
+
+## FAZA B — bpp (PR 2)
+
+Komendy z `~/Programowanie/bpp`. Testy: `UV_NO_SYNC=1 uv run --all-extras pytest …`
+(testcontainers z optional.dev; bez tego `uv run` zdejmie zależność). Wyniki
+piszemy do `/tmp` i grepujemy (nie uruchamiamy testów dwa razy).
+
+### Task B0: dev-setup — lokalny djangoql z `lookup_name`
+
+- [ ] **Step 1: Zainstaluj editable djangoql do venva bpp (tymczasowo, NIE commitujemy)**
+
+```bash
+cd ~/Programowanie/bpp
+uv pip install -e ~/Programowanie/djangoql-iplweb
+```
+
+- [ ] **Step 2: Zweryfikuj, że `lookup_name` jest dostępne**
+
+Run:
+```bash
+cd ~/Programowanie/bpp
+UV_NO_SYNC=1 uv run python -c "import inspect; from djangoql.extras import AutocompleteField; print('lookup_name' in inspect.signature(AutocompleteField.__init__).parameters)"
+```
+Expected: `True`
+
+(Wszystkie kolejne komendy testowe w fazie B uruchamiamy z prefiksem
+`UV_NO_SYNC=1`, żeby `uv run` nie przeładował zależności i nie zdjął editable.)
+
+### Task B1: `BppZapytanieSchema` z pickerami `__rel`
+
+**Files:**
+- Modify: `~/Programowanie/bpp/src/bpp/views/zapytanie.py`
+- Test: `~/Programowanie/bpp/src/bpp/tests/test_zapytanie.py`
+
+- [ ] **Step 1: Dopisz testy schematu (na koniec test_zapytanie.py)**
+
+```python
+@pytest.mark.django_db
+def test_tytul_rel_picker_filters_by_pk():
+    from djangoql.queryset import apply_search
+
+    from bpp.models import Autor
+    from bpp.models.autor import Tytul
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    prof = baker.make(Tytul, nazwa="profesor", skrot="prof.")
+    dr = baker.make(Tytul, nazwa="doktor", skrot="dr")
+    a1 = baker.make("bpp.Autor", nazwisko="Kowalski", tytul=prof)
+    baker.make("bpp.Autor", nazwisko="Nowak", tytul=dr)
+
+    qs = apply_search(
+        Autor.objects.all(),
+        'tytul__rel = "profesor [%d]"' % prof.pk,
+        schema=BppZapytanieSchema,
+    )
+    assert list(qs) == [a1]
+
+
+@pytest.mark.django_db
+def test_tytul_dot_traversal_still_works():
+    from djangoql.queryset import apply_search
+
+    from bpp.models import Autor
+    from bpp.models.autor import Tytul
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    prof = baker.make(Tytul, nazwa="profesor", skrot="prof.")
+    a1 = baker.make("bpp.Autor", nazwisko="Kowalski", tytul=prof)
+
+    qs = apply_search(
+        Autor.objects.all(), 'tytul.skrot = "prof."', schema=BppZapytanieSchema
+    )
+    assert list(qs) == [a1]
+
+
+@pytest.mark.django_db
+def test_aktualna_jednostka_rel_picker_filters_by_pk():
+    from djangoql.queryset import apply_search
+
+    from bpp.models import Autor, Jednostka
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    j = baker.make(Jednostka, nazwa="Katedra X")
+    a1 = baker.make("bpp.Autor", nazwisko="Kowalski", aktualna_jednostka=j)
+    baker.make("bpp.Autor", nazwisko="Nowak")
+
+    qs = apply_search(
+        Autor.objects.all(),
+        'aktualna_jednostka__rel = "Katedra X [%d]"' % j.pk,
+        schema=BppZapytanieSchema,
+    )
+    assert list(qs) == [a1]
+
+
+@pytest.mark.django_db
+def test_autor_schema_has_rel_fields_and_keeps_relations():
+    from bpp.models import Autor
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    schema = BppZapytanieSchema(Autor)
+    fields = schema.models["bpp.autor"]
+    assert "tytul__rel" in fields
+    assert "aktualna_jednostka__rel" in fields
+    assert fields["tytul"].type == "relation"  # trawersacja zachowana
+
+
+@pytest.mark.django_db
+def test_rekord_schema_has_autorzy_rel_pickers():
+    from bpp.models.cache import Autorzy, Rekord
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    schema = BppZapytanieSchema(Rekord)
+    autorzy_fields = schema.models[schema.model_label(Autorzy)]
+    assert "autor__rel" in autorzy_fields
+    assert "jednostka__rel" in autorzy_fields
+    assert autorzy_fields["autor"].type == "relation"
+
+
+@pytest.mark.django_db
+def test_rekord_autorzy_autor_rel_filters_real_fk():
+    from djangoql.queryset import apply_search
+
+    from bpp.models.cache import Rekord
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    qs = apply_search(
+        Rekord.objects.all(),
+        'autorzy.autor__rel = "X [1]"',
+        schema=BppZapytanieSchema,
+    )
+    sql = str(qs.query).lower()
+    assert "autor__rel" not in sql  # remap zadziałał (nie filtruje alt-nazwy)
+    assert "autor_id" in sql
+```
+
+- [ ] **Step 2: Uruchom — RED**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py -k "rel or traversal or schema" -v 2>&1 | tee /tmp/bpp_b1.log`
+Expected: FAIL — `ImportError: cannot import name 'BppZapytanieSchema'`.
+
+- [ ] **Step 3: Dodaj `BppZapytanieSchema` w `zapytanie.py`**
+
+W `src/bpp/views/zapytanie.py` zmień import djangoql (jest `from djangoql.extras
+import ExtrasSchema`) — zostaw `ExtrasSchema`, dodaj importy modeli i klasę.
+Tuż po istniejących importach modeli (`from bpp.models import Autor`,
+`from bpp.models.cache import Rekord`) dodaj:
+
+```python
+from bpp.models.autor import Tytul
+from bpp.models.cache import Autorzy
+```
+
+A po stałych `MODELS = {...}` (przed klasą `WprowadzanieDanychOrSuperuserMixin`)
+dodaj:
+
+```python
+class BppZapytanieSchema(ExtrasSchema):
+    """ExtrasSchema z pickerami ``<fk>__rel`` obok trawersacji z kropką.
+
+    Notacja z kropką (``autorzy.autor.nazwisko``, ``tytul.skrot``) zostaje
+    domyślna dla FK. ``<fk>__rel`` to picker autocomplete: wybierasz konkretny
+    obiekt z podpowiedzi i filtruje po jego pk (``lookup_name`` wskazuje realny
+    FK), z fallbackiem free-text (icontains po ``search_fields``).
+    """
+
+    autocomplete = {
+        Autorzy: {
+            "autor__rel": {
+                "lookup_name": "autor",
+                "url": "bpp:public-autor-autocomplete",
+                "search_fields": ["nazwisko", "imiona"],
+            },
+            "jednostka__rel": {
+                "lookup_name": "jednostka",
+                "url": "bpp:jednostka-autocomplete",
+                "search_fields": ["nazwa", "skrot"],
+            },
+        },
+        Autor: {
+            "tytul__rel": {
+                "lookup_name": "tytul",
+                "queryset": Tytul.objects.all(),
+                "search_fields": ["nazwa", "skrot"],
+            },
+            "aktualna_jednostka__rel": {
+                "lookup_name": "aktualna_jednostka",
+                "url": "bpp:jednostka-autocomplete",
+                "search_fields": ["nazwa", "skrot"],
+            },
+        },
+    }
+
+    # Nazwy syntetyczne (nie ma ich w modelu) — bez tego nie zostaną
+    # zintrospektowane ani podpowiedziane.
+    _REL_FIELDS = {
+        Autorzy: ["autor__rel", "jednostka__rel"],
+        Autor: ["tytul__rel", "aktualna_jednostka__rel"],
+    }
+
+    def get_fields(self, model):
+        fields = list(super().get_fields(model))
+        fields += self._REL_FIELDS.get(model, [])
+        return fields
+```
+
+- [ ] **Step 4: Uruchom — GREEN**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py -k "rel or traversal or schema" -v 2>&1 | tee /tmp/bpp_b1.log`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Programowanie/bpp
+git add src/bpp/views/zapytanie.py src/bpp/tests/test_zapytanie.py
+git commit -m "feat(zapytanie): BppZapytanieSchema — pickery <fk>__rel obok trawersacji
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" -- src/bpp/views/zapytanie.py src/bpp/tests/test_zapytanie.py
+```
+
+### Task B2: podepnij schemat do widoku (apply_search / introspect / suggestions)
+
+**Files:**
+- Modify: `~/Programowanie/bpp/src/bpp/views/zapytanie.py`
+- Test: `~/Programowanie/bpp/src/bpp/tests/test_zapytanie.py`
+
+- [ ] **Step 1: Dopisz test widoku (przez klienta)**
+
+```python
+@pytest.mark.django_db
+def test_zapytanie_view_tytul_rel_picker(superuser_client):
+    from bpp.models.autor import Tytul
+
+    prof = baker.make(Tytul, nazwa="profesor", skrot="prof.")
+    baker.make("bpp.Autor", nazwisko="Kowalski", tytul=prof)
+
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "autor", "query": 'tytul__rel = "profesor [%d]"' % prof.pk},
+    )
+    assert response.status_code == 200
+    assert response.context["error"] is None
+    assert response.context["count"] == 1
+```
+
+- [ ] **Step 2: Uruchom — RED**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py::test_zapytanie_view_tytul_rel_picker -v 2>&1 | tee /tmp/bpp_b2.log`
+Expected: FAIL — `Unknown field: tytul__rel` (widok wciąż używa `ExtrasSchema`, który nie zna `__rel`).
+
+- [ ] **Step 3: Zamień `ExtrasSchema` → `BppZapytanieSchema` w 3 miejscach**
+
+W `src/bpp/views/zapytanie.py`:
+- w `ZapytanieView.render_results`:
+  `queryset = apply_search(queryset, query, schema=ExtrasSchema)` →
+  `queryset = apply_search(queryset, query, schema=BppZapytanieSchema)`
+- w `ZapytanieIntrospectView.get`:
+  `schema = ExtrasSchema(model)` → `schema = BppZapytanieSchema(model)`
+- w `ZapytanieSuggestionsView.get`:
+  `view = SuggestionsAPIView.as_view(schema=ExtrasSchema(model))` →
+  `view = SuggestionsAPIView.as_view(schema=BppZapytanieSchema(model))`
+
+- [ ] **Step 4: Uruchom — GREEN**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py::test_zapytanie_view_tytul_rel_picker -v 2>&1 | tee /tmp/bpp_b2.log`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Programowanie/bpp
+git add src/bpp/views/zapytanie.py src/bpp/tests/test_zapytanie.py
+git commit -m "feat(zapytanie): podepnij BppZapytanieSchema w widoku i endpointach
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" -- src/bpp/views/zapytanie.py src/bpp/tests/test_zapytanie.py
+```
+
+### Task B3: endpoint sugestii zwraca opcje pickera
+
+**Files:**
+- Test: `~/Programowanie/bpp/src/bpp/tests/test_zapytanie.py`
+
+(Implementacja już gotowa po B2 — to test regresyjny wiązania endpointu sugestii
+z pickerami: deterministycznie dla `tytul__rel` (queryset), smoke dla
+`autorzy.autor__rel` (provider DAL in-process; fulltext autora bywa niedet.).)
+
+- [ ] **Step 1: Dopisz testy**
+
+```python
+@pytest.mark.django_db
+def test_zapytanie_suggestions_tytul_rel_returns_options(superuser_client):
+    from bpp.models.autor import Tytul
+
+    prof = baker.make(Tytul, nazwa="profesor", skrot="prof.")
+    url = reverse("bpp:zapytanie_suggestions", kwargs={"model_key": "autor"})
+    response = superuser_client.get(url, {"field": "tytul__rel", "search": "prof"})
+    assert response.status_code == 200
+    data = response.json()
+    assert any("[%d]" % prof.pk in item for item in data["items"])
+
+
+@pytest.mark.django_db
+def test_zapytanie_suggestions_autor_rel_dal_smoke(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    url = reverse("bpp:zapytanie_suggestions", kwargs={"model_key": "rekord"})
+    response = superuser_client.get(
+        url, {"field": "autorzy.autor__rel", "search": "Kowal"}
+    )
+    assert response.status_code == 200
+    assert isinstance(response.json()["items"], list)
+```
+
+- [ ] **Step 2: Uruchom — GREEN (test potwierdza wiązanie z B2)**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py -k suggestions -v 2>&1 | tee /tmp/bpp_b3.log`
+Expected: PASS. (Jeśli `tytul__rel` padnie z „doesn't support suggestions" — sprawdź, że config ma `queryset`; jeśli `autorzy.autor__rel` padnie na resolve url — sprawdź nazwę `bpp:public-autor-autocomplete`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/Programowanie/bpp
+git add src/bpp/tests/test_zapytanie.py
+git commit -m "test(zapytanie): endpoint sugestii zwraca opcje pickerow __rel
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" -- src/bpp/tests/test_zapytanie.py
+```
+
+### Task B4: `explain_empty()` — kontekst „dlaczego 0"
+
+**Files:**
+- Modify: `~/Programowanie/bpp/src/bpp/views/zapytanie.py`
+- Test: `~/Programowanie/bpp/src/bpp/tests/test_zapytanie.py`
+
+- [ ] **Step 1: Dopisz testy**
+
+```python
+def _breakdown_leaves(node):
+    if not node["children"]:
+        yield node
+    for ch in node["children"]:
+        yield from _breakdown_leaves(ch)
+
+
+@pytest.mark.django_db
+def test_zapytanie_breakdown_explains_zero(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    response = superuser_client.get(
+        reverse(URL),
+        {
+            "model": "autor",
+            "query": 'nazwisko = "Kowalski" and imiona = "asdfo"',
+        },
+    )
+    assert response.status_code == 200
+    assert response.context["count"] == 0
+    breakdown = response.context["breakdown"]
+    assert breakdown is not None
+    assert breakdown["count"] == 0
+    leaves = {leaf["text"]: leaf["count"] for leaf in _breakdown_leaves(breakdown)}
+    assert any("asdfo" in t and c == 0 for t, c in leaves.items())
+
+
+@pytest.mark.django_db
+def test_zapytanie_no_breakdown_when_results(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski")
+    response = superuser_client.get(
+        reverse(URL), {"model": "autor", "query": 'nazwisko = "Kowalski"'}
+    )
+    assert response.context["count"] == 1
+    assert response.context["breakdown"] is None
+```
+
+- [ ] **Step 2: Uruchom — RED**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py -k breakdown -v 2>&1 | tee /tmp/bpp_b4.log`
+Expected: FAIL — `KeyError: 'breakdown'` (kontekst nie ma jeszcze klucza).
+
+- [ ] **Step 3: Podłącz `explain_empty` w `render_results`**
+
+W `src/bpp/views/zapytanie.py`:
+
+Na górze pliku dodaj importy:
+```python
+import logging
+
+from djangoql.breakdown import explain_empty
+```
+i pod importami zdefiniuj logger:
+```python
+logger = logging.getLogger(__name__)
+```
+
+W `ZapytanieView.render_results`, po bloku `try/except` (po tym jak ustalone
+są `count`, `error`), a przed budową `context`, dodaj:
+
+```python
+        breakdown = None
+        if error is None and count == 0:
+            try:
+                breakdown = explain_empty(
+                    model.objects.all(), query, schema=BppZapytanieSchema
+                )
+            except (DjangoQLError, FieldError, ValidationError, ValueError):
+                logger.exception(
+                    "explain_empty zawiodlo dla zapytania %r (model=%s)",
+                    query,
+                    model_key,
+                )
+                breakdown = None
+```
+
+i dorzuć `breakdown=breakdown` do wywołania `self.get_context_data(...)`:
+
+```python
+        context = self.get_context_data(
+            form=form,
+            results=results_page,
+            count=count,
+            error=error,
+            model_key=model_key,
+            query=query,
+            breakdown=breakdown,
+        )
+```
+
+- [ ] **Step 4: Uruchom — GREEN**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py -k breakdown -v 2>&1 | tee /tmp/bpp_b4.log`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Programowanie/bpp
+git add src/bpp/views/zapytanie.py src/bpp/tests/test_zapytanie.py
+git commit -m "feat(zapytanie): explain_empty — rozbicie 'dlaczego 0 wynikow'
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" -- src/bpp/views/zapytanie.py src/bpp/tests/test_zapytanie.py
+```
+
+### Task B5: szablon — render rozbicia
+
+**Files:**
+- Create: `~/Programowanie/bpp/src/bpp/templates/bpp/_zapytanie_breakdown.html`
+- Modify: `~/Programowanie/bpp/src/bpp/templates/bpp/zapytanie.html` (linia ~435)
+- Test: `~/Programowanie/bpp/src/bpp/tests/test_zapytanie.py`
+
+- [ ] **Step 1: Dopisz test renderu HTML**
+
+```python
+@pytest.mark.django_db
+def test_zapytanie_breakdown_rendered_in_html(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    response = superuser_client.get(
+        reverse(URL),
+        {
+            "model": "autor",
+            "query": 'nazwisko = "Kowalski" and imiona = "asdfo"',
+        },
+    )
+    html = response.content.decode("utf-8")
+    assert "Dlaczego 0 wynikow" in html
+    assert "asdfo" in html
+```
+
+- [ ] **Step 2: Uruchom — RED**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py::test_zapytanie_breakdown_rendered_in_html -v 2>&1 | tee /tmp/bpp_b5.log`
+Expected: FAIL — brak „Dlaczego 0 wynikow" w HTML.
+
+- [ ] **Step 3: Utwórz partial `_zapytanie_breakdown.html`**
+
+Treść pliku `src/bpp/templates/bpp/_zapytanie_breakdown.html`:
+
+```django
+{# Rekurencyjny widok rozbicia "dlaczego 0 wynikow". #}
+{# Oczekuje `node` (dict: text, count, role, children, truncated) i `is_root`. #}
+{% if is_root %}
+    <div class="callout warning zapytanie-breakdown-box" role="status">
+        <h3><span class="fi-info"></span> Dlaczego 0 wynikow?</h3>
+        {% if node.truncated %}
+            <p><em>Pokazano tylko warunki najwyzszego poziomu (zapytanie zbyt zlozone, aby rozbic w calosci).</em></p>
+        {% endif %}
+    </div>
+{% endif %}
+<ul class="zapytanie-breakdown role-{{ node.role }}">
+    <li>
+        <code>{{ node.text }}</code> &rarr; <strong>{{ node.count }}</strong> trafien
+        {% if node.role == "killer_and" %}
+            <span class="label alert">tu koncza sie dane: po polaczeniu zostaje 0</span>
+        {% elif node.role == "dead_or_branch" %}
+            <span class="label secondary">ta galaz OR nic nie wnosi (0 trafien)</span>
+        {% endif %}
+        {% for child in node.children %}
+            {% include "bpp/_zapytanie_breakdown.html" with node=child is_root=False %}
+        {% endfor %}
+    </li>
+</ul>
+```
+
+- [ ] **Step 4: Wstaw include w `zapytanie.html` (po „Brak rekordow…")**
+
+Zmień blok (ok. linii 434-436):
+
+```django
+            {% else %}
+                <p><em>Brak rekordow pasujacych do zapytania.</em></p>
+            {% endif %}
+```
+
+na:
+
+```django
+            {% else %}
+                <p><em>Brak rekordow pasujacych do zapytania.</em></p>
+                {% if breakdown %}
+                    {% include "bpp/_zapytanie_breakdown.html" with node=breakdown is_root=True %}
+                {% endif %}
+            {% endif %}
+```
+
+- [ ] **Step 5: Uruchom — GREEN**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py::test_zapytanie_breakdown_rendered_in_html -v 2>&1 | tee /tmp/bpp_b5.log`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Programowanie/bpp
+git add src/bpp/templates/bpp/_zapytanie_breakdown.html src/bpp/templates/bpp/zapytanie.html src/bpp/tests/test_zapytanie.py
+git commit -m "feat(zapytanie): szablon rozbicia 'dlaczego 0 wynikow'
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" -- src/bpp/templates/bpp/_zapytanie_breakdown.html src/bpp/templates/bpp/zapytanie.html src/bpp/tests/test_zapytanie.py
+```
+
+### Task B6: przykłady pickerów + news fragment
+
+**Files:**
+- Modify: `~/Programowanie/bpp/src/bpp/views/zapytanie.py` (`EXAMPLES`)
+- Create: `~/Programowanie/bpp/src/bpp/newsfragments/+zapytanie-autocomplete-rel.feature.rst`
+
+- [ ] **Step 1: Dodaj przykłady pickerów w `EXAMPLES` (forma free-text)**
+
+W `EXAMPLES`, w poziomie 1 (`"level": 1`), do grupy Rekord (`"model": MODEL_REKORD`)
+dodaj na końcu listy `items`:
+```python
+                    ("Po autorze (autocomplete)", 'autorzy.autor__rel = "Kowalski"'),
+                    ("Po jednostce (autocomplete)", 'autorzy.jednostka__rel = "Kardiologii"'),
+```
+a do grupy Autor (`"model": MODEL_AUTOR`) dodaj na końcu listy `items`:
+```python
+                    ("Po tytule (autocomplete)", 'tytul__rel = "prof."'),
+                    ("Po jednostce (autocomplete)", 'aktualna_jednostka__rel = "Kardiologii"'),
+```
+
+- [ ] **Step 2: Uruchom testy przykładów — GREEN**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py -k "examples" -v 2>&1 | tee /tmp/bpp_b6.log`
+Expected: PASS (przykłady parsowalne; brak unary `not`; oba modele pokryte).
+
+- [ ] **Step 3: Utwórz news fragment**
+
+Plik `src/bpp/newsfragments/+zapytanie-autocomplete-rel.feature.rst`:
+```rst
+Widok „Szukaj zapytaniem": pola ``<fk>__rel`` z autocomplete (wybór autora,
+jednostki, tytułu naukowego z podpowiedzi i filtrowanie po wybranym obiekcie),
+obok dotychczasowej składni z kropką. Gdy zapytanie zwróci 0 rekordów, widok
+pokazuje teraz rozbicie wyjaśniające, który warunek wyzerował wynik.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/Programowanie/bpp
+git add src/bpp/views/zapytanie.py src/bpp/newsfragments/+zapytanie-autocomplete-rel.feature.rst
+git commit -m "feat(zapytanie): przyklady pickerow __rel + news fragment
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" -- src/bpp/views/zapytanie.py src/bpp/newsfragments/+zapytanie-autocomplete-rel.feature.rst
+```
+
+### Task B7: bump zależności na wydaną wersję djangoql (po release)
+
+**Files:**
+- Modify: `~/Programowanie/bpp/pyproject.toml`
+- Modify: `~/Programowanie/bpp/uv.lock`
+
+⚠️ Wykonać **po** opublikowaniu djangoql-iplweb 0.23.0 na PyPI (checkpoint po A3).
+
+- [ ] **Step 1: Podnieś minimalną wersję**
+
+W `pyproject.toml` zmień `"djangoql-iplweb>=0.22.0",` na `"djangoql-iplweb>=0.23.0",`
+(dostosuj numer, jeśli release dostał inną wersję).
+
+- [ ] **Step 2: Odśwież lock + zdejmij editable**
+
+```bash
+cd ~/Programowanie/bpp
+uv lock
+uv sync --all-extras
+```
+
+- [ ] **Step 3: Zweryfikuj, że venv ma wydaną wersję (nie editable)**
+
+Run:
+```bash
+cd ~/Programowanie/bpp
+uv run python -c "import djangoql, os; p=os.path.dirname(djangoql.__file__); print('local-editable' if 'Programowanie/djangoql-iplweb' in p else 'pypi-wheel', getattr(djangoql,'__version__','?'))"
+```
+Expected: `pypi-wheel 0.23.0` (lub wyższa).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/Programowanie/bpp
+git add pyproject.toml uv.lock
+git commit -m "build(deps): wymagaj djangoql-iplweb>=0.23.0 (lookup_name dla pickerow __rel)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" -- pyproject.toml uv.lock
+```
+
+### Task B8: pełna weryfikacja + push + PR 2
+
+- [ ] **Step 1: Pełny zestaw testów zapytania (GREEN)**
+
+Run: `cd ~/Programowanie/bpp && UV_NO_SYNC=1 uv run --all-extras pytest src/bpp/tests/test_zapytanie.py -n auto -v 2>&1 | tee /tmp/bpp_zapytanie_full.log; grep -E "passed|failed|error" /tmp/bpp_zapytanie_full.log | tail -3`
+Expected: wszystkie PASS, 0 failed.
+
+- [ ] **Step 2: pre-commit na zmienionych plikach (bez argumentów)**
+
+Run: `cd ~/Programowanie/bpp && pre-commit run 2>&1 | tee /tmp/bpp_precommit.log`
+Expected: Passed/Skipped. Jeśli coś zgłosi — popraw ręcznie Editem (NIE `ruff --fix` batch), commit poprawki.
+
+- [ ] **Step 3: Push gałęzi**
+
+```bash
+cd ~/Programowanie/bpp
+git push -u origin bpp-zapytanie-autocomplete-rel
+```
+
+- [ ] **Step 4: Otwórz PR 2**
+
+```bash
+cd ~/Programowanie/bpp
+gh pr create --base dev --head bpp-zapytanie-autocomplete-rel \
+  --title "feat(zapytanie): pickery __rel (autocomplete) + wyjaśnienie 0 wyników" \
+  --body "$(cat <<'EOF'
+Widok „Szukaj zapytaniem": pola `<fk>__rel` z autocomplete (autor, jednostka,
+tytuł naukowy) obok zachowanej trawersacji z kropką, plus rozbicie
+`explain_empty()` gdy zapytanie zwraca 0 rekordów.
+
+Wymaga djangoql-iplweb >= 0.23.0 (kwarg `lookup_name`).
+
+Spec: `docs/superpowers/specs/2026-06-04-zapytanie-autocomplete-rel-i-wyjasnienie-zero-design.md`
+Plan: `docs/superpowers/plans/2026-06-04-zapytanie-autocomplete-rel.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Notatki / ryzyka
+
+- **Rekord to widok zmaterializowany** (`managed=False`). Testy pickerów dla
+  Rekord (B1) sprawdzają resolve + SQL (bez realnych wierszy), bo budowanie
+  Rekordu wymaga `transactional_db` + `denorms.flush()`. Jeśli zechcesz test
+  end-to-end na realnych danych Rekord — użyj fixture'ów `transactional_db`,
+  `denorms`, `make_ciagle`, `autor`, `jednostka` (wzorzec z
+  `src/bpp/tests/test_cache/test_cache.py`) i `denorms.flush()`.
+- **DAL `public-autor-autocomplete`** używa `fulltext_filter` — w testach treść
+  wyników bywa niedeterministyczna (tsvector), stąd dla `autorzy.autor__rel`
+  test sugestii jest smoke (status + lista), a twardą asercję treści robimy na
+  `tytul__rel` (provider queryset, deterministyczny icontains).
+- **Picker tylko filtruje po pk** (`= pk`, `!=`, `in`) + fallback free-text
+  icontains; operatory na podpolach (`startswith` itp.) zostają na ścieżce z
+  kropką (niezmienione).
+- **`explain_empty` liczy 1×`count()` na węzeł AST** (guard `max_nodes=50`).
+  Dla Rekord to kilka dodatkowych count-ów na ścieżce „dało 0" — akceptowalne.
+- **Editable djangoql w fazie B** jest tylko do dev-loopu (B0); commitowana
+  zależność to bump wersji w B7. Wszystkie komendy testowe fazy B mają
+  `UV_NO_SYNC=1`, żeby `uv run` nie zdjął editable.
+- **Komentarze Django** w partialu: każdy `{# … #}` w jednej linii (reguła
+  projektu). Ikony: Foundation (`fi-info`) — `zapytanie.html` dziedziczy po
+  `base.html`.

--- a/docs/superpowers/specs/2026-06-04-zapytanie-autocomplete-rel-i-wyjasnienie-zero-design.md
+++ b/docs/superpowers/specs/2026-06-04-zapytanie-autocomplete-rel-i-wyjasnienie-zero-design.md
@@ -1,0 +1,295 @@
+# Zapytanie DjangoQL: pickery `__rel` (autocomplete) + wyjaśnienie „0 wyników"
+
+Data: 2026-06-04
+Status: **Do akceptacji.**
+
+## Problem
+
+Widok „Szukaj zapytaniem" (`/bpp/zapytanie/`, `ZapytanieView`) pozwala pisać
+zapytania DjangoQL po modelach `Rekord` i `Autor`. Dwa braki:
+
+1. **Brak wygodnego wyboru obiektu.** Żeby zawęzić do konkretnego autora trzeba
+   pisać `autorzy.autor.nazwisko = "Kowalski" and autorzy.autor.imiona = "Jan"`
+   — łatwo o literówkę (URL użytkownika z `imiona = "asdfo"` zwraca 0), a
+   nazwisko nie jest unikalne. Tak samo jednostka i tytuł naukowy.
+2. **Brak informacji „dlaczego 0".** Gdy poprawne składniowo zapytanie zwraca 0
+   rekordów, użytkownik nie wie, który warunek wyzerował wynik.
+
+djangoql-iplweb 0.22 dostarcza oba klocki:
+- `djangoql.extras.AutocompleteField` + `AutocompleteSchemaMixin` — pole-picker,
+  które podpowiada wartości z dowolnego źródła (np. endpoint DAL) i filtruje po
+  pk wybranego obiektu (`= pk`, `!=`, `in`), z fallbackiem free-text
+  (icontains po `search_fields`).
+- `djangoql.breakdown.explain_empty(queryset, search, schema=…, max_nodes=50)` —
+  dla zapytania zwracającego 0 wierszy zwraca drzewko
+  `{text, count, role, children}` wskazujące „zabójczy" `AND` (`killer_and`) i
+  martwe gałęzie `OR` (`dead_or_branch`).
+
+## Decyzja kluczowa (potwierdzona z użytkownikiem)
+
+`AutocompleteField` zamienia FK w **liść-picker** — pod jego nazwą nie da się
+już trawersować w podpola. To świadoma decyzja projektowa djangoql-iplweb
+(spec `autocomplete-value-fields-design.md:36-37`, doc
+`integrating-django-autocomplete-light.md:37-39`): *„Need both → use a second
+field name."*
+
+Wybrano **drogę A — dwie nazwy** (zamiast „drogi B": jedna nazwa robi oba —
+odrzuconej):
+
+- **Notacja z kropką zostaje domyślna dla każdego FK** (trawersacja bez zmian:
+  `autorzy.autor.nazwisko`, `tytul.skrot`, `aktualna_jednostka.nazwa`, … —
+  wszystkie obecne przykłady i URL użytkownika działają dalej).
+- **`<fk>__rel` = picker** (podwójny underscore — spójnie z rodziną pól
+  pochodnych `__count`/`__sum`/`__avg`/`__min`/`__max`; `rel` = „filtruj po
+  całym obiekcie powiązanym"). Picker filtruje po pk wybranego rekordu, z
+  fallbackiem free-text.
+
+**Aktualizacja zakresu (po dalszej rozmowie):** `<fk>__rel` zostaje
+udokumentowane jako **idiom djangoql-iplweb** „relacja z kropką + picker obok",
+a do `AutocompleteField` dochodzi malutki, **addytywny** kwarg `lookup_name`
+(domyślnie `None` → zachowanie identyczne jak dziś, nie psuje niczego). To NIE
+jest odrzucona „droga B" — to tylko ergonomia wzorca dwóch nazw. Dzięki temu
+BPP **nie potrzebuje własnej podklasy** — używa `AutocompleteField` wprost z
+`lookup_name`. Szczegóły deliverable'u w pakiecie: osobny spec w repo
+djangoql-iplweb (`docs/superpowers/specs/2026-06-04-autocomplete-lookup-name-rel-idiom-design.md`).
+
+**Świadomie NIE** opieramy podpowiedzi na distinct-wartościach z bazy
+(`StrField.get_options` z `.distinct()`) — przy dużych tabelach (autor,
+jednostka) byłoby ich „mega dużo". Picker robi ograniczone zapytanie top-N
+(`limit=50`) przez endpoint DAL albo mały queryset.
+
+## Zakres pól
+
+| Model | Trawersacja (zostaje, bez zmian) | Picker (nowy) | Źródło sugestii | `lookup_name` |
+|---|---|---|---|---|
+| `Rekord` → `Autorzy` | `autorzy.autor.*` | `autorzy.autor__rel` | DAL `bpp:public-autor-autocomplete` | `autor` |
+| `Rekord` → `Autorzy` | `autorzy.jednostka.*` | `autorzy.jednostka__rel` | DAL `bpp:jednostka-autocomplete` | `jednostka` |
+| `Autor` | `tytul.*` | `tytul__rel` | queryset `Tytul.objects.all()` | `tytul` |
+| `Autor` | `aktualna_jednostka.*` | `aktualna_jednostka__rel` | DAL `bpp:jednostka-autocomplete` | `aktualna_jednostka` |
+
+Uwagi:
+- **Autor — autocomplete**: używamy `public-autor-autocomplete`
+  (`PublicAutorAutocomplete`), nie `autor-autocomplete` (`AutorAutocomplete`).
+  Ten drugi wymaga grupy `GR_WPROWADZANIE_DANYCH` (footgun dla superuserów
+  spoza grupy, którzy mają dostęp do widoku) i dokleja do etykiet emoji
+  📚PBN / 🏛️MNISW oraz opcję „utwórz" — co psułoby format `"Label [id]"`.
+  `PublicAutorAutocomplete` zwraca czyste `str(autor)` bez grupy i bez markerów.
+- **Tytuł — brak endpointu DAL**, więc picker korzysta z providera `queryset`
+  (`Tytul.objects.all()`, `search_fields=['nazwa','skrot']`). Tabela jest
+  malutka (~kilkanaście wierszy), więc to bez znaczenia wydajnościowo.
+- **Jednostka** — picker w obu kontekstach; endpoint `jednostka-autocomplete`
+  (`JednostkaAutocomplete`) nie ma wymogu grupy i zwraca czyste etykiety.
+- Autor jako picker **nie** ma sensu w modelu `Autor` (tam pytamy o autorów
+  wprost po `nazwisko`/`imiona`), więc go tam nie dodajemy.
+
+## Architektura
+
+### Zależność: djangoql-iplweb z kwargiem `lookup_name`
+
+BPP wymaga wersji djangoql-iplweb z addytywnym kwargiem
+`AutocompleteField(lookup_name=…)` (patrz osobny spec w repo pakietu). W trakcie
+parallel-devu BPP korzysta z lokalnego editable checkoutu
+(`~/Programowanie/djangoql-iplweb/`); docelowo `pyproject.toml` bumpuje minimalną
+wersję djangoql-iplweb do tej z `lookup_name`. **Bez tego kwargu** picker pod
+nazwą `autor__rel` filtrowałby nieistniejącą kolumnę `autor__rel` zamiast FK
+`autor`.
+
+### Schemat (po stronie BPP, w `src/bpp/views/zapytanie.py`)
+
+`<fk>__rel` to nazwa syntetyczna (nie ma jej w modelu), więc filtruje realny FK
+przez `lookup_name`. Nie potrzeba podklasy — wystarczy `AutocompleteField`
+z kwargiem:
+
+```python
+from djangoql.extras import AutocompleteField, ExtrasSchema
+from bpp.models import Autor, Tytul
+from bpp.models.cache import Autorzy
+
+class BppZapytanieSchema(ExtrasSchema):
+    autocomplete = {
+        Autorzy: {
+            "autor__rel": {
+                "lookup_name": "autor",
+                "url": "bpp:public-autor-autocomplete",
+                "search_fields": ["nazwisko", "imiona"],
+            },
+            "jednostka__rel": {
+                "lookup_name": "jednostka",
+                "url": "bpp:jednostka-autocomplete",
+                "search_fields": ["nazwa", "skrot"],
+            },
+        },
+        Autor: {
+            "tytul__rel": {
+                "lookup_name": "tytul",
+                "queryset": Tytul.objects.all(),
+                "search_fields": ["nazwa", "skrot"],
+            },
+            "aktualna_jednostka__rel": {
+                "lookup_name": "aktualna_jednostka",
+                "url": "bpp:jednostka-autocomplete",
+                "search_fields": ["nazwa", "skrot"],
+            },
+        },
+    }
+
+    # Nazwy syntetyczne nie są realnymi polami modelu, więc muszą być dorzucone
+    # do introspekcji, inaczej nie zostaną zbudowane ani podpowiedziane.
+    _REL_FIELDS = {
+        Autorzy: ["autor__rel", "jednostka__rel"],
+        Autor: ["tytul__rel", "aktualna_jednostka__rel"],
+    }
+
+    def get_fields(self, model):
+        fields = list(super().get_fields(model))
+        fields += self._REL_FIELDS.get(model, [])
+        return fields
+```
+
+Działanie lookupu (`AutocompleteField.get_lookup` / `_free_text_lookup` budują
+ścieżkę z `path + [self.get_lookup_name()]`, a `get_lookup_name()` zwraca teraz
+`lookup_name`):
+- picker po pk: `autorzy.autor__rel = "Jan [42]"` → `autorzy__autor = 42`
+  (Django filtruje FK po pk wprost),
+- fallback free-text: `autorzy.autor__rel = "kowal"` →
+  `autorzy__autor__nazwisko icontains "kowal"` OR `…__imiona icontains …`.
+
+Pozostałe szczegóły schematu:
+- `_build_autocomplete_field` robi `AutocompleteField(**config)` z dicta —
+  `lookup_name` trafia do kwargów, `name` ustawia mixin na `"autor__rel"`.
+- `get_fields` dorzuca syntetyczne nazwy → `introspect()` woła
+  `get_field_instance(model, "autor__rel")` → `AutocompleteSchemaMixin`
+  znajduje wpis w `autocomplete` i buduje `AutocompleteField`.
+- Pole jest „suggested" (domyślnie) i `async_options=True` (brak choices), więc
+  serializer wystawia `options: true` i widget pobiera podpowiedzi asynchronicznie
+  przez istniejący endpoint — `__rel` jest **odkrywalne** w autocomplete obok
+  zwykłej relacji `autor`.
+- Schemat jest tworzony per-model (`BppZapytanieSchema(Rekord)` /
+  `(Autor)`); `__rel` rejestrują się zawsze, gdy dany model jest introspektowany
+  (Autorzy osiągany przez `autorzy`, Autor jako root lub przez `autorzy.autor`).
+
+### 3. Podpięcie schematu w widoku
+
+W `zapytanie.py` zamieniamy bezpośrednie użycia `ExtrasSchema` na
+`BppZapytanieSchema` w trzech miejscach:
+- `render_results`: `apply_search(queryset, query, schema=BppZapytanieSchema)`,
+- `ZapytanieIntrospectView`: `BppZapytanieSchema(model)`,
+- `ZapytanieSuggestionsView`: `SuggestionsAPIView.as_view(schema=BppZapytanieSchema(model))`.
+
+### 4. Wyjaśnienie „0 wyników"
+
+W `render_results`, gdy zapytanie jest poprawne i `count == 0`:
+
+```python
+from djangoql.breakdown import explain_empty
+
+breakdown = None
+if count == 0:
+    try:
+        breakdown = explain_empty(
+            model.objects.all(), query, schema=BppZapytanieSchema
+        )
+    except (DjangoQLError, FieldError, ValidationError, ValueError):
+        logger.exception("explain_empty zawiodło dla zapytania %r", query)
+        breakdown = None  # degradacja: pokaż '0 wyników' bez rozbicia
+```
+
+- Wołane tylko dla `count == 0` (leniwie). `explain_empty` jest bezpieczne —
+  query już przeszło `apply_search`, więc parse/validate się powiedzie; mimo to
+  owijamy w try/except (logujemy, nie połykamy po cichu — zgodnie z regułami
+  projektu) tak, że błąd rozbicia degraduje do zwykłego „0 wyników".
+- `breakdown` trafia do kontekstu i renderuje się w szablonie.
+- Koszt: jeden `count()` na węzeł AST (guard `max_nodes=50`). Typowe zapytania
+  2–4 warunków = kilka `count()`. `Rekord` to duży widok zmaterializowany, ale
+  to akceptowalne dla ścieżki „dało 0, wytłumacz dlaczego".
+
+### 5. Szablon
+
+Nowy partial `src/bpp/templates/bpp/_zapytanie_breakdown.html` renderowany pod
+komunikatem „0 wyników" w `zapytanie.html` (rozszerza `base.html` → ikony
+**Foundation Icons**, nie emoji). Rekurencyjnie pokazuje drzewko:
+- każdy liść: `tekst warunku → N trafień`,
+- `killer_and`: podświetlony („tu kończą się dane: po połączeniu warunków
+  zostaje 0"),
+- `dead_or_branch`: oznaczony („ta gałąź OR nic nie wnosi — 0 trafień"),
+- `truncated` na korzeniu: dopisek, że rozbito tylko górne warunki (bez cichego
+  ucinania).
+- Mapowanie `role` → polskie etykiety po stronie szablonu/widoku.
+- Komentarze Django wyłącznie jedno-liniowe `{# … #}` (reguła projektu) lub
+  `{% comment %}`.
+
+### 6. Przykłady (`EXAMPLES`)
+
+Wszystkie obecne przykłady **zostają** (trawersacja działa). Dodajemy kilka z
+pickerami. **Decyzja: przykłady używają formy free-text (bez sztucznego
+`[id]`)** — jest poprawna składniowo, „kopiowalna", a realne `[id]` użytkownik
+i tak dostaje z autocomplete (sztuczne `[1]` w przykładzie mogłoby trafić w
+nieistniejący pk):
+- Rekord: `autorzy.autor__rel = "Kowalski"`,
+  `autorzy.jednostka__rel = "II WL" and rok >= 2022`,
+- Autor: `tytul__rel = "prof."`,
+  `aktualna_jednostka__rel = "Katedra" and orcid != ""`.
+
+Każdy nowy przykład przejdzie `test_zapytanie_examples_are_valid_djangoql`
+(walidacja składni `DjangoQLParser`, nie wykonania) oraz
+`test_zapytanie_examples_no_unary_not`.
+
+## Pliki do zmiany
+
+### W repo djangoql-iplweb (osobny spec + TDD — patrz repo pakietu)
+
+- `djangoql/extras.py` — addytywny kwarg `lookup_name` na `AutocompleteField`
+  (+ `get_lookup_name()` → `self._lookup_name or self.name`).
+- `docs/integrating-django-autocomplete-light.md` — nowa sekcja: idiom
+  „relacja z kropką + picker `<fk>__rel` obok".
+- `test_project/…`, `CHANGES.rst` — test kwargu + wpis (additive, non-breaking).
+- release + wersja, do której BPP bumpuje minimalną zależność.
+
+### W repo bpp
+
+- `src/bpp/views/zapytanie.py` — `BppZapytanieSchema(ExtrasSchema)` (z mapą
+  `autocomplete` + `get_fields`), podpięcie `explain_empty`, użycie schematu w
+  3 miejscach (`render_results`, `ZapytanieIntrospectView`,
+  `ZapytanieSuggestionsView`), nowe przykłady, `import logging` + `logger`.
+- `src/bpp/templates/bpp/zapytanie.html` — sekcja „dlaczego 0" (include
+  partiala) w gałęzi `count == 0`.
+- `src/bpp/templates/bpp/_zapytanie_breakdown.html` — nowy partial (rekurencyjny).
+- `pyproject.toml` — bump minimalnej wersji `djangoql-iplweb` do tej z
+  `lookup_name`.
+- `src/bpp/tests/test_zapytanie.py` — nowe testy.
+- `src/bpp/newsfragments/+zapytanie-autocomplete-rel.feature.rst` — news fragment.
+
+## Plan testów (pytest, model_bakery, `@pytest.mark.django_db`)
+
+Pickery:
+- `autorzy.autor__rel = "X [<pk>]"` filtruje `autorzy__autor = pk` (Rekord ma
+  autora o tym pk → trafia; inny pk → 0).
+- free-text fallback: `autorzy.autor__rel = "kowal"` → icontains po
+  `autorzy__autor__nazwisko`/`imiona`.
+- `tytul__rel = "prof. [<pk>]"` → `tytul_id = pk`; `aktualna_jednostka__rel`
+  analogicznie.
+- introspekcja/serializacja: schemat dla Rekord i Autor zawiera `*__rel` jako
+  pola z `options: true`; trawersacja (`autorzy.autor.nazwisko`, `tytul.skrot`)
+  **nadal** działa (regresja — kluczowe: nie wyłączyliśmy kropki).
+- endpoint sugestii: `ZapytanieSuggestionsView` dla
+  `field=autorzy.autor__rel&search=…` zwraca itemy `"… [id]"` (provider DAL
+  wołany in-process z bieżącym requestem).
+
+Wyjaśnienie „0":
+- AND dwóch warunków, drugi daje 0 → `explain_empty` zwraca drzewo z
+  `killer_and` i liściem `count == 0` (odtworzenie scenariusza z URL użytkownika:
+  `nazwisko = "Kowalski"` → N, `imiona = "asdfo"` → 0).
+- zapytanie z trafieniami → `count > 0` → brak rozbicia (None), brak sekcji.
+- widok: GET z zapytaniem zwracającym 0 renderuje sekcję „dlaczego 0";
+  z wynikami — nie renderuje.
+- degradacja: gdy `explain_empty` rzuci (zamockowane) → strona renderuje „0
+  wyników" bez rozbicia, log zawiera wpis (nie 500).
+
+## Poza zakresem
+
+- Zmiany w pakiecie djangoql-iplweb (to byłaby droga B: jedna nazwa robi oba —
+  odrzucona na rzecz drogi A).
+- Zmiany w completion-widgecie (JS) — feature jest w 100% server-side.
+- Picker dla innych FK (charakter_formalny, zrodlo, wydawca, jezyk itd.) — można
+  dodać później tym samym wzorcem, jeśli zajdzie potrzeba.
+- Głęboka paginacja sugestii (djangoql v1 zwraca jedną stronę top-N).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ dependencies = [
     "requests-oauthlib==2.0.0",
     "django-cacheops>=7.2,<8",
     "django-constance>=4.3.5",
-    "djangoql-iplweb==0.21.0",
+    "djangoql-iplweb>=0.23.0",
     "django-weasyprint>=2.5.0",
     "django-templated-email>=3.0.0",
     "django-formtools>=2.6.1,<3",

--- a/src/bpp/admin/autor.py
+++ b/src/bpp/admin/autor.py
@@ -7,6 +7,7 @@ from dynamic_admin_columns.mixins import DynamicColumnsMixin
 from ewaluacja_liczba_n.models import IloscUdzialowDlaAutoraZaRok
 from pbn_api.models import Scientist
 
+from ..djangoql_schema import BppQLSchema
 from ..models import (  # Publikacja_Habilitacyjna
     Autor,
     Autor_Absencja,
@@ -199,6 +200,7 @@ class AutorAdmin(
 ):
     djangoql_completion_enabled_by_default = False
     djangoql_completion = True
+    djangoql_schema = BppQLSchema
 
     max_allowed_export_items = 5000
 

--- a/src/bpp/admin/autor_dyscyplina.py
+++ b/src/bpp/admin/autor_dyscyplina.py
@@ -14,6 +14,7 @@ from bpp.admin.filters import (
     PBN_UID_IDAutoraObecnyFilter,
 )
 from bpp.admin.xlsx_export.mixins import EksportDanychMixin
+from bpp.djangoql_schema import BppQLSchema
 from bpp.models import Autor, Autor_Dyscyplina
 
 
@@ -131,6 +132,7 @@ class Autor_DyscyplinaAdmin(
 ):
     djangoql_completion_enabled_by_default = True
     djangoql_completion = True
+    djangoql_schema = BppQLSchema
 
     max_allowed_export_items = 10000
 

--- a/src/bpp/admin/jednostka.py
+++ b/src/bpp/admin/jednostka.py
@@ -6,6 +6,7 @@ from django.utils.html import format_html
 from djangoql.admin import DjangoQLSearchMixin
 from mptt.admin import DraggableMPTTAdmin
 
+from bpp.djangoql_schema import BppQLSchema
 from bpp.models import Autor_Jednostka, Uczelnia
 
 from ..models.struktura import Jednostka, Jednostka_Wydzial
@@ -45,6 +46,7 @@ class JednostkaAdmin(
 ):
     djangoql_completion_enabled_by_default = False
     djangoql_completion = True
+    djangoql_schema = BppQLSchema
 
     change_list_template = "admin/grappelli_mptt_change_list.html"
 

--- a/src/bpp/admin/patent.py
+++ b/src/bpp/admin/patent.py
@@ -1,7 +1,9 @@
 from django import forms
 from django.contrib import admin
+from djangoql.admin import DjangoQLSearchMixin
 from taggit.forms import TextareaTagWidget
 
+from bpp.djangoql_schema import BppQLSchema
 from bpp.models.patent import Patent, Patent_Autor
 
 from .core import generuj_inline_dla_autorow
@@ -81,12 +83,17 @@ class PatentResource(resources.Wydawnictwo_ResourceBase):
 
 
 class Patent_Admin(
+    DjangoQLSearchMixin,
     ConstanceScoringFieldsMixin,
     AdnotacjeZDatamiMixin,
     EksportDanychZFormatowanieMixin,
     ExportActionsMixin,
     Wydawnictwo_ZwarteAdmin_Baza,
 ):
+    djangoql_completion_enabled_by_default = False
+    djangoql_completion = True
+    djangoql_schema = BppQLSchema
+
     resource_classes = [PatentResource]
     bibtex_resource_class = resources.PatentBibTeXResource
 

--- a/src/bpp/admin/praca_doktorska.py
+++ b/src/bpp/admin/praca_doktorska.py
@@ -1,12 +1,14 @@
 from dal import autocomplete
 from django import forms
 from django.contrib import admin
+from djangoql.admin import DjangoQLSearchMixin
 from taggit.forms import TextareaTagWidget
 
 from bpp.admin.helpers.widgets import (
     COMMA_DECIMAL_FIELD_OVERRIDE,
     NIZSZE_TEXTFIELD_Z_MAPA_ZNAKOW,
 )
+from bpp.djangoql_schema import BppQLSchema
 
 from ..models import Autor, Jednostka, Praca_Doktorska
 from .actions import ustaw_po_korekcie, ustaw_przed_korekta, ustaw_w_trakcie_korekty
@@ -55,8 +57,12 @@ DOKTORSKA_FIELDS = (
 
 
 class Praca_Doktorska_Habilitacyjna_Admin_Base(
-    AdnotacjeZDatamiMixin, BaseBppAdminMixin, admin.ModelAdmin
+    DjangoQLSearchMixin, AdnotacjeZDatamiMixin, BaseBppAdminMixin, admin.ModelAdmin
 ):
+    djangoql_completion_enabled_by_default = False
+    djangoql_completion = True
+    djangoql_schema = BppQLSchema
+
     formfield_overrides = {
         **NIZSZE_TEXTFIELD_Z_MAPA_ZNAKOW,
         **COMMA_DECIMAL_FIELD_OVERRIDE,

--- a/src/bpp/admin/wydawca.py
+++ b/src/bpp/admin/wydawca.py
@@ -7,6 +7,7 @@ from djangoql.admin import DjangoQLSearchMixin
 from bpp.admin.core import DynamicAdminFilterMixin
 from bpp.admin.filters import PBN_UID_IDObecnyFilter
 from bpp.const import PBN_UID_LEN
+from bpp.djangoql_schema import BppQLSchema
 from bpp.models import Wydawca
 from bpp.models.wydawca import Poziom_Wydawcy
 from pbn_api.models import Publisher
@@ -95,6 +96,7 @@ class WydawcaForm(forms.ModelForm):
 class WydawcaAdmin(DynamicAdminFilterMixin, DjangoQLSearchMixin, admin.ModelAdmin):
     djangoql_completion_enabled_by_default = False
     djangoql_completion = True
+    djangoql_schema = BppQLSchema
 
     form = WydawcaForm
 

--- a/src/bpp/admin/wydawnictwo_ciagle.py
+++ b/src/bpp/admin/wydawnictwo_ciagle.py
@@ -38,6 +38,7 @@ from bpp.admin.helpers.widgets import (
     NIZSZE_TEXTFIELD_Z_MAPA_ZNAKOW,
 )
 from bpp.admin.nagroda import NagrodaInline
+from bpp.djangoql_schema import BppQLSchema
 from bpp.models import (  # Publikacja_Habilitacyjna
     Charakter_Formalny,
     Wydawnictwo_Ciagle,
@@ -294,6 +295,7 @@ class Wydawnictwo_CiagleAdmin(
 
     djangoql_completion_enabled_by_default = False
     djangoql_completion = True
+    djangoql_schema = BppQLSchema
 
     formfield_overrides = {
         **NIZSZE_TEXTFIELD_Z_MAPA_ZNAKOW,

--- a/src/bpp/admin/wydawnictwo_zwarte.py
+++ b/src/bpp/admin/wydawnictwo_zwarte.py
@@ -22,6 +22,7 @@ from bpp.admin.filters import (
 )
 from bpp.admin.helpers import fieldsets
 from bpp.admin.helpers.widgets import COMMA_DECIMAL_FIELD_OVERRIDE
+from bpp.djangoql_schema import BppQLSchema
 from bpp.models import (
     Charakter_Formalny,
     Wydawca,
@@ -467,6 +468,7 @@ class Wydawnictwo_ZwarteAdmin(
     form = Wydawnictwo_ZwarteForm
     djangoql_completion_enabled_by_default = False
     djangoql_completion = True
+    djangoql_schema = BppQLSchema
     search_fields = Wydawnictwo_ZwarteAdmin_Baza.search_fields
     resource_classes = [resources.Wydawnictwo_ZwarteResource]
     bibtex_resource_class = resources.Wydawnictwo_ZwarteBibTeXResource

--- a/src/bpp/admin/zrodlo.py
+++ b/src/bpp/admin/zrodlo.py
@@ -4,6 +4,7 @@ from django import forms
 from django.contrib import admin
 from djangoql.admin import DjangoQLSearchMixin
 
+from bpp.djangoql_schema import BppQLSchema
 from bpp.models.zrodlo import Redakcja_Zrodla
 from pbn_api.models import Journal
 
@@ -113,6 +114,7 @@ class ZrodloAdmin(
 ):
     djangoql_completion_enabled_by_default = False
     djangoql_completion = True
+    djangoql_schema = BppQLSchema
 
     form = ZrodloForm
 

--- a/src/bpp/djangoql_schema.py
+++ b/src/bpp/djangoql_schema.py
@@ -1,0 +1,144 @@
+"""Wspólny schemat DjangoQL dla BPP — auto-pickery ``<fk>__rel``.
+
+Trzon współdzielony przez widok „Szukaj zapytaniem" (`bpp.views.zapytanie`) i
+adminy z ``DjangoQLSearchMixin`` (ustawiają ``djangoql_schema = BppQLSchema``).
+
+Idea: dla KAŻDEGO klucza obcego (FK) modelu, którego model docelowy ma
+pole-etykietę (nazwa/skrot/tytuł/opis bibliograficzny…), auto-generujemy
+„picker" pod nazwą ``<fk>__rel``. Wybierasz obiekt z podpowiedzi i filtruje po
+jego pk (``lookup_name`` wskazuje realny FK), z fallbackiem free-text (icontains
+po polach-etykietach). Notacja z kropką (``zrodlo.nazwa``) zostaje domyślna dla
+FK — picker tylko ją uzupełnia.
+
+Lookup nie podpowiada ukrytych: queryset filtruje boolowskie pola widoczności
+(``widoczny``/``widoczna``/``widoczne``/``visible``/``enabled``/``pokazuj`` =
+True, ``disabled``/``ukryty``… = False). FK do modeli bez pola-etykiety
+(np. ``pbn_uid`` → ``Journal``) oraz rodzic ``rekord`` (cache/through) są
+pomijane.
+"""
+
+from django.core.exceptions import FieldDoesNotExist
+from django.db import models
+from django.utils.html import strip_tags
+from djangoql.extras import AutocompleteField, ExtrasSchema
+
+#: Pola-etykiety wg priorytetu — czym opisać i po czym szukać obiekt w pickerze.
+#: Opis bibliograficzny jako pierwszy: dla publikacji jest najczytelniejszy.
+_LABEL_FIELDS = (
+    "opis_bibliograficzny_cache",
+    "nazwa",
+    "skrot",
+    "tytul_oryginalny",
+    "nazwisko",
+    "imiona",
+    "kod",
+)
+#: Boolowskie pola widoczności: widoczne, gdy True.
+_VISIBLE_WHEN_TRUE = (
+    "widoczny",
+    "widoczna",
+    "widoczne",
+    "visible",
+    "enabled",
+    "pokazuj",
+)
+#: Boolowskie pola „ukrycia": widoczne, gdy False.
+_VISIBLE_WHEN_FALSE = ("disabled", "ukryty", "ukryta", "ukryte")
+_REL_SUFFIX = "__rel"
+#: FK pomijane (rodzic cache/through — pickowanie rodzica nie ma sensu).
+_SKIP_FK = ("rekord",)
+
+
+def _field_names(model):
+    return {f.name for f in model._meta.get_fields() if isinstance(f, models.Field)}
+
+
+def _label_fields(model):
+    """Pola-etykiety modelu (przecięcie z ``_LABEL_FIELDS``, wg priorytetu)."""
+    names = _field_names(model)
+    return [f for f in _LABEL_FIELDS if f in names]
+
+
+def _is_bool_field(model, name):
+    try:
+        return isinstance(model._meta.get_field(name), models.BooleanField)
+    except FieldDoesNotExist:
+        return False
+
+
+def _visible_qs(model):
+    """Queryset modelu z odfiltrowanymi niewidocznymi pozycjami."""
+    qs = model.objects.all()
+    for name in _VISIBLE_WHEN_TRUE:
+        if _is_bool_field(model, name):
+            qs = qs.filter(**{name: True})
+    for name in _VISIBLE_WHEN_FALSE:
+        if _is_bool_field(model, name):
+            qs = qs.filter(**{name: False})
+    return qs
+
+
+def _picker_label(model):
+    """Callable ``obj -> etykieta`` dla pickera; dla publikacji preferuje opis
+    bibliograficzny (bez HTML). ``None`` → AutocompleteField użyje ``str(obj)``."""
+    if "opis_bibliograficzny_cache" in _field_names(model):
+
+        def label(obj):
+            return strip_tags(getattr(obj, "opis_bibliograficzny_cache", "") or "")
+
+        return label
+    return None
+
+
+def _picker_fks(model):
+    """FK (many_to_one) modelu nadające się na picker — model docelowy ma
+    pole-etykietę i nie jest to pomijany rodzic ``rekord``."""
+    out = []
+    for f in model._meta.get_fields():
+        if not (f.is_relation and getattr(f, "many_to_one", False)):
+            continue
+        if f.related_model is None or f.name in _SKIP_FK:
+            continue
+        if not _label_fields(f.related_model):
+            continue
+        out.append(f)
+    return out
+
+
+class RelPickerSchemaMixin:
+    """Mixin auto-generujący pickery ``<fk>__rel`` (patrz docstring modułu)."""
+
+    def get_fields(self, model):
+        fields = list(super().get_fields(model))
+        fields += [f.name + _REL_SUFFIX for f in _picker_fks(model)]
+        return fields
+
+    def get_field_instance(self, model, field_name):
+        if field_name.endswith(_REL_SUFFIX):
+            fk_name = field_name[: -len(_REL_SUFFIX)]
+            try:
+                fk = model._meta.get_field(fk_name)
+            except FieldDoesNotExist:
+                fk = None
+            if fk is not None and fk.is_relation and fk.related_model is not None:
+                related = fk.related_model
+                return AutocompleteField(
+                    model=model,
+                    name=field_name,
+                    lookup_name=fk_name,
+                    nullable=getattr(fk, "null", False),
+                    queryset=_visible_qs(related),
+                    search_fields=_label_fields(related),
+                    label=_picker_label(related),
+                )
+        return super().get_field_instance(model, field_name)
+
+
+class BppQLSchema(RelPickerSchemaMixin, ExtrasSchema):
+    """ExtrasSchema (agregaty + części dat) + auto-pickery ``<fk>__rel``.
+
+    Wspólny dla widoku „Szukaj zapytaniem" i adminów (``djangoql_schema =
+    BppQLSchema``). Mapa modeli jest budowana lazy per-model, więc ten sam
+    schemat obsługuje dowolny model (Rekord, Autor, Wydawnictwo_*, Patent,
+    Praca_Doktorska/Habilitacyjna, …).
+    """

--- a/src/bpp/newsfragments/+admin-djangoql-rel.feature.rst
+++ b/src/bpp/newsfragments/+admin-djangoql-rel.feature.rst
@@ -1,0 +1,6 @@
+Wyszukiwarka DjangoQL w adminie (Źródło, Autor, Wydawca, Jednostka,
+Autor-Dyscyplina, Wydawnictwo ciągłe/zwarte oraz nowo włączone Patent, Praca
+doktorska i habilitacyjna) używa teraz wspólnego schematu ``BppQLSchema``:
+pickery ``<fk>__rel`` z autocomplete wyboru obiektu (po widocznych pozycjach),
+agregaty relacji, części dat oraz rozbicie „dlaczego 0 wyników". Publikacje są
+opisywane/szukane przez opis bibliograficzny.

--- a/src/bpp/newsfragments/+zapytanie-autocomplete-rel.feature.rst
+++ b/src/bpp/newsfragments/+zapytanie-autocomplete-rel.feature.rst
@@ -1,0 +1,4 @@
+Widok „Szukaj zapytaniem": pola ``<fk>__rel`` z autocomplete (wybór autora,
+jednostki, tytułu naukowego z podpowiedzi i filtrowanie po wybranym obiekcie),
+obok dotychczasowej składni z kropką. Gdy zapytanie zwróci 0 rekordów, widok
+pokazuje teraz rozbicie wyjaśniające, który warunek wyzerował wynik.

--- a/src/bpp/templates/bpp/_zapytanie_breakdown.html
+++ b/src/bpp/templates/bpp/_zapytanie_breakdown.html
@@ -1,0 +1,23 @@
+{# Rekurencyjny widok rozbicia "dlaczego 0 wynikow". #}
+{# Oczekuje `node` (dict: text, count, role, children, truncated) i `is_root`. #}
+{% if is_root %}
+    <div class="callout warning zapytanie-breakdown-box" role="status">
+        <h3><span class="fi-info"></span> Dlaczego 0 wynikow?</h3>
+        {% if node.truncated %}
+            <p><em>Pokazano tylko warunki najwyzszego poziomu (zapytanie zbyt zlozone, aby rozbic w calosci).</em></p>
+        {% endif %}
+    </div>
+{% endif %}
+<ul class="zapytanie-breakdown role-{{ node.role }}">
+    <li>
+        <code>{{ node.text }}</code> &rarr; <strong>{{ node.count }}</strong> trafien
+        {% if node.role == "killer_and" %}
+            <span class="label alert">tu koncza sie dane: po polaczeniu zostaje 0</span>
+        {% elif node.role == "dead_or_branch" %}
+            <span class="label secondary">ta galaz OR nic nie wnosi (0 trafien)</span>
+        {% endif %}
+        {% for child in node.children %}
+            {% include "bpp/_zapytanie_breakdown.html" with node=child is_root=False %}
+        {% endfor %}
+    </li>
+</ul>

--- a/src/bpp/templates/bpp/_zapytanie_breakdown.html
+++ b/src/bpp/templates/bpp/_zapytanie_breakdown.html
@@ -1,20 +1,19 @@
-{# Rekurencyjny widok rozbicia "dlaczego 0 wynikow". #}
-{# Oczekuje `node` (dict: text, count, role, children, truncated) i `is_root`. #}
+{# Rekurencyjny widok rozbicia „dlaczego 0 wyników". #}
+{# Oczekuje `node` (dict: text, count, label, children, truncated) i `is_root`. #}
 {% if is_root %}
-    <div class="callout warning zapytanie-breakdown-box" role="status">
-        <h3><span class="fi-info"></span> Dlaczego 0 wynikow?</h3>
+    <p class="zapytanie-breakdown-title">
+        <span class="fi-info"></span> Dlaczego 0 wyników?
         {% if node.truncated %}
-            <p><em>Pokazano tylko warunki najwyzszego poziomu (zapytanie zbyt zlozone, aby rozbic w calosci).</em></p>
+            <span class="zapytanie-breakdown-trunc">(pokazano tylko warunki najwyższego poziomu — zapytanie zbyt złożone, by rozbić w całości)</span>
         {% endif %}
-    </div>
+    </p>
 {% endif %}
-<ul class="zapytanie-breakdown role-{{ node.role }}">
+<ul class="zapytanie-breakdown">
     <li>
-        <code>{{ node.text }}</code> &rarr; <strong>{{ node.count }}</strong> trafien
-        {% if node.role == "killer_and" %}
-            <span class="label alert">tu koncza sie dane: po polaczeniu zostaje 0</span>
-        {% elif node.role == "dead_or_branch" %}
-            <span class="label secondary">ta galaz OR nic nie wnosi (0 trafien)</span>
+        <code>{{ node.text }}</code>
+        <span class="zapytanie-breakdown-count{% if node.count == 0 and not is_root %} zapytanie-breakdown-count--zero{% endif %}">→ {{ node.count }} trafień</span>
+        {% if node.label %}
+            <span class="zapytanie-breakdown-note">{{ node.label }}</span>
         {% endif %}
         {% for child in node.children %}
             {% include "bpp/_zapytanie_breakdown.html" with node=child is_root=False %}

--- a/src/bpp/templates/bpp/zapytanie.html
+++ b/src/bpp/templates/bpp/zapytanie.html
@@ -433,6 +433,9 @@
                 {% include "bpp/_zapytanie_pager.html" %}
             {% else %}
                 <p><em>Brak rekordow pasujacych do zapytania.</em></p>
+                {% if breakdown %}
+                    {% include "bpp/_zapytanie_breakdown.html" with node=breakdown is_root=True %}
+                {% endif %}
             {% endif %}
         {% endif %}
     </div>

--- a/src/bpp/templates/bpp/zapytanie.html
+++ b/src/bpp/templates/bpp/zapytanie.html
@@ -199,6 +199,42 @@
             color: #64748b;
             white-space: nowrap;
         }
+        /* Rozbicie "dlaczego 0 wynikow" — delikatne, jak naglowek + lista */
+        .zapytanie-breakdown-title {
+            font-size: 0.9rem;
+            font-weight: 600;
+            color: #6b7280;
+            margin: 0.9rem 0 0.3rem;
+        }
+        .zapytanie-breakdown-title .fi-info { color: #9ca3af; }
+        .zapytanie-breakdown-trunc {
+            font-weight: 400;
+            font-style: italic;
+            color: #9ca3af;
+        }
+        ul.zapytanie-breakdown {
+            list-style: none;
+            margin: 0 0 0 0.25rem;
+            font-size: 0.9rem;
+            line-height: 1.5;
+        }
+        ul.zapytanie-breakdown ul.zapytanie-breakdown { margin-left: 1.1rem; }
+        ul.zapytanie-breakdown li { margin: 0.1rem 0; }
+        .zapytanie-breakdown code {
+            font-size: 0.82rem;
+            background: #f3f4f6;
+            color: #374151;
+            padding: 0.05rem 0.3rem;
+            border-radius: 3px;
+        }
+        .zapytanie-breakdown-count { color: #9ca3af; }
+        .zapytanie-breakdown-count--zero { color: #dc2626; font-weight: 600; }
+        .zapytanie-breakdown-note {
+            margin-left: 0.4rem;
+            color: #b45309;
+            font-style: italic;
+            font-size: 0.82rem;
+        }
     </style>
 {% endblock %}
 

--- a/src/bpp/tests/test_zapytanie.py
+++ b/src/bpp/tests/test_zapytanie.py
@@ -530,3 +530,46 @@ def test_picker_excludes_hidden_records(superuser_client):
     items = response.json()["items"]
     assert any(f"[{widoczny.pk}]" in item for item in items)
     assert not any(f"[{ukryty.pk}]" in item for item in items)
+
+
+@pytest.mark.django_db
+def test_schema_publication_models_have_pickers():
+    """Wspólny BppQLSchema auto-generuje pickery dla modeli publikacji
+    (admin Patent/doktorat/habilitacja korzysta z tego samego schematu)."""
+    from bpp.djangoql_schema import BppQLSchema
+    from bpp.models import Patent, Praca_Doktorska, Praca_Habilitacyjna
+
+    cases = {
+        Patent: ["status_korekty__rel", "wydzial__rel"],
+        Praca_Doktorska: [
+            "autor__rel",
+            "promotor__rel",
+            "wydawca__rel",
+            "jednostka__rel",
+        ],
+        Praca_Habilitacyjna: ["jednostka__rel", "wydawca__rel", "typ_kbn__rel"],
+    }
+    for model, expected in cases.items():
+        schema = BppQLSchema(model)
+        fields = schema.models[schema.model_label(model)]
+        for name in expected:
+            assert name in fields, f"{model.__name__}: brak {name}"
+
+
+def test_publication_admins_use_bpp_ql_schema():
+    """Adminy publikacji (w tym nowo włączone) mają djangoql_schema = BppQLSchema."""
+    from bpp.admin.patent import Patent_Admin
+    from bpp.admin.praca_doktorska import Praca_DoktorskaAdmin
+    from bpp.admin.praca_habilitacyjna import Praca_HabilitacyjnaAdmin
+    from bpp.admin.wydawnictwo_ciagle import Wydawnictwo_CiagleAdmin
+    from bpp.admin.wydawnictwo_zwarte import Wydawnictwo_ZwarteAdmin
+    from bpp.djangoql_schema import BppQLSchema
+
+    for admin_cls in (
+        Patent_Admin,
+        Praca_DoktorskaAdmin,
+        Praca_HabilitacyjnaAdmin,
+        Wydawnictwo_CiagleAdmin,
+        Wydawnictwo_ZwarteAdmin,
+    ):
+        assert admin_cls.djangoql_schema is BppQLSchema, admin_cls.__name__

--- a/src/bpp/tests/test_zapytanie.py
+++ b/src/bpp/tests/test_zapytanie.py
@@ -213,3 +213,103 @@ def test_zapytanie_examples_no_unary_not():
             f"Unary 'not (...)' znaleziono w przykladzie "
             f"(level={level}, model={model}, desc={desc!r}): {query!r}"
         )
+
+
+@pytest.mark.django_db
+def test_tytul_rel_picker_filters_by_pk():
+    from djangoql.queryset import apply_search
+
+    from bpp.models import Autor
+    from bpp.models.autor import Tytul
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    # Baseline DB may already contain these titles (tytul.json fixture).
+    prof, _ = Tytul.objects.get_or_create(nazwa="profesor", defaults={"skrot": "prof."})
+    dr, _ = Tytul.objects.get_or_create(nazwa="doktor", defaults={"skrot": "dr"})
+    a1 = baker.make("bpp.Autor", nazwisko="Kowalski", tytul=prof)
+    baker.make("bpp.Autor", nazwisko="Nowak", tytul=dr)
+
+    qs = apply_search(
+        Autor.objects.all(),
+        'tytul__rel = "profesor [%d]"' % prof.pk,
+        schema=BppZapytanieSchema,
+    )
+    assert list(qs) == [a1]
+
+
+@pytest.mark.django_db
+def test_tytul_dot_traversal_still_works():
+    from djangoql.queryset import apply_search
+
+    from bpp.models import Autor
+    from bpp.models.autor import Tytul
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    # Baseline DB may already contain this title (tytul.json fixture).
+    prof, _ = Tytul.objects.get_or_create(nazwa="profesor", defaults={"skrot": "prof."})
+    a1 = baker.make("bpp.Autor", nazwisko="Kowalski", tytul=prof)
+
+    qs = apply_search(
+        Autor.objects.all(), 'tytul.skrot = "prof."', schema=BppZapytanieSchema
+    )
+    assert list(qs) == [a1]
+
+
+@pytest.mark.django_db
+def test_aktualna_jednostka_rel_picker_filters_by_pk():
+    from djangoql.queryset import apply_search
+
+    from bpp.models import Autor, Jednostka
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    j = baker.make(Jednostka, nazwa="Katedra X")
+    a1 = baker.make("bpp.Autor", nazwisko="Kowalski", aktualna_jednostka=j)
+    baker.make("bpp.Autor", nazwisko="Nowak")
+
+    qs = apply_search(
+        Autor.objects.all(),
+        'aktualna_jednostka__rel = "Katedra X [%d]"' % j.pk,
+        schema=BppZapytanieSchema,
+    )
+    assert list(qs) == [a1]
+
+
+@pytest.mark.django_db
+def test_autor_schema_has_rel_fields_and_keeps_relations():
+    from bpp.models import Autor
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    schema = BppZapytanieSchema(Autor)
+    fields = schema.models["bpp.autor"]
+    assert "tytul__rel" in fields
+    assert "aktualna_jednostka__rel" in fields
+    assert fields["tytul"].type == "relation"  # trawersacja zachowana
+
+
+@pytest.mark.django_db
+def test_rekord_schema_has_autorzy_rel_pickers():
+    from bpp.models.cache import Autorzy, Rekord
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    schema = BppZapytanieSchema(Rekord)
+    autorzy_fields = schema.models[schema.model_label(Autorzy)]
+    assert "autor__rel" in autorzy_fields
+    assert "jednostka__rel" in autorzy_fields
+    assert autorzy_fields["autor"].type == "relation"
+
+
+@pytest.mark.django_db
+def test_rekord_autorzy_autor_rel_filters_real_fk():
+    from djangoql.queryset import apply_search
+
+    from bpp.models.cache import Rekord
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    qs = apply_search(
+        Rekord.objects.all(),
+        'autorzy.autor__rel = "X [1]"',
+        schema=BppZapytanieSchema,
+    )
+    sql = str(qs.query).lower()
+    assert "autor__rel" not in sql  # remap zadziałał (nie filtruje alt-nazwy)
+    assert "autor_id" in sql

--- a/src/bpp/tests/test_zapytanie.py
+++ b/src/bpp/tests/test_zapytanie.py
@@ -313,3 +313,91 @@ def test_rekord_autorzy_autor_rel_filters_real_fk():
     sql = str(qs.query).lower()
     assert "autor__rel" not in sql  # remap zadziałał (nie filtruje alt-nazwy)
     assert "autor_id" in sql
+
+
+@pytest.mark.django_db
+def test_zapytanie_view_tytul_rel_picker(superuser_client):
+    from bpp.models.autor import Tytul
+
+    prof, _ = Tytul.objects.get_or_create(
+        nazwa="profesor", defaults={"skrot": "prof."}
+    )
+    baker.make("bpp.Autor", nazwisko="Kowalski", tytul=prof)
+
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "autor", "query": 'tytul__rel = "profesor [%d]"' % prof.pk},
+    )
+    assert response.status_code == 200
+    assert response.context["error"] is None
+    assert response.context["count"] == 1
+
+
+@pytest.mark.django_db
+def test_zapytanie_suggestions_tytul_rel_returns_options(superuser_client):
+    from bpp.models.autor import Tytul
+
+    prof, _ = Tytul.objects.get_or_create(
+        nazwa="profesor", defaults={"skrot": "prof."}
+    )
+    url = reverse("bpp:zapytanie_suggestions", kwargs={"model_key": "autor"})
+    response = superuser_client.get(url, {"field": "tytul__rel", "search": "profesor"})
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert any("[%d]" % prof.pk in item for item in items)
+
+
+@pytest.mark.django_db
+def test_zapytanie_suggestions_autor_rel_dal_smoke(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    url = reverse("bpp:zapytanie_suggestions", kwargs={"model_key": "rekord"})
+    response = superuser_client.get(
+        url, {"field": "autorzy.autor__rel", "search": "Kowal"}
+    )
+    assert response.status_code == 200
+    assert isinstance(response.json()["items"], list)
+
+
+def _breakdown_leaves(node):
+    if not node["children"]:
+        yield node
+    for ch in node["children"]:
+        yield from _breakdown_leaves(ch)
+
+
+@pytest.mark.django_db
+def test_zapytanie_breakdown_explains_zero(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "autor", "query": 'nazwisko = "Kowalski" and imiona = "asdfo"'},
+    )
+    assert response.status_code == 200
+    assert response.context["count"] == 0
+    breakdown = response.context["breakdown"]
+    assert breakdown is not None
+    assert breakdown["count"] == 0
+    leaves = {leaf["text"]: leaf["count"] for leaf in _breakdown_leaves(breakdown)}
+    assert any("asdfo" in t and c == 0 for t, c in leaves.items())
+
+
+@pytest.mark.django_db
+def test_zapytanie_no_breakdown_when_results(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski")
+    response = superuser_client.get(
+        reverse(URL), {"model": "autor", "query": 'nazwisko = "Kowalski"'}
+    )
+    assert response.context["count"] == 1
+    assert response.context["breakdown"] is None
+
+
+@pytest.mark.django_db
+def test_zapytanie_breakdown_rendered_in_html(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "autor", "query": 'nazwisko = "Kowalski" and imiona = "asdfo"'},
+    )
+    html = response.content.decode("utf-8")
+    assert "Dlaczego 0 wynikow" in html
+    assert "asdfo" in html

--- a/src/bpp/tests/test_zapytanie.py
+++ b/src/bpp/tests/test_zapytanie.py
@@ -399,5 +399,67 @@ def test_zapytanie_breakdown_rendered_in_html(superuser_client):
         {"model": "autor", "query": 'nazwisko = "Kowalski" and imiona = "asdfo"'},
     )
     html = response.content.decode("utf-8")
-    assert "Dlaczego 0 wynikow" in html
+    assert "Dlaczego 0 wyników" in html
+    assert "ten warunek nie pasuje do żadnego rekordu" in html
     assert "asdfo" in html
+    # warunek z 0 trafień (poza korzeniem) ma czerwoną liczbę
+    assert "zapytanie-breakdown-count--zero" in html
+
+
+@pytest.mark.django_db
+def test_zapytanie_breakdown_culprit_on_leaf_not_root(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "autor", "query": 'nazwisko = "Kowalski" and imiona = "asdfo"'},
+    )
+    breakdown = response.context["breakdown"]
+    assert breakdown["label"] is None  # korzeń (główne zapytanie) bez etykiety
+    leaves = list(_breakdown_leaves(breakdown))
+    culprit = next(leaf for leaf in leaves if "asdfo" in leaf["text"])
+    assert culprit["count"] == 0
+    assert culprit["label"] == "ten warunek nie pasuje do żadnego rekordu"
+    other = next(leaf for leaf in leaves if "Kowalski" in leaf["text"])
+    assert other["label"] is None  # warunek z trafieniami nie jest winowajcą
+
+
+@pytest.mark.django_db
+def test_zapytanie_breakdown_root_intersection_not_labeled(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    baker.make("bpp.Autor", nazwisko="Nowak", imiona="Anna")
+    response = superuser_client.get(
+        reverse(URL),
+        {"model": "autor", "query": 'nazwisko = "Kowalski" and imiona = "Anna"'},
+    )
+    breakdown = response.context["breakdown"]
+    assert breakdown["count"] == 0
+    assert breakdown["label"] is None  # głównego zapytania nie etykietujemy
+    # każdy warunek z osobna coś zwraca (>=1), więc żaden liść nie jest winowajcą
+    for leaf in _breakdown_leaves(breakdown):
+        assert leaf["count"] >= 1
+        assert leaf["label"] is None
+
+
+@pytest.mark.django_db
+def test_zapytanie_breakdown_no_label_on_dead_or_branch(superuser_client):
+    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    response = superuser_client.get(
+        reverse(URL),
+        {
+            "model": "autor",
+            "query": (
+                '(nazwisko = "Kowalski" or nazwisko = "Xyz") and imiona = "asdfo"'
+            ),
+        },
+    )
+    breakdown = response.context["breakdown"]
+    assert breakdown["count"] == 0
+    leaves = list(_breakdown_leaves(breakdown))
+    # martwa gałąź w NIEPUSTYM OR — nie winowajca, bez etykiety (koniec z szumem)
+    xyz = next(leaf for leaf in leaves if "Xyz" in leaf["text"])
+    assert xyz["count"] == 0
+    assert xyz["label"] is None
+    # realny winowajca: warunek z 0 trafień połączony AND-em
+    asdfo = next(leaf for leaf in leaves if "asdfo" in leaf["text"])
+    assert asdfo["count"] == 0
+    assert asdfo["label"] == "ten warunek nie pasuje do żadnego rekordu"

--- a/src/bpp/tests/test_zapytanie.py
+++ b/src/bpp/tests/test_zapytanie.py
@@ -231,7 +231,7 @@ def test_tytul_rel_picker_filters_by_pk():
 
     qs = apply_search(
         Autor.objects.all(),
-        'tytul__rel = "profesor [%d]"' % prof.pk,
+        f'tytul__rel = "profesor [{prof.pk}]"',
         schema=BppZapytanieSchema,
     )
     assert list(qs) == [a1]
@@ -268,7 +268,7 @@ def test_aktualna_jednostka_rel_picker_filters_by_pk():
 
     qs = apply_search(
         Autor.objects.all(),
-        'aktualna_jednostka__rel = "Katedra X [%d]"' % j.pk,
+        f'aktualna_jednostka__rel = "Katedra X [{j.pk}]"',
         schema=BppZapytanieSchema,
     )
     assert list(qs) == [a1]
@@ -319,14 +319,12 @@ def test_rekord_autorzy_autor_rel_filters_real_fk():
 def test_zapytanie_view_tytul_rel_picker(superuser_client):
     from bpp.models.autor import Tytul
 
-    prof, _ = Tytul.objects.get_or_create(
-        nazwa="profesor", defaults={"skrot": "prof."}
-    )
+    prof, _ = Tytul.objects.get_or_create(nazwa="profesor", defaults={"skrot": "prof."})
     baker.make("bpp.Autor", nazwisko="Kowalski", tytul=prof)
 
     response = superuser_client.get(
         reverse(URL),
-        {"model": "autor", "query": 'tytul__rel = "profesor [%d]"' % prof.pk},
+        {"model": "autor", "query": f'tytul__rel = "profesor [{prof.pk}]"'},
     )
     assert response.status_code == 200
     assert response.context["error"] is None
@@ -337,14 +335,12 @@ def test_zapytanie_view_tytul_rel_picker(superuser_client):
 def test_zapytanie_suggestions_tytul_rel_returns_options(superuser_client):
     from bpp.models.autor import Tytul
 
-    prof, _ = Tytul.objects.get_or_create(
-        nazwa="profesor", defaults={"skrot": "prof."}
-    )
+    prof, _ = Tytul.objects.get_or_create(nazwa="profesor", defaults={"skrot": "prof."})
     url = reverse("bpp:zapytanie_suggestions", kwargs={"model_key": "autor"})
     response = superuser_client.get(url, {"field": "tytul__rel", "search": "profesor"})
     assert response.status_code == 200
     items = response.json()["items"]
-    assert any("[%d]" % prof.pk in item for item in items)
+    assert any(f"[{prof.pk}]" in item for item in items)
 
 
 @pytest.mark.django_db
@@ -463,3 +459,74 @@ def test_zapytanie_breakdown_no_label_on_dead_or_branch(superuser_client):
     asdfo = next(leaf for leaf in leaves if "asdfo" in leaf["text"])
     assert asdfo["count"] == 0
     assert asdfo["label"] == "ten warunek nie pasuje do żadnego rekordu"
+
+
+@pytest.mark.django_db
+def test_rekord_zrodlo_rel_filters_real_fk():
+    from djangoql.queryset import apply_search
+
+    from bpp.models.cache import Rekord
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    qs = apply_search(
+        Rekord.objects.all(), 'zrodlo__rel = "X [1]"', schema=BppZapytanieSchema
+    )
+    sql = str(qs.query).lower()
+    assert "zrodlo__rel" not in sql  # remap na realny FK
+    assert "zrodlo_id" in sql
+
+
+@pytest.mark.django_db
+def test_rekord_and_autorzy_have_extended_pickers():
+    from bpp.models.cache import Autorzy, Rekord
+    from bpp.views.zapytanie import BppZapytanieSchema
+
+    schema = BppZapytanieSchema(Rekord)
+    rekord_fields = schema.models[schema.model_label(Rekord)]
+    for name in (
+        "zrodlo__rel",
+        "wydawca__rel",
+        "konferencja__rel",
+        "wydawnictwo_nadrzedne__rel",
+        "charakter_formalny__rel",
+        "jezyk__rel",
+        "typ_kbn__rel",
+        "status_korekty__rel",
+        "openaccess_licencja__rel",
+    ):
+        assert name in rekord_fields, name
+    assert rekord_fields["zrodlo"].type == "relation"  # trawersacja zachowana
+
+    autorzy_fields = schema.models[schema.model_label(Autorzy)]
+    for name in (
+        "dyscyplina_naukowa__rel",
+        "kierunek_studiow__rel",
+        "typ_odpowiedzialnosci__rel",
+    ):
+        assert name in autorzy_fields, name
+
+
+@pytest.mark.django_db
+def test_zapytanie_suggestions_zrodlo_rel(superuser_client):
+    from bpp.models import Zrodlo
+
+    z = baker.make(Zrodlo, nazwa="Nature Reviews Cardiology")
+    url = reverse("bpp:zapytanie_suggestions", kwargs={"model_key": "rekord"})
+    response = superuser_client.get(url, {"field": "zrodlo__rel", "search": "Nature"})
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert any(f"[{z.pk}]" in item for item in items)
+
+
+@pytest.mark.django_db
+def test_picker_excludes_hidden_records(superuser_client):
+    from bpp.models import Jezyk
+
+    widoczny = baker.make(Jezyk, nazwa="ZZTESTwidoczny", widoczny=True)
+    ukryty = baker.make(Jezyk, nazwa="ZZTESTukryty", widoczny=False)
+    url = reverse("bpp:zapytanie_suggestions", kwargs={"model_key": "rekord"})
+    response = superuser_client.get(url, {"field": "jezyk__rel", "search": "ZZTEST"})
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert any(f"[{widoczny.pk}]" in item for item in items)
+    assert not any(f"[{ukryty.pk}]" in item for item in items)

--- a/src/bpp/views/zapytanie.py
+++ b/src/bpp/views/zapytanie.py
@@ -4,43 +4,27 @@ import logging
 from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import FieldDoesNotExist, FieldError, ValidationError
+from django.core.exceptions import FieldError, ValidationError
 from django.core.paginator import Paginator
-from django.db import models
 from django.http import Http404, HttpResponse
 from django.urls import NoReverseMatch, reverse
 from django.views.generic import FormView, View
 from djangoql.breakdown import explain_empty
 from djangoql.exceptions import DjangoQLError
-from djangoql.extras import ExtrasSchema
 from djangoql.queryset import apply_search
 from djangoql.serializers import SuggestionsAPISerializer
 from djangoql.views import SuggestionsAPIView
 
 from bpp.const import GR_WPROWADZANIE_DANYCH
-from bpp.models import (
-    Autor,
-    Charakter_Formalny,
-    Dyscyplina_Naukowa,
-    Jezyk,
-    Kierunek_Studiow,
-    Konferencja,
-    Status_Korekty,
-    Typ_KBN,
-    Typ_Odpowiedzialnosci,
-    Wydawca,
-    Wydawnictwo_Zwarte,
-    Zrodlo,
-)
-from bpp.models.autor import Tytul
-from bpp.models.cache import Autorzy, Rekord
-from bpp.models.openaccess import (
-    Czas_Udostepnienia_OpenAccess,
-    Licencja_OpenAccess,
-    Wersja_Tekstu_OpenAccess,
-)
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Autor
+from bpp.models.cache import Rekord
 
 logger = logging.getLogger(__name__)
+
+# Alias zgodności: schemat przeniesiony do bpp.djangoql_schema (wspólny trzon
+# dla widoku i adminów). Widok i testy odwołują się do BppZapytanieSchema.
+BppZapytanieSchema = BppQLSchema
 
 MODEL_REKORD = "rekord"
 MODEL_AUTOR = "autor"
@@ -286,117 +270,6 @@ EXAMPLES = [
         ],
     },
 ]
-
-
-def _dal_picker(lookup_name, url, search_fields):
-    """Config pickera ``<fk>__rel`` korzystającego z czystego endpointu DAL."""
-    return {
-        "lookup_name": lookup_name,
-        "url": url,
-        "search_fields": list(search_fields),
-    }
-
-
-_VISIBILITY_FIELDS = ("widoczny", "widoczna", "widoczne")
-
-
-def _visible_qs(model):
-    """Queryset modelu z odfiltrowanymi niewidocznymi pozycjami, jeśli model ma
-    boolowskie pole ``widoczny``/``widoczna``/``widoczne`` — żeby lookup nie
-    podpowiadał ukrytych rekordów. W przeciwnym razie pełny ``all()``.
-    """
-    for name in _VISIBILITY_FIELDS:
-        try:
-            field = model._meta.get_field(name)
-        except FieldDoesNotExist:
-            continue
-        if isinstance(field, models.BooleanField):
-            return model.objects.filter(**{name: True})
-    return model.objects.all()
-
-
-def _qs_picker(lookup_name, model, search_fields=("nazwa", "skrot")):
-    """Config pickera ``<fk>__rel`` z querysetu modelu — icontains po
-    ``search_fields``, ograniczony limitem AutocompleteField. Używane zamiast
-    endpointów DAL, które bywają bramkowane grupą albo doklejają opcję „utwórz".
-    Niewidoczne pozycje są odfiltrowane (patrz :func:`_visible_qs`).
-    """
-    return {
-        "lookup_name": lookup_name,
-        "queryset": _visible_qs(model),
-        "search_fields": list(search_fields),
-    }
-
-
-class BppZapytanieSchema(ExtrasSchema):
-    """ExtrasSchema z pickerami ``<fk>__rel`` obok trawersacji z kropką.
-
-    Kropka (``autorzy.autor.nazwisko``, ``tytul.skrot``, ``zrodlo.nazwa``)
-    zostaje domyślna dla każdego FK. ``<fk>__rel`` to picker: wybierasz obiekt
-    z podpowiedzi i filtruje po jego pk (``lookup_name`` = realny FK), z
-    fallbackiem free-text (icontains po ``search_fields``). ``autor`` i
-    ``jednostka`` używają czystych endpointów DAL; reszta — querysetów
-    (bramkowane / „create" endpointy DAL odpadają).
-    """
-
-    autocomplete = {
-        Autorzy: {
-            "autor__rel": _dal_picker(
-                "autor", "bpp:public-autor-autocomplete", ["nazwisko", "imiona"]
-            ),
-            "jednostka__rel": _dal_picker(
-                "jednostka", "bpp:jednostka-widoczna-autocomplete", ["nazwa", "skrot"]
-            ),
-            "dyscyplina_naukowa__rel": _qs_picker(
-                "dyscyplina_naukowa", Dyscyplina_Naukowa, ["nazwa", "kod"]
-            ),
-            "kierunek_studiow__rel": _qs_picker("kierunek_studiow", Kierunek_Studiow),
-            "typ_odpowiedzialnosci__rel": _qs_picker(
-                "typ_odpowiedzialnosci", Typ_Odpowiedzialnosci
-            ),
-        },
-        Autor: {
-            "tytul__rel": _qs_picker("tytul", Tytul),
-            "aktualna_jednostka__rel": _dal_picker(
-                "aktualna_jednostka",
-                "bpp:jednostka-widoczna-autocomplete",
-                ["nazwa", "skrot"],
-            ),
-        },
-        Rekord: {
-            "zrodlo__rel": _qs_picker("zrodlo", Zrodlo),
-            "wydawca__rel": _qs_picker("wydawca", Wydawca, ["nazwa"]),
-            "konferencja__rel": _qs_picker("konferencja", Konferencja, ["nazwa"]),
-            "wydawnictwo_nadrzedne__rel": _qs_picker(
-                "wydawnictwo_nadrzedne", Wydawnictwo_Zwarte, ["tytul_oryginalny"]
-            ),
-            "charakter_formalny__rel": _qs_picker(
-                "charakter_formalny", Charakter_Formalny
-            ),
-            "typ_kbn__rel": _qs_picker("typ_kbn", Typ_KBN),
-            "jezyk__rel": _qs_picker("jezyk", Jezyk),
-            "status_korekty__rel": _qs_picker(
-                "status_korekty", Status_Korekty, ["nazwa"]
-            ),
-            "openaccess_wersja_tekstu__rel": _qs_picker(
-                "openaccess_wersja_tekstu", Wersja_Tekstu_OpenAccess
-            ),
-            "openaccess_licencja__rel": _qs_picker(
-                "openaccess_licencja", Licencja_OpenAccess
-            ),
-            "openaccess_czas_publikacji__rel": _qs_picker(
-                "openaccess_czas_publikacji", Czas_Udostepnienia_OpenAccess
-            ),
-        },
-    }
-
-    def get_fields(self, model):
-        # Picker `<fk>__rel` to nazwa syntetyczna (nie ma jej w modelu) — trzeba
-        # ją dorzucić do introspekcji, inaczej nie będzie zbudowana ani
-        # podpowiedziana. Klucze mapy `autocomplete` to dokładnie te nazwy.
-        fields = list(super().get_fields(model))
-        fields += list(self.autocomplete.get(model, {}).keys())
-        return fields
 
 
 class WprowadzanieDanychOrSuperuserMixin(LoginRequiredMixin, UserPassesTestMixin):

--- a/src/bpp/views/zapytanie.py
+++ b/src/bpp/views/zapytanie.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
@@ -8,6 +9,7 @@ from django.core.paginator import Paginator
 from django.http import Http404, HttpResponse
 from django.urls import NoReverseMatch, reverse
 from django.views.generic import FormView, View
+from djangoql.breakdown import explain_empty
 from djangoql.exceptions import DjangoQLError
 from djangoql.extras import ExtrasSchema
 from djangoql.queryset import apply_search
@@ -18,6 +20,8 @@ from bpp.const import GR_WPROWADZANIE_DANYCH
 from bpp.models import Autor
 from bpp.models.autor import Tytul
 from bpp.models.cache import Autorzy, Rekord
+
+logger = logging.getLogger(__name__)
 
 MODEL_REKORD = "rekord"
 MODEL_AUTOR = "autor"
@@ -53,6 +57,11 @@ EXAMPLES = [
                     ("", 'charakter_formalny.skrot = "AC"'),
                     ("", 'tytul_oryginalny ~ "covid" and rok = 2023'),
                     ("", 'doi != ""'),
+                    ("Po autorze (autocomplete)", 'autorzy.autor__rel = "Kowalski"'),
+                    (
+                        "Po jednostce (autocomplete)",
+                        'autorzy.jednostka__rel = "Kardiologii"',
+                    ),
                 ],
             },
             {
@@ -64,6 +73,11 @@ EXAMPLES = [
                     ("", 'nazwisko = "Kowalski" and imiona = "Jan"'),
                     ("", 'orcid != ""'),
                     ("", 'aktualna_jednostka.nazwa ~ "Medycyny"'),
+                    ("Po tytule (autocomplete)", 'tytul__rel = "prof."'),
+                    (
+                        "Po jednostce (autocomplete)",
+                        'aktualna_jednostka__rel = "Kardiologii"',
+                    ),
                 ],
             },
         ],
@@ -384,7 +398,7 @@ class ZapytanieView(WprowadzanieDanychOrSuperuserMixin, FormView):
         count = None
 
         try:
-            queryset = apply_search(queryset, query, schema=ExtrasSchema)
+            queryset = apply_search(queryset, query, schema=BppZapytanieSchema)
             # Filtrowanie po relacjach "do wielu" (np. autorzy.autor.nazwisko)
             # tworzy JOIN, ktory zwielokrotnia ten sam rekord raz na kazdy
             # pasujacy wiersz powiazany. .distinct() zwija te duplikaty, zeby
@@ -400,6 +414,20 @@ class ZapytanieView(WprowadzanieDanychOrSuperuserMixin, FormView):
         if results_page is not None and model_key == MODEL_REKORD:
             self._attach_admin_urls(results_page)
 
+        breakdown = None
+        if error is None and count == 0:
+            try:
+                breakdown = explain_empty(
+                    model.objects.all(), query, schema=BppZapytanieSchema
+                )
+            except (DjangoQLError, FieldError, ValidationError, ValueError):
+                logger.exception(
+                    "explain_empty zawiodlo dla zapytania %r (model=%s)",
+                    query,
+                    model_key,
+                )
+                breakdown = None
+
         context = self.get_context_data(
             form=form,
             results=results_page,
@@ -407,6 +435,7 @@ class ZapytanieView(WprowadzanieDanychOrSuperuserMixin, FormView):
             error=error,
             model_key=model_key,
             query=query,
+            breakdown=breakdown,
         )
         return self.render_to_response(context)
 
@@ -450,7 +479,7 @@ class ZapytanieIntrospectView(WprowadzanieDanychOrSuperuserMixin, View):
         suggestions_url = reverse(
             "bpp:zapytanie_suggestions", kwargs={"model_key": model_key}
         )
-        schema = ExtrasSchema(model)
+        schema = BppZapytanieSchema(model)
         payload = SuggestionsAPISerializer(suggestions_url).serialize(schema)
         return HttpResponse(
             content=json.dumps(payload),
@@ -461,5 +490,5 @@ class ZapytanieIntrospectView(WprowadzanieDanychOrSuperuserMixin, View):
 class ZapytanieSuggestionsView(WprowadzanieDanychOrSuperuserMixin, View):
     def get(self, request, model_key):
         model = _resolve_model_or_404(model_key)
-        view = SuggestionsAPIView.as_view(schema=ExtrasSchema(model))
+        view = SuggestionsAPIView.as_view(schema=BppZapytanieSchema(model))
         return view(request)

--- a/src/bpp/views/zapytanie.py
+++ b/src/bpp/views/zapytanie.py
@@ -4,8 +4,9 @@ import logging
 from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import FieldError, ValidationError
+from django.core.exceptions import FieldDoesNotExist, FieldError, ValidationError
 from django.core.paginator import Paginator
+from django.db import models
 from django.http import Http404, HttpResponse
 from django.urls import NoReverseMatch, reverse
 from django.views.generic import FormView, View
@@ -17,9 +18,27 @@ from djangoql.serializers import SuggestionsAPISerializer
 from djangoql.views import SuggestionsAPIView
 
 from bpp.const import GR_WPROWADZANIE_DANYCH
-from bpp.models import Autor
+from bpp.models import (
+    Autor,
+    Charakter_Formalny,
+    Dyscyplina_Naukowa,
+    Jezyk,
+    Kierunek_Studiow,
+    Konferencja,
+    Status_Korekty,
+    Typ_KBN,
+    Typ_Odpowiedzialnosci,
+    Wydawca,
+    Wydawnictwo_Zwarte,
+    Zrodlo,
+)
 from bpp.models.autor import Tytul
 from bpp.models.cache import Autorzy, Rekord
+from bpp.models.openaccess import (
+    Czas_Udostepnienia_OpenAccess,
+    Licencja_OpenAccess,
+    Wersja_Tekstu_OpenAccess,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -269,52 +288,114 @@ EXAMPLES = [
 ]
 
 
+def _dal_picker(lookup_name, url, search_fields):
+    """Config pickera ``<fk>__rel`` korzystającego z czystego endpointu DAL."""
+    return {
+        "lookup_name": lookup_name,
+        "url": url,
+        "search_fields": list(search_fields),
+    }
+
+
+_VISIBILITY_FIELDS = ("widoczny", "widoczna", "widoczne")
+
+
+def _visible_qs(model):
+    """Queryset modelu z odfiltrowanymi niewidocznymi pozycjami, jeśli model ma
+    boolowskie pole ``widoczny``/``widoczna``/``widoczne`` — żeby lookup nie
+    podpowiadał ukrytych rekordów. W przeciwnym razie pełny ``all()``.
+    """
+    for name in _VISIBILITY_FIELDS:
+        try:
+            field = model._meta.get_field(name)
+        except FieldDoesNotExist:
+            continue
+        if isinstance(field, models.BooleanField):
+            return model.objects.filter(**{name: True})
+    return model.objects.all()
+
+
+def _qs_picker(lookup_name, model, search_fields=("nazwa", "skrot")):
+    """Config pickera ``<fk>__rel`` z querysetu modelu — icontains po
+    ``search_fields``, ograniczony limitem AutocompleteField. Używane zamiast
+    endpointów DAL, które bywają bramkowane grupą albo doklejają opcję „utwórz".
+    Niewidoczne pozycje są odfiltrowane (patrz :func:`_visible_qs`).
+    """
+    return {
+        "lookup_name": lookup_name,
+        "queryset": _visible_qs(model),
+        "search_fields": list(search_fields),
+    }
+
+
 class BppZapytanieSchema(ExtrasSchema):
     """ExtrasSchema z pickerami ``<fk>__rel`` obok trawersacji z kropką.
 
-    Notacja z kropką (``autorzy.autor.nazwisko``, ``tytul.skrot``) zostaje
-    domyślna dla FK. ``<fk>__rel`` to picker autocomplete: wybierasz konkretny
-    obiekt z podpowiedzi i filtruje po jego pk (``lookup_name`` wskazuje realny
-    FK), z fallbackiem free-text (icontains po ``search_fields``).
+    Kropka (``autorzy.autor.nazwisko``, ``tytul.skrot``, ``zrodlo.nazwa``)
+    zostaje domyślna dla każdego FK. ``<fk>__rel`` to picker: wybierasz obiekt
+    z podpowiedzi i filtruje po jego pk (``lookup_name`` = realny FK), z
+    fallbackiem free-text (icontains po ``search_fields``). ``autor`` i
+    ``jednostka`` używają czystych endpointów DAL; reszta — querysetów
+    (bramkowane / „create" endpointy DAL odpadają).
     """
 
     autocomplete = {
         Autorzy: {
-            "autor__rel": {
-                "lookup_name": "autor",
-                "url": "bpp:public-autor-autocomplete",
-                "search_fields": ["nazwisko", "imiona"],
-            },
-            "jednostka__rel": {
-                "lookup_name": "jednostka",
-                "url": "bpp:jednostka-autocomplete",
-                "search_fields": ["nazwa", "skrot"],
-            },
+            "autor__rel": _dal_picker(
+                "autor", "bpp:public-autor-autocomplete", ["nazwisko", "imiona"]
+            ),
+            "jednostka__rel": _dal_picker(
+                "jednostka", "bpp:jednostka-widoczna-autocomplete", ["nazwa", "skrot"]
+            ),
+            "dyscyplina_naukowa__rel": _qs_picker(
+                "dyscyplina_naukowa", Dyscyplina_Naukowa, ["nazwa", "kod"]
+            ),
+            "kierunek_studiow__rel": _qs_picker("kierunek_studiow", Kierunek_Studiow),
+            "typ_odpowiedzialnosci__rel": _qs_picker(
+                "typ_odpowiedzialnosci", Typ_Odpowiedzialnosci
+            ),
         },
         Autor: {
-            "tytul__rel": {
-                "lookup_name": "tytul",
-                "queryset": Tytul.objects.all(),
-                "search_fields": ["nazwa", "skrot"],
-            },
-            "aktualna_jednostka__rel": {
-                "lookup_name": "aktualna_jednostka",
-                "url": "bpp:jednostka-autocomplete",
-                "search_fields": ["nazwa", "skrot"],
-            },
+            "tytul__rel": _qs_picker("tytul", Tytul),
+            "aktualna_jednostka__rel": _dal_picker(
+                "aktualna_jednostka",
+                "bpp:jednostka-widoczna-autocomplete",
+                ["nazwa", "skrot"],
+            ),
         },
-    }
-
-    # Nazwy syntetyczne (nie ma ich w modelu) — bez tego nie zostaną
-    # zintrospektowane ani podpowiedziane.
-    _REL_FIELDS = {
-        Autorzy: ["autor__rel", "jednostka__rel"],
-        Autor: ["tytul__rel", "aktualna_jednostka__rel"],
+        Rekord: {
+            "zrodlo__rel": _qs_picker("zrodlo", Zrodlo),
+            "wydawca__rel": _qs_picker("wydawca", Wydawca, ["nazwa"]),
+            "konferencja__rel": _qs_picker("konferencja", Konferencja, ["nazwa"]),
+            "wydawnictwo_nadrzedne__rel": _qs_picker(
+                "wydawnictwo_nadrzedne", Wydawnictwo_Zwarte, ["tytul_oryginalny"]
+            ),
+            "charakter_formalny__rel": _qs_picker(
+                "charakter_formalny", Charakter_Formalny
+            ),
+            "typ_kbn__rel": _qs_picker("typ_kbn", Typ_KBN),
+            "jezyk__rel": _qs_picker("jezyk", Jezyk),
+            "status_korekty__rel": _qs_picker(
+                "status_korekty", Status_Korekty, ["nazwa"]
+            ),
+            "openaccess_wersja_tekstu__rel": _qs_picker(
+                "openaccess_wersja_tekstu", Wersja_Tekstu_OpenAccess
+            ),
+            "openaccess_licencja__rel": _qs_picker(
+                "openaccess_licencja", Licencja_OpenAccess
+            ),
+            "openaccess_czas_publikacji__rel": _qs_picker(
+                "openaccess_czas_publikacji", Czas_Udostepnienia_OpenAccess
+            ),
+        },
     }
 
     def get_fields(self, model):
+        # Picker `<fk>__rel` to nazwa syntetyczna (nie ma jej w modelu) — trzeba
+        # ją dorzucić do introspekcji, inaczej nie będzie zbudowana ani
+        # podpowiedziana. Klucze mapy `autocomplete` to dokładnie te nazwy.
         fields = list(super().get_fields(model))
-        fields += self._REL_FIELDS.get(model, [])
+        fields += list(self.autocomplete.get(model, {}).keys())
         return fields
 
 

--- a/src/bpp/views/zapytanie.py
+++ b/src/bpp/views/zapytanie.py
@@ -366,6 +366,40 @@ class ZapytanieForm(forms.Form):
     )
 
 
+def _annotate_breakdown(node, is_root=True, on_zero_path=True):
+    """Dodaje do każdego węzła drzewa rozbicia pole ``label`` (tekst albo None)
+    — komunikat wskazujący realnego „winowajcę" zerowego wyniku.
+
+    Idea: idziemy „ścieżką zera". Dziecko jest na ścieżce zera tylko jeśli SAMO
+    ma 0 trafień — bo wtedy jego pustka propaguje się w górę przez AND (każdy
+    zerowy operand zeruje AND) albo współtworzy puste OR. Zero pochłonięte przez
+    NIEPUSTE OR (np. ``(A or B)`` które zwraca >0, mimo że B=0) NIE jest
+    winowajcą — i nie dostaje etykiety (koniec z szumem na martwych gałęziach).
+
+    Etykietę dostaje tylko NAJGŁĘBSZY węzeł na ścieżce zera (ten, poniżej
+    którego nie ma już zera) — czyli realny powód pustki:
+    - liść z 0 trafień → „warunek nie pasuje do niczego",
+    - AND-przecięcie (każdy operand z osobna >0, ale razem 0) → etykieta na AND.
+
+    Korzeń (główne zapytanie) NIE dostaje etykiety — i tak wiadomo, że ma 0 (po
+    to renderujemy rozbicie). Liczone z samych ``count`` + struktury — bez
+    polegania na rolach z djangoql.
+    """
+    children = node["children"]
+    child_on_zero = [on_zero_path and c["count"] == 0 for c in children]
+    is_deepest_zero = on_zero_path and node["count"] == 0 and not any(child_on_zero)
+    label = None
+    if is_deepest_zero and not is_root:
+        if children:
+            label = "każdy warunek z osobna coś zwraca, ale ich połączenie daje 0"
+        else:
+            label = "ten warunek nie pasuje do żadnego rekordu"
+    node["label"] = label
+    for child, czp in zip(children, child_on_zero, strict=True):
+        _annotate_breakdown(child, is_root=False, on_zero_path=czp)
+    return node
+
+
 class ZapytanieView(WprowadzanieDanychOrSuperuserMixin, FormView):
     template_name = "bpp/zapytanie.html"
     form_class = ZapytanieForm
@@ -427,6 +461,8 @@ class ZapytanieView(WprowadzanieDanychOrSuperuserMixin, FormView):
                     model_key,
                 )
                 breakdown = None
+            if breakdown is not None:
+                _annotate_breakdown(breakdown)
 
         context = self.get_context_data(
             form=form,

--- a/src/bpp/views/zapytanie.py
+++ b/src/bpp/views/zapytanie.py
@@ -16,7 +16,8 @@ from djangoql.views import SuggestionsAPIView
 
 from bpp.const import GR_WPROWADZANIE_DANYCH
 from bpp.models import Autor
-from bpp.models.cache import Rekord
+from bpp.models.autor import Tytul
+from bpp.models.cache import Autorzy, Rekord
 
 MODEL_REKORD = "rekord"
 MODEL_AUTOR = "autor"
@@ -252,6 +253,55 @@ EXAMPLES = [
         ],
     },
 ]
+
+
+class BppZapytanieSchema(ExtrasSchema):
+    """ExtrasSchema z pickerami ``<fk>__rel`` obok trawersacji z kropką.
+
+    Notacja z kropką (``autorzy.autor.nazwisko``, ``tytul.skrot``) zostaje
+    domyślna dla FK. ``<fk>__rel`` to picker autocomplete: wybierasz konkretny
+    obiekt z podpowiedzi i filtruje po jego pk (``lookup_name`` wskazuje realny
+    FK), z fallbackiem free-text (icontains po ``search_fields``).
+    """
+
+    autocomplete = {
+        Autorzy: {
+            "autor__rel": {
+                "lookup_name": "autor",
+                "url": "bpp:public-autor-autocomplete",
+                "search_fields": ["nazwisko", "imiona"],
+            },
+            "jednostka__rel": {
+                "lookup_name": "jednostka",
+                "url": "bpp:jednostka-autocomplete",
+                "search_fields": ["nazwa", "skrot"],
+            },
+        },
+        Autor: {
+            "tytul__rel": {
+                "lookup_name": "tytul",
+                "queryset": Tytul.objects.all(),
+                "search_fields": ["nazwa", "skrot"],
+            },
+            "aktualna_jednostka__rel": {
+                "lookup_name": "aktualna_jednostka",
+                "url": "bpp:jednostka-autocomplete",
+                "search_fields": ["nazwa", "skrot"],
+            },
+        },
+    }
+
+    # Nazwy syntetyczne (nie ma ich w modelu) — bez tego nie zostaną
+    # zintrospektowane ani podpowiedziane.
+    _REL_FIELDS = {
+        Autorzy: ["autor__rel", "jednostka__rel"],
+        Autor: ["tytul__rel", "aktualna_jednostka__rel"],
+    }
+
+    def get_fields(self, model):
+        fields = list(super().get_fields(model))
+        fields += self._REL_FIELDS.get(model, [])
+        return fields
 
 
 class WprowadzanieDanychOrSuperuserMixin(LoginRequiredMixin, UserPassesTestMixin):

--- a/uv.lock
+++ b/uv.lock
@@ -456,7 +456,7 @@ requires-dist = [
     { name = "django-tinymce", specifier = ">=5.0.0" },
     { name = "django-weasyprint", specifier = ">=2.5.0" },
     { name = "django-webmaster-verification", specifier = "==0.4.3" },
-    { name = "djangoql-iplweb", specifier = "==0.21.0" },
+    { name = "djangoql-iplweb", specifier = ">=0.23.0" },
     { name = "djangorestframework", specifier = "==3.17.1" },
     { name = "gunicorn", specifier = ">=26.0.0" },
     { name = "isbnlib", specifier = ">=3.10.14" },
@@ -2223,14 +2223,14 @@ wheels = [
 
 [[package]]
 name = "djangoql-iplweb"
-version = "0.21.0"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/81/3bdfae4611dc83680f938211fe1bf1f34fd44e47d2295120905c7fd6f839/djangoql_iplweb-0.21.0.tar.gz", hash = "sha256:d65e696b234be1082b3d8216922001b3267ccb4d98eb1ac98b7bd909c6f49057", size = 230892, upload-time = "2026-06-03T19:15:15.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/e0/c3164c6afb2cb9da40cb0b9f1b94c1c0e4dcffee0b585f24978f63017fb3/djangoql_iplweb-0.23.0.tar.gz", hash = "sha256:e830893e88354592b03810c46c7918e475991747ff1a95415bb246916e88b38d", size = 248317, upload-time = "2026-06-04T09:21:54.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/d7/895e46505d4faf9058a7acdadb635880a55c0caffd6b627f36db067468fe/djangoql_iplweb-0.21.0-py3-none-any.whl", hash = "sha256:bb86c84938fa4b9a8a8e9f7582d9716d0bacdbc6288c99c485dc0e8cd8f0b8d3", size = 256958, upload-time = "2026-06-03T19:15:12.35Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a2/9c884132b408899dd836b43a7c1bd0b16fea173ea9b8c2f089186806df6c/djangoql_iplweb-0.23.0-py3-none-any.whl", hash = "sha256:20fb4af8770ab30a0bfb5190ecad58f5e02aa3ea76f2cb1aa969547fafe07b1f", size = 283909, upload-time = "2026-06-04T09:21:52.825Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Widok „Szukaj zapytaniem": pola `<fk>__rel` z autocomplete (autor, jednostka, tytuł naukowy) obok zachowanej trawersacji z kropką, plus rozbicie `explain_empty()` gdy zapytanie zwraca 0 rekordów.

## Co
- **Pickery `<fk>__rel`** (djangoql 0.23.0 `lookup_name`): `autorzy.autor__rel`, `autorzy.jednostka__rel` (Rekord), `tytul__rel`, `aktualna_jednostka__rel` (Autor). Wybierasz konkretny obiekt z podpowiedzi → filtr po pk; fallback free-text (icontains). **Trawersacja z kropką działa bez zmian** (`autorzy.autor.nazwisko`, `tytul.skrot`, …).
- **„Dlaczego 0 wyników"**: `explain_empty()` rozbija zapytanie i wskazuje warunek, który wyzerował wynik (killer AND / martwe gałęzie OR). Renderowane pod komunikatem braku wyników.
- Źródła sugestii: `public-autor-autocomplete`, `jednostka-autocomplete` (DAL, in-process), `Tytul.objects.all()` (queryset).
- Bump `djangoql-iplweb>=0.23.0`. Przykłady free-text + news fragment.

## Testy
74 passed (`src/bpp/tests/test_zapytanie.py`): picker po pk, zachowana trawersacja, introspekcja schematu, endpoint sugestii, breakdown „0", render HTML.

Spec: `docs/superpowers/specs/2026-06-04-zapytanie-autocomplete-rel-i-wyjasnienie-zero-design.md`
Plan: `docs/superpowers/plans/2026-06-04-zapytanie-autocomplete-rel.md`

Zależny od djangoql-iplweb 0.23.0 (PR iplweb/djangoql-iplweb#11, zmergowany + wydany).

🤖 Generated with [Claude Code](https://claude.com/claude-code)