### PR TITLE
perf(pbn_import): tnij szczyt pamięci importu źródeł (importuj_zrodla)

### DIFF
--- a/src/pbn_integrator/importer/sources.py
+++ b/src/pbn_integrator/importer/sources.py
@@ -80,14 +80,21 @@ def dopisz_jedno_zrodlo(pbn_journal, rodzaj_periodyk, dyscypliny_cache):
         Dyscyplina_Zrodla.objects.bulk_create(dyscypliny_zrodel, ignore_conflicts=True)
 
 
-def _process_journal_thread_safe(pbn_journal, rodzaj_periodyk, dyscypliny_cache):
-    """Thread-safe wrapper for processing a single journal."""
+def _process_journal_thread_safe(journal_id, rodzaj_periodyk, dyscypliny_cache):
+    """Thread-safe wrapper for processing a single journal.
+
+    Receives only the journal *id* and loads the full ``Journal`` (with its
+    heavy ``versions`` JSON) here, inside the worker thread, so the object is
+    freed as soon as the thread is done with it. Keeping at most
+    ``max_workers`` journals resident at once is what bounds peak memory.
+    """
     close_old_connections()
     try:
+        pbn_journal = Journal.objects.get(pk=journal_id)
         dopisz_jedno_zrodlo(pbn_journal, rodzaj_periodyk, dyscypliny_cache)
-        return {"success": True, "journal_id": pbn_journal.pk, "error": None}
+        return {"success": True, "journal_id": journal_id, "error": None}
     except Exception as e:
-        return {"success": False, "journal_id": pbn_journal.pk, "error": str(e)}
+        return {"success": False, "journal_id": journal_id, "error": str(e)}
     finally:
         close_old_connections()
 
@@ -100,15 +107,21 @@ def importuj_zrodla(max_workers=None, disable_threading=False):
     rodzaj_periodyk = Rodzaj_Zrodla.objects.get(nazwa="periodyk")
     dyscypliny_cache = {d.nazwa: d for d in Dyscyplina_Naukowa.objects.all()}
 
-    # Filter already imported - supports re-entrancy
+    # Filter already imported - supports re-entrancy.
+    # Gather only primary keys, never the full objects: each ``Journal`` row
+    # carries a large ``versions`` JSON blob, so materializing the whole table
+    # at once is what used to blow up memory. We load each journal lazily,
+    # inside the worker, where it is freed right after processing.
     imported_ids = Zrodlo.objects.filter(pbn_uid__isnull=False).values_list(
         "pbn_uid_id", flat=True
     )
