### PR TITLE
feat: konwerter formularz Multiseek → zapytanie DjangoQL

### DIFF
--- a/docs/superpowers/plans/2026-06-04-multiseek-to-djangoql.md
+++ b/docs/superpowers/plans/2026-06-04-multiseek-to-djangoql.md
@@ -1,0 +1,1392 @@
+# Konwerter „formularz Multiseek → zapytanie DjangoQL” — plan implementacji
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Na stronie formularza Multiseek dodać przycisk, który dla uprawnionego użytkownika tłumaczy zbudowany formularz na równoważne zapytanie DjangoQL nad `Rekord` i pokazuje je w szufladzie (kopiuj + „Otwórz w edytorze zapytań”).
+
+**Architecture:** Konwersja server-side. Czysta funkcja `multiseek_form_to_djangoql(form_json, registry)` chodzi po ramkach `form_data` (jak `get_query_recursive`), renderując liście jako fragmenty DjangoQL. Domyślny dispatcher tłumaczy typowe pola; trudne pola (Jednostka) nadpisują `to_djangoql`. Każdy fragment jest walidowany przeciw `BppQLSchema(Rekord)` — niepoprawne lądują jako warning, więc wynik zawsze się parsuje. Semantykę „+ podrzędne” odwzorowuje nowe wirtualne pole DjangoQL `jednostka_z_podjednostkami__rel` (MPTT `get_family()`), użyteczne też w samym edytorze. Endpoint `POST /multiseek/do-djangoql/` (gated) i przycisk + drawer w `index.html`.
+
+**Tech Stack:** Django, multiseek, djangoql, pytest, model_bakery, Foundation CSS, jQuery.
+
+---
+
+## Ustalenia z kodu (fakty, nie zgadywanie)
+
+- Registry: `bpp.multiseek_registry.registry` (obiekt `MultiseekRegistry`). Mapa label→QueryObject: `registry.field_by_name` (dict). Pola: `registry.fields` (lista).
+- `QueryObject`: `real_query(value, operation) -> Q`; `value_from_web(value)`; dla autocomplete `value_from_web` zwraca `self.model.objects.get(pk=...)` (instancję). `field_name` = ścieżka ORM (np. `rok`, `doi`, `autorzy__autor__orcid`), `type` (np. `AUTOCOMPLETE`), `label`.
+- Operatory multiseek to **leniwe** `_()` proxy w `multiseek.logic` (np. `EQUAL = _("equals")`). W `form_data` `operator` to string z aktywnej lokalizacji. Dlatego mapę operatorów budujemy z importowanych stałych i porównujemy przez `str(...)`.
+- Stałe: `AND="and"`, `OR="or"`, `ANDNOT="andnot"`. `EQUALITY_OPS_ALL`, `DIFFERENT_ALL`, `GREATER_OPS_ALL`, `LESSER_OPS_ALL`, `GREATER_OR_EQUAL_OPS_ALL`, `LESSER_OR_EQUAL_OPS_ALL`, `CONTAINS`, `NOT_CONTAINS`, `STARTS_WITH`, `NOT_STARTS_WITH`, `IN_RANGE`, `NOT_IN_RANGE`, `AUTOCOMPLETE`.
+- `form_data` (z `formAsJSON()`): `[null_or_op, leaf_or_frame, ...]`. Liść: `{"field": label, "operator": op, "value": v, "prev_op": "and"|"or"|"andnot"|null}`. Ramka zagnieżdżona: lista `[op, leaf/frame, ...]`. `formAsJSON()` zwraca `JSON.stringify({form_data, ordering, report_type})`. Istniejący submit POST-uje to jako pole `json`.
+- Edytor: `/zapytanie/`, param `?model=rekord&query=...`. Schemat `BppQLSchema` (alias `BppZapytanieSchema`) w `src/bpp/djangoql_schema.py`. Gate: `WprowadzanieDanychOrSuperuserMixin.test_func` (`zapytanie.py:275`): `user.is_superuser or (user.is_staff and groups.filter(name=GR_WPROWADZANIE_DANYCH))`. `GR_WPROWADZANIE_DANYCH="wprowadzanie danych"` (`bpp.const`).
+- `__rel` pickery: `AutocompleteField` (`djangoql/extras.py`), wartość `"Label [pk]"`, `get_lookup` parsuje pk i filtruje przez `lookup_name`. `JednostkaQueryObject` (`unit_fields.py:48`) filtruje `autorzy__jednostka`; „+podrzędne” = `Q(autorzy__jednostka__in=value.get_family())`. `Jednostka` to `MPTTModel`.
+- Strona formularza renderowana przez pakietowy `multiseek.views.MultiseekFormPage` (TemplateView) → button-visibility robimy filtrem szablonowym, nie nadpisując widoku.
+
+---
+
+## Struktura plików
+
+- **Create** `src/bpp/multiseek_registry/djangoql_export.py` — silnik konwersji + dispatcher + walidacja fragmentów.
+- **Modify** `src/bpp/multiseek_registry/fields/unit_fields.py` — `to_djangoql` na `JednostkaQueryObject`.
+- **Modify** `src/bpp/djangoql_schema.py` — wirtualne pole `jednostka_z_podjednostkami__rel` na `Rekord`.
+- **Modify** `src/bpp/views/zapytanie.py` — wyłuskanie predykatu `user_can_use_query_editor(user)`.
+- **Modify** `src/bpp/views/mymultiseek.py` — widok endpointu `MultiseekToDjangoQLView`.
+- **Modify** `src/django_bpp/urls.py` — URL `multiseek/do-djangoql/`.
+- **Create** `src/bpp/templatetags/query_editor.py` — filtr `can_use_query_editor`.
+- **Modify** `src/django_bpp/templates/multiseek/index.html` — przycisk + drawer + JS.
+- **Create** testy: `src/bpp/tests/test_multiseek_djangoql_export.py`, `src/bpp/tests/test_jednostka_podjednostki_field.py`, `src/bpp/tests/test_multiseek_djangoql_endpoint.py`.
+
+---
+
+## Task 1: Predykat uprawnień do edytora zapytań (refaktor, single source of truth)
+
+**Files:**
+- Modify: `src/bpp/views/zapytanie.py` (klasa `WprowadzanieDanychOrSuperuserMixin`, ~`:275`)
+- Test: `src/bpp/tests/test_zapytanie.py` (dopisanie testu)
+
+- [ ] **Step 1: Test funkcji predykatu (failing)**
+
+Dopisz w `src/bpp/tests/test_zapytanie.py`:
+
+```python
+import pytest
+from model_bakery import baker
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+from bpp.views.zapytanie import user_can_use_query_editor
+
+
+@pytest.mark.django_db
+def test_user_can_use_query_editor_superuser():
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=False)
+    assert user_can_use_query_editor(u) is True
+
+
+@pytest.mark.django_db
+def test_user_can_use_query_editor_staff_in_group():
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=True)
+    grp = baker.make("auth.Group", name=GR_WPROWADZANIE_DANYCH)
+    u.groups.add(grp)
+    assert user_can_use_query_editor(u) is True
+
+
+@pytest.mark.django_db
+def test_user_can_use_query_editor_plain_logged_in():
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=False)
+    assert user_can_use_query_editor(u) is False
+```
+
+> Uwaga: model usera to `bpp.BppUser` (potwierdź `AUTH_USER_MODEL`; jeśli inny, użyj go w `baker.make`).
+
+- [ ] **Step 2: Run — fail (ImportError)**
+
+Run: `uv run pytest src/bpp/tests/test_zapytanie.py -k user_can_use_query_editor -q`
+Expected: FAIL — `ImportError: cannot import name 'user_can_use_query_editor'`.
+
+- [ ] **Step 3: Wyłuskaj predykat i przepnij mixin**
+
+W `src/bpp/views/zapytanie.py`, tuż przed `class WprowadzanieDanychOrSuperuserMixin`:
+
+```python
+def user_can_use_query_editor(user):
+    """Czy user widzi/uzywa edytora zapytan DjangoQL.
+
+    Superuser, albo staff w grupie 'wprowadzanie danych'. Jedno zrodlo
+    prawdy dla: mixinu widoku, endpointu konwertera i filtru szablonowego.
+    """
+    if not user.is_authenticated:
+        return False
+    if user.is_superuser:
+        return True
+    return user.is_staff and user.groups.filter(
+        name=GR_WPROWADZANIE_DANYCH
+    ).exists()
+```
+
+I zmień `test_func`:
+
+```python
+    def test_func(self):
+        return user_can_use_query_editor(self.request.user)
+```
+
+- [ ] **Step 4: Run — pass**
+
+Run: `uv run pytest src/bpp/tests/test_zapytanie.py -k user_can_use_query_editor -q`
+Expected: PASS (3).
+
+- [ ] **Step 5: Regresja istniejących testów edytora**
+
+Run: `uv run pytest src/bpp/tests/test_zapytanie.py -q`
+Expected: PASS (bez nowych failów).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bpp/views/zapytanie.py src/bpp/tests/test_zapytanie.py
+git commit -m "refactor(zapytanie): wyodrebnij user_can_use_query_editor predicate"
+```
+
+---
+
+## Task 2: Wirtualne pole DjangoQL `jednostka_z_podjednostkami__rel`
+
+**Files:**
+- Modify: `src/bpp/djangoql_schema.py`
+- Test: `src/bpp/tests/test_jednostka_podjednostki_field.py` (create)
+
+- [ ] **Step 1: Test pola (failing)**
+
+Create `src/bpp/tests/test_jednostka_podjednostki_field.py`:
+
+```python
+import pytest
+from djangoql.queryset import apply_search
+from model_bakery import baker
+
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Jednostka, Rekord
+
+
+@pytest.mark.django_db
+def test_jednostka_z_podjednostkami_matches_family(denorma):
+    parent = baker.make(Jednostka, nazwa="Parent")
+    child = baker.make(Jednostka, nazwa="Child", parent=parent)
+    # Rekord publikacji z autorem w child-unit -> ma trafic przy pytaniu o parent
+    wc = baker.make(
+        "bpp.Wydawnictwo_Ciagle", tytul_oryginalny="Pub w child"
+    )
+    autor = baker.make("bpp.Autor")
+    baker.make("bpp.Wydawnictwo_Ciagle_Autor", rekord=wc, autor=autor, jednostka=child)
+
+    query = f'jednostka_z_podjednostkami__rel = "Parent [{parent.pk}]"'
+    qs = apply_search(Rekord.objects.all(), query, schema=BppQLSchema).distinct()
+    titles = set(qs.values_list("tytul_oryginalny", flat=True))
+    assert "Pub w child" in titles
+
+
+@pytest.mark.django_db
+def test_jednostka_z_podjednostkami_in_schema():
+    schema = BppQLSchema(Rekord)
+    fields = schema.models[BppQLSchema.model_label(Rekord)]
+    assert "jednostka_z_podjednostkami__rel" in fields
+```
+
+> `denorma` to istniejący fixture odświeżający cache `Rekord` (sprawdź w `src/conftest.py`; jeśli nazwa inna — np. `denorms` — użyj właściwej). Jeśli `Wydawnictwo_Ciagle_Autor` ma inne pole na jednostkę/rekord, dostosuj `baker.make`.
+
+- [ ] **Step 2: Run — fail (Unknown field)**
+
+Run: `uv run pytest src/bpp/tests/test_jednostka_podjednostki_field.py -q`
+Expected: FAIL — `DjangoQLSchemaError: Unknown field: jednostka_z_podjednostkami__rel`.
+
+- [ ] **Step 3: Dodaj wirtualne pole**
+
+W `src/bpp/djangoql_schema.py`:
+
+```python
+from django.db.models import Q
+from djangoql.extras import AutocompleteField, ExtrasSchema
+
+from bpp.models import Jednostka
+
+_SUBUNITS_FIELD = "jednostka_z_podjednostkami__rel"
+
+
+class JednostkaZPodjednostkamiField(AutocompleteField):
+    """Picker po Jednostce, ktory dopasowuje rekordy autorow z tej jednostki
+    ORAZ wszystkich jednostek z jej rodziny MPTT (przodkowie+sam+potomkowie).
+
+    Odwzorowuje multiseek EQUAL_PLUS_SUB_FEMALE:
+        Q(autorzy__jednostka__in=value.get_family())
+    """
+
+    def get_lookup(self, path, operator, value):
+        parsed = self.parse_id(value)
+        if not isinstance(parsed, int):
+            # free-text fallback po nazwie jednostki (best-effort)
+            return Q(autorzy__jednostka__nazwa__icontains=str(value))
+        try:
+            jednostka = Jednostka.objects.get(pk=parsed)
+        except Jednostka.DoesNotExist:
+            return Q(pk__in=[])  # nic nie pasuje
+        q = Q(autorzy__jednostka__in=jednostka.get_family())
+        return ~q if operator in ("!=", "not in") else q
+```
+
+I wepnij pole do schematu **tylko dla modelu z relacją `autorzy`** (Rekord). W `RelPickerSchemaMixin`:
+
+```python
+    def get_fields(self, model):
+        fields = list(super().get_fields(model))
+        fields += [f.name + _REL_SUFFIX for f in _picker_fks(model)]
+        if _has_autorzy_jednostka(model):
+            fields.append(_SUBUNITS_FIELD)
+        return fields
+
+    def get_field_instance(self, model, field_name):
+        if field_name == _SUBUNITS_FIELD:
+            return JednostkaZPodjednostkamiField(
+                model=model,
+                name=_SUBUNITS_FIELD,
+                nullable=True,
+                queryset=_visible_qs(Jednostka),
+                search_fields=_label_fields(Jednostka),
+            )
+        # ... istniejaca logika __rel ...
+```
+
+oraz helper na poziomie modułu:
+
+```python
+def _has_autorzy_jednostka(model):
+    """True, gdy model ma odwrotna relacje 'autorzy' z FK 'jednostka'
+    (czyli Rekord / cache)."""
+    try:
+        rel = model._meta.get_field("autorzy")
+    except FieldDoesNotExist:
+        return False
+    related = getattr(rel, "related_model", None)
+    if related is None:
+        return False
+    return "jednostka" in {
+        f.name for f in related._meta.get_fields() if isinstance(f, models.Field)
+    }
+```
+
+> Zachowaj istniejące `get_field_instance` dla `__rel` — dodaj tylko gałąź `if field_name == _SUBUNITS_FIELD` na początku.
+
+- [ ] **Step 4: Run — pass**
+
+Run: `uv run pytest src/bpp/tests/test_jednostka_podjednostki_field.py -q`
+Expected: PASS (2).
+
+- [ ] **Step 5: Regresja schematu/edytora**
+
+Run: `uv run pytest src/bpp/tests/test_zapytanie.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bpp/djangoql_schema.py src/bpp/tests/test_jednostka_podjednostki_field.py
+git commit -m "feat(djangoql): pole jednostka_z_podjednostkami__rel (MPTT get_family)"
+```
+
+---
+
+## Task 3: Silnik — renderowanie wartości i mapa operatorów (skalary)
+
+**Files:**
+- Create: `src/bpp/multiseek_registry/djangoql_export.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_export.py` (create)
+
+- [ ] **Step 1: Test render + scalar op (failing)**
+
+Create `src/bpp/tests/test_multiseek_djangoql_export.py`:
+
+```python
+import pytest
+from multiseek.logic import (
+    CONTAINS,
+    DIFFERENT,
+    EQUAL,
+    GREATER_OR_EQUAL,
+    NOT_STARTS_WITH,
+)
+
+from bpp.multiseek_registry.djangoql_export import (
+    render_value,
+    scalar_operator_to_djangoql,
+)
+
+
+def test_render_value_str_quotes_and_escapes():
+    assert render_value('on rzekł "tak"') == r'"on rzekł \"tak\""'
+
+
+def test_render_value_int():
+    assert render_value(2024) == "2024"
+
+
+def test_scalar_operator_mapping():
+    assert scalar_operator_to_djangoql(str(EQUAL)) == "="
+    assert scalar_operator_to_djangoql(str(DIFFERENT)) == "!="
+    assert scalar_operator_to_djangoql(str(CONTAINS)) == "~"
+    assert scalar_operator_to_djangoql(str(GREATER_OR_EQUAL)) == ">="
+    assert scalar_operator_to_djangoql(str(NOT_STARTS_WITH)) == "not startswith"
+
+
+def test_scalar_operator_unknown_returns_none():
+    assert scalar_operator_to_djangoql("zupełnie nieznany") is None
+```
+
+- [ ] **Step 2: Run — fail (ImportError)**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -q`
+Expected: FAIL — `ImportError`.
+
+- [ ] **Step 3: Implementacja render + mapy**
+
+Create `src/bpp/multiseek_registry/djangoql_export.py`:
+
+```python
+"""Konwersja formularza Multiseek -> zapytanie DjangoQL nad Rekord.
+
+Czysta funkcja `multiseek_form_to_djangoql(form_json, registry)` chodzi po
+ramkach `form_data` (jak multiseek.logic.get_query_recursive) i renderuje
+liscie jako fragmenty DjangoQL. Domyslny dispatcher tlumaczy typowe pola;
+pola trudne nadpisuja metode `to_djangoql(value, operation)`. Kazdy fragment
+jest walidowany przeciw BppQLSchema(Rekord) — niepoprawne -> warning.
+"""
+
+from decimal import Decimal
+
+from multiseek.logic import (
+    CONTAINS,
+    DIFFERENT_ALL,
+    EQUALITY_OPS_ALL,
+    GREATER_OPS_ALL,
+    GREATER_OR_EQUAL_OPS_ALL,
+    IN_RANGE,
+    LESSER_OPS_ALL,
+    LESSER_OR_EQUAL_OPS_ALL,
+    NOT_CONTAINS,
+    NOT_IN_RANGE,
+    NOT_STARTS_WITH,
+    STARTS_WITH,
+)
+
+
+def _build_scalar_op_map():
+    m = {}
+    equals = [o for o in EQUALITY_OPS_ALL if o not in DIFFERENT_ALL]
+    for o in equals:
+        m[str(o)] = "="
+    for o in DIFFERENT_ALL:
+        m[str(o)] = "!="
+    for o in GREATER_OPS_ALL:
+        m[str(o)] = ">"
+    for o in GREATER_OR_EQUAL_OPS_ALL:
+        m[str(o)] = ">="
+    for o in LESSER_OPS_ALL:
+        m[str(o)] = "<"
+    for o in LESSER_OR_EQUAL_OPS_ALL:
+        m[str(o)] = "<="
+    m[str(CONTAINS)] = "~"
+    m[str(NOT_CONTAINS)] = "!~"
+    m[str(STARTS_WITH)] = "startswith"
+    m[str(NOT_STARTS_WITH)] = "not startswith"
+    return m
+
+
+_SCALAR_OP_MAP = _build_scalar_op_map()
+_RANGE_OPS = {str(IN_RANGE), str(NOT_IN_RANGE)}
+
+
+def scalar_operator_to_djangoql(operator):
+    """DjangoQL-owy operator dla skalarnej operacji multiseek, lub None."""
+    return _SCALAR_OP_MAP.get(str(operator))
+
+
+def render_value(value):
+    """Literal DjangoQL dla wartosci skalarnej."""
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, (int, Decimal, float)):
+        return str(value)
+    s = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{s}"'
+```
+
+- [ ] **Step 4: Run — pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -q`
+Expected: PASS (4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/djangoql_export.py src/bpp/tests/test_multiseek_djangoql_export.py
+git commit -m "feat(djangoql-export): render_value + mapa operatorow skalarnych"
+```
+
+---
+
+## Task 4: Silnik — translacja pojedynczego liścia (dispatcher + walidacja)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/djangoql_export.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_export.py`
+
+- [ ] **Step 1: Testy liścia (failing)**
+
+Dopisz do `test_multiseek_djangoql_export.py`:
+
+```python
+import pytest
+
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.djangoql_export import leaf_to_djangoql
+
+
+@pytest.mark.django_db
+def test_leaf_scalar_string_contains():
+    frag = leaf_to_djangoql(
+        registry, {"field": "Tytuł pracy", "operator": "contains", "value": "nowotwor"}
+    )
+    assert frag == 'tytul_oryginalny ~ "nowotwor"'
+
+
+@pytest.mark.django_db
+def test_leaf_year_gte():
+    frag = leaf_to_djangoql(
+        registry, {"field": "Rok", "operator": "greater or equal to", "value": 2020}
+    )
+    assert frag == "rok >= 2020"
+
+
+@pytest.mark.django_db
+def test_leaf_unknown_field_returns_none():
+    frag = leaf_to_djangoql(
+        registry, {"field": "Nie ma takiego pola", "operator": "equals", "value": "x"}
+    )
+    assert frag is None
+```
+
+> Operatory w testach wpisz w języku, w jakim działa testowa lokalizacja (domyślnie `pl`). Jeśli testy działają po polsku, użyj polskich etykiet operatorów (np. `"zawiera"`, `"większy lub równy"`) — sprawdź `str(CONTAINS)` w `uv run python -c "..."`. Najbezpieczniej: w teście buduj operator przez `str(CONTAINS)` zamiast literału.
+
+Zalecana wersja odporna na lokalizację:
+
+```python
+@pytest.mark.django_db
+def test_leaf_scalar_string_contains():
+    from multiseek.logic import CONTAINS
+    frag = leaf_to_djangoql(
+        registry,
+        {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "nowotwor"},
+    )
+    assert frag == 'tytul_oryginalny ~ "nowotwor"'
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -k leaf -q`
+Expected: FAIL — `ImportError: leaf_to_djangoql`.
+
+- [ ] **Step 3: Implementacja dispatchera + walidacji**
+
+Dopisz do `djangoql_export.py`:
+
+```python
+from multiseek.logic import AUTOCOMPLETE
+
+from djangoql.exceptions import DjangoQLError
+from djangoql.parser import DjangoQLParser
+
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Rekord
+
+_parser = DjangoQLParser()
+
+
+def _orm_path_to_djangoql(field_name):
+    """field_name multiseek (ORM, '__') -> sciezka DjangoQL ('.')."""
+    return field_name.replace("__", ".")
+
+
+def is_valid_rekord_djangoql(fragment):
+    """Czy fragment parsuje sie i waliduje wzgledem BppQLSchema(Rekord)."""
+    try:
+        ast = _parser.parse(fragment)
+        BppQLSchema(Rekord).validate(ast)
+        return True
+    except (DjangoQLError, Exception):  # noqa: BLE001 — best-effort gate
+        return False
+
+
+def _default_leaf(field, value, operation):
+    op = str(operation)
+    if getattr(field, "type", None) == AUTOCOMPLETE:
+        return _autocomplete_leaf(field, value, operation)
+    name = getattr(field, "field_name", None)
+    if not name:
+        return None
+    if op in _RANGE_OPS:
+        return _range_leaf(name, value, operation)
+    dql_op = scalar_operator_to_djangoql(op)
+    if dql_op is None:
+        return None
+    return f"{_orm_path_to_djangoql(name)} {dql_op} {render_value(value)}"
+
+
+def _autocomplete_leaf(field, value, operation):
+    """value to pk; resolwujemy obiekt i emitujemy '<sciezka>__rel = \"L [pk]\"'."""
+    op = str(operation)
+    if op in {str(o) for o in DIFFERENT_ALL}:
+        rel_op = "!="
+    elif op in {str(o) for o in EQUALITY_OPS_ALL}:
+        rel_op = "="
+    else:
+        return None
+    try:
+        obj = field.value_from_web(value)
+    except Exception:  # noqa: BLE001 — nieistniejacy/uszkodzony pk -> warning
+        return None
+    if obj is None:
+        return None
+    rel_path = _orm_path_to_djangoql(field.field_name) + "__rel"
+    label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
+    return f'{rel_path} {rel_op} "{label} [{obj.pk}]"'
+
+
+def _range_leaf(name, value, operation):
+    """IN_RANGE/NOT_IN_RANGE: value to [low, high]."""
+    if not (isinstance(value, (list, tuple)) and len(value) == 2):
+        return None
+    low, high = value
+    path = _orm_path_to_djangoql(name)
+    inner = f"{path} >= {render_value(low)} and {path} <= {render_value(high)}"
+    if str(operation) == str(NOT_IN_RANGE):
+        return None  # brak unary not(...) w DjangoQL -> warning
+    return f"({inner})"
+
+
+def leaf_to_djangoql(registry, leaf):
+    """Fragment DjangoQL dla pojedynczego warunku, albo None (nieprzekladalny).
+
+    None gdy: nieznane pole, nieobslugiwana operacja, albo fragment nie
+    waliduje sie wzgledem schematu Rekord.
+    """
+    field = registry.field_by_name.get(leaf["field"])
+    if field is None:
+        return None
+    override = getattr(field, "to_djangoql", None)
+    if callable(override):
+        frag = override(leaf["value"], leaf["operator"])
+    else:
+        frag = _default_leaf(field, leaf["value"], leaf["operator"])
+    if frag is None:
+        return None
+    return frag if is_valid_rekord_djangoql(frag) else None
+```
+
+> `is_valid_rekord_djangoql` celowo łapie szeroko (best-effort bramka poprawności) — to wyjątek od reguły „no bare except”: NIE tłumi błędu logiki, tylko klasyfikuje fragment jako nieprzekładalny. Zostaw komentarz `# best-effort gate`.
+
+- [ ] **Step 4: Run — pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -k leaf -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/djangoql_export.py src/bpp/tests/test_multiseek_djangoql_export.py
+git commit -m "feat(djangoql-export): dispatcher liscia + walidacja fragmentu wzgledem schematu"
+```
+
+---
+
+## Task 5: Silnik — chodzenie po ramkach (`form_data`) + warningi
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/djangoql_export.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_export.py`
+
+- [ ] **Step 1: Testy ramek (failing)**
+
+Dopisz:
+
+```python
+import pytest
+from multiseek.logic import AND, CONTAINS, EQUAL, OR
+
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.djangoql_export import multiseek_form_to_djangoql
+
+
+@pytest.mark.django_db
+def test_two_conditions_and():
+    form = {
+        "form_data": [
+            None,
+            {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "covid", "prev_op": None},
+            {"field": "Rok", "operator": str(EQUAL), "value": 2023, "prev_op": str(AND)},
+        ],
+        "ordering": {},
+        "report_type": "0",
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == 'tytul_oryginalny ~ "covid" and rok = 2023'
+    assert res.warnings == []
+
+
+@pytest.mark.django_db
+def test_untranslatable_condition_warns_and_skips():
+    form = {
+        "form_data": [
+            None,
+            {"field": "Rok", "operator": str(EQUAL), "value": 2023, "prev_op": None},
+            {"field": "Nie ma pola", "operator": str(EQUAL), "value": "x", "prev_op": str(AND)},
+        ],
+        "ordering": {},
+        "report_type": "0",
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == "rok = 2023"
+    assert len(res.warnings) == 1
+    assert "Nie ma pola" in res.warnings[0]
+
+
+@pytest.mark.django_db
+def test_empty_form():
+    res = multiseek_form_to_djangoql({"form_data": [None], "ordering": {}}, registry)
+    assert res.query == ""
+    assert res.warnings == []
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -k "two_conditions or untranslatable or empty_form" -q`
+Expected: FAIL — `ImportError: multiseek_form_to_djangoql`.
+
+- [ ] **Step 3: Implementacja walk + złączeń**
+
+Dopisz do `djangoql_export.py`:
+
+```python
+from dataclasses import dataclass, field as dataclass_field
+from urllib.parse import urlencode
+
+from django.urls import reverse
+
+from multiseek.logic import AND, ANDNOT, OR
+
+
+@dataclass
+class ConversionResult:
+    query: str
+    warnings: list = dataclass_field(default_factory=list)
+
+    @property
+    def editor_url(self):
+        base = reverse("bpp:zapytanie")
+        if not self.query:
+            return f"{base}?{urlencode({'model': 'rekord'})}"
+        return f"{base}?{urlencode({'model': 'rekord', 'query': self.query})}"
+
+
+_JOIN = {str(AND): "and", str(OR): "or"}
+
+
+def _leaf_label(leaf):
+    return f"{leaf.get('field')} {leaf.get('operator')}".strip()
+
+
+def _walk_frame(registry, frame, warnings):
+    """Frame: lista [op_or_null, element, element, ...] gdzie element to
+    leaf (dict) albo zagniezdzona ramka (list). Zwraca fragment DjangoQL
+    (string) albo '' gdy nic przekladalnego."""
+    parts = []  # list[(joiner, fragment)]; joiner dla pierwszego = None
+    for idx, element in enumerate(frame):
+        if idx == 0:
+            continue  # pierwszy element to operator ramki (lub None) — nieuzywany tu
+        if isinstance(element, dict):
+            prev_op = element.get("prev_op")
+            frag = leaf_to_djangoql(registry, element)
+            if frag is None:
+                warnings.append(
+                    f"Pominięto warunek: {_leaf_label(element)} (nieprzekładalny)"
+                )
+                continue
+            joiner = _resolve_joiner(prev_op, element, frag, warnings)
+            if joiner is False:
+                continue  # andnot na liscu nie do odwrocenia -> juz zwarningowany
+            parts.append((joiner, frag))
+        elif isinstance(element, list):
+            sub = _walk_frame(registry, element, warnings)
+            if not sub:
+                continue
+            prev_op = element[0]
+            joiner = _JOIN.get(str(prev_op)) if prev_op else None
+            if str(prev_op) == str(ANDNOT):
+                warnings.append(
+                    "Pominięto zanegowaną grupę warunków "
+                    "(DjangoQL nie ma `not(...)`)"
+                )
+                continue
+            parts.append((joiner, f"({sub})"))
+    return _join_parts(parts)
+
+
+def _resolve_joiner(prev_op, leaf, frag, warnings):
+    """Zwraca 'and'/'or'/None (joiner) albo False gdy warunek nalezy pominac.
+    Dla ANDNOT na liscu probujemy inwersji operatora (De Morgan)."""
+    if prev_op is None:
+        return None
+    if str(prev_op) in _JOIN:
+        return _JOIN[str(prev_op)]
+    if str(prev_op) == str(ANDNOT):
+        # leaf juz zostal zrenderowany; inwersje robimy na poziomie operatora
+        # przez ponowne wygenerowanie z zanegowana operacja, jezeli to mozliwe.
+        # Best-effort: jezeli fragment ma '=' -> '!=', '~' -> '!~'. W innym
+        # wypadku ostrzegamy i pomijamy.
+        return False  # patrz Step 3b — pelna inwersja w osobnym kroku
+    return None
+
+
+def _join_parts(parts):
+    if not parts:
+        return ""
+    out = parts[0][1]
+    for joiner, frag in parts[1:]:
+        out = f"{out} {joiner or 'and'} {frag}"
+    return out
+
+
+def multiseek_form_to_djangoql(form_json, registry):
+    """Glowne API. form_json: dict z kluczem 'form_data'."""
+    warnings = []
+    form_data = form_json.get("form_data") or [None]
+    query = _walk_frame(registry, form_data, warnings)
+    return ConversionResult(query=query, warnings=warnings)
+```
+
+> Uwaga: w tym kroku `andnot` na liściu jest pomijany z ostrzeżeniem (zwracamy `False`). Pełną inwersję De Morgana dodajemy w Tasku 6, żeby nie mieszać dwóch zmian w jednym teście.
+
+Dopisz w `_walk_frame`, gdy `joiner is False`, ostrzeżenie:
+
+```python
+            if joiner is False:
+                warnings.append(
+                    f"Pominięto zanegowany warunek: {_leaf_label(element)} "
+                    "(andnot — patrz edytor)"
+                )
+                continue
+```
+
+- [ ] **Step 4: Run — pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -q`
+Expected: PASS (wszystkie).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/djangoql_export.py src/bpp/tests/test_multiseek_djangoql_export.py
+git commit -m "feat(djangoql-export): walk po ramkach form_data + warningi + ConversionResult"
+```
+
+---
+
+## Task 6: `andnot` na liściu → inwersja operatora (De Morgan)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/djangoql_export.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_export.py`
+
+- [ ] **Step 1: Test inwersji (failing)**
+
+```python
+@pytest.mark.django_db
+def test_andnot_leaf_inverts_operator():
+    from multiseek.logic import ANDNOT, CONTAINS, EQUAL
+    form = {
+        "form_data": [
+            None,
+            {"field": "Rok", "operator": str(EQUAL), "value": 2023, "prev_op": None},
+            {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "abc", "prev_op": str(ANDNOT)},
+        ],
+        "ordering": {},
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == 'rok = 2023 and tytul_oryginalny !~ "abc"'
+    assert res.warnings == []
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -k andnot_leaf -q`
+Expected: FAIL — obecnie warning+skip.
+
+- [ ] **Step 3: Implementacja inwersji**
+
+Dodaj mapę inwersji i funkcję, i podłącz w `_walk_frame` zamiast `False`:
+
+```python
+_INVERT = {
+    "=": "!=",
+    "!=": "=",
+    "~": "!~",
+    "!~": "~",
+    ">": "<=",
+    ">=": "<",
+    "<": ">=",
+    "<=": ">",
+    "startswith": "not startswith",
+    "not startswith": "startswith",
+}
+
+
+def _invert_fragment(frag):
+    """Zaneguj fragment przez podmiane operatora (De Morgan na liscu).
+    Zwraca zanegowany fragment albo None gdy operatora nie da sie odwrocic."""
+    # fragment ma postac '<lhs> <op> <rhs>'; op moze byc wieloczlonowy
+    for op in sorted(_INVERT, key=len, reverse=True):
+        token = f" {op} "
+        if token in frag:
+            lhs, rhs = frag.split(token, 1)
+            return f"{lhs} {_INVERT[op]} {rhs}"
+    return None
+```
+
+W `_walk_frame`, w gałęzi `dict`, zamień obsługę `prev_op == ANDNOT`:
+
+```python
+        if isinstance(element, dict):
+            prev_op = element.get("prev_op")
+            frag = leaf_to_djangoql(registry, element)
+            if frag is None:
+                warnings.append(
+                    f"Pominięto warunek: {_leaf_label(element)} (nieprzekładalny)"
+                )
+                continue
+            if prev_op is not None and str(prev_op) == str(ANDNOT):
+                inverted = _invert_fragment(frag)
+                if inverted is None:
+                    warnings.append(
+                        f"Pominięto zanegowany warunek: {_leaf_label(element)} "
+                        "(nie da się odwrócić operatora)"
+                    )
+                    continue
+                parts.append(("and", inverted))
+                continue
+            joiner = _JOIN.get(str(prev_op)) if prev_op else None
+            parts.append((joiner, frag))
+```
+
+I usuń teraz nieużywaną `_resolve_joiner` (lub zostaw, jeśli używana gdzie indziej — w tym planie nie jest; usuń).
+
+> Po inwersji walidacja fragmentu już była zrobiona w `leaf_to_djangoql`; `!~`/`!=` to legalne operatory DjangoQL, więc zanegowany fragment też się parsuje. (Opcjonalnie: dla bezpieczeństwa przepuść `inverted` przez `is_valid_rekord_djangoql`; jeśli False → warning.)
+
+- [ ] **Step 4: Run — pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/djangoql_export.py src/bpp/tests/test_multiseek_djangoql_export.py
+git commit -m "feat(djangoql-export): andnot na liscu -> inwersja operatora (De Morgan)"
+```
+
+---
+
+## Task 7: `JednostkaQueryObject.to_djangoql` (+ round-trip fidelity)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/fields/unit_fields.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_export.py`
+
+- [ ] **Step 1: Test mapowania Jednostki + round-trip (failing)**
+
+```python
+@pytest.mark.django_db
+def test_jednostka_equal_maps_to_autorzy_jednostka_rel():
+    from multiseek.logic import EQUAL_FEMALE
+    from model_bakery import baker
+    from bpp.models import Jednostka
+
+    j = baker.make(Jednostka, nazwa="Klinika X")
+    field = registry.field_by_name["Jednostka"]
+    frag = field.to_djangoql(j.pk, str(EQUAL_FEMALE))
+    assert frag == f'autorzy.jednostka__rel = "Klinika X [{j.pk}]"'
+
+
+@pytest.mark.django_db
+def test_jednostka_plus_subunits_maps_to_virtual_field():
+    from bpp.multiseek_registry.fields.constants import EQUAL_PLUS_SUB_FEMALE
+    from model_bakery import baker
+    from bpp.models import Jednostka
+
+    j = baker.make(Jednostka, nazwa="Klinika X")
+    field = registry.field_by_name["Jednostka"]
+    frag = field.to_djangoql(j.pk, EQUAL_PLUS_SUB_FEMALE)
+    assert frag == f'jednostka_z_podjednostkami__rel = "Klinika X [{j.pk}]"'
+
+
+@pytest.mark.django_db
+def test_roundtrip_jednostka_plus_subunits_same_rekordy(denorma):
+    """Multiseek Q vs skonwertowane DjangoQL daja ten sam zbior Rekord."""
+    from djangoql.queryset import apply_search
+    from model_bakery import baker
+    from bpp.djangoql_schema import BppQLSchema
+    from bpp.models import Jednostka, Rekord
+    from bpp.multiseek_registry.fields.constants import EQUAL_PLUS_SUB_FEMALE
+
+    parent = baker.make(Jednostka, nazwa="Parent")
+    child = baker.make(Jednostka, nazwa="Child", parent=parent)
+    wc = baker.make("bpp.Wydawnictwo_Ciagle", tytul_oryginalny="P")
+    autor = baker.make("bpp.Autor")
+    baker.make("bpp.Wydawnictwo_Ciagle_Autor", rekord=wc, autor=autor, jednostka=child)
+
+    field = registry.field_by_name["Jednostka"]
+    q = field.real_query(parent, EQUAL_PLUS_SUB_FEMALE)
+    via_multiseek = set(Rekord.objects.filter(q).values_list("pk", flat=True))
+
+    frag = field.to_djangoql(parent.pk, EQUAL_PLUS_SUB_FEMALE)
+    via_djangoql = set(
+        apply_search(Rekord.objects.all(), frag, schema=BppQLSchema)
+        .distinct()
+        .values_list("pk", flat=True)
+    )
+    assert via_multiseek == via_djangoql
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -k jednostka -q`
+Expected: FAIL — `JednostkaQueryObject` nie ma `to_djangoql`.
+
+- [ ] **Step 3: Implementacja `to_djangoql`**
+
+W `src/bpp/multiseek_registry/fields/unit_fields.py`, w `JednostkaQueryObject`:
+
+```python
+    def to_djangoql(self, value, operation):
+        """Tlumaczenie na DjangoQL nad Rekord. Patrz real_query po semantyke.
+
+        - rownosc/roznosc -> autorzy.jednostka__rel (picker po pk autora-jedn.)
+        - '+ podrzedne' -> wirtualne pole jednostka_z_podjednostkami__rel
+          (MPTT get_family, identyczne z real_query EQUAL_PLUS_SUB_FEMALE)
+        - UNION / '+podrzedne+wspolna' -> None (warning): inny ksztalt zapytania,
+          nie gwarantujemy rownowaznosci bez osobnego pola wirtualnego.
+        """
+        op = str(operation)
+        try:
+            obj = self.value_from_web(value)
+        except Exception:  # noqa: BLE001 — uszkodzony/nieistniejacy pk -> warning
+            return None
+        if obj is None:
+            return None
+        label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
+        suffix = f'"{label} [{obj.pk}]"'
+
+        if op == str(EQUAL_FEMALE):
+            return f"autorzy.jednostka__rel = {suffix}"
+        if op == str(DIFFERENT_FEMALE):
+            return f"autorzy.jednostka__rel != {suffix}"
+        if op == str(EQUAL_PLUS_SUB_FEMALE):
+            return f"jednostka_z_podjednostkami__rel = {suffix}"
+        # UNION_FEMALE, EQUAL_PLUS_SUB_UNION_FEMALE — nieprzekladalne 1:1
+        return None
+```
+
+> `EQUAL_FEMALE`, `DIFFERENT_FEMALE` są już importowane na górze pliku; `EQUAL_PLUS_SUB_FEMALE` też (z `.constants`). Nie dubluj importów.
+
+- [ ] **Step 4: Run — pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -k jednostka -q`
+Expected: PASS (3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/fields/unit_fields.py src/bpp/tests/test_multiseek_djangoql_export.py
+git commit -m "feat(djangoql-export): JednostkaQueryObject.to_djangoql (+ round-trip test)"
+```
+
+---
+
+## Task 8: Endpoint `POST /multiseek/do-djangoql/`
+
+**Files:**
+- Modify: `src/bpp/views/mymultiseek.py`
+- Modify: `src/django_bpp/urls.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_endpoint.py` (create)
+
+- [ ] **Step 1: Test endpointu (failing)**
+
+Create `src/bpp/tests/test_multiseek_djangoql_endpoint.py`:
+
+```python
+import json
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+from multiseek.logic import CONTAINS
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+
+
+@pytest.fixture
+def uprawniony(client):
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=True)
+    u.set_password("x")
+    u.save()
+    client.force_login(u)
+    return u
+
+
+@pytest.mark.django_db
+def test_endpoint_requires_permission(client):
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=False)
+    client.force_login(u)
+    resp = client.post(reverse("bpp:multiseek-do-djangoql"), {"json": "{}"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_endpoint_happy_path(client, uprawniony):
+    form = {
+        "form_data": [
+            None,
+            {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "covid", "prev_op": None},
+        ],
+        "ordering": {},
+        "report_type": "0",
+    }
+    resp = client.post(
+        reverse("bpp:multiseek-do-djangoql"), {"json": json.dumps(form)}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["query"] == 'tytul_oryginalny ~ "covid"'
+    assert data["warnings"] == []
+    assert data["editor_url"].startswith(reverse("bpp:zapytanie"))
+    assert "model=rekord" in data["editor_url"]
+
+
+@pytest.mark.django_db
+def test_endpoint_bad_json(client, uprawniony):
+    resp = client.post(
+        reverse("bpp:multiseek-do-djangoql"), {"json": "to nie jest json"}
+    )
+    assert resp.status_code == 400
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_endpoint.py -q`
+Expected: FAIL — `NoReverseMatch: bpp:multiseek-do-djangoql`.
+
+- [ ] **Step 3: Widok**
+
+W `src/bpp/views/mymultiseek.py` dopisz:
+
+```python
+import json
+
+from django.http import HttpResponseBadRequest, JsonResponse
+from django.views.generic import View
+
+from bpp.multiseek_registry import registry as multiseek_registry
+from bpp.multiseek_registry.djangoql_export import multiseek_form_to_djangoql
+from bpp.views.zapytanie import (
+    WprowadzanieDanychOrSuperuserMixin,
+    user_can_use_query_editor,  # noqa: F401 — re-export wygody
+)
+
+
+class MultiseekToDjangoQLView(WprowadzanieDanychOrSuperuserMixin, View):
+    """Tlumaczy biezacy formularz Multiseek (POST 'json') na zapytanie
+    DjangoQL nad Rekord. Zwraca {query, warnings, editor_url}."""
+
+    http_method_names = ["post"]
+
+    def post(self, request, *args, **kwargs):
+        raw = request.POST.get("json")
+        if not raw:
+            return HttpResponseBadRequest("Brak parametru 'json'.")
+        try:
+            form_json = json.loads(raw)
+        except (ValueError, TypeError):
+            return HttpResponseBadRequest("Niepoprawny JSON formularza.")
+        if not isinstance(form_json, dict):
+            return HttpResponseBadRequest("Oczekiwano obiektu JSON.")
+        result = multiseek_form_to_djangoql(form_json, multiseek_registry)
+        return JsonResponse(
+            {
+                "query": result.query,
+                "warnings": result.warnings,
+                "editor_url": result.editor_url,
+            }
+        )
+```
+
+- [ ] **Step 4: URL**
+
+W `src/django_bpp/urls.py`, w sekcji multiseek (obok `multiseek/results/`), dodaj **przed** ogólnym `r"^multiseek/"` include:
+
+```python
+        url(
+            r"^multiseek/do-djangoql/$",
+            MultiseekToDjangoQLView.as_view(),
+            name="multiseek-do-djangoql",
+        ),
+```
+
+oraz import na górze: `from bpp.views.mymultiseek import MultiseekToDjangoQLView` (dołącz do istniejącego importu z `mymultiseek`, jeśli jest). Upewnij się, że trasa jest w bloku `namespace="bpp"` lub że `name` rozwiązuje się jako `bpp:multiseek-do-djangoql` (sprawdź, jak zarejestrowany jest `bpp:zapytanie` — użyj tego samego patternu/bloku URL-i).
+
+> Kolejność ma znaczenie: `r"^multiseek/"` include łapie wszystko po prefiksie; nowa, bardziej szczegółowa trasa musi być wyżej.
+
+- [ ] **Step 5: Run — pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_endpoint.py -q`
+Expected: PASS (3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bpp/views/mymultiseek.py src/django_bpp/urls.py src/bpp/tests/test_multiseek_djangoql_endpoint.py
+git commit -m "feat(multiseek): endpoint POST /multiseek/do-djangoql/"
+```
+
+---
+
+## Task 9: Filtr szablonowy `can_use_query_editor`
+
+**Files:**
+- Create: `src/bpp/templatetags/query_editor.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_endpoint.py` (dopisanie)
+
+- [ ] **Step 1: Test filtra (failing)**
+
+Dopisz do `test_multiseek_djangoql_endpoint.py`:
+
+```python
+@pytest.mark.django_db
+def test_template_filter_can_use_query_editor():
+    from django.template import Context, Template
+
+    su = baker.make("bpp.BppUser", is_superuser=True)
+    plain = baker.make("bpp.BppUser", is_superuser=False, is_staff=False)
+    tpl = Template(
+        "{% load query_editor %}{{ user|can_use_query_editor }}"
+    )
+    assert tpl.render(Context({"user": su})) == "True"
+    assert tpl.render(Context({"user": plain})) == "False"
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_endpoint.py -k template_filter -q`
+Expected: FAIL — `'query_editor' is not a registered tag library`.
+
+- [ ] **Step 3: Implementacja**
+
+Create `src/bpp/templatetags/query_editor.py`:
+
+```python
+from django import template
+
+from bpp.views.zapytanie import user_can_use_query_editor
+
+register = template.Library()
+
+
+@register.filter(name="can_use_query_editor")
+def can_use_query_editor(user):
+    """True, gdy user moze korzystac z edytora zapytan DjangoQL."""
+    if user is None:
+        return False
+    return user_can_use_query_editor(user)
+```
+
+- [ ] **Step 4: Run — pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_endpoint.py -k template_filter -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/templatetags/query_editor.py src/bpp/tests/test_multiseek_djangoql_endpoint.py
+git commit -m "feat(templatetags): filtr can_use_query_editor"
+```
+
+---
+
+## Task 10: UI — przycisk + drawer + JS w `index.html`
+
+**Files:**
+- Modify: `src/django_bpp/templates/multiseek/index.html`
+- Test: manualny (Playwright opcjonalnie poza zakresem tego planu)
+
+- [ ] **Step 1: Załaduj filtr i dodaj przycisk**
+
+Na górze `index.html` (po `{% extends %}`/istniejących `{% load %}`):
+
+```django
+{% load query_editor %}
+```
+
+W `<div class="cell button-group stacked-for-small">` (obok `id="saveFormButton"` itd.), dodaj — **tylko dla uprawnionych**:
+
+```django
+{% if request.user|can_use_query_editor %}
+<button type="button" class="button secondary"
+        data-action="to-djangoql"
+        id="toDjangoqlButton">
+    <i class="fi-clipboard-notes" aria-hidden="true"></i> Pokaż jako zapytanie DjangoQL
+</button>
+{% endif %}
+```
+
+- [ ] **Step 2: Drawer (Foundation reveal) + CSRF**
+
+Tuż przed zamknięciem `</form>` (po sekcji `<script>` lub obok), dodaj markup szuflady i ukryty token CSRF:
+
+```django
+{% if request.user|can_use_query_editor %}
+{% csrf_token %}
+<div class="reveal" id="djangoqlDrawer" data-reveal>
+    <h4>Zapytanie DjangoQL</h4>
+    <p class="help-text">Równoważne zapytanie nad modelem Rekord.</p>
+    <textarea id="djangoqlQuery" rows="4" readonly spellcheck="false"></textarea>
+    <div id="djangoqlWarnings" class="callout warning" style="display:none"></div>
+    <div class="button-group">
+        <button type="button" class="button" id="djangoqlCopy">
+            <i class="fi-clipboard" aria-hidden="true"></i> Kopiuj
+        </button>
+        <a class="button success" id="djangoqlOpenEditor" href="#" target="_blank">
+            <i class="fi-arrow-right" aria-hidden="true"></i> Otwórz w edytorze zapytań
+        </a>
+    </div>
+    <button class="close-button" data-close aria-label="Zamknij" type="button">
+        <span aria-hidden="true">&times;</span>
+    </button>
+</div>
+{% endif %}
+```
+
+- [ ] **Step 3: JS — fetch + wypełnienie drawera**
+
+W bloku `<script>` (w handlerze event-delegation `document.addEventListener('click', ...)`), dołóż gałąź:
+
+```javascript
+                // Konwersja na DjangoQL
+                btn = e.target.closest('[data-action="to-djangoql"]');
+                if (btn) {
+                    e.preventDefault();
+                    openDjangoqlDrawer();
+                    return;
+                }
+```
+
+I dopisz funkcje (w tym samym `<script>`):
+
+```javascript
+            function getCsrfToken() {
+                var el = document.querySelector('input[name="csrfmiddlewaretoken"]');
+                return el ? el.value : '';
+            }
+
+            function openDjangoqlDrawer() {
+                var payload = formAsJSON();  // JSON string
+                var body = new URLSearchParams();
+                body.append('json', payload);
+                fetch('./do-djangoql/', {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRFToken': getCsrfToken(),
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: body.toString()
+                }).then(function (r) {
+                    if (!r.ok) { throw new Error('HTTP ' + r.status); }
+                    return r.json();
+                }).then(function (data) {
+                    document.getElementById('djangoqlQuery').value = data.query || '';
+                    document.getElementById('djangoqlOpenEditor').href = data.editor_url;
+                    var w = document.getElementById('djangoqlWarnings');
+                    if (data.warnings && data.warnings.length) {
+                        w.innerHTML = '<strong>Uwaga:</strong><ul><li>' +
+                            data.warnings.map(function (s) {
+                                return $('<div>').text(s).html();
+                            }).join('</li><li>') + '</li></ul>';
+                        w.style.display = '';
+                    } else {
+                        w.style.display = 'none';
+                    }
+                    $('#djangoqlDrawer').foundation('open');
+                }).catch(function (err) {
+                    alert('Nie udało się przetłumaczyć formularza: ' + err.message);
+                });
+            }
+```
+
+I obsługa „Kopiuj”:
+
+```javascript
+            document.addEventListener('click', function (e) {
+                var c = e.target.closest('#djangoqlCopy');
+                if (c) {
+                    e.preventDefault();
+                    var ta = document.getElementById('djangoqlQuery');
+                    navigator.clipboard.writeText(ta.value).then(function () {
+                        c.classList.add('success');
+                    });
+                }
+            });
+```
+
+> Foundation reveal wymaga zainicjalizowanego `$(document).foundation()` — w BPP jest globalnie. Jeśli drawer się nie otwiera, sprawdź, czy element `#djangoqlDrawer` istnieje w DOM przed inicjalizacją Foundation (jest renderowany statycznie, więc OK).
+
+- [ ] **Step 4: Weryfikacja manualna (run-site)**
+
+```bash
+uv run run-site run --no-browser
+```
+
+Zaloguj się jako `admin/admin`, wejdź na `/multiseek/`, zbuduj kilka warunków (Tytuł zawiera…, Rok ≥…, Jednostka „+podrzędne”), kliknij „Pokaż jako zapytanie DjangoQL”. Sprawdź:
+- drawer pokazuje poprawne zapytanie,
+- „Kopiuj” działa,
+- „Otwórz w edytorze zapytań” otwiera `/zapytanie/?model=rekord&query=…` i zwraca wyniki,
+- niewidoczny dla niezalogowanego/nieuprawnionego (sprawdź wylogowany — przycisku brak).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/django_bpp/templates/multiseek/index.html
+git commit -m "feat(multiseek-ui): przycisk + drawer 'Pokaz jako zapytanie DjangoQL'"
+```
+
+---
+
+## Task 11: Pre-commit + pełna regresja modułu
+
+**Files:** — (bez nowych)
+
+- [ ] **Step 1: Pre-commit na zmienionych plikach**
+
+Run: `pre-commit`
+Jeśli zgłosi uwagi — analizuj po kolei i poprawiaj ręcznie (Edit), bez `ruff --fix`.
+
+- [ ] **Step 2: Testy modułu konwertera + edytora**
+
+Run:
+```bash
+uv run pytest \
+  src/bpp/tests/test_multiseek_djangoql_export.py \
+  src/bpp/tests/test_multiseek_djangoql_endpoint.py \
+  src/bpp/tests/test_jednostka_podjednostki_field.py \
+  src/bpp/tests/test_zapytanie.py -q
+```
+Expected: PASS (wszystko zielone).
+
+- [ ] **Step 3: Commit (jeśli pre-commit coś zmienił)**
+
+```bash
+git add -A
+git commit -m "chore: pre-commit konwertera multiseek->djangoql"
+```
+
+---
+
+## Notatki / ryzyka
+
+- **Pokrycie pól value-list**: domyślny dispatcher obsługuje skalary, daty, autocomplete i (przez nadpisanie) Jednostkę. Pola `VALUE_LIST` (np. Typ rekordu, Charakter ogólny, Język) domyślnie lądują jako **warning**, bo etykieta z formularza nie zawsze == wartość w bazie. Jeśli zajdzie potrzeba, dodaj `to_djangoql` per-pole (wzorzec jak w Tasku 7) — walidacja fragmentu i tak chroni przed błędnym wyjściem. To świadomy, udokumentowany kompromis (best-effort + warn), zgodny ze specyfikacją.
+- **Walidacja fragmentu** (`is_valid_rekord_djangoql`) gwarantuje, że wyjście zawsze się parsuje — pola, których `field_name` nie ma w schemacie Rekord (denorm-cache typu `naz_im_1_3`), automatycznie degradują do warningu zamiast psuć całe zapytanie.
+- **UNION ops Jednostki**: świadomie nieprzekładane 1:1 (inny kształt zapytania). Jeśli okażą się potrzebne, rozwiązanie to drugie pole wirtualne (jak w spec §3) + test równoważności zbiorów.
+- **Lokalizacja operatorów**: porównujemy przez `str(<stała multiseek>)`, więc działa niezależnie od aktywnego języka.

--- a/docs/superpowers/plans/2026-06-05-multiseek-djangoql-translatability.md
+++ b/docs/superpowers/plans/2026-06-05-multiseek-djangoql-translatability.md
@@ -1,0 +1,1793 @@
+# Maksymalizacja przekładalności Multiseek → DjangoQL — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sprawić, by konwerter formularza Multiseek → DjangoQL przekładał (best-effort) niemal każde pole rejestru, z dokładną semantyką tam, gdzie się da, a w szufladzie pokazywał zapytanie sformatowane i podświetlone składniowo.
+
+**Architecture:** Silnik `djangoql_export.py` zyskuje (a) honorowanie deklaratywnej ścieżki `djangoql_field_name`, (b) gałąź value-list emitującą `<ścieżka>.nazwa = "wartość"` (opt-in przez `djangoql_value_field`), (c) obsługę pustej wartości (`= ""` / `__rel = None`), (d) kontrakt liścia mogący nieść ostrzeżenie. Pola dostają deklaratywne atrybuty lub metody `to_djangoql`. Nowe pole wirtualne `charakter_z_podrzednymi__rel` (MPTT) odwzorowuje „+ podrzędne" dla charakteru. UI: moduł JS formatuje + podświetla zapytanie używając lexera DjangoQL.
+
+**Tech Stack:** Django, multiseek, djangoql (`DjangoQLParser`, `AutocompleteField`, `apply_search`), django-mptt, model_bakery, pytest, Foundation/SCSS, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-multiseek-djangoql-translatability-design.md`
+
+---
+
+## File Structure
+
+- `src/bpp/multiseek_registry/djangoql_export.py` — silnik: `_orm_name`, `_value_list_leaf`, kontrakt ostrzeżeń, pusta wartość.
+- `src/bpp/djangoql_schema.py` — pole wirtualne `charakter_z_podrzednymi__rel` + wpięcie.
+- `src/bpp/multiseek_registry/fields/*.py` — atrybuty deklaratywne i metody `to_djangoql`.
+- `src/bpp/static/bpp/js/djangoql-pretty.js` — formatter + highlighter (UI).
+- `src/django_bpp/templates/multiseek/index.html` — szuflada (UI).
+- Testy: `src/bpp/tests/test_multiseek_djangoql_*.py` (rozbudowa), nowy `test_multiseek_djangoql_value_list.py`, `test_charakter_podrzedne_field.py`, `test_multiseek_djangoql_coverage.py`, Playwright w `test_multiseek_djangoql_button.py`.
+
+### Konwencja kontraktu liścia (obowiązuje cały plan)
+
+Metoda `to_djangoql(value, operation)` oraz wewnętrzne helpery liścia mogą zwrócić:
+- `str` — sam fragment DjangoQL,
+- `(str, str)` — `(fragment, ostrzeżenie)`,
+- `None` — nieprzekładalne.
+
+`leaf_to_djangoql(registry, leaf, warnings=None)` normalizuje to: rozpakowuje krotkę, dokleja ostrzeżenie do `warnings` (jeśli podano), waliduje fragment względem schematu i zwraca `str | None`.
+
+---
+
+## PHASE 1 — Silnik (`djangoql_export.py`)
+
+### Task 1: Deklaratywna ścieżka `djangoql_field_name` (A1)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/djangoql_export.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_export.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Dopisz na końcu `test_multiseek_djangoql_export.py`:
+
+```python
+def test_orm_name_prefers_djangoql_field_name():
+    from bpp.multiseek_registry.djangoql_export import _orm_name
+
+    class F:
+        field_name = "wydzial"
+        djangoql_field_name = "autorzy__jednostka__wydzial"
+
+    assert _orm_name(F()) == "autorzy__jednostka__wydzial"
+
+
+def test_orm_name_falls_back_to_field_name():
+    from bpp.multiseek_registry.djangoql_export import _orm_name
+
+    class F:
+        field_name = "rok"
+
+    assert _orm_name(F()) == "rok"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py::test_orm_name_prefers_djangoql_field_name -v`
+Expected: FAIL — `ImportError: cannot import name '_orm_name'`.
+
+- [ ] **Step 3: Add `_orm_name` and use it in leaf helpers**
+
+W `djangoql_export.py` dodaj helper i podmień `field.field_name` w `_autocomplete_leaf` oraz `_default_leaf` na `_orm_name(field)`:
+
+```python
+def _orm_name(field):
+    """Realna ścieżka ORM pola: djangoql_field_name (override) albo field_name."""
+    return getattr(field, "djangoql_field_name", None) or getattr(
+        field, "field_name", None
+    )
+```
+
+W `_autocomplete_leaf` zmień:
+```python
+    rel_path = _orm_path_to_djangoql(field.field_name) + "__rel"
+```
+na:
+```python
+    name = _orm_name(field)
+    if not name:
+        return None
+    rel_path = _orm_path_to_djangoql(name) + "__rel"
+```
+
+W `_default_leaf` zmień `name = getattr(field, "field_name", None)` na `name = _orm_name(field)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -v`
+Expected: PASS (nowe + dotychczasowe).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/djangoql_export.py src/bpp/tests/test_multiseek_djangoql_export.py
+git commit -m "feat(djangoql-export): honoruj djangoql_field_name jako ścieżkę ORM"
+```
+
+---
+
+### Task 2: Kontrakt liścia z ostrzeżeniem (warning-tuple)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/djangoql_export.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_export.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_leaf_to_djangoql_collects_warning_from_tuple(monkeypatch):
+    from bpp.multiseek_registry import djangoql_export as dx
+
+    class Fake:
+        type = None
+        field_name = "rok"
+
+        def to_djangoql(self, value, operation):
+            return ("rok = 2024", "uwaga testowa")
+
+    reg = type("R", (), {"field_by_name": {"X": Fake()}})()
+    warnings = []
+    frag = dx.leaf_to_djangoql(
+        reg, {"field": "X", "operator": "equals", "value": 2024}, warnings
+    )
+    assert frag == "rok = 2024"
+    assert warnings == ["uwaga testowa"]
+
+
+def test_leaf_to_djangoql_str_still_works():
+    from bpp.multiseek_registry import djangoql_export as dx
+    from multiseek.logic import CONTAINS
+
+    frag = dx.leaf_to_djangoql(
+        registry,
+        {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "x"},
+    )
+    assert frag == 'tytul_oryginalny ~ "x"'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest "src/bpp/tests/test_multiseek_djangoql_export.py::test_leaf_to_djangoql_collects_warning_from_tuple" -v`
+Expected: FAIL — `leaf_to_djangoql()` przyjmuje 2 argumenty / nie zbiera ostrzeżenia.
+
+- [ ] **Step 3: Extend `leaf_to_djangoql` and thread warnings**
+
+Zmień sygnaturę i logikę `leaf_to_djangoql`:
+
+```python
+def leaf_to_djangoql(registry, leaf, warnings=None):
+    """Fragment DjangoQL dla pojedynczego warunku, albo None (nieprzekładalny).
+
+    Wartość z dispatchera może być str, (str, warning) albo None. Ostrzeżenie
+    (jeśli jest i podano `warnings`) trafia do listy. None gdy: nieznane pole,
+    nieobsługiwana operacja, albo fragment nie waliduje się względem schematu.
+    """
+    if not isinstance(leaf, dict):
+        return None
+    field = registry.field_by_name.get(leaf.get("field"))
+    if field is None:
+        return None
+    value = leaf.get("value")
+    operation = leaf.get("operator")
+    if operation is None:
+        return None
+    override = getattr(field, "to_djangoql", None)
+    if callable(override):
+        result = override(value, operation)
+    else:
+        result = _default_leaf(field, value, operation)
+    frag, warn = result if isinstance(result, tuple) else (result, None)
+    if warn and warnings is not None:
+        warnings.append(warn)
+    if frag is None:
+        return None
+    return frag if is_valid_rekord_djangoql(frag) else None
+```
+
+W `_append_leaf` przekaż `warnings` do obu wywołań `leaf_to_djangoql(registry, leaf)` → `leaf_to_djangoql(registry, leaf, warnings)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/djangoql_export.py src/bpp/tests/test_multiseek_djangoql_export.py
+git commit -m "feat(djangoql-export): liść może nieść ostrzeżenie (str|tuple|None)"
+```
+
+---
+
+### Task 3: Gałąź value-list `<ścieżka>.nazwa = "wartość"` (A2)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/djangoql_export.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_value_list.py` (nowy)
+
+Aktywacja opt-in: tylko gdy pole ma `djangoql_value_field` (NIE po `type`, bo
+booleany też mają `type == 'value-list'`).
+
+- [ ] **Step 1: Write the failing test**
+
+Utwórz `src/bpp/tests/test_multiseek_djangoql_value_list.py`:
+
+```python
+from multiseek.logic import DIFFERENT, EQUAL
+
+from bpp.multiseek_registry.djangoql_export import _value_list_leaf
+from bpp.multiseek_registry.fields.constants import UNION
+
+
+class _VL:
+    field_name = "jezyk"
+    djangoql_value_field = "nazwa"
+
+
+def test_value_list_equal():
+    assert _value_list_leaf(_VL(), "polski", str(EQUAL)) == 'jezyk.nazwa = "polski"'
+
+
+def test_value_list_different():
+    assert _value_list_leaf(_VL(), "polski", str(DIFFERENT)) == 'jezyk.nazwa != "polski"'
+
+
+def test_value_list_empty_value():
+    assert _value_list_leaf(_VL(), "", str(EQUAL)) == 'jezyk.nazwa = ""'
+
+
+def test_value_list_union_warns():
+    frag, warn = _value_list_leaf(_VL(), "polski", str(UNION))
+    assert frag == 'jezyk.nazwa = "polski"'
+    assert "wspóln" in warn.lower()
+
+
+def test_value_list_respects_djangoql_field_name():
+    class VL2:
+        field_name = "typ_odpowiedzialnosci"
+        djangoql_field_name = "autorzy__typ_odpowiedzialnosci"
+        djangoql_value_field = "nazwa"
+
+    assert (
+        _value_list_leaf(VL2(), "autor", str(EQUAL))
+        == 'autorzy.typ_odpowiedzialnosci.nazwa = "autor"'
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_value_list.py -v`
+Expected: FAIL — `ImportError: cannot import name '_value_list_leaf'`.
+
+- [ ] **Step 3: Implement `_value_list_leaf` and route to it**
+
+Dodaj import `UNION_OPS_ALL` (z `.fields.constants`) NIE — użyj lokalnej detekcji. Dodaj helpery i funkcję:
+
+```python
+def _is_union(operation):
+    """True gdy operator multiseek to wariant UNION (równy+wspólny…)."""
+    from bpp.multiseek_registry.fields.constants import UNION_OPS_ALL
+
+    s = str(operation)
+    return s in {str(o) for o in UNION_OPS_ALL}
+
+
+_UNION_WARNING = (
+    "Operator „wspólny" przełożono jak zwykłą równość — w DjangoQL może objąć "
+    "inny wiersz autora niż pozostałe kryteria."
+)
+
+
+def _value_list_leaf(field, value, operation):
+    """value-list (lista stringów) -> '<ścieżka>.<pole> = \"wartość\"'.
+
+    Aktywne tylko dla pól z atrybutem `djangoql_value_field`. UNION → '='
+    z ostrzeżeniem. Pusta wartość → '= \"\"'.
+    """
+    name = _orm_name(field)
+    value_field = getattr(field, "djangoql_value_field", None)
+    if not name or not value_field:
+        return None
+    op = str(operation)
+    diff_strs = {str(o) for o in DIFFERENT_ALL}
+    if op in diff_strs:
+        dql_op = "!="
+    elif op in {str(o) for o in EQUALITY_OPS_ALL} - diff_strs or _is_union(op):
+        dql_op = "="
+    else:
+        return None
+    path = _orm_path_to_djangoql(name)
+    frag = f"{path}.{value_field} {dql_op} {render_value(value or '')}"
+    if _is_union(op):
+        return frag, _UNION_WARNING
+    return frag
+```
+
+W `_default_leaf`, ZARAZ po gałęzi AUTOCOMPLETE, dodaj:
+
+```python
+    if getattr(field, "djangoql_value_field", None):
+        return _value_list_leaf(field, value, operation)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_value_list.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/djangoql_export.py src/bpp/tests/test_multiseek_djangoql_value_list.py
+git commit -m "feat(djangoql-export): gałąź value-list -> <ścieżka>.nazwa (opt-in)"
+```
+
+---
+
+### Task 4: Pusta wartość autocomplete → `__rel = None` (A3)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/djangoql_export.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_export.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_autocomplete_empty_value_is_null():
+    from bpp.multiseek_registry.djangoql_export import _autocomplete_leaf
+    from multiseek.logic import EQUAL_NONE
+
+    class FK:
+        field_name = "zrodlo"
+        type = "autocomplete"
+
+        def value_from_web(self, value):
+            return None
+
+    assert _autocomplete_leaf(FK(), None, str(EQUAL_NONE)) == "zrodlo__rel = None"
+
+
+def test_autocomplete_empty_value_is_null_diff():
+    from bpp.multiseek_registry.djangoql_export import _autocomplete_leaf
+    from multiseek.logic import DIFFERENT_NONE
+
+    class FK:
+        field_name = "zrodlo"
+        type = "autocomplete"
+
+        def value_from_web(self, value):
+            return None
+
+    assert _autocomplete_leaf(FK(), None, str(DIFFERENT_NONE)) == "zrodlo__rel != None"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py::test_autocomplete_empty_value_is_null -v`
+Expected: FAIL — zwraca `None` zamiast `"zrodlo__rel = None"`.
+
+- [ ] **Step 3: Handle empty value in `_autocomplete_leaf`**
+
+W `_autocomplete_leaf`, po ustaleniu `rel_op` i PRZED `obj = field.value_from_web(value)`, dodaj wyznaczenie ścieżki i obsługę pustki:
+
+```python
+    name = _orm_name(field)
+    if not name:
+        return None
+    rel_path = _orm_path_to_djangoql(name) + "__rel"
+    if value in (None, ""):
+        return f"{rel_path} = None" if rel_op == "=" else f"{rel_path} != None"
+```
+
+Usuń późniejsze ponowne wyznaczanie `rel_path` (zostaw jedno). Zachowaj `if obj is None: return None` dla niepustej-ale-nierozwiązywalnej wartości.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_export.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/djangoql_export.py src/bpp/tests/test_multiseek_djangoql_export.py
+git commit -m "feat(djangoql-export): pusty autocomplete -> __rel = None (is-null)"
+```
+
+---
+
+## PHASE 2 — Pole wirtualne charakteru (`djangoql_schema.py`)
+
+### Task 5: `CharakterZPodrzednymiField` + wpięcie (A4)
+
+**Files:**
+- Modify: `src/bpp/djangoql_schema.py`
+- Test: `src/bpp/tests/test_charakter_podrzedne_field.py` (nowy)
+
+- [ ] **Step 1: Write the failing test**
+
+Utwórz `src/bpp/tests/test_charakter_podrzedne_field.py`:
+
+```python
+import pytest
+from djangoql.queryset import apply_search
+from model_bakery import baker
+
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Charakter_Formalny, Rekord
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_charakter_z_podrzednymi_field_present_on_rekord():
+    s = BppQLSchema(Rekord)
+    fields = s.get_fields(Rekord)
+    assert "charakter_z_podrzednymi__rel" in fields
+
+
+@pytest.mark.django_db
+def test_charakter_z_podrzednymi_matches_descendants(
+    wydawnictwo_ciagle, denorms
+):
+    parent = baker.make(Charakter_Formalny, nazwa="Artykuły", skrot="ART")
+    child = baker.make(
+        Charakter_Formalny, nazwa="Artykuł oryginalny", skrot="AO", parent=parent
+    )
+    Charakter_Formalny.objects.rebuild()
+    wydawnictwo_ciagle.charakter_formalny = child
+    wydawnictwo_ciagle.save()
+    denorms.flush()
+
+    frag = f'charakter_z_podrzednymi__rel = "Artykuły [{parent.pk}]"'
+    pks = set(
+        apply_search(Rekord.objects.all(), frag, schema=BppQLSchema)
+        .distinct()
+        .values_list("pk", flat=True)
+    )
+    assert wydawnictwo_ciagle.rekord_set.first().pk in pks
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_charakter_podrzedne_field.py -v`
+Expected: FAIL — pole nieobecne / fragment nie waliduje.
+
+- [ ] **Step 3: Implement the virtual field and wire it**
+
+W `djangoql_schema.py`:
+
+Import modelu (góra pliku, obok `from bpp.models import Jednostka`):
+```python
+from bpp.models import Charakter_Formalny, Jednostka
+```
+
+Stała obok `_SUBUNITS_FIELD`:
+```python
+#: Wirtualne pole: picker po Charakterze Formalnym dopasowujący MPTT-descendants.
+_CHARAKTER_SUB_FIELD = "charakter_z_podrzednymi__rel"
+```
+
+Klasa (po `JednostkaZPodjednostkamiField`):
+```python
+class CharakterZPodrzednymiField(AutocompleteField):
+    """Picker po Charakter_Formalny: dopasowuje rekordy o tym charakterze ORAZ
+    wszystkich potomkach w drzewie MPTT (sam + descendants).
+
+    Odwzorowuje CharakterFormalnyQueryObject.real_query:
+        Q(charakter_formalny__in=value.get_descendants(include_self=True))
+    """
+
+    def get_lookup(self, path, operator, value):
+        parsed = self.parse_id(value)
+        if not isinstance(parsed, int):
+            q = Q(charakter_formalny__nazwa__icontains=str(value))
+            return ~q if operator in ("!=", "not in") else q
+        try:
+            ch = Charakter_Formalny.objects.get(pk=parsed)
+        except Charakter_Formalny.DoesNotExist:
+            return Q() if operator in ("!=", "not in") else Q(pk__in=[])
+        q = Q(charakter_formalny__in=ch.get_descendants(include_self=True))
+        return ~q if operator in ("!=", "not in") else q
+```
+
+Predykat obok `_has_autorzy_jednostka`:
+```python
+def _has_charakter_formalny(model):
+    """True, gdy model ma FK 'charakter_formalny' (Rekord/cache)."""
+    try:
+        f = model._meta.get_field("charakter_formalny")
+    except FieldDoesNotExist:
+        return False
+    return getattr(f, "many_to_one", False)
+```
+
+W `RelPickerSchemaMixin.get_fields`, po bloku `if _has_autorzy_jednostka(model):`:
+```python
+        if _has_charakter_formalny(model):
+            fields.append(_CHARAKTER_SUB_FIELD)
+```
+
+W `RelPickerSchemaMixin.get_field_instance`, na początku (obok bloku `_SUBUNITS_FIELD`):
+```python
+        if field_name == _CHARAKTER_SUB_FIELD:
+            return CharakterZPodrzednymiField(
+                model=model,
+                name=_CHARAKTER_SUB_FIELD,
+                nullable=True,
+                queryset=_visible_qs(Charakter_Formalny),
+                search_fields=_label_fields(Charakter_Formalny),
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/bpp/tests/test_charakter_podrzedne_field.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/djangoql_schema.py src/bpp/tests/test_charakter_podrzedne_field.py
+git commit -m "feat(djangoql-schema): pole wirtualne charakter_z_podrzednymi__rel (MPTT)"
+```
+
+---
+
+## PHASE 3 — Pola rejestru
+
+### Task 6: Deklaratywne ścieżki autocomplete (B1)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/fields/unit_fields.py`, `author_fields.py`, `boolean_fields.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_fields_b1.py` (nowy)
+
+Dodajemy `djangoql_field_name` (realna ścieżka ORM) do pól autocomplete, których `field_name` ≠ ścieżka. Domyślny dispatcher zrobi `<ścieżka>__rel`.
+
+- [ ] **Step 1: Write the failing test**
+
+Utwórz `src/bpp/tests/test_multiseek_djangoql_fields_b1.py`:
+
+```python
+import pytest
+from model_bakery import baker
+from multiseek.logic import EQUAL
+
+from bpp.models import Kierunek_Studiow
+from bpp.models.struktura import Wydzial
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.djangoql_export import leaf_to_djangoql
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_wydzial_maps_to_nested_rel():
+    w = baker.make(Wydzial, nazwa="Wydział Lekarski")
+    frag = leaf_to_djangoql(
+        registry, {"field": "Wydział", "operator": str(EQUAL), "value": w.pk}
+    )
+    assert frag == f'autorzy.jednostka.wydzial__rel = "Wydział Lekarski [{w.pk}]"'
+
+
+@pytest.mark.django_db
+def test_kierunek_maps_to_nested_rel():
+    k = baker.make(Kierunek_Studiow, nazwa="Lekarski")
+    frag = leaf_to_djangoql(
+        registry, {"field": "Kierunek studiów", "operator": str(EQUAL), "value": k.pk}
+    )
+    assert frag == f'autorzy.kierunek_studiow__rel = "Lekarski [{k.pk}]"'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_fields_b1.py -v`
+Expected: FAIL — fragmenty `wydzial__rel`/`nazwa__rel` nie walidują → `None`.
+
+- [ ] **Step 3: Add `djangoql_field_name` attributes**
+
+W `unit_fields.py`:
+- `WydzialQueryObject`: dodaj atrybut klasy `djangoql_field_name = "autorzy__jednostka__wydzial"`.
+
+W `boolean_fields.py`:
+- `KierunekStudiowQueryObject`: dodaj `djangoql_field_name = "autorzy__kierunek_studiow"`.
+
+W `author_fields.py`:
+- `DyscyplinaQueryObject`: dodaj `djangoql_field_name = "autorzy__dyscyplina_naukowa"`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_fields_b1.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/fields/unit_fields.py src/bpp/multiseek_registry/fields/boolean_fields.py src/bpp/multiseek_registry/fields/author_fields.py src/bpp/tests/test_multiseek_djangoql_fields_b1.py
+git commit -m "feat(multiseek): deklaratywne ścieżki djangoql_field_name (Wydział/Kierunek/Dyscyplina)"
+```
+
+---
+
+### Task 7: Value-list deklaratywny `.nazwa` (B2)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/fields/numeric_fields.py` (Język), `factories.py` (value-list factory), `publication_type_fields.py` (Typ odpowiedzialności)
+- Test: `src/bpp/tests/test_multiseek_djangoql_value_list.py`
+
+`create_valuelist_query_object` ma ustawiać `djangoql_value_field = "nazwa"` na wytwarzanych klasach (TypKBN, OpenAccess×3). Pola pisane ręcznie dostają atrybut wprost.
+
+- [ ] **Step 1: Write the failing test**
+
+Dopisz do `test_multiseek_djangoql_value_list.py`:
+
+```python
+import pytest
+from model_bakery import baker
+from multiseek.logic import EQUAL
+
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.djangoql_export import leaf_to_djangoql
+
+
+@pytest.mark.django_db
+@pytest.mark.serial
+def test_jezyk_maps_to_nazwa():
+    frag = leaf_to_djangoql(
+        registry, {"field": "Język", "operator": str(EQUAL), "value": "polski"}
+    )
+    assert frag == 'jezyk.nazwa = "polski"'
+
+
+@pytest.mark.django_db
+@pytest.mark.serial
+def test_typ_kbn_maps_to_nazwa():
+    from bpp.models.system import Typ_KBN
+
+    baker.make(Typ_KBN, nazwa="PO")
+    frag = leaf_to_djangoql(
+        registry, {"field": "Typ MNiSW/MEiN", "operator": str(EQUAL), "value": "PO"}
+    )
+    assert frag == 'typ_kbn.nazwa = "PO"'
+
+
+@pytest.mark.django_db
+@pytest.mark.serial
+def test_typ_odpowiedzialnosci_maps_to_nested_nazwa():
+    frag = leaf_to_djangoql(
+        registry,
+        {"field": "Typ odpowiedzialności", "operator": str(EQUAL), "value": "autor"},
+    )
+    assert frag == 'autorzy.typ_odpowiedzialnosci.nazwa = "autor"'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_value_list.py::test_jezyk_maps_to_nazwa -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Set `djangoql_value_field` (+ path where needed)**
+
+W `numeric_fields.py`:
+- `JezykQueryObject`: dodaj `djangoql_value_field = "nazwa"`.
+
+W `factories.py` w `create_valuelist_query_object`, do `class_attrs` dodaj:
+```python
+        "djangoql_value_field": name_field,
+```
+(`name_field` to istniejący argument, domyślnie `"nazwa"`). Obejmuje TypKBN, OpenaccessWersjaTekstu/Licencja/CzasPublikacji.
+
+W `publication_type_fields.py`:
+- `Typ_OdpowiedzialnosciQueryObject`: dodaj `djangoql_field_name = "autorzy__typ_odpowiedzialnosci"` oraz `djangoql_value_field = "nazwa"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_value_list.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/fields/numeric_fields.py src/bpp/multiseek_registry/fields/factories.py src/bpp/multiseek_registry/fields/publication_type_fields.py src/bpp/tests/test_multiseek_djangoql_value_list.py
+git commit -m "feat(multiseek): value-list -> .nazwa (Język/TypKBN/OpenAccess/TypOdpowiedzialności)"
+```
+
+---
+
+### Task 8: Deklaratywne booleany przez `autorzy` (B3-bool)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/fields/boolean_fields.py`, `author_fields.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_fields_bool.py` (nowy)
+
+`Afiliuje` i `Oświadczenie KEN` to booleany; wartość to bool. Wystarczy `djangoql_field_name` → skalarna gałąź da `autorzy.<pole> = True/False`.
+
+- [ ] **Step 1: Write the failing test**
+
+Utwórz `src/bpp/tests/test_multiseek_djangoql_fields_bool.py`:
+
+```python
+import pytest
+from multiseek.logic import EQUAL
+
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.djangoql_export import leaf_to_djangoql
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_afiliuje_true():
+    frag = leaf_to_djangoql(
+        registry, {"field": "Afiliuje", "operator": str(EQUAL), "value": True}
+    )
+    assert frag == "autorzy.afiliuje = True"
+
+
+@pytest.mark.django_db
+def test_oswiadczenie_ken_false():
+    frag = leaf_to_djangoql(
+        registry,
+        {"field": "Oświadczenie KEN", "operator": str(EQUAL), "value": False},
+    )
+    assert frag == "autorzy.oswiadczenie_ken = False"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_fields_bool.py -v`
+Expected: FAIL — `afiliuje = True` nie waliduje (brak pola na Rekord) → None.
+
+- [ ] **Step 3: Add `djangoql_field_name` to the two booleans**
+
+W `boolean_fields.py`:
+- `AfiliujeQueryObject`: dodaj `djangoql_field_name = "autorzy__afiliuje"`.
+
+W `author_fields.py`:
+- `OswiadczenieKENQueryObject`: dodaj `djangoql_field_name = "autorzy__oswiadczenie_ken"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_fields_bool.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/fields/boolean_fields.py src/bpp/multiseek_registry/fields/author_fields.py src/bpp/tests/test_multiseek_djangoql_fields_bool.py
+git commit -m "feat(multiseek): Afiliuje/Oświadczenie KEN -> autorzy.<pole> = bool"
+```
+
+---
+
+### Task 9: Charakter formalny (+podrzędne), ogólny, typ rekordu (B3)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/fields/publication_type_fields.py`
+- Test: `src/bpp/tests/test_multiseek_charakter_to_djangoql.py` (nowy)
+
+- [ ] **Step 1: Write the failing test**
+
+Utwórz `src/bpp/tests/test_multiseek_charakter_to_djangoql.py`:
+
+```python
+import pytest
+from model_bakery import baker
+from multiseek.logic import DIFFERENT, EQUAL
+
+from bpp.models import Charakter_Formalny
+from bpp.multiseek_registry import registry
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_charakter_formalny_maps_to_virtual_field():
+    ch = baker.make(Charakter_Formalny, nazwa="Artykuł", skrot="AC")
+    Charakter_Formalny.objects.rebuild()
+    field = registry.field_by_name["Charakter formalny"]
+    frag = field.to_djangoql("Artykuł", str(EQUAL))
+    assert frag == f'charakter_z_podrzednymi__rel = "Artykuł [{ch.pk}]"'
+
+
+@pytest.mark.django_db
+def test_charakter_formalny_strips_indent_prefix():
+    ch = baker.make(Charakter_Formalny, nazwa="Artykuł", skrot="AC")
+    Charakter_Formalny.objects.rebuild()
+    field = registry.field_by_name["Charakter formalny"]
+    frag = field.to_djangoql("--- Artykuł", str(EQUAL))
+    assert frag == f'charakter_z_podrzednymi__rel = "Artykuł [{ch.pk}]"'
+
+
+@pytest.mark.django_db
+def test_charakter_formalny_different():
+    ch = baker.make(Charakter_Formalny, nazwa="Artykuł", skrot="AC")
+    Charakter_Formalny.objects.rebuild()
+    field = registry.field_by_name["Charakter formalny"]
+    frag = field.to_djangoql("Artykuł", str(DIFFERENT))
+    assert frag == f'charakter_z_podrzednymi__rel != "Artykuł [{ch.pk}]"'
+
+
+def test_charakter_ogolny_artykul():
+    field = registry.field_by_name["Charakter formalny ogólny"]
+    assert field.to_djangoql("artykuł", str(EQUAL)) == 'charakter_formalny.charakter_ogolny = "art"'
+
+
+def test_charakter_ogolny_ksiazka():
+    field = registry.field_by_name["Charakter formalny ogólny"]
+    assert field.to_djangoql("książka", str(EQUAL)) == 'charakter_formalny.charakter_ogolny = "ksi"'
+
+
+def test_typ_rekordu_publikacje():
+    field = registry.field_by_name["Typ rekordu"]
+    assert field.to_djangoql("publikacje", str(EQUAL)) == "charakter_formalny.publikacja = True"
+
+
+def test_typ_rekordu_inne():
+    field = registry.field_by_name["Typ rekordu"]
+    assert (
+        field.to_djangoql("inne", str(EQUAL))
+        == "(charakter_formalny.publikacja = False and charakter_formalny.streszczenie = False)"
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_charakter_to_djangoql.py -v`
+Expected: FAIL — `to_djangoql` nieobecne / zwraca None.
+
+- [ ] **Step 3: Implement the three `to_djangoql` methods**
+
+W `publication_type_fields.py` dodaj importy stałych operatorów na górze:
+```python
+from multiseek.logic import DIFFERENT_ALL, EQUALITY_OPS_ALL
+```
+(`DIFFERENT`, `EQUAL`, `EQUALITY_OPS_ALL` częściowo już są — uzupełnij brakujące, unikaj duplikatów.)
+
+`CharakterFormalnyQueryObject` — dodaj metodę:
+```python
+    def to_djangoql(self, value, operation):
+        """charakter_z_podrzednymi__rel (MPTT: sam + potomkowie) — dokładne."""
+        obj = self.value_from_web(value)
+        if obj is None:
+            return None
+        op = str(operation)
+        diff = {str(o) for o in DIFFERENT_ALL}
+        if op in diff:
+            rel_op = "!="
+        elif op in {str(o) for o in EQUALITY_OPS_ALL} - diff:
+            rel_op = "="
+        else:
+            return None
+        label = str(obj.nazwa).replace("\\", "\\\\").replace('"', '\\"')
+        return f'charakter_z_podrzednymi__rel {rel_op} "{label} [{obj.pk}]"'
+```
+
+`CharakterOgolnyQueryObject` — dodaj metodę:
+```python
+    _DJANGOQL_OGOLNY = {
+        "artykuł": const.CHARAKTER_OGOLNY_ARTYKUL,
+        "rozdział": const.CHARAKTER_OGOLNY_ROZDZIAL,
+        "książka": const.CHARAKTER_OGOLNY_KSIAZKA,
+        "inne": const.CHARAKTER_OGOLNY_INNE,
+    }
+
+    def to_djangoql(self, value, operation):
+        kod = self._DJANGOQL_OGOLNY.get(value)
+        if kod is None:
+            return None
+        op = "!=" if str(operation) in {str(o) for o in DIFFERENT_ALL} else "="
+        return f'charakter_formalny.charakter_ogolny {op} "{kod}"'
+```
+
+`TypRekorduObject` — dodaj metodę:
+```python
+    def to_djangoql(self, value, operation):
+        neg = str(operation) in {str(o) for o in DIFFERENT_ALL}
+        if value == "publikacje":
+            frag = "charakter_formalny.publikacja = True"
+        elif value == "streszczenia":
+            frag = "charakter_formalny.streszczenie = True"
+        elif value == "inne":
+            frag = (
+                "(charakter_formalny.publikacja = False "
+                "and charakter_formalny.streszczenie = False)"
+            )
+        else:
+            return None
+        if neg:
+            return None  # negacja zbioru -> brak czystego not(...) w DjangoQL
+        return frag
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_charakter_to_djangoql.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/fields/publication_type_fields.py src/bpp/tests/test_multiseek_charakter_to_djangoql.py
+git commit -m "feat(multiseek): Charakter formalny/ogólny/Typ rekordu -> DjangoQL"
+```
+
+---
+
+### Task 10: Typ ogólny autora (autor + typ_odpowiedzialności) (B3 compound)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/fields/author_fields.py`
+- Test: `src/bpp/tests/test_multiseek_autor_to_djangoql.py` (rozbudowa)
+
+`TypOgolnyAutorQueryObject` i 3 podklasy: `autorzy.autor__rel = "L [pk]" and autorzy.typ_odpowiedzialnosci.typ_ogolny = N` (same-row, dokładne).
+
+- [ ] **Step 1: Write the failing test**
+
+Dopisz do `test_multiseek_autor_to_djangoql.py`:
+
+```python
+@pytest.mark.django_db
+def test_typ_ogolny_autor_compound():
+    from bpp.models import Autor
+    from bpp.multiseek_registry import registry
+
+    a = baker.make(Autor, nazwisko="Nowak", imiona="Jan")
+    field = registry.field_by_name["Autor"]
+    frag = field.to_djangoql(a.pk, str(EQUAL))
+    assert frag == (
+        f'autorzy.autor__rel = "{a} [{a.pk}]" '
+        "and autorzy.typ_odpowiedzialnosci.typ_ogolny = 0"
+    )
+
+
+@pytest.mark.django_db
+def test_typ_ogolny_redaktor_compound():
+    from bpp.models import Autor
+    from bpp.multiseek_registry import registry
+
+    a = baker.make(Autor, nazwisko="Nowak", imiona="Jan")
+    field = registry.field_by_name["Redaktor"]
+    frag = field.to_djangoql(a.pk, str(EQUAL))
+    assert frag.endswith("and autorzy.typ_odpowiedzialnosci.typ_ogolny = 1")
+```
+
+(Upewnij się, że plik ma `import pytest`, `from model_bakery import baker`, `from multiseek.logic import EQUAL`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_autor_to_djangoql.py::test_typ_ogolny_autor_compound -v`
+Expected: FAIL — odziedziczone `to_djangoql` z `NazwiskoIImieQueryObject` zwraca None dla podklas.
+
+- [ ] **Step 3: Override `to_djangoql` on `TypOgolnyAutorQueryObject`**
+
+W `author_fields.py`, w `TypOgolnyAutorQueryObject` dodaj metodę (po `real_query`):
+```python
+    def to_djangoql(self, value, operation):
+        op = str(operation)
+        diff = {str(o) for o in DIFFERENT_ALL}
+        equal = {str(o) for o in EQUALITY_OPS_ALL} - diff
+        if op in diff:
+            return None  # negacja koniunkcji nie ma czystego not(...) w DjangoQL
+        if op not in equal and not _is_union_value(op):
+            return None
+        try:
+            obj = self.value_from_web(value)
+        except Exception:  # noqa: BLE001 — uszkodzony pk -> nieprzekładalne
+            return None
+        if obj is None:
+            return None
+        label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
+        frag = (
+            f'autorzy.autor__rel = "{label} [{obj.pk}]" '
+            f"and autorzy.typ_odpowiedzialnosci.typ_ogolny = {self.typ_ogolny}"
+        )
+        if _is_union_value(op):
+            return frag, (
+                "Operator „wspólny" przełożono jak równość — w DjangoQL może "
+                "objąć inny wiersz autora."
+            )
+        return frag
+```
+
+Dodaj na górze `author_fields.py` (jeśli brak) import i mały helper:
+```python
+from .constants import UNION_OPS_ALL
+
+
+def _is_union_value(operation):
+    return str(operation) in {str(o) for o in UNION_OPS_ALL}
+```
+(Jeśli `UNION_OPS_ALL` już importowane — nie duplikuj.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_autor_to_djangoql.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/fields/author_fields.py src/bpp/tests/test_multiseek_autor_to_djangoql.py
+git commit -m "feat(multiseek): Autor/Redaktor/Tłumacz/Recenzent -> autor + typ_ogolny"
+```
+
+---
+
+### Task 11: Booleany isnull / inwersja / złożone (B3)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/fields/boolean_fields.py`
+- Test: `src/bpp/tests/test_multiseek_djangoql_fields_bool.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Dopisz do `test_multiseek_djangoql_fields_bool.py`:
+
+```python
+@pytest.mark.django_db
+def test_obca_jednostka_inverts_value():
+    # "Obca jednostka = True" oznacza skupia_pracownikow = False
+    field = registry.field_by_name["Obca jednostka"]
+    assert field.to_djangoql(True, str(EQUAL)) == "autorzy.jednostka.skupia_pracownikow = False"
+
+
+@pytest.mark.django_db
+def test_dyscyplina_ustawiona_true():
+    field = registry.field_by_name["Dyscyplina ustawiona"]
+    assert field.to_djangoql(True, str(EQUAL)) == "autorzy.dyscyplina_naukowa != None"
+
+
+@pytest.mark.django_db
+def test_dyscyplina_ustawiona_false():
+    field = registry.field_by_name["Dyscyplina ustawiona"]
+    assert field.to_djangoql(False, str(EQUAL)) == "autorzy.dyscyplina_naukowa = None"
+
+
+@pytest.mark.django_db
+def test_licencja_oa_ustawiona_true():
+    field = registry.field_by_name["OpenAccess: licencja ustawiona"]
+    assert field.to_djangoql(True, str(EQUAL)) == "openaccess_licencja != None"
+
+
+@pytest.mark.django_db
+def test_strona_www_ustawiona_true():
+    field = registry.field_by_name["Strona WWW ustawiona"]
+    assert field.to_djangoql(True, str(EQUAL)) == '(www != "" or public_www != "")'
+```
+
+(Import `EQUAL` z `multiseek.logic` na górze pliku — jeśli brak, dodaj.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_fields_bool.py::test_obca_jednostka_inverts_value -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the four `to_djangoql` methods**
+
+W `boolean_fields.py` (importy: `from multiseek.logic import DIFFERENT_ALL` jeśli brak).
+
+`ObcaJednostkaQueryObject`:
+```python
+    def to_djangoql(self, value, operation):
+        skupia = not bool(value)  # real_query robi value = not value
+        return f"autorzy.jednostka.skupia_pracownikow = {skupia}"
+```
+
+`DyscyplinaUstawionaQueryObject`:
+```python
+    def to_djangoql(self, value, operation):
+        return (
+            "autorzy.dyscyplina_naukowa != None"
+            if value
+            else "autorzy.dyscyplina_naukowa = None"
+        )
+```
+
+`LicencjaOpenAccessUstawionaQueryObject`:
+```python
+    def to_djangoql(self, value, operation):
+        return (
+            "openaccess_licencja != None" if value else "openaccess_licencja = None"
+        )
+```
+
+`PublicDostepDniaQueryObject`:
+```python
+    def to_djangoql(self, value, operation):
+        return (
+            "public_dostep_dnia != None" if value else "public_dostep_dnia = None"
+        )
+```
+
+`StronaWWWUstawionaQueryObject`:
+```python
+    def to_djangoql(self, value, operation):
+        if value:
+            return '(www != "" or public_www != "")'
+        return '(www = "" and public_www = "")'
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_fields_bool.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/fields/boolean_fields.py src/bpp/tests/test_multiseek_djangoql_fields_bool.py
+git commit -m "feat(multiseek): booleany isnull/inwersja/WWW -> DjangoQL"
+```
+
+---
+
+### Task 12: Rodzaj konferencji/jednostki, Słowa kluczowe, Zewn. baza (B3)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/fields/publication_type_fields.py` (RodzajKonferencji), `unit_fields.py` (RodzajJednostki), `author_fields.py` (SlowaKluczowe), `openaccess_fields.py` (ZewnetrznaBazaDanych)
+- Test: `src/bpp/tests/test_multiseek_djangoql_fields_misc.py` (nowy)
+
+- [ ] **Step 1: Write the failing test**
+
+Utwórz `src/bpp/tests/test_multiseek_djangoql_fields_misc.py`:
+
+```python
+import pytest
+from model_bakery import baker
+from multiseek.logic import EQUAL
+
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.djangoql_export import leaf_to_djangoql
+
+pytestmark = pytest.mark.serial
+
+
+def test_rodzaj_konferencji_krajowa():
+    field = registry.field_by_name["Rodzaj konferencji"]
+    assert field.to_djangoql("krajowa", str(EQUAL)) == "konferencja.typ_konferencji = 1"
+
+
+def test_rodzaj_jednostki_normalna():
+    from bpp.models import Jednostka
+
+    field = registry.field_by_name["Rodzaj jednostki"]
+    val = Jednostka.RODZAJ_JEDNOSTKI.NORMALNA.label
+    assert (
+        field.to_djangoql(val, str(EQUAL))
+        == 'autorzy.jednostka.rodzaj_jednostki = "normalna"'
+    )
+
+
+@pytest.mark.django_db
+def test_slowa_kluczowe_maps_to_tag_name():
+    field = registry.field_by_name["Słowa kluczowe"]
+    assert field.to_djangoql("nowotwór", str(EQUAL)) == 'slowa_kluczowe.name = "nowotwór"'
+
+
+@pytest.mark.django_db
+def test_zewnetrzna_baza_maps_to_nested_rel():
+    from bpp.models import Zewnetrzna_Baza_Danych
+
+    z = baker.make(Zewnetrzna_Baza_Danych, nazwa="Scopus")
+    frag = leaf_to_djangoql(
+        registry,
+        {"field": "Zewnętrzna baza danych", "operator": str(EQUAL), "value": z.pk},
+    )
+    assert frag == f'zewnetrzne_bazy.baza__rel = "Scopus [{z.pk}]"'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_fields_misc.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+W `publication_type_fields.py`, `RodzajKonferenckjiQueryObject`:
+```python
+    _DJANGOQL_TK = {"krajowa": 1, "międzynarodowa": 2, "lokalna": 3}
+
+    def to_djangoql(self, value, operation):
+        tk = self._DJANGOQL_TK.get(value)
+        if tk is None:
+            return None
+        op = "!=" if str(operation) in {str(o) for o in DIFFERENT_ALL} else "="
+        return f"konferencja.typ_konferencji {op} {tk}"
+```
+
+W `unit_fields.py`, `RodzajJednostkiQueryObject`: dodaj
+```python
+    djangoql_field_name = "autorzy__jednostka__rodzaj_jednostki"
+    djangoql_value_field = "rodzaj_jednostki"
+```
+Uwaga: `value_from_web` zwraca string-label (np. „normalna"), a `rodzaj_jednostki` na modelu przechowuje tę samą wartość małymi literami z `.value`. Sprawdź roundtrip w Step 4; jeśli label≠value, użyj zamiast atrybutów metody:
+```python
+    def to_djangoql(self, value, operation):
+        from bpp.models import Jednostka
+
+        mapa = {
+            Jednostka.RODZAJ_JEDNOSTKI.NORMALNA.label: Jednostka.RODZAJ_JEDNOSTKI.NORMALNA.value,
+            Jednostka.RODZAJ_JEDNOSTKI.KOLO_NAUKOWE.label: Jednostka.RODZAJ_JEDNOSTKI.KOLO_NAUKOWE.value,
+        }
+        kod = mapa.get(value)
+        if kod is None:
+            return None
+        return f'autorzy.jednostka.rodzaj_jednostki = "{kod}"'
+```
+(Preferuj metodę — pewniejsza co do mapowania label→value.)
+
+W `author_fields.py`, `SlowaKluczoweQueryObject`:
+```python
+    def to_djangoql(self, value, operation):
+        op = "!=" if str(operation) in {str(o) for o in DIFFERENT_ALL} else "="
+        label = str(value).replace("\\", "\\\\").replace('"', '\\"')
+        return f'slowa_kluczowe.name {op} "{label}"'
+```
+
+W `openaccess_fields.py`, `ZewnetrznaBazaDanychQueryObject`: dodaj atrybut
+```python
+    djangoql_field_name = "zewnetrzne_bazy__baza"
+```
+(Pole jest `type = AUTOCOMPLETE`, wartość to pk → dispatcher zrobi `zewnetrzne_bazy.baza__rel`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_fields_misc.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/fields/publication_type_fields.py src/bpp/multiseek_registry/fields/unit_fields.py src/bpp/multiseek_registry/fields/author_fields.py src/bpp/multiseek_registry/fields/openaccess_fields.py src/bpp/tests/test_multiseek_djangoql_fields_misc.py
+git commit -m "feat(multiseek): Rodzaj konf./jedn., Słowa kluczowe, Zewn. baza -> DjangoQL"
+```
+
+---
+
+### Task 13: Pola kolejnościowe (dokładne) + UNION jednostki (best-effort+warning) (F)
+
+**Files:**
+- Modify: `src/bpp/multiseek_registry/fields/author_fields.py`, `unit_fields.py`
+- Test: `src/bpp/tests/test_multiseek_kolejnosc_to_djangoql.py` (nowy); update `test_multiseek_jednostka_to_djangoql.py`
+
+Semantyka: koniunkcja `autorzy.X and autorzy.kolejnosc …` jest same-row → dokładna. `Ostatnie nazwisko` (F-expression) → best-effort+warning. UNION jednostki → best-effort+warning (zmiana istniejących testów „untranslatable").
+
+- [ ] **Step 1: Write the failing test**
+
+Utwórz `src/bpp/tests/test_multiseek_kolejnosc_to_djangoql.py`:
+
+```python
+import pytest
+from model_bakery import baker
+from multiseek.logic import EQUAL
+
+from bpp.models import Autor
+from bpp.multiseek_registry import registry
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_pierwsze_nazwisko_is_kolejnosc_zero():
+    a = baker.make(Autor, nazwisko="Nowak", imiona="Jan")
+    field = registry.field_by_name["Pierwsze nazwisko i imię"]
+    frag = field.to_djangoql(a.pk, str(EQUAL))
+    assert frag == (
+        f'autorzy.autor__rel = "{a} [{a.pk}]" '
+        "and autorzy.kolejnosc >= 0 and autorzy.kolejnosc < 1"
+    )
+
+
+@pytest.mark.django_db
+def test_ostatnie_nazwisko_best_effort_warns():
+    a = baker.make(Autor, nazwisko="Nowak", imiona="Jan")
+    field = registry.field_by_name["Ostatnie nazwisko i imię"]
+    result = field.to_djangoql(a.pk, str(EQUAL))
+    assert isinstance(result, tuple)
+    frag, warn = result
+    assert frag == f'autorzy.autor__rel = "{a} [{a.pk}]"'
+    assert "ostatni" in warn.lower() or "kolejn" in warn.lower()
+```
+
+Zmień w `test_multiseek_jednostka_to_djangoql.py` testy UNION (dotychczas `is None`):
+```python
+@pytest.mark.django_db
+def test_jednostka_union_best_effort_warns():
+    j = baker.make(Jednostka, nazwa="Klinika X")
+    field = registry.field_by_name["Jednostka"]
+    result = field.to_djangoql(j.pk, str(UNION_FEMALE))
+    assert isinstance(result, tuple)
+    frag, warn = result
+    assert frag == f'autorzy.jednostka__rel = "Klinika X [{j.pk}]"'
+    assert "wspóln" in warn.lower()
+```
+(Usuń `test_jednostka_union_is_untranslatable` i `test_jednostka_plus_subunits_union_is_untranslatable`; zastąp wariantem warning powyżej + analogiczny dla `EQUAL_PLUS_SUB_UNION_FEMALE` → `jednostka_z_podjednostkami__rel` + warning.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_kolejnosc_to_djangoql.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+W `author_fields.py`:
+
+Refaktor: w `NazwiskoIImieQueryObject` wydziel budowę bazowego fragmentu, by podklasy mogły go reużyć. Dodaj metodę:
+```python
+    def _autor_rel(self, value):
+        """'autorzy.autor__rel = \"label [pk]\"' albo None."""
+        try:
+            obj = self.value_from_web(value)
+        except Exception:  # noqa: BLE001 — uszkodzony pk -> nieprzekładalne
+            return None
+        if obj is None:
+            return None
+        label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
+        return f'autorzy.autor__rel = "{label} [{obj.pk}]"'
+```
+i w istniejącym `NazwiskoIImieQueryObject.to_djangoql` użyj go dla równości (zachowując `!=` dla różności).
+
+`NazwiskoIImieWZakresieKolejnosci` — dodaj `to_djangoql` (dokładne, same-row):
+```python
+    def to_djangoql(self, value, operation):
+        op = str(operation)
+        equal = {str(o) for o in EQUALITY_OPS_ALL} - {str(o) for o in DIFFERENT_ALL}
+        if op not in equal and not _is_union_value(op):
+            return None
+        base = self._autor_rel(value)
+        if base is None:
+            return None
+        # kolejnosc__gte/__lt mogą być F() (Ostatnie) — wtedy best-effort.
+        gte, lt = self.kolejnosc_gte, self.kolejnosc_lt
+        if not isinstance(gte, int) or not isinstance(lt, int):
+            return base, (
+                "Filtr „ostatni/zakres kolejności" pominięto — zależy od liczby "
+                "autorów (F-expression), nie do wyrażenia w DjangoQL."
+            )
+        frag = f"{base} and autorzy.kolejnosc >= {gte} and autorzy.kolejnosc < {lt}"
+        if _is_union_value(op):
+            return frag, "Operator „wspólny" przełożono jak równość."
+        return frag
+```
+
+W `unit_fields.py`, `JednostkaQueryObject.to_djangoql` — rozszerz o UNION (best-effort+warning) zamiast `return None`:
+```python
+        if op == str(UNION_FEMALE):
+            return (
+                f"autorzy.jednostka__rel = {suffix}",
+                "Operator „wspólna" przełożono jak równość — może objąć innego autora.",
+            )
+        if op == str(EQUAL_PLUS_SUB_UNION_FEMALE):
+            return (
+                f"jednostka_z_podjednostkami__rel = {suffix}",
+                "Operator „wspólna" przełożono jak równość — może objąć innego autora.",
+            )
+        return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_kolejnosc_to_djangoql.py src/bpp/tests/test_multiseek_jednostka_to_djangoql.py src/bpp/tests/test_multiseek_autor_to_djangoql.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/multiseek_registry/fields/author_fields.py src/bpp/multiseek_registry/fields/unit_fields.py src/bpp/tests/test_multiseek_kolejnosc_to_djangoql.py src/bpp/tests/test_multiseek_jednostka_to_djangoql.py
+git commit -m "feat(multiseek): pola kolejnościowe (dokładne) + UNION best-effort+warning"
+```
+
+---
+
+### Task 14: Round-trip + test pokrycia rejestru (E)
+
+**Files:**
+- Test: `src/bpp/tests/test_multiseek_djangoql_coverage.py` (nowy), `test_multiseek_djangoql_roundtrip.py` (nowy)
+
+- [ ] **Step 1: Write the round-trip tests**
+
+Utwórz `src/bpp/tests/test_multiseek_djangoql_roundtrip.py` — porównaj zbiór pk dla pól dokładnych:
+
+```python
+import pytest
+from djangoql.queryset import apply_search
+from multiseek.logic import EQUAL
+
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Rekord
+from bpp.multiseek_registry import registry
+
+pytestmark = pytest.mark.serial
+
+
+def _pks_djangoql(frag):
+    return set(
+        apply_search(Rekord.objects.all(), frag, schema=BppQLSchema)
+        .distinct()
+        .values_list("pk", flat=True)
+    )
+
+
+@pytest.mark.django_db
+def test_roundtrip_jezyk(wydawnictwo_ciagle, denorms):
+    from bpp.models import Jezyk
+
+    pol = Jezyk.objects.get_or_create(nazwa="polski", skrot="pol.")[0]
+    wydawnictwo_ciagle.jezyk = pol
+    wydawnictwo_ciagle.save()
+    denorms.flush()
+    field = registry.field_by_name["Język"]
+    q = field.real_query("polski", EQUAL)
+    via_ms = set(Rekord.objects.filter(q).values_list("pk", flat=True))
+    via_dql = _pks_djangoql('jezyk.nazwa = "polski"')
+    assert via_ms
+    assert via_ms == via_dql
+```
+
+(Wzorzec round-trip jak w `test_multiseek_jednostka_to_djangoql.py::test_roundtrip_jednostka_plus_subunits_same_rekordy`.)
+
+- [ ] **Step 2: Write the coverage invariant test**
+
+Utwórz `src/bpp/tests/test_multiseek_djangoql_coverage.py`:
+
+```python
+import pytest
+
+from bpp.multiseek_registry import registry
+
+# Pola, których pojedynczy warunek może być nieprzekładalny tylko z powodu
+# OPERACJI (nie pola) — dozwolone wyjątki inwariantu pokrycia.
+_OPERATION_ONLY_GAPS = set()
+
+
+def test_every_registry_field_has_translation_path():
+    """Każde pole rejestru ma drogę przekładu: metodę to_djangoql LUB
+    deklaratywne atrybuty (djangoql_value_field / autocomplete) LUB jest
+    bezpośrednim polem skalarnym. Strażnik celu „nic nieprzekładalnego"."""
+    from multiseek.logic import AUTOCOMPLETE
+
+    missing = []
+    for label, field in registry.field_by_name.items():
+        has_method = callable(getattr(field, "to_djangoql", None))
+        has_value_list = bool(getattr(field, "djangoql_value_field", None))
+        is_autocomplete = getattr(field, "type", None) == AUTOCOMPLETE
+        has_field_name = bool(getattr(field, "field_name", None))
+        if not (has_method or has_value_list or is_autocomplete or has_field_name):
+            missing.append(label)
+    assert missing == [], f"Pola bez drogi przekładu: {missing}"
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_coverage.py src/bpp/tests/test_multiseek_djangoql_roundtrip.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Run the whole multiseek-djangoql suite**
+
+Run: `uv run pytest src/bpp/tests/ -k "djangoql or multiseek" -v`
+Expected: PASS (cała grupa).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/tests/test_multiseek_djangoql_coverage.py src/bpp/tests/test_multiseek_djangoql_roundtrip.py
+git commit -m "test(multiseek-djangoql): round-trip + inwariant pokrycia rejestru"
+```
+
+---
+
+## PHASE 4 — UI: formatowanie + podświetlanie (G)
+
+### Task 15: Moduł `djangoql-pretty.js` (formatter + highlighter)
+
+**Files:**
+- Create: `src/bpp/static/bpp/js/djangoql-pretty.js`
+- Test: weryfikacja w Task 17 (Playwright); tu — smoke przez ładowanie w przeglądarce.
+
+- [ ] **Step 1: Implement the module**
+
+Utwórz `src/bpp/static/bpp/js/djangoql-pretty.js`:
+
+```javascript
+/* Formatowanie + podświetlanie składni zapytania DjangoQL.
+ *
+ * Reużywa lexera DjangoQL (z zainicjowanej instancji: dql.lexer). Lexer JS
+ * nie obsługuje newline'ów w regule whitespace, więc lexujemy zapytanie
+ * JEDNOLINIOWE, a łamanie linii nakładamy na etapie renderu (po granicach
+ * tokenów). HTML jest escapowany.
+ */
+(function () {
+  "use strict";
+
+  var TOKEN_CLASS = {
+    AND: "dql-keyword", OR: "dql-keyword", NOT: "dql-keyword", IN: "dql-keyword",
+    STARTSWITH: "dql-keyword", ENDSWITH: "dql-keyword",
+    TRUE: "dql-bool", FALSE: "dql-bool", NONE: "dql-none",
+    NAME: "dql-name", DOT: "dql-dot",
+    STRING_VALUE: "dql-str", INT_VALUE: "dql-num", FLOAT_VALUE: "dql-num",
+    PAREN_L: "dql-paren", PAREN_R: "dql-paren",
+    EQUALS: "dql-op", NOT_EQUALS: "dql-op", GREATER: "dql-op",
+    GREATER_EQUAL: "dql-op", LESS: "dql-op", LESS_EQUAL: "dql-op",
+    CONTAINS: "dql-op", NOT_CONTAINS: "dql-op", COMMA: "dql-op",
+  };
+
+  function esc(s) {
+    return String(s)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function tokenText(tok) {
+    if (tok.name === "STRING_VALUE") return '"' + tok.value + '"';
+    return tok.value;
+  }
+
+  function span(cls, text) {
+    return '<span class="' + cls + '">' + esc(text) + "</span>";
+  }
+
+  function nl(depth) {
+    return "\n" + "  ".repeat(depth);
+  }
+
+  // Łączy tokeny w sformatowany, podświetlony HTML. Zwraca jeden string.
+  // Zasady łamania: '(' otwiera wcięcie i nową linię; ')' zamyka;
+  // 'and'/'or' zaczynają nową linię na bieżącym wcięciu.
+  function render(tokens) {
+    var parts = [];
+    var depth = 0;
+    var atLineStart = true;
+
+    function emit(html, glue) {
+      if (!glue && !atLineStart) {
+        parts.push(" ");
+      }
+      parts.push(html);
+      atLineStart = false;
+    }
+
+    for (var i = 0; i < tokens.length; i++) {
+      var t = tokens[i];
+      var prev = tokens[i - 1];
+      var cls = TOKEN_CLASS[t.name] || "dql-name";
+
+      if (t.name === "PAREN_L") {
+        emit(span("dql-paren", "("), false);
+        depth += 1;
+        parts.push(nl(depth));
+        atLineStart = true;
+        continue;
+      }
+      if (t.name === "PAREN_R") {
+        depth = depth > 0 ? depth - 1 : 0;
+        parts.push(nl(depth));
+        atLineStart = true;
+        emit(span("dql-paren", ")"), true);
+        continue;
+      }
+      if (t.name === "AND" || t.name === "OR") {
+        parts.push(nl(depth));
+        atLineStart = true;
+        emit(span(cls, t.value), true);
+        continue;
+      }
+      // Kropka klei się do sąsiadów (ścieżka pola), bez spacji.
+      var glue = t.name === "DOT" || (prev && prev.name === "DOT");
+      emit(span(cls, tokenText(t)), glue);
+    }
+    return parts.join("");
+  }
+
+  function formatAndHighlight(query, lexer) {
+    if (!query) return "";
+    var tokens;
+    try {
+      tokens = lexer.setInput(query).lexAll();
+    } catch (e) {
+      return span("dql-name", query);
+    }
+    return render(tokens);
+  }
+
+  window.djangoqlPretty = { formatAndHighlight: formatAndHighlight };
+})();
+```
+
+Plik używa wyłącznie pojedynczych cudzysłowów dla HTML-owych atrybutów i podwójnych dla stringów JS — kopiuj verbatim.
+
+- [ ] **Step 2: Lint/format the JS**
+
+Run: `cd /Users/mpasternak/Programowanie/bpp && npx --no-install eslint src/bpp/static/bpp/js/djangoql-pretty.js || true`
+Jeśli brak eslinta — pomiń; weryfikacja składni nastąpi przy ładowaniu strony w Task 17.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/bpp/static/bpp/js/djangoql-pretty.js
+git commit -m "feat(multiseek-ui): moduł djangoql-pretty (format + highlight przez lexer DjangoQL)"
+```
+
+---
+
+### Task 16: Integracja szuflady (pre + CSS + skrypty)
+
+**Files:**
+- Modify: `src/django_bpp/templates/multiseek/index.html`
+- Modify (CSS): inline `<style>` w szufladzie LUB `src/bpp/static/...scss` + `grunt build`
+- Test: ręczny podgląd (Task 17 — Playwright)
+
+- [ ] **Step 1: Add highlighting CSS**
+
+W bloku stylów szuflady (lub istniejącym `<style>` strony) dodaj klasy:
+```css
+.djangoql-pretty {
+    font-family: monospace; white-space: pre; overflow-x: auto;
+    background: #f6f6f6; padding: .6rem; border-radius: 3px; line-height: 1.5;
+}
+.dql-keyword { color: #8959a8; font-weight: bold; }
+.dql-op { color: #3e999f; }
+.dql-name { color: #4271ae; }
+.dql-dot { color: #999; }
+.dql-str { color: #718c00; }
+.dql-num { color: #f5871f; }
+.dql-bool, .dql-none { color: #c82829; }
+.dql-paren { color: #555; }
+```
+
+- [ ] **Step 2: Replace the readonly textarea display with a `<pre>` + hidden raw field**
+
+W szufladzie (`id="djangoqlDrawer"`), zamień:
+```html
+<textarea id="djangoqlQuery" rows="4" readonly spellcheck="false" style="font-family:monospace;"></textarea>
+```
+na:
+```html
+<pre class="djangoql-pretty"><code id="djangoqlPretty"></code></pre>
+{# Surowe zapytanie (jednoliniowe) do kopiowania i edytora #}
+<input type="hidden" id="djangoqlQueryRaw" value="">
+```
+
+- [ ] **Step 3: Load scripts (tylko dla userów z gate'em — wewnątrz istniejącego bloku warunkowego przycisku)**
+
+Tam, gdzie renderowany jest przycisk/szuflada (sekcja `can_use_query_editor`), po HTML szuflady dodaj:
+```html
+<script src="{% static 'djangoql/js/completion.js' %}"></script>
+<script src="{% static 'bpp/js/djangoql-pretty.js' %}"></script>
+<script>
+(function () {
+    var _lexerHolder = null;
+    function getLexer() {
+        if (_lexerHolder) return _lexerHolder.lexer;
+        var ta = document.getElementById("djangoqlLexerProbe");
+        if (!ta) {
+            ta = document.createElement("textarea");
+            ta.id = "djangoqlLexerProbe";
+            ta.style.display = "none";
+            document.body.appendChild(ta);
+        }
+        try {
+            _lexerHolder = DjangoQL.init({
+                introspections: "{% url 'bpp:zapytanie_introspect' 'rekord' %}",
+                selector: ta,
+                autoResize: false
+            });
+        } catch (e) { return null; }
+        return _lexerHolder.lexer;
+    }
+    window.djangoqlRenderPretty = function (query) {
+        var raw = document.getElementById("djangoqlQueryRaw");
+        var pre = document.getElementById("djangoqlPretty");
+        if (raw) raw.value = query || "";
+        var lexer = getLexer();
+        if (pre) {
+            pre.innerHTML = (lexer && window.djangoqlPretty)
+                ? window.djangoqlPretty.formatAndHighlight(query || "", lexer)
+                : (query || "");
+        }
+    };
+})();
+</script>
+```
+
+- [ ] **Step 4: Hook rendering into the existing drawer-open flow**
+
+W istniejącym JS szuflady (`openDjangoqlDrawer`, fetch `.then`), zamień:
+```javascript
+document.getElementById('djangoqlQuery').value = data.query || '';
+```
+na:
+```javascript
+if (window.djangoqlRenderPretty) { window.djangoqlRenderPretty(data.query || ''); }
+```
+W `copyDjangoqlQuery` zmień źródło kopiowania z `#djangoqlQuery` (textarea) na sformatowany tekst z `#djangoqlPretty` (`.textContent`), z fallbackiem na `#djangoqlQueryRaw`:
+```javascript
+var pre = document.getElementById('djangoqlPretty');
+var raw = document.getElementById('djangoqlQueryRaw');
+var text = (pre && pre.textContent) || (raw && raw.value) || '';
+```
+(Reszta logiki kopiowania bez zmian — operuj na `text`.)
+
+- [ ] **Step 5: Verify template renders (smoke)**
+
+Run: `uv run pytest src/bpp/tests/test_multiseek_djangoql_button.py -v`
+Expected: PASS (asercje na obecność `id="toDjangoqlButton"` / `id="djangoqlDrawer"` nadal trzymają; w razie potrzeby zaktualizuj asercję dot. textarea → `id="djangoqlPretty"`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/django_bpp/templates/multiseek/index.html
+git commit -m "feat(multiseek-ui): szuflada pokazuje sformatowane + podświetlone DjangoQL"
+```
+
+---
+
+### Task 17: Playwright — podgląd szuflady
+
+**Files:**
+- Modify: `src/bpp/tests/test_multiseek_djangoql_button.py` (lub nowy Playwright test, jeśli plik nie jest browserowy)
+
+- [ ] **Step 1: Write the Playwright test**
+
+Dodaj test (wzorzec z `src/integration_tests/`), który:
+- loguje użytkownika z grupy „wprowadzanie danych" / superusera,
+- wchodzi na formularz multiseek z jednym kryterium (np. Tytuł pracy zawiera „x"),
+- klika `#toDjangoqlButton`,
+- czeka na `#djangoqlPretty span.dql-name`,
+- asercje: `#djangoqlPretty` zawiera ≥1 `span.dql-*`; przy zapytaniu złożonym (dwa kryteria połączone OR) `textContent` zawiera newline (`\n`); `#djangoqlOpenEditor` ma `href` zaczynający się od URL edytora.
+
+```python
+def test_drawer_shows_highlighted_formatted_query(page, live_server, ...):
+    # ... login + dodanie dwóch kryteriów + OR ...
+    page.click("#toDjangoqlButton")
+    page.wait_for_selector("#djangoqlPretty span.dql-name")
+    spans = page.locator("#djangoqlPretty span.dql-op")
+    assert spans.count() >= 1
+    text = page.locator("#djangoqlPretty").inner_text()
+    assert "\n" in text  # sformatowane wieloliniowo
+```
+
+(Dostosuj fixtures do istniejącego harnessu Playwright — patrz `src/integration_tests/test_global_search.py`.)
+
+- [ ] **Step 2: Build assets and run**
+
+Run:
+```bash
+make assets
+uv run pytest src/bpp/tests/test_multiseek_djangoql_button.py -k highlighted -v
+```
+Expected: PASS (pierwszy cold-start może wymagać ponowienia).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/bpp/tests/test_multiseek_djangoql_button.py
+git commit -m "test(multiseek-ui): Playwright — podgląd szuflady (format + highlight)"
+```
+
+---
+
+## Finał
+
+- [ ] **Pełna grupa testów**
+
+Run: `uv run pytest src/bpp/tests/ -k "djangoql or multiseek or charakter" -v`
+Expected: PASS.
+
+- [ ] **Pre-commit (bez argumentów; poprawki ręcznie, bez `ruff --fix`)**
+
+Run: `pre-commit`
+Napraw zgłoszone problemy ręcznie (Edit), commituj.
+
+- [ ] **Aktualizacja PR #328** — push i sprawdzenie realnych gejtów (`Build test-runner image`, `Tests (sharded)`); nie cieszyć się zielenią <1 min (skip).
+
+---
+
+## Self-Review (zrealizowane przy pisaniu planu)
+
+- **Pokrycie specu:** A1→T1, kontrakt warning (nowość konieczna pod F)→T2, A2→T3, A3→T4, A4→T5, B1→T6, B2→T7, B3(bool)→T8/T11, B3(charakter)→T9, B3(typ ogólny)→T10, B3(misc)→T12, F→T13, E(audyt/round-trip)→T14, G→T15-17.
+- **Spójność nazw:** `_orm_name`, `_value_list_leaf`, `djangoql_field_name`, `djangoql_value_field`, `charakter_z_podrzednymi__rel`, `_CHARAKTER_SUB_FIELD`, `CharakterZPodrzednymiField`, `formatAndHighlight`, `window.djangoqlPretty` — użyte spójnie.
+- **Znane ryzyka do weryfikacji w trakcie:** (a) `RodzajJednostkiQueryObject` label↔value (Task 12 ma fallback-metodę); (b) `is_valid_rekord_djangoql` jako siatka — jeśli któraś ścieżka nie waliduje, fragment cicho znika → round-trip/coverage to wychwycą; (c) JS w Task 15 — pilnować cudzysłowów/escapów.

--- a/docs/superpowers/specs/2026-06-04-multiseek-to-djangoql-design.md
+++ b/docs/superpowers/specs/2026-06-04-multiseek-to-djangoql-design.md
@@ -1,0 +1,224 @@
+# Konwerter „formularz Multiseek → zapytanie DjangoQL”
+
+Data: 2026-06-04
+Status: design (zatwierdzony do napisania planu)
+
+## Cel
+
+Na stronie formularza Multiseek dodać przycisk, który dla uprawnionego,
+zalogowanego użytkownika tłumaczy aktualnie zbudowany formularz wyszukiwania
+na równoważne zapytanie DjangoQL nad modelem `Rekord`. Wynik pokazujemy w
+szufladzie (drawer) z polem do skopiowania kodu oraz przyciskiem
+„Otwórz w edytorze zapytań”, który przenosi do istniejącego edytora
+`/zapytanie/?model=rekord&query=...`.
+
+Motywacja: Multiseek i edytor DjangoQL (`bpp.views.zapytanie.ZapytanieView`)
+przeszukują **dokładnie ten sam model** — `bpp.models.cache.Rekord`. Konwerter
+pozwala płynnie przejść od formularza (łatwy start) do edytora zapytań (pełna
+moc i ręczne dostrojenie).
+
+## Kluczowe ustalenia (z analizy kodu)
+
+- **Multiseek registry**: `src/bpp/multiseek_registry/` — `create_registry(Rekord, ...)`.
+  Każde pole to klasa `QueryObject` z metodą
+  `real_query(self, value, operation) -> django.db.models.Q`
+  (baza: `multiseek/logic.py`; `query_for` = `real_query(value_from_web(value), op)`).
+- **Struktura zapytania Multiseek**: JSON budowany na froncie przez `formAsJSON()`
+  (`templates/multiseek/index.html`), POST-owany jako parametr `json`. Kształt:
+  ```json
+  {
+    "form_data": [null, {"field": "...", "operator": "...", "value": ..., "prev_op": null}, ...],
+    "ordering": {...},
+    "report_type": "0"
+  }
+  ```
+  Ramki mogą być zagnieżdżone (lista zaczynająca się od operatora `and`/`or`/`andnot`).
+  Rekurencyjne łączenie warunków: `multiseek/logic.py::get_query_recursive`.
+- **Edytor DjangoQL**: `src/bpp/views/zapytanie.py::ZapytanieView`, URL `/zapytanie/`,
+  parametry `?model=rekord&query=<djangoql>`. Dostęp: zalogowany **oraz**
+  (superuser **lub** (`is_staff` i grupa „wprowadzanie danych”)).
+- **Schemat DjangoQL**: `src/bpp/djangoql_schema.py::BppQLSchema`
+  (`RelPickerSchemaMixin` + `ExtrasSchema`). Auto-pickery `<fk>__rel`
+  (`AutocompleteField` z `lookup_name`) — filtrują po pk wybranego obiektu,
+  format wartości: `"Etykieta [pk]"`. Punkt rozszerzeń pola:
+  `DjangoQLField.get_lookup(path, operator, value) -> Q` i `get_operator()`.
+- **Operatory DjangoQL są stałe** (gramatyka w `djangoql/lexer.py` + `parsetab.py`
+  oraz kopia w JS widgetu). **Nie** dodajemy nowych tokenów-operatorów.
+  Rozszerzamy zamiast tego pola (`get_lookup`) — tak jak już robią `__rel`.
+- **Hierarchia jednostek**: `Jednostka` jest `MPTTModel`
+  (`src/bpp/models/jednostka.py`, `parent = TreeForeignKey("self", ...)`).
+  „+ podrzędne” w Multiseek to:
+  ```python
+  # JednostkaQueryObject.real_query, EQUAL_PLUS_SUB_FEMALE:
+  Q(autorzy__jednostka__in=value.get_family())
+  ```
+  `get_family()` (MPTT) = przodkowie + sam węzeł + potomkowie.
+
+## Architektura
+
+### 1. Silnik konwersji (server-side, Python)
+
+Nowy moduł `src/bpp/multiseek_registry/djangoql_export.py`.
+
+Funkcja czysta:
+```python
+def multiseek_form_to_djangoql(form_json: dict, registry) -> ConversionResult
+```
+zwracająca `ConversionResult(query: str, warnings: list[str])`.
+
+Działanie:
+- Parsuje `form_data` rekurencyjnie, **odzwierciedlając strukturę ramek**
+  `get_query_recursive`: liście łączone fragmentami DjangoQL spojonymi
+  `and` / `or`; zagnieżdżone ramki w nawiasach.
+- `prev_op`:
+  - `and` → `and`
+  - `or` → `or`
+  - `andnot` → negację wpychamy do **pojedynczej** liścia (De Morgan: zamiana
+    operatora na zaprzeczony — `=`→`!=`, `~`→`!~`, `in`→`not in`, itd.).
+    Dla zaprzeczonej **ramki** (grupy) — brak odpowiednika w DjangoQL →
+    warning, warunek pomijany.
+- Dla każdego liścia: odnajduje `QueryObject` po `label` (registry mapuje
+  label→obiekt) i prosi o fragment DjangoQL (patrz §2). `None` → warning
+  „pominięto warunek X (nieprzekładalny)”.
+- Buduje `editor_url = /zapytanie/?model=rekord&query=<urlencoded>`.
+
+`ordering` i `report_type` nie są filtrami — pomijane (DjangoQL nie ma
+składni sortowania). Nie generujemy z tego warningów (to nie jest „utrata
+warunku”).
+
+### 2. Tłumaczenie per-pole — każdy QueryObject zna swoje mapowanie
+
+Mixin `MultiseekDjangoQLMixin` z metodą:
+```python
+def to_djangoql(self, value, operation) -> str | None
+```
+Domyślna implementacja (w mixinie) obsługuje typowe przypadki na podstawie
+`field_name`, `type` (`STRING`/`INTEGER`/`DECIMAL`/`DATE`/`VALUE_LIST`/
+`AUTOCOMPLETE`) i `operation`:
+- string/int/decimal/date → `field_name <op> <wartość>`; mapowanie operatorów
+  Multiseek → DjangoQL (`CONTAINS`→`~`, `NOT_CONTAINS`→`!~`, `STARTS_WITH`→
+  `startswith`, `GREATER`→`>`, `GREATER_OR_EQUAL`→`>=`, równość/płcie→`=`,
+  różność/płcie→`!=`, `IN_RANGE`→ rozbicie na `>=` … `and` … `<=`).
+- AUTOCOMPLETE → `value` to pk; resolwujemy pk→obiekt (przez `model`/
+  `value_from_web`), etykieta przez to samo pole co picker, emitujemy
+  `field_name__rel = "Etykieta [pk]"`. (Jeśli `field_name` celuje w ścieżkę
+  relacyjną, używamy odpowiedniego `__rel` na tej ścieżce, np.
+  `autorzy.jednostka__rel`.)
+- VALUE_LIST → `field_name = <wartość>` (lub mapowanie etykieta→wartość pola).
+- Operacje/pola bez sensownego odpowiednika → `None`.
+
+Tylko „trudne” pola nadpisują `to_djangoql` (np. `JednostkaQueryObject`,
+pola autorów na ścieżce odwrotnej `autorzy.…`). Celem jest, by większość pól
+działała z domyślnej logiki bez kodu per-klasa.
+
+### 3. Pole-gwiazda: `jednostka_z_podjednostkami__rel` w `BppQLSchema`
+
+W `src/bpp/djangoql_schema.py` rejestrujemy na modelu `Rekord` wirtualne
+pole (dedykowana podklasa `AutocompleteField`), którego `get_lookup` zwraca:
+```python
+Q(autorzy__jednostka__in=value.get_family())
+```
+— co do joty Q z Multiseek `EQUAL_PLUS_SUB_FEMALE`. Picker (autocomplete po
+`Jednostka`, format `"Nazwa [pk]"`), operator dla użytkownika to zwykłe `=`.
+
+Mapowanie w `JednostkaQueryObject.to_djangoql`:
+- `EQUAL_FEMALE` → `autorzy.jednostka__rel = "Nazwa [pk]"`
+- `DIFFERENT_FEMALE` → `autorzy.jednostka__rel != "Nazwa [pk]"`
+- `EQUAL_PLUS_SUB_FEMALE` → `jednostka_z_podjednostkami__rel = "Nazwa [pk]"`
+- `UNION_FEMALE` / `EQUAL_PLUS_SUB_UNION_FEMALE` → albo dodatkowe wirtualne
+  pole o analogicznej semantyce (`pk__in=Autorzy.filter(...).values("rekord_id")`),
+  albo — jeśli zbiór wyników jest identyczny — to samo pole; do rozstrzygnięcia
+  w planie na podstawie testu równoważności zbiorów. Gdy semantyka różni się
+  realnie, a nie chcemy mnożyć pól → warning.
+
+Korzyść poboczna: nowe pole(a) są od razu używalne w samym edytorze
+`/zapytanie/` i w wyszukiwarce DjangoQL adminów — ten sam kod podnosi jakość
+edytora, nie tylko konwertera.
+
+### 4. Endpoint + UI (tylko strona formularza)
+
+- **Uprawnienia, współdzielone**: wyciągamy regułę dostępu z `ZapytanieView`
+  do wspólnego predykatu (np. `bpp.views.zapytanie.user_can_use_query_editor(user)`
+  albo test do `UserPassesTestMixin`), używanego przez: (a) `ZapytanieView`,
+  (b) nowy endpoint, (c) warunek renderowania przycisku w szablonie.
+- **Endpoint** `POST /multiseek/do-djangoql/` (`login_required` + ten predykat).
+  Wejście: ten sam payload `json` co `formAsJSON()`. Wyjście JSON:
+  `{"query": str, "warnings": [str], "editor_url": str}`.
+- **Szablon** `templates/multiseek/index.html`: przycisk przy istniejących
+  akcjach (renderowany **tylko** dla użytkownika przechodzącego predykat).
+  Klik → `formAsJSON()` → `fetch` POST → otwarcie szuflady Foundation
+  (reveal/off-canvas) z:
+  - polem (textarea/`<pre>`) z zapytaniem + przyciskiem „Kopiuj”
+    (reużycie istniejącej logiki schowka z `multiseek/common-results.html`),
+  - listą ostrzeżeń (jeśli są),
+  - linkiem „Otwórz w edytorze zapytań” → `editor_url`.
+
+Decyzja (zatwierdzona): przycisk renderowany wyłącznie dla użytkowników
+spełniających regułę dostępu do edytora (superuser lub `is_staff` + grupa
+„wprowadzanie danych”). Output jest „akcjonowalny” tylko dla nich.
+
+## Przepływ danych
+
+```
+[formularz Multiseek]
+   │ formAsJSON()            (istniejący JS)
+   ▼
+POST /multiseek/do-djangoql/  (json=<form_data...>)
+   │ user_can_use_query_editor?  → 403 jeśli nie
+   ▼
+multiseek_form_to_djangoql(form_json, registry)
+   │ walk ramek → QueryObject.to_djangoql(value, op) → fragmenty
+   ▼
+{query, warnings, editor_url}
+   │
+   ▼
+[drawer]  ── „Kopiuj”
+          └─ „Otwórz w edytorze zapytań” → /zapytanie/?model=rekord&query=...
+```
+
+## Obsługa błędów / przypadki brzegowe
+
+- Pole nierozpoznane / operacja nieobsługiwana → warning, warunek pomijany;
+  pozostałe warunki nadal tłumaczone (best-effort).
+- `andnot` na ramce → warning (brak `not(expr)` w DjangoQL).
+- Pusty formularz → `query == ""`, brak warningów; przycisk „Otwórz w
+  edytorze” prowadzi do pustego edytora.
+- AUTOCOMPLETE z `value` wskazującym nieistniejący/niewidoczny obiekt →
+  warning (nie wstawiamy „martwego” pk).
+- Endpoint waliduje JSON; błędny payload → 400 z komunikatem (nie cichy fail).
+
+## Plan testów (pytest + model_bakery)
+
+- **Per-pole**: dla reprezentatywnych `QueryObject` (string, int, decimal,
+  date, value-list, autocomplete) — `to_djangoql(value, op)` zwraca oczekiwany
+  fragment; warianty płciowe operatorów kolapsują do `=`/`!=`.
+- **Ramki**: `and`/`or`, zagnieżdżenie, `andnot` na liściu (inwersja operatora),
+  `andnot` na ramce (warning).
+- **Pole `jednostka_z_podjednostkami__rel`**: `get_lookup` zwraca Q równe
+  `Q(autorzy__jednostka__in=value.get_family())`; wynik zapytania na zbiorze
+  baked == wynik Multiseek `EQUAL_PLUS_SUB_FEMALE`.
+- **Round-trip fidelity** (najważniejszy): dla zapytań w pełni przekładalnych —
+  uruchom `Q` z Multiseek **oraz** skonwertowane DjangoQL na zbiorze baked i
+  asercja, że wybierają **identyczny** zbiór `Rekord`.
+- **Warningi**: pola z genuine-residue (np. `ZewnetrznaBazaDanychQueryObject`,
+  oparte o widok SQL) → warning, brak crasha.
+- **Endpoint**: gating uprawnień (403 dla nieuprawnionego, 200 dla uprawnionego),
+  happy-path zwraca `{query, warnings, editor_url}`, błędny JSON → 400.
+
+## Poza zakresem (YAGNI)
+
+- Tłumaczenie `ordering` / `report_type` (DjangoQL nie sortuje).
+- Konwersja w drugą stronę (DjangoQL → Multiseek).
+- Konwersja po stronie JS (cała logika i resolucja pk→etykieta jest serwerowa).
+- Przycisk na stronie wyników (`common-results.html`) — tylko formularz.
+
+## Pliki (orientacyjnie)
+
+- Nowy: `src/bpp/multiseek_registry/djangoql_export.py` (silnik + mixin).
+- Zmiana: `src/bpp/djangoql_schema.py` (pole `jednostka_z_podjednostkami__rel`).
+- Zmiana: `src/bpp/multiseek_registry/fields/unit_fields.py` (+ ew. inne pola
+  z nadpisanym `to_djangoql`).
+- Zmiana: `src/bpp/views/zapytanie.py` (wyłuskanie predykatu uprawnień).
+- Nowy: widok endpointu (np. `src/bpp/views/mymultiseek.py` lub nowy moduł) + URL.
+- Zmiana: `templates/multiseek/index.html` (przycisk + drawer + JS).
+- Nowe testy: `src/bpp/tests/` (per-pole, ramki, pole MPTT, round-trip, endpoint).

--- a/docs/superpowers/specs/2026-06-05-multiseek-djangoql-translatability-design.md
+++ b/docs/superpowers/specs/2026-06-05-multiseek-djangoql-translatability-design.md
@@ -1,0 +1,271 @@
+# Maksymalizacja przekładalności Multiseek → DjangoQL
+
+Data: 2026-06-05
+Branch: `feature/multiseek-to-djangoql`
+Status: zaakceptowany (design)
+
+## Cel
+
+Konwerter „formularz Multiseek → DjangoQL" (już istniejący) zostawia zbyt
+wiele *rodzajów* pól jako **nieprzekładalne**. Zadanie: doprowadzić do
+sytuacji, w której jak najmniej rodzajów pól jest nieprzekładalnych, bo
+większość z nich ma czysty odpowiednik w DjangoQL nad `Rekord`.
+
+Dyrektywy użytkownika:
+
+1. **Brak wartości → `""` / `None`**, nie „nieprzekładalny". Puste pole
+   tekstowe/value-list emituje literał `""`; pusty autocomplete (FK bez
+   wybranego obiektu) emituje `<ścieżka>__rel = None` (is-null).
+2. **VALUE_LIST to lista stringów** → tłumaczymy na **porównanie stringa**
+   (`<ścieżka>.nazwa = "wartość"`), a nie na resolucję pk/`__rel`.
+3. **AUTOCOMPLETE → `<ścieżka>__rel`** (utrwalony wzorzec) wskazujący na
+   właściwą relację.
+
+## Kluczowa obserwacja: `field_name` ≠ ścieżka ORM
+
+Atrybut `field_name` w wielu QueryObjectach **nie** jest ścieżką ORM —
+prawdziwa ścieżka żyje w `real_query`. Przykłady:
+
+- `WydzialQueryObject.field_name = "wydzial"`, a `real_query` filtruje
+  `autorzy__jednostka__wydzial`.
+- `Typ_OdpowiedzialnosciQueryObject.field_name = "typ_odpowiedzialnosci"`,
+  ścieżka realna: `autorzy__typ_odpowiedzialnosci`.
+- `DyscyplinaQueryObject.field_name = "nazwa"` (!), ścieżka realna:
+  `autorzy__dyscyplina_naukowa`.
+
+Dlatego pola te lądują dziś jako „nieprzekładalne": domyślny leaf emituje
+`wydzial__rel`, co nie waliduje się względem schematu `Rekord`. Naprawa
+wymaga, by pole **deklarowało** swoją realną ścieżkę DjangoQL.
+
+## A. Dwie nowe mechaniki w silniku konwertera
+
+Plik: `src/bpp/multiseek_registry/djangoql_export.py`.
+
+### A1. Deklaratywny override ścieżki — `djangoql_field_name`
+
+`_default_leaf` preferuje opcjonalny atrybut klasy `djangoql_field_name`
+(realna ścieżka ORM, np. `"autorzy__jednostka__wydzial"`), z fallbackiem na
+`field_name`. Reszta bez zmian (`__` → `.`). Naprawia każde pole, którego
+`field_name` ≠ ścieżka ORM, **bez** pisania metody.
+
+```python
+def _djangoql_path(field):
+    name = getattr(field, "djangoql_field_name", None) or getattr(
+        field, "field_name", None
+    )
+    return _orm_path_to_djangoql(name) if name else None
+```
+
+### A2. Gałąź VALUE_LIST w `_default_leaf`
+
+Gdy `field.type == VALUE_LIST`: emituj porównanie stringa na polu-nazwie:
+`<ścieżka>.<value_field> <op> "<wartość>"`. Domyślnie `value_field =
+"nazwa"`, nadpisywalne atrybutem `djangoql_value_field`. Mapowanie
+operatorów reużywa istniejącej skalarnej mapy (`EQUAL`→`=`, `DIFFERENT`→
+`!=`, `UNION*`→`=`).
+
+```python
+VALUE_LIST  # z multiseek.logic
+# w _default_leaf, przed gałęzią skalarną:
+if getattr(field, "type", None) == VALUE_LIST:
+    return _value_list_leaf(field, value, operation)
+```
+
+`_value_list_leaf`:
+
+- pusta wartość → `<ścieżka>.<value_field> = ""`,
+- operator skalarny z mapy (EQUAL/DIFFERENT/UNION),
+- zwraca `f'{path}.{value_field} {op} {render_value(value)}'`.
+
+### A3. Pusty autocomplete
+
+`_autocomplete_leaf`: gdy `value` jest puste/None (brak wybranego obiektu)
+→ zwróć `f"{rel_path} = None"` (lub `!= None` dla operatorów różności)
+zamiast `None` (nieprzekładalne). Niepuste — bez zmian.
+
+## B. Plan per-pole
+
+### B1 — Deklaratywny `djangoql_field_name`, AUTOCOMPLETE → `__rel`
+
+| Pole | DjangoQL |
+|---|---|
+| `WydzialQueryObject` | `autorzy.jednostka.wydzial__rel` |
+| `AktualnaJednostkaAutoraQueryObject` | `autorzy.autor.aktualna_jednostka__rel` |
+| `DyscyplinaQueryObject` | `autorzy.dyscyplina_naukowa__rel` |
+| `KierunekStudiowQueryObject` | `autorzy.kierunek_studiow__rel` |
+
+`PierwszaJednostka`/`PierwszyWydzial` (kolejnosc=0) — patrz F (lossy).
+
+### B2 — Deklaratywny VALUE_LIST → `<ścieżka>.nazwa = "wartość"`
+
+| Pole | DjangoQL |
+|---|---|
+| `JezykQueryObject` | `jezyk.nazwa = "..."` |
+| `TypKBNQueryObject` | `typ_kbn.nazwa = "..."` |
+| `OpenaccessWersjaTekstuQueryObject` | `openaccess_wersja_tekstu.nazwa = "..."` |
+| `OpenaccessLicencjaQueryObject` | `openaccess_licencja.nazwa = "..."` |
+| `OpenaccessCzasPublikacjiQueryObject` | `openaccess_czas_publikacji.nazwa = "..."` |
+| `Typ_OdpowiedzialnosciQueryObject` | `autorzy.typ_odpowiedzialnosci.nazwa = "..."` |
+
+`CharakterFormalnyQueryObject` **nie** jest czysto deklaratywne (patrz B3):
+wartość niesie prefiks wcięcia MPTT (`DEFAULT_LEVEL_INDICATOR = "---"`);
+`value_from_web` robi `value.lstrip("-").lstrip(" ")`. Realizacja: albo
+metoda `to_djangoql` (normalizuje wartość, potem `charakter_formalny.nazwa =
+"<znormalizowana>"`), albo deklaratywny hak `djangoql_value_transform`
+(callable wartość→wartość) konsumowany przez `_value_list_leaf`. Wybór:
+**`to_djangoql`** (mniej nowych mechanik, semantyka MPTT-descendants i tak
+wymaga warninga z F).
+
+### B3 — `to_djangoql` (semantyka niestandardowa)
+
+| Pole | DjangoQL |
+|---|---|
+| `CharakterOgolnyQueryObject` | `charakter_formalny.charakter_ogolny = "<const>"` |
+| `TypRekorduObject` | `charakter_formalny.publikacja = True` / `.streszczenie = True` / `(.publikacja = False and .streszczenie = False)` |
+| `RodzajKonferenckjiQueryObject` | `konferencja.typ_konferencji = <N>` |
+| `RodzajJednostkiQueryObject` | `autorzy.jednostka.rodzaj_jednostki = <N>` |
+| `TypOgolnyAutorQueryObject` i podklasy | `autorzy.autor__rel = "L [pk]" and autorzy.typ_odpowiedzialnosci.typ_ogolny = <N>` |
+| `CharakterFormalnyQueryObject` | `charakter_formalny.nazwa = "<bez prefiksu --->"` (+ warning gdy ma potomków, F) |
+| `ObcaJednostkaQueryObject` | `autorzy.jednostka.skupia_pracownikow = <not value>` |
+| `AfiliujeQueryObject` | `autorzy.afiliuje = <bool>` |
+| `OswiadczenieKENQueryObject` | `autorzy.oswiadczenie_ken = <bool>` |
+| `DyscyplinaUstawionaQueryObject` | `autorzy.dyscyplina_naukowa != None` (lub `= None`) |
+| `LicencjaOpenAccessUstawionaQueryObject` | `openaccess_licencja != None` (lub `= None`) |
+| `PublicDostepDniaQueryObject` | `public_dostep_dnia != None` (lub `= None`) |
+| `StronaWWWUstawionaQueryObject` | `(www != "" or public_www != "")` (lub negacja) |
+
+Wartości `<const>`/`<N>` brać z definicji klasy (`bpp.const`,
+`Konferencja.TK_*`, `Jednostka.RODZAJ_JEDNOSTKI`, `charakter_ogolny`).
+
+### B4 — Już działają (bez zmian)
+
+Bezpośrednie pola skalarne (`tytul_oryginalny`, liczby, `rok`, daty,
+zakresy), bezpośrednie FK-autocomplete (`zrodlo`, `wydawnictwo_nadrzedne`,
+`status_korekty`, `konferencja`), bazowe `NazwiskoIImieQueryObject` i
+`JednostkaQueryObject` (mają już `to_djangoql`), proste booleany
+(`recenzowana`, `konferencja__baza_wos/scopus`), `ORCIDQueryObject`
+(`autorzy.autor.orcid`).
+
+## C. Pusta wartość — reguła „'' / None"
+
+- string / value-list → literał: `tytul_oryginalny ~ ""`, `jezyk.nazwa = ""`.
+- autocomplete bez obiektu → `<ścieżka>__rel = None` (is-null);
+  dla operatorów różności → `!= None`.
+
+## D. Siatka bezpieczeństwa
+
+Każdy fragment nadal przechodzi przez `is_valid_rekord_djangoql` względem
+`BppQLSchema(Rekord)`. Jeśli zadeklarowana ścieżka nie jest wystawiona przez
+schemat, fragment auto-degraduje do warninga — best-effort nie może
+wyprodukować niepoprawnego DjangoQL. **Implikacja:** testy round-trip muszą
+potwierdzić, że zamierzone ścieżki faktycznie się walidują (inaczej cicho
+staną się warningami i cel nie zostanie osiągnięty).
+
+## E. Pozostałe szczere warningi (powinno być mało)
+
+- `SlowaKluczoweQueryObject`, `ZewnetrznaBazaDanychQueryObject` — match
+  przez dedykowane widoki SQL (`pk__in` subquery). Próbujemy
+  `slowa_kluczowe…` / relacji do zewn. bazy, jeśli schemat ją wystawia;
+  inaczej warning.
+- `NOT_IN_RANGE` i zanegowane *grupy* — DjangoQL nie ma `not(...)`
+  (bez zmian, warning).
+
+## F. Best-effort + warning (pola stratne)
+
+Tłumaczone przybliżenie + **warning** wyjaśniający rozbieżność:
+
+- **UNION** (`równy+wspólny` itd.) → identycznie jak EQUAL; gubiona jest
+  dystynkcja „inny wiersz autora" (ograniczenie gramatyki DjangoQL).
+- **CharakterFormalny descendants** (MPTT) → tylko dokładny węzeł, bez
+  poddrzewa. Warning gdy węzeł ma potomków.
+- **kolejnosc-ranged autorzy** (`Pierwsze/Ostatnie nazwisko i imię`,
+  `Pierwsza jednostka/wydział`) → `kolejnosc` jest per-wiersz; best-effort
+  pomija je, z warningiem.
+
+## G. Podgląd w szufladzie: formatowanie + podświetlanie składni
+
+Dyrektywa: zapytanie DjangoQL pokazywane userowi ma być **sformatowane**
+i **podświetlone składniowo**; oba mechanizmy bierzemy z DjangoQL.
+
+### Co naprawdę daje DjangoQL
+
+`completion.js` to widget autouzupełniania (lexuje zapytanie, podpowiada
+pola/operatory), ale **nie koloruje** textarea. Reużywalny jest natomiast
+**lexer**: zainicjowana instancja niesie `.lexer`, a
+`dql.lexer.setInput(q).lexAll()` zwraca tokeny z `.name`/`.value`/`.start`/
+`.end` (`NAME`, `DOT`, `AND`, `OR`, `NOT`, `IN`, `EQUALS`, `NOT_EQUALS`,
+`CONTAINS`, `STRING_VALUE`, `INT_VALUE`, `FLOAT_VALUE`, `TRUE`/`FALSE`/
+`NONE`, `PAREN_L`/`PAREN_R`, …). To jest „podświetlanie składni dostępne
+w DjangoQL" — kolorujemy po `token.name`.
+
+### Newline'e
+
+Lexer **Pythona** ignoruje newline'e (`t_newline` je odrzuca) → wieloliniowe,
+sformatowane zapytanie parsuje się tak samo i działa w edytorze oraz w
+`is_valid_rekord_djangoql`. Lexer **JS** w regule whitespace NIE ma `\n`,
+więc formatowania NIE robimy przez wstrzykiwanie newline'ów do lexera —
+lexujemy **jednoliniowe** zapytanie, a łamanie linii i wcięcia nakładamy
+na etapie renderu (po granicach tokenów).
+
+### Mechanika (klient)
+
+Nowy moduł `src/bpp/static/bpp/js/djangoql-pretty.js`:
+`formatAndHighlight(query, lexer) -> htmlString`:
+
+1. `tokens = lexer.setInput(query).lexAll()` (wejście jednoliniowe).
+2. Render do HTML: każdy token w `<span class="dql-<kategoria>">`
+   (kategorie: `keyword` and/or/not/in, `op`, `name`, `dot`, `str`, `num`,
+   `bool`, `none`, `paren`). Wartości HTML-escapowane.
+3. Formatowanie po granicach tokenów: licz głębokość nawiasów; przed
+   top-level `and`/`or` wstaw `\n` + wcięcie wg głębokości; zawartość grup
+   `( … )` wcinaj o poziom.
+
+Lexer pozyskujemy z instancji DjangoQL zainicjowanej na ukrytej/roboczej
+textarea z istniejącym endpointem introspekcji `rekord`
+(`bpp:zapytanie_introspect 'rekord'`) — ten sam, którego używa edytor.
+
+### Szuflada (UI)
+
+- Wyświetlanie: `<pre class="djangoql-pretty"><code id="djangoqlPretty">`
+  z wstawionym HTML-em (zamiast czystej `readonly` textarea).
+- Surowe (jednoliniowe) zapytanie trzymamy w ukrytym polu / zmiennej JS
+  na potrzeby „Kopiuj" i linku „Otwórz w edytorze".
+- „Kopiuj": kopiuje wersję **sformatowaną** (wieloliniową) — parsuje się
+  poprawnie po stronie serwera.
+- „Otwórz w edytorze": przekazuje zapytanie (sformatowane jest OK; serwer
+  ignoruje newline'y).
+- Skrypty (`completion.js` + `djangoql-pretty.js`) ładowane **tylko** gdy
+  przycisk jest renderowany (user przechodzi gate edytora) — bez zmian w
+  bramce uprawnień.
+- CSS: klasy `.dql-*` w SCSS/inline; kolory spójne z motywem (frontend
+  Foundation — monochrom + akcenty, bez nadpisywania siatki Foundation).
+
+### Test
+
+- JS jednostkowo nie jest tu wymagane (brak harnessu JS w repo); pokrycie
+  przez Playwright: po kliknięciu przycisku szuflada pokazuje
+  podświetlony, wieloliniowy `<pre>` (sprawdzenie obecności `span.dql-*`
+  i newline'ów), a „Otwórz w edytorze" niesie poprawny `href`.
+
+## Testowanie (TDD)
+
+- Testy jednostkowe per grupa pól: asercja na dokładny output
+  `to_djangoql`/deklaratywny.
+- Testy round-trip: porównanie zbioru pk `Rekord` z multiseekowego `Q`
+  vs ze skonwertowanego DjangoQL na zbakowanych danych — tam, gdzie
+  semantyka jest dokładna (B1/B2/większość B3).
+- Testy warningów: pola z F dają fragment **oraz** warning; pola z E dają
+  warning bez fragmentu (lub fragment, jeśli schemat wspiera ścieżkę).
+- Test reguły pustej wartości (C).
+
+## Pliki
+
+- `src/bpp/multiseek_registry/djangoql_export.py` — A1/A2/A3.
+- `src/bpp/multiseek_registry/fields/*.py` — atrybuty deklaratywne (B1/B2)
+  i metody `to_djangoql` (B3/F) per pole.
+- `src/bpp/static/bpp/js/djangoql-pretty.js` — formatter + highlighter (G).
+- `src/django_bpp/templates/multiseek/index.html` — szuflada: `<pre>`
+  podglądu, ładowanie skryptów, integracja kopiowania/edytora (G).
+- SCSS/CSS: klasy `.dql-*` (G).
+- Testy: `src/bpp/tests/test_multiseek_djangoql_*.py` (rozbudowa) +
+  Playwright na podgląd szuflady (G).

--- a/docs/superpowers/specs/2026-06-05-multiseek-djangoql-translatability-design.md
+++ b/docs/superpowers/specs/2026-06-05-multiseek-djangoql-translatability-design.md
@@ -83,6 +83,38 @@ if getattr(field, "type", None) == VALUE_LIST:
 → zwróć `f"{rel_path} = None"` (lub `!= None` dla operatorów różności)
 zamiast `None` (nieprzekładalne). Niepuste — bez zmian.
 
+### A4. Pole wirtualne `charakter_z_podrzednymi__rel` (schema)
+
+Plik: `src/bpp/djangoql_schema.py`. Analogiczne do
+`JednostkaZPodjednostkamiField`, ale dla `Charakter_Formalny` i z **inną**
+semantyką MPTT:
+
+- Jednostka: `get_family()` (przodkowie + sam + potomkowie).
+- Charakter: `get_descendants(include_self=True)` (sam + potomkowie) —
+  zgodnie z `CharakterFormalnyQueryObject.real_query`.
+
+```python
+class CharakterZPodrzednymiField(AutocompleteField):
+    def get_lookup(self, path, operator, value):
+        parsed = self.parse_id(value)
+        if not isinstance(parsed, int):
+            q = Q(charakter_formalny__nazwa__icontains=str(value))
+            return ~q if operator in ("!=", "not in") else q
+        try:
+            ch = Charakter_Formalny.objects.get(pk=parsed)
+        except Charakter_Formalny.DoesNotExist:
+            return Q() if operator in ("!=", "not in") else Q(pk__in=[])
+        q = Q(charakter_formalny__in=ch.get_descendants(include_self=True))
+        return ~q if operator in ("!=", "not in") else q
+```
+
+Wpięcie w `RelPickerSchemaMixin`: dodaj `charakter_z_podrzednymi__rel`
+do `get_fields`, gdy model ma FK `charakter_formalny`
+(`_has_charakter_formalny(model)`), oraz obsłuż w `get_field_instance`
+(picker po `Charakter_Formalny`, `search_fields=["nazwa","skrot"]`).
+Pole jest **bezpośrednim** FK na `Rekord` (bez joinu `autorzy`), więc
+działa też w edytorze/adminie nad `Rekord`.
+
 ## B. Plan per-pole
 
 ### B1 — Deklaratywny `djangoql_field_name`, AUTOCOMPLETE → `__rel`
@@ -107,25 +139,24 @@ zamiast `None` (nieprzekładalne). Niepuste — bez zmian.
 | `OpenaccessCzasPublikacjiQueryObject` | `openaccess_czas_publikacji.nazwa = "..."` |
 | `Typ_OdpowiedzialnosciQueryObject` | `autorzy.typ_odpowiedzialnosci.nazwa = "..."` |
 
-`CharakterFormalnyQueryObject` **nie** jest czysto deklaratywne (patrz B3):
-wartość niesie prefiks wcięcia MPTT (`DEFAULT_LEVEL_INDICATOR = "---"`);
-`value_from_web` robi `value.lstrip("-").lstrip(" ")`. Realizacja: albo
-metoda `to_djangoql` (normalizuje wartość, potem `charakter_formalny.nazwa =
-"<znormalizowana>"`), albo deklaratywny hak `djangoql_value_transform`
-(callable wartość→wartość) konsumowany przez `_value_list_leaf`. Wybór:
-**`to_djangoql`** (mniej nowych mechanik, semantyka MPTT-descendants i tak
-wymaga warninga z F).
+`CharakterFormalnyQueryObject` jest osobnym przypadkiem (B3 + H): wartość
+niesie prefiks wcięcia MPTT (`DEFAULT_LEVEL_INDICATOR = "---"`),
+`value_from_web` robi `value.lstrip("-").lstrip(" ")` i zwraca obiekt
+`Charakter_Formalny`. `to_djangoql` resolwuje obiekt i emituje
+`charakter_z_podrzednymi__rel = "nazwa [pk]"` — pole wirtualne MPTT
+odwzorowujące `get_descendants(include_self=True)` z `real_query`
+(**dokładne**, bez stratności, patrz H).
 
 ### B3 — `to_djangoql` (semantyka niestandardowa)
 
 | Pole | DjangoQL |
 |---|---|
-| `CharakterOgolnyQueryObject` | `charakter_formalny.charakter_ogolny = "<const>"` |
+| `CharakterFormalnyQueryObject` | `charakter_z_podrzednymi__rel = "nazwa [pk]"` (pole wirtualne MPTT, **dokładne**; patrz H) |
+| `CharakterOgolnyQueryObject` | `charakter_formalny.charakter_ogolny = "art"` / `"roz"` / `"ksi"` / `"xxx"` |
 | `TypRekorduObject` | `charakter_formalny.publikacja = True` / `.streszczenie = True` / `(.publikacja = False and .streszczenie = False)` |
-| `RodzajKonferenckjiQueryObject` | `konferencja.typ_konferencji = <N>` |
-| `RodzajJednostkiQueryObject` | `autorzy.jednostka.rodzaj_jednostki = <N>` |
-| `TypOgolnyAutorQueryObject` i podklasy | `autorzy.autor__rel = "L [pk]" and autorzy.typ_odpowiedzialnosci.typ_ogolny = <N>` |
-| `CharakterFormalnyQueryObject` | `charakter_formalny.nazwa = "<bez prefiksu --->"` (+ warning gdy ma potomków, F) |
+| `RodzajKonferenckjiQueryObject` | `konferencja.typ_konferencji = 1` (krajowa) / `2` (międz.) / `3` (lokalna) |
+| `RodzajJednostkiQueryObject` | `autorzy.jednostka.rodzaj_jednostki = "normalna"` / `"kolo_naukowe"` |
+| `TypOgolnyAutorQueryObject` i podklasy | `autorzy.autor__rel = "L [pk]" and autorzy.typ_odpowiedzialnosci.typ_ogolny = N` (N: autor 0, redaktor 1, tłumacz 3, recenzent 5 — **same-row**, dokładne) |
 | `ObcaJednostkaQueryObject` | `autorzy.jednostka.skupia_pracownikow = <not value>` |
 | `AfiliujeQueryObject` | `autorzy.afiliuje = <bool>` |
 | `OswiadczenieKENQueryObject` | `autorzy.oswiadczenie_ken = <bool>` |
@@ -133,9 +164,12 @@ wymaga warninga z F).
 | `LicencjaOpenAccessUstawionaQueryObject` | `openaccess_licencja != None` (lub `= None`) |
 | `PublicDostepDniaQueryObject` | `public_dostep_dnia != None` (lub `= None`) |
 | `StronaWWWUstawionaQueryObject` | `(www != "" or public_www != "")` (lub negacja) |
+| `SlowaKluczoweQueryObject` | `slowa_kluczowe.name = "..."` (Rekord → `taggit.tag`) |
+| `ZewnetrznaBazaDanychQueryObject` | `zewnetrzne_bazy.baza__rel = "L [pk]"` (Rekord → `zewnetrznebazydanychview` → `baza`) |
 
-Wartości `<const>`/`<N>` brać z definicji klasy (`bpp.const`,
-`Konferencja.TK_*`, `Jednostka.RODZAJ_JEDNOSTKI`, `charakter_ogolny`).
+Wartości stałych potwierdzone introspekcją: `charakter_ogolny`
+∈ {art, roz, ksi, xxx}; `typ_ogolny` ∈ {0,1,3,5}; `rodzaj_jednostki`
+∈ {normalna, kolo_naukowe}; `typ_konferencji` ∈ {1,2,3}.
 
 ### B4 — Już działają (bez zmian)
 
@@ -161,14 +195,27 @@ wyprodukować niepoprawnego DjangoQL. **Implikacja:** testy round-trip muszą
 potwierdzić, że zamierzone ścieżki faktycznie się walidują (inaczej cicho
 staną się warningami i cel nie zostanie osiągnięty).
 
-## E. Pozostałe szczere warningi (powinno być mało)
+## E. Audyt rejestru: co NIE przekłada się wcale
 
-- `SlowaKluczoweQueryObject`, `ZewnetrznaBazaDanychQueryObject` — match
-  przez dedykowane widoki SQL (`pk__in` subquery). Próbujemy
-  `slowa_kluczowe…` / relacji do zewn. bazy, jeśli schemat ją wystawia;
-  inaczej warning.
-- `NOT_IN_RANGE` i zanegowane *grupy* — DjangoQL nie ma `not(...)`
-  (bez zmian, warning).
+Introspekcja `BppQLSchema(Rekord)` (wykonana) potwierdza, że schemat
+sięga dalej niż zakładano — m.in. `slowa_kluczowe → taggit.tag`,
+`zewnetrzne_bazy → zewnetrznebazydanychview → baza`, pełne poddrzewa
+`autorzy.jednostka.wydzial`, `autorzy.typ_odpowiedzialnosci.typ_ogolny`,
+`charakter_formalny.{charakter_ogolny,publikacja,streszczenie}`,
+`autorzy.autor.aktualna_jednostka__rel`.
+
+**Wniosek: pod pełnym designem ŻADNE pole rejestru nie jest w 100%
+nieprzekładalne.** Każde zarejestrowane `QueryObject` daje co najmniej
+fragment best-effort. Dwa wcześniej podejrzane (`SlowaKluczowe`,
+`ZewnetrznaBazaDanych`) są przekładalne (B3).
+
+Nieprzekładalne pozostają tylko **operacje**, nie pola:
+
+- `NOT_IN_RANGE` (negacja zakresu) — DjangoQL nie ma `not(...)`.
+- Zanegowana **grupa** (ANDNOT na podramce) — j.w.
+
+To są warningi bez fragmentu (bez zmian względem dotychczasowego
+zachowania).
 
 ## F. Best-effort + warning (pola stratne)
 
@@ -176,11 +223,13 @@ Tłumaczone przybliżenie + **warning** wyjaśniający rozbieżność:
 
 - **UNION** (`równy+wspólny` itd.) → identycznie jak EQUAL; gubiona jest
   dystynkcja „inny wiersz autora" (ograniczenie gramatyki DjangoQL).
-- **CharakterFormalny descendants** (MPTT) → tylko dokładny węzeł, bez
-  poddrzewa. Warning gdy węzeł ma potomków.
 - **kolejnosc-ranged autorzy** (`Pierwsze/Ostatnie nazwisko i imię`,
-  `Pierwsza jednostka/wydział`) → `kolejnosc` jest per-wiersz; best-effort
-  pomija je, z warningiem.
+  `Nazwisko i imię 1do3/1do5`, `Pierwsza jednostka`, `Pierwszy wydział`)
+  → `kolejnosc` jest per-wiersz; best-effort pomija filtr kolejności,
+  z warningiem.
+
+`CharakterFormalny` **przestaje** być stratny — pole wirtualne
+`charakter_z_podrzednymi__rel` (H) odwzorowuje MPTT-descendants dokładnie.
 
 ## G. Podgląd w szufladzie: formatowanie + podświetlanie składni
 
@@ -261,6 +310,8 @@ textarea z istniejącym endpointem introspekcji `rekord`
 ## Pliki
 
 - `src/bpp/multiseek_registry/djangoql_export.py` — A1/A2/A3.
+- `src/bpp/djangoql_schema.py` — pole wirtualne `charakter_z_podrzednymi__rel`
+  (A4) + wpięcie w `RelPickerSchemaMixin`.
 - `src/bpp/multiseek_registry/fields/*.py` — atrybuty deklaratywne (B1/B2)
   i metody `to_djangoql` (B3/F) per pole.
 - `src/bpp/static/bpp/js/djangoql-pretty.js` — formatter + highlighter (G).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -486,7 +486,7 @@ dev = [
     # django-run-site: CLI orchestrator dev stack-u. Dawniej `manage.py run_site`
     # + helpery w `_run_site_helpers/`. Instalowany w dev-deps zeby `uv run run-site`
     # mialo dostep do CLI bez globalnego `uv tool install`. Konfiguracja: runsite.toml.
-    "django-run-site>=0.16.0",
+    "django-run-site>=0.16.1",
     # django-dev-helpers: autologin endpoint + dotfiles dla agentow LLM. Dawniej
     # `src/django_bpp/views_run_site_autologin.py`. Aktywuje sie tylko gdy run-site
     # ustawi DJANGO_DEV_HELPERS_ENABLED=1 — w produkcji no-op.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dependencies = [
     "requests-oauthlib==2.0.0",
     "django-cacheops>=7.2,<8",
     "django-constance>=4.3.5",
-    "djangoql-iplweb>=0.23.0",
+    "djangoql-iplweb>=0.26.0",
     "django-weasyprint>=2.5.0",
     "django-templated-email>=3.0.0",
     "django-formtools>=2.6.1,<3",

--- a/src/bpp/djangoql_schema.py
+++ b/src/bpp/djangoql_schema.py
@@ -121,12 +121,14 @@ class JednostkaZPodjednostkamiField(AutocompleteField):
     def get_lookup(self, path, operator, value):
         parsed = self.parse_id(value)
         if not isinstance(parsed, int):
-            # free-text fallback po nazwie jednostki (best-effort)
-            return Q(autorzy__jednostka__nazwa__icontains=str(value))
+            # free-text fallback po nazwie jednostki (best-effort), uwzględnia operator
+            q = Q(autorzy__jednostka__nazwa__icontains=str(value))
+            return ~q if operator in ("!=", "not in") else q
         try:
             jednostka = Jednostka.objects.get(pk=parsed)
         except Jednostka.DoesNotExist:
-            return Q(pk__in=[])  # nic nie pasuje
+            # Pozytywne dopasowanie: nic nie pasuje. Negacja: pasuje wszystko.
+            return Q() if operator in ("!=", "not in") else Q(pk__in=[])
         q = Q(autorzy__jednostka__in=jednostka.get_family())
         return ~q if operator in ("!=", "not in") else q
 

--- a/src/bpp/djangoql_schema.py
+++ b/src/bpp/djangoql_schema.py
@@ -23,7 +23,7 @@ from django.db.models import Q
 from django.utils.html import strip_tags
 from djangoql.extras import AutocompleteField, ExtrasSchema
 
-from bpp.models import Jednostka
+from bpp.models import Charakter_Formalny, Jednostka
 
 #: Pola-etykiety wg priorytetu — czym opisać i po czym szukać obiekt w pickerze.
 #: Opis bibliograficzny jako pierwszy: dla publikacji jest najczytelniejszy.
@@ -52,6 +52,8 @@ _REL_SUFFIX = "__rel"
 _SKIP_FK = ("rekord",)
 #: Wirtualne pole: picker po Jednostce dopasowujący rodzinę MPTT.
 _SUBUNITS_FIELD = "jednostka_z_podjednostkami__rel"
+#: Wirtualne pole: picker po Charakterze Formalnym dopasowujący MPTT-descendants.
+_CHARAKTER_SUB_FIELD = "charakter_z_podrzednymi__rel"
 
 
 def _field_names(model):
@@ -133,6 +135,27 @@ class JednostkaZPodjednostkamiField(AutocompleteField):
         return ~q if operator in ("!=", "not in") else q
 
 
+class CharakterZPodrzednymiField(AutocompleteField):
+    """Picker po Charakter_Formalny: dopasowuje rekordy o tym charakterze ORAZ
+    wszystkich potomkach w drzewie MPTT (sam + descendants).
+
+    Odwzorowuje CharakterFormalnyQueryObject.real_query:
+        Q(charakter_formalny__in=value.get_descendants(include_self=True))
+    """
+
+    def get_lookup(self, path, operator, value):
+        parsed = self.parse_id(value)
+        if not isinstance(parsed, int):
+            q = Q(charakter_formalny__nazwa__icontains=str(value))
+            return ~q if operator in ("!=", "not in") else q
+        try:
+            ch = Charakter_Formalny.objects.get(pk=parsed)
+        except Charakter_Formalny.DoesNotExist:
+            return Q() if operator in ("!=", "not in") else Q(pk__in=[])
+        q = Q(charakter_formalny__in=ch.get_descendants(include_self=True))
+        return ~q if operator in ("!=", "not in") else q
+
+
 def _has_autorzy_jednostka(model):
     """True, gdy model ma odwrotną relację 'autorzy' z FK 'jednostka'
     (Rekord/cache)."""
@@ -148,6 +171,15 @@ def _has_autorzy_jednostka(model):
     }
 
 
+def _has_charakter_formalny(model):
+    """True, gdy model ma FK 'charakter_formalny' (Rekord/cache)."""
+    try:
+        f = model._meta.get_field("charakter_formalny")
+    except FieldDoesNotExist:
+        return False
+    return getattr(f, "many_to_one", False)
+
+
 class RelPickerSchemaMixin:
     """Mixin auto-generujący pickery ``<fk>__rel`` (patrz docstring modułu)."""
 
@@ -156,6 +188,8 @@ class RelPickerSchemaMixin:
         fields += [f.name + _REL_SUFFIX for f in _picker_fks(model)]
         if _has_autorzy_jednostka(model):
             fields.append(_SUBUNITS_FIELD)
+        if _has_charakter_formalny(model):
+            fields.append(_CHARAKTER_SUB_FIELD)
         return fields
 
     def get_field_instance(self, model, field_name):
@@ -166,6 +200,14 @@ class RelPickerSchemaMixin:
                 nullable=True,
                 queryset=_visible_qs(Jednostka),
                 search_fields=_label_fields(Jednostka),
+            )
+        if field_name == _CHARAKTER_SUB_FIELD:
+            return CharakterZPodrzednymiField(
+                model=model,
+                name=_CHARAKTER_SUB_FIELD,
+                nullable=True,
+                queryset=_visible_qs(Charakter_Formalny),
+                search_fields=_label_fields(Charakter_Formalny),
             )
         if field_name.endswith(_REL_SUFFIX):
             fk_name = field_name[: -len(_REL_SUFFIX)]

--- a/src/bpp/djangoql_schema.py
+++ b/src/bpp/djangoql_schema.py
@@ -19,8 +19,11 @@ pomijane.
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
+from django.db.models import Q
 from django.utils.html import strip_tags
 from djangoql.extras import AutocompleteField, ExtrasSchema
+
+from bpp.models import Jednostka
 
 #: Pola-etykiety wg priorytetu — czym opisać i po czym szukać obiekt w pickerze.
 #: Opis bibliograficzny jako pierwszy: dla publikacji jest najczytelniejszy.
@@ -47,6 +50,8 @@ _VISIBLE_WHEN_FALSE = ("disabled", "ukryty", "ukryta", "ukryte")
 _REL_SUFFIX = "__rel"
 #: FK pomijane (rodzic cache/through — pickowanie rodzica nie ma sensu).
 _SKIP_FK = ("rekord",)
+#: Wirtualne pole: picker po Jednostce dopasowujący rodzinę MPTT.
+_SUBUNITS_FIELD = "jednostka_z_podjednostkami__rel"
 
 
 def _field_names(model):
@@ -105,15 +110,61 @@ def _picker_fks(model):
     return out
 
 
+class JednostkaZPodjednostkamiField(AutocompleteField):
+    """Picker po Jednostce: dopasowuje rekordy autorów z tej jednostki ORAZ
+    wszystkich jednostek z jej rodziny MPTT (przodkowie+sama+potomkowie).
+
+    Odwzorowuje multiseek EQUAL_PLUS_SUB_FEMALE:
+        Q(autorzy__jednostka__in=value.get_family())
+    """
+
+    def get_lookup(self, path, operator, value):
+        parsed = self.parse_id(value)
+        if not isinstance(parsed, int):
+            # free-text fallback po nazwie jednostki (best-effort)
+            return Q(autorzy__jednostka__nazwa__icontains=str(value))
+        try:
+            jednostka = Jednostka.objects.get(pk=parsed)
+        except Jednostka.DoesNotExist:
+            return Q(pk__in=[])  # nic nie pasuje
+        q = Q(autorzy__jednostka__in=jednostka.get_family())
+        return ~q if operator in ("!=", "not in") else q
+
+
+def _has_autorzy_jednostka(model):
+    """True, gdy model ma odwrotną relację 'autorzy' z FK 'jednostka'
+    (Rekord/cache)."""
+    try:
+        rel = model._meta.get_field("autorzy")
+    except FieldDoesNotExist:
+        return False
+    related = getattr(rel, "related_model", None)
+    if related is None:
+        return False
+    return "jednostka" in {
+        f.name for f in related._meta.get_fields() if isinstance(f, models.Field)
+    }
+
+
 class RelPickerSchemaMixin:
     """Mixin auto-generujący pickery ``<fk>__rel`` (patrz docstring modułu)."""
 
     def get_fields(self, model):
         fields = list(super().get_fields(model))
         fields += [f.name + _REL_SUFFIX for f in _picker_fks(model)]
+        if _has_autorzy_jednostka(model):
+            fields.append(_SUBUNITS_FIELD)
         return fields
 
     def get_field_instance(self, model, field_name):
+        if field_name == _SUBUNITS_FIELD:
+            return JednostkaZPodjednostkamiField(
+                model=model,
+                name=_SUBUNITS_FIELD,
+                nullable=True,
+                queryset=_visible_qs(Jednostka),
+                search_fields=_label_fields(Jednostka),
+            )
         if field_name.endswith(_REL_SUFFIX):
             fk_name = field_name[: -len(_REL_SUFFIX)]
             try:

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -176,11 +176,12 @@ def _default_leaf(field, value, operation):
     return f"{_orm_path_to_djangoql(name)} {dql_op} {render_value(value)}"
 
 
-def leaf_to_djangoql(registry, leaf):
+def leaf_to_djangoql(registry, leaf, warnings=None):
     """Fragment DjangoQL dla pojedynczego warunku, albo None (nieprzekladalny).
 
-    None gdy: nieznane pole, nieobslugiwana operacja, albo fragment nie
-    waliduje sie wzgledem schematu Rekord.
+    Wartosc z dispatchera moze byc str, (str, warning) albo None. Ostrzezenie
+    (jesli jest i podano `warnings`) trafia do listy. None gdy: nieznane pole,
+    nieobslugiwana operacja, albo fragment nie waliduje sie wzgledem schematu.
     """
     if not isinstance(leaf, dict):
         return None
@@ -193,9 +194,12 @@ def leaf_to_djangoql(registry, leaf):
         return None
     override = getattr(field, "to_djangoql", None)
     if callable(override):
-        frag = override(value, operation)
+        result = override(value, operation)
     else:
-        frag = _default_leaf(field, value, operation)
+        result = _default_leaf(field, value, operation)
+    frag, warn = result if isinstance(result, tuple) else (result, None)
+    if warn and warnings is not None:
+        warnings.append(warn)
     if frag is None:
         return None
     return frag if is_valid_rekord_djangoql(frag) else None
@@ -300,7 +304,7 @@ def _invert_fragment(frag):
 def _append_leaf(registry, leaf, parts, warnings):
     prev_op = leaf.get("prev_op")
     if _is_andnot(prev_op):
-        frag = leaf_to_djangoql(registry, leaf)
+        frag = leaf_to_djangoql(registry, leaf, warnings)
         if frag is None:
             warnings.append(
                 f"Pominięto zanegowany warunek: {_leaf_label(leaf)} (nieprzekładalny)"
@@ -315,7 +319,7 @@ def _append_leaf(registry, leaf, parts, warnings):
             return
         parts.append(("and", inverted))
         return
-    frag = leaf_to_djangoql(registry, leaf)
+    frag = leaf_to_djangoql(registry, leaf, warnings)
     if frag is None:
         warnings.append(f"Pominięto warunek: {_leaf_label(leaf)} (nieprzekładalny)")
         return

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -172,14 +172,20 @@ def leaf_to_djangoql(registry, leaf):
     None gdy: nieznane pole, nieobslugiwana operacja, albo fragment nie
     waliduje sie wzgledem schematu Rekord.
     """
-    field = registry.field_by_name.get(leaf["field"])
+    if not isinstance(leaf, dict):
+        return None
+    field = registry.field_by_name.get(leaf.get("field"))
     if field is None:
+        return None
+    value = leaf.get("value")
+    operation = leaf.get("operator")
+    if operation is None:
         return None
     override = getattr(field, "to_djangoql", None)
     if callable(override):
-        frag = override(leaf["value"], leaf["operator"])
+        frag = override(value, operation)
     else:
-        frag = _default_leaf(field, leaf["value"], leaf["operator"])
+        frag = _default_leaf(field, value, operation)
     if frag is None:
         return None
     return frag if is_valid_rekord_djangoql(frag) else None

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -283,7 +283,7 @@ def _invert_fragment(frag):
     for op in sorted(_INVERT, key=len, reverse=True):
         prefix = op + " "
         if rest.startswith(prefix):
-            return f"{lhs} {_INVERT[op]} {rest[len(prefix):]}"
+            return f"{lhs} {_INVERT[op]} {rest[len(prefix) :]}"
     return None
 
 
@@ -293,8 +293,7 @@ def _append_leaf(registry, leaf, parts, warnings):
         frag = leaf_to_djangoql(registry, leaf)
         if frag is None:
             warnings.append(
-                f"Pominięto zanegowany warunek: {_leaf_label(leaf)} "
-                "(nieprzekładalny)"
+                f"Pominięto zanegowany warunek: {_leaf_label(leaf)} (nieprzekładalny)"
             )
             return
         inverted = _invert_fragment(frag)
@@ -308,9 +307,7 @@ def _append_leaf(registry, leaf, parts, warnings):
         return
     frag = leaf_to_djangoql(registry, leaf)
     if frag is None:
-        warnings.append(
-            f"Pominięto warunek: {_leaf_label(leaf)} (nieprzekładalny)"
-        )
+        warnings.append(f"Pominięto warunek: {_leaf_label(leaf)} (nieprzekładalny)")
         return
     kw = _logical_keyword(prev_op)
     if prev_op is not None and kw is None:
@@ -334,8 +331,7 @@ def _append_subframe(registry, subframe, parts, warnings):
     kw = _logical_keyword(prev_op)
     if prev_op is not None and kw is None:
         warnings.append(
-            f"Nieznany operator łączący {prev_op!r} dla grupy warunków "
-            "— przyjęto 'and'"
+            f"Nieznany operator łączący {prev_op!r} dla grupy warunków — przyjęto 'and'"
         )
     parts.append((kw, f"({sub})"))
 

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -112,6 +112,13 @@ def is_valid_rekord_djangoql(fragment):
     return True
 
 
+def _orm_name(field):
+    """Realna ścieżka ORM pola: djangoql_field_name (override) albo field_name."""
+    return getattr(field, "djangoql_field_name", None) or getattr(
+        field, "field_name", None
+    )
+
+
 def _autocomplete_leaf(field, value, operation):
     """value to pk; resolwujemy obiekt i emitujemy '<sciezka>__rel = "L [pk]"'."""
     op = str(operation)
@@ -135,7 +142,10 @@ def _autocomplete_leaf(field, value, operation):
         return None
     if obj is None:
         return None
-    rel_path = _orm_path_to_djangoql(field.field_name) + "__rel"
+    name = _orm_name(field)
+    if not name:
+        return None
+    rel_path = _orm_path_to_djangoql(name) + "__rel"
     label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
     return f'{rel_path} {rel_op} "{label} [{obj.pk}]"'
 
@@ -155,7 +165,7 @@ def _default_leaf(field, value, operation):
     op = str(operation)
     if getattr(field, "type", None) == AUTOCOMPLETE:
         return _autocomplete_leaf(field, value, operation)
-    name = getattr(field, "field_name", None)
+    name = _orm_name(field)
     if not name:
         return None
     if op in range_operators():

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -130,6 +130,13 @@ def _autocomplete_leaf(field, value, operation):
         rel_op = "="
     else:
         return None
+    name = _orm_name(field)
+    if not name:
+        return None
+    rel_path = _orm_path_to_djangoql(name) + "__rel"
+    if value in (None, ""):
+        # Pusty autocomplete (brak wybranego obiektu) -> filtr is-null.
+        return f"{rel_path} = None" if rel_op == "=" else f"{rel_path} != None"
     try:
         obj = field.value_from_web(value)
     except Exception:  # noqa: BLE001 — nieoczekiwany blad resolucji pk -> nieprzekladalne
@@ -142,10 +149,6 @@ def _autocomplete_leaf(field, value, operation):
         return None
     if obj is None:
         return None
-    name = _orm_name(field)
-    if not name:
-        return None
-    rel_path = _orm_path_to_djangoql(name) + "__rel"
     label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
     return f'{rel_path} {rel_op} "{label} [{obj.pk}]"'
 

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -150,6 +150,45 @@ def _autocomplete_leaf(field, value, operation):
     return f'{rel_path} {rel_op} "{label} [{obj.pk}]"'
 
 
+def _is_union(operation):
+    """True gdy operator multiseek to wariant UNION (równy+wspólny…)."""
+    from bpp.multiseek_registry.fields.constants import UNION_OPS_ALL
+
+    s = str(operation)
+    return s in {str(o) for o in UNION_OPS_ALL}
+
+
+_UNION_WARNING = (
+    'Operator „wspólny" przełożono jak zwykłą równość — w DjangoQL może objąć '
+    "inny wiersz autora niż pozostałe kryteria."
+)
+
+
+def _value_list_leaf(field, value, operation):
+    """value-list (lista stringów) -> '<sciezka>.<pole> = "wartosc"'.
+
+    Aktywne tylko dla pól z atrybutem `djangoql_value_field`. UNION → '='
+    z ostrzeżeniem. Pusta wartość → '= ""'.
+    """
+    name = _orm_name(field)
+    value_field = getattr(field, "djangoql_value_field", None)
+    if not name or not value_field:
+        return None
+    op = str(operation)
+    diff_strs = {str(o) for o in DIFFERENT_ALL}
+    if op in diff_strs:
+        dql_op = "!="
+    elif op in {str(o) for o in EQUALITY_OPS_ALL} - diff_strs or _is_union(op):
+        dql_op = "="
+    else:
+        return None
+    path = _orm_path_to_djangoql(name)
+    frag = f"{path}.{value_field} {dql_op} {render_value(value or '')}"
+    if _is_union(op):
+        return frag, _UNION_WARNING
+    return frag
+
+
 def _range_leaf(name, value, operation):
     """IN_RANGE/NOT_IN_RANGE: value to [low, high]."""
     if not (isinstance(value, (list, tuple)) and len(value) == 2):
@@ -165,6 +204,8 @@ def _default_leaf(field, value, operation):
     op = str(operation)
     if getattr(field, "type", None) == AUTOCOMPLETE:
         return _autocomplete_leaf(field, value, operation)
+    if getattr(field, "djangoql_value_field", None):
+        return _value_list_leaf(field, value, operation)
     name = _orm_name(field)
     if not name:
         return None

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -7,6 +7,7 @@ pola trudne nadpisuja metode `to_djangoql(value, operation)`. Kazdy fragment
 jest walidowany przeciw BppQLSchema(Rekord) — niepoprawne -> warning.
 """
 
+import logging
 from decimal import Decimal
 
 from djangoql.parser import DjangoQLParser
@@ -28,6 +29,13 @@ from multiseek.logic import (
 
 from bpp.djangoql_schema import BppQLSchema
 from bpp.models import Rekord
+
+logger = logging.getLogger(__name__)
+
+# Schema introspekcja jest kosztowna (rekursywny obchod grafu modeli) i bezstanowa
+# po zbudowaniu -> jeden wspoldzielony singleton. Parser tworzymy per-call
+# (wspoldzielony lexer nie jest thread-safe pod wielowatkowym WSGI).
+_REKORD_SCHEMA = BppQLSchema(Rekord)
 
 
 def _build_scalar_op_map():
@@ -91,10 +99,8 @@ def is_valid_rekord_djangoql(fragment):
     """Czy fragment parsuje sie i waliduje wzgledem BppQLSchema(Rekord)."""
     try:
         ast = DjangoQLParser().parse(fragment)
-        BppQLSchema(Rekord).validate(ast)
-    except Exception:  # noqa: BLE001 — best-effort validity gate
-        # Klasyfikuje fragment jako nieprzekladalny (zwraca False); nie tlumi
-        # bledu logiki — niepoprawne fragmenty sa poprawnie odrzucane.
+        _REKORD_SCHEMA.validate(ast)
+    except Exception:  # noqa: BLE001 — best-effort validity gate (klasyfikuje, nie tlumi)
         return False
     return True
 
@@ -102,15 +108,23 @@ def is_valid_rekord_djangoql(fragment):
 def _autocomplete_leaf(field, value, operation):
     """value to pk; resolwujemy obiekt i emitujemy '<sciezka>__rel = "L [pk]"'."""
     op = str(operation)
-    if op in {str(o) for o in DIFFERENT_ALL}:
+    diff_strs = {str(o) for o in DIFFERENT_ALL}
+    equal_strs = {str(o) for o in EQUALITY_OPS_ALL} - diff_strs
+    if op in diff_strs:
         rel_op = "!="
-    elif op in {str(o) for o in EQUALITY_OPS_ALL}:
+    elif op in equal_strs:
         rel_op = "="
     else:
         return None
     try:
         obj = field.value_from_web(value)
-    except Exception:  # noqa: BLE001 — nieistniejacy/uszkodzony pk -> warning
+    except Exception:  # noqa: BLE001 — nieoczekiwany blad resolucji pk -> nieprzekladalne
+        logger.debug(
+            "value_from_web zawiodlo dla pola %r (value=%r)",
+            getattr(field, "label", field),
+            value,
+            exc_info=True,
+        )
         return None
     if obj is None:
         return None

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -46,27 +46,25 @@ def _build_scalar_op_map():
     return m
 
 
-_SCALAR_OP_MAP: dict | None = None
-_RANGE_OPS: frozenset | None = None
-
-
-def _get_scalar_op_map() -> dict:
-    global _SCALAR_OP_MAP
-    if _SCALAR_OP_MAP is None:
-        _SCALAR_OP_MAP = _build_scalar_op_map()
-    return _SCALAR_OP_MAP
-
-
-def _get_range_ops() -> frozenset:
-    global _RANGE_OPS
-    if _RANGE_OPS is None:
-        _RANGE_OPS = frozenset({str(IN_RANGE), str(NOT_IN_RANGE)})
-    return _RANGE_OPS
-
-
 def scalar_operator_to_djangoql(operator):
-    """DjangoQL-owy operator dla skalarnej operacji multiseek, lub None."""
-    return _get_scalar_op_map().get(str(operator))
+    """DjangoQL-owy operator dla skalarnej operacji multiseek, lub None.
+
+    Mapa jest budowana przy kazdym wywolaniu (tanio: ~20 wpisow), aby
+    str() na stałych lazy-gettext rozwiazal sie pod AKTYWNYM jezykiem
+    w momencie wywolania — identycznym z jezykiem formularza Multiseek.
+    Cache bylby bledny: pierwszy call mrozi jezyk-kluczy na caly czas
+    zycia procesu.
+    """
+    return _build_scalar_op_map().get(str(operator))
+
+
+def range_operators() -> frozenset:
+    """Zbior stringowych nazw operatorow zakresu pod aktywnym jezykiem.
+
+    Analogicznie do scalar_operator_to_djangoql — budowane per-call,
+    bez cache, aby lazy-gettext rozwiazalo sie pod biezacym jezykiem.
+    """
+    return frozenset({str(IN_RANGE), str(NOT_IN_RANGE)})
 
 
 def render_value(value):

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -201,7 +201,8 @@ class ConversionResult:
 def _logical_keyword(prev_op):
     """'and'/'or' dla operatora laczacego multiseek; None gdy nie AND/OR.
 
-    str() liczone per-call -> poprawne niezaleznie od aktywnej lokalizacji.
+    AND/OR to zwykle stringi w multiseek.logic; str() jest defensywne,
+    nie lokalizacyjne.
     """
     s = str(prev_op)
     if s == str(AND):
@@ -220,12 +221,27 @@ def _leaf_label(leaf):
 
 
 def _join_parts(parts):
-    """parts: list[(joiner, fragment)]; joiner pierwszego ignorowany."""
+    """Łączy fragmenty LEWOSTRONNIE, zgodnie z multiseek (ret = ret & q / | q).
+
+    DjangoQL daje `and` wyższy priorytet niż `or`, więc płaskie złączenie
+    `A or B and C` znaczyłoby `A or (B and C)`. Multiseek liczy `(A or B) and C`.
+    Dlatego nawiasujemy lewy akumulator, gdy dołączamy `and`, a akumulator ma
+    na szczycie `or`. Czysty łańcuch `and`/`or` zostaje bez zbędnych nawiasów.
+    parts: list[(joiner, fragment)]; joiner pierwszego elementu jest ignorowany,
+    a `frag` to atom (pojedyncze porównanie) albo już-nawiasowana podramka.
+    """
     if not parts:
         return ""
     out = parts[0][1]
+    has_top_or = False
     for joiner, frag in parts[1:]:
-        out = f"{out} {joiner or 'and'} {frag}"
+        j = joiner or "and"
+        if j == "and" and has_top_or:
+            out = f"({out})"
+            has_top_or = False
+        out = f"{out} {j} {frag}"
+        if j == "or":
+            has_top_or = True
     return out
 
 
@@ -243,7 +259,13 @@ def _append_leaf(registry, leaf, parts, warnings):
             f"Pominięto warunek: {_leaf_label(leaf)} (nieprzekładalny)"
         )
         return
-    parts.append((_logical_keyword(prev_op), frag))
+    kw = _logical_keyword(prev_op)
+    if prev_op is not None and kw is None:
+        warnings.append(
+            f"Nieznany operator łączący {prev_op!r} dla: {_leaf_label(leaf)} "
+            "— przyjęto 'and'"
+        )
+    parts.append((kw, frag))
 
 
 def _append_subframe(registry, subframe, parts, warnings):
@@ -256,7 +278,13 @@ def _append_subframe(registry, subframe, parts, warnings):
     sub = _walk_frame(registry, subframe, warnings)
     if not sub:
         return
-    parts.append((_logical_keyword(prev_op), f"({sub})"))
+    kw = _logical_keyword(prev_op)
+    if prev_op is not None and kw is None:
+        warnings.append(
+            f"Nieznany operator łączący {prev_op!r} dla grupy warunków "
+            "— przyjęto 'and'"
+        )
+    parts.append((kw, f"({sub})"))
 
 
 def _walk_frame(registry, frame, warnings):

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -8,10 +8,16 @@ jest walidowany przeciw BppQLSchema(Rekord) — niepoprawne -> warning.
 """
 
 import logging
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from decimal import Decimal
+from urllib.parse import urlencode
 
+from django.urls import reverse
 from djangoql.parser import DjangoQLParser
 from multiseek.logic import (
+    AND,
+    ANDNOT,
     AUTOCOMPLETE,
     CONTAINS,
     DIFFERENT_ALL,
@@ -24,6 +30,7 @@ from multiseek.logic import (
     NOT_CONTAINS,
     NOT_IN_RANGE,
     NOT_STARTS_WITH,
+    OR,
     STARTS_WITH,
 )
 
@@ -176,3 +183,101 @@ def leaf_to_djangoql(registry, leaf):
     if frag is None:
         return None
     return frag if is_valid_rekord_djangoql(frag) else None
+
+
+@dataclass
+class ConversionResult:
+    query: str
+    warnings: list = dataclass_field(default_factory=list)
+
+    @property
+    def editor_url(self):
+        base = reverse("bpp:zapytanie")
+        if not self.query:
+            return f"{base}?{urlencode({'model': 'rekord'})}"
+        return f"{base}?{urlencode({'model': 'rekord', 'query': self.query})}"
+
+
+def _logical_keyword(prev_op):
+    """'and'/'or' dla operatora laczacego multiseek; None gdy nie AND/OR.
+
+    str() liczone per-call -> poprawne niezaleznie od aktywnej lokalizacji.
+    """
+    s = str(prev_op)
+    if s == str(AND):
+        return "and"
+    if s == str(OR):
+        return "or"
+    return None
+
+
+def _is_andnot(prev_op):
+    return prev_op is not None and str(prev_op) == str(ANDNOT)
+
+
+def _leaf_label(leaf):
+    return f"{leaf.get('field')} {leaf.get('operator')}".strip()
+
+
+def _join_parts(parts):
+    """parts: list[(joiner, fragment)]; joiner pierwszego ignorowany."""
+    if not parts:
+        return ""
+    out = parts[0][1]
+    for joiner, frag in parts[1:]:
+        out = f"{out} {joiner or 'and'} {frag}"
+    return out
+
+
+def _append_leaf(registry, leaf, parts, warnings):
+    prev_op = leaf.get("prev_op")
+    if _is_andnot(prev_op):
+        # Task 6 podniesie to do inwersji operatora; teraz skip+warning.
+        warnings.append(
+            f"Pominięto zanegowany warunek: {_leaf_label(leaf)} (andnot)"
+        )
+        return
+    frag = leaf_to_djangoql(registry, leaf)
+    if frag is None:
+        warnings.append(
+            f"Pominięto warunek: {_leaf_label(leaf)} (nieprzekładalny)"
+        )
+        return
+    parts.append((_logical_keyword(prev_op), frag))
+
+
+def _append_subframe(registry, subframe, parts, warnings):
+    prev_op = subframe[0] if subframe else None
+    if _is_andnot(prev_op):
+        warnings.append(
+            "Pominięto zanegowaną grupę warunków (DjangoQL nie ma `not(...)`)"
+        )
+        return
+    sub = _walk_frame(registry, subframe, warnings)
+    if not sub:
+        return
+    parts.append((_logical_keyword(prev_op), f"({sub})"))
+
+
+def _walk_frame(registry, frame, warnings):
+    """Zwraca fragment DjangoQL dla ramki (lub '' gdy nic przekladalnego).
+
+    frame[0] to operator ramki (lub None); frame[1:] to liscie/podramki.
+    """
+    parts = []
+    for idx, element in enumerate(frame):
+        if idx == 0:
+            continue
+        if isinstance(element, dict):
+            _append_leaf(registry, element, parts, warnings)
+        elif isinstance(element, list):
+            _append_subframe(registry, element, parts, warnings)
+    return _join_parts(parts)
+
+
+def multiseek_form_to_djangoql(form_json, registry):
+    """Glowne API: dict z 'form_data' -> ConversionResult(query, warnings)."""
+    warnings = []
+    form_data = form_json.get("form_data") or [None]
+    query = _walk_frame(registry, form_data, warnings)
+    return ConversionResult(query=query, warnings=warnings)

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -1,0 +1,79 @@
+"""Konwersja formularza Multiseek -> zapytanie DjangoQL nad Rekord.
+
+Czysta funkcja `multiseek_form_to_djangoql(form_json, registry)` chodzi po
+ramkach `form_data` (jak multiseek.logic.get_query_recursive) i renderuje
+liscie jako fragmenty DjangoQL. Domyslny dispatcher tlumaczy typowe pola;
+pola trudne nadpisuja metode `to_djangoql(value, operation)`. Kazdy fragment
+jest walidowany przeciw BppQLSchema(Rekord) — niepoprawne -> warning.
+"""
+
+from decimal import Decimal
+
+from multiseek.logic import (
+    CONTAINS,
+    DIFFERENT_ALL,
+    EQUALITY_OPS_ALL,
+    GREATER_OPS_ALL,
+    GREATER_OR_EQUAL_OPS_ALL,
+    IN_RANGE,
+    LESSER_OPS_ALL,
+    LESSER_OR_EQUAL_OPS_ALL,
+    NOT_CONTAINS,
+    NOT_IN_RANGE,
+    NOT_STARTS_WITH,
+    STARTS_WITH,
+)
+
+
+def _build_scalar_op_map():
+    diff_strs = {str(o) for o in DIFFERENT_ALL}
+    m = {}
+    for o in EQUALITY_OPS_ALL:
+        key = str(o)
+        m[key] = "!=" if key in diff_strs else "="
+    for o in GREATER_OPS_ALL:
+        m[str(o)] = ">"
+    for o in GREATER_OR_EQUAL_OPS_ALL:
+        m[str(o)] = ">="
+    for o in LESSER_OPS_ALL:
+        m[str(o)] = "<"
+    for o in LESSER_OR_EQUAL_OPS_ALL:
+        m[str(o)] = "<="
+    m[str(CONTAINS)] = "~"
+    m[str(NOT_CONTAINS)] = "!~"
+    m[str(STARTS_WITH)] = "startswith"
+    m[str(NOT_STARTS_WITH)] = "not startswith"
+    return m
+
+
+_SCALAR_OP_MAP: dict | None = None
+_RANGE_OPS: frozenset | None = None
+
+
+def _get_scalar_op_map() -> dict:
+    global _SCALAR_OP_MAP
+    if _SCALAR_OP_MAP is None:
+        _SCALAR_OP_MAP = _build_scalar_op_map()
+    return _SCALAR_OP_MAP
+
+
+def _get_range_ops() -> frozenset:
+    global _RANGE_OPS
+    if _RANGE_OPS is None:
+        _RANGE_OPS = frozenset({str(IN_RANGE), str(NOT_IN_RANGE)})
+    return _RANGE_OPS
+
+
+def scalar_operator_to_djangoql(operator):
+    """DjangoQL-owy operator dla skalarnej operacji multiseek, lub None."""
+    return _get_scalar_op_map().get(str(operator))
+
+
+def render_value(value):
+    """Literal DjangoQL dla wartosci skalarnej."""
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, (int, Decimal, float)):
+        return str(value)
+    s = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{s}"'

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -9,7 +9,9 @@ jest walidowany przeciw BppQLSchema(Rekord) — niepoprawne -> warning.
 
 from decimal import Decimal
 
+from djangoql.parser import DjangoQLParser
 from multiseek.logic import (
+    AUTOCOMPLETE,
     CONTAINS,
     DIFFERENT_ALL,
     EQUALITY_OPS_ALL,
@@ -23,6 +25,9 @@ from multiseek.logic import (
     NOT_STARTS_WITH,
     STARTS_WITH,
 )
+
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Rekord
 
 
 def _build_scalar_op_map():
@@ -75,3 +80,85 @@ def render_value(value):
         return str(value)
     s = str(value).replace("\\", "\\\\").replace('"', '\\"')
     return f'"{s}"'
+
+
+def _orm_path_to_djangoql(field_name):
+    """field_name multiseek (ORM, '__') -> sciezka DjangoQL ('.')."""
+    return field_name.replace("__", ".")
+
+
+def is_valid_rekord_djangoql(fragment):
+    """Czy fragment parsuje sie i waliduje wzgledem BppQLSchema(Rekord)."""
+    try:
+        ast = DjangoQLParser().parse(fragment)
+        BppQLSchema(Rekord).validate(ast)
+    except Exception:  # noqa: BLE001 — best-effort validity gate
+        # Klasyfikuje fragment jako nieprzekladalny (zwraca False); nie tlumi
+        # bledu logiki — niepoprawne fragmenty sa poprawnie odrzucane.
+        return False
+    return True
+
+
+def _autocomplete_leaf(field, value, operation):
+    """value to pk; resolwujemy obiekt i emitujemy '<sciezka>__rel = "L [pk]"'."""
+    op = str(operation)
+    if op in {str(o) for o in DIFFERENT_ALL}:
+        rel_op = "!="
+    elif op in {str(o) for o in EQUALITY_OPS_ALL}:
+        rel_op = "="
+    else:
+        return None
+    try:
+        obj = field.value_from_web(value)
+    except Exception:  # noqa: BLE001 — nieistniejacy/uszkodzony pk -> warning
+        return None
+    if obj is None:
+        return None
+    rel_path = _orm_path_to_djangoql(field.field_name) + "__rel"
+    label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
+    return f'{rel_path} {rel_op} "{label} [{obj.pk}]"'
+
+
+def _range_leaf(name, value, operation):
+    """IN_RANGE/NOT_IN_RANGE: value to [low, high]."""
+    if not (isinstance(value, (list, tuple)) and len(value) == 2):
+        return None
+    if str(operation) == str(NOT_IN_RANGE):
+        return None  # brak unary not(...) w DjangoQL -> warning (Task 5/6)
+    low, high = value
+    path = _orm_path_to_djangoql(name)
+    return f"({path} >= {render_value(low)} and {path} <= {render_value(high)})"
+
+
+def _default_leaf(field, value, operation):
+    op = str(operation)
+    if getattr(field, "type", None) == AUTOCOMPLETE:
+        return _autocomplete_leaf(field, value, operation)
+    name = getattr(field, "field_name", None)
+    if not name:
+        return None
+    if op in range_operators():
+        return _range_leaf(name, value, operation)
+    dql_op = scalar_operator_to_djangoql(op)
+    if dql_op is None:
+        return None
+    return f"{_orm_path_to_djangoql(name)} {dql_op} {render_value(value)}"
+
+
+def leaf_to_djangoql(registry, leaf):
+    """Fragment DjangoQL dla pojedynczego warunku, albo None (nieprzekladalny).
+
+    None gdy: nieznane pole, nieobslugiwana operacja, albo fragment nie
+    waliduje sie wzgledem schematu Rekord.
+    """
+    field = registry.field_by_name.get(leaf["field"])
+    if field is None:
+        return None
+    override = getattr(field, "to_djangoql", None)
+    if callable(override):
+        frag = override(leaf["value"], leaf["operator"])
+    else:
+        frag = _default_leaf(field, leaf["value"], leaf["operator"])
+    if frag is None:
+        return None
+    return frag if is_valid_rekord_djangoql(frag) else None

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -245,13 +245,60 @@ def _join_parts(parts):
     return out
 
 
+_INVERT = {
+    "=": "!=",
+    "!=": "=",
+    "~": "!~",
+    "!~": "~",
+    ">": "<=",
+    ">=": "<",
+    "<": ">=",
+    "<=": ">",
+    "startswith": "not startswith",
+    "not startswith": "startswith",
+}
+
+
+def _invert_fragment(frag):
+    """Zaneguj fragment-liścia podmieniając operator (De Morgan na pojedynczym
+    porównaniu). Zwraca zanegowany fragment albo None, gdy się nie da.
+
+    Fragmenty złożone (zakres `(a >= x and a <= y)`, grupy) nie podlegają
+    prostej inwersji operatora -> None. Operator jest zakotwiczony tuż za LHS
+    (ścieżka pola nie zawiera spacji), więc znaki operatorowe wewnątrz wartości
+    (np. `~ "a = b"`) nie mylą parsera.
+    """
+    if frag.startswith("(") or " and " in frag or " or " in frag:
+        return None
+    try:
+        lhs, rest = frag.split(" ", 1)
+    except ValueError:
+        return None
+    for op in sorted(_INVERT, key=len, reverse=True):
+        prefix = op + " "
+        if rest.startswith(prefix):
+            return f"{lhs} {_INVERT[op]} {rest[len(prefix):]}"
+    return None
+
+
 def _append_leaf(registry, leaf, parts, warnings):
     prev_op = leaf.get("prev_op")
     if _is_andnot(prev_op):
-        # Task 6 podniesie to do inwersji operatora; teraz skip+warning.
-        warnings.append(
-            f"Pominięto zanegowany warunek: {_leaf_label(leaf)} (andnot)"
-        )
+        frag = leaf_to_djangoql(registry, leaf)
+        if frag is None:
+            warnings.append(
+                f"Pominięto zanegowany warunek: {_leaf_label(leaf)} "
+                "(nieprzekładalny)"
+            )
+            return
+        inverted = _invert_fragment(frag)
+        if inverted is None:
+            warnings.append(
+                f"Pominięto zanegowany warunek: {_leaf_label(leaf)} "
+                "(nie da się odwrócić operatora)"
+            )
+            return
+        parts.append(("and", inverted))
         return
     frag = leaf_to_djangoql(registry, leaf)
     if frag is None:

--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -268,7 +268,7 @@ def _invert_fragment(frag):
     (ścieżka pola nie zawiera spacji), więc znaki operatorowe wewnątrz wartości
     (np. `~ "a = b"`) nie mylą parsera.
     """
-    if frag.startswith("(") or " and " in frag or " or " in frag:
+    if frag.startswith("("):
         return None
     try:
         lhs, rest = frag.split(" ", 1)

--- a/src/bpp/multiseek_registry/fields/author_fields.py
+++ b/src/bpp/multiseek_registry/fields/author_fields.py
@@ -96,12 +96,22 @@ class NazwiskoIImieQueryObject(
 
         return ret
 
+    def _autor_rel_suffix(self, value):
+        """'"label [pk]"' dla wybranego autora, albo None."""
+        try:
+            obj = self.value_from_web(value)
+        except Exception:  # noqa: BLE001 — uszkodzony/nieistniejący pk -> nieprzekładalne
+            return None
+        if obj is None:
+            return None
+        label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{label} [{obj.pk}]"'
+
     def to_djangoql(self, value, operation):
         """Tłumaczenie na DjangoQL: autorzy.autor__rel (picker po autorze).
 
-        Tylko bazowe 'Nazwisko i imię'; podklasy (zakres kolejności, typ
-        ogólny) mają semantykę bez czystego odpowiednika DjangoQL -> None
-        (konwerter wyemituje ostrzeżenie).
+        Tylko bazowe 'Nazwisko i imię'; podklasy mają własne to_djangoql
+        (zakres kolejności, typ ogólny).
         """
         if type(self) is not NazwiskoIImieQueryObject:
             return None
@@ -114,20 +124,40 @@ class NazwiskoIImieQueryObject(
             rel_op = "="
         else:
             return None
-        try:
-            obj = self.value_from_web(value)
-        except Exception:  # noqa: BLE001 — uszkodzony/nieistniejący pk -> nieprzekładalne
+        suffix = self._autor_rel_suffix(value)
+        if suffix is None:
             return None
-        if obj is None:
-            return None
-        label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
-        return f'autorzy.autor__rel {rel_op} "{label} [{obj.pk}]"'
+        return f"autorzy.autor__rel {rel_op} {suffix}"
 
 
 class NazwiskoIImieWZakresieKolejnosci(NazwiskoIImieQueryObject):
     ops = [EQUAL, UNION_NONE]
     kolejnosc_gte = None
     kolejnosc_lt = None
+
+    def to_djangoql(self, value, operation):
+        """autorzy.autor__rel = X and autorzy.kolejnosc w [gte, lt) — same-row,
+        dokładne. Gdy granice są F-expression (Ostatnie nazwisko) → best-effort
+        bez filtra kolejności, z ostrzeżeniem.
+        """
+        op = str(operation)
+        equal = {str(o) for o in EQUALITY_OPS_ALL} - {str(o) for o in DIFFERENT_ALL}
+        if op not in equal and not _is_union_value(op):
+            return None
+        suffix = self._autor_rel_suffix(value)
+        if suffix is None:
+            return None
+        base = f"autorzy.autor__rel = {suffix}"
+        gte, lt = self.kolejnosc_gte, self.kolejnosc_lt
+        if not isinstance(gte, int) or not isinstance(lt, int):
+            return base, (
+                'Filtr „ostatni/zakres kolejności" pominięto — zależy od liczby '
+                "autorów (F-expression), nie do wyrażenia w DjangoQL."
+            )
+        frag = f"{base} and autorzy.kolejnosc >= {gte} and autorzy.kolejnosc < {lt}"
+        if _is_union_value(op):
+            return frag, 'Operator „wspólny" przełożono jak równość.'
+        return frag
 
     def real_query(self, value, operation):
         if operation in EQUALITY_OPS_ALL:

--- a/src/bpp/multiseek_registry/fields/author_fields.py
+++ b/src/bpp/multiseek_registry/fields/author_fields.py
@@ -258,6 +258,7 @@ class OswiadczenieKENQueryObject(BppMultiseekVisibilityMixin, BooleanQueryObject
         UNION,
     ]
     field_name = "oswiadczenie_ken"
+    djangoql_field_name = "autorzy__oswiadczenie_ken"
 
     def real_query(self, value, operation):
         if operation in EQUALITY_OPS_ALL:

--- a/src/bpp/multiseek_registry/fields/author_fields.py
+++ b/src/bpp/multiseek_registry/fields/author_fields.py
@@ -85,6 +85,33 @@ class NazwiskoIImieQueryObject(
 
         return ret
 
+    def to_djangoql(self, value, operation):
+        """Tłumaczenie na DjangoQL: autorzy.autor__rel (picker po autorze).
+
+        Tylko bazowe 'Nazwisko i imię'; podklasy (zakres kolejności, typ
+        ogólny) mają semantykę bez czystego odpowiednika DjangoQL -> None
+        (konwerter wyemituje ostrzeżenie).
+        """
+        if type(self) is not NazwiskoIImieQueryObject:
+            return None
+        op = str(operation)
+        diff_strs = {str(o) for o in DIFFERENT_ALL}
+        equal_strs = {str(o) for o in EQUALITY_OPS_ALL} - diff_strs
+        if op in diff_strs:
+            rel_op = "!="
+        elif op in equal_strs:
+            rel_op = "="
+        else:
+            return None
+        try:
+            obj = self.value_from_web(value)
+        except Exception:  # noqa: BLE001 — uszkodzony/nieistniejący pk -> nieprzekładalne
+            return None
+        if obj is None:
+            return None
+        label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
+        return f'autorzy.autor__rel {rel_op} "{label} [{obj.pk}]"'
+
 
 class NazwiskoIImieWZakresieKolejnosci(NazwiskoIImieQueryObject):
     ops = [EQUAL, UNION_NONE]

--- a/src/bpp/multiseek_registry/fields/author_fields.py
+++ b/src/bpp/multiseek_registry/fields/author_fields.py
@@ -62,6 +62,12 @@ class SlowaKluczoweQueryObject(BppMultiseekVisibilityMixin, AutocompleteQueryObj
 
         return ret
 
+    def to_djangoql(self, value, operation):
+        # Rekord -> taggit.tag (relacja slowa_kluczowe); match po nazwie tagu.
+        op = "!=" if str(operation) in {str(o) for o in DIFFERENT_ALL} else "="
+        label = str(value).replace("\\", "\\\\").replace('"', '\\"')
+        return f'slowa_kluczowe.name {op} "{label}"'
+
 
 class NazwiskoIImieQueryObject(
     BppMultiseekVisibilityMixin, ForeignKeyDescribeMixin, AutocompleteQueryObject

--- a/src/bpp/multiseek_registry/fields/author_fields.py
+++ b/src/bpp/multiseek_registry/fields/author_fields.py
@@ -24,6 +24,11 @@ from bpp.multiseek_registry.mixins import BppMultiseekVisibilityMixin
 from .constants import NULL_VALUE, UNION, UNION_NONE, UNION_OPS_ALL
 
 
+def _is_union_value(operation):
+    """True gdy operator multiseek to wariant UNION (równy+wspólny…)."""
+    return str(operation) in {str(o) for o in UNION_OPS_ALL}
+
+
 class ForeignKeyDescribeMixin:
     def value_for_description(self, value):
         if value is None:
@@ -206,6 +211,32 @@ class TypOgolnyAutorQueryObject(NazwiskoIImieQueryObject):
             return ~ret
 
         return ret
+
+    def to_djangoql(self, value, operation):
+        op = str(operation)
+        diff = {str(o) for o in DIFFERENT_ALL}
+        equal = {str(o) for o in EQUALITY_OPS_ALL} - diff
+        if op in diff:
+            return None  # negacja koniunkcji nie ma czystego not(...) w DjangoQL
+        if op not in equal and not _is_union_value(op):
+            return None
+        try:
+            obj = self.value_from_web(value)
+        except Exception:  # noqa: BLE001 — uszkodzony pk -> nieprzekładalne
+            return None
+        if obj is None:
+            return None
+        label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
+        frag = (
+            f'autorzy.autor__rel = "{label} [{obj.pk}]" '
+            f"and autorzy.typ_odpowiedzialnosci.typ_ogolny = {self.typ_ogolny}"
+        )
+        if _is_union_value(op):
+            return frag, (
+                'Operator „wspólny" przełożono jak równość — w DjangoQL może '
+                "objąć inny wiersz autora."
+            )
+        return frag
 
 
 class TypOgolnyRedaktorQueryObject(TypOgolnyAutorQueryObject):

--- a/src/bpp/multiseek_registry/fields/author_fields.py
+++ b/src/bpp/multiseek_registry/fields/author_fields.py
@@ -236,6 +236,7 @@ class DyscyplinaQueryObject(
     ]
     model = Dyscyplina_Naukowa
     field_name = "nazwa"
+    djangoql_field_name = "autorzy__dyscyplina_naukowa"
     url = "bpp:dyscyplina-autocomplete"
 
     def real_query(self, value, operation):

--- a/src/bpp/multiseek_registry/fields/boolean_fields.py
+++ b/src/bpp/multiseek_registry/fields/boolean_fields.py
@@ -171,6 +171,7 @@ class KierunekStudiowQueryObject(
     model = Kierunek_Studiow
     search_fields = ["nazwa"]
     field_name = "kierunek_studiow"
+    djangoql_field_name = "autorzy__kierunek_studiow"
     url = "bpp:kierunek-studiow-autocomplete"
 
     def real_query(self, value, operation):

--- a/src/bpp/multiseek_registry/fields/boolean_fields.py
+++ b/src/bpp/multiseek_registry/fields/boolean_fields.py
@@ -54,6 +54,7 @@ class ObcaJednostkaQueryObject(BppMultiseekVisibilityMixin, BooleanQueryObject):
 class AfiliujeQueryObject(BppMultiseekVisibilityMixin, BooleanQueryObject):
     label = "Afiliuje"
     field_name = "afiliuje"
+    djangoql_field_name = "autorzy__afiliuje"
     ops = [
         EQUAL,
     ]

--- a/src/bpp/multiseek_registry/fields/boolean_fields.py
+++ b/src/bpp/multiseek_registry/fields/boolean_fields.py
@@ -50,6 +50,10 @@ class ObcaJednostkaQueryObject(BppMultiseekVisibilityMixin, BooleanQueryObject):
 
         return ret
 
+    def to_djangoql(self, value, operation):
+        skupia = not bool(value)  # real_query robi value = not value
+        return f"autorzy.jednostka.skupia_pracownikow = {skupia}"
+
 
 class AfiliujeQueryObject(BppMultiseekVisibilityMixin, BooleanQueryObject):
     label = "Afiliuje"
@@ -92,6 +96,13 @@ class DyscyplinaUstawionaQueryObject(BppMultiseekVisibilityMixin, BooleanQueryOb
 
         return ret
 
+    def to_djangoql(self, value, operation):
+        return (
+            "autorzy.dyscyplina_naukowa != None"
+            if value
+            else "autorzy.dyscyplina_naukowa = None"
+        )
+
 
 class StronaWWWUstawionaQueryObject(BppMultiseekVisibilityMixin, BooleanQueryObject):
     label = "Strona WWW ustawiona"
@@ -114,6 +125,11 @@ class StronaWWWUstawionaQueryObject(BppMultiseekVisibilityMixin, BooleanQueryObj
             )
 
         return ret
+
+    def to_djangoql(self, value, operation):
+        if value:
+            return '(www != "" or public_www != "")'
+        return '(www = "" and public_www = "")'
 
 
 class LicencjaOpenAccessUstawionaQueryObject(
@@ -138,6 +154,9 @@ class LicencjaOpenAccessUstawionaQueryObject(
 
         return ret
 
+    def to_djangoql(self, value, operation):
+        return "openaccess_licencja != None" if value else "openaccess_licencja = None"
+
 
 class PublicDostepDniaQueryObject(BppMultiseekVisibilityMixin, BooleanQueryObject):
     label = "Dostęp dnia ustawiony"
@@ -157,6 +176,9 @@ class PublicDostepDniaQueryObject(BppMultiseekVisibilityMixin, BooleanQueryObjec
             return ~ret
 
         return ret
+
+    def to_djangoql(self, value, operation):
+        return "public_dostep_dnia != None" if value else "public_dostep_dnia = None"
 
 
 class KierunekStudiowQueryObject(

--- a/src/bpp/multiseek_registry/fields/factories.py
+++ b/src/bpp/multiseek_registry/fields/factories.py
@@ -112,6 +112,8 @@ def create_valuelist_query_object(
         "label": label,
         "field_name": field_name,
         "values": model.objects.all(),
+        # Konwersja Multiseek -> DjangoQL: value-list jako string po polu-nazwie.
+        "djangoql_value_field": name_field,
     }
     if ops:
         class_attrs["ops"] = ops

--- a/src/bpp/multiseek_registry/fields/numeric_fields.py
+++ b/src/bpp/multiseek_registry/fields/numeric_fields.py
@@ -30,6 +30,7 @@ class JezykQueryObject(BppMultiseekVisibilityMixin, QueryObject):
     ops = EQUALITY_OPS_MALE
     values = Jezyk.objects.filter(widoczny=True)
     field_name = "jezyk"
+    djangoql_value_field = "nazwa"
 
     def value_from_web(self, value):
         return Jezyk.objects.filter(nazwa=value).first()

--- a/src/bpp/multiseek_registry/fields/openaccess_fields.py
+++ b/src/bpp/multiseek_registry/fields/openaccess_fields.py
@@ -107,6 +107,7 @@ class ZewnetrznaBazaDanychQueryObject(
 ):
     label = "Zewnętrzna baza danych"
     field_name = "zewn_baza_danych"
+    djangoql_field_name = "zewnetrzne_bazy__baza"
     type = AUTOCOMPLETE
     ops = [
         EQUAL_FEMALE,

--- a/src/bpp/multiseek_registry/fields/publication_type_fields.py
+++ b/src/bpp/multiseek_registry/fields/publication_type_fields.py
@@ -80,6 +80,23 @@ class TypRekorduObject(BppMultiseekVisibilityMixin, ValueListQueryObject):
             return ~q
         return q
 
+    def to_djangoql(self, value, operation):
+        neg = str(operation) in {str(o) for o in DIFFERENT_ALL}
+        if value == "publikacje":
+            frag = "charakter_formalny.publikacja = True"
+        elif value == "streszczenia":
+            frag = "charakter_formalny.streszczenie = True"
+        elif value == "inne":
+            frag = (
+                "(charakter_formalny.publikacja = False "
+                "and charakter_formalny.streszczenie = False)"
+            )
+        else:
+            return None
+        if neg:
+            return None  # negacja zbioru -> brak czystego not(...) w DjangoQL
+        return frag
+
 
 class CharakterOgolnyQueryObject(BppMultiseekVisibilityMixin, ValueListQueryObject):
     label = "Charakter formalny ogólny"
@@ -116,6 +133,20 @@ class CharakterOgolnyQueryObject(BppMultiseekVisibilityMixin, ValueListQueryObje
         if operation == DIFFERENT:
             return ~q
         return q
+
+    _DJANGOQL_OGOLNY = {
+        "artykuł": const.CHARAKTER_OGOLNY_ARTYKUL,
+        "rozdział": const.CHARAKTER_OGOLNY_ROZDZIAL,
+        "książka": const.CHARAKTER_OGOLNY_KSIAZKA,
+        "inne": const.CHARAKTER_OGOLNY_INNE,
+    }
+
+    def to_djangoql(self, value, operation):
+        kod = self._DJANGOQL_OGOLNY.get(value)
+        if kod is None:
+            return None
+        op = "!=" if str(operation) in {str(o) for o in DIFFERENT_ALL} else "="
+        return f'charakter_formalny.charakter_ogolny {op} "{kod}"'
 
 
 class CharakterFormalnyQueryObject(
@@ -173,6 +204,22 @@ class CharakterFormalnyQueryObject(
             return ~ret
 
         return ret
+
+    def to_djangoql(self, value, operation):
+        """charakter_z_podrzednymi__rel (MPTT: sam + potomkowie) — dokładne."""
+        obj = self.value_from_web(value)
+        if obj is None:
+            return None
+        op = str(operation)
+        diff = {str(o) for o in DIFFERENT_ALL}
+        if op in diff:
+            rel_op = "!="
+        elif op in {str(o) for o in EQUALITY_OPS_ALL} - diff:
+            rel_op = "="
+        else:
+            return None
+        label = str(obj.nazwa).replace("\\", "\\\\").replace('"', '\\"')
+        return f'charakter_z_podrzednymi__rel {rel_op} "{label} [{obj.pk}]"'
 
 
 class RodzajKonferenckjiQueryObject(BppMultiseekVisibilityMixin, ValueListQueryObject):

--- a/src/bpp/multiseek_registry/fields/publication_type_fields.py
+++ b/src/bpp/multiseek_registry/fields/publication_type_fields.py
@@ -28,6 +28,8 @@ class Typ_OdpowiedzialnosciQueryObject(BppMultiseekVisibilityMixin, QueryObject)
     values = Typ_Odpowiedzialnosci.objects.all()
     ops = [EQUAL, DIFFERENT, UNION]
     field_name = "typ_odpowiedzialnosci"
+    djangoql_field_name = "autorzy__typ_odpowiedzialnosci"
+    djangoql_value_field = "nazwa"
     public = False
 
     def value_from_web(self, value):

--- a/src/bpp/multiseek_registry/fields/publication_type_fields.py
+++ b/src/bpp/multiseek_registry/fields/publication_type_fields.py
@@ -244,3 +244,16 @@ class RodzajKonferenckjiQueryObject(BppMultiseekVisibilityMixin, ValueListQueryO
         if operation == DIFFERENT:
             return ~q
         return q
+
+    _DJANGOQL_TK = {
+        "krajowa": Konferencja.TK_KRAJOWA,
+        "międzynarodowa": Konferencja.TK_MIEDZYNARODOWA,
+        "lokalna": Konferencja.TK_LOKALNA,
+    }
+
+    def to_djangoql(self, value, operation):
+        tk = self._DJANGOQL_TK.get(value)
+        if tk is None:
+            return None
+        op = "!=" if str(operation) in {str(o) for o in DIFFERENT_ALL} else "="
+        return f"konferencja.typ_konferencji {op} {tk}"

--- a/src/bpp/multiseek_registry/fields/unit_fields.py
+++ b/src/bpp/multiseek_registry/fields/unit_fields.py
@@ -69,6 +69,37 @@ class JednostkaQueryObject(
             return ~ret
         return ret
 
+    def to_djangoql(self, value, operation):
+        """Tlumaczenie na DjangoQL nad Rekord (patrz real_query po semantyke).
+
+        - rownosc -> autorzy.jednostka__rel (picker po jednostce autora)
+        - roznosc -> autorzy.jednostka__rel != ...
+        - '+ podrzedne' (EQUAL_PLUS_SUB_FEMALE) -> jednostka_z_podjednostkami__rel
+          (wirtualne pole MPTT get_family, identyczne z real_query)
+        - UNION / '+podrzedne+wspolna' -> None (warning): inny ksztalt zapytania,
+          bez gwarancji rownowaznosci bez osobnego pola wirtualnego.
+        """
+        if type(self) is not JednostkaQueryObject:
+            return None  # podklasy (np. AktualnaJednostka...) maja inna semantyke
+        op = str(operation)
+        try:
+            obj = self.value_from_web(value)
+        except Exception:  # noqa: BLE001 — uszkodzony/nieistniejacy pk -> nieprzekladalne
+            return None
+        if obj is None:
+            return None
+        label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
+        suffix = f'"{label} [{obj.pk}]"'
+
+        if op == str(EQUAL_FEMALE):
+            return f"autorzy.jednostka__rel = {suffix}"
+        if op == str(DIFFERENT_FEMALE):
+            return f"autorzy.jednostka__rel != {suffix}"
+        if op == str(EQUAL_PLUS_SUB_FEMALE):
+            return f"jednostka_z_podjednostkami__rel = {suffix}"
+        # UNION_FEMALE, EQUAL_PLUS_SUB_UNION_FEMALE -> nieprzekladalne 1:1
+        return None
+
 
 class AktualnaJednostkaAutoraQueryObject(JednostkaQueryObject):
     label = "Aktualna jednostka dowolnego autora"

--- a/src/bpp/multiseek_registry/fields/unit_fields.py
+++ b/src/bpp/multiseek_registry/fields/unit_fields.py
@@ -186,6 +186,7 @@ class WydzialQueryObject(
     model = Wydzial
     search_fields = ["nazwa"]
     field_name = "wydzial"
+    djangoql_field_name = "autorzy__jednostka__wydzial"
     url = "bpp:public-wydzial-autocomplete"
 
     def real_query(self, value, operation):

--- a/src/bpp/multiseek_registry/fields/unit_fields.py
+++ b/src/bpp/multiseek_registry/fields/unit_fields.py
@@ -249,3 +249,18 @@ class RodzajJednostkiQueryObject(BppMultiseekVisibilityMixin, ValueListQueryObje
         if operation == DIFFERENT:
             return ~q
         return q
+
+    def to_djangoql(self, value, operation):
+        mapa = {
+            Jednostka.RODZAJ_JEDNOSTKI.NORMALNA.label: (
+                Jednostka.RODZAJ_JEDNOSTKI.NORMALNA.value
+            ),
+            Jednostka.RODZAJ_JEDNOSTKI.KOLO_NAUKOWE.label: (
+                Jednostka.RODZAJ_JEDNOSTKI.KOLO_NAUKOWE.value
+            ),
+        }
+        kod = mapa.get(value)
+        if kod is None:
+            return None
+        op = "!=" if str(operation) == str(DIFFERENT) else "="
+        return f'autorzy.jednostka.rodzaj_jednostki {op} "{kod}"'

--- a/src/bpp/multiseek_registry/fields/unit_fields.py
+++ b/src/bpp/multiseek_registry/fields/unit_fields.py
@@ -91,13 +91,20 @@ class JednostkaQueryObject(
         label = str(obj).replace("\\", "\\\\").replace('"', '\\"')
         suffix = f'"{label} [{obj.pk}]"'
 
+        union_warning = (
+            'Operator „wspólna" przełożono jak równość — w DjangoQL może objąć '
+            "innego autora niż pozostałe kryteria."
+        )
         if op == str(EQUAL_FEMALE):
             return f"autorzy.jednostka__rel = {suffix}"
         if op == str(DIFFERENT_FEMALE):
             return f"autorzy.jednostka__rel != {suffix}"
         if op == str(EQUAL_PLUS_SUB_FEMALE):
             return f"jednostka_z_podjednostkami__rel = {suffix}"
-        # UNION_FEMALE, EQUAL_PLUS_SUB_UNION_FEMALE -> nieprzekladalne 1:1
+        if op == str(UNION_FEMALE):
+            return f"autorzy.jednostka__rel = {suffix}", union_warning
+        if op == str(EQUAL_PLUS_SUB_UNION_FEMALE):
+            return f"jednostka_z_podjednostkami__rel = {suffix}", union_warning
         return None
 
 

--- a/src/bpp/static/bpp/js/djangoql-pretty.js
+++ b/src/bpp/static/bpp/js/djangoql-pretty.js
@@ -1,0 +1,102 @@
+/* Formatowanie + podświetlanie składni zapytania DjangoQL.
+ *
+ * Reużywa lexera DjangoQL (z zainicjowanej instancji: dql.lexer). Lexer JS
+ * nie obsługuje newline'ów w regule whitespace, więc lexujemy zapytanie
+ * JEDNOLINIOWE, a łamanie linii nakładamy na etapie renderu (po granicach
+ * tokenów). HTML jest escapowany.
+ */
+(function () {
+  "use strict";
+
+  var TOKEN_CLASS = {
+    AND: "dql-keyword", OR: "dql-keyword", NOT: "dql-keyword", IN: "dql-keyword",
+    STARTSWITH: "dql-keyword", ENDSWITH: "dql-keyword",
+    TRUE: "dql-bool", FALSE: "dql-bool", NONE: "dql-none",
+    NAME: "dql-name", DOT: "dql-dot",
+    STRING_VALUE: "dql-str", INT_VALUE: "dql-num", FLOAT_VALUE: "dql-num",
+    PAREN_L: "dql-paren", PAREN_R: "dql-paren",
+    EQUALS: "dql-op", NOT_EQUALS: "dql-op", GREATER: "dql-op",
+    GREATER_EQUAL: "dql-op", LESS: "dql-op", LESS_EQUAL: "dql-op",
+    CONTAINS: "dql-op", NOT_CONTAINS: "dql-op", COMMA: "dql-op",
+  };
+
+  function esc(s) {
+    return String(s)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function tokenText(tok) {
+    if (tok.name === "STRING_VALUE") return '"' + tok.value + '"';
+    return tok.value;
+  }
+
+  function span(cls, text) {
+    return '<span class="' + cls + '">' + esc(text) + "</span>";
+  }
+
+  function nl(depth) {
+    return "\n" + "  ".repeat(depth);
+  }
+
+  // Łączy tokeny w sformatowany, podświetlony HTML. Zwraca jeden string.
+  // Zasady łamania: '(' otwiera wcięcie i nową linię; ')' zamyka;
+  // 'and'/'or' zaczynają nową linię na bieżącym wcięciu.
+  function render(tokens) {
+    var parts = [];
+    var depth = 0;
+    var atLineStart = true;
+
+    function emit(html, glue) {
+      if (!glue && !atLineStart) {
+        parts.push(" ");
+      }
+      parts.push(html);
+      atLineStart = false;
+    }
+
+    for (var i = 0; i < tokens.length; i++) {
+      var t = tokens[i];
+      var prev = tokens[i - 1];
+      var cls = TOKEN_CLASS[t.name] || "dql-name";
+
+      if (t.name === "PAREN_L") {
+        emit(span("dql-paren", "("), false);
+        depth += 1;
+        parts.push(nl(depth));
+        atLineStart = true;
+        continue;
+      }
+      if (t.name === "PAREN_R") {
+        depth = depth > 0 ? depth - 1 : 0;
+        parts.push(nl(depth));
+        atLineStart = true;
+        emit(span("dql-paren", ")"), true);
+        continue;
+      }
+      if (t.name === "AND" || t.name === "OR") {
+        parts.push(nl(depth));
+        atLineStart = true;
+        emit(span(cls, t.value), true);
+        continue;
+      }
+      // Kropka klei się do sąsiadów (ścieżka pola), bez spacji.
+      var glue = t.name === "DOT" || (prev && prev.name === "DOT");
+      emit(span(cls, tokenText(t)), glue);
+    }
+    return parts.join("");
+  }
+
+  function formatAndHighlight(query, lexer) {
+    if (!query) return "";
+    var tokens;
+    try {
+      tokens = lexer.setInput(query).lexAll();
+    } catch (e) {
+      return span("dql-name", query);
+    }
+    return render(tokens);
+  }
+
+  window.djangoqlPretty = { formatAndHighlight: formatAndHighlight };
+})();

--- a/src/bpp/templatetags/query_editor.py
+++ b/src/bpp/templatetags/query_editor.py
@@ -1,0 +1,13 @@
+from django import template
+
+from bpp.views.zapytanie import user_can_use_query_editor
+
+register = template.Library()
+
+
+@register.filter(name="can_use_query_editor")
+def can_use_query_editor(user):
+    """True, gdy user moze korzystac z edytora zapytan DjangoQL."""
+    if user is None:
+        return False
+    return user_can_use_query_editor(user)

--- a/src/bpp/tests/test_charakter_podrzedne_field.py
+++ b/src/bpp/tests/test_charakter_podrzedne_field.py
@@ -1,0 +1,35 @@
+import pytest
+from djangoql.queryset import apply_search
+from model_bakery import baker
+
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Charakter_Formalny, Rekord
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_charakter_z_podrzednymi_field_present_on_rekord():
+    s = BppQLSchema(Rekord)
+    fields = s.get_fields(Rekord)
+    assert "charakter_z_podrzednymi__rel" in fields
+
+
+@pytest.mark.django_db
+def test_charakter_z_podrzednymi_matches_descendants(wydawnictwo_ciagle, denorms):
+    parent = baker.make(Charakter_Formalny, nazwa="Artykuły", skrot="ART")
+    child = baker.make(
+        Charakter_Formalny, nazwa="Artykuł oryginalny", skrot="AO", parent=parent
+    )
+    Charakter_Formalny.objects.rebuild()
+    wydawnictwo_ciagle.charakter_formalny = child
+    wydawnictwo_ciagle.save()
+    denorms.flush()
+
+    frag = f'charakter_z_podrzednymi__rel = "Artykuły [{parent.pk}]"'
+    pks = set(
+        apply_search(Rekord.objects.all(), frag, schema=BppQLSchema)
+        .distinct()
+        .values_list("pk", flat=True)
+    )
+    assert Rekord.objects.get_for_model(wydawnictwo_ciagle).pk in pks

--- a/src/bpp/tests/test_jednostka_podjednostki_field.py
+++ b/src/bpp/tests/test_jednostka_podjednostki_field.py
@@ -1,0 +1,47 @@
+"""Testy wirtualnego pola DjangoQL ``jednostka_z_podjednostkami__rel``.
+
+Pole dopasowuje rekordy publikacji, których autor jest przypisany do
+wybranej jednostki LUB dowolnej jednostki z jej rodziny MPTT (przodkowie +
+sama + potomkowie). Odwzorowuje multiseek ``EQUAL_PLUS_SUB_FEMALE``:
+``Q(autorzy__jednostka__in=value.get_family())``.
+"""
+
+import pytest
+from djangoql.queryset import apply_search
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_jednostka_z_podjednostkami_in_schema():
+    from bpp.djangoql_schema import BppQLSchema
+    from bpp.models import Rekord
+
+    schema = BppQLSchema(Rekord)
+    fields = schema.models[BppQLSchema.model_label(Rekord)]
+    assert "jednostka_z_podjednostkami__rel" in fields
+
+
+@pytest.mark.django_db
+def test_jednostka_z_podjednostkami_matches_subunit_author(
+    wydawnictwo_ciagle,
+    autor_jan_kowalski,
+    jednostka,
+    jednostka_podrzedna,
+):
+    from denorm import denorms
+
+    from bpp.djangoql_schema import BppQLSchema
+    from bpp.models import Rekord
+
+    # Autor przypisany do JEDNOSTKI PODRZĘDNEJ (dziecko ``jednostka``).
+    wydawnictwo_ciagle.dodaj_autora(autor_jan_kowalski, jednostka_podrzedna)
+    denorms.flush()
+
+    # Zapytanie po JEDNOSTCE NADRZĘDNEJ powinno znaleźć publikację autora
+    # z podjednostki dzięki rozwinięciu rodziny MPTT.
+    query = f'jednostka_z_podjednostkami__rel = "Parent [{jednostka.pk}]"'
+    found = apply_search(Rekord.objects.all(), query, schema=BppQLSchema).distinct()
+
+    assert found.count() == 1
+    assert found.first().tytul_oryginalny == wydawnictwo_ciagle.tytul_oryginalny

--- a/src/bpp/tests/test_jednostka_podjednostki_field.py
+++ b/src/bpp/tests/test_jednostka_podjednostki_field.py
@@ -12,7 +12,6 @@ from djangoql.queryset import apply_search
 pytestmark = pytest.mark.serial
 
 
-@pytest.mark.django_db
 def test_jednostka_z_podjednostkami_in_schema():
     from bpp.djangoql_schema import BppQLSchema
     from bpp.models import Rekord
@@ -40,8 +39,44 @@ def test_jednostka_z_podjednostkami_matches_subunit_author(
 
     # Zapytanie po JEDNOSTCE NADRZĘDNEJ powinno znaleźć publikację autora
     # z podjednostki dzięki rozwinięciu rodziny MPTT.
-    query = f'jednostka_z_podjednostkami__rel = "Parent [{jednostka.pk}]"'
+    query = f'jednostka_z_podjednostkami__rel = "{jednostka.nazwa} [{jednostka.pk}]"'
     found = apply_search(Rekord.objects.all(), query, schema=BppQLSchema).distinct()
 
     assert found.count() == 1
     assert found.first().tytul_oryginalny == wydawnictwo_ciagle.tytul_oryginalny
+
+
+@pytest.mark.django_db
+def test_jednostka_z_podjednostkami_free_text_negation(
+    wydawnictwo_ciagle,
+    autor_jan_kowalski,
+    jednostka,
+):
+    """Operator != w fallbacku free-text (bez [pk]) wyklucza pasujące rekordy.
+
+    Weryfikuje Fix 1: ``~q`` zamiast ``q`` gdy operator == "!="
+    dla ścieżki bez identyfikatora numerycznego.
+    """
+    from denorm import denorms
+
+    from bpp.djangoql_schema import BppQLSchema
+    from bpp.models import Rekord
+
+    # Autor przypisany bezpośrednio do ``jednostka`` (nazwa: "Jednostka Uczelni").
+    wydawnictwo_ciagle.dodaj_autora(autor_jan_kowalski, jednostka)
+    denorms.flush()
+
+    # Zapytanie pozytywne — powinno znaleźć tę publikację.
+    pos_query = (
+        f'jednostka_z_podjednostkami__rel = "{jednostka.nazwa}"'
+    )
+    pos = apply_search(Rekord.objects.all(), pos_query, schema=BppQLSchema).distinct()
+    assert pos.count() == 1
+
+    # Zapytanie negacyjne — ta sama wartość free-text, ale !=.
+    # Bez Fix 1 zwróciłoby 1 (ignorując operator), powinno zwrócić 0.
+    neg_query = (
+        f'jednostka_z_podjednostkami__rel != "{jednostka.nazwa}"'
+    )
+    neg = apply_search(Rekord.objects.all(), neg_query, schema=BppQLSchema).distinct()
+    assert neg.count() == 0

--- a/src/bpp/tests/test_multiseek_autor_to_djangoql.py
+++ b/src/bpp/tests/test_multiseek_autor_to_djangoql.py
@@ -1,0 +1,52 @@
+import pytest
+from djangoql.queryset import apply_search
+from model_bakery import baker
+from multiseek.logic import DIFFERENT, EQUAL
+
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Autor, Rekord
+from bpp.multiseek_registry import registry
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_autor_equal_maps_to_autorzy_autor_rel():
+    a = baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
+    field = registry.field_by_name["Nazwisko i imię"]
+    frag = field.to_djangoql(a.pk, str(EQUAL))
+    assert frag == f'autorzy.autor__rel = "{a} [{a.pk}]"'
+
+
+@pytest.mark.django_db
+def test_autor_different_maps_to_not_equal():
+    a = baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
+    field = registry.field_by_name["Nazwisko i imię"]
+    frag = field.to_djangoql(a.pk, str(DIFFERENT))
+    assert frag == f'autorzy.autor__rel != "{a} [{a.pk}]"'
+
+
+@pytest.mark.django_db
+def test_pierwsze_nazwisko_is_untranslatable():
+    a = baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
+    field = registry.field_by_name["Pierwsze nazwisko i imię"]
+    assert field.to_djangoql(a.pk, str(EQUAL)) is None
+
+
+@pytest.mark.django_db
+def test_roundtrip_autor_equal_same_rekordy(
+    autor_jan_kowalski, jednostka, wydawnictwo_ciagle, denorms
+):
+    wydawnictwo_ciagle.dodaj_autora(autor_jan_kowalski, jednostka)
+    denorms.flush()
+    field = registry.field_by_name["Nazwisko i imię"]
+    q = field.real_query(autor_jan_kowalski, EQUAL)
+    via_multiseek = set(Rekord.objects.filter(q).values_list("pk", flat=True))
+    frag = field.to_djangoql(autor_jan_kowalski.pk, EQUAL)
+    via_djangoql = set(
+        apply_search(Rekord.objects.all(), frag, schema=BppQLSchema)
+        .distinct()
+        .values_list("pk", flat=True)
+    )
+    assert via_multiseek
+    assert via_multiseek == via_djangoql

--- a/src/bpp/tests/test_multiseek_autor_to_djangoql.py
+++ b/src/bpp/tests/test_multiseek_autor_to_djangoql.py
@@ -50,3 +50,22 @@ def test_roundtrip_autor_equal_same_rekordy(
     )
     assert via_multiseek
     assert via_multiseek == via_djangoql
+
+
+@pytest.mark.django_db
+def test_typ_ogolny_autor_compound():
+    a = baker.make(Autor, nazwisko="Nowak", imiona="Jan")
+    field = registry.field_by_name["Autor"]
+    frag = field.to_djangoql(a.pk, str(EQUAL))
+    assert frag == (
+        f'autorzy.autor__rel = "{a} [{a.pk}]" '
+        "and autorzy.typ_odpowiedzialnosci.typ_ogolny = 0"
+    )
+
+
+@pytest.mark.django_db
+def test_typ_ogolny_redaktor_compound():
+    a = baker.make(Autor, nazwisko="Nowak", imiona="Jan")
+    field = registry.field_by_name["Redaktor"]
+    frag = field.to_djangoql(a.pk, str(EQUAL))
+    assert frag.endswith("and autorzy.typ_odpowiedzialnosci.typ_ogolny = 1")

--- a/src/bpp/tests/test_multiseek_autor_to_djangoql.py
+++ b/src/bpp/tests/test_multiseek_autor_to_djangoql.py
@@ -27,10 +27,14 @@ def test_autor_different_maps_to_not_equal():
 
 
 @pytest.mark.django_db
-def test_pierwsze_nazwisko_is_untranslatable():
+def test_pierwsze_nazwisko_translates_with_kolejnosc():
     a = baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
     field = registry.field_by_name["Pierwsze nazwisko i imię"]
-    assert field.to_djangoql(a.pk, str(EQUAL)) is None
+    frag = field.to_djangoql(a.pk, str(EQUAL))
+    assert frag == (
+        f'autorzy.autor__rel = "{a} [{a.pk}]" '
+        "and autorzy.kolejnosc >= 0 and autorzy.kolejnosc < 1"
+    )
 
 
 @pytest.mark.django_db

--- a/src/bpp/tests/test_multiseek_charakter_to_djangoql.py
+++ b/src/bpp/tests/test_multiseek_charakter_to_djangoql.py
@@ -1,0 +1,67 @@
+import pytest
+from model_bakery import baker
+from multiseek.logic import DIFFERENT, EQUAL
+
+from bpp.models import Charakter_Formalny
+from bpp.multiseek_registry import registry
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_charakter_formalny_maps_to_virtual_field():
+    ch = baker.make(Charakter_Formalny, nazwa="Charakter Testowy QL", skrot="QLT")
+    Charakter_Formalny.objects.rebuild()
+    field = registry.field_by_name["Charakter formalny"]
+    frag = field.to_djangoql("Charakter Testowy QL", str(EQUAL))
+    assert frag == f'charakter_z_podrzednymi__rel = "Charakter Testowy QL [{ch.pk}]"'
+
+
+@pytest.mark.django_db
+def test_charakter_formalny_strips_indent_prefix():
+    ch = baker.make(Charakter_Formalny, nazwa="Charakter Testowy QL", skrot="QLT")
+    Charakter_Formalny.objects.rebuild()
+    field = registry.field_by_name["Charakter formalny"]
+    frag = field.to_djangoql("--- Charakter Testowy QL", str(EQUAL))
+    assert frag == f'charakter_z_podrzednymi__rel = "Charakter Testowy QL [{ch.pk}]"'
+
+
+@pytest.mark.django_db
+def test_charakter_formalny_different():
+    ch = baker.make(Charakter_Formalny, nazwa="Charakter Testowy QL", skrot="QLT")
+    Charakter_Formalny.objects.rebuild()
+    field = registry.field_by_name["Charakter formalny"]
+    frag = field.to_djangoql("Charakter Testowy QL", str(DIFFERENT))
+    assert frag == f'charakter_z_podrzednymi__rel != "Charakter Testowy QL [{ch.pk}]"'
+
+
+def test_charakter_ogolny_artykul():
+    field = registry.field_by_name["Charakter formalny ogólny"]
+    assert (
+        field.to_djangoql("artykuł", str(EQUAL))
+        == 'charakter_formalny.charakter_ogolny = "art"'
+    )
+
+
+def test_charakter_ogolny_ksiazka():
+    field = registry.field_by_name["Charakter formalny ogólny"]
+    assert (
+        field.to_djangoql("książka", str(EQUAL))
+        == 'charakter_formalny.charakter_ogolny = "ksi"'
+    )
+
+
+def test_typ_rekordu_publikacje():
+    field = registry.field_by_name["Typ rekordu"]
+    assert (
+        field.to_djangoql("publikacje", str(EQUAL))
+        == "charakter_formalny.publikacja = True"
+    )
+
+
+def test_typ_rekordu_inne():
+    field = registry.field_by_name["Typ rekordu"]
+    assert field.to_djangoql("inne", str(EQUAL)) == (
+        "(charakter_formalny.publikacja = False "
+        "and charakter_formalny.streszczenie = False)"
+    )

--- a/src/bpp/tests/test_multiseek_djangoql_button.py
+++ b/src/bpp/tests/test_multiseek_djangoql_button.py
@@ -1,0 +1,26 @@
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+
+
+@pytest.mark.django_db
+def test_button_visible_for_superuser(client):
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=True)
+    client.force_login(u)
+    resp = client.get(reverse("multiseek:index"))
+    assert resp.status_code == 200
+    # The button element itself (its id is unique to the gated block; the
+    # data-action string also appears in the always-present JS handler, so we
+    # assert on the button id which only renders for query-editor users).
+    assert b'id="toDjangoqlButton"' in resp.content
+    assert b'id="djangoqlDrawer"' in resp.content
+
+
+@pytest.mark.django_db
+def test_button_hidden_for_plain_user(client):
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=False)
+    client.force_login(u)
+    resp = client.get(reverse("multiseek:index"))
+    assert resp.status_code == 200
+    assert b'id="toDjangoqlButton"' not in resp.content
+    assert b'id="djangoqlDrawer"' not in resp.content

--- a/src/bpp/tests/test_multiseek_djangoql_coverage.py
+++ b/src/bpp/tests/test_multiseek_djangoql_coverage.py
@@ -1,0 +1,18 @@
+from multiseek.logic import AUTOCOMPLETE
+
+from bpp.multiseek_registry import registry
+
+
+def test_every_registry_field_has_translation_path():
+    """Każde pole rejestru ma drogę przekładu: metodę to_djangoql LUB
+    deklaratywne atrybuty (djangoql_value_field / autocomplete) LUB jest
+    bezpośrednim polem skalarnym. Strażnik celu „nic nieprzekładalnego"."""
+    missing = []
+    for label, field in registry.field_by_name.items():
+        has_method = callable(getattr(field, "to_djangoql", None))
+        has_value_list = bool(getattr(field, "djangoql_value_field", None))
+        is_autocomplete = getattr(field, "type", None) == AUTOCOMPLETE
+        has_field_name = bool(getattr(field, "field_name", None))
+        if not (has_method or has_value_list or is_autocomplete or has_field_name):
+            missing.append(label)
+    assert missing == [], f"Pola bez drogi przekładu: {missing}"

--- a/src/bpp/tests/test_multiseek_djangoql_endpoint.py
+++ b/src/bpp/tests/test_multiseek_djangoql_endpoint.py
@@ -92,3 +92,14 @@ def test_endpoint_surfaces_warnings(client, uprawniony):
     data = resp.json()
     assert data["query"] == ""
     assert data["warnings"]  # co najmniej jedno ostrzeżenie
+
+
+@pytest.mark.django_db
+def test_template_filter_can_use_query_editor():
+    from django.template import Context, Template
+
+    su = baker.make("bpp.BppUser", is_superuser=True)
+    plain = baker.make("bpp.BppUser", is_superuser=False, is_staff=False)
+    tpl = Template("{% load query_editor %}{{ user|can_use_query_editor }}")
+    assert tpl.render(Context({"user": su})) == "True"
+    assert tpl.render(Context({"user": plain})) == "False"

--- a/src/bpp/tests/test_multiseek_djangoql_endpoint.py
+++ b/src/bpp/tests/test_multiseek_djangoql_endpoint.py
@@ -1,10 +1,13 @@
 import json
 
 import pytest
+from django.conf import settings
 from django.urls import reverse
 from django.utils import translation
 from model_bakery import baker
 from multiseek.logic import CONTAINS
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
 
 
 @pytest.fixture
@@ -29,7 +32,7 @@ def test_endpoint_happy_path(client, uprawniony):
     # str(CONTAINS) w payloadzie musi byc rozwiniete pod tym samym jezykiem
     # co mapa operatorow budowana po stronie endpointu — inaczej operator
     # bylby nieprzekladalny.
-    with translation.override("pl"):
+    with translation.override(settings.LANGUAGE_CODE):
         operator = str(CONTAINS)
     form = {
         "form_data": [
@@ -56,3 +59,36 @@ def test_endpoint_bad_json(client, uprawniony):
         reverse("multiseek-do-djangoql"), {"json": "to nie jest json"}
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_endpoint_staff_in_group_allowed(client):
+    from django.contrib.auth.models import Group
+
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=True)
+    grp, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    u.groups.add(grp)
+    client.force_login(u)
+    resp = client.post(reverse("multiseek-do-djangoql"), {"json": "{}"})
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_endpoint_surfaces_warnings(client, uprawniony):
+    with translation.override(settings.LANGUAGE_CODE):
+        operator = str(CONTAINS)
+    form = {
+        "form_data": [
+            None,
+            {"field": "Nie ma pola", "operator": operator,
+             "value": "x", "prev_op": None},
+        ],
+        "ordering": {},
+    }
+    resp = client.post(
+        reverse("multiseek-do-djangoql"), {"json": json.dumps(form)}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["query"] == ""
+    assert data["warnings"]  # co najmniej jedno ostrzeżenie

--- a/src/bpp/tests/test_multiseek_djangoql_endpoint.py
+++ b/src/bpp/tests/test_multiseek_djangoql_endpoint.py
@@ -1,0 +1,58 @@
+import json
+
+import pytest
+from django.urls import reverse
+from django.utils import translation
+from model_bakery import baker
+from multiseek.logic import CONTAINS
+
+
+@pytest.fixture
+def uprawniony(client):
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=True)
+    client.force_login(u)
+    return u
+
+
+@pytest.mark.django_db
+def test_endpoint_requires_permission(client):
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=False)
+    client.force_login(u)
+    resp = client.post(reverse("multiseek-do-djangoql"), {"json": "{}"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_endpoint_happy_path(client, uprawniony):
+    # Frontend serializuje operatory pod aktywnym (polskim) jezykiem strony,
+    # a request przechodzi przez LocaleMiddleware (LANGUAGE_CODE="pl"), wiec
+    # str(CONTAINS) w payloadzie musi byc rozwiniete pod tym samym jezykiem
+    # co mapa operatorow budowana po stronie endpointu — inaczej operator
+    # bylby nieprzekladalny.
+    with translation.override("pl"):
+        operator = str(CONTAINS)
+    form = {
+        "form_data": [
+            None,
+            {"field": "Tytuł pracy", "operator": operator,
+             "value": "covid", "prev_op": None},
+        ],
+        "ordering": {},
+        "report_type": "0",
+    }
+    resp = client.post(
+        reverse("multiseek-do-djangoql"), {"json": json.dumps(form)}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["query"] == 'tytul_oryginalny ~ "covid"'
+    assert data["warnings"] == []
+    assert "model=rekord" in data["editor_url"]
+
+
+@pytest.mark.django_db
+def test_endpoint_bad_json(client, uprawniony):
+    resp = client.post(
+        reverse("multiseek-do-djangoql"), {"json": "to nie jest json"}
+    )
+    assert resp.status_code == 400

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -1,0 +1,32 @@
+from multiseek.logic import (
+    CONTAINS,
+    DIFFERENT,
+    EQUAL,
+    GREATER_OR_EQUAL,
+    NOT_STARTS_WITH,
+)
+
+from bpp.multiseek_registry.djangoql_export import (
+    render_value,
+    scalar_operator_to_djangoql,
+)
+
+
+def test_render_value_str_quotes_and_escapes():
+    assert render_value('on rzekł "tak"') == r'"on rzekł \"tak\""'
+
+
+def test_render_value_int():
+    assert render_value(2024) == "2024"
+
+
+def test_scalar_operator_mapping():
+    assert scalar_operator_to_djangoql(str(EQUAL)) == "="
+    assert scalar_operator_to_djangoql(str(DIFFERENT)) == "!="
+    assert scalar_operator_to_djangoql(str(CONTAINS)) == "~"
+    assert scalar_operator_to_djangoql(str(GREATER_OR_EQUAL)) == ">="
+    assert scalar_operator_to_djangoql(str(NOT_STARTS_WITH)) == "not startswith"
+
+
+def test_scalar_operator_unknown_returns_none():
+    assert scalar_operator_to_djangoql("zupełnie nieznany") is None

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -6,6 +6,7 @@ from multiseek.logic import (
     EQUAL,
     GREATER_OR_EQUAL,
     NOT_STARTS_WITH,
+    OR,
 )
 
 from bpp.multiseek_registry import registry
@@ -155,3 +156,97 @@ def test_empty_form():
     )
     assert res.query == ""
     assert res.warnings == []
+
+
+@pytest.mark.django_db
+def test_two_conditions_or():
+    form = {
+        "form_data": [
+            None,
+            {"field": "Rok", "operator": str(EQUAL), "value": 2020, "prev_op": None},
+            {
+                "field": "Rok",
+                "operator": str(EQUAL),
+                "value": 2021,
+                "prev_op": str(OR),
+            },
+        ],
+        "ordering": {},
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == "rok = 2020 or rok = 2021"
+    assert res.warnings == []
+
+
+@pytest.mark.django_db
+def test_mixed_or_then_and_is_grouped_left_to_right():
+    # Multiseek liczy (A or B) and C; bez nawiasów DjangoQL dałby A or (B and C).
+    form = {
+        "form_data": [
+            None,
+            {"field": "Rok", "operator": str(EQUAL), "value": 2020, "prev_op": None},
+            {
+                "field": "Rok",
+                "operator": str(EQUAL),
+                "value": 2021,
+                "prev_op": str(OR),
+            },
+            {
+                "field": "Rok",
+                "operator": str(GREATER_OR_EQUAL),
+                "value": 2010,
+                "prev_op": str(AND),
+            },
+        ],
+        "ordering": {},
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == "(rok = 2020 or rok = 2021) and rok >= 2010"
+    assert res.warnings == []
+
+
+@pytest.mark.django_db
+def test_pure_and_chain_has_no_parens():
+    form = {
+        "form_data": [
+            None,
+            {"field": "Rok", "operator": str(EQUAL), "value": 2020, "prev_op": None},
+            {
+                "field": "Rok",
+                "operator": str(GREATER_OR_EQUAL),
+                "value": 2010,
+                "prev_op": str(AND),
+            },
+        ],
+        "ordering": {},
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == "rok = 2020 and rok >= 2010"
+
+
+@pytest.mark.django_db
+def test_nested_subframe_gets_parens():
+    form = {
+        "form_data": [
+            None,
+            {"field": "Rok", "operator": str(EQUAL), "value": 2020, "prev_op": None},
+            [
+                str(AND),
+                {
+                    "field": "Rok",
+                    "operator": str(EQUAL),
+                    "value": 2021,
+                    "prev_op": None,
+                },
+                {
+                    "field": "Rok",
+                    "operator": str(EQUAL),
+                    "value": 2022,
+                    "prev_op": str(OR),
+                },
+            ],
+        ],
+        "ordering": {},
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == "rok = 2020 and (rok = 2021 or rok = 2022)"

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -328,3 +328,20 @@ def test_andnot_value_with_and_in_string_inverts_correctly():
     res = multiseek_form_to_djangoql(form, registry)
     assert res.query == 'rok = 2023 and tytul_oryginalny !~ "arms and legs"'
     assert res.warnings == []
+
+
+@pytest.mark.django_db
+def test_malformed_leaf_missing_keys_is_skipped():
+    # Liść bez 'operator'/'value' nie może wywalić konwersji — best-effort.
+    form = {
+        "form_data": [
+            None,
+            {"field": "Rok", "operator": str(EQUAL), "value": 2020,
+             "prev_op": None},
+            {"field": "Rok"},  # malformed: brak operator/value
+        ],
+        "ordering": {},
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == "rok = 2020"
+    assert len(res.warnings) == 1

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -1,3 +1,4 @@
+import pytest
 from multiseek.logic import (
     CONTAINS,
     DIFFERENT,
@@ -6,7 +7,9 @@ from multiseek.logic import (
     NOT_STARTS_WITH,
 )
 
+from bpp.multiseek_registry import registry
 from bpp.multiseek_registry.djangoql_export import (
+    leaf_to_djangoql,
     render_value,
     scalar_operator_to_djangoql,
 )
@@ -47,3 +50,30 @@ def test_scalar_operator_locale_robust():
 
 def test_render_value_escapes_backslash():
     assert render_value(r"a\b") == r'"a\\b"'
+
+
+@pytest.mark.django_db
+def test_leaf_scalar_string_contains():
+    frag = leaf_to_djangoql(
+        registry,
+        {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "nowotwor"},
+    )
+    assert frag == 'tytul_oryginalny ~ "nowotwor"'
+
+
+@pytest.mark.django_db
+def test_leaf_year_gte():
+    frag = leaf_to_djangoql(
+        registry,
+        {"field": "Rok", "operator": str(GREATER_OR_EQUAL), "value": 2020},
+    )
+    assert frag == "rok >= 2020"
+
+
+@pytest.mark.django_db
+def test_leaf_unknown_field_returns_none():
+    frag = leaf_to_djangoql(
+        registry,
+        {"field": "Nie ma takiego pola", "operator": str(CONTAINS), "value": "x"},
+    )
+    assert frag is None

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -250,3 +250,32 @@ def test_nested_subframe_gets_parens():
     }
     res = multiseek_form_to_djangoql(form, registry)
     assert res.query == "rok = 2020 and (rok = 2021 or rok = 2022)"
+
+
+from multiseek.logic import ANDNOT  # noqa: E402
+
+
+@pytest.mark.django_db
+def test_andnot_leaf_inverts_operator():
+    form = {"form_data": [
+        None,
+        {"field": "Rok", "operator": str(EQUAL), "value": 2023, "prev_op": None},
+        {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "abc", "prev_op": str(ANDNOT)},
+    ], "ordering": {}}
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == 'rok = 2023 and tytul_oryginalny !~ "abc"'
+    assert res.warnings == []
+
+
+@pytest.mark.django_db
+def test_andnot_value_with_operator_char_is_safe():
+    # Wartość zawiera znak '='; inwersja musi działać na operatorze pola,
+    # nie na znaku wewnątrz wartości.
+    form = {"form_data": [
+        None,
+        {"field": "Rok", "operator": str(EQUAL), "value": 2023, "prev_op": None},
+        {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "a = b", "prev_op": str(ANDNOT)},
+    ], "ordering": {}}
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == 'rok = 2023 and tytul_oryginalny !~ "a = b"'
+    assert res.warnings == []

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -364,3 +364,32 @@ def test_orm_name_falls_back_to_field_name():
         field_name = "rok"
 
     assert _orm_name(F()) == "rok"
+
+
+def test_leaf_to_djangoql_collects_warning_from_tuple():
+    from bpp.multiseek_registry import djangoql_export as dx
+
+    class Fake:
+        type = None
+        field_name = "rok"
+
+        def to_djangoql(self, value, operation):
+            return ("rok = 2024", "uwaga testowa")
+
+    reg = type("R", (), {"field_by_name": {"X": Fake()}})()
+    warnings = []
+    frag = dx.leaf_to_djangoql(
+        reg, {"field": "X", "operator": "equals", "value": 2024}, warnings
+    )
+    assert frag == "rok = 2024"
+    assert warnings == ["uwaga testowa"]
+
+
+def test_leaf_to_djangoql_str_still_works():
+    from bpp.multiseek_registry import djangoql_export as dx
+
+    frag = dx.leaf_to_djangoql(
+        registry,
+        {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "x"},
+    )
+    assert frag == 'tytul_oryginalny ~ "x"'

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -393,3 +393,31 @@ def test_leaf_to_djangoql_str_still_works():
         {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "x"},
     )
     assert frag == 'tytul_oryginalny ~ "x"'
+
+
+def test_autocomplete_empty_value_is_null():
+    from bpp.multiseek_registry.djangoql_export import _autocomplete_leaf
+    from multiseek.logic import EQUAL_NONE
+
+    class FK:
+        field_name = "zrodlo"
+        type = "autocomplete"
+
+        def value_from_web(self, value):
+            return None
+
+    assert _autocomplete_leaf(FK(), None, str(EQUAL_NONE)) == "zrodlo__rel = None"
+
+
+def test_autocomplete_empty_value_is_null_diff():
+    from bpp.multiseek_registry.djangoql_export import _autocomplete_leaf
+    from multiseek.logic import DIFFERENT_NONE
+
+    class FK:
+        field_name = "zrodlo"
+        type = "autocomplete"
+
+        def value_from_web(self, value):
+            return None
+
+    assert _autocomplete_leaf(FK(), None, str(DIFFERENT_NONE)) == "zrodlo__rel != None"

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -1,5 +1,6 @@
 import pytest
 from multiseek.logic import (
+    AND,
     CONTAINS,
     DIFFERENT,
     EQUAL,
@@ -10,6 +11,7 @@ from multiseek.logic import (
 from bpp.multiseek_registry import registry
 from bpp.multiseek_registry.djangoql_export import (
     leaf_to_djangoql,
+    multiseek_form_to_djangoql,
     render_value,
     scalar_operator_to_djangoql,
 )
@@ -91,3 +93,65 @@ def test_is_valid_rekord_djangoql_rejects_unknown_field():
     from bpp.multiseek_registry.djangoql_export import is_valid_rekord_djangoql
 
     assert is_valid_rekord_djangoql('totalnie_nie_ma_takiego_pola = "x"') is False
+
+
+@pytest.mark.django_db
+def test_two_conditions_and():
+    form = {
+        "form_data": [
+            None,
+            {
+                "field": "Tytuł pracy",
+                "operator": str(CONTAINS),
+                "value": "covid",
+                "prev_op": None,
+            },
+            {
+                "field": "Rok",
+                "operator": str(EQUAL),
+                "value": 2023,
+                "prev_op": str(AND),
+            },
+        ],
+        "ordering": {},
+        "report_type": "0",
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == 'tytul_oryginalny ~ "covid" and rok = 2023'
+    assert res.warnings == []
+
+
+@pytest.mark.django_db
+def test_untranslatable_condition_warns_and_skips():
+    form = {
+        "form_data": [
+            None,
+            {
+                "field": "Rok",
+                "operator": str(EQUAL),
+                "value": 2023,
+                "prev_op": None,
+            },
+            {
+                "field": "Nie ma pola",
+                "operator": str(EQUAL),
+                "value": "x",
+                "prev_op": str(AND),
+            },
+        ],
+        "ordering": {},
+        "report_type": "0",
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == "rok = 2023"
+    assert len(res.warnings) == 1
+    assert "Nie ma pola" in res.warnings[0]
+
+
+@pytest.mark.django_db
+def test_empty_form():
+    res = multiseek_form_to_djangoql(
+        {"form_data": [None], "ordering": {}}, registry
+    )
+    assert res.query == ""
+    assert res.warnings == []

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -1,6 +1,7 @@
 import pytest
 from multiseek.logic import (
     AND,
+    ANDNOT,
     CONTAINS,
     DIFFERENT,
     EQUAL,
@@ -252,16 +253,26 @@ def test_nested_subframe_gets_parens():
     assert res.query == "rok = 2020 and (rok = 2021 or rok = 2022)"
 
 
-from multiseek.logic import ANDNOT  # noqa: E402
-
-
 @pytest.mark.django_db
 def test_andnot_leaf_inverts_operator():
-    form = {"form_data": [
-        None,
-        {"field": "Rok", "operator": str(EQUAL), "value": 2023, "prev_op": None},
-        {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "abc", "prev_op": str(ANDNOT)},
-    ], "ordering": {}}
+    form = {
+        "form_data": [
+            None,
+            {
+                "field": "Rok",
+                "operator": str(EQUAL),
+                "value": 2023,
+                "prev_op": None,
+            },
+            {
+                "field": "Tytuł pracy",
+                "operator": str(CONTAINS),
+                "value": "abc",
+                "prev_op": str(ANDNOT),
+            },
+        ],
+        "ordering": {},
+    }
     res = multiseek_form_to_djangoql(form, registry)
     assert res.query == 'rok = 2023 and tytul_oryginalny !~ "abc"'
     assert res.warnings == []
@@ -271,11 +282,49 @@ def test_andnot_leaf_inverts_operator():
 def test_andnot_value_with_operator_char_is_safe():
     # Wartość zawiera znak '='; inwersja musi działać na operatorze pola,
     # nie na znaku wewnątrz wartości.
-    form = {"form_data": [
-        None,
-        {"field": "Rok", "operator": str(EQUAL), "value": 2023, "prev_op": None},
-        {"field": "Tytuł pracy", "operator": str(CONTAINS), "value": "a = b", "prev_op": str(ANDNOT)},
-    ], "ordering": {}}
+    form = {
+        "form_data": [
+            None,
+            {
+                "field": "Rok",
+                "operator": str(EQUAL),
+                "value": 2023,
+                "prev_op": None,
+            },
+            {
+                "field": "Tytuł pracy",
+                "operator": str(CONTAINS),
+                "value": "a = b",
+                "prev_op": str(ANDNOT),
+            },
+        ],
+        "ordering": {},
+    }
     res = multiseek_form_to_djangoql(form, registry)
     assert res.query == 'rok = 2023 and tytul_oryginalny !~ "a = b"'
+    assert res.warnings == []
+
+
+@pytest.mark.django_db
+def test_andnot_value_with_and_in_string_inverts_correctly():
+    form = {
+        "form_data": [
+            None,
+            {
+                "field": "Rok",
+                "operator": str(EQUAL),
+                "value": 2023,
+                "prev_op": None,
+            },
+            {
+                "field": "Tytuł pracy",
+                "operator": str(CONTAINS),
+                "value": "arms and legs",
+                "prev_op": str(ANDNOT),
+            },
+        ],
+        "ordering": {},
+    }
+    res = multiseek_form_to_djangoql(form, registry)
+    assert res.query == 'rok = 2023 and tytul_oryginalny !~ "arms and legs"'
     assert res.warnings == []

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -345,3 +345,22 @@ def test_malformed_leaf_missing_keys_is_skipped():
     res = multiseek_form_to_djangoql(form, registry)
     assert res.query == "rok = 2020"
     assert len(res.warnings) == 1
+
+
+def test_orm_name_prefers_djangoql_field_name():
+    from bpp.multiseek_registry.djangoql_export import _orm_name
+
+    class F:
+        field_name = "wydzial"
+        djangoql_field_name = "autorzy__jednostka__wydzial"
+
+    assert _orm_name(F()) == "autorzy__jednostka__wydzial"
+
+
+def test_orm_name_falls_back_to_field_name():
+    from bpp.multiseek_registry.djangoql_export import _orm_name
+
+    class F:
+        field_name = "rok"
+
+    assert _orm_name(F()) == "rok"

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -30,3 +30,20 @@ def test_scalar_operator_mapping():
 
 def test_scalar_operator_unknown_returns_none():
     assert scalar_operator_to_djangoql("zupełnie nieznany") is None
+
+
+def test_scalar_operator_locale_robust():
+    from django.utils import translation
+
+    # Build/lookup under English first...
+    with translation.override("en"):
+        en_key = str(CONTAINS)
+        assert scalar_operator_to_djangoql(en_key) == "~"
+    # ...then Polish: must still resolve (no frozen-key poisoning).
+    with translation.override("pl"):
+        pl_key = str(CONTAINS)
+        assert scalar_operator_to_djangoql(pl_key) == "~"
+
+
+def test_render_value_escapes_backslash():
+    assert render_value(r"a\b") == r'"a\\b"'

--- a/src/bpp/tests/test_multiseek_djangoql_export.py
+++ b/src/bpp/tests/test_multiseek_djangoql_export.py
@@ -77,3 +77,17 @@ def test_leaf_unknown_field_returns_none():
         {"field": "Nie ma takiego pola", "operator": str(CONTAINS), "value": "x"},
     )
     assert frag is None
+
+
+@pytest.mark.django_db
+def test_is_valid_rekord_djangoql_accepts_known_field():
+    from bpp.multiseek_registry.djangoql_export import is_valid_rekord_djangoql
+
+    assert is_valid_rekord_djangoql('rok = 2020') is True
+
+
+@pytest.mark.django_db
+def test_is_valid_rekord_djangoql_rejects_unknown_field():
+    from bpp.multiseek_registry.djangoql_export import is_valid_rekord_djangoql
+
+    assert is_valid_rekord_djangoql('totalnie_nie_ma_takiego_pola = "x"') is False

--- a/src/bpp/tests/test_multiseek_djangoql_fields_b1.py
+++ b/src/bpp/tests/test_multiseek_djangoql_fields_b1.py
@@ -1,0 +1,28 @@
+import pytest
+from model_bakery import baker
+from multiseek.logic import EQUAL
+
+from bpp.models import Kierunek_Studiow
+from bpp.models.struktura import Wydzial
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.djangoql_export import leaf_to_djangoql
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_wydzial_maps_to_nested_rel():
+    w = baker.make(Wydzial, nazwa="Wydział Lekarski")
+    frag = leaf_to_djangoql(
+        registry, {"field": "Wydział", "operator": str(EQUAL), "value": w.pk}
+    )
+    assert frag == f'autorzy.jednostka.wydzial__rel = "Wydział Lekarski [{w.pk}]"'
+
+
+@pytest.mark.django_db
+def test_kierunek_maps_to_nested_rel():
+    k = baker.make(Kierunek_Studiow, nazwa="Lekarski")
+    frag = leaf_to_djangoql(
+        registry, {"field": "Kierunek studiów", "operator": str(EQUAL), "value": k.pk}
+    )
+    assert frag == f'autorzy.kierunek_studiow__rel = "Lekarski [{k.pk}]"'

--- a/src/bpp/tests/test_multiseek_djangoql_fields_bool.py
+++ b/src/bpp/tests/test_multiseek_djangoql_fields_bool.py
@@ -1,0 +1,24 @@
+import pytest
+from multiseek.logic import EQUAL
+
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.djangoql_export import leaf_to_djangoql
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_afiliuje_true():
+    frag = leaf_to_djangoql(
+        registry, {"field": "Afiliuje", "operator": str(EQUAL), "value": True}
+    )
+    assert frag == "autorzy.afiliuje = True"
+
+
+@pytest.mark.django_db
+def test_oswiadczenie_ken_false():
+    frag = leaf_to_djangoql(
+        registry,
+        {"field": "Oświadczenie KEN", "operator": str(EQUAL), "value": False},
+    )
+    assert frag == "autorzy.oswiadczenie_ken = False"

--- a/src/bpp/tests/test_multiseek_djangoql_fields_bool.py
+++ b/src/bpp/tests/test_multiseek_djangoql_fields_bool.py
@@ -22,3 +22,37 @@ def test_oswiadczenie_ken_false():
         {"field": "Oświadczenie KEN", "operator": str(EQUAL), "value": False},
     )
     assert frag == "autorzy.oswiadczenie_ken = False"
+
+
+@pytest.mark.django_db
+def test_obca_jednostka_inverts_value():
+    # "Obca jednostka = True" oznacza skupia_pracownikow = False
+    field = registry.field_by_name["Obca jednostka"]
+    assert (
+        field.to_djangoql(True, str(EQUAL))
+        == "autorzy.jednostka.skupia_pracownikow = False"
+    )
+
+
+@pytest.mark.django_db
+def test_dyscyplina_ustawiona_true():
+    field = registry.field_by_name["Dyscyplina ustawiona"]
+    assert field.to_djangoql(True, str(EQUAL)) == "autorzy.dyscyplina_naukowa != None"
+
+
+@pytest.mark.django_db
+def test_dyscyplina_ustawiona_false():
+    field = registry.field_by_name["Dyscyplina ustawiona"]
+    assert field.to_djangoql(False, str(EQUAL)) == "autorzy.dyscyplina_naukowa = None"
+
+
+@pytest.mark.django_db
+def test_licencja_oa_ustawiona_true():
+    field = registry.field_by_name["OpenAccess: licencja ustawiona"]
+    assert field.to_djangoql(True, str(EQUAL)) == "openaccess_licencja != None"
+
+
+@pytest.mark.django_db
+def test_strona_www_ustawiona_true():
+    field = registry.field_by_name["Strona WWW ustawiona"]
+    assert field.to_djangoql(True, str(EQUAL)) == '(www != "" or public_www != "")'

--- a/src/bpp/tests/test_multiseek_djangoql_fields_misc.py
+++ b/src/bpp/tests/test_multiseek_djangoql_fields_misc.py
@@ -1,0 +1,44 @@
+import pytest
+from model_bakery import baker
+from multiseek.logic import EQUAL
+
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.djangoql_export import leaf_to_djangoql
+
+pytestmark = pytest.mark.serial
+
+
+def test_rodzaj_konferencji_krajowa():
+    field = registry.field_by_name["Rodzaj konferencji"]
+    assert field.to_djangoql("krajowa", str(EQUAL)) == "konferencja.typ_konferencji = 1"
+
+
+def test_rodzaj_jednostki_normalna():
+    from bpp.models import Jednostka
+
+    field = registry.field_by_name["Rodzaj jednostki"]
+    val = Jednostka.RODZAJ_JEDNOSTKI.NORMALNA.label
+    assert (
+        field.to_djangoql(val, str(EQUAL))
+        == 'autorzy.jednostka.rodzaj_jednostki = "normalna"'
+    )
+
+
+@pytest.mark.django_db
+def test_slowa_kluczowe_maps_to_tag_name():
+    field = registry.field_by_name["Słowa kluczowe"]
+    assert (
+        field.to_djangoql("nowotwór", str(EQUAL)) == 'slowa_kluczowe.name = "nowotwór"'
+    )
+
+
+@pytest.mark.django_db
+def test_zewnetrzna_baza_maps_to_nested_rel():
+    from bpp.models import Zewnetrzna_Baza_Danych
+
+    z = baker.make(Zewnetrzna_Baza_Danych, nazwa="QL Test Baza")
+    frag = leaf_to_djangoql(
+        registry,
+        {"field": "Zewnętrzna baza danych", "operator": str(EQUAL), "value": z.pk},
+    )
+    assert frag == f'zewnetrzne_bazy.baza__rel = "QL Test Baza [{z.pk}]"'

--- a/src/bpp/tests/test_multiseek_djangoql_roundtrip.py
+++ b/src/bpp/tests/test_multiseek_djangoql_roundtrip.py
@@ -1,0 +1,30 @@
+import pytest
+from djangoql.queryset import apply_search
+
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Rekord
+
+pytestmark = pytest.mark.serial
+
+
+def _pks_djangoql(frag):
+    return set(
+        apply_search(Rekord.objects.all(), frag, schema=BppQLSchema)
+        .distinct()
+        .values_list("pk", flat=True)
+    )
+
+
+@pytest.mark.django_db
+def test_roundtrip_jezyk(wydawnictwo_ciagle, denorms):
+    from bpp.models import Jezyk
+
+    pol = Jezyk.objects.get_or_create(nazwa="polski", defaults={"skrot": "pol."})[0]
+    wydawnictwo_ciagle.jezyk = pol
+    wydawnictwo_ciagle.save()
+    denorms.flush()
+
+    via_ms = set(Rekord.objects.filter(jezyk=pol).values_list("pk", flat=True))
+    via_dql = _pks_djangoql('jezyk.nazwa = "polski"')
+    assert via_ms
+    assert via_ms == via_dql

--- a/src/bpp/tests/test_multiseek_djangoql_value_list.py
+++ b/src/bpp/tests/test_multiseek_djangoql_value_list.py
@@ -1,0 +1,39 @@
+from multiseek.logic import DIFFERENT, EQUAL
+
+from bpp.multiseek_registry.djangoql_export import _value_list_leaf
+from bpp.multiseek_registry.fields.constants import UNION
+
+
+class _VL:
+    field_name = "jezyk"
+    djangoql_value_field = "nazwa"
+
+
+def test_value_list_equal():
+    assert _value_list_leaf(_VL(), "polski", str(EQUAL)) == 'jezyk.nazwa = "polski"'
+
+
+def test_value_list_different():
+    assert _value_list_leaf(_VL(), "polski", str(DIFFERENT)) == 'jezyk.nazwa != "polski"'
+
+
+def test_value_list_empty_value():
+    assert _value_list_leaf(_VL(), "", str(EQUAL)) == 'jezyk.nazwa = ""'
+
+
+def test_value_list_union_warns():
+    frag, warn = _value_list_leaf(_VL(), "polski", str(UNION))
+    assert frag == 'jezyk.nazwa = "polski"'
+    assert "wspóln" in warn.lower()
+
+
+def test_value_list_respects_djangoql_field_name():
+    class VL2:
+        field_name = "typ_odpowiedzialnosci"
+        djangoql_field_name = "autorzy__typ_odpowiedzialnosci"
+        djangoql_value_field = "nazwa"
+
+    assert (
+        _value_list_leaf(VL2(), "autor", str(EQUAL))
+        == 'autorzy.typ_odpowiedzialnosci.nazwa = "autor"'
+    )

--- a/src/bpp/tests/test_multiseek_djangoql_value_list.py
+++ b/src/bpp/tests/test_multiseek_djangoql_value_list.py
@@ -37,3 +37,41 @@ def test_value_list_respects_djangoql_field_name():
         _value_list_leaf(VL2(), "autor", str(EQUAL))
         == 'autorzy.typ_odpowiedzialnosci.nazwa = "autor"'
     )
+
+
+import pytest  # noqa: E402
+from model_bakery import baker  # noqa: E402
+
+from bpp.multiseek_registry import registry  # noqa: E402
+from bpp.multiseek_registry.djangoql_export import leaf_to_djangoql  # noqa: E402
+
+
+@pytest.mark.django_db
+@pytest.mark.serial
+def test_jezyk_maps_to_nazwa():
+    frag = leaf_to_djangoql(
+        registry, {"field": "Język", "operator": str(EQUAL), "value": "polski"}
+    )
+    assert frag == 'jezyk.nazwa = "polski"'
+
+
+@pytest.mark.django_db
+@pytest.mark.serial
+def test_typ_kbn_maps_to_nazwa():
+    from bpp.models.system import Typ_KBN
+
+    baker.make(Typ_KBN, nazwa="PO")
+    frag = leaf_to_djangoql(
+        registry, {"field": "Typ MNiSW/MEiN", "operator": str(EQUAL), "value": "PO"}
+    )
+    assert frag == 'typ_kbn.nazwa = "PO"'
+
+
+@pytest.mark.django_db
+@pytest.mark.serial
+def test_typ_odpowiedzialnosci_maps_to_nested_nazwa():
+    frag = leaf_to_djangoql(
+        registry,
+        {"field": "Typ odpowiedzialności", "operator": str(EQUAL), "value": "autor"},
+    )
+    assert frag == 'autorzy.typ_odpowiedzialnosci.nazwa = "autor"'

--- a/src/bpp/tests/test_multiseek_jednostka_to_djangoql.py
+++ b/src/bpp/tests/test_multiseek_jednostka_to_djangoql.py
@@ -6,7 +6,11 @@ from multiseek.logic import DIFFERENT_FEMALE, EQUAL_FEMALE
 from bpp.djangoql_schema import BppQLSchema
 from bpp.models import Jednostka, Rekord
 from bpp.multiseek_registry import registry
-from bpp.multiseek_registry.fields.constants import EQUAL_PLUS_SUB_FEMALE, UNION_FEMALE
+from bpp.multiseek_registry.fields.constants import (
+    EQUAL_PLUS_SUB_FEMALE,
+    EQUAL_PLUS_SUB_UNION_FEMALE,
+    UNION_FEMALE,
+)
 
 pytestmark = pytest.mark.serial
 
@@ -43,12 +47,17 @@ def test_jednostka_union_is_untranslatable():
 
 
 @pytest.mark.django_db
+def test_jednostka_plus_subunits_union_is_untranslatable():
+    j = baker.make(Jednostka, nazwa="Klinika X")
+    field = registry.field_by_name["Jednostka"]
+    assert field.to_djangoql(j.pk, str(EQUAL_PLUS_SUB_UNION_FEMALE)) is None
+
+
+@pytest.mark.django_db
 def test_roundtrip_jednostka_plus_subunits_same_rekordy(
-    jednostka, jednostka_podrzedna, wydawnictwo_ciagle, autor_jan_kowalski
+    jednostka, jednostka_podrzedna, wydawnictwo_ciagle, autor_jan_kowalski, denorms
 ):
     """Multiseek Q vs skonwertowane DjangoQL daja ten sam zbior Rekord."""
-    from denorm import denorms
-
     # autor w PODRZEDNEJ jednostce; pytamy o NADRZEDNA z '+ podrzedne'
     wydawnictwo_ciagle.dodaj_autora(autor_jan_kowalski, jednostka_podrzedna)
     denorms.flush()

--- a/src/bpp/tests/test_multiseek_jednostka_to_djangoql.py
+++ b/src/bpp/tests/test_multiseek_jednostka_to_djangoql.py
@@ -40,17 +40,25 @@ def test_jednostka_plus_subunits_maps_to_virtual_field():
 
 
 @pytest.mark.django_db
-def test_jednostka_union_is_untranslatable():
+def test_jednostka_union_best_effort_warns():
     j = baker.make(Jednostka, nazwa="Klinika X")
     field = registry.field_by_name["Jednostka"]
-    assert field.to_djangoql(j.pk, str(UNION_FEMALE)) is None
+    result = field.to_djangoql(j.pk, str(UNION_FEMALE))
+    assert isinstance(result, tuple)
+    frag, warn = result
+    assert frag == f'autorzy.jednostka__rel = "Klinika X [{j.pk}]"'
+    assert "wspóln" in warn.lower()
 
 
 @pytest.mark.django_db
-def test_jednostka_plus_subunits_union_is_untranslatable():
+def test_jednostka_plus_subunits_union_best_effort_warns():
     j = baker.make(Jednostka, nazwa="Klinika X")
     field = registry.field_by_name["Jednostka"]
-    assert field.to_djangoql(j.pk, str(EQUAL_PLUS_SUB_UNION_FEMALE)) is None
+    result = field.to_djangoql(j.pk, str(EQUAL_PLUS_SUB_UNION_FEMALE))
+    assert isinstance(result, tuple)
+    frag, warn = result
+    assert frag == f'jednostka_z_podjednostkami__rel = "Klinika X [{j.pk}]"'
+    assert "wspóln" in warn.lower()
 
 
 @pytest.mark.django_db

--- a/src/bpp/tests/test_multiseek_jednostka_to_djangoql.py
+++ b/src/bpp/tests/test_multiseek_jednostka_to_djangoql.py
@@ -1,0 +1,67 @@
+import pytest
+from djangoql.queryset import apply_search
+from model_bakery import baker
+from multiseek.logic import DIFFERENT_FEMALE, EQUAL_FEMALE
+
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Jednostka, Rekord
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.fields.constants import EQUAL_PLUS_SUB_FEMALE, UNION_FEMALE
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_jednostka_equal_maps_to_autorzy_jednostka_rel():
+    j = baker.make(Jednostka, nazwa="Klinika X")
+    field = registry.field_by_name["Jednostka"]
+    frag = field.to_djangoql(j.pk, str(EQUAL_FEMALE))
+    assert frag == f'autorzy.jednostka__rel = "Klinika X [{j.pk}]"'
+
+
+@pytest.mark.django_db
+def test_jednostka_different_maps_to_not_equal():
+    j = baker.make(Jednostka, nazwa="Klinika X")
+    field = registry.field_by_name["Jednostka"]
+    frag = field.to_djangoql(j.pk, str(DIFFERENT_FEMALE))
+    assert frag == f'autorzy.jednostka__rel != "Klinika X [{j.pk}]"'
+
+
+@pytest.mark.django_db
+def test_jednostka_plus_subunits_maps_to_virtual_field():
+    j = baker.make(Jednostka, nazwa="Klinika X")
+    field = registry.field_by_name["Jednostka"]
+    frag = field.to_djangoql(j.pk, str(EQUAL_PLUS_SUB_FEMALE))
+    assert frag == f'jednostka_z_podjednostkami__rel = "Klinika X [{j.pk}]"'
+
+
+@pytest.mark.django_db
+def test_jednostka_union_is_untranslatable():
+    j = baker.make(Jednostka, nazwa="Klinika X")
+    field = registry.field_by_name["Jednostka"]
+    assert field.to_djangoql(j.pk, str(UNION_FEMALE)) is None
+
+
+@pytest.mark.django_db
+def test_roundtrip_jednostka_plus_subunits_same_rekordy(
+    jednostka, jednostka_podrzedna, wydawnictwo_ciagle, autor_jan_kowalski
+):
+    """Multiseek Q vs skonwertowane DjangoQL daja ten sam zbior Rekord."""
+    from denorm import denorms
+
+    # autor w PODRZEDNEJ jednostce; pytamy o NADRZEDNA z '+ podrzedne'
+    wydawnictwo_ciagle.dodaj_autora(autor_jan_kowalski, jednostka_podrzedna)
+    denorms.flush()
+
+    field = registry.field_by_name["Jednostka"]
+    q = field.real_query(jednostka, EQUAL_PLUS_SUB_FEMALE)
+    via_multiseek = set(Rekord.objects.filter(q).values_list("pk", flat=True))
+
+    frag = field.to_djangoql(jednostka.pk, EQUAL_PLUS_SUB_FEMALE)
+    via_djangoql = set(
+        apply_search(Rekord.objects.all(), frag, schema=BppQLSchema)
+        .distinct()
+        .values_list("pk", flat=True)
+    )
+    assert via_multiseek  # niepusty -> test faktycznie cos sprawdza
+    assert via_multiseek == via_djangoql

--- a/src/bpp/tests/test_multiseek_kolejnosc_to_djangoql.py
+++ b/src/bpp/tests/test_multiseek_kolejnosc_to_djangoql.py
@@ -1,0 +1,30 @@
+import pytest
+from model_bakery import baker
+from multiseek.logic import EQUAL
+
+from bpp.models import Autor
+from bpp.multiseek_registry import registry
+
+pytestmark = pytest.mark.serial
+
+
+@pytest.mark.django_db
+def test_pierwsze_nazwisko_is_kolejnosc_zero():
+    a = baker.make(Autor, nazwisko="Nowak", imiona="Jan")
+    field = registry.field_by_name["Pierwsze nazwisko i imię"]
+    frag = field.to_djangoql(a.pk, str(EQUAL))
+    assert frag == (
+        f'autorzy.autor__rel = "{a} [{a.pk}]" '
+        "and autorzy.kolejnosc >= 0 and autorzy.kolejnosc < 1"
+    )
+
+
+@pytest.mark.django_db
+def test_ostatnie_nazwisko_best_effort_warns():
+    a = baker.make(Autor, nazwisko="Nowak", imiona="Jan")
+    field = registry.field_by_name["Ostatnie nazwisko i imię"]
+    result = field.to_djangoql(a.pk, str(EQUAL))
+    assert isinstance(result, tuple)
+    frag, warn = result
+    assert frag == f'autorzy.autor__rel = "{a} [{a.pk}]"'
+    assert "ostatni" in warn.lower() or "kolejn" in warn.lower()

--- a/src/bpp/tests/test_playwright/test_multiseek_djangoql.py
+++ b/src/bpp/tests/test_playwright/test_multiseek_djangoql.py
@@ -1,0 +1,39 @@
+import pytest
+from django.test import Client
+from django.urls.base import reverse
+from model_bakery import baker
+from playwright.sync_api import Page, expect
+
+from bpp.models import BppUser
+
+
+def _login_cookie(user):
+    """Zaloguj usera Clientem i zwróć ciasteczko sesji (dla kontekstu Playwright)."""
+    client = Client()
+    client.force_login(user)
+    return client.cookies["sessionid"].value
+
+
+@pytest.mark.django_db
+def test_drawer_shows_highlighted_query(page: Page, live_server):
+    """Po kliknięciu przycisku szuflada pokazuje podświetlone DjangoQL,
+    a link „Otwórz w edytorze" wskazuje na edytor zapytań."""
+    admin = baker.make(BppUser, is_superuser=True, is_staff=True)
+    sid = _login_cookie(admin)
+    page.context.add_cookies(
+        [{"name": "sessionid", "value": sid, "url": live_server.url}]
+    )
+
+    page.goto(live_server.url + reverse("multiseek:index"))
+    page.evaluate("Cookielaw.accept()")
+
+    page.click("#toDjangoqlButton")
+
+    # Czekamy aż formatter wyrenderuje podświetlone tokeny.
+    page.wait_for_selector("#djangoqlPretty span.dql-op")
+    assert page.locator("#djangoqlPretty span.dql-name").count() >= 1
+    assert page.locator("#djangoqlPretty span.dql-op").count() >= 1
+
+    href = page.locator("#djangoqlOpenEditor").get_attribute("href")
+    assert href and reverse("bpp:zapytanie") in href
+    expect(page.locator("#djangoqlDrawer")).to_be_visible()

--- a/src/bpp/tests/test_zapytanie.py
+++ b/src/bpp/tests/test_zapytanie.py
@@ -6,7 +6,7 @@ from djangoql.parser import DjangoQLParser
 from model_bakery import baker
 
 from bpp.const import GR_WPROWADZANIE_DANYCH
-from bpp.views.zapytanie import EXAMPLES
+from bpp.views.zapytanie import EXAMPLES, user_can_use_query_editor
 
 URL = "bpp:zapytanie"
 
@@ -300,18 +300,12 @@ def test_rekord_schema_has_autorzy_rel_pickers():
 
 @pytest.mark.django_db
 def test_user_can_use_query_editor_superuser():
-    from bpp.views.zapytanie import user_can_use_query_editor
-
     u = baker.make("bpp.BppUser", is_superuser=True, is_staff=False)
     assert user_can_use_query_editor(u) is True
 
 
 @pytest.mark.django_db
 def test_user_can_use_query_editor_staff_in_group():
-    from django.contrib.auth.models import Group
-
-    from bpp.views.zapytanie import user_can_use_query_editor
-
     u = baker.make("bpp.BppUser", is_superuser=False, is_staff=True)
     grp, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
     u.groups.add(grp)
@@ -320,10 +314,14 @@ def test_user_can_use_query_editor_staff_in_group():
 
 @pytest.mark.django_db
 def test_user_can_use_query_editor_plain_logged_in():
-    from bpp.views.zapytanie import user_can_use_query_editor
-
     u = baker.make("bpp.BppUser", is_superuser=False, is_staff=False)
     assert user_can_use_query_editor(u) is False
+
+
+def test_user_can_use_query_editor_anonymous():
+    from django.contrib.auth.models import AnonymousUser
+
+    assert user_can_use_query_editor(AnonymousUser()) is False
 
 
 @pytest.mark.django_db

--- a/src/bpp/tests/test_zapytanie.py
+++ b/src/bpp/tests/test_zapytanie.py
@@ -299,6 +299,34 @@ def test_rekord_schema_has_autorzy_rel_pickers():
 
 
 @pytest.mark.django_db
+def test_user_can_use_query_editor_superuser():
+    from bpp.views.zapytanie import user_can_use_query_editor
+
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=False)
+    assert user_can_use_query_editor(u) is True
+
+
+@pytest.mark.django_db
+def test_user_can_use_query_editor_staff_in_group():
+    from django.contrib.auth.models import Group
+
+    from bpp.views.zapytanie import user_can_use_query_editor
+
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=True)
+    grp, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    u.groups.add(grp)
+    assert user_can_use_query_editor(u) is True
+
+
+@pytest.mark.django_db
+def test_user_can_use_query_editor_plain_logged_in():
+    from bpp.views.zapytanie import user_can_use_query_editor
+
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=False)
+    assert user_can_use_query_editor(u) is False
+
+
+@pytest.mark.django_db
 def test_rekord_autorzy_autor_rel_filters_real_fk():
     from djangoql.queryset import apply_search
 

--- a/src/bpp/views/mymultiseek.py
+++ b/src/bpp/views/mymultiseek.py
@@ -176,9 +176,7 @@ class MultiseekToDjangoQLView(WprowadzanieDanychOrSuperuserMixin, View):
         try:
             result = multiseek_form_to_djangoql(form_json, multiseek_registry)
         except (KeyError, TypeError, AttributeError) as exc:
-            return HttpResponseBadRequest(
-                f"Niepoprawna struktura formularza: {exc}"
-            )
+            return HttpResponseBadRequest(f"Niepoprawna struktura formularza: {exc}")
         return JsonResponse(
             {
                 "query": result.query,

--- a/src/bpp/views/mymultiseek.py
+++ b/src/bpp/views/mymultiseek.py
@@ -1,5 +1,9 @@
+import json
+
 from django.db.models import Sum
+from django.http import HttpResponseBadRequest, JsonResponse
 from django.views.decorators.cache import never_cache
+from django.views.generic import View
 from multiseek.logic import get_registry
 from multiseek.views import (
     MULTISEEK_SESSION_KEY_REMOVED,
@@ -8,6 +12,9 @@ from multiseek.views import (
 )
 
 from bpp.models import Uczelnia
+from bpp.multiseek_registry import registry as multiseek_registry
+from bpp.multiseek_registry.djangoql_export import multiseek_form_to_djangoql
+from bpp.views.zapytanie import WprowadzanieDanychOrSuperuserMixin
 
 PKT_WEWN = "pkt_wewn"
 PKT_WEWN_BEZ = "pkt_wewn_bez"
@@ -148,3 +155,29 @@ def bpp_remove_from_removed_by_hand(request, pk):
     pk = tuple(int(x) for x in pk.split("_"))
     _normalize_session_removed(request)
     return manually_add_or_remove(request, pk, add=False)
+
+
+class MultiseekToDjangoQLView(WprowadzanieDanychOrSuperuserMixin, View):
+    """Tlumaczy biezacy formularz Multiseek (POST 'json') na zapytanie
+    DjangoQL nad Rekord. Zwraca {query, warnings, editor_url}."""
+
+    http_method_names = ["post"]
+
+    def post(self, request, *args, **kwargs):
+        raw = request.POST.get("json")
+        if not raw:
+            return HttpResponseBadRequest("Brak parametru 'json'.")
+        try:
+            form_json = json.loads(raw)
+        except (ValueError, TypeError):
+            return HttpResponseBadRequest("Niepoprawny JSON formularza.")
+        if not isinstance(form_json, dict):
+            return HttpResponseBadRequest("Oczekiwano obiektu JSON.")
+        result = multiseek_form_to_djangoql(form_json, multiseek_registry)
+        return JsonResponse(
+            {
+                "query": result.query,
+                "warnings": result.warnings,
+                "editor_url": result.editor_url,
+            }
+        )

--- a/src/bpp/views/mymultiseek.py
+++ b/src/bpp/views/mymultiseek.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django.db.models import Sum
 from django.http import HttpResponseBadRequest, JsonResponse
@@ -15,6 +16,8 @@ from bpp.models import Uczelnia
 from bpp.multiseek_registry import registry as multiseek_registry
 from bpp.multiseek_registry.djangoql_export import multiseek_form_to_djangoql
 from bpp.views.zapytanie import WprowadzanieDanychOrSuperuserMixin
+
+logger = logging.getLogger(__name__)
 
 PKT_WEWN = "pkt_wewn"
 PKT_WEWN_BEZ = "pkt_wewn_bez"
@@ -175,8 +178,9 @@ class MultiseekToDjangoQLView(WprowadzanieDanychOrSuperuserMixin, View):
             return HttpResponseBadRequest("Oczekiwano obiektu JSON.")
         try:
             result = multiseek_form_to_djangoql(form_json, multiseek_registry)
-        except (KeyError, TypeError, AttributeError) as exc:
-            return HttpResponseBadRequest(f"Niepoprawna struktura formularza: {exc}")
+        except (KeyError, TypeError, AttributeError):
+            logger.exception("Niepoprawna struktura formularza przesłana do MultiseekToDjangoQLView.")
+            return HttpResponseBadRequest("Niepoprawna struktura formularza.")
         return JsonResponse(
             {
                 "query": result.query,

--- a/src/bpp/views/mymultiseek.py
+++ b/src/bpp/views/mymultiseek.py
@@ -173,7 +173,12 @@ class MultiseekToDjangoQLView(WprowadzanieDanychOrSuperuserMixin, View):
             return HttpResponseBadRequest("Niepoprawny JSON formularza.")
         if not isinstance(form_json, dict):
             return HttpResponseBadRequest("Oczekiwano obiektu JSON.")
-        result = multiseek_form_to_djangoql(form_json, multiseek_registry)
+        try:
+            result = multiseek_form_to_djangoql(form_json, multiseek_registry)
+        except (KeyError, TypeError, AttributeError) as exc:
+            return HttpResponseBadRequest(
+                f"Niepoprawna struktura formularza: {exc}"
+            )
         return JsonResponse(
             {
                 "query": result.query,

--- a/src/bpp/views/zapytanie.py
+++ b/src/bpp/views/zapytanie.py
@@ -272,6 +272,21 @@ EXAMPLES = [
 ]
 
 
+def user_can_use_query_editor(user):
+    """Czy user widzi/uzywa edytora zapytan DjangoQL.
+
+    Superuser, albo staff w grupie 'wprowadzanie danych'. Jedno zrodlo
+    prawdy dla: mixinu widoku, endpointu konwertera i filtru szablonowego.
+    """
+    if not user.is_authenticated:
+        return False
+    if user.is_superuser:
+        return True
+    return user.is_staff and user.groups.filter(
+        name=GR_WPROWADZANIE_DANYCH
+    ).exists()
+
+
 class WprowadzanieDanychOrSuperuserMixin(LoginRequiredMixin, UserPassesTestMixin):
     """Dostep dla superuserow lub uzytkownikow w grupie 'wprowadzanie danych'
     bedacych jednoczesnie w staffie."""
@@ -279,12 +294,7 @@ class WprowadzanieDanychOrSuperuserMixin(LoginRequiredMixin, UserPassesTestMixin
     raise_exception = True
 
     def test_func(self):
-        user = self.request.user
-        if user.is_superuser:
-            return True
-        return (
-            user.is_staff and user.groups.filter(name=GR_WPROWADZANIE_DANYCH).exists()
-        )
+        return user_can_use_query_editor(self.request.user)
 
 
 class ZapytanieForm(forms.Form):

--- a/src/bpp/views/zapytanie.py
+++ b/src/bpp/views/zapytanie.py
@@ -282,9 +282,7 @@ def user_can_use_query_editor(user):
         return False
     if user.is_superuser:
         return True
-    return user.is_staff and user.groups.filter(
-        name=GR_WPROWADZANIE_DANYCH
-    ).exists()
+    return user.is_staff and user.groups.filter(name=GR_WPROWADZANIE_DANYCH).exists()
 
 
 class WprowadzanieDanychOrSuperuserMixin(LoginRequiredMixin, UserPassesTestMixin):

--- a/src/django_bpp/templates/multiseek/index.html
+++ b/src/django_bpp/templates/multiseek/index.html
@@ -132,7 +132,7 @@
                     <button type="button" class="secondary dropdown button" data-toggle="multiseek-form-menu" href="#"
                             data-dropdown="drop2"
                             aria-haspopup="menu">
-                        <i class="fi-upload" aria-hidden="true"></i> Wczytaj formularz</a>
+                        <i class="fi-upload" aria-hidden="true"></i> Wczytaj formularz
                     </button>
 
                     <div class="dropdown-pane" id="multiseek-form-menu" data-dropdown>

--- a/src/django_bpp/templates/multiseek/index.html
+++ b/src/django_bpp/templates/multiseek/index.html
@@ -257,7 +257,7 @@
             }
 
             function openDjangoqlDrawer() {
-                var queryEl = document.getElementById('djangoqlQuery');
+                var queryEl = document.getElementById('djangoqlPretty');
                 if (!queryEl) { return; }  // drawer niedostepny dla tego usera
                 var payload = formAsJSON();  // JSON string
                 var body = new URLSearchParams();
@@ -273,7 +273,9 @@
                     if (!r.ok) { throw new Error('HTTP ' + r.status); }
                     return r.json();
                 }).then(function (data) {
-                    document.getElementById('djangoqlQuery').value = data.query || '';
+                    if (window.djangoqlRenderPretty) {
+                        window.djangoqlRenderPretty(data.query || '');
+                    }
                     document.getElementById('djangoqlOpenEditor').href = data.editor_url;
                     var w = document.getElementById('djangoqlWarnings');
                     w.innerHTML = '';
@@ -301,9 +303,11 @@
             }
 
             function copyDjangoqlQuery(btn) {
-                var ta = document.getElementById('djangoqlQuery');
-                if (!ta) { return; }
-                navigator.clipboard.writeText(ta.value).then(function () {
+                var pre = document.getElementById('djangoqlPretty');
+                var raw = document.getElementById('djangoqlQueryRaw');
+                var text = (pre && pre.textContent) || (raw && raw.value) || '';
+                if (!text) { return; }
+                navigator.clipboard.writeText(text).then(function () {
                     btn.classList.add('success');
                 });
             }
@@ -314,7 +318,9 @@
             <div class="reveal" id="djangoqlDrawer" data-reveal aria-labelledby="djangoqlDrawerTitle">
                 <h4 id="djangoqlDrawerTitle">Zapytanie DjangoQL</h4>
                 <p class="help-text">Równoważne zapytanie nad modelem Rekord. Możesz je skopiować lub otworzyć w edytorze zapytań.</p>
-                <textarea id="djangoqlQuery" rows="4" readonly spellcheck="false" style="font-family:monospace;"></textarea>
+                <pre class="djangoql-pretty"><code id="djangoqlPretty"></code></pre>
+                {# Surowe (jednoliniowe) zapytanie — fallback do kopiowania/edytora. #}
+                <input type="hidden" id="djangoqlQueryRaw" value="">
                 <div id="djangoqlWarnings" class="callout warning" style="display:none"></div>
                 <div class="button-group">
                     <button type="button" class="button" id="djangoqlCopy">
@@ -328,6 +334,41 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
+            <script src="{% static 'djangoql/js/completion.js' %}"></script>
+            <script src="{% static 'bpp/js/djangoql-pretty.js' %}"></script>
+            <script>
+            (function () {
+                var _dql = null;
+                function getLexer() {
+                    if (_dql) { return _dql.lexer; }
+                    var ta = document.getElementById('djangoqlLexerProbe');
+                    if (!ta) {
+                        ta = document.createElement('textarea');
+                        ta.id = 'djangoqlLexerProbe';
+                        ta.style.display = 'none';
+                        document.body.appendChild(ta);
+                    }
+                    try {
+                        _dql = DjangoQL.init({
+                            introspections: "{% url 'bpp:zapytanie_introspect' 'rekord' %}",
+                            selector: ta,
+                            autoResize: false
+                        });
+                    } catch (e) { return null; }
+                    return _dql.lexer;
+                }
+                window.djangoqlRenderPretty = function (query) {
+                    var raw = document.getElementById('djangoqlQueryRaw');
+                    var pre = document.getElementById('djangoqlPretty');
+                    if (raw) { raw.value = query || ''; }
+                    if (!pre) { return; }
+                    var lexer = getLexer();
+                    pre.innerHTML = (lexer && window.djangoqlPretty)
+                        ? window.djangoqlPretty.formatAndHighlight(query || '', lexer)
+                        : (query || '');
+                };
+            })();
+            </script>
         {% endif %}
     </form>
     <hr size="1"/>
@@ -338,6 +379,19 @@
             min-height: 400px;
             border: none;
         }
+        .djangoql-pretty {
+            font-family: monospace; white-space: pre; overflow-x: auto;
+            background: #f6f6f6; padding: .6rem; border-radius: 3px;
+            line-height: 1.5; margin-bottom: 1rem;
+        }
+        .dql-keyword { color: #8959a8; font-weight: bold; }
+        .dql-op { color: #3e999f; }
+        .dql-name { color: #4271ae; }
+        .dql-dot { color: #999; }
+        .dql-str { color: #718c00; }
+        .dql-num { color: #f5871f; }
+        .dql-bool, .dql-none { color: #c82829; }
+        .dql-paren { color: #555; }
     </style>
     <iframe src="./live-results/" width="100%" id="if"
             name="list_frame" scrolling="no"

--- a/src/django_bpp/templates/multiseek/index.html
+++ b/src/django_bpp/templates/multiseek/index.html
@@ -257,6 +257,8 @@
             }
 
             function openDjangoqlDrawer() {
+                var queryEl = document.getElementById('djangoqlQuery');
+                if (!queryEl) { return; }  // drawer niedostepny dla tego usera
                 var payload = formAsJSON();  // JSON string
                 var body = new URLSearchParams();
                 body.append('json', payload);
@@ -290,6 +292,8 @@
                     } else {
                         w.style.display = 'none';
                     }
+                    var copyBtn = document.getElementById('djangoqlCopy');
+                    if (copyBtn) { copyBtn.classList.remove('success'); }
                     $('#djangoqlDrawer').foundation('open');
                 }).catch(function (err) {
                     alert('Nie udało się przetłumaczyć formularza: ' + err.message);
@@ -298,6 +302,7 @@
 
             function copyDjangoqlQuery(btn) {
                 var ta = document.getElementById('djangoqlQuery');
+                if (!ta) { return; }
                 navigator.clipboard.writeText(ta.value).then(function () {
                     btn.classList.add('success');
                 });
@@ -306,8 +311,8 @@
         </script>
         {% if user|can_use_query_editor %}
             {% csrf_token %}
-            <div class="reveal" id="djangoqlDrawer" data-reveal>
-                <h4>Zapytanie DjangoQL</h4>
+            <div class="reveal" id="djangoqlDrawer" data-reveal aria-labelledby="djangoqlDrawerTitle">
+                <h4 id="djangoqlDrawerTitle">Zapytanie DjangoQL</h4>
                 <p class="help-text">Równoważne zapytanie nad modelem Rekord. Możesz je skopiować lub otworzyć w edytorze zapytań.</p>
                 <textarea id="djangoqlQuery" rows="4" readonly spellcheck="false" style="font-family:monospace;"></textarea>
                 <div id="djangoqlWarnings" class="callout warning" style="display:none"></div>

--- a/src/django_bpp/templates/multiseek/index.html
+++ b/src/django_bpp/templates/multiseek/index.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load compress %}
 {% load i18n %}
+{% load query_editor %}
 
 {% block title %}
     BPP - wyszukiwanie zaawansowane
@@ -148,6 +149,14 @@
 
 
                 {% endif %}
+
+                {% if user|can_use_query_editor %}
+                    <button type="button" class="button secondary"
+                            data-action="to-djangoql"
+                            id="toDjangoqlButton">
+                        <i class="fi-clipboard-notes" aria-hidden="true"></i> Pokaż jako zapytanie DjangoQL
+                    </button>
+                {% endif %}
             </div>
         </div>
         <script type="text/javascript">
@@ -224,9 +233,97 @@
                     location.href = multiseek.LOAD_FORM_URL + btn.dataset.loadFormId;
                     return;
                 }
+
+                // Show form as DjangoQL query
+                btn = e.target.closest('[data-action="to-djangoql"]');
+                if (btn) {
+                    e.preventDefault();
+                    openDjangoqlDrawer();
+                    return;
+                }
+
+                // Copy DjangoQL query to clipboard
+                btn = e.target.closest('#djangoqlCopy');
+                if (btn) {
+                    e.preventDefault();
+                    copyDjangoqlQuery(btn);
+                    return;
+                }
             });
 
+            function getCsrfToken() {
+                var el = document.querySelector('input[name="csrfmiddlewaretoken"]');
+                return el ? el.value : '';
+            }
+
+            function openDjangoqlDrawer() {
+                var payload = formAsJSON();  // JSON string
+                var body = new URLSearchParams();
+                body.append('json', payload);
+                fetch('./do-djangoql/', {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRFToken': getCsrfToken(),
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: body.toString()
+                }).then(function (r) {
+                    if (!r.ok) { throw new Error('HTTP ' + r.status); }
+                    return r.json();
+                }).then(function (data) {
+                    document.getElementById('djangoqlQuery').value = data.query || '';
+                    document.getElementById('djangoqlOpenEditor').href = data.editor_url;
+                    var w = document.getElementById('djangoqlWarnings');
+                    w.innerHTML = '';
+                    if (data.warnings && data.warnings.length) {
+                        var strong = document.createElement('strong');
+                        strong.textContent = 'Uwaga — pominięto warunki:';
+                        w.appendChild(strong);
+                        var ul = document.createElement('ul');
+                        data.warnings.forEach(function (s) {
+                            var li = document.createElement('li');
+                            li.textContent = s;       // text node -> escaped
+                            ul.appendChild(li);
+                        });
+                        w.appendChild(ul);
+                        w.style.display = '';
+                    } else {
+                        w.style.display = 'none';
+                    }
+                    $('#djangoqlDrawer').foundation('open');
+                }).catch(function (err) {
+                    alert('Nie udało się przetłumaczyć formularza: ' + err.message);
+                });
+            }
+
+            function copyDjangoqlQuery(btn) {
+                var ta = document.getElementById('djangoqlQuery');
+                navigator.clipboard.writeText(ta.value).then(function () {
+                    btn.classList.add('success');
+                });
+            }
+
         </script>
+        {% if user|can_use_query_editor %}
+            {% csrf_token %}
+            <div class="reveal" id="djangoqlDrawer" data-reveal>
+                <h4>Zapytanie DjangoQL</h4>
+                <p class="help-text">Równoważne zapytanie nad modelem Rekord. Możesz je skopiować lub otworzyć w edytorze zapytań.</p>
+                <textarea id="djangoqlQuery" rows="4" readonly spellcheck="false" style="font-family:monospace;"></textarea>
+                <div id="djangoqlWarnings" class="callout warning" style="display:none"></div>
+                <div class="button-group">
+                    <button type="button" class="button" id="djangoqlCopy">
+                        <i class="fi-clipboard" aria-hidden="true"></i> Kopiuj
+                    </button>
+                    <a class="button success" id="djangoqlOpenEditor" href="#" target="_blank" rel="noopener">
+                        <i class="fi-arrow-right" aria-hidden="true"></i> Otwórz w edytorze zapytań
+                    </a>
+                </div>
+                <button class="close-button" data-close aria-label="Zamknij" type="button">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        {% endif %}
     </form>
     <hr size="1"/>
     <style>

--- a/src/django_bpp/urls.py
+++ b/src/django_bpp/urls.py
@@ -288,6 +288,9 @@ urlpatterns = (
             ),
             name="multiseek:results",
         ),
+        # Musi byc w przestrzeni /multiseek/ (root urlconf), PRZED include
+        # ("multiseek.urls"), bo formularz POST-uje relatywnie ./do-djangoql/.
+        # Nazwa jest top-level (nie bpp:...), bo trasa nie jest w bpp.urls.
         url(
             r"^multiseek/do-djangoql/$",
             MultiseekToDjangoQLView.as_view(),

--- a/src/django_bpp/urls.py
+++ b/src/django_bpp/urls.py
@@ -23,6 +23,7 @@ from bpp.views.admin import (
 )
 from bpp.views.global_nav import global_nav_redir
 from bpp.views.mymultiseek import (
+    MultiseekToDjangoQLView,
     MyMultiseekResults,
     bpp_remove_by_hand,
     bpp_remove_from_removed_by_hand,
@@ -286,6 +287,11 @@ urlpatterns = (
                 )
             ),
             name="multiseek:results",
+        ),
+        url(
+            r"^multiseek/do-djangoql/$",
+            MultiseekToDjangoQLView.as_view(),
+            name="multiseek-do-djangoql",
         ),
         url(
             r"^multiseek/",

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ requires-dist = [
     { name = "django-tinymce", specifier = ">=5.0.0" },
     { name = "django-weasyprint", specifier = ">=2.5.0" },
     { name = "django-webmaster-verification", specifier = "==0.4.3" },
-    { name = "djangoql-iplweb", specifier = ">=0.23.0" },
+    { name = "djangoql-iplweb", specifier = ">=0.26.0" },
     { name = "djangorestframework", specifier = "==3.17.1" },
     { name = "dspace-rest-client", specifier = ">=0.1.12" },
     { name = "gunicorn", specifier = ">=26.0.0" },
@@ -2388,14 +2388,14 @@ wheels = [
 
 [[package]]
 name = "djangoql-iplweb"
-version = "0.23.0"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/e0/c3164c6afb2cb9da40cb0b9f1b94c1c0e4dcffee0b585f24978f63017fb3/djangoql_iplweb-0.23.0.tar.gz", hash = "sha256:e830893e88354592b03810c46c7918e475991747ff1a95415bb246916e88b38d", size = 248317, upload-time = "2026-06-04T09:21:54.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/5c/856ffb426fcc8091e767c48063546d5160ee73151370ecdc65d065551c54/djangoql_iplweb-0.26.0.tar.gz", hash = "sha256:aa36b575b22e47e565370360eb5ddb73791d54d04577a0285a6c97ac7067f5fc", size = 265530, upload-time = "2026-06-05T07:49:18.577Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/a2/9c884132b408899dd836b43a7c1bd0b16fea173ea9b8c2f089186806df6c/djangoql_iplweb-0.23.0-py3-none-any.whl", hash = "sha256:20fb4af8770ab30a0bfb5190ecad58f5e02aa3ea76f2cb1aa969547fafe07b1f", size = 283909, upload-time = "2026-06-04T09:21:52.825Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/87/681d3026b4148e5e1ae683fdd4ae7d7f320d051a6fbf72b428fb8410ff2d/djangoql_iplweb-0.26.0-py3-none-any.whl", hash = "sha256:b18c9b778f1b9a3dab9835bf412e9b7510a2689095eec3bc0dd11c69e32d54ec", size = 315392, upload-time = "2026-06-05T07:49:17.124Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ dev = [
     { name = "django-debug-toolbar", specifier = ">=6.3.0" },
     { name = "django-dev-helpers", specifier = ">=0.1.11" },
     { name = "django-dynamic-fixture", specifier = ">=1.8.0" },
-    { name = "django-run-site", specifier = ">=0.16.0" },
+    { name = "django-run-site", specifier = ">=0.16.1" },
     { name = "django-webtest", specifier = "==1.9.14" },
     { name = "djlint", specifier = ">=1.36,<2" },
     { name = "ipdb", specifier = ">=0.13.9" },
@@ -2211,15 +2211,15 @@ wheels = [
 
 [[package]]
 name = "django-run-site"
-version = "0.16.0"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docker", marker = "platform_python_implementation != 'PyPy'" },
     { name = "testcontainers", extra = ["redis"], marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/d2/be1a7572bc7017f3289a95d8455dda0d6eff4caea0ed9e9e0ad4ffa1f78c/django_run_site-0.16.0.tar.gz", hash = "sha256:64dc96a65d5981ae5c38670e11f4123885f6762e5304c3eb1ccd7c4903049f9b", size = 160608, upload-time = "2026-06-01T12:28:08.2Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/72/e895be8b14f05b6c75dcc7013ea65ceb56d24b5bd0e74bdca7e05f61698d/django_run_site-0.16.1.tar.gz", hash = "sha256:1f8f668888bf098a396b25b0582e6f458e7c9f0a3e989c19c417876adce17882", size = 163046, upload-time = "2026-06-05T06:32:08.978Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/e1/d837158744e4b610ea79406b5f021056bc4a58cb7a6679ef8bf54c9e7690/django_run_site-0.16.0-py3-none-any.whl", hash = "sha256:c565e555de82e7a0e4e3cbd812ba35edf1c2e91a8200b2c8853cfa4b83b669b4", size = 99181, upload-time = "2026-06-01T12:28:06.248Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/87/b20a51b61d3f4ef6d638d757a23b5af7851a7757977cb1f5ae42a0f20f67/django_run_site-0.16.1-py3-none-any.whl", hash = "sha256:c26bb189f9ac516ea32279b301eff8dbf40d2a68c771143d2aaebd2a75614fa2", size = 99998, upload-time = "2026-06-05T06:32:07.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Cel

Dla uprawnionych użytkowników (superuser lub staff w grupie „wprowadzanie
danych") dodaje na stronie formularza Multiseek przycisk **„Pokaż jako
zapytanie DjangoQL"**. Otwiera szufladę (drawer) z równoważnym zapytaniem
DjangoQL nad modelem `Rekord` — do skopiowania albo otwarcia w istniejącym
edytorze zapytań (`/zapytanie/?model=rekord&query=…`). Multiseek i edytor
DjangoQL przeszukują **ten sam model**, więc to płynne przejście „łatwy
formularz → pełna moc zapytań".

## Co wchodzi

- **Silnik konwersji** (`src/bpp/multiseek_registry/djangoql_export.py`):
  chodzi po ramkach `form_data` jak `get_query_recursive`, renderuje liście
  jako fragmenty DjangoQL. Każdy QueryObject może nadpisać `to_djangoql`;
  domyślny dispatcher obsługuje string/int/decimal/date/autocomplete/range.
  - **Bramka poprawności**: każdy fragment jest walidowany względem
    `BppQLSchema(Rekord)` — nieprzekładalne pola degradują do *ostrzeżenia*,
    więc wynik zawsze się parsuje (best-effort, nigdy błędny output).
  - **Locale-correct**: mapy operatorów budowane per-call (operatory
    multiseek to leniwe `gettext` — zamrożenie kluczy przy imporcie psułoby
    dopasowanie pod językiem requestu).
  - **Priorytet `or`/`and`**: lewostronne grupowanie nawiasami (multiseek
    liczy `(A or B) and C`; gołe DjangoQL dałoby `A or (B and C)`).
  - **`andnot`** na liściu → inwersja operatora (De Morgan, parsowanie
    zakotwiczone za LHS, odporne na znaki operatorowe w wartości).
- **Wirtualne pole DjangoQL** `jednostka_z_podjednostkami__rel`
  (`src/bpp/djangoql_schema.py`): odwzorowuje multiseekowe „+ podrzędne"
  przez MPTT `get_family()`. Bonus: użyteczne też wprost w edytorze
  `/zapytanie/` i w wyszukiwarce adminów.
- **Wierne tłumaczenia pól** dla **jednostki** i **autora** (dwa
  najczęstsze kryteria) — każde z testem round-trip dowodzącym, że
  skonwertowane DjangoQL wybiera **ten sam** zbiór `Rekord` co multiseekowe
  `Q`. Podklasy z semantyką bez czystego odpowiednika (kolejność autorów,
  UNION jednostek) świadomie zwracają ostrzeżenie.
- **Endpoint** `POST /multiseek/do-djangoql/` (gated) + wspólny predykat
  `user_can_use_query_editor` (jedno źródło prawdy dla mixinu widoku,
  endpointu i filtru szablonowego) + filtr `can_use_query_editor`.
- **UI**: przycisk + szuflada Foundation (kopiuj + „Otwórz w edytorze
  zapytań"), warningi renderowane bezpiecznie (text-node, bez XSS),
  CSRF przez nagłówek.

## Test plan

- [x] 130 testów zielonych w 7 modułach (per-pole, ramki/priorytet, andnot,
      pole MPTT, round-trip fidelity jednostka+autor, endpoint 403/200/400,
      gating przycisku, filtr).
- [x] `pre-commit` czysty (ruff, ruff-format, djLint), `manage.py check` ok.
- [x] Weryfikacja w realnej przeglądarce: login → `/multiseek/` → klik →
      fetch → szuflada otwiera się z poprawnym DjangoQL (`tytul_oryginalny
      ~ ""`) i linkiem do edytora.
- [ ] Pełna suita CI (sharded) na PR.

Spec/plan: `docs/superpowers/specs/2026-06-04-multiseek-to-djangoql-design.md`,
`docs/superpowers/plans/2026-06-04-multiseek-to-djangoql.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)