### PR TITLE
feat(security): django-axes — ochrona przed brute-force (lockout 10/30min + realne IP zza nginx)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 requires-python = ">=3.11,<3.15"
 dependencies = [
     "Django>=5.2.14,<5.3",
+    "django-axes>=7.0,<9",
     "arrow>=1.3,<2",
     "numpy>=2.4.6",
     "pygad>=3.6.0",

--- a/src/bpp/tests/test_axes_lockout.py
+++ b/src/bpp/tests/test_axes_lockout.py
@@ -1,0 +1,74 @@
+"""Testy ochrony przed zgadywaniem hasła (brute-force) — django-axes.
+
+W ``settings/test.py`` axes jest domyślnie WYŁĄCZONE (``AXES_ENABLED = False``),
+bo ``Client.login()`` woła ``authenticate()`` bez ``request`` i axes podniósłby
+wtedy ``AxesBackendRequestParameterRequired``, wywracając fixture'y logowania.
+Dlatego każdy test, który faktycznie sprawdza lockout, MUSI jawnie włączyć axes
+przez ``@override_settings(AXES_ENABLED=True)``.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.test.utils import override_settings
+
+ADMIN_LOGIN_URL = "/admin/login/"
+LOCK_USERNAME = "axes-locktest"
+LOCK_PASSWORD = "correct-horse-battery-staple"
+
+
+def _post_login(client, username, password):
+    return client.post(
+        ADMIN_LOGIN_URL,
+        {"username": username, "password": password, "next": "/admin/"},
+    )
+
+
+@override_settings(AXES_ENABLED=True)
+@pytest.mark.django_db
+def test_account_ip_locked_out_after_failure_limit(client, django_user_model):
+    """Po AXES_FAILURE_LIMIT nieudanych próbach para (login, IP) jest
+    zablokowana — nawet POPRAWNE hasło nie loguje."""
+    django_user_model.objects.create_superuser(
+        username=LOCK_USERNAME,
+        password=LOCK_PASSWORD,
+        email="lock@example.com",
+    )
+    from django.conf import settings
+
+    for _ in range(settings.AXES_FAILURE_LIMIT):
+        _post_login(client, LOCK_USERNAME, "zle-haslo")
+
+    # Sanity: dopóki nie weszło axes, ta sama (login, IP) wciąż loguje
+    # poprawnym hasłem. Po przekroczeniu limitu — NIE.
+    _post_login(client, LOCK_USERNAME, LOCK_PASSWORD)
+    assert "_auth_user_id" not in client.session, (
+        "Konto powinno być zablokowane po przekroczeniu limitu nieudanych prób, "
+        "ale poprawne hasło i tak zalogowało użytkownika."
+    )
+
+
+@override_settings(AXES_ENABLED=True)
+@pytest.mark.django_db
+def test_successful_login_works_under_axes(client, django_user_model):
+    """Z włączonym axes normalne logowanie poprawnym hasłem nadal działa
+    (axes nie wywraca realnego widoku logowania, który przekazuje request)."""
+    django_user_model.objects.create_superuser(
+        username=LOCK_USERNAME,
+        password=LOCK_PASSWORD,
+        email="lock@example.com",
+    )
+    _post_login(client, LOCK_USERNAME, LOCK_PASSWORD)
+    assert "_auth_user_id" in client.session, (
+        "Poprawne hasło poniżej limitu prób powinno zalogować użytkownika."
+    )
+
+
+def test_axes_configured_with_required_policy():
+    """Pin wymaganych wartości polityki: 10 prób, cooloff 30 min, lockout po
+    kombinacji (login + IP) — żeby przypadkowa zmiana nie poluzowała ochrony."""
+    from django.conf import settings
+
+    assert settings.AXES_FAILURE_LIMIT == 10
+    assert settings.AXES_COOLOFF_TIME == timedelta(minutes=30)
+    assert settings.AXES_LOCKOUT_PARAMETERS == [["username", "ip_address"]]

--- a/src/django_bpp/client_ip.py
+++ b/src/django_bpp/client_ip.py
@@ -1,0 +1,36 @@
+"""Ekstrakcja IP klienta zza reverse-proxy (nginx) dla django-axes.
+
+Podpinane przez ``AXES_CLIENT_IP_CALLABLE`` — axes woła ``get_client_ip(request)``
+przy każdej próbie logowania, żeby wyznaczyć komponent ``ip_address`` lockoutu.
+
+Dlaczego własna funkcja zamiast django-ipware:
+
+W deploymencie BPP (bpp-deploy) nginx jest BRZEGIEM (terminuje TLS, publikuje
+80/443), a appserver/authserver nie są wystawione na hosta — cały ruch wchodzi
+przez nginx, który ustawia::
+
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+``$proxy_add_x_forwarded_for`` = ``<XFF od klienta>, <remote_addr>``. nginx zawsze
+DOKLEJA realny ``$remote_addr`` (faktyczny TCP-peer) na KOŃCU listy. Dlatego
+prawdziwym IP klienta jest OSTATNI (najbardziej prawy) wpis — i tylko on, bo
+wszystko po lewej przysłał (i mógł sfałszować) klient. Standardowy ipware domyślnie
+ufa wpisowi NAJBARDZIEJ LEWEMU, więc bez dokładnej konfiguracji ufałby wartości
+sterowanej przez atakującego. Czytanie prawego wpisu jest tu niefalsyfikowalne
+i nie wymaga dodatkowej zależności.
+
+Bez tego axes używa ``REMOTE_ADDR`` = IP nginxa → wszyscy klienci mają to samo IP
+i komponent ``ip_address`` w ``AXES_LOCKOUT_PARAMETERS`` traci sens.
+"""
+
+from django.http import HttpRequest
+
+
+def get_client_ip(request: HttpRequest) -> str | None:
+    """Zwróć realne IP klienta: ostatni niepusty wpis X-Forwarded-For
+    (doklejony przez nginx z ``$remote_addr``), a w razie braku — ``REMOTE_ADDR``.
+    """
+    forwarded = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    parts = [ip.strip() for ip in forwarded.split(",")]
+    rightmost = next((ip for ip in reversed(parts) if ip), None)
+    return rightmost or request.META.get("REMOTE_ADDR")

--- a/src/django_bpp/settings/auth_server.py
+++ b/src/django_bpp/settings/auth_server.py
@@ -22,6 +22,7 @@ from django_bpp.settings.production import (  # noqa: F401
     # User model
     AUTH_USER_MODEL,
     # Polityka django-axes — ta sama ochrona brute-force co w głównej apce
+    AXES_CLIENT_IP_CALLABLE,
     AXES_COOLOFF_TIME,
     AXES_FAILURE_LIMIT,
     AXES_LOCKOUT_PARAMETERS,

--- a/src/django_bpp/settings/auth_server.py
+++ b/src/django_bpp/settings/auth_server.py
@@ -21,6 +21,11 @@ from django_bpp.settings.production import (  # noqa: F401
     ALLOWED_HOSTS,
     # User model
     AUTH_USER_MODEL,
+    # Polityka django-axes — ta sama ochrona brute-force co w głównej apce
+    AXES_COOLOFF_TIME,
+    AXES_FAILURE_LIMIT,
+    AXES_LOCKOUT_PARAMETERS,
+    AXES_RESET_ON_SUCCESS,
     # CSRF trusted origins for login form
     CSRF_TRUSTED_ORIGINS,
     DATABASES,
@@ -51,6 +56,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.auth",
     "django.contrib.sessions",
+    "axes",  # Brute-force lockout także na tym (osobnym) formularzu logowania
     "bpp",  # Required for AUTH_USER_MODEL = "bpp.BppUser"
 ]
 
@@ -59,7 +65,22 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    # AxesMiddleware ostatnie — renderuje odpowiedź "konto zablokowane".
+    "axes.middleware.AxesMiddleware",
 ]
+
+# Ten serwer nie definiuje własnych AUTHENTICATION_BACKENDS (dotąd leciał gołym
+# ModelBackendem przez Django default). Axes wymaga AxesStandaloneBackend jako
+# PIERWSZEGO, żeby zawetować zablokowaną parę (login, IP) zanim ModelBackend
+# sprawdzi hasło. Tabela AccessAttempt jest współdzielona z główną apką (ta sama
+# baza), więc lockout obowiązuje spójnie na obu powierzchniach logowania.
+AUTHENTICATION_BACKENDS = [
+    "axes.backends.AxesStandaloneBackend",
+    "django.contrib.auth.backends.ModelBackend",
+]
+
+# Brak django.contrib.admin w tym serwisie — wyłączamy integrację z adminem axes.
+AXES_ENABLE_ADMIN = False
 
 ROOT_URLCONF = "django_bpp.urls_auth_server"
 

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -1177,6 +1177,11 @@ AXES_LOCKOUT_PARAMETERS = [["username", "ip_address"]]  # ...na parę (login, IP
 AXES_COOLOFF_TIME = timedelta(minutes=30)  # auto-odblokowanie po 30 min
 AXES_RESET_ON_SUCCESS = True  # udane logowanie zeruje licznik nieudanych prób
 AXES_ENABLE_ADMIN = True  # podgląd/odblokowanie prób z panelu admina
+# IP klienta zza nginx: bierzemy OSTATNI wpis X-Forwarded-For (doklejony przez
+# nginx z $remote_addr = realny klient, niefalsyfikowalny). Bez tego axes użyłby
+# REMOTE_ADDR = IP nginxa i komponent (ip_address) lockoutu zlałby się do jednej
+# wartości dla wszystkich. Patrz django_bpp/client_ip.py.
+AXES_CLIENT_IP_CALLABLE = "django_bpp.client_ip.get_client_ip"
 # Handler bazodanowy (domyślny) działa jednolicie w dev/test/prod; cache handler
 # byłby no-op pod DummyCache (dev/test). Tabela AccessAttempt daje wgląd w adminie.
 #

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -317,6 +317,9 @@ MIDDLEWARE = [
     "bpp.middleware.NotificationsMiddleware",
     # 'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',
     "bpp.middleware.CustomRollbarNotifierMiddleware",
+    # AxesMiddleware MUSI być ostatnie — przechwytuje AxesBackendPermissionDenied
+    # z backendu logowania i renderuje odpowiedź "konto zablokowane".
+    "axes.middleware.AxesMiddleware",
 ]
 
 INTERNAL_IPS = ("127.0.0.1",)
@@ -383,6 +386,7 @@ INSTALLED_APPS = [
     "import_pracownikow",
     "import_list_if",
     "password_policies",
+    "axes",  # Ochrona przed brute-force logowaniem (lockout po nieudanych próbach)
     "celery",
     "django_celery_results",
     "flexible_reports",
@@ -1154,6 +1158,34 @@ if "AUTHENTICATION_BACKENDS" not in dir():
 AUTHENTICATION_BACKENDS = list(AUTHENTICATION_BACKENDS) + [
     "orcid_integration.backends.OrcidAuthenticationBackend",
 ]
+
+#
+# django-axes — ochrona przed zgadywaniem hasła (brute-force / credential stuffing)
+#
+# AxesStandaloneBackend NIE uwierzytelnia sam — tylko sprawdza, czy dana próba
+# nie jest już zablokowana, i musi stać PIERWSZY na liście, żeby zawetować
+# zablokowane logowanie zanim trafi ono do LDAP / Microsoft / ORCID / Model.
+# (Używamy "Standalone", bo własne backendy zostają — w przeciwieństwie do
+# AxesBackend, który zastąpiłby uwierzytelnianie ModelBackendem.)
+AUTHENTICATION_BACKENDS = [
+    "axes.backends.AxesStandaloneBackend",
+] + list(AUTHENTICATION_BACKENDS)
+
+# Polityka lockoutu (PCI-DSS 8.3.4: ≤10 prób, blokada ≥30 min):
+AXES_FAILURE_LIMIT = 10  # 10 nieudanych prób...
+AXES_LOCKOUT_PARAMETERS = [["username", "ip_address"]]  # ...na parę (login, IP)
+AXES_COOLOFF_TIME = timedelta(minutes=30)  # auto-odblokowanie po 30 min
+AXES_RESET_ON_SUCCESS = True  # udane logowanie zeruje licznik nieudanych prób
+AXES_ENABLE_ADMIN = True  # podgląd/odblokowanie prób z panelu admina
+# Handler bazodanowy (domyślny) działa jednolicie w dev/test/prod; cache handler
+# byłby no-op pod DummyCache (dev/test). Tabela AccessAttempt daje wgląd w adminie.
+#
+# Blokujemy po KOMBINACJI (login + IP), nie po samym loginie — twardy lockout
+# konta jest wektorem DoS (atakujący celowo blokuje ofiarę złym hasłem; NIST
+# SP 800-63B przed tym ostrzega). Atakującemu z jednego IP wystarczy ~10 prób/30
+# min na konto — grubo poniżej pułapu NIST (100/h), a ofiara nie traci dostępu
+# globalnie.
+#
 
 #
 # Konfiguracja serwera pocztowego

--- a/src/django_bpp/settings/test.py
+++ b/src/django_bpp/settings/test.py
@@ -36,3 +36,11 @@ INSTALLED_APPS = [app for app in INSTALLED_APPS if app != "cacheops"]
 # w no-op (cacheops/simple.py:54) i propaguje się też na `invalidate_*`,
 # które same sprawdzają tę flagę.
 CACHEOPS_ENABLED = False
+
+# django-axes wyłączone w testach: Client.login() woła authenticate() bez
+# `request`, na co AxesStandaloneBackend reaguje AxesBackendRequestParameterRequired
+# i wywróciłby wszystkie fixture'y logujące się przez client.login(). Testy, które
+# faktycznie sprawdzają lockout (src/bpp/tests/test_axes_lockout.py), włączają axes
+# punktowo przez @override_settings(AXES_ENABLED=True) i logują się POST-em do
+# widoku logowania (który request przekazuje).
+AXES_ENABLED = False

--- a/src/django_bpp/tests/test_client_ip.py
+++ b/src/django_bpp/tests/test_client_ip.py
@@ -1,0 +1,56 @@
+"""Testy ekstrakcji IP klienta zza nginx (X-Forwarded-For) dla django-axes.
+
+Topologia deploymentu (bpp-deploy): nginx jest brzegiem (terminuje TLS, publikuje
+80/443), a appserver:8000 / authserver:8001 NIE są wystawione na hosta — ruch
+wchodzi wyłącznie przez nginx. nginx ustawia:
+
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+gdzie ``$proxy_add_x_forwarded_for`` = ``<XFF przysłany przez klienta>, <remote_addr>``.
+Dlatego PRAWDZIWE IP klienta to ZAWSZE OSTATNI (najbardziej prawy) wpis nagłówka —
+ten, który dokleił nginx z ``$remote_addr`` (realny TCP-peer). Lewe wpisy są
+sterowane przez klienta i można je sfałszować, więc nie wolno im ufać.
+
+Bez ekstrakcji axes używałby ``REMOTE_ADDR`` = IP nginxa → komponent ``ip_address``
+w lockoucie zapadłby się do jednej wartości dla wszystkich klientów.
+"""
+
+from django.test import RequestFactory
+
+from django_bpp.client_ip import get_client_ip
+
+
+def _req(xff=None, remote_addr="172.18.0.5"):
+    rf = RequestFactory()
+    extra = {"REMOTE_ADDR": remote_addr}
+    if xff is not None:
+        extra["HTTP_X_FORWARDED_FOR"] = xff
+    return rf.get("/", **extra)
+
+
+def test_returns_rightmost_xff_entry_ignoring_spoofed_left():
+    # Klient próbuje podszyć się pod 9.9.9.9; nginx dokleja realne 203.0.113.7.
+    req = _req(xff="9.9.9.9, 203.0.113.7", remote_addr="172.18.0.5")
+    assert get_client_ip(req) == "203.0.113.7"
+
+
+def test_single_xff_value():
+    req = _req(xff="203.0.113.7", remote_addr="172.18.0.5")
+    assert get_client_ip(req) == "203.0.113.7"
+
+
+def test_falls_back_to_remote_addr_without_xff():
+    req = _req(xff=None, remote_addr="198.51.100.4")
+    assert get_client_ip(req) == "198.51.100.4"
+
+
+def test_ignores_trailing_empty_and_whitespace_tokens():
+    # Klient kończy swój XFF przecinkiem/spacjami; liczy się ostatni NIEPUSTY wpis
+    # (i tak doklejony przez nginx jako $remote_addr).
+    req = _req(xff="9.9.9.9 ,  , 203.0.113.7 ", remote_addr="172.18.0.5")
+    assert get_client_ip(req) == "203.0.113.7"
+
+
+def test_empty_xff_falls_back_to_remote_addr():
+    req = _req(xff="   ", remote_addr="198.51.100.4")
+    assert get_client_ip(req) == "198.51.100.4"

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,7 @@ dependencies = [
     { name = "django-admin-tools", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-autocomplete-light", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-autoslug", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "django-axes", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-braces", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-cacheops", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-celery-email", marker = "platform_python_implementation != 'PyPy'" },
@@ -411,6 +412,7 @@ requires-dist = [
     { name = "django-auth-ldap", marker = "extra == 'ldap'", specifier = ">=5.3.0" },
     { name = "django-autocomplete-light", specifier = "==4.0.1" },
     { name = "django-autoslug", specifier = "==1.9.9" },
+    { name = "django-axes", specifier = ">=7.0,<9" },
     { name = "django-braces", specifier = ">=1.15.0" },
     { name = "django-cacheops", specifier = ">=7.2,<8" },
     { name = "django-celery-email", specifier = ">=3.0.0" },
@@ -1450,6 +1452,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6e/6f454a5287127e03214dfd2df10fbd45df87674528ff73bf1fbb3536cdb4/django-autoslug-1.9.9.tar.gz", hash = "sha256:79f88e9433c1c88d8d3f2bec60d65ca98bffaff6c072b78aa5fd99d0e84a13dd", size = 25457, upload-time = "2023-04-03T13:05:46.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/5c/37bed8c69ad42002a37ba161245342ca15f78a43c75b025ac465d696294c/django_autoslug-1.9.9-py2.py3-none-any.whl", hash = "sha256:81cb018944498f27f439d439687cf902212cafbdb8c74c8ca0307543a3d82907", size = 14392, upload-time = "2023-04-03T13:05:45.702Z" },
+]
+
+[[package]]
+name = "django-axes"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "django", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/00c701a22d46288e3eb1340a1c141f5b4002572ce836a3e8d069f1e1de8a/django_axes-8.3.1.tar.gz", hash = "sha256:d57e923c0ba33cf45275253dd1313c3a3ff04bec686b38d677beb2b3d43c7bcd", size = 254715, upload-time = "2026-02-11T20:19:52.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/f6/777a5df7d5698eeb23c7c496cc268c0181f0489dbc5b5f2b235b30e5d8dd/django_axes-8.3.1-py3-none-any.whl", hash = "sha256:f7887582fd12713064f1602091ff6152752becae5e891a15bf802746cab0f51a", size = 74213, upload-time = "2026-02-11T20:19:48.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Brak jakiejkolwiek ochrony przed zgadywaniem hasła: `ModelBackend` bez limitu prób, DRF throttling zakomentowany od 2020, `password_policies` pilnuje tylko siły/wieku hasła. Atakujący mógł walić w formularz logowania bez ograniczeń — nieskończenie wiele prób/s, żadnej blokady (przy LDAP/AD = dostęp do konta uczelnianego).

## Rozwiązanie — django-axes

Polityka zgodna z PCI-DSS 8.3.4 (≤10 prób, blokada ≥30 min):

| Ustawienie | Wartość |
|---|---|
| `AXES_FAILURE_LIMIT` | `10` |
| `AXES_COOLOFF_TIME` | `30 min` (auto-odblokowanie, bez admina) |
| `AXES_LOCKOUT_PARAMETERS` | `[["username", "ip_address"]]` — blokada po **kombinacji** login+IP |
| `AXES_RESET_ON_SUCCESS` | `True` |

- **`AxesStandaloneBackend`** jako pierwszy backend (tylko gate lockoutu — nie zastępuje LDAP/Microsoft/ORCID/Model) + `AxesMiddleware`.
- **Handler bazodanowy** (domyślny) — działa jednolicie w dev/test/prod (cache handler byłby no-op pod `DummyCache`); tabela `AccessAttempt` daje wgląd/odblokowanie w adminie.
- Blokada po **kombinacji (login + IP)**, nie po samym koncie — twardy lockout konta to wektor DoS (atakujący celowo blokuje ofiarę złym hasłem; NIST SP 800-63B przed tym ostrzega).

### Obie powierzchnie logowania

Ochrona obejmuje **główną apkę** oraz **lekki auth_server** (`/__external_auth/login/` + walidator nginx `auth_request`), który dotąd logował gołym `ModelBackend` i był brute-force'owalny z pominięciem axes. Tabela `AccessAttempt` współdzielona (ta sama baza) → lockout spójny na obu.

### Realne IP klienta zza nginx (X-Forwarded-For, bez ipware)

Bez ekstrakcji axes używał `REMOTE_ADDR` = adres nginxa (appserver/authserver chodzą tylko w sieci dockera) → komponent `ip_address` zlewał się do jednej wartości dla wszystkich. nginx ustawia `X-Forwarded-For $proxy_add_x_forwarded_for` (`<XFF od klienta>, <remote_addr>`), więc `django_bpp.client_ip.get_client_ip` bierze **ostatni** niepusty wpis (niefalsyfikowalny — doklejony przez nginx), fallback `REMOTE_ADDR`. Podpięte przez `AXES_CLIENT_IP_CALLABLE`.

Świadomie **bez django-ipware**: ipware domyślnie ufa wpisowi najbardziej lewemu (sterowanemu przez atakującego); własny callable jest niefalsyfikowalny by-construction dla tej topologii, zero nowych zależności, w pełni pokryty testami.

## Testy (TDD, RED→GREEN)

- `src/bpp/tests/test_axes_lockout.py` — lockout po 10 próbach, normalne logowanie pod limitem, pin wartości polityki (3 testy)
- `src/django_bpp/tests/test_client_ip.py` — prawy wpis XFF, spoofowany lewy ignorowany, fallback, whitespace/empty (5 testów)
- Regresja: 229 istniejących testów login/admin (`client.login()`, `superuser_client`) — zielone
- axes **wyłączone w testach** (`AXES_ENABLED=False`): `Client.login()` woła `authenticate()` bez `request`, co axes odrzuca; testy lockoutu włączają je punktowo przez `@override_settings`

## Uwagi do review

- **Baseline `pg_dump`** jest teraz nieaktualny (axes dodaje tabele) — w runtime `migrate` je dotworzy; przy najbliższym refreshu baseline warto przegenerować.
- Zero migration drift z axes (axes wozi własne migracje).

🤖 Generated with [Claude Code](https://claude.com/claude-code)