### PR TITLE
perf(cache): trigger bpp_refresh_cache() — filtr po surowym PK + pruning indeksów (#311, #309)

### DIFF
--- a/docs/superpowers/plans/2026-06-04-cache-trigger-pk-filter.md
+++ b/docs/superpowers/plans/2026-06-04-cache-trigger-pk-filter.md
@@ -1,0 +1,381 @@
+# Optymalizacja triggera cache: filtr po surowym PK — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Przyspieszyć trigger `bpp_refresh_cache()` odświeżający `bpp_rekord_mat`
+i `bpp_autorzy_mat`, zamieniając filtr po wyliczanej kolumnie-tablicy (`Seq Scan`
++ drogie planowanie 5-gałęziowej unii) na filtr po surowym, indeksowanym PK
+tabeli bazowej (`Index Cond` seek), bez zmiany zawartości cache.
+
+**Architecture:** Do każdego z 10 widoków per-typ (`*_view`, `*_autorzy`)
+doklejamy przez `CREATE OR REPLACE VIEW` skalarną kolumnę `object_id_raw`
+(= PK publikacji). Przepisujemy funkcję `bpp_refresh_cache()` tak, by SELECT-em
+źródłowym celowała w konkretny widok per-typ (wg `TD["table_name"]`) i filtrowała
+po `object_id_raw`. Operacje na mat-tabelach (DELETE / `ON CONFLICT (id)`)
+zostają na indeksowanej tablicy `id`. `bpp_rekord` / `bpp_autorzy` / mat-tabele
+/ widoki zależne pozostają nietknięte (brak `DROP … CASCADE`).
+
+**Tech Stack:** PostgreSQL, plpython3u, Django migrations (RunPython +
+`load_custom_sql`), pytest + model_bakery.
+
+**Powiązane issues:** #311 (ta optymalizacja), #309 (niedeterministyczny advisory
+lock — domykany przy okazji rewrite'u funkcji).
+
+---
+
+## Kontekst i dowody (dlaczego)
+
+Trigger jest `FOR EACH ROW` na 8 tabelach (5 publikacji + 3 `*_autor`), wszystkie
+wołają `bpp_refresh_cache()` (plpython3u). Najnowsza wersja funkcji:
+`src/bpp/migrations/0399_fix_refresh_cache_upsert.sql`. Funkcja dla
+zmienionego rekordu robi upsert do mat-tabel selektem:
+
+```sql
+SELECT ... FROM bpp_rekord  WHERE id = ARRAY[ct, obj]::INTEGER[2]
+SELECT ... FROM bpp_autorzy WHERE id = ARRAY[ct, obj]::INTEGER[2] [AND autor_id = X]
+```
+
+`bpp_rekord`/`bpp_autorzy` = `UNION ALL` 5 pod-widoków; `id` = `ARRAY[(SELECT ct…),
+tabela.id]`. PostgreSQL nie rozkłada `array_eq` na `tabela.id = obj`, więc:
+
+- predykat ląduje jako `Filter`, nie `Index Cond` → **Seq Scan** tabel bazowych,
+- skanowane są **wszystkie 5 gałęzi** (ct to InitPlan, nieznany statycznie),
+- drogie **planowanie** unii, powtarzane przy każdym `plpy.execute`.
+
+**EXPLAIN ANALYZE na realnym dumpie produkcyjnym (~2 tys. rekordów):**
+
+| | Obecnie (`bpp_rekord` WHERE id = ARRAY[6,830]) | Po (`*_view` WHERE object_id_raw = 830) |
+|---|---|---|
+| Dostęp do tabeli | `Seq Scan` 1658 wierszy | `Index Cond: (id = 830)` |
+| Planning Time | 22,6 ms | 2,5 ms |
+| Execution Time | 2,3 ms | 0,2 ms |
+
+Część wykonawcza skaluje się z rozmiarem tabeli → na produkcji (100k+) przewaga
+rośnie liniowo.
+
+**Potwierdzenie kwalifikowalności indeksu (`enable_seqscan=off`, niezależne od
+liczby wierszy):** `id = ARRAY[…]` → `Filter`; `(id)[2] = obj` → `Filter`
+(Postgres nie zwija subskryptu konstruktora tablicy); `surowa_kolumna = obj` →
+`Index Cond`. Jedyne wyjście: filtr po realnej skalarnej kolumnie = PK bazowy.
+
+**Weryfikacja, że `CREATE OR REPLACE VIEW` z dokejoną kolumną nie psuje zależnych
+`SELECT *`:** sprawdzone empirycznie — widok zależny zachowuje zamrożoną listę
+kolumn, mat-tabela (snapshot) nietknięta.
+
+---
+
+## Mapowanie trigger → widok per-typ → surowy PK
+
+| Tabela triggera | Odśwież | Widok rekordu | Widok autorów | `object_id_raw` ze źródła |
+|---|---|---|---|---|
+| `bpp_wydawnictwo_ciagle` | rekord+autorzy | `bpp_wydawnictwo_ciagle_view` | `bpp_wydawnictwo_ciagle_autorzy` | `…ciagle.id` / `…ciagle_autor.rekord_id` |
+| `bpp_wydawnictwo_ciagle_autor` | autorzy | — | `bpp_wydawnictwo_ciagle_autorzy` | `…ciagle_autor.rekord_id` |
+| `bpp_wydawnictwo_zwarte` | rekord+autorzy | `bpp_wydawnictwo_zwarte_view` | `bpp_wydawnictwo_zwarte_autorzy` | `…zwarte.id` / `…zwarte_autor.rekord_id` |
+| `bpp_wydawnictwo_zwarte_autor` | autorzy | — | `bpp_wydawnictwo_zwarte_autorzy` | `…zwarte_autor.rekord_id` |
+| `bpp_patent` | rekord+autorzy | `bpp_patent_view` | `bpp_patent_autorzy` | `…patent.id` / `…patent_autor.rekord_id` |
+| `bpp_patent_autor` | autorzy | — | `bpp_patent_autorzy` | `…patent_autor.rekord_id` |
+| `bpp_praca_doktorska` | rekord+autorzy | `bpp_praca_doktorska_view` | `bpp_praca_doktorska_autorzy` | `…doktorska.id` |
+| `bpp_praca_habilitacyjna` | rekord+autorzy | `bpp_praca_habilitacyjna_view` | `bpp_praca_habilitacyjna_autorzy` | `…habilitacyjna.id` |
+
+Widoki autorów through-table (`ciagle/zwarte/patent_autorzy`) wystawiają
+`object_id_raw = <tabela>_autor.rekord_id` (indeks na `rekord_id` istnieje).
+Widoki doktorat/habilitacja (`FROM praca…, bpp_autor`) wystawiają
+`object_id_raw = praca….id` (PK). `autor_id` we wszystkich jest realną kolumną.
+
+---
+
+## File Structure
+
+- **Create** `src/bpp/migrations/0421_cache_trigger_pk_filter.sql` — 10×
+  `CREATE OR REPLACE VIEW` (dokejona `object_id_raw`) + `CREATE OR REPLACE
+  FUNCTION bpp_refresh_cache()` (routing + filtr po `object_id_raw` +
+  deterministyczny advisory lock).
+- **Create** `src/bpp/migrations/0421_cache_trigger_pk_filter.py` — `RunPython`
+  ładujący SQL przez `load_custom_sql` (wzorzec jak `0418_*`), `dependencies =
+  [("bpp", "0420_autor_pokazuj_siec_powiazan_and_more")]`, reverse = przywrócenie
+  poprzednich definicji (lub `noop` z komentarzem — patrz Task 4).
+- **Create/Modify test** `src/bpp/tests/test_cache/test_cache_pk_filter.py` —
+  testy poprawności (treść cache identyczna) + obecność `object_id_raw`.
+- Widoki bazowe generujemy z **żywej bazy** (`pg_get_viewdef`, stan po 0420),
+  doklejając kolumnę przed głównym `FROM` — to ground truth, bezpieczniejsze niż
+  ręczne przepisywanie 660 linii DDL.
+
+---
+
+## Task 1: Wygeneruj SQL widoków per-typ z dokejoną `object_id_raw`
+
+**Files:**
+- Create: `src/bpp/migrations/0421_cache_trigger_pk_filter.sql` (część widokowa)
+
+- [ ] **Step 1: Wyciągnij definicje 10 widoków z żywej bazy i dokej kolumnę.**
+
+Dla każdego widoku: `pg_get_viewdef(<view>, true)`, wstaw `, <raw_expr> AS
+object_id_raw` bezpośrednio przed pierwszą linią `^   FROM ` (3 spacje = główny
+FROM; subzapytania są głębiej wcięte), owiń w `CREATE OR REPLACE VIEW <view> AS
+… ;`. Mapowanie `raw_expr` jak w tabeli wyżej. Skrypt pomocniczy
+(uruchom przy podłączonym `run-site`):
+
+```bash
+PG_PORT=$(cat .dev_helpers_pg_port); export PGPASSWORD=password
+PSQL="psql -h localhost -p $PG_PORT -U bpp -d bpp -X -tA"
+emit() { # $1=view $2=raw_expr
+  echo "CREATE OR REPLACE VIEW $1 AS"
+  $PSQL -c "SELECT pg_get_viewdef('$1'::regclass, true);" \
+    | awk -v raw="$2" '/^   FROM / && !d {print "    , " raw " AS object_id_raw"; d=1} {print}'
+  echo ";"
+  echo
+}
+{
+  emit bpp_wydawnictwo_ciagle_view          bpp_wydawnictwo_ciagle.id
+  emit bpp_wydawnictwo_zwarte_view          bpp_wydawnictwo_zwarte.id
+  emit bpp_patent_view                      bpp_patent.id
+  emit bpp_praca_doktorska_view             bpp_praca_doktorska.id
+  emit bpp_praca_habilitacyjna_view         bpp_praca_habilitacyjna.id
+  emit bpp_wydawnictwo_ciagle_autorzy       bpp_wydawnictwo_ciagle_autor.rekord_id
+  emit bpp_wydawnictwo_zwarte_autorzy       bpp_wydawnictwo_zwarte_autor.rekord_id
+  emit bpp_patent_autorzy                   bpp_patent_autor.rekord_id
+  emit bpp_praca_doktorska_autorzy          bpp_praca_doktorska.id
+  emit bpp_praca_habilitacyjna_autorzy      bpp_praca_habilitacyjna.id
+} > /tmp/views_part.sql
+```
+
+- [ ] **Step 2: Zweryfikuj składnię (apply + rollback w transakcji).**
+
+```bash
+( echo "BEGIN;"; cat /tmp/views_part.sql; echo "ROLLBACK;" ) \
+  | psql -h localhost -p "$PG_PORT" -U bpp -d bpp -X -v ON_ERROR_STOP=1
+```
+Expected: brak błędów (ROLLBACK na końcu). Jeśli któryś widok ma główny `FROM`
+z innym wcięciem niż 3 spacje — popraw `awk` i ponów.
+
+- [ ] **Step 3: Potwierdź seek dla wariantu zoptymalizowanego.**
+
+```bash
+( echo "BEGIN;"; cat /tmp/views_part.sql;
+  echo "EXPLAIN SELECT * FROM bpp_wydawnictwo_ciagle_view WHERE object_id_raw = 830;";
+  echo "ROLLBACK;" ) | psql -h localhost -p "$PG_PORT" -U bpp -d bpp -X | grep -i "Index Cond"
+```
+Expected: `Index Cond: (id = 830)`.
+
+## Task 2: Przepisz funkcję `bpp_refresh_cache()`
+
+**Files:**
+- Modify: `src/bpp/migrations/0421_cache_trigger_pk_filter.sql` (część funkcji)
+
+- [ ] **Step 1: Dopisz `CREATE OR REPLACE FUNCTION` z routingiem.** Kluczowe
+  różnice względem `0399`:
+  - jawny słownik routingu `TABLE → (pub_base, is_through)`,
+  - źródłowy SELECT z widoku per-typ: `… FROM {pub_base}_view WHERE object_id_raw
+    = {object_id}` (rekord) oraz `… FROM {pub_base}_autorzy WHERE object_id_raw =
+    {object_id} [AND autor_id = {autor_id}]` (autorzy),
+  - filtr mat-tabel (DELETE / ON CONFLICT) **bez zmian** — `id`/`rekord_id =
+    ARRAY[ct,obj]`,
+  - advisory lock: `plpy.execute("SELECT pg_advisory_xact_lock(%s, %s)",
+    [content_type_id, object_id])` (domyka #309),
+  - `content_type_id` liczony dla `pub_base` (nie dla modelu `*_autor`).
+
+Pełny szkielet funkcji w sekcji „Szkielet funkcji" poniżej.
+
+- [ ] **Step 2: Dopisz część funkcji do pliku `.sql`** (po części widokowej),
+  całość owinięta w `BEGIN; … COMMIT;`.
+
+## Task 3: Migracja `.py`
+
+**Files:**
+- Create: `src/bpp/migrations/0421_cache_trigger_pk_filter.py`
+
+- [ ] **Step 1: Napisz migrację wzorem `0418_autor_dyscyplina_trigger_on_conflict.py`.**
+
+```python
+from pathlib import Path
+from django.db import connection, migrations
+
+
+def load_sql(apps, schema_editor):
+    sql_file = Path(__file__).parent / "0421_cache_trigger_pk_filter.sql"
+    with open(sql_file) as f:
+        sql = f.read()
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0420_autor_pokazuj_siec_powiazan_and_more"),
+    ]
+    operations = [
+        migrations.RunPython(load_sql, migrations.RunPython.noop),
+    ]
+```
+
+- [ ] **Step 2: Uruchom migrację na żywej bazie i sprawdź brak błędów.**
+
+Run: `uv run python src/manage.py migrate bpp` (przy działającym `run-site`
+wskaż jego port przez zmienne — albo odpal w ramach pytest/testcontainers).
+Expected: `Applying bpp.0421_cache_trigger_pk_filter… OK`.
+
+## Task 4: Testy poprawności (cache niezmieniony)
+
+**Files:**
+- Create: `src/bpp/tests/test_cache/test_cache_pk_filter.py`
+
+- [ ] **Step 1: Test — `object_id_raw` istnieje i daje seek.**
+
+```python
+import pytest
+from django.db import connection
+
+
+@pytest.mark.django_db
+def test_object_id_raw_present_on_views():
+    views = [
+        "bpp_wydawnictwo_ciagle_view", "bpp_wydawnictwo_zwarte_view",
+        "bpp_patent_view", "bpp_praca_doktorska_view",
+        "bpp_praca_habilitacyjna_view", "bpp_wydawnictwo_ciagle_autorzy",
+        "bpp_wydawnictwo_zwarte_autorzy", "bpp_patent_autorzy",
+        "bpp_praca_doktorska_autorzy", "bpp_praca_habilitacyjna_autorzy",
+    ]
+    with connection.cursor() as c:
+        for v in views:
+            c.execute(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_name=%s AND column_name='object_id_raw'", [v])
+            assert c.fetchone(), f"{v} nie ma object_id_raw"
+```
+
+- [ ] **Step 2: Test — edycja publikacji aktualizuje `bpp_rekord_mat` (treść).**
+
+```python
+from model_bakery import baker
+from bpp.models import Rekord, Wydawnictwo_Ciagle
+
+
+@pytest.mark.django_db
+def test_edit_refreshes_rekord_mat():
+    w = baker.make(Wydawnictwo_Ciagle, tytul_oryginalny="STARY")
+    w.tytul_oryginalny = "NOWY TYTUL"
+    w.save()
+    assert Rekord.objects.get_for_model(w).tytul_oryginalny == "NOWY TYTUL"
+```
+
+- [ ] **Step 3: Test — dodanie/edycja autora aktualizuje `bpp_autorzy_mat`.**
+
+```python
+from bpp.models import Autor, Jednostka
+
+
+@pytest.mark.django_db
+def test_author_change_refreshes_autorzy_mat():
+    w = baker.make(Wydawnictwo_Ciagle)
+    a = baker.make(Autor)
+    j = baker.make(Jednostka)
+    w.dodaj_autora(a, j)
+    rec = Rekord.objects.get_for_model(w)
+    assert rec.autorzy_set.filter(autor=a).exists()
+```
+
+- [ ] **Step 4: Uruchom istniejące + nowe testy cache.**
+
+Run: `uv run pytest src/bpp/tests/test_cache/ -q`
+Expected: PASS (istniejące testy cache to siatka bezpieczeństwa — zachowanie
+musi być identyczne).
+
+## Task 5: Weryfikacja i commit
+
+- [ ] **Step 1: `ruff check` / `ruff format` na zmienionych plikach `.py`.**
+- [ ] **Step 2: Pełny przebieg `test_cache` + smoke kilku testów multiseek
+  (które czytają `bpp_rekord_mat`).**
+- [ ] **Step 3: Commit** (`feat(cache): filtr triggera po surowym PK …`,
+  `Closes #311`, `Closes #309`).
+
+---
+
+## Szkielet funkcji `bpp_refresh_cache()`
+
+```python
+table_name = TD["table_name"]
+event = TD["event"]
+field = "old" if event in ("DELETE", "UPDATE") else "new"
+
+# routing: tabela triggera -> (bazowa tabela publikacji, czy to through-table autorow)
+ROUTING = {
+    "bpp_wydawnictwo_ciagle":       ("bpp_wydawnictwo_ciagle", False),
+    "bpp_wydawnictwo_ciagle_autor": ("bpp_wydawnictwo_ciagle", True),
+    "bpp_wydawnictwo_zwarte":       ("bpp_wydawnictwo_zwarte", False),
+    "bpp_wydawnictwo_zwarte_autor": ("bpp_wydawnictwo_zwarte", True),
+    "bpp_patent":                   ("bpp_patent", False),
+    "bpp_patent_autor":             ("bpp_patent", True),
+    "bpp_praca_doktorska":          ("bpp_praca_doktorska", False),
+    "bpp_praca_habilitacyjna":      ("bpp_praca_habilitacyjna", False),
+}
+pub_base, is_through = ROUTING[table_name]
+model_name = pub_base.split("_", 1)[1]          # np. 'wydawnictwo_ciagle'
+app_name = pub_base.split("_", 1)[0]            # 'bpp'
+
+# object_id = PK publikacji
+object_id = TD[field]["rekord_id"] if is_through else TD[field]["id"]
+
+# content_type_id (cache w GD jak w 0399)
+cache_key = "django_content_type_ver_2"
+if GD.get(cache_key) is None:
+    GD[cache_key] = {}
+if pub_base not in GD[cache_key]:
+    r = plpy.execute(
+        "SELECT id FROM django_content_type "
+        "WHERE app_label = '%s' AND model = '%s'" % (app_name, model_name))
+    GD[cache_key][pub_base] = r[0]["id"]
+content_type_id = GD[cache_key][pub_base]
+
+# co odświeżamy
+refresh_rekord = not is_through
+refresh_autor = True            # publikacje: tak; through: tak (tylko autorzy)
+
+rekord_view = pub_base + "_view"
+autorzy_view = pub_base + "_autorzy"
+
+# filtr autora przy edycji wiersza *_autor — nie przeliczaj wszystkich autorow
+autor_extra = ""
+if is_through:
+    autor_extra = " AND autor_id = %s" % TD[field]["autor_id"]
+
+mat_id_arr = "ARRAY[%s, %s]::INTEGER[2]" % (content_type_id, object_id)
+
+# kolumny mat-tabel z cache (jak 0399) -> get_table_columns()
+# ... (bez zmian względem 0399: dynamiczna lista kolumn + ON CONFLICT (id))
+
+plpy.execute("SELECT pg_advisory_xact_lock(%s, %s)",
+             [content_type_id, object_id])   # deterministyczny lock (domyka #309)
+
+with plpy.subtransaction():
+    if refresh_rekord:
+        # DELETE FROM bpp_rekord_mat WHERE id = <mat_id_arr>
+        # if not DELETE: INSERT INTO bpp_rekord_mat (<cols>)
+        #   SELECT <cols> FROM {rekord_view} WHERE object_id_raw = {object_id}
+        #   ON CONFLICT (id) DO UPDATE SET <set>
+        # (DELETE bpp_rekord_mat kaskaduje na bpp_autorzy_mat — patrz 0399)
+        ...
+    if refresh_autor:
+        # DELETE FROM bpp_autorzy_mat WHERE rekord_id = <mat_id_arr> {autor_extra}
+        # if not DELETE: INSERT INTO bpp_autorzy_mat (<cols>)
+        #   SELECT <cols> FROM {autorzy_view}
+        #   WHERE object_id_raw = {object_id} {autor_extra}
+        #   ON CONFLICT (id) DO UPDATE SET <set>
+        ...
+```
+
+Uwaga: zachowujemy logikę „DELETE rekordu kaskaduje na autorzy_mat (FK), więc po
+odświeżeniu rekordu odświeżamy też autorzy" z `0399`. Część budująca dynamiczną
+listę kolumn, `ON CONFLICT (id)` i `plpy.subtransaction()` przenosimy z `0399`
+bez zmian — różni się **tylko** klauzula źródłowa (`FROM … WHERE object_id_raw`)
+i klucz advisory lock.
+
+## Reverse migracji
+
+`RunPython.noop` jako reverse jest akceptowalne (forward jest idempotentny —
+`CREATE OR REPLACE`), ALE czystszy reverse to ponowne załadowanie poprzednich
+definicji: `load_custom_sql("0403_autorzy_ostatnio_zmieniony")`,
+`load_custom_sql("0402_autorzy_data_oswiadczenia")`,
+`load_custom_sql("0399_fix_refresh_cache_upsert")`. Wybór: **noop + komentarz**
+(views per-typ z `object_id_raw` są nieszkodliwe wstecznie, a stара funkcja i tak
+zostałaby nadpisana forwardem) — chyba że review wymaga pełnego rollbacku.
+```

--- a/src/bpp/migrations/0421_cache_trigger_pk_filter.py
+++ b/src/bpp/migrations/0421_cache_trigger_pk_filter.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from django.db import connection, migrations
+
+
+def load_sql(apps, schema_editor):
+    sql_file = Path(__file__).parent / "0421_cache_trigger_pk_filter.sql"
+    with open(sql_file) as f:
+        sql = f.read()
+    # connection.cursor() zamiast schema_editor.execute() — w ciele funkcji
+    # plpython3u sa znaki `%`, ktore schema_editor probowalby interpretowac
+    # jako placeholdery parametrow.
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0420_autor_pokazuj_siec_powiazan_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(load_sql, migrations.RunPython.noop),
+    ]

--- a/src/bpp/migrations/0421_cache_trigger_pk_filter.sql
+++ b/src/bpp/migrations/0421_cache_trigger_pk_filter.sql
@@ -1,0 +1,575 @@
+-- Optymalizacja triggera cache (issue #311) + deterministyczny advisory lock (#309).
+-- Dokleja object_id_raw (surowy PK) do 10 widokow per-typ i przepisuje
+-- bpp_refresh_cache() tak, by filtrowac po surowym PK (Index seek) zamiast
+-- po wyliczanej kolumnie-tablicy na unii (Seq Scan).
+-- Widoki bazowe wygenerowane z pg_get_viewdef (stan po migracji 0420).
+BEGIN;
+
+-- ============ 1) Widoki per-typ + object_id_raw ============
+CREATE OR REPLACE VIEW bpp_wydawnictwo_ciagle_view AS
+ SELECT ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'wydawnictwo_ciagle'::text), bpp_wydawnictwo_ciagle.id] AS id,
+    bpp_wydawnictwo_ciagle.tytul_oryginalny,
+    bpp_wydawnictwo_ciagle.tytul,
+    bpp_wydawnictwo_ciagle.search_index,
+    bpp_wydawnictwo_ciagle.rok,
+    bpp_wydawnictwo_ciagle.jezyk_id,
+    bpp_wydawnictwo_ciagle.typ_kbn_id,
+    bpp_wydawnictwo_ciagle.charakter_formalny_id,
+    bpp_wydawnictwo_ciagle.zrodlo_id,
+    NULL::integer AS wydawnictwo_nadrzedne_id,
+    NULL::text AS wydawnictwo,
+    bpp_wydawnictwo_ciagle.informacje,
+    bpp_wydawnictwo_ciagle.szczegoly,
+    bpp_wydawnictwo_ciagle.uwagi,
+    bpp_wydawnictwo_ciagle.impact_factor,
+    bpp_wydawnictwo_ciagle.punkty_kbn,
+    bpp_wydawnictwo_ciagle.index_copernicus,
+    bpp_wydawnictwo_ciagle.punktacja_wewnetrzna,
+    bpp_wydawnictwo_ciagle.punktacja_snip,
+    bpp_wydawnictwo_ciagle.kwartyl_w_wos,
+    bpp_wydawnictwo_ciagle.kwartyl_w_scopus,
+    bpp_wydawnictwo_ciagle.adnotacje,
+    bpp_wydawnictwo_ciagle.utworzono,
+    bpp_wydawnictwo_ciagle.ostatnio_zmieniony,
+    bpp_wydawnictwo_ciagle.tytul_oryginalny_sort,
+    bpp_wydawnictwo_ciagle.opis_bibliograficzny_cache,
+    bpp_wydawnictwo_ciagle.opis_bibliograficzny_autorzy_cache,
+    bpp_wydawnictwo_ciagle.opis_bibliograficzny_zapisani_autorzy_cache,
+    bpp_wydawnictwo_ciagle.slug,
+    bpp_wydawnictwo_ciagle.recenzowana,
+    bpp_wydawnictwo_ciagle.liczba_znakow_wydawniczych,
+    bpp_wydawnictwo_ciagle.www,
+    bpp_wydawnictwo_ciagle.dostep_dnia,
+    bpp_wydawnictwo_ciagle.public_www,
+    bpp_wydawnictwo_ciagle.public_dostep_dnia,
+    bpp_wydawnictwo_ciagle.openaccess_czas_publikacji_id,
+    bpp_wydawnictwo_ciagle.openaccess_licencja_id,
+    bpp_wydawnictwo_ciagle.openaccess_tryb_dostepu_id,
+    bpp_wydawnictwo_ciagle.openaccess_wersja_tekstu_id,
+    bpp_wydawnictwo_ciagle.openaccess_ilosc_miesiecy,
+    bpp_wydawnictwo_ciagle.openaccess_data_opublikowania,
+    bpp_wydawnictwo_ciagle.konferencja_id,
+    count(bpp_wydawnictwo_ciagle_autor.autor_id) AS liczba_autorow,
+    bpp_wydawnictwo_ciagle.liczba_cytowan,
+    bpp_wydawnictwo_ciagle.status_korekty_id,
+    lower(bpp_wydawnictwo_ciagle.doi::text) AS doi,
+    bpp_wydawnictwo_ciagle.pbn_uid_id,
+    NULL::text AS isbn,
+    NULL::text AS e_isbn,
+    bpp_wydawnictwo_ciagle.slowa_kluczowe_eng,
+    NULL::integer AS wydawca_id
+    , bpp_wydawnictwo_ciagle.id AS object_id_raw
+   FROM bpp_wydawnictwo_ciagle
+     LEFT JOIN bpp_wydawnictwo_ciagle_autor ON bpp_wydawnictwo_ciagle.id = bpp_wydawnictwo_ciagle_autor.rekord_id
+  GROUP BY bpp_wydawnictwo_ciagle.id;
+;
+
+CREATE OR REPLACE VIEW bpp_wydawnictwo_zwarte_view AS
+ SELECT ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'wydawnictwo_zwarte'::text), bpp_wydawnictwo_zwarte.id] AS id,
+    bpp_wydawnictwo_zwarte.tytul_oryginalny,
+    bpp_wydawnictwo_zwarte.tytul,
+    bpp_wydawnictwo_zwarte.search_index,
+    bpp_wydawnictwo_zwarte.rok,
+    bpp_wydawnictwo_zwarte.jezyk_id,
+    bpp_wydawnictwo_zwarte.typ_kbn_id,
+    bpp_wydawnictwo_zwarte.charakter_formalny_id,
+    NULL::integer AS zrodlo_id,
+    bpp_wydawnictwo_zwarte.wydawnictwo_nadrzedne_id,
+    bpp_wydawnictwo_zwarte.wydawca_opis AS wydawnictwo,
+    bpp_wydawnictwo_zwarte.informacje,
+    bpp_wydawnictwo_zwarte.szczegoly,
+    bpp_wydawnictwo_zwarte.uwagi,
+    bpp_wydawnictwo_zwarte.impact_factor,
+    bpp_wydawnictwo_zwarte.punkty_kbn,
+    bpp_wydawnictwo_zwarte.index_copernicus,
+    bpp_wydawnictwo_zwarte.punktacja_wewnetrzna,
+    bpp_wydawnictwo_zwarte.punktacja_snip,
+    NULL::integer AS kwartyl_w_wos,
+    NULL::integer AS kwartyl_w_scopus,
+    bpp_wydawnictwo_zwarte.adnotacje,
+    bpp_wydawnictwo_zwarte.utworzono,
+    bpp_wydawnictwo_zwarte.ostatnio_zmieniony,
+    bpp_wydawnictwo_zwarte.tytul_oryginalny_sort,
+    bpp_wydawnictwo_zwarte.opis_bibliograficzny_cache,
+    bpp_wydawnictwo_zwarte.opis_bibliograficzny_autorzy_cache,
+    bpp_wydawnictwo_zwarte.opis_bibliograficzny_zapisani_autorzy_cache,
+    bpp_wydawnictwo_zwarte.slug,
+    bpp_wydawnictwo_zwarte.recenzowana,
+    bpp_wydawnictwo_zwarte.liczba_znakow_wydawniczych,
+    bpp_wydawnictwo_zwarte.www,
+    bpp_wydawnictwo_zwarte.dostep_dnia,
+    bpp_wydawnictwo_zwarte.public_www,
+    bpp_wydawnictwo_zwarte.public_dostep_dnia,
+    bpp_wydawnictwo_zwarte.openaccess_czas_publikacji_id,
+    bpp_wydawnictwo_zwarte.openaccess_licencja_id,
+    bpp_wydawnictwo_zwarte.openaccess_tryb_dostepu_id,
+    bpp_wydawnictwo_zwarte.openaccess_wersja_tekstu_id,
+    bpp_wydawnictwo_zwarte.openaccess_ilosc_miesiecy,
+    bpp_wydawnictwo_zwarte.openaccess_data_opublikowania,
+    bpp_wydawnictwo_zwarte.konferencja_id,
+    count(bpp_wydawnictwo_zwarte_autor.autor_id) AS liczba_autorow,
+    bpp_wydawnictwo_zwarte.liczba_cytowan,
+    bpp_wydawnictwo_zwarte.status_korekty_id,
+    lower(bpp_wydawnictwo_zwarte.doi::text) AS doi,
+    bpp_wydawnictwo_zwarte.pbn_uid_id,
+    TRIM(BOTH FROM replace(replace(replace(bpp_wydawnictwo_zwarte.isbn::text, '-'::text, ''::text), ' '::text, ''::text), '.'::text, ''::text)) AS isbn,
+    TRIM(BOTH FROM replace(replace(replace(bpp_wydawnictwo_zwarte.e_isbn::text, '-'::text, ''::text), ' '::text, ''::text), '.'::text, ''::text)) AS e_isbn,
+    bpp_wydawnictwo_zwarte.slowa_kluczowe_eng,
+    bpp_wydawnictwo_zwarte.wydawca_id
+    , bpp_wydawnictwo_zwarte.id AS object_id_raw
+   FROM bpp_wydawnictwo_zwarte
+     LEFT JOIN bpp_wydawnictwo_zwarte_autor ON bpp_wydawnictwo_zwarte.id = bpp_wydawnictwo_zwarte_autor.rekord_id
+  GROUP BY bpp_wydawnictwo_zwarte.id;
+;
+
+CREATE OR REPLACE VIEW bpp_patent_view AS
+ SELECT ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'patent'::text), bpp_patent.id] AS id,
+    bpp_patent.tytul_oryginalny,
+    NULL::text AS tytul,
+    bpp_patent.search_index,
+    bpp_patent.rok,
+    ( SELECT bpp_jezyk.id
+           FROM bpp_jezyk
+          WHERE bpp_jezyk.skrot::text = 'pol.'::text) AS jezyk_id,
+    ( SELECT bpp_typ_kbn.id
+           FROM bpp_typ_kbn
+          WHERE bpp_typ_kbn.skrot::text = 'PO'::text) AS typ_kbn_id,
+    ( SELECT bpp_charakter_formalny.id
+           FROM bpp_charakter_formalny
+          WHERE bpp_charakter_formalny.skrot::text = 'PAT'::text) AS charakter_formalny_id,
+    NULL::integer AS zrodlo_id,
+    NULL::integer AS wydawnictwo_nadrzedne_id,
+    NULL::text AS wydawnictwo,
+    bpp_patent.informacje,
+    bpp_patent.szczegoly,
+    bpp_patent.uwagi,
+    bpp_patent.impact_factor,
+    bpp_patent.punkty_kbn,
+    bpp_patent.index_copernicus,
+    bpp_patent.punktacja_wewnetrzna,
+    bpp_patent.punktacja_snip,
+    NULL::integer AS kwartyl_w_wos,
+    NULL::integer AS kwartyl_w_scopus,
+    bpp_patent.adnotacje,
+    bpp_patent.utworzono,
+    bpp_patent.ostatnio_zmieniony,
+    bpp_patent.tytul_oryginalny_sort,
+    bpp_patent.opis_bibliograficzny_cache,
+    bpp_patent.opis_bibliograficzny_autorzy_cache,
+    bpp_patent.opis_bibliograficzny_zapisani_autorzy_cache,
+    bpp_patent.slug,
+    bpp_patent.recenzowana,
+    0 AS liczba_znakow_wydawniczych,
+    bpp_patent.www,
+    bpp_patent.dostep_dnia,
+    bpp_patent.public_www,
+    bpp_patent.public_dostep_dnia,
+    NULL::integer AS openaccess_czas_publikacji_id,
+    NULL::integer AS openaccess_licencja_id,
+    NULL::integer AS openaccess_tryb_dostepu_id,
+    NULL::integer AS openaccess_wersja_tekstu_id,
+    NULL::integer AS openaccess_ilosc_miesiecy,
+    NULL::date AS openaccess_data_opublikowania,
+    NULL::integer AS konferencja_id,
+    count(bpp_patent_autor.autor_id) AS liczba_autorow,
+    NULL::integer AS liczba_cytowan,
+    bpp_patent.status_korekty_id,
+    NULL::text AS doi,
+    NULL::text AS pbn_uid_id,
+    NULL::text AS isbn,
+    NULL::text AS e_isbn,
+    bpp_patent.slowa_kluczowe_eng,
+    NULL::integer AS wydawca_id
+    , bpp_patent.id AS object_id_raw
+   FROM bpp_patent
+     LEFT JOIN bpp_patent_autor ON bpp_patent.id = bpp_patent_autor.rekord_id
+  GROUP BY bpp_patent.id;
+;
+
+CREATE OR REPLACE VIEW bpp_praca_doktorska_view AS
+ SELECT ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'praca_doktorska'::text), id] AS id,
+    tytul_oryginalny,
+    tytul,
+    search_index,
+    rok,
+    jezyk_id,
+    typ_kbn_id,
+    ( SELECT bpp_charakter_formalny.id
+           FROM bpp_charakter_formalny
+          WHERE bpp_charakter_formalny.skrot::text = 'D'::text) AS charakter_formalny_id,
+    NULL::integer AS zrodlo_id,
+    NULL::integer AS wydawnictwo_nadrzedne_id,
+    wydawca_opis AS wydawnictwo,
+    informacje,
+    szczegoly,
+    uwagi,
+    impact_factor,
+    punkty_kbn,
+    index_copernicus,
+    punktacja_wewnetrzna,
+    punktacja_snip,
+    NULL::integer AS kwartyl_w_wos,
+    NULL::integer AS kwartyl_w_scopus,
+    adnotacje,
+    utworzono,
+    ostatnio_zmieniony,
+    tytul_oryginalny_sort,
+    opis_bibliograficzny_cache,
+    opis_bibliograficzny_autorzy_cache,
+    opis_bibliograficzny_zapisani_autorzy_cache,
+    slug,
+    recenzowana,
+    0 AS liczba_znakow_wydawniczych,
+    www,
+    dostep_dnia,
+    public_www,
+    public_dostep_dnia,
+    NULL::integer AS openaccess_czas_publikacji_id,
+    NULL::integer AS openaccess_licencja_id,
+    NULL::integer AS openaccess_tryb_dostepu_id,
+    NULL::integer AS openaccess_wersja_tekstu_id,
+    NULL::integer AS openaccess_ilosc_miesiecy,
+    NULL::date AS openaccess_data_opublikowania,
+    NULL::integer AS konferencja_id,
+    1 AS liczba_autorow,
+    liczba_cytowan,
+    status_korekty_id,
+    lower(doi::text) AS doi,
+    pbn_uid_id,
+    replace(replace(replace(isbn::text, '-'::text, ''::text), ' '::text, ''::text), '.'::text, ''::text) AS isbn,
+    replace(replace(replace(e_isbn::text, '-'::text, ''::text), ' '::text, ''::text), '.'::text, ''::text) AS e_isbn,
+    slowa_kluczowe_eng,
+    NULL::integer AS wydawca_id
+    , bpp_praca_doktorska.id AS object_id_raw
+   FROM bpp_praca_doktorska;
+;
+
+CREATE OR REPLACE VIEW bpp_praca_habilitacyjna_view AS
+ SELECT ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'praca_habilitacyjna'::text), id] AS id,
+    tytul_oryginalny,
+    tytul,
+    search_index,
+    rok,
+    jezyk_id,
+    typ_kbn_id,
+    ( SELECT bpp_charakter_formalny.id
+           FROM bpp_charakter_formalny
+          WHERE bpp_charakter_formalny.skrot::text = 'H'::text) AS charakter_formalny_id,
+    NULL::integer AS zrodlo_id,
+    NULL::integer AS wydawnictwo_nadrzedne_id,
+    wydawca_opis AS wydawnictwo,
+    informacje,
+    szczegoly,
+    uwagi,
+    impact_factor,
+    punkty_kbn,
+    index_copernicus,
+    punktacja_wewnetrzna,
+    punktacja_snip,
+    NULL::integer AS kwartyl_w_wos,
+    NULL::integer AS kwartyl_w_scopus,
+    adnotacje,
+    utworzono,
+    ostatnio_zmieniony,
+    tytul_oryginalny_sort,
+    opis_bibliograficzny_cache,
+    opis_bibliograficzny_autorzy_cache,
+    opis_bibliograficzny_zapisani_autorzy_cache,
+    slug,
+    recenzowana,
+    0 AS liczba_znakow_wydawniczych,
+    www,
+    dostep_dnia,
+    public_www,
+    public_dostep_dnia,
+    NULL::integer AS openaccess_czas_publikacji_id,
+    NULL::integer AS openaccess_licencja_id,
+    NULL::integer AS openaccess_tryb_dostepu_id,
+    NULL::integer AS openaccess_wersja_tekstu_id,
+    NULL::integer AS openaccess_ilosc_miesiecy,
+    NULL::date AS openaccess_data_opublikowania,
+    NULL::integer AS konferencja_id,
+    1 AS liczba_autorow,
+    liczba_cytowan,
+    status_korekty_id,
+    lower(doi::text) AS doi,
+    pbn_uid_id,
+    replace(replace(replace(isbn::text, '-'::text, ''::text), ' '::text, ''::text), '.'::text, ''::text) AS isbn,
+    replace(replace(replace(e_isbn::text, '-'::text, ''::text), ' '::text, ''::text), '.'::text, ''::text) AS e_isbn,
+    slowa_kluczowe_eng,
+    NULL::integer AS wydawca_id
+    , bpp_praca_habilitacyjna.id AS object_id_raw
+   FROM bpp_praca_habilitacyjna;
+;
+
+CREATE OR REPLACE VIEW bpp_wydawnictwo_ciagle_autorzy AS
+ SELECT ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'wydawnictwo_ciagle'::text), rekord_id] AS rekord_id,
+    ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'wydawnictwo_ciagle'::text), id] AS id,
+    autor_id,
+    jednostka_id,
+    kolejnosc,
+    typ_odpowiedzialnosci_id,
+    zapisany_jako,
+    zatrudniony,
+    afiliuje,
+    dyscyplina_naukowa_id,
+    upowaznienie_pbn,
+    profil_orcid,
+    kierunek_studiow_id,
+    oswiadczenie_ken,
+    przypieta,
+    data_oswiadczenia
+    , bpp_wydawnictwo_ciagle_autor.rekord_id AS object_id_raw
+   FROM bpp_wydawnictwo_ciagle_autor;
+;
+
+CREATE OR REPLACE VIEW bpp_wydawnictwo_zwarte_autorzy AS
+ SELECT ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'wydawnictwo_zwarte'::text), rekord_id] AS rekord_id,
+    ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'wydawnictwo_zwarte'::text), id] AS id,
+    autor_id,
+    jednostka_id,
+    kolejnosc,
+    typ_odpowiedzialnosci_id,
+    zapisany_jako,
+    zatrudniony,
+    afiliuje,
+    dyscyplina_naukowa_id,
+    upowaznienie_pbn,
+    profil_orcid,
+    kierunek_studiow_id,
+    oswiadczenie_ken,
+    przypieta,
+    data_oswiadczenia
+    , bpp_wydawnictwo_zwarte_autor.rekord_id AS object_id_raw
+   FROM bpp_wydawnictwo_zwarte_autor;
+;
+
+CREATE OR REPLACE VIEW bpp_patent_autorzy AS
+ SELECT ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'patent'::text), rekord_id] AS rekord_id,
+    ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'patent'::text), id] AS id,
+    autor_id,
+    jednostka_id,
+    kolejnosc,
+    typ_odpowiedzialnosci_id,
+    zapisany_jako,
+    zatrudniony,
+    afiliuje,
+    dyscyplina_naukowa_id,
+    upowaznienie_pbn,
+    profil_orcid,
+    NULL::integer AS kierunek_studiow_id,
+    NULL::boolean AS oswiadczenie_ken,
+    przypieta,
+    data_oswiadczenia
+    , bpp_patent_autor.rekord_id AS object_id_raw
+   FROM bpp_patent_autor;
+;
+
+CREATE OR REPLACE VIEW bpp_praca_doktorska_autorzy AS
+ SELECT ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'praca_doktorska'::text), bpp_praca_doktorska.id] AS rekord_id,
+    ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'praca_doktorska'::text), bpp_praca_doktorska.id] AS "array",
+    bpp_praca_doktorska.autor_id,
+    bpp_praca_doktorska.jednostka_id,
+    1 AS kolejnosc,
+    ( SELECT bpp_typ_odpowiedzialnosci.id
+           FROM bpp_typ_odpowiedzialnosci
+          WHERE bpp_typ_odpowiedzialnosci.skrot::text = 'aut.'::text) AS typ_odpowiedzialnosci_id,
+    (bpp_autor.nazwisko::text || ' '::text) || bpp_autor.imiona::text AS zapisany_jako,
+    true AS zatrudniony,
+    true AS afiliuje,
+    NULL::integer AS dyscyplina_naukowa_id,
+    false AS upowaznienie_pbn,
+    false AS profil_orcid,
+    NULL::integer AS kierunek_studiow_id,
+    NULL::boolean AS oswiadczenie_ken,
+    true AS przypieta,
+    NULL::date AS data_oswiadczenia
+    , bpp_praca_doktorska.id AS object_id_raw
+   FROM bpp_praca_doktorska,
+    bpp_autor
+  WHERE bpp_autor.id = bpp_praca_doktorska.autor_id;
+;
+
+CREATE OR REPLACE VIEW bpp_praca_habilitacyjna_autorzy AS
+ SELECT ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'praca_habilitacyjna'::text), bpp_praca_habilitacyjna.id] AS rekord_id,
+    ARRAY[( SELECT django_content_type.id
+           FROM django_content_type
+          WHERE django_content_type.app_label::text = 'bpp'::text AND django_content_type.model::text = 'praca_habilitacyjna'::text), bpp_praca_habilitacyjna.id] AS id,
+    bpp_praca_habilitacyjna.autor_id,
+    bpp_praca_habilitacyjna.jednostka_id,
+    1 AS kolejnosc,
+    ( SELECT bpp_typ_odpowiedzialnosci.id
+           FROM bpp_typ_odpowiedzialnosci
+          WHERE bpp_typ_odpowiedzialnosci.skrot::text = 'aut.'::text) AS typ_odpowiedzialnosci_id,
+    (bpp_autor.nazwisko::text || ' '::text) || bpp_autor.imiona::text AS zapisany_jako,
+    true AS zatrudniony,
+    true AS afiliuje,
+    NULL::integer AS dyscyplina_naukowa_id,
+    false AS upowaznienie_pbn,
+    false AS profil_orcid,
+    NULL::integer AS kierunek_studiow_id,
+    NULL::boolean AS oswiadczenie_ken,
+    true AS przypieta,
+    NULL::date AS data_oswiadczenia
+    , bpp_praca_habilitacyjna.id AS object_id_raw
+   FROM bpp_praca_habilitacyjna,
+    bpp_autor
+  WHERE bpp_autor.id = bpp_praca_habilitacyjna.autor_id;
+;
+
+-- ============ 2) Funkcja triggera ============
+CREATE OR REPLACE FUNCTION bpp_refresh_cache()
+  RETURNS TRIGGER
+  LANGUAGE plpython3u
+  AS $$
+    # Odswieza bpp_rekord_mat / bpp_autorzy_mat dla POJEDYNCZEGO rekordu.
+    #
+    # Optymalizacja (issue #311): zamiast SELECT-owac ze zlozonej unii
+    # bpp_rekord / bpp_autorzy filtrujac po WYLICZANEJ kolumnie-tablicy
+    # (id = ARRAY[ct, obj]) — co dawalo Seq Scan wszystkich 5 tabel bazowych —
+    # rutujemy SELECT do konkretnego widoku per-typ (wg TD["table_name"]) i
+    # filtrujemy po surowej, indeksowanej kolumnie object_id_raw (= PK tabeli
+    # bazowej). To daje Index Cond seek zamiast skanu.
+    #
+    # Operacje po stronie mat-tabel (DELETE / ON CONFLICT (id)) dzialaja dalej
+    # na indeksowanej kolumnie-tablicy `id` — bez zmian.
+
+    table_name = TD["table_name"]
+    event = TD["event"]
+    field = "old" if event in ("DELETE", "UPDATE") else "new"
+
+    # Routing: tabela triggera -> (bazowa tabela publikacji, czy to through-table autorow)
+    ROUTING = {
+        "bpp_wydawnictwo_ciagle":       ("bpp_wydawnictwo_ciagle", False),
+        "bpp_wydawnictwo_ciagle_autor": ("bpp_wydawnictwo_ciagle", True),
+        "bpp_wydawnictwo_zwarte":       ("bpp_wydawnictwo_zwarte", False),
+        "bpp_wydawnictwo_zwarte_autor": ("bpp_wydawnictwo_zwarte", True),
+        "bpp_patent":                   ("bpp_patent", False),
+        "bpp_patent_autor":             ("bpp_patent", True),
+        "bpp_praca_doktorska":          ("bpp_praca_doktorska", False),
+        "bpp_praca_habilitacyjna":      ("bpp_praca_habilitacyjna", False),
+    }
+    pub_base, is_through = ROUTING[table_name]
+    app_name, model_name = pub_base.split("_", 1)
+
+    # object_id = PK publikacji (dla through-table jest w rekord_id, inaczej w id)
+    object_id = TD[field]["rekord_id"] if is_through else TD[field]["id"]
+
+    # cache content_type_id oraz listy kolumn w GD (per-backend, na czas polaczenia)
+    cache_key = "django_content_type_ver_2"
+    columns_cache_key = "table_columns_ver_2"
+    if GD.get(cache_key) is None:
+        GD[cache_key] = {}
+    if GD.get(columns_cache_key) is None:
+        GD[columns_cache_key] = {}
+
+    if pub_base not in GD[cache_key]:
+        res = plpy.execute(
+            "SELECT id FROM django_content_type "
+            "WHERE app_label = '%s' AND model = '%s'" % (app_name, model_name))
+        GD[cache_key][pub_base] = res[0]["id"]
+    content_type_id = GD[cache_key][pub_base]
+
+    # Co odswiezamy: publikacja -> rekord + wszyscy autorzy; through -> tylko ten autor.
+    refresh_rekord = not is_through
+    refresh_autor = True
+
+    rekord_view = pub_base + "_view"
+    autorzy_view = pub_base + "_autorzy"
+
+    # Przy edycji wiersza *_autor odswiez tylko tego jednego autora.
+    autor_extra = ""
+    if is_through:
+        autor_extra = " AND autor_id = %s" % TD[field]["autor_id"]
+
+    mat_arr = "ARRAY[%s, %s]::INTEGER[2]" % (content_type_id, object_id)
+
+    def get_table_columns(mat_table):
+        if mat_table not in GD[columns_cache_key]:
+            res = plpy.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = 'public' AND table_name = '%s' "
+                "ORDER BY ordinal_position" % mat_table)
+            GD[columns_cache_key][mat_table] = [r["column_name"] for r in res]
+        return GD[columns_cache_key][mat_table]
+
+    def upsert(mat_table, mat_where, source_view, source_where):
+        # DELETE starych (obsluga przypadku, gdy rekord wypadl ze zrodla),
+        # potem INSERT ... SELECT ... ON CONFLICT (id) DO UPDATE (obsluga wyscigu).
+        plpy.execute("DELETE FROM " + mat_table + " WHERE " + mat_where)
+        if event == "DELETE":
+            return
+        # INSERT po nazwach kolumn tabeli mat, SELECT po nazwach kolumn widoku.
+        # Odpowiadaja sobie POZYCYJNIE: widok to zrodlo tabeli mat + dorzucone
+        # na koncu object_id_raw. Mapowanie pozycyjne (a nie po nazwie) jest
+        # odporne na to, ze pojedynczy widok moze nazwac kolumne-tablice inaczej
+        # niz tabela mat — np. bpp_praca_doktorska_autorzy ma 'array' zamiast
+        # 'id' (nieaaliasowane ARRAY[...]); unia normalizowala nazwe z pierwszej
+        # galezi, ale pojedynczy widok juz nie.
+        # Cytujemy identyfikatory ("...") — niektore kolumny widokow nazywaja
+        # sie jak slowa zarezerwowane (np. 'array' w bpp_praca_doktorska_autorzy,
+        # nieaaliasowane ARRAY[...]) i bez cudzyslowow daja blad skladni.
+        def q(c):
+            return '"' + c + '"'
+
+        mat_cols = get_table_columns(mat_table)
+        src_cols = [c for c in get_table_columns(source_view) if c != "object_id_raw"]
+        set_clause = ", ".join(
+            "%s = EXCLUDED.%s" % (q(c), q(c)) for c in mat_cols if c != "id")
+        plpy.execute(
+            "INSERT INTO " + mat_table +
+            " (" + ", ".join(q(c) for c in mat_cols) + ") "
+            "SELECT " + ", ".join(q(c) for c in src_cols) + " FROM " + source_view +
+            " WHERE " + source_where +
+            " ON CONFLICT (id) DO UPDATE SET " + set_clause)
+
+    # Deterministyczny advisory lock (domyka #309): para int4 (ct, obj),
+    # zamiast hash(f"...") ktory byl losowy per-backend (PYTHONHASHSEED).
+    plpy.execute("SELECT pg_advisory_xact_lock(%s, %s)" % (content_type_id, object_id))
+
+    with plpy.subtransaction():
+        if refresh_rekord:
+            # DELETE bpp_rekord_mat kaskaduje (FK) na bpp_autorzy_mat — dlatego
+            # ponizej i tak odswiezamy autorow.
+            upsert(
+                "bpp_rekord_mat",
+                "id = " + mat_arr,
+                rekord_view,
+                "object_id_raw = %s" % object_id)
+        if refresh_autor:
+            upsert(
+                "bpp_autorzy_mat",
+                "rekord_id = " + mat_arr + autor_extra,
+                autorzy_view,
+                ("object_id_raw = %s" % object_id) + autor_extra)
+$$;
+
+COMMIT;

--- a/src/bpp/migrations/0422_drop_unused_cache_indexes.py
+++ b/src/bpp/migrations/0422_drop_unused_cache_indexes.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from django.db import connection, migrations
+
+
+def _run(filename):
+    def inner(apps, schema_editor):
+        sql_file = Path(__file__).parent / filename
+        with open(sql_file) as f:
+            sql = f.read()
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+
+    return inner
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0421_cache_trigger_pk_filter"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _run("0422_drop_unused_cache_indexes.sql"),
+            _run("0422_drop_unused_cache_indexes_reverse.sql"),
+        ),
+    ]

--- a/src/bpp/migrations/0422_drop_unused_cache_indexes.sql
+++ b/src/bpp/migrations/0422_drop_unused_cache_indexes.sql
@@ -1,0 +1,33 @@
+-- Usuniecie nieuzywanych / redundantnych indeksow na mat-tabelach cache.
+-- Potwierdzone pg_stat_user_indexes z produkcji (idx_scan=0 lub redundantny
+-- prefiks). Mniej indeksow = mniejsza amplifikacja zapisu triggera
+-- bpp_refresh_cache() (DELETE+INSERT na kazde odswiezenie) + mniej miejsca.
+-- Zachowane: indeksy uzywane, unikalne, FK, wariant upper() trigramow
+-- (kod szuka przez upper()/iexact; surowe gin(col) mialy 0 uzyc).
+BEGIN;
+-- bpp_rekord_mat: surowe trigramy (martwe; uzywany wariant upper())
+DROP INDEX IF EXISTS bpp_rekord_mat_public_www;   -- gin(public_www), 0 uzyc (jest _public_www_gin)
+DROP INDEX IF EXISTS bpp_rekord_mat_www;          -- gin(www), 0 uzyc (jest _www_gin)
+DROP INDEX IF EXISTS bpp_rekord_mat_doi_gin;      -- gin(doi), 0 uzyc (jest _doi=upper)
+DROP INDEX IF EXISTS bpp_rekord_mat_isbn;         -- gin(isbn), 0 uzyc (jest _isbn_gin=upper)
+DROP INDEX IF EXISTS bpp_rekord_mat_e_isbn;       -- gin(e_isbn), 0 uzyc
+DROP INDEX IF EXISTS bpp_rekord_mat_e_isbn_gin;   -- gin(upper(e_isbn)), 0 uzyc
+-- bpp_rekord_mat: btree na polach tekstowych szukanych trigramem (0 uzyc)
+DROP INDEX IF EXISTS bpp_rekord_mat_public_www_idx; -- btree(public_www), 0 uzyc
+DROP INDEX IF EXISTS bpp_rekord_mat_www_idx;        -- btree(www), 0 uzyc
+DROP INDEX IF EXISTS bpp_rekord_mat_isbn_idx;       -- btree(isbn), 0 uzyc
+DROP INDEX IF EXISTS bpp_rekord_mat_e;              -- btree(uwagi) free-text, 0 uzyc
+DROP INDEX IF EXISTS bpp_rekord_mat_f;              -- btree(adnotacje) free-text, 3 uzycia
+-- bpp_rekord_mat: btree na kolumnach nieuzywanych w zapytaniach (0 uzyc)
+DROP INDEX IF EXISTS bpp_rekord_mat_9;  -- index_copernicus
+DROP INDEX IF EXISTS bpp_rekord_mat_5;  -- wydawnictwo
+DROP INDEX IF EXISTS bpp_rekord_mat_n;  -- openaccess_tryb_dostepu_id (nie-FK)
+DROP INDEX IF EXISTS bpp_rekord_mat_k;  -- recenzowana (bool)
+DROP INDEX IF EXISTS bpp_rekord_mat_q;  -- dostep_dnia
+DROP INDEX IF EXISTS bpp_rekord_mat_p;  -- liczba_cytowan
+-- bpp_autorzy_mat
+DROP INDEX IF EXISTS bpp_autorzy_mat_7;   -- upowaznienie_pbn (bool), 0 uzyc
+DROP INDEX IF EXISTS bpp_autorzy_mat_11;  -- przypieta (bool), 0 uzyc
+DROP INDEX IF EXISTS bpp_autorzy_mat_12;  -- data_oswiadczenia, 0 uzyc
+DROP INDEX IF EXISTS bpp_autorzy_mat_6;   -- dyscyplina_naukowa_id: redundantny prefiks _8 (dyscyplina, rekord_id)
+COMMIT;

--- a/src/bpp/migrations/0422_drop_unused_cache_indexes_reverse.sql
+++ b/src/bpp/migrations/0422_drop_unused_cache_indexes_reverse.sql
@@ -1,0 +1,24 @@
+-- Reverse migracji 0422: odtworzenie skasowanych indeksow (dokladne definicje).
+BEGIN;
+CREATE INDEX bpp_rekord_mat_public_www ON public.bpp_rekord_mat USING gin (public_www gin_trgm_ops);
+CREATE INDEX bpp_rekord_mat_www ON public.bpp_rekord_mat USING gin (www gin_trgm_ops);
+CREATE INDEX bpp_rekord_mat_doi_gin ON public.bpp_rekord_mat USING gin (doi gin_trgm_ops);
+CREATE INDEX bpp_rekord_mat_e ON public.bpp_rekord_mat USING btree (uwagi);
+CREATE INDEX bpp_rekord_mat_9 ON public.bpp_rekord_mat USING btree (index_copernicus);
+CREATE INDEX bpp_rekord_mat_public_www_idx ON public.bpp_rekord_mat USING btree (public_www);
+CREATE INDEX bpp_rekord_mat_www_idx ON public.bpp_rekord_mat USING btree (www);
+CREATE INDEX bpp_rekord_mat_isbn ON public.bpp_rekord_mat USING gin (isbn gin_trgm_ops);
+CREATE INDEX bpp_rekord_mat_isbn_idx ON public.bpp_rekord_mat USING btree (isbn);
+CREATE INDEX bpp_rekord_mat_5 ON public.bpp_rekord_mat USING btree (wydawnictwo);
+CREATE INDEX bpp_rekord_mat_n ON public.bpp_rekord_mat USING btree (openaccess_tryb_dostepu_id);
+CREATE INDEX bpp_rekord_mat_k ON public.bpp_rekord_mat USING btree (recenzowana);
+CREATE INDEX bpp_rekord_mat_q ON public.bpp_rekord_mat USING btree (dostep_dnia);
+CREATE INDEX bpp_rekord_mat_p ON public.bpp_rekord_mat USING btree (liczba_cytowan);
+CREATE INDEX bpp_rekord_mat_e_isbn ON public.bpp_rekord_mat USING gin (e_isbn gin_trgm_ops);
+CREATE INDEX bpp_rekord_mat_e_isbn_gin ON public.bpp_rekord_mat USING gin (upper(e_isbn) gin_trgm_ops);
+CREATE INDEX bpp_rekord_mat_f ON public.bpp_rekord_mat USING btree (adnotacje);
+CREATE INDEX bpp_autorzy_mat_7 ON public.bpp_autorzy_mat USING btree (upowaznienie_pbn);
+CREATE INDEX bpp_autorzy_mat_11 ON public.bpp_autorzy_mat USING btree (przypieta);
+CREATE INDEX bpp_autorzy_mat_12 ON public.bpp_autorzy_mat USING btree (data_oswiadczenia);
+CREATE INDEX bpp_autorzy_mat_6 ON public.bpp_autorzy_mat USING btree (dyscyplina_naukowa_id);
+COMMIT;

--- a/src/bpp/tests/test_cache/test_cache_pk_filter.py
+++ b/src/bpp/tests/test_cache/test_cache_pk_filter.py
@@ -1,0 +1,80 @@
+"""Testy optymalizacji triggera cache (issue #311): widoki per-typ wystawiają
+surową kolumnę object_id_raw, a bpp_refresh_cache() filtruje po niej (index seek)
+zamiast po wyliczanej kolumnie-tablicy na unii. Zachowanie cache musi pozostać
+identyczne — to jest siatka bezpieczeństwa dla tej zmiany.
+"""
+
+import pytest
+from django.db import connection
+from model_bakery import baker
+
+from bpp.models import Autor, Jednostka, Rekord, Wydawnictwo_Ciagle
+
+VIEWS_Z_OBJECT_ID_RAW = [
+    "bpp_wydawnictwo_ciagle_view",
+    "bpp_wydawnictwo_zwarte_view",
+    "bpp_patent_view",
+    "bpp_praca_doktorska_view",
+    "bpp_praca_habilitacyjna_view",
+    "bpp_wydawnictwo_ciagle_autorzy",
+    "bpp_wydawnictwo_zwarte_autorzy",
+    "bpp_patent_autorzy",
+    "bpp_praca_doktorska_autorzy",
+    "bpp_praca_habilitacyjna_autorzy",
+]
+
+
+@pytest.mark.django_db
+def test_object_id_raw_obecne_na_wszystkich_widokach():
+    with connection.cursor() as c:
+        for v in VIEWS_Z_OBJECT_ID_RAW:
+            c.execute(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_name = %s AND column_name = 'object_id_raw'",
+                [v],
+            )
+            assert c.fetchone() is not None, f"{v} nie ma kolumny object_id_raw"
+
+
+@pytest.mark.django_db
+def test_object_id_raw_daje_index_seek_na_pk():
+    """Filtr po object_id_raw musi schodzić do Index Cond na PK tabeli bazowej,
+    nie do Seq Scan (sedno optymalizacji)."""
+    wc = baker.make(Wydawnictwo_Ciagle)
+    with connection.cursor() as c:
+        c.execute(
+            "EXPLAIN SELECT * FROM bpp_wydawnictwo_ciagle_view "
+            "WHERE object_id_raw = %s",
+            [wc.pk],
+        )
+        plan = "\n".join(row[0] for row in c.fetchall())
+    assert "Index Cond" in plan, plan
+    assert "Seq Scan on bpp_wydawnictwo_ciagle " not in plan, plan
+
+
+@pytest.mark.django_db
+def test_edycja_publikacji_odswieza_rekord_mat(standard_data, denorms):
+    wc = baker.make(
+        Wydawnictwo_Ciagle, tytul_oryginalny="STARY TYTUL", szczegoly="sz", uwagi="u"
+    )
+    assert Rekord.objects.get_for_model(wc).tytul_oryginalny == "STARY TYTUL"
+    wc.tytul_oryginalny = "NOWY TYTUL"
+    wc.save()
+    assert Rekord.objects.get_for_model(wc).tytul_oryginalny == "NOWY TYTUL"
+
+
+@pytest.mark.django_db
+def test_dodanie_i_usuniecie_autora_odswieza_autorzy_mat(standard_data, denorms):
+    wc = baker.make(
+        Wydawnictwo_Ciagle, tytul_oryginalny="Test", szczegoly="sz", uwagi="u"
+    )
+    a = baker.make(Autor, imiona="Jan", nazwisko="Kowalski")
+    j = baker.make(Jednostka)
+    wca = wc.dodaj_autora(a, j)
+    denorms.flush()
+    assert Rekord.objects.get_for_model(wc).autorzy_set.filter(autor=a).exists()
+
+    # edycja/usunięcie jednego wiersza *_autor (ścieżka through-table z autor_id)
+    wca.delete()
+    denorms.flush()
+    assert not Rekord.objects.get_for_model(wc).autorzy_set.filter(autor=a).exists()


### PR DESCRIPTION
## Cel

Optymalizacja triggera `bpp_refresh_cache()` odświeżającego `bpp_rekord_mat` /
`bpp_autorzy_mat` oraz porządki w indeksach tych tabel. Bez zmiany zawartości
cache — różni się tylko plan wykonania i zestaw indeksów.

Domyka #311 (optymalizacja triggera + widoków) i #309 (niedeterministyczny
advisory lock).

## Co i dlaczego

**1. Filtr po surowym PK zamiast po tablicy na unii (#311).**
Trigger SELECT-ował ze złożonej unii `bpp_rekord`/`bpp_autorzy` filtrując po
**wyliczanej** kolumnie-tablicy `id = ARRAY[ct, obj]`. PostgreSQL nie rozkłada
`array_eq` na predykat po PK → `Seq Scan` wszystkich 5 tabel bazowych +
kosztowne planowanie unii, na **każde** odpalenie (FOR EACH ROW na 8 tabelach).

Zmiana dokleja `object_id_raw` (surowy PK) do 10 widoków per-typ przez
`CREATE OR REPLACE VIEW` (bez `DROP CASCADE` — mat-tabele i widoki zależne
nietknięte) i rutuje SELECT do konkretnego widoku per-typ z filtrem po
`object_id_raw` → **Index seek**. Kolumny mapowane pozycyjnie + cytowane
(widoki doktorat/habilitacja nie mają tabeli autorów, ich kolumna-tablica
nazywa się `array`, nie `id`).

**2. Deterministyczny advisory lock (#309).**
`hash(f"...")` był losowy per-backend (PYTHONHASHSEED) → lock nic nie
serializował. Zamiana na `pg_advisory_xact_lock(content_type_id, object_id)`.

**3. Usunięcie 21 nieużywanych/redundantnych indeksów** na `bpp_rekord_mat`
(42→25) i `bpp_autorzy_mat` (13→9), potwierdzone `pg_stat_user_indexes` z
produkcji. Modele `managed=False` → brak driftu Django (`makemigrations
--check`: clean). Mniej indeksów = mniejsza amplifikacja zapisu triggera.

## Pomiary na realnym dumpie produkcyjnym (122 232 rekordy, 516 626 autorów)

| | przed | po |
|---|---|---|
| SELECT źródłowy triggera | ~30 ms (10× Seq Scan), plan ~4 ms | ~0,02 ms (Index seek), plan ~0,1 ms |
| UPDATE 1 rekordu (warm) | ~64 ms | ~2 ms |
| treść cache (md5 rekord_mat+autorzy_mat) | — | bit-w-bit identyczna, 5 typów |

## Testy

- `src/bpp/tests/test_cache/` — 43/43 (w tym nowe testy `object_id_raw`,
  index-seek, oraz ścieżki doktorat/habilitacja i through-table).
- Treść cache zweryfikowana md5 na produkcji dla wszystkich 5 typów publikacji.
- Wyszukiwanie (doi/isbn/public_www) dalej trafia w zachowany indeks `upper()`
  (zweryfikowane `EXPLAIN`-em).

## Uwaga wdrożeniowa

Widoki bazowe w migracji 0421 wygenerowane z `pg_get_viewdef` (stan po 0420).
Migracja 0422 (DROP INDEX) jest odwracalna — reverse odtwarza dokładne
definicje.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
