### PR TITLE
docs(dspace): usuń mylące zdanie o baseline.sql z noty o bezpieczeństwie hasła

### DIFF
--- a/docs/administrator/integracja-dspace.md
+++ b/docs/administrator/integracja-dspace.md
@@ -31,7 +31,6 @@ i rozwiń sekcję **„DSpace"**. Ustaw:
 
 !!! note "Bezpieczeństwo hasła"
     Hasło API jest szyfrowane (Fernet) wspólnym kluczem instalacji.
-    Nie trafia do zrzutów słownikowych bazy (`baseline.sql`).
 
 ## 2. Mapowania kolekcji (Charakter formalny → kolekcja DSpace)
 

--- a/docs/uzytkownik/eksportowanie-do-dspace.md
+++ b/docs/uzytkownik/eksportowanie-do-dspace.md
@@ -18,7 +18,7 @@ rekordów przez redaktora.
    Wydawnictwa zwarte, Patenty, Prace doktorskie lub Prace
    habilitacyjne.
 2. Zaznacz rekordy do wysłania (checkboxy po lewej).
-3. Z listy akcji nad tabelą wybierz:
+3. Z listy akcji **na dole listy** (pasek akcji jest pod tabelą) wybierz:
    - **Wyślij do DSpace** — wysyłka od razu, z podsumowaniem na ekranie.
      Limit **10 rekordów** naraz.
    - **Wyślij do DSpace w tle** — wysyłka w tle (kolejka zadań), gdy


### PR DESCRIPTION
## Co i dlaczego

W `docs/administrator/integracja-dspace.md`, w nocie **„Bezpieczeństwo hasła"** (sekcja *1. Konfiguracja połączenia na obiekcie Uczelnia*) usuwam zdanie:

> Nie trafia do zrzutów słownikowych bazy (`baseline.sql`).

`baseline.sql` to zrzut **tabel słownikowych** (Charakter_Formalny, Język, typy PBN itd.) — nie obejmuje rekordów `Uczelnia`, więc hasło API z definicji nigdy by tam nie trafiło. W nocie *o szyfrowaniu hasła* zdanie sugerowało, że `baseline.sql` to potencjalny wektor wycieku sekretów — wprowadzało zamęt zamiast go usuwać. Pozostaje wystarczająca informacja: hasło jest szyfrowane Fernetem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