-    journals = list(
-        Journal.objects.filter(status="ACTIVE").exclude(pk__in=Subquery(imported_ids))
+    journal_ids = list(
+        Journal.objects.filter(status="ACTIVE")
+        .exclude(pk__in=Subquery(imported_ids))
+        .values_list("pk", flat=True)
     )
 
-    if not journals:
+    if not journal_ids:
         return
 
     # Determine thread count
@@ -116,9 +129,13 @@ def importuj_zrodla(max_workers=None, disable_threading=False):
         max_workers = max(1, (os.cpu_count() or 4) * 3 // 4)
 
     if disable_threading or max_workers == 1:
-        # Sequential fallback
-        for journal in pbar(journals, label="Dopisywanie źródeł MNISW..."):
-            dopisz_jedno_zrodlo(journal, rodzaj_periodyk, dyscypliny_cache)
+        # Sequential fallback - load one journal at a time.
+        for journal_id in pbar(journal_ids, label="Dopisywanie źródeł MNISW..."):
+            dopisz_jedno_zrodlo(
+                Journal.objects.get(pk=journal_id),
+                rodzaj_periodyk,
+                dyscypliny_cache,
+            )
     else:
         # Parallel execution
         errors = []
@@ -126,11 +143,11 @@ def importuj_zrodla(max_workers=None, disable_threading=False):
             futures = {
                 executor.submit(
                     _process_journal_thread_safe,
-                    journal,
+                    journal_id,
                     rodzaj_periodyk,
                     dyscypliny_cache,
-                ): journal
-                for journal in journals
+                ): journal_id
+                for journal_id in journal_ids
             }
 
             for future in pbar(

--- a/src/pbn_integrator/tests/test_importuj_zrodla_memory.py
+++ b/src/pbn_integrator/tests/test_importuj_zrodla_memory.py
@@ -1,0 +1,95 @@
+"""Memory-footprint regression tests for ``importuj_zrodla``.
+
+The source import used to materialize *every* active ``Journal`` (each
+carrying a potentially large ``versions`` JSON blob) into one Python list
+and then capture each object twice inside the ``ThreadPoolExecutor``
+futures dict. Peak memory scaled with the whole journal table.
+
+The fix mirrors the already-memory-safe ``source_scoring_import``: gather
+only primary keys up front and load each full ``Journal`` lazily inside the
+worker thread, where it is garbage-collected right after processing. These
+tests lock in that contract:
+
+1. the thread worker accepts a journal *id* and loads the object itself;
+2. ``importuj_zrodla`` dispatches lightweight *ids* to the pool, never the
+   heavy ``Journal`` instances.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Rodzaj_Zrodla, Zrodlo
+from pbn_api.models import Journal
+
+
+def _make_active_journal(title="Testowe czasopismo"):
+    """Bake an ACTIVE PBN Journal with a usable ``current_version``."""
+    return baker.make(
+        Journal,
+        status="ACTIVE",
+        versions=[
+            {
+                "current": True,
+                "object": {
+                    "title": title,
+                    "issn": "1234-5678",
+                    "eissn": "",
+                    "points": {},
+                    "disciplines": [],
+                },
+            }
+        ],
+    )
+
+
+@pytest.mark.django_db
+def test_worker_accepts_id_and_loads_journal_lazily(monkeypatch):
+    """The worker takes a journal *id* (str) and loads the object itself.
+
+    Passing only the id is what keeps memory bounded: the heavy ``Journal``
+    (with its ``versions`` JSON) is fetched inside the thread and freed right
+    after, so at most ``max_workers`` journals are resident at once.
+    """
+    from pbn_integrator.importer import sources as sources_mod
+
+    # The worker calls ``close_old_connections()`` because it is meant to run
+    # in a pool thread; under a rolled-back test transaction that would close
+    # the connection and hide the just-created row. Stub the pool hygiene out
+    # so we can assert the lazy-load behavior we actually care about.
+    monkeypatch.setattr(sources_mod, "close_old_connections", lambda: None)
+
+    rodzaj_periodyk, _ = Rodzaj_Zrodla.objects.get_or_create(nazwa="periodyk")
+    journal = _make_active_journal()
+
+    result = sources_mod._process_journal_thread_safe(journal.pk, rodzaj_periodyk, {})
+
+    assert result["success"] is True, result
+    assert Zrodlo.objects.filter(pbn_uid_id=journal.pk).exists()
+
+
+@pytest.mark.django_db
+def test_importuj_zrodla_dispatches_ids_not_objects(monkeypatch):
+    """``importuj_zrodla`` must hand the pool ids, not ``Journal`` objects.
+
+    Dispatching ids (32-char strings) instead of fully-hydrated model
+    instances is the whole point of the memory fix.
+    """
+    from pbn_integrator.importer import sources as sources_mod
+
+    Rodzaj_Zrodla.objects.get_or_create(nazwa="periodyk")
+    _make_active_journal()
+
+    captured = []
+
+    def fake_worker(arg, rodzaj_periodyk, dyscypliny_cache):
+        captured.append(arg)
+        return {"success": True, "journal_id": arg, "error": None}
+
+    monkeypatch.setattr(sources_mod, "_process_journal_thread_safe", fake_worker)
+
+    sources_mod.importuj_zrodla(max_workers=2)
+
+    assert captured, "worker was never invoked"
+    assert all(isinstance(arg, str) for arg in captured), (
+        f"expected journal ids (str), got: {[type(a).__name__ for a in captured]}"
+    )


### PR DESCRIPTION
## Problem

Import z PBN — w szczególności **import źródeł (czasopism)** — powodował, że proces zajmował bardzo dużo pamięci (rzędu GB), prowadząc do OOM/swappingu na produkcji.

## Przyczyna

`importuj_zrodla` (`src/pbn_integrator/importer/sources.py`) materializowało **całą** tabelę `Journal` do listy Pythona:

```python
journals = list(Journal.objects.filter(status="ACTIVE").exclude(...))
```

Każdy `Journal` niesie ciężkie pole `versions` (JSONField — wszystkie wersje, punktacja 2017–2026, dyscypliny: multi-KB do dziesiątek-KB na wiersz). Następnie każdy obiekt był trzymany **podwójnie** w słowniku future-ów `ThreadPoolExecutora` (jako argument zadania **i** jako wartość dict), żywy aż do końca funkcji. Szczyt ≈ **2× cała tabela JSON-a**.

## Naprawa

Wzoruje się na już-bezpiecznym `source_scoring_import.py`: zbieramy wyłącznie klucze i ładujemy każdy `Journal` leniwie w workerze, gdzie jest zwalniany zaraz po przetworzeniu.

- `_process_journal_thread_safe` przyjmuje `journal_id` (string), robi `Journal.objects.get(pk=...)` w wątku.
- `importuj_zrodla` zbiera `values_list("pk", flat=True)` zamiast pełnych obiektów.
- `Subquery` zamiast `pk__in=list(...)` (wykluczenie zostaje w SQL).

Szczyt pamięci spada z „cała tabela JSON-a" (~GB) do „~max_workers obiektów" (dziesiątki MB), niezależnie od rozmiaru tabeli.

## Testy

`src/pbn_integrator/tests/test_importuj_zrodla_memory.py` (TDD, kontrakt napędzony RED→GREEN):
- worker przyjmuje **ID** i ładuje obiekt leniwie (tworzy `Zrodlo`);
- `importuj_zrodla` dyspozytuje do puli **ID-stringi**, nie obiekty `Journal`.

Lokalnie zielone (`5 passed` + regresja `test_integrator_import.py` `10 passed`), `ruff check`/`format` czyste.

## Zakres / dalsze kroki

To pierwszy z sześciu hotspotów zidentyfikowanych w audycie `pbn_integrator`. Pozostałe (publikacje, oświadczenia, wydawcy, DOI/ISBN) opisane w spec+planie:
- `docs/superpowers/specs/2026-06-04-pbn-import-pamiec-design.md`
- `docs/superpowers/plans/2026-06-04-pbn-import-pamiec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)