### PR TITLE
feat(pbn-import): domyślna jednostka/wydział tylko z placeholderem "Domyśln…"

### DIFF
--- a/src/pbn_import/templates/pbn_import/dashboard.html
+++ b/src/pbn_import/templates/pbn_import/dashboard.html
@@ -143,11 +143,15 @@
             {% if uzywaj_wydzialow %}
             <div class="pbn-import__modal-field--spaced">
                 <label>Domyślny wydział:</label>
-                {% if wydzialy.count == 1 %}
+                {# Auto-podstawiamy bez wyboru TYLKO gdy jedyny wydział to #}
+                {# placeholder "Domyślny" (wtedy wydzial_domyslny jest ustawiony). #}
+                {# W przeciwnym razie pokazujemy select z pustą opcją, żeby #}
+                {# użytkownik świadomie wybrał realny wydział. #}
+                {% if wydzialy.count == 1 and wydzial_domyslny %}
                 <input type="hidden" name="wydzial_domyslny_id" value="{{ wydzialy.0.pk }}">
                 <span class="pbn-import__readonly-value">{{ wydzialy.0.nazwa }}</span>
                 {% else %}
-                <select name="wydzial_domyslny_id" id="wydzial_domyslny_select">
+                <select name="wydzial_domyslny_id" id="wydzial_domyslny_select" required>
                     <option value="">-- Wybierz wydział --</option>
                     {% for w in wydzialy %}
                     <option value="{{ w.pk }}"{% if wydzial_domyslny and wydzial_domyslny.pk == w.pk %} selected{% endif %}>
@@ -164,12 +168,14 @@
 
             <div class="pbn-import__modal-field--spaced">
                 <label>Domyślna jednostka:</label>
-                {% if jednostki.count == 1 %}
+                {# Jak wyżej: ukryte pole bez wyboru dozwolone tylko dla #}
+                {# placeholdera "Domyślna" (jednostka_domyslna ustawiona). #}
+                {% if jednostki.count == 1 and jednostka_domyslna %}
                 <input type="hidden" name="jednostka_domyslna_id" value="{{ jednostki.0.pk }}">
                 <span class="pbn-import__readonly-value">{{ jednostki.0.nazwa }}</span>
                 {% else %}
                 <select name="jednostka_domyslna_id" id="jednostka_domyslna_select"
-                        class="jednostka-select2" style="width: 100%;">
+                        class="jednostka-select2" style="width: 100%;" required>
                     <option value="">-- Wybierz jednostkę --</option>
                     {% for j in jednostki %}
                     <option value="{{ j.pk }}"{% if jednostka_domyslna and jednostka_domyslna.pk == j.pk %} selected{% endif %}>

--- a/src/pbn_import/tests/test_views_dashboard.py
+++ b/src/pbn_import/tests/test_views_dashboard.py
@@ -139,6 +139,117 @@ class TestImportDashboardView:
         assert session1 in response.context["recent_sessions"]
         assert session2 not in response.context["recent_sessions"]
 
+    def test_dashboard_default_unit_prefers_domyslna_name(self, django_user_model):
+        """Default unit must be the one whose nazwa contains 'Domyśln…'."""
+        from bpp.models import Jednostka
+
+        client = Client()
+        user = baker.make(django_user_model, is_superuser=True)
+        client.force_login(user)
+        uczelnia = baker.make(Uczelnia, pbn_integracja=True)
+
+        # A real unit that sorts first under the default ordering (by nazwa),
+        # to prove the name match wins over mere queryset ordering.
+        baker.make(
+            Jednostka,
+            nazwa="AAA Prawdziwa Jednostka",
+            skupia_pracownikow=True,
+            uczelnia=uczelnia,
+        )
+        domyslna = baker.make(
+            Jednostka,
+            nazwa="Jednostka Domyślna",
+            skupia_pracownikow=True,
+            uczelnia=uczelnia,
+        )
+
+        response = client.get(reverse("pbn_import:dashboard"))
+
+        assert response.context["jednostka_domyslna"] == domyslna
+
+    def test_dashboard_default_unit_empty_without_domyslna(self, django_user_model):
+        """No 'Domyśln…' unit → no pre-selected unit (user must choose)."""
+        from bpp.models import Jednostka
+
+        client = Client()
+        user = baker.make(django_user_model, is_superuser=True)
+        client.force_login(user)
+        uczelnia = baker.make(Uczelnia, pbn_integracja=True)
+
+        baker.make(
+            Jednostka,
+            nazwa="Katedra Czegokolwiek",
+            skupia_pracownikow=True,
+            uczelnia=uczelnia,
+        )
+        baker.make(
+            Jednostka,
+            nazwa="Instytut Czegoś Innego",
+            skupia_pracownikow=True,
+            uczelnia=uczelnia,
+        )
+
+        response = client.get(reverse("pbn_import:dashboard"))
+
+        assert response.context["jednostka_domyslna"] is None
+
+    def test_dashboard_default_faculty_prefers_domyslny_name(self, django_user_model):
+        """Default faculty must be the one whose nazwa contains 'Domyśln…'."""
+        from bpp.models import Wydzial
+
+        client = Client()
+        user = baker.make(django_user_model, is_superuser=True)
+        client.force_login(user)
+        uczelnia = baker.make(Uczelnia, pbn_integracja=True)
+
+        baker.make(Wydzial, nazwa="AAA Wydział Prawdziwy", uczelnia=uczelnia)
+        domyslny = baker.make(Wydzial, nazwa="Wydział Domyślny", uczelnia=uczelnia)
+
+        response = client.get(reverse("pbn_import:dashboard"))
+
+        assert response.context["wydzial_domyslny"] == domyslny
+
+    def test_dashboard_default_faculty_empty_without_domyslny(self, django_user_model):
+        """No 'Domyśln…' faculty → no pre-selected faculty (user must choose)."""
+        from bpp.models import Wydzial
+
+        client = Client()
+        user = baker.make(django_user_model, is_superuser=True)
+        client.force_login(user)
+        uczelnia = baker.make(Uczelnia, pbn_integracja=True)
+
+        baker.make(Wydzial, nazwa="Wydział Lekarski", uczelnia=uczelnia)
+        baker.make(Wydzial, nazwa="Wydział Farmaceutyczny", uczelnia=uczelnia)
+
+        response = client.get(reverse("pbn_import:dashboard"))
+
+        assert response.context["wydzial_domyslny"] is None
+
+    def test_dashboard_single_real_unit_renders_select_not_hidden(
+        self, django_user_model
+    ):
+        """A lone real unit must be choosable (select), never auto-forced."""
+        from bpp.models import Jednostka
+
+        client = Client()
+        user = baker.make(django_user_model, is_superuser=True)
+        client.force_login(user)
+        uczelnia = baker.make(Uczelnia, pbn_integracja=True, uzywaj_wydzialow=False)
+        baker.make(
+            Jednostka,
+            nazwa="Jedyna Realna Jednostka",
+            skupia_pracownikow=True,
+            uczelnia=uczelnia,
+        )
+
+        response = client.get(reverse("pbn_import:dashboard"))
+        content = response.content.decode("utf-8")
+
+        assert response.context["jednostka_domyslna"] is None
+        # The empty placeholder option proves a real select (conscious choice),
+        # not a hidden auto-submitted value.
+        assert "-- Wybierz jednostkę --" in content
+
 
 # ============================================================================
 # START IMPORT VIEW TESTS
@@ -161,9 +272,13 @@ class TestStartImportView:
 
     def test_start_import_creates_session(self, django_user_model):
         """Test start import creates ImportSession"""
+        from bpp.models import Jednostka
+
         client = Client()
         user = baker.make(django_user_model, is_superuser=True)
-        baker.make(Uczelnia, pbn_integracja=True)
+        # uzywaj_wydzialow=False → only the default unit is required.
+        uczelnia = baker.make(Uczelnia, pbn_integracja=True, uzywaj_wydzialow=False)
+        jednostka = baker.make(Jednostka, skupia_pracownikow=True, uczelnia=uczelnia)
         client.force_login(user)
 
         with (
@@ -179,6 +294,7 @@ class TestStartImportView:
                     "initial": "on",
                     "zrodla": "on",
                     "wydawcy": "on",
+                    "jednostka_domyslna_id": jednostka.pk,
                 },
             )
 
@@ -188,12 +304,13 @@ class TestStartImportView:
 
     def test_start_import_stores_config(self, django_user_model):
         """Test start import stores configuration from POST data"""
-        from bpp.models import Wydzial
+        from bpp.models import Jednostka, Wydzial
 
         client = Client()
         user = baker.make(django_user_model, is_superuser=True)
         uczelnia = baker.make(Uczelnia, pbn_integracja=True)
         wydzial = baker.make(Wydzial, nazwa="IT Department", uczelnia=uczelnia)
+        jednostka = baker.make(Jednostka, skupia_pracownikow=True, uczelnia=uczelnia)
         client.force_login(user)
 
         with (
@@ -210,6 +327,7 @@ class TestStartImportView:
                     "zrodla": "on",
                     "delete_existing": "on",
                     "wydzial_domyslny_id": wydzial.pk,
+                    "jednostka_domyslna_id": jednostka.pk,
                 },
             )
 
@@ -220,9 +338,12 @@ class TestStartImportView:
 
     def test_start_import_redirects_to_dashboard(self, django_user_model):
         """Test start import redirects to dashboard after creation"""
+        from bpp.models import Jednostka
+
         client = Client()
         user = baker.make(django_user_model, is_superuser=True)
-        baker.make(Uczelnia, pbn_integracja=True)
+        uczelnia = baker.make(Uczelnia, pbn_integracja=True, uzywaj_wydzialow=False)
+        jednostka = baker.make(Jednostka, skupia_pracownikow=True, uczelnia=uczelnia)
         client.force_login(user)
 
         with (
@@ -234,11 +355,83 @@ class TestStartImportView:
 
             response = client.post(
                 reverse("pbn_import:start"),
-                {},
+                {"jednostka_domyslna_id": jednostka.pk},
                 follow=False,
             )
 
         assert response.status_code in [302, 303, 307]  # Redirect codes
+
+    def test_start_import_blocked_without_unit(self, django_user_model):
+        """Empty default-unit field must block the import (conscious choice)."""
+        client = Client()
+        user = baker.make(django_user_model, is_superuser=True)
+        baker.make(Uczelnia, pbn_integracja=True, uzywaj_wydzialow=False)
+        client.force_login(user)
+
+        with (
+            patch("pbn_import.tasks.run_pbn_import") as mock_task,
+            patch("pbn_import.views.get_channel_layer"),
+            patch("pbn_import.views.async_to_sync"),
+        ):
+            mock_task.delay.return_value = MagicMock(id="task-123")
+
+            response = client.post(
+                reverse("pbn_import:start"),
+                {"initial": "on"},
+            )
+
+        assert not ImportSession.objects.filter(user=user).exists()
+        assert response.status_code in [302, 303, 307]
+
+    def test_start_import_blocked_without_faculty_when_used(self, django_user_model):
+        """When wydziały are used, an empty faculty field blocks the import."""
+        from bpp.models import Jednostka
+
+        client = Client()
+        user = baker.make(django_user_model, is_superuser=True)
+        uczelnia = baker.make(Uczelnia, pbn_integracja=True, uzywaj_wydzialow=True)
+        jednostka = baker.make(Jednostka, skupia_pracownikow=True, uczelnia=uczelnia)
+        client.force_login(user)
+
+        with (
+            patch("pbn_import.tasks.run_pbn_import") as mock_task,
+            patch("pbn_import.views.get_channel_layer"),
+            patch("pbn_import.views.async_to_sync"),
+        ):
+            mock_task.delay.return_value = MagicMock(id="task-123")
+
+            client.post(
+                reverse("pbn_import:start"),
+                {"jednostka_domyslna_id": jednostka.pk},
+            )
+
+        assert not ImportSession.objects.filter(user=user).exists()
+
+    def test_start_import_allowed_without_faculty_when_not_used(
+        self, django_user_model
+    ):
+        """When wydziały are not used, faculty is not required."""
+        from bpp.models import Jednostka
+
+        client = Client()
+        user = baker.make(django_user_model, is_superuser=True)
+        uczelnia = baker.make(Uczelnia, pbn_integracja=True, uzywaj_wydzialow=False)
+        jednostka = baker.make(Jednostka, skupia_pracownikow=True, uczelnia=uczelnia)
+        client.force_login(user)
+
+        with (
+            patch("pbn_import.tasks.run_pbn_import") as mock_task,
+            patch("pbn_import.views.get_channel_layer"),
+            patch("pbn_import.views.async_to_sync"),
+        ):
+            mock_task.delay.return_value = MagicMock(id="task-123")
+
+            client.post(
+                reverse("pbn_import:start"),
+                {"jednostka_domyslna_id": jednostka.pk},
+            )
+
+        assert ImportSession.objects.filter(user=user).exists()
 
 
 # ============================================================================

--- a/src/pbn_import/views.py
+++ b/src/pbn_import/views.py
@@ -111,14 +111,17 @@ class ImportDashboardView(LoginRequiredMixin, ImportPermissionMixin, TemplateVie
         context["wydzialy"] = wydzialy
         context["jednostki"] = jednostki
 
-        # Domyślnie wybrany wydział - pierwszy dostępny
-        context["wydzial_domyslny"] = wydzialy.first()
-
-        # Jednostka domyślna - szukaj "JD" lub pierwsza dostępna
-        jednostka_domyslna = Jednostka.objects.filter(skrot="JD").first()
-        if not jednostka_domyslna:
-            jednostka_domyslna = jednostki.first()
-        context["jednostka_domyslna"] = jednostka_domyslna
+        # Domyślnie zaznaczony wydział/jednostka: WYŁĄCZNIE encja-placeholder
+        # mająca "Domyślny"/"Domyślna" w nazwie (taka, jaką tworzą
+        # znajdz_lub_utworz_*_domyslny). Jeśli takiej nie ma — pole zostaje
+        # PUSTE i użytkownik musi świadomie wybrać prawdziwą jednostkę/wydział.
+        # Nie podstawiamy tu nigdy losowej, realnej jednostki uczelni.
+        context["wydzial_domyslny"] = wydzialy.filter(
+            nazwa__icontains="domyśln"
+        ).first()
+        context["jednostka_domyslna"] = jednostki.filter(
+            nazwa__icontains="domyśln"
+        ).first()
 
         # Import steps for dynamic form rendering (from step_definitions.py)
         context["import_steps"] = get_form_steps()
@@ -151,6 +154,28 @@ class StartImportView(LoginRequiredMixin, ImportPermissionMixin, View):
         jednostka = (
             Jednostka.objects.filter(pk=jednostka_id).first() if jednostka_id else None
         )
+
+        # Domyślna jednostka/wydział muszą być świadomie wybrane przez
+        # użytkownika — nie pozwalamy ruszyć importu z pustym polem (w domyślnym
+        # widoku nic nie jest pre-zaznaczone, chyba że istnieje placeholder
+        # "Domyślna…"). Wydział egzekwujemy tylko gdy uczelnia używa wydziałów.
+        uczelnia = Uczelnia.objects.get_default()
+        uzywaj_wydzialow = uczelnia.uzywaj_wydzialow if uczelnia else False
+
+        errors = []
+        if jednostka is None:
+            errors.append("Wybierz domyślną jednostkę przed rozpoczęciem importu.")
+        if uzywaj_wydzialow and wydzial is None:
+            errors.append("Wybierz domyślny wydział przed rozpoczęciem importu.")
+
+        if errors:
+            for error in errors:
+                messages.error(request, error)
+            if request.headers.get("HX-Request"):
+                response = HttpResponse()
+                response["HX-Redirect"] = reverse("pbn_import:dashboard")
+                return response
+            return redirect("pbn_import:dashboard")
 
         # Build config dynamically from step_definitions
         disable_keys = get_all_disable_keys()


### PR DESCRIPTION
## Problem

Panel importu PBN (`/pbn_import/`) pre-zaznaczał jako **domyślną** prawdziwą jednostkę/wydział uczelni:
- wydział: `wydzialy.first()` (pierwszy po `["kolejnosc","skrot"]` — de facto losowo),
- jednostka: `Jednostka.objects.filter(skrot="JD").first()`, a w razie braku `jednostki.first()`.

Użytkownik mógł nieświadomie ruszyć import z losowo podstawioną **realną** jednostką uczelni.

## Rozwiązanie

Domyślnie pre-zaznaczamy **wyłącznie** placeholder „Domyśln…", a jeśli go nie ma — pole zostaje **puste** i user musi wybrać świadomie.

- **`ImportDashboardView`** — `wydzial_domyslny` / `jednostka_domyslna` = encja z `nazwa__icontains="domyśln"` (łapie „Domyślny"/„Domyślna" oraz placeholdery tworzone przez `znajdz_lub_utworz_*_domyslny`) albo `None`. Nigdy nie podstawiamy losowej realnej jednostki.
- **`dashboard.html`** — ukryte pole (auto-podstawienie bez wyboru) zostaje **tylko** gdy jedyna encja to placeholder „Domyśln…". Pojedyncza **realna** jednostka/wydział → renderuje `<select>` z pustą opcją „— Wybierz —" + `required`, więc wybór jest świadomy.
- **`StartImportView`** — import **blokowany** (komunikat + redirect, bez utworzenia sesji), gdy jednostka pusta; wydział wymagany tylko gdy `uczelnia.uzywaj_wydzialow`.

## Testy

TDD (red→green). 7 nowych testów: domyślne pre-zaznaczenie placeholdera, brak placeholdera → puste pole, render `<select>` dla pojedynczej realnej jednostki, walidacja blokująca import bez jednostki/wydziału. Zaktualizowane istniejące start-import testy pod nowy kontrakt. Cała suita `pbn_import` (113) zielona, ruff czysty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)