### PR TITLE
style(dspace): ruff format pola dspace_* na Uczelni

### DIFF
--- a/src/bpp/models/uczelnia.py
+++ b/src/bpp/models/uczelnia.py
@@ -398,9 +398,7 @@ class Uczelnia(ModelZAdnotacjami, ModelZPBN_ID, NazwaISkrot, NazwaWDopelniaczu):
     dspace_api_username = models.CharField(
         "Użytkownik API DSpace", max_length=255, blank=True, default=""
     )
-    dspace_api_password = EncryptedTextField(
-        "Hasło API DSpace", blank=True, default=""
-    )
+    dspace_api_password = EncryptedTextField("Hasło API DSpace", blank=True, default="")
     dspace_domyslny_jezyk_dc = models.CharField(
         "Domyślny język dc.language.iso",
         max_length=8,


### PR DESCRIPTION
Drobny porządek po merge #305: `ruff format` zwija wywołanie
`EncryptedTextField` (pole `dspace_api_password` na `Uczelnia`) do jednej
linii — mieści się w 88 znakach.

Pole dodano we wcześniejszym commicie gałęzi `dspace-export`, więc nie
przeszło przez `ruff format` na *moim* zestawie zmienionych plików; CI
„Lint changed files" (ruff format na diffie vs `dev`) to wyłapał już po
zmergowaniu #305. To czysto kosmetyczna zmiana (semantycznie identyczna),
żeby przyszłe edycje `uczelnia.py` nie wywalały lintera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)