### PR TITLE
[codex] Add PBN import coverage tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 coverage.json
+coverage-*.json
 cov_html/
 *,cover
 

--- a/src/pbn_import/management/commands/fix_missing_imported_pubs.py
+++ b/src/pbn_import/management/commands/fix_missing_imported_pubs.py
@@ -127,7 +127,12 @@ Przykłady użycia:
 
         # Konwertuj do listy jeśli to QuerySet (dla możliwości filtrowania po typie)
         if hasattr(missing, "count"):
-            missing_count = missing.count()
+            try:
+                missing_count = missing.count()
+            except TypeError:
+                # ``get_missing_publications`` returns a plain list when --type
+                # filtering is used; list.count() requires an argument.
+                missing_count = len(missing)
             missing_list = list(missing)
         else:
             missing_list = list(missing)

--- a/src/pbn_import/management/commands/pbn_import.py
+++ b/src/pbn_import/management/commands/pbn_import.py
@@ -3,7 +3,6 @@
 import questionary
 from django.contrib.auth import get_user_model
 
-from bpp.models import Uczelnia
 from pbn_api.management.commands.util import PBNBaseCommand
 from pbn_import.models import ImportSession
 from pbn_import.utils import ImportManager
@@ -159,9 +158,8 @@ class Command(PBNBaseCommand):
             return None
         return user
 
-    def _ensure_pbn_integration(self):
+    def _ensure_pbn_integration(self, uczelnia):
         """Włącz integrację PBN jeśli wyłączona."""
-        uczelnia = Uczelnia.objects.get()
         if uczelnia and not uczelnia.pbn_integracja:
             uczelnia.pbn_integracja = True
             uczelnia.save(update_fields=["pbn_integracja"])
@@ -192,7 +190,8 @@ class Command(PBNBaseCommand):
             return
 
         # Włącz integrację PBN jeśli wyłączona
-        self._ensure_pbn_integration()
+        uczelnia = getattr(self, "_resolved_uczelnia", None)
+        self._ensure_pbn_integration(uczelnia)
 
         # Utwórz klienta PBN używając PBNBaseCommand.get_client()
         client = self.get_client(
@@ -212,7 +211,12 @@ class Command(PBNBaseCommand):
         self.stdout.write(f"Utworzono sesję importu {session.id}")
 
         # Utwórz i uruchom managera importu
-        manager = ImportManager(session=session, client=client, config=session.config)
+        manager = ImportManager(
+            session=session,
+            client=client,
+            config=session.config,
+            uczelnia=uczelnia,
+        )
 
         try:
             self.stdout.write("Rozpoczynam import...")

--- a/src/pbn_import/tests/test_command_helpers.py
+++ b/src/pbn_import/tests/test_command_helpers.py
@@ -1,0 +1,188 @@
+"""Tests for shared PBN import command helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import CommandError
+from model_bakery import baker
+
+from bpp.models import Jednostka, Uczelnia
+from pbn_api.exceptions import HttpException
+from pbn_import.utils.command_helpers import (
+    get_validated_default_jednostka,
+    import_publication_with_statements,
+)
+
+
+@pytest.mark.django_db
+def test_get_validated_default_jednostka_uses_explicit_unit_name():
+    uczelnia = baker.make(Uczelnia)
+    jednostka = baker.make(Jednostka, nazwa="Chosen unit", uczelnia=uczelnia)
+
+    assert get_validated_default_jednostka("Chosen unit", uczelnia) == jednostka
+
+
+@pytest.mark.django_db
+def test_get_validated_default_jednostka_rejects_missing_explicit_unit():
+    uczelnia = baker.make(Uczelnia)
+
+    with pytest.raises(CommandError, match="nie istnieje"):
+        get_validated_default_jednostka("Missing unit", uczelnia)
+
+
+def test_get_validated_default_jednostka_rejects_missing_or_ambiguous_uczelnia():
+    with patch(
+        "pbn_import.utils.command_helpers.Uczelnia.objects.count", return_value=0
+    ):
+        with pytest.raises(CommandError, match="Brak uczelni"):
+            get_validated_default_jednostka()
+
+    with patch(
+        "pbn_import.utils.command_helpers.Uczelnia.objects.count", return_value=2
+    ):
+        with pytest.raises(CommandError, match="więcej niż jedna uczelnia"):
+            get_validated_default_jednostka()
+
+
+@pytest.mark.django_db
+def test_get_validated_default_jednostka_creates_default_for_single_uczelnia():
+    uczelnia = baker.make(Uczelnia)
+    default = baker.make(Jednostka, uczelnia=uczelnia)
+
+    with patch(
+        "pbn_import.utils.command_helpers.Uczelnia.objects.count", return_value=1
+    ):
+        with patch(
+            "pbn_import.utils.command_helpers.Uczelnia.objects.get",
+            return_value=uczelnia,
+        ):
+            with patch(
+                "pbn_import.utils.command_helpers."
+                "znajdz_lub_utworz_jednostke_domyslna",
+                return_value=(default, False),
+            ):
+                assert get_validated_default_jednostka() == default
+
+
+def test_import_publication_with_statements_success():
+    publication = MagicMock()
+    client = MagicMock()
+    default_jednostka = MagicMock()
+
+    with patch(
+        "pbn_import.utils.command_helpers.importuj_publikacje_po_pbn_uid_id",
+        return_value=publication,
+    ) as import_publication:
+        with patch(
+            "pbn_import.utils.command_helpers."
+            "importuj_oswiadczenia_pojedynczej_publikacji",
+            return_value=(3, 2),
+        ) as import_statements:
+            result = import_publication_with_statements(
+                "pbn-1",
+                client,
+                default_jednostka,
+                force=True,
+                rodzaj_periodyk="periodical",
+                dyscypliny_cache={"2.3": "disc"},
+                inconsistency_callback="callback",
+            )
+
+    assert result == (publication, None, (3, 2))
+    import_publication.assert_called_once_with(
+        "pbn-1",
+        client=client,
+        default_jednostka=default_jednostka,
+        force=True,
+        rodzaj_periodyk="periodical",
+        dyscypliny_cache={"2.3": "disc"},
+        inconsistency_callback="callback",
+    )
+    import_statements.assert_called_once_with(
+        client,
+        "pbn-1",
+        default_jednostka=default_jednostka,
+        inconsistency_callback="callback",
+    )
+
+
+def test_import_publication_with_statements_skips_statements_when_disabled():
+    with patch(
+        "pbn_import.utils.command_helpers.importuj_publikacje_po_pbn_uid_id",
+        return_value=MagicMock(),
+    ):
+        with patch(
+            "pbn_import.utils.command_helpers."
+            "importuj_oswiadczenia_pojedynczej_publikacji"
+        ) as import_statements:
+            result, error_info, statement_counts = import_publication_with_statements(
+                "pbn-1",
+                MagicMock(),
+                MagicMock(),
+                with_statements=False,
+            )
+
+    assert result is not None
+    assert error_info is None
+    assert statement_counts is None
+    import_statements.assert_not_called()
+
+
+def test_import_publication_with_statements_keeps_publication_on_statement_http_error():
+    publication = MagicMock()
+
+    with patch(
+        "pbn_import.utils.command_helpers.importuj_publikacje_po_pbn_uid_id",
+        return_value=publication,
+    ):
+        with patch(
+            "pbn_import.utils.command_helpers."
+            "importuj_oswiadczenia_pojedynczej_publikacji",
+            side_effect=HttpException(404, "https://pbn.example.test", "not found"),
+        ):
+            result, error_info, statement_counts = import_publication_with_statements(
+                "pbn-1",
+                MagicMock(),
+                MagicMock(),
+            )
+
+    assert result == publication
+    assert error_info == {
+        "message": "Publikacja OK, błąd oświadczeń: HTTP 404",
+        "traceback": None,
+    }
+    assert statement_counts is None
+
+
+def test_import_publication_with_statements_reports_publication_http_error():
+    with patch(
+        "pbn_import.utils.command_helpers.importuj_publikacje_po_pbn_uid_id",
+        side_effect=HttpException(500, "https://pbn.example.test", "server exploded"),
+    ):
+        result, error_info, statement_counts = import_publication_with_statements(
+            "pbn-1",
+            MagicMock(),
+            MagicMock(),
+        )
+
+    assert result is None
+    assert "HTTP 500: server exploded" in error_info["message"]
+    assert "traceback" in error_info
+    assert statement_counts is None
+
+
+def test_import_publication_with_statements_reports_generic_error():
+    with patch(
+        "pbn_import.utils.command_helpers.importuj_publikacje_po_pbn_uid_id",
+        side_effect=RuntimeError("bad import"),
+    ):
+        result, error_info, statement_counts = import_publication_with_statements(
+            "pbn-1",
+            MagicMock(),
+            MagicMock(),
+        )
+
+    assert result is None
+    assert error_info["message"] == "bad import"
+    assert "traceback" in error_info
+    assert statement_counts is None

--- a/src/pbn_import/tests/test_command_pbn_import.py
+++ b/src/pbn_import/tests/test_command_pbn_import.py
@@ -1,0 +1,225 @@
+"""Tests for the modern ``pbn_import`` management command."""
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management.base import OutputWrapper
+from model_bakery import baker
+
+from bpp.models import Uczelnia
+from pbn_import.management.commands.pbn_import import (
+    Command,
+    build_config_from_options,
+)
+from pbn_import.models import ImportSession
+from pbn_import.utils.step_definitions import ALL_STEP_DEFINITIONS
+
+
+def command_options(**overrides):
+    options = {
+        "app_id": "app-id",
+        "app_token": "app-token",
+        "base_url": "https://pbn.example.test",
+        "user_token": "user-token",
+        "delete_existing": False,
+        "wydzial_domyslny": "Wydzial Domyslny",
+        "wydzial_domyslny_skrot": "WD",
+        "username": None,
+        "noinput": True,
+    }
+    for step in ALL_STEP_DEFINITIONS:
+        options[f"disable_{step['form_field']}"] = False
+    options.update(overrides)
+    return options
+
+
+def make_command():
+    command = Command()
+    command.stdout = OutputWrapper(StringIO())
+    command.stderr = OutputWrapper(StringIO())
+    return command
+
+
+def test_build_config_from_options_maps_all_step_disable_keys():
+    options = command_options(
+        delete_existing=True,
+        disable_zrodla=True,
+        disable_publikacje=True,
+    )
+
+    config = build_config_from_options(options)
+
+    assert config["app_id"] == "app-id"
+    assert config["base_url"] == "https://pbn.example.test"
+    assert config["delete_existing"] is True
+    assert config["disable_zrodla"] is True
+    assert config["disable_publikacje"] is True
+
+    for step in ALL_STEP_DEFINITIONS:
+        assert step["disable_key"] in config
+
+
+@pytest.mark.django_db
+def test_get_import_user_uses_explicit_username(django_user_model):
+    user = baker.make(django_user_model, username="chosen-user")
+
+    assert make_command()._get_import_user({"username": "chosen-user"}) == user
+
+
+@pytest.mark.django_db
+def test_get_import_user_falls_back_to_first_superuser(django_user_model):
+    baker.make(django_user_model, username="normal-user", is_superuser=False)
+    superuser = baker.make(django_user_model, username="admin-user", is_superuser=True)
+
+    assert make_command()._get_import_user({}) == superuser
+
+
+@pytest.mark.django_db
+def test_get_import_user_returns_none_without_superuser(django_user_model):
+    baker.make(django_user_model, username="normal-user", is_superuser=False)
+
+    assert make_command()._get_import_user({}) is None
+
+
+@pytest.mark.django_db
+def test_ensure_pbn_integration_enables_single_uczelnia():
+    uczelnia = baker.make(Uczelnia, pbn_integracja=False)
+
+    make_command()._ensure_pbn_integration(uczelnia)
+
+    uczelnia.refresh_from_db()
+    assert uczelnia.pbn_integracja is True
+
+
+@pytest.mark.django_db
+def test_handle_noinput_creates_session_and_runs_manager(django_user_model):
+    user = baker.make(django_user_model, username="import-user", is_superuser=False)
+    uczelnia = baker.make(Uczelnia, pbn_integracja=True)
+    command = make_command()
+    command._resolved_uczelnia = uczelnia
+    client = MagicMock()
+
+    with patch.object(command, "_ensure_pbn_integration") as ensure_integration:
+        with patch.object(command, "get_client", return_value=client) as get_client:
+            with patch(
+                "pbn_import.management.commands.pbn_import.ImportManager"
+            ) as manager_class:
+                manager_class.return_value.run.return_value = {
+                    "success": True,
+                    "results": {"initial_setup": {"ok": True}},
+                }
+
+                command.handle(**command_options(username=user.username))
+
+    ensure_integration.assert_called_once_with(uczelnia)
+    get_client.assert_called_once_with(
+        app_id="app-id",
+        app_token="app-token",
+        base_url="https://pbn.example.test",
+        user_token="user-token",
+    )
+    session = ImportSession.objects.get(user=user)
+    assert session.config["wydzial_domyslny"] == "Wydzial Domyslny"
+    assert session.config["disable_initial"] is False
+    manager_class.assert_called_once_with(
+        session=session,
+        client=client,
+        config=session.config,
+        uczelnia=uczelnia,
+    )
+
+
+@pytest.mark.django_db
+def test_handle_uses_resolved_uczelnia_for_integration_and_manager(django_user_model):
+    user = baker.make(django_user_model, username="import-user", is_superuser=False)
+    other_uczelnia = baker.make(Uczelnia, pbn_integracja=False)
+    resolved_uczelnia = baker.make(Uczelnia, pbn_integracja=False)
+    command = make_command()
+    command._resolved_uczelnia = resolved_uczelnia
+    client = MagicMock()
+
+    with patch.object(command, "get_client", return_value=client):
+        with patch("pbn_import.management.commands.pbn_import.ImportManager") as manager:
+            manager.return_value.run.return_value = {
+                "initial_setup": {"ok": True},
+            }
+
+            command.handle(**command_options(username=user.username))
+
+    other_uczelnia.refresh_from_db()
+    resolved_uczelnia.refresh_from_db()
+    assert other_uczelnia.pbn_integracja is False
+    assert resolved_uczelnia.pbn_integracja is True
+
+    session = ImportSession.objects.get(user=user)
+    manager.assert_called_once_with(
+        session=session,
+        client=client,
+        config=session.config,
+        uczelnia=resolved_uczelnia,
+    )
+
+
+@pytest.mark.django_db
+def test_handle_interactive_cancel_does_not_create_session(django_user_model):
+    baker.make(django_user_model, username="admin-user", is_superuser=True)
+    command = make_command()
+
+    with patch.object(command, "run_interactive", return_value=None):
+        command.handle(**command_options(noinput=False))
+
+    assert ImportSession.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_handle_reraises_manager_error_and_writes_session_error(django_user_model):
+    user = baker.make(django_user_model, username="import-user", is_superuser=False)
+    command = make_command()
+
+    with patch.object(command, "_ensure_pbn_integration"):
+        with patch.object(command, "get_client", return_value=MagicMock()):
+            with patch(
+                "pbn_import.management.commands.pbn_import.ImportManager"
+            ) as manager_class:
+                manager_class.return_value.run.side_effect = RuntimeError("boom")
+
+                with pytest.raises(RuntimeError, match="boom"):
+                    command.handle(**command_options(username=user.username))
+
+    assert ImportSession.objects.filter(user=user).exists()
+    assert "Import nieudany" in command.stderr._out.getvalue()
+
+
+def test_run_interactive_cancel_on_step_selection():
+    command = make_command()
+
+    with patch(
+        "pbn_import.management.commands.pbn_import.questionary.checkbox"
+    ) as checkbox:
+        checkbox.return_value.ask.return_value = None
+
+        assert command.run_interactive(command_options(noinput=False)) is None
+
+    assert "Anulowano" in command.stdout._out.getvalue()
+
+
+def test_run_interactive_applies_selected_steps_and_delete_choice():
+    command = make_command()
+    selected = ["initial", "publikacje"]
+
+    with patch(
+        "pbn_import.management.commands.pbn_import.questionary.checkbox"
+    ) as checkbox:
+        with patch(
+            "pbn_import.management.commands.pbn_import.questionary.confirm"
+        ) as confirm:
+            checkbox.return_value.ask.return_value = selected
+            confirm.return_value.ask.side_effect = [True, True]
+
+            options = command.run_interactive(command_options(noinput=False))
+
+    assert options["delete_existing"] is True
+    assert options["disable_initial"] is False
+    assert options["disable_publikacje"] is False
+    assert options["disable_zrodla"] is True

--- a/src/pbn_import/tests/test_consumers.py
+++ b/src/pbn_import/tests/test_consumers.py
@@ -1,0 +1,197 @@
+"""Tests for PBN import WebSocket consumer payloads."""
+
+import datetime
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from asgiref.sync import async_to_sync
+from django.utils import timezone
+from model_bakery import baker
+
+from pbn_import.consumers import ImportProgressConsumer
+from pbn_import.models import ImportLog, ImportSession
+
+
+def make_consumer(session_id, user):
+    consumer = ImportProgressConsumer()
+    consumer.session_id = session_id
+    consumer.room_group_name = f"import_{session_id}"
+    consumer.scope = {
+        "url_route": {"kwargs": {"session_id": session_id}},
+        "user": user,
+    }
+    consumer.channel_name = "test-channel"
+    consumer.channel_layer = AsyncMock()
+    consumer.accept = AsyncMock()
+    consumer.close = AsyncMock()
+    consumer.send = AsyncMock()
+    return consumer
+
+
+@pytest.mark.django_db(transaction=True)
+def test_connect_accepts_owner_and_sends_initial_status(django_user_model):
+    user = baker.make(django_user_model)
+    session = baker.make(
+        ImportSession,
+        user=user,
+        status="running",
+        current_step="source_import",
+        current_step_progress=25,
+        completed_steps=1,
+        total_steps=4,
+    )
+    consumer = make_consumer(session.pk, user)
+
+    async_to_sync(consumer.connect)()
+
+    consumer.channel_layer.group_add.assert_awaited_once_with(
+        f"import_{session.pk}", "test-channel"
+    )
+    consumer.accept.assert_awaited_once_with()
+    sent_payloads = [
+        json.loads(call.kwargs["text_data"]) for call in consumer.send.await_args_list
+    ]
+    assert sent_payloads[0]["type"] == "connection"
+    assert sent_payloads[1]["type"] == "status_update"
+    assert sent_payloads[1]["status"]["status"] == "running"
+    assert sent_payloads[1]["status"]["current_step"] == "source_import"
+    assert sent_payloads[1]["status"]["progress"] == session.overall_progress
+    assert sent_payloads[1]["status"]["completed_steps"] == 1
+    assert sent_payloads[1]["status"]["total_steps"] == 4
+    assert sent_payloads[1]["status"]["duration"]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_connect_closes_for_unauthenticated_user(django_user_model):
+    owner = baker.make(django_user_model)
+    session = baker.make(ImportSession, user=owner)
+    anonymous = type("Anonymous", (), {"is_authenticated": False})()
+    consumer = make_consumer(session.pk, anonymous)
+
+    async_to_sync(consumer.connect)()
+
+    consumer.close.assert_awaited_once_with()
+    consumer.accept.assert_not_awaited()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_staff_user_can_view_foreign_session(django_user_model):
+    owner = baker.make(django_user_model)
+    staff = baker.make(django_user_model, is_staff=True)
+    session = baker.make(ImportSession, user=owner)
+    consumer = make_consumer(session.pk, staff)
+
+    assert async_to_sync(consumer.has_permission)() is True
+
+
+@pytest.mark.django_db(transaction=True)
+def test_has_permission_false_for_missing_session(django_user_model):
+    user = baker.make(django_user_model)
+    consumer = make_consumer(999_999, user)
+
+    assert async_to_sync(consumer.has_permission)() is False
+
+
+@pytest.mark.django_db(transaction=True)
+def test_get_recent_logs_returns_oldest_first(django_user_model):
+    user = baker.make(django_user_model)
+    session = baker.make(ImportSession, user=user)
+    older = baker.make(ImportLog, session=session, level="info", message="older")
+    newer = baker.make(ImportLog, session=session, level="warning", message="newer")
+    now = timezone.now()
+    ImportLog.objects.filter(pk=older.pk).update(
+        timestamp=now - datetime.timedelta(minutes=1)
+    )
+    ImportLog.objects.filter(pk=newer.pk).update(timestamp=now)
+    consumer = make_consumer(session.pk, user)
+
+    logs = async_to_sync(consumer.get_recent_logs)(limit=2)
+
+    assert [log["message"] for log in logs] == [older.message, newer.message]
+    assert logs[0]["level"] == "info"
+    assert "timestamp" in logs[0]
+
+
+def test_receive_ping_status_and_logs_requests():
+    consumer = make_consumer(1, user=object())
+    consumer.send_current_status = AsyncMock()
+    consumer.send_recent_logs = AsyncMock()
+
+    async_to_sync(consumer.receive)(
+        text_data=json.dumps({"type": "ping", "timestamp": "t1"})
+    )
+    async_to_sync(consumer.receive)(text_data=json.dumps({"type": "request_status"}))
+    async_to_sync(consumer.receive)(text_data=json.dumps({"type": "request_logs"}))
+
+    assert json.loads(consumer.send.await_args.kwargs["text_data"]) == {
+        "type": "pong",
+        "timestamp": "t1",
+    }
+    consumer.send_current_status.assert_awaited_once_with()
+    consumer.send_recent_logs.assert_awaited_once_with()
+
+
+def test_event_handlers_serialize_payloads():
+    consumer = make_consumer(1, user=object())
+
+    async_to_sync(consumer.import_update)({"data": {"progress": 10}})
+    async_to_sync(consumer.progress_update)(
+        {"progress": 50, "current_step": "step", "message": "msg"}
+    )
+    async_to_sync(consumer.log_entry)(
+        {
+            "timestamp": "2026-06-05T10:00:00",
+            "level": "info",
+            "step": "source_import",
+            "message": "done",
+        }
+    )
+    async_to_sync(consumer.status_change)(
+        {"old_status": "running", "new_status": "completed", "message": "ok"}
+    )
+    async_to_sync(consumer.statistics_update)({"statistics": {"x": 1}})
+    async_to_sync(consumer.completion_notification)(
+        {"success": True, "message": "completed"}
+    )
+
+    payloads = [
+        json.loads(call.kwargs["text_data"]) for call in consumer.send.await_args_list
+    ]
+    assert payloads == [
+        {"type": "import_update", "data": {"progress": 10}},
+        {
+            "type": "progress_update",
+            "progress": 50,
+            "current_step": "step",
+            "message": "msg",
+        },
+        {
+            "type": "log_entry",
+            "log": {
+                "timestamp": "2026-06-05T10:00:00",
+                "level": "info",
+                "step": "source_import",
+                "message": "done",
+            },
+        },
+        {
+            "type": "status_change",
+            "old_status": "running",
+            "new_status": "completed",
+            "message": "ok",
+        },
+        {"type": "statistics_update", "statistics": {"x": 1}},
+        {"type": "completion", "success": True, "message": "completed"},
+    ]
+
+
+def test_disconnect_removes_channel_from_group():
+    consumer = make_consumer(123, user=object())
+    consumer.room_group_name = "import_123"
+
+    async_to_sync(consumer.disconnect)(1000)
+
+    consumer.channel_layer.group_discard.assert_awaited_once_with(
+        "import_123", "test-channel"
+    )

--- a/src/pbn_import/tests/test_error_handling.py
+++ b/src/pbn_import/tests/test_error_handling.py
@@ -1,12 +1,17 @@
 """Tests for error handling in PBN import"""
 
 import traceback
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from pbn_import.models import ImportLog, ImportSession
-from pbn_import.utils.base import ImportStepBase
+from pbn_import.utils.base import (
+    CancelledException,
+    ImportStepBase,
+    TqdmSessionProgress,
+    pbar_with_callback,
+)
 
 
 @pytest.mark.django_db
@@ -164,3 +169,130 @@ def test_handle_pbn_error_non_auth():
         log = ImportLog.objects.filter(session=session, level="error").first()
         assert log is not None
         assert "Regular error" in log.message
+
+
+@pytest.mark.django_db
+def test_tqdm_session_progress_updates_throttles_and_clears(django_user_model):
+    user = django_user_model.objects.create_user(username="progress-user")
+    session = ImportSession.objects.create(user=user)
+    progress = TqdmSessionProgress(session, "batch")
+
+    with patch("pbn_import.utils.base.time.time", return_value=100.0):
+        progress.update(1, 4, "first")
+
+    session.refresh_from_db()
+    assert session.progress_data["current_subtask"] == {
+        "name": "batch",
+        "description": "first",
+        "current": 1,
+        "total": 4,
+        "percentage": 25,
+    }
+
+    with patch("pbn_import.utils.base.time.time", return_value=100.1):
+        progress.update(2, 4, "throttled")
+
+    session.refresh_from_db()
+    assert session.progress_data["current_subtask"]["description"] == "first"
+
+    with patch("pbn_import.utils.base.time.time", return_value=100.2):
+        progress.update(4, 4, "done")
+
+    session.refresh_from_db()
+    assert session.progress_data["current_subtask"]["description"] == "done"
+    assert session.progress_data["current_subtask"]["percentage"] == 100
+
+    progress.clear()
+    session.refresh_from_db()
+    assert "current_subtask" not in session.progress_data
+
+
+def test_pbar_with_callback_updates_and_clears_callback():
+    callback = MagicMock()
+
+    class FakeTqdm:
+        def __init__(self, iterator, **kwargs):
+            self.iterator = iterator
+
+        def __enter__(self):
+            return iter(self.iterator)
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("tqdm.tqdm", side_effect=lambda iterator, **kwargs: FakeTqdm(iterator)):
+        assert list(pbar_with_callback(["a", "b"], 2, "desc", callback)) == [
+            "a",
+            "b",
+        ]
+
+    assert callback.update.call_args_list == [
+        call(1, 2, "desc"),
+        call(2, 2, "desc"),
+    ]
+    callback.clear.assert_called_once_with()
+
+
+def test_pbar_with_callback_raises_when_cancelled():
+    class FakeTqdm:
+        def __init__(self, iterator, **kwargs):
+            self.iterator = iterator
+
+        def __enter__(self):
+            return iter(self.iterator)
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("tqdm.tqdm", side_effect=lambda iterator, **kwargs: FakeTqdm(iterator)):
+        with pytest.raises(CancelledException, match="Import został anulowany"):
+            list(
+                pbar_with_callback(
+                    range(20),
+                    20,
+                    "desc",
+                    check_cancel_func=lambda: True,
+                )
+            )
+
+
+@pytest.mark.django_db
+def test_import_step_base_call_runs_start_finish_and_returns(django_user_model):
+    user = django_user_model.objects.create_user(username="call-user")
+    session = ImportSession.objects.create(user=user)
+
+    class SuccessfulStep(ImportStepBase):
+        step_name = "successful_step"
+        step_description = "Successful step"
+
+        def run(self):
+            return {"ok": True}
+
+    result = SuccessfulStep(session).__call__()
+
+    session.refresh_from_db()
+    assert result == {"ok": True}
+    assert session.current_step == "successful_step"
+    assert ImportLog.objects.filter(session=session, level="success").exists()
+
+
+@pytest.mark.django_db
+def test_import_step_base_call_logs_and_reraises_run_error(django_user_model):
+    user = django_user_model.objects.create_user(username="fail-user")
+    session = ImportSession.objects.create(user=user)
+
+    class FailingStep(ImportStepBase):
+        step_name = "failing_step"
+
+        def run(self):
+            raise RuntimeError("run failed")
+
+    with patch("pbn_import.utils.base.rollbar.report_exc_info"):
+        with pytest.raises(RuntimeError, match="run failed"):
+            FailingStep(session).__call__()
+
+    assert ImportLog.objects.filter(
+        session=session,
+        level="error",
+        message__contains="Krytyczny błąd w failing_step",
+    ).exists()

--- a/src/pbn_import/tests/test_fix_commands.py
+++ b/src/pbn_import/tests/test_fix_commands.py
@@ -1,0 +1,761 @@
+"""Focused unit tests for PBN import repair management commands."""
+
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
+from django.core.management.base import CommandError, OutputWrapper
+
+from pbn_import.management.commands.fix_import_dat_oswiadczen_pbn import (
+    Command as StatementDateCommand,
+)
+from pbn_import.management.commands.fix_missing_imported_pubs import (
+    Command as MissingPublicationCommand,
+)
+from pbn_import.management.commands.fix_pbn_import_oswiadczen_ksiazki import (
+    Command as BookStatementTypeCommand,
+)
+
+
+def make_command(command_cls):
+    command = command_cls()
+    command.stdout = OutputWrapper(StringIO())
+    command.stderr = OutputWrapper(StringIO())
+    return command
+
+
+@pytest.mark.parametrize(
+    "options,expected",
+    [
+        ({"rok": None, "rok_min": None, "rok_max": None}, None),
+        ({"rok": 2024, "rok_min": None, "rok_max": None}, (2024, 2024)),
+        ({"rok": None, "rok_min": 2022, "rok_max": 2025}, (2022, 2025)),
+    ],
+)
+def test_statement_date_year_range(options, expected):
+    command = make_command(StatementDateCommand)
+
+    command._validate_year_parameters(options)
+
+    assert command._get_year_range(options) == expected
+
+
+@pytest.mark.parametrize(
+    "options,message",
+    [
+        (
+            {"rok": 2024, "rok_min": 2022, "rok_max": None},
+            "Nie można używać --rok",
+        ),
+        (
+            {"rok": None, "rok_min": 2022, "rok_max": None},
+            "muszą być używane razem",
+        ),
+        (
+            {"rok": None, "rok_min": 2025, "rok_max": 2022},
+            "nie może być większy",
+        ),
+    ],
+)
+def test_statement_date_rejects_invalid_year_parameters(options, message):
+    command = make_command(StatementDateCommand)
+
+    with pytest.raises(CommandError, match=message):
+        command._validate_year_parameters(options)
+
+
+def test_statement_date_should_skip_by_year():
+    command = make_command(StatementDateCommand)
+    author_link = SimpleNamespace(rekord=SimpleNamespace(rok=2024))
+
+    assert command._should_skip_by_year(author_link, None) is False
+    assert command._should_skip_by_year(author_link, (2020, 2023)) is True
+    assert command._should_skip_by_year(author_link, (2024, 2024)) is False
+
+
+def test_statement_date_parser_accepts_repair_options():
+    parser = make_command(StatementDateCommand).create_parser(
+        "manage.py",
+        "fix_import_dat_oswiadczen_pbn",
+    )
+
+    options = parser.parse_args(["--dry-run", "--nadpisz", "--rok", "2024"])
+
+    assert options.dry_run is True
+    assert options.nadpisz is True
+    assert options.rok == 2024
+
+
+def test_statement_date_print_config_info_for_dry_run_and_year_range():
+    command = make_command(StatementDateCommand)
+
+    command._print_config_info(dry_run=True, nadpisz=True, year_range=(2022, 2025))
+
+    output = command.stdout._out.getvalue()
+    assert "TRYB TESTOWY" in output
+    assert "Lata do przetworzenia: 2022-2025" in output
+    assert "Tryb nadpisywania" in output
+
+
+def test_statement_date_print_config_info_for_all_years_without_overwrite():
+    command = make_command(StatementDateCommand)
+
+    command._print_config_info(dry_run=False, nadpisz=False, year_range=None)
+
+    output = command.stdout._out.getvalue()
+    assert "Przetwarzanie wszystkich lat" in output
+    assert "Aktualizacja tylko rekordów z pustą datą" in output
+
+
+def test_statement_date_summary_reports_missing_and_skipped_counts():
+    command = make_command(StatementDateCommand)
+
+    command._print_summary(
+        updated_count=2,
+        skipped_year_filter=3,
+        skipped_existing_date=4,
+        missing_publication=[("pub-1", "Title")],
+        missing_autor=[("person-1", "Jan Kowalski")],
+        missing_link=[("Book title", "Jan Kowalski", 2024, "pub-2")],
+    )
+
+    output = command.stdout._out.getvalue()
+    assert "Zaktualizowano: 2" in output
+    assert "Pominięto (brak powiązania): 3" in output
+    assert "Pominięto (filtr roku): 3" in output
+    assert "Pominięto (istniejąca data): 4" in output
+
+
+def test_statement_date_missing_details_truncates_long_lists():
+    command = make_command(StatementDateCommand)
+
+    command._print_missing_details(
+        list(range(16)),
+        "Braki",
+        lambda item: f"item-{item}",
+    )
+
+    output = command.stdout._out.getvalue()
+    assert "Braki (16)" in output
+    assert "item-0" in output
+    assert "... i 1 więcej" in output
+
+
+def test_missing_publication_prepare_list_applies_limit():
+    command = make_command(MissingPublicationCommand)
+
+    class FakeQuerySet:
+        def __init__(self, items):
+            self.items = items
+
+        def count(self):
+            return len(self.items)
+
+        def __iter__(self):
+            return iter(self.items)
+
+    with patch.object(
+        command,
+        "get_missing_publications",
+        return_value=FakeQuerySet([1, 2, 3]),
+    ):
+        missing_list, missing_count = command._prepare_missing_list({"limit": 2})
+
+    assert missing_list == [1, 2]
+    assert missing_count == 3
+
+
+def test_missing_publication_prepare_list_accepts_list_from_type_filter():
+    command = make_command(MissingPublicationCommand)
+
+    with patch.object(command, "get_missing_publications", return_value=[1, 2, 3]):
+        missing_list, missing_count = command._prepare_missing_list({"limit": None})
+
+    assert missing_list == [1, 2, 3]
+    assert missing_count == 3
+
+
+def test_missing_publication_get_missing_publications_filters_by_uid():
+    command = make_command(MissingPublicationCommand)
+    rekord_qs = MagicMock()
+    rekord_qs.exclude.return_value = rekord_qs
+    rekord_qs.values_list.return_value = ["existing-pub"]
+    missing_qs = MagicMock()
+
+    with patch(
+        "pbn_import.management.commands.fix_missing_imported_pubs.Rekord.objects"
+    ) as rekordy:
+        with patch(
+            "pbn_import.management.commands.fix_missing_imported_pubs."
+            "Publication.objects"
+        ) as publications:
+            rekordy.exclude.return_value = rekord_qs
+            publications.exclude.return_value = missing_qs
+            missing_qs.filter.return_value = "filtered"
+
+            result = command.get_missing_publications(
+                {"pbn_uid": "target-pub", "type": None}
+            )
+
+    assert result == "filtered"
+    publications.exclude.assert_called_once_with(pk__in={"existing-pub"})
+    missing_qs.filter.assert_called_once_with(pk="target-pub")
+
+
+def test_missing_publication_get_missing_publications_filters_by_type():
+    command = make_command(MissingPublicationCommand)
+    rekord_qs = MagicMock()
+    rekord_qs.exclude.return_value = rekord_qs
+    rekord_qs.values_list.return_value = []
+    article = SimpleNamespace(current_version={"object": {"type": "ARTICLE"}})
+    book = SimpleNamespace(current_version={"object": {"type": "BOOK"}})
+    without_version = SimpleNamespace(current_version=None)
+
+    with patch(
+        "pbn_import.management.commands.fix_missing_imported_pubs.Rekord.objects"
+    ) as rekordy:
+        with patch(
+            "pbn_import.management.commands.fix_missing_imported_pubs."
+            "Publication.objects"
+        ) as publications:
+            rekordy.exclude.return_value = rekord_qs
+            publications.exclude.return_value = [article, book, without_version]
+
+            result = command.get_missing_publications({"pbn_uid": None, "type": "BOOK"})
+
+    assert result == [book]
+
+
+def test_missing_publication_parser_accepts_repair_options():
+    parser = make_command(MissingPublicationCommand).create_parser(
+        "manage.py",
+        "fix_missing_imported_pubs",
+    )
+
+    options = parser.parse_args(
+        [
+            "--dry-run",
+            "--pbn-uid",
+            "pub-1",
+            "--type",
+            "BOOK",
+            "--limit",
+            "5",
+            "--max-errors",
+            "2",
+            "--verbose",
+        ]
+    )
+
+    assert options.dry_run is True
+    assert options.pbn_uid == "pub-1"
+    assert options.type == "BOOK"
+    assert options.limit == 5
+    assert options.max_errors == 2
+    assert options.verbose is True
+
+
+def test_missing_publication_process_single_publication_imported():
+    command = make_command(MissingPublicationCommand)
+    publication = SimpleNamespace(
+        pk="pub-1",
+        mongoId="mongo-1",
+        year=2024,
+        current_version={"object": {"title": "Publication title"}},
+    )
+
+    with patch(
+        "pbn_import.management.commands.fix_missing_imported_pubs."
+        "import_publication_with_statements",
+        return_value=("bpp-record", None, (2, 0)),
+    ) as import_publication:
+        status, data = command._process_single_publication(
+            publication,
+            client="client",
+            default_jednostka="unit",
+            rodzaj_periodyk="periodic",
+            dyscypliny_cache={"discipline": "object"},
+            verbose=False,
+        )
+
+    import_publication.assert_called_once_with(
+        "mongo-1",
+        "client",
+        "unit",
+        force=False,
+        with_statements=True,
+        rodzaj_periodyk="periodic",
+        dyscypliny_cache={"discipline": "object"},
+    )
+    assert status == "imported"
+    assert data == 2
+
+
+def test_missing_publication_process_single_publication_error():
+    command = make_command(MissingPublicationCommand)
+    publication = SimpleNamespace(
+        pk="pub-1",
+        mongoId="mongo-1",
+        year=2024,
+        current_version={"object": {"title": "Publication title"}},
+    )
+
+    with patch(
+        "pbn_import.management.commands.fix_missing_imported_pubs."
+        "import_publication_with_statements",
+        return_value=(None, {"message": "cannot import", "traceback": "tb"}, None),
+    ):
+        status, data = command._process_single_publication(
+            publication,
+            client="client",
+            default_jednostka="unit",
+            rodzaj_periodyk=None,
+            dyscypliny_cache={},
+            verbose=True,
+        )
+
+    assert status == "error"
+    assert data == {
+        "pbn_uid": "pub-1",
+        "title": "Publication title",
+        "year": 2024,
+        "message": "cannot import",
+        "traceback": "tb",
+    }
+    assert "Błąd dla pub-1" in command.stderr._out.getvalue()
+
+
+def test_missing_publication_process_single_publication_skipped():
+    command = make_command(MissingPublicationCommand)
+    publication = SimpleNamespace(
+        pk="pub-1",
+        mongoId="mongo-1",
+        year=2024,
+        current_version=None,
+    )
+
+    with patch(
+        "pbn_import.management.commands.fix_missing_imported_pubs."
+        "import_publication_with_statements",
+        return_value=(None, None, None),
+    ):
+        status, data = command._process_single_publication(
+            publication,
+            client="client",
+            default_jednostka="unit",
+            rodzaj_periodyk=None,
+            dyscypliny_cache={},
+            verbose=True,
+        )
+
+    assert status == "skipped"
+    assert data is None
+    assert "Pominięto: pub-1" in command.stdout._out.getvalue()
+
+
+def test_missing_publication_dry_run_summary_reports_all_sections():
+    command = make_command(MissingPublicationCommand)
+
+    command._display_dry_run_summary(
+        imported=2,
+        skipped=3,
+        errors=[{"pbn_uid": "pub-1"}],
+        statements_total=4,
+    )
+
+    output = command.stdout._out.getvalue()
+    assert "TRYB DRY-RUN" in output
+    assert "Zaimportowano by: 2" in output
+    assert "Oświadczeń by: 4" in output
+    assert "Pominięto by: 3" in output
+    assert "Błędów: 1" in output
+
+
+def test_missing_publication_display_summary_reports_errors_and_traceback():
+    command = make_command(MissingPublicationCommand)
+
+    command._display_summary(
+        imported=1,
+        skipped=2,
+        errors=[
+            {
+                "pbn_uid": "pub-1",
+                "title": "Very long title " * 10,
+                "year": 2024,
+                "message": "cannot import",
+                "traceback": "traceback text",
+            }
+        ],
+        statements_total=3,
+        stopped_early=True,
+    )
+
+    output = command.stdout._out.getvalue()
+    assert "Zaimportowano: 1" in output
+    assert "Oświadczeń: 3" in output
+    assert "Pominięto: 2" in output
+    assert "Import przerwany" in output
+    assert "PBN UID: pub-1" in output
+    assert "traceback text" in output
+
+
+def test_missing_publication_handle_inner_returns_when_no_missing():
+    command = make_command(MissingPublicationCommand)
+
+    with patch.object(command, "_prepare_missing_list", return_value=([], 0)):
+        command._handle_inner({"limit": None}, dry_run=False)
+
+    assert "Wszystkie publikacje PBN" in command.stdout._out.getvalue()
+
+
+def test_missing_publication_handle_inner_imports_and_displays_summary():
+    command = make_command(MissingPublicationCommand)
+    default_jednostka = SimpleNamespace(__str__=lambda self: "Default unit")
+
+    with patch.object(command, "_prepare_missing_list", return_value=(["pub"], 1)):
+        with patch(
+            "pbn_import.management.commands.fix_missing_imported_pubs."
+            "get_validated_default_jednostka",
+            return_value=default_jednostka,
+        ):
+            with patch.object(command, "get_client", return_value="client"):
+                with patch.object(
+                    command,
+                    "_import_publications",
+                    return_value=(1, 0, [], 3, False),
+                ) as import_publications:
+                    with patch.object(command, "_display_summary") as display_summary:
+                        command._handle_inner(
+                            {
+                                "limit": None,
+                                "jednostka": None,
+                                "app_id": "app-id",
+                                "app_token": "app-token",
+                                "base_url": "https://pbn.example.test",
+                                "user_token": "user-token",
+                                "verbose": False,
+                            },
+                            dry_run=False,
+                        )
+
+    import_publications.assert_called_once_with(
+        ["pub"], "client", default_jednostka, ANY
+    )
+    display_summary.assert_called_once_with(1, 0, [], 3, False)
+
+
+def test_book_statement_type_expected_type():
+    command = make_command(BookStatementTypeCommand)
+    typ_autor = SimpleNamespace(nazwa="autor")
+    typ_redaktor = SimpleNamespace(nazwa="redaktor")
+
+    assert (
+        command._get_expected_typ(SimpleNamespace(type="AUTHOR"), typ_autor, typ_redaktor)
+        is typ_autor
+    )
+    assert (
+        command._get_expected_typ(SimpleNamespace(type="EDITOR"), typ_autor, typ_redaktor)
+        is typ_redaktor
+    )
+    with pytest.raises(ValueError, match="Nieznany typ"):
+        command._get_expected_typ(
+            SimpleNamespace(type="TRANSLATOR"),
+            typ_autor,
+            typ_redaktor,
+        )
+
+
+def test_book_statement_type_parser_accepts_repair_options():
+    parser = make_command(BookStatementTypeCommand).create_parser(
+        "manage.py",
+        "fix_pbn_import_oswiadczen_ksiazki",
+    )
+
+    options = parser.parse_args(
+        [
+            "--dry-run",
+            "--verbose",
+            "--publikacja",
+            "pub-1",
+            "--integruj-dyscypliny",
+        ]
+    )
+
+    assert options.dry_run is True
+    assert options.verbose is True
+    assert options.publikacja == "pub-1"
+    assert options.integruj_dyscypliny is True
+
+
+def test_book_statement_type_print_config_info():
+    command = make_command(BookStatementTypeCommand)
+
+    command._print_config_info(
+        {
+            "dry_run": True,
+            "publikacja": "pub-1",
+            "integruj_dyscypliny": True,
+        }
+    )
+
+    output = command.stdout._out.getvalue()
+    assert "TRYB TESTOWY" in output
+    assert "Przetwarzanie publikacji: pub-1" in output
+    assert "Integracja dyscyplin: TAK" in output
+
+
+def test_book_statement_type_print_config_info_for_all_books():
+    command = make_command(BookStatementTypeCommand)
+
+    command._print_config_info(
+        {
+            "dry_run": False,
+            "publikacja": None,
+            "integruj_dyscypliny": False,
+        }
+    )
+
+    assert "Przetwarzanie wszystkich książek z PBN" in command.stdout._out.getvalue()
+
+
+def test_book_statement_type_print_summary_reports_errors():
+    command = make_command(BookStatementTypeCommand)
+
+    command._print_summary(
+        fixed_count=2,
+        skipped_no_wa=3,
+        skipped_matching=4,
+        errors=[f"error-{index}" for index in range(12)],
+    )
+
+    output = command.stdout._out.getvalue()
+    assert "Naprawiono: 2" in output
+    assert "brak powiązania autor-publikacja): 3" in output
+    assert "typ już zgodny): 4" in output
+    assert "Błędy: 12" in output
+    assert "... i 2 więcej" in output
+
+
+def test_book_statement_type_get_books_queryset_filters_existing_publication():
+    command = make_command(BookStatementTypeCommand)
+    queryset = MagicMock()
+    queryset.filter.return_value.exists.return_value = True
+
+    with patch(
+        "pbn_import.management.commands.fix_pbn_import_oswiadczen_ksiazki."
+        "Wydawnictwo_Zwarte.objects"
+    ) as objects:
+        objects.exclude.return_value = queryset
+
+        assert command._get_books_queryset("pub-1") == queryset.filter.return_value
+
+    objects.exclude.assert_called_once_with(pbn_uid_id=None)
+    queryset.filter.assert_called_once_with(pbn_uid_id="pub-1")
+
+
+def test_book_statement_type_get_books_queryset_rejects_missing_publication():
+    command = make_command(BookStatementTypeCommand)
+    queryset = MagicMock()
+    queryset.filter.return_value.exists.return_value = False
+
+    with patch(
+        "pbn_import.management.commands.fix_pbn_import_oswiadczen_ksiazki."
+        "Wydawnictwo_Zwarte.objects"
+    ) as objects:
+        objects.exclude.return_value = queryset
+
+        with pytest.raises(CommandError, match="Nie znaleziono publikacji"):
+            command._get_books_queryset("missing")
+
+
+def test_book_statement_type_update_counters():
+    command = make_command(BookStatementTypeCommand)
+    counters = {"fixed": 0, "no_wa": 0, "matching": 0, "to_integrate": []}
+    statement = object()
+
+    command._update_counters("fixed", counters, statement, integruj_dyscypliny=True)
+    command._update_counters("no_wa", counters, statement, integruj_dyscypliny=True)
+    command._update_counters("matching", counters, statement, integruj_dyscypliny=True)
+
+    assert counters == {
+        "fixed": 1,
+        "no_wa": 1,
+        "matching": 1,
+        "to_integrate": [statement],
+    }
+
+
+def test_book_statement_type_find_author_record_branches():
+    command = make_command(BookStatementTypeCommand)
+
+    class DoesNotExist(Exception):
+        pass
+
+    class MultipleObjectsReturned(Exception):
+        pass
+
+    manager_model = SimpleNamespace(
+        DoesNotExist=DoesNotExist,
+        MultipleObjectsReturned=MultipleObjectsReturned,
+    )
+    manager = MagicMock(model=manager_model)
+    book = SimpleNamespace(
+        autorzy_set=manager,
+        tytul_oryginalny="Book title",
+    )
+    expected_typ = SimpleNamespace(nazwa="redaktor")
+
+    manager.get.return_value = "wa"
+    assert command._find_autor_record(book, "autor", expected_typ, verbose=False) == (
+        "wa",
+        None,
+    )
+
+    manager.reset_mock()
+    manager.get.side_effect = DoesNotExist
+    assert command._find_autor_record(book, "autor", expected_typ, verbose=True) == (
+        None,
+        "no_wa",
+    )
+
+    manager.reset_mock()
+    manager.get.side_effect = [MultipleObjectsReturned, "matching-wa"]
+    assert command._find_autor_record(book, "autor", expected_typ, verbose=False) == (
+        None,
+        "matching",
+    )
+
+    fallback_wa = object()
+    manager.reset_mock()
+    manager.get.side_effect = [MultipleObjectsReturned, DoesNotExist]
+    manager.filter.return_value.first.return_value = fallback_wa
+    assert command._find_autor_record(book, "autor", expected_typ, verbose=False) == (
+        fallback_wa,
+        None,
+    )
+
+
+def test_book_statement_type_process_single_statement_updates_mismatched_type():
+    command = make_command(BookStatementTypeCommand)
+    typ_autor = SimpleNamespace(nazwa="autor")
+    typ_redaktor = SimpleNamespace(nazwa="redaktor")
+    wa = SimpleNamespace(
+        typ_odpowiedzialnosci=typ_autor,
+        save=MagicMock(),
+    )
+    book = SimpleNamespace(tytul_oryginalny="Book title")
+    statement = SimpleNamespace(
+        type="EDITOR",
+        get_bpp_autor=MagicMock(return_value="BPP author"),
+    )
+
+    with patch.object(command, "_find_autor_record", return_value=(wa, None)):
+        result = command._process_single_statement(
+            book,
+            statement,
+            typ_autor,
+            typ_redaktor,
+            dry_run=False,
+            verbose=True,
+        )
+
+    assert result == "fixed"
+    assert wa.typ_odpowiedzialnosci is typ_redaktor
+    wa.save.assert_called_once_with(update_fields=["typ_odpowiedzialnosci"])
+
+
+def test_book_statement_type_process_single_statement_dry_run_does_not_save():
+    command = make_command(BookStatementTypeCommand)
+    typ_autor = SimpleNamespace(nazwa="autor")
+    typ_redaktor = SimpleNamespace(nazwa="redaktor")
+    wa = SimpleNamespace(
+        typ_odpowiedzialnosci=typ_autor,
+        save=MagicMock(),
+    )
+    book = SimpleNamespace(tytul_oryginalny="Book title")
+    statement = SimpleNamespace(
+        type="EDITOR",
+        get_bpp_autor=MagicMock(return_value="BPP author"),
+    )
+
+    with patch.object(command, "_find_autor_record", return_value=(wa, None)):
+        result = command._process_single_statement(
+            book,
+            statement,
+            typ_autor,
+            typ_redaktor,
+            dry_run=True,
+            verbose=False,
+        )
+
+    assert result == "fixed"
+    assert wa.typ_odpowiedzialnosci is typ_autor
+    wa.save.assert_not_called()
+
+
+def test_book_statement_type_process_single_statement_matching_and_missing_author():
+    command = make_command(BookStatementTypeCommand)
+    typ_autor = SimpleNamespace(nazwa="autor")
+    typ_redaktor = SimpleNamespace(nazwa="redaktor")
+    book = SimpleNamespace(tytul_oryginalny="Book title")
+
+    missing_author = SimpleNamespace(
+        type="AUTHOR",
+        personId="person-1",
+        get_bpp_autor=MagicMock(return_value=None),
+    )
+    assert (
+        command._process_single_statement(
+            book,
+            missing_author,
+            typ_autor,
+            typ_redaktor,
+            dry_run=False,
+            verbose=True,
+        )
+        == "no_wa"
+    )
+
+    matching_wa = SimpleNamespace(typ_odpowiedzialnosci=typ_autor)
+    matching_statement = SimpleNamespace(
+        type="AUTHOR",
+        get_bpp_autor=MagicMock(return_value="BPP author"),
+    )
+    with patch.object(command, "_find_autor_record", return_value=(matching_wa, None)):
+        assert (
+            command._process_single_statement(
+                book,
+                matching_statement,
+                typ_autor,
+                typ_redaktor,
+                dry_run=False,
+                verbose=False,
+            )
+            == "matching"
+        )
+
+
+def test_book_statement_type_integrate_disciplines_reports_verbose_errors():
+    command = make_command(BookStatementTypeCommand)
+    statement = SimpleNamespace(publicationId="pub-1")
+
+    with patch(
+        "pbn_integrator.utils.statements."
+        "integruj_oswiadczenia_z_instytucji_pojedyncza_praca",
+        side_effect=RuntimeError("cannot integrate"),
+    ) as integrate:
+        with patch("bpp.models.Uczelnia.objects") as uczelnie:
+            uczelnie.get.return_value = SimpleNamespace(domyslna_jednostka="unit")
+
+            command._integrate_disciplines([statement], verbose=True)
+
+    integrate.assert_called_once_with(
+        statement,
+        set(),
+        set(),
+        default_jednostka="unit",
+    )
+    output = command.stdout._out.getvalue()
+    assert "Błąd integracji: pub-1" in output
+    assert "Zintegrowano dyscypliny dla 1 rekordów" in output

--- a/src/pbn_import/tests/test_importer_wrappers.py
+++ b/src/pbn_import/tests/test_importer_wrappers.py
@@ -1,0 +1,562 @@
+"""Focused tests for small PBN import step wrappers."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Jednostka, Uczelnia
+from pbn_api.models import Institution
+from pbn_import.models import ImportInconsistency, ImportLog, ImportSession
+from pbn_import.utils.author_import import AuthorImporter
+from pbn_import.utils.conference_import import ConferenceImporter
+from pbn_import.utils.fee_import import FeeImporter
+from pbn_import.utils.publisher_import import PublisherImporter
+from pbn_import.utils.source_import import SourceImporter
+from pbn_import.utils.statement_import import StatementImporter
+
+
+@pytest.fixture
+def session(db, django_user_model):
+    user = baker.make(django_user_model)
+    return baker.make(ImportSession, user=user, config={})
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make(Uczelnia, pbn_uid=baker.make(Institution))
+
+
+def test_author_importer_skips_without_uczelnia_uid(session):
+    result = AuthorImporter(session, client=MagicMock(), uczelnia=None).run()
+
+    assert result == {"authors_imported": False, "reason": "No Uczelnia PBN UID"}
+    assert ImportLog.objects.filter(session=session, level="warning").exists()
+
+
+def test_author_importer_downloads_and_integrates_authors(session, uczelnia):
+    importer = AuthorImporter(session, client=MagicMock(), uczelnia=uczelnia)
+    callback = MagicMock()
+
+    with patch.object(importer, "create_subtask_progress", return_value=callback):
+        with patch.object(importer, "clear_subtask_progress") as clear:
+            with patch("pbn_import.utils.author_import.pobierz_ludzi_z_uczelni") as dl:
+                with patch(
+                    "pbn_import.utils.author_import.integruj_autorow_z_uczelni"
+                ) as integrate:
+                    result = importer.run()
+
+    dl.assert_called_once_with(
+        importer.client, uczelnia.pbn_uid_id, callback=callback
+    )
+    integrate.assert_called_once_with(
+        importer.client,
+        uczelnia.pbn_uid_id,
+        import_unexistent=True,
+        callback=callback,
+    )
+    assert clear.call_count == 2
+    assert result == {
+        "authors_imported": True,
+        "uczelnia_pbn_uid": uczelnia.pbn_uid_id,
+        "error_count": 0,
+    }
+
+
+def test_author_importer_records_download_and_integration_errors(session, uczelnia):
+    importer = AuthorImporter(session, client=MagicMock(), uczelnia=uczelnia)
+
+    with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+        with patch(
+            "pbn_import.utils.author_import.pobierz_ludzi_z_uczelni",
+            side_effect=RuntimeError("download failed"),
+        ):
+            with patch(
+                "pbn_import.utils.author_import.integruj_autorow_z_uczelni",
+                side_effect=RuntimeError("integration failed"),
+            ):
+                with patch(
+                    "pbn_import.utils.base.rollbar.report_exc_info"
+                ) as report_exc_info:
+                    result = importer.run()
+
+    assert report_exc_info.call_count == 2
+    assert result["error_count"] == 2
+    assert importer.errors == [
+        "Nie udało się pobrać autorów: download failed",
+        "Nie udało się zintegrować autorów: integration failed",
+    ]
+    assert list(
+        ImportLog.objects.filter(session=session, level="error")
+        .order_by("pk")
+        .values_list("message", flat=True)
+    ) == importer.errors
+
+
+def test_source_importer_success(session):
+    importer = SourceImporter(session, client=MagicMock())
+    callback = MagicMock()
+
+    with patch.object(importer, "create_subtask_progress", return_value=callback):
+        with patch("pbn_import.utils.source_import.pobierz_zrodla_mnisw") as download:
+            with patch(
+                "pbn_import.utils.source_import.importer.importuj_zrodla",
+                return_value=12,
+            ) as import_sources:
+                result = importer.run()
+
+    download.assert_called_once_with(importer.client, callback=callback)
+    import_sources.assert_called_once_with()
+    assert result == {"sources_imported": True, "error_count": 0}
+
+
+def test_source_importer_reraises_database_import_error(session):
+    importer = SourceImporter(session, client=MagicMock())
+
+    with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+        with patch("pbn_import.utils.source_import.pobierz_zrodla_mnisw"):
+            with patch(
+                "pbn_import.utils.source_import.importer.importuj_zrodla",
+                side_effect=RuntimeError("import failed"),
+            ):
+                with patch.object(importer, "handle_error") as handle_error:
+                    with pytest.raises(RuntimeError, match="import failed"):
+                        importer.run()
+
+    handle_error.assert_called_once()
+
+
+def test_source_importer_continues_after_non_auth_download_error(session):
+    importer = SourceImporter(session, client=MagicMock())
+
+    with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+        with patch(
+            "pbn_import.utils.source_import.pobierz_zrodla_mnisw",
+            side_effect=RuntimeError("download failed"),
+        ):
+            with patch.object(importer, "handle_pbn_error") as handle_pbn_error:
+                with patch(
+                    "pbn_import.utils.source_import.importer.importuj_zrodla"
+                ):
+                    result = importer.run()
+
+    handle_pbn_error.assert_called_once()
+    assert result["sources_imported"] is True
+
+
+def test_publisher_importer_success_and_clears_progress(session):
+    importer = PublisherImporter(session, client=MagicMock())
+    callback = MagicMock()
+
+    with patch.object(importer, "create_subtask_progress", return_value=callback):
+        with patch.object(importer, "clear_subtask_progress") as clear:
+            with patch("pbn_import.utils.publisher_import.pobierz_wydawcow_mnisw") as dl:
+                with patch(
+                    "pbn_import.utils.publisher_import.importer.importuj_wydawcow",
+                    return_value=5,
+                ) as import_publishers:
+                    result = importer.run()
+
+    dl.assert_called_once_with(importer.client)
+    import_publishers.assert_called_once_with(callback=callback)
+    clear.assert_called_once_with()
+    assert result == {"publishers_imported": True, "error_count": 0}
+
+
+def test_publisher_importer_records_both_download_and_import_errors(session):
+    importer = PublisherImporter(session, client=MagicMock())
+
+    with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+        with patch(
+            "pbn_import.utils.publisher_import.pobierz_wydawcow_mnisw",
+            side_effect=RuntimeError("download failed"),
+        ):
+            with patch(
+                "pbn_import.utils.publisher_import.importer.importuj_wydawcow",
+                side_effect=RuntimeError("import failed"),
+            ):
+                with patch.object(importer, "handle_error") as handle_error:
+                    result = importer.run()
+
+    assert handle_error.call_count == 2
+    assert result["publishers_imported"] is True
+
+
+def test_conference_importer_success_and_error_paths(session):
+    importer = ConferenceImporter(session, client=MagicMock())
+
+    with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+        with patch("pbn_import.utils.conference_import.pobierz_konferencje") as dl:
+            result = importer.run()
+
+    dl.assert_called_once()
+    assert result == {"conferences_imported": True, "error_count": 0}
+
+    failing = ConferenceImporter(session, client=MagicMock())
+    with patch.object(failing, "create_subtask_progress", return_value=MagicMock()):
+        with patch(
+            "pbn_import.utils.conference_import.pobierz_konferencje",
+            side_effect=RuntimeError("conference failed"),
+        ):
+            with patch.object(failing, "handle_error") as handle_error:
+                result = failing.run()
+
+    handle_error.assert_called_once()
+    assert result["conferences_imported"] is True
+
+
+class FakeRecord:
+    def __init__(self, pbn_uid_id):
+        self.pbn_uid_id = pbn_uid_id
+        self.save = MagicMock()
+
+
+class FakePublicationClass:
+    def __init__(self, name, records):
+        self.__name__ = name
+        self.objects = MagicMock()
+        self.objects.exclude.return_value = records
+
+
+def test_fee_importer_updates_records_from_batch_api(session):
+    record = FakeRecord(123)
+    ciagle = FakePublicationClass("Wydawnictwo_Ciagle", [record])
+    zwarte = FakePublicationClass("Wydawnictwo_Zwarte", [])
+    client = MagicMock()
+    client.get_publication_fees_batch.return_value = {
+        "123": {
+            "fee": {
+                "costFreePublication": True,
+                "researchPotentialFinancialResources": True,
+                "researchOrDevelopmentProjectsFinancialResources": False,
+                "other": True,
+                "amount": 250,
+            }
+        }
+    }
+
+    with patch("pbn_import.utils.fee_import.Wydawnictwo_Ciagle", ciagle):
+        with patch("pbn_import.utils.fee_import.Wydawnictwo_Zwarte", zwarte):
+            result = FeeImporter(session, client=client).run()
+
+    client.get_publication_fees_batch.assert_called_once_with([123])
+    assert record.opl_pub_cost_free is True
+    assert record.opl_pub_research_potential is True
+    assert record.opl_pub_research_or_development_projects is False
+    assert record.opl_pub_other is True
+    assert record.opl_pub_amount == 250
+    record.save.assert_called_once()
+    assert result == {
+        "fees_imported": 1,
+        "fees_failed": 0,
+        "api_calls": 1,
+        "error_count": 0,
+    }
+
+
+def test_fee_importer_counts_failed_batch(session):
+    records = [FakeRecord(123), FakeRecord(456)]
+    ciagle = FakePublicationClass("Wydawnictwo_Ciagle", records)
+    zwarte = FakePublicationClass("Wydawnictwo_Zwarte", [])
+    client = MagicMock()
+    client.get_publication_fees_batch.side_effect = RuntimeError("fee API failed")
+    importer = FeeImporter(session, client=client)
+
+    with patch("pbn_import.utils.fee_import.Wydawnictwo_Ciagle", ciagle):
+        with patch("pbn_import.utils.fee_import.Wydawnictwo_Zwarte", zwarte):
+            with patch.object(importer, "handle_error") as handle_error:
+                result = importer.run()
+
+    handle_error.assert_called_once()
+    assert result["fees_imported"] == 0
+    assert result["fees_failed"] == 2
+    assert result["api_calls"] == 0
+
+
+def test_statement_importer_returns_when_publication_setup_missing(session):
+    importer = StatementImporter(session, client=MagicMock(), uczelnia=None)
+
+    with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+        with patch("pbn_import.utils.statement_import.pobierz_oswiadczenia_z_instytucji"):
+            with patch.object(
+                importer.publication_importer,
+                "_setup_uczelnia_and_jednostka",
+                return_value=None,
+            ):
+                result = importer.run()
+
+    assert result == {
+        "statements_imported": False,
+        "reason": "No Uczelnia PBN UID",
+    }
+
+
+def test_statement_importer_full_success_logs_inconsistency_summary(
+    session,
+    uczelnia,
+):
+    importer = StatementImporter(session, client=MagicMock(), uczelnia=uczelnia)
+    default_jednostka = baker.make(Jednostka, uczelnia=uczelnia)
+    importer.publication_importer.default_jednostka = default_jednostka
+
+    def integrate_with_inconsistency(**kwargs):
+        kwargs["inconsistency_callback"](
+            "author_not_found",
+            pbn_publication=SimpleNamespace(mongoId="pub-1", title="PBN title"),
+            message="missing author",
+        )
+
+    with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+        with patch("pbn_import.utils.statement_import.pobierz_oswiadczenia_z_instytucji"):
+            with patch.object(
+                importer.publication_importer,
+                "_setup_uczelnia_and_jednostka",
+                return_value=uczelnia,
+            ):
+                with patch.object(
+                    importer,
+                    "_download_missing_publications",
+                    return_value={"downloaded": 1, "failed": 0, "errors": []},
+                ):
+                    with patch(
+                        "pbn_import.utils.statement_import."
+                        "integruj_oswiadczenia_z_instytucji",
+                        side_effect=integrate_with_inconsistency,
+                    ) as integrate:
+                        result = importer.run()
+
+    integrate.assert_called_once_with(
+        missing_publication_callback=None,
+        inconsistency_callback=integrate.call_args.kwargs["inconsistency_callback"],
+        default_jednostka=default_jednostka,
+        uczelnia=uczelnia,
+    )
+    assert result == {"statements_imported": True, "error_count": 0}
+    assert session.inconsistencies.count() == 1
+    assert ImportLog.objects.filter(
+        session=session,
+        level="warning",
+        message__contains="Znaleziono 1 nieścisłości",
+    ).exists()
+    assert ImportLog.objects.filter(
+        session=session,
+        level="success",
+        message="Oświadczenia zintegrowane pomyślnie",
+    ).exists()
+
+
+def test_statement_importer_records_download_and_integration_errors(session, uczelnia):
+    importer = StatementImporter(session, client=MagicMock(), uczelnia=uczelnia)
+    importer.publication_importer.default_jednostka = baker.make(
+        Jednostka, uczelnia=uczelnia
+    )
+
+    with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+        with patch(
+            "pbn_import.utils.statement_import.pobierz_oswiadczenia_z_instytucji",
+            side_effect=RuntimeError("download failed"),
+        ):
+            with patch.object(
+                importer.publication_importer,
+                "_setup_uczelnia_and_jednostka",
+                return_value=uczelnia,
+            ):
+                with patch.object(
+                    importer,
+                    "_download_missing_publications",
+                    return_value={"downloaded": 0, "failed": 0, "errors": []},
+                ):
+                    with patch(
+                        "pbn_import.utils.statement_import."
+                        "integruj_oswiadczenia_z_instytucji",
+                        side_effect=RuntimeError("integration failed"),
+                    ):
+                        with patch(
+                            "pbn_import.utils.base.rollbar.report_exc_info"
+                        ) as report_exc_info:
+                            result = importer.run()
+
+    assert report_exc_info.call_count == 2
+    assert result == {"statements_imported": True, "error_count": 2}
+    assert importer.errors == [
+        "Nie udało się pobrać oświadczeń: download failed",
+        "Nie udało się zintegrować oświadczeń: integration failed",
+    ]
+    assert list(
+        ImportLog.objects.filter(session=session, level="error")
+        .order_by("pk")
+        .values_list("message", flat=True)
+    ) == importer.errors
+
+
+def test_statement_download_missing_publications_no_statement_ids(session):
+    importer = StatementImporter(session, client=MagicMock(), uczelnia=None)
+
+    with patch(
+        "pbn_import.utils.statement_import.OswiadczenieInstytucji.objects"
+    ) as statements:
+        statements.values_list.return_value.distinct.return_value = []
+
+        assert importer._download_missing_publications(MagicMock()) is None
+
+
+def test_statement_download_missing_publications_no_missing_publications(session):
+    importer = StatementImporter(session, client=MagicMock(), uczelnia=None)
+
+    with patch(
+        "pbn_import.utils.statement_import.OswiadczenieInstytucji.objects"
+    ) as statements:
+        with patch("pbn_import.utils.statement_import.Rekord.objects") as rekordy:
+            statements.values_list.return_value.distinct.return_value = ["pub-1"]
+            rekordy.exclude.return_value.values_list.return_value = ["pub-1"]
+
+            result = importer._download_missing_publications(MagicMock())
+
+    assert result == {"downloaded": 0, "failed": 0, "errors": []}
+
+
+def test_statement_download_missing_publications_downloads_and_logs_errors(session):
+    importer = StatementImporter(session, client=MagicMock(), uczelnia=None)
+    default_jednostka = baker.make(Jednostka)
+
+    with patch(
+        "pbn_import.utils.statement_import.OswiadczenieInstytucji.objects"
+    ) as statements:
+        with patch("pbn_import.utils.statement_import.Rekord.objects") as rekordy:
+            with patch.object(
+                importer, "create_subtask_progress", return_value=MagicMock()
+            ):
+                with patch(
+                    "pbn_import.utils.statement_import."
+                    "pobierz_brakujace_publikacje_batch",
+                    return_value={
+                        "downloaded": 1,
+                        "failed": 1,
+                        "errors": ["missing pub failed"],
+                    },
+                ) as download:
+                    statements.values_list.return_value.distinct.return_value = [
+                        "pub-1",
+                        "pub-2",
+                    ]
+                    rekordy.objects = rekordy
+                    rekordy.exclude.return_value.values_list.return_value = ["pub-1"]
+
+                    result = importer._download_missing_publications(default_jednostka)
+
+    download.assert_called_once_with(
+        client=importer.client,
+        missing_pbn_uids={"pub-2"},
+        default_jednostka=default_jednostka,
+        max_workers=8,
+        callback=download.call_args.kwargs["callback"],
+    )
+    assert result["downloaded"] == 1
+    assert ImportLog.objects.filter(
+        session=session, level="warning", message__contains="missing pub failed"
+    ).exists()
+
+
+def test_statement_download_missing_publications_handles_batch_error(session):
+    importer = StatementImporter(session, client=MagicMock(), uczelnia=None)
+
+    with patch(
+        "pbn_import.utils.statement_import.OswiadczenieInstytucji.objects"
+    ) as statements:
+        with patch("pbn_import.utils.statement_import.Rekord.objects") as rekordy:
+            with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+                with patch.object(importer, "clear_subtask_progress") as clear:
+                    with patch(
+                        "pbn_import.utils.statement_import."
+                        "pobierz_brakujace_publikacje_batch",
+                        side_effect=RuntimeError("batch failed"),
+                    ):
+                        with patch(
+                            "pbn_import.utils.base.rollbar.report_exc_info"
+                        ) as report_exc_info:
+                            statements.values_list.return_value.distinct.return_value = [
+                                "pub-1"
+                            ]
+                            rekordy.exclude.return_value.values_list.return_value = []
+
+                            result = importer._download_missing_publications(
+                                MagicMock()
+                            )
+
+    assert result is None
+    report_exc_info.assert_called_once()
+    assert importer.errors == [
+        "Nie udało się pobrać brakujących publikacji: batch failed"
+    ]
+    assert ImportLog.objects.filter(
+        session=session,
+        level="error",
+        message="Nie udało się pobrać brakujących publikacji: batch failed",
+    ).exists()
+    clear.assert_called_once_with()
+
+
+def test_statement_inconsistency_callback_creates_record(session):
+    importer = StatementImporter(session, client=MagicMock(), uczelnia=None)
+    callback = importer._create_inconsistency_callback()
+    pbn_publication = SimpleNamespace(mongoId="pub-1", title="PBN publication")
+    pbn_author = SimpleNamespace(pk="author-1", lastName="Kowalski", name="Jan")
+
+    callback(
+        "author_not_found",
+        pbn_publication=pbn_publication,
+        pbn_author=pbn_author,
+        discipline="2.3",
+        message="missing author",
+        action_taken="reported",
+    )
+
+    inconsistency = session.inconsistencies.get()
+    assert inconsistency.inconsistency_type == "author_not_found"
+    assert inconsistency.pbn_publication_id == "pub-1"
+    assert inconsistency.pbn_author_name == "Kowalski Jan"
+    assert inconsistency.message == "missing author"
+
+
+def test_statement_inconsistency_callback_records_bpp_publication_details(session):
+    importer = StatementImporter(session, client=MagicMock(), uczelnia=None)
+    callback = importer._create_inconsistency_callback()
+    content_type = baker.make("contenttypes.ContentType")
+    bpp_publication = SimpleNamespace(pk=123, tytul_oryginalny="BPP title")
+    bpp_author = SimpleNamespace(pk=456, __str__=lambda self: "BPP author")
+
+    with patch(
+        "pbn_import.utils.statement_import.ContentType.objects.get_for_model",
+        return_value=content_type,
+    ):
+        callback(
+            "publication_not_found",
+            bpp_publication=bpp_publication,
+            bpp_author=bpp_author,
+            message="publication mismatch",
+        )
+
+    inconsistency = session.inconsistencies.get()
+    assert inconsistency.bpp_publication_id == 123
+    assert inconsistency.bpp_publication_content_type == content_type
+    assert inconsistency.bpp_publication_title == "BPP title"
+    assert inconsistency.bpp_author_id == 456
+
+
+def test_statement_inconsistency_callback_logs_persistence_failure(session):
+    importer = StatementImporter(session, client=MagicMock(), uczelnia=None)
+    callback = importer._create_inconsistency_callback()
+
+    with patch.object(
+        ImportInconsistency.objects,
+        "create",
+        side_effect=RuntimeError("cannot save inconsistency"),
+    ):
+        callback("author_not_found", message="broken")
+
+    assert ImportLog.objects.filter(
+        session=session,
+        level="warning",
+        message__contains="Błąd podczas zapisu nieścisłości",
+    ).exists()

--- a/src/pbn_import/tests/test_initial_setup.py
+++ b/src/pbn_import/tests/test_initial_setup.py
@@ -1,0 +1,151 @@
+"""Tests for the PBN import initial setup step."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Dyscyplina_Naukowa, Jezyk, Uczelnia
+from pbn_api.models import Institution
+from pbn_import.models import ImportLog, ImportSession
+from pbn_import.utils.initial_setup import InitialSetup
+
+
+@pytest.fixture
+def session(db, django_user_model):
+    user = baker.make(django_user_model)
+    return baker.make(ImportSession, user=user, config={})
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make(Uczelnia, nazwa="Uniwersytet Testowy", pbn_integracja=False)
+
+
+def test_run_full_setup_uses_existing_client_and_matches_uczelnia(session, uczelnia):
+    client = MagicMock()
+    matched = baker.make(Institution)
+    setup = InitialSetup(session, client=client, uczelnia=uczelnia)
+
+    with patch("pbn_import.utils.initial_setup.integruj_jezyki") as jezyki:
+        with patch("pbn_import.utils.initial_setup.integruj_kraje") as kraje:
+            with patch("pbn_import.utils.initial_setup.pobierz_instytucje_polon"):
+                with patch(
+                    "pbn_import.utils.initial_setup.matchuj_uczelnie",
+                    return_value=matched,
+                ):
+                    result = setup.run()
+
+    jezyki.assert_called_once_with(client, create_if_not_exists=True)
+    kraje.assert_called_once_with(client)
+    client.download_disciplines.assert_called_once()
+    client.sync_disciplines.assert_called_once()
+    uczelnia.refresh_from_db()
+    session.refresh_from_db()
+    assert uczelnia.pbn_integracja is True
+    assert uczelnia.pbn_uid_id == matched.pk
+    assert session.config["uczelnia_auto_matched"] is True
+    assert result["languages_integrated"] is True
+    assert result["uczelnia_matched"] is True
+
+
+def test_run_without_client_creates_client_from_uczelnia(session, uczelnia):
+    client = MagicMock()
+    setup = InitialSetup(session, client=None, uczelnia=uczelnia)
+
+    with patch.object(uczelnia, "pbn_client", return_value=client) as pbn_client:
+        with patch("pbn_import.utils.initial_setup.integruj_jezyki"):
+            with patch("pbn_import.utils.initial_setup.integruj_kraje"):
+                with patch("pbn_import.utils.initial_setup.pobierz_instytucje_polon"):
+                    with patch(
+                        "pbn_import.utils.initial_setup.matchuj_uczelnie",
+                        return_value=None,
+                    ):
+                        result = setup.run()
+
+    pbn_client.assert_called_once_with()
+    assert setup.client == client
+    assert result["institutions_fetched"] is True
+
+
+def test_run_without_working_client_falls_back_to_minimal_setup(session, uczelnia):
+    setup = InitialSetup(session, client=None, uczelnia=uczelnia)
+
+    with patch.object(uczelnia, "pbn_client", side_effect=RuntimeError("no config")):
+        result = setup.run()
+
+    uczelnia.refresh_from_db()
+    assert uczelnia.pbn_integracja is True
+    assert result["minimal_setup"] is True
+    assert Jezyk.objects.filter(nazwa="polski").exists()
+    assert Dyscyplina_Naukowa.objects.filter(kod="2.3").exists()
+
+
+def test_language_authorization_error_stops_import(session, uczelnia):
+    setup = InitialSetup(session, client=MagicMock(), uczelnia=uczelnia)
+
+    with patch(
+        "pbn_import.utils.initial_setup.integruj_jezyki",
+        side_effect=RuntimeError("auth failed"),
+    ):
+        with patch.object(setup, "is_authorization_error", return_value=True):
+            with pytest.raises(Exception, match="Brak autoryzacji PBN"):
+                setup.run()
+
+    assert ImportLog.objects.filter(session=session, level="critical").exists()
+
+
+def test_language_non_authorization_error_uses_minimal_setup(session, uczelnia):
+    setup = InitialSetup(session, client=MagicMock(), uczelnia=uczelnia)
+
+    with patch(
+        "pbn_import.utils.initial_setup.integruj_jezyki",
+        side_effect=RuntimeError("temporary outage"),
+    ):
+        with patch.object(setup, "is_authorization_error", return_value=False):
+            result = setup.run()
+
+    assert result["minimal_setup"] is True
+    assert ImportLog.objects.filter(
+        session=session,
+        level="warning",
+        message__contains="Nie można zintegrować języków",
+    ).exists()
+
+
+def test_later_pbn_errors_are_delegated_and_import_continues(session, uczelnia):
+    client = MagicMock()
+    client.download_disciplines.side_effect = RuntimeError("disciplines failed")
+    setup = InitialSetup(session, client=client, uczelnia=uczelnia)
+
+    with patch("pbn_import.utils.initial_setup.integruj_jezyki"):
+        with patch(
+            "pbn_import.utils.initial_setup.integruj_kraje",
+            side_effect=RuntimeError("countries failed"),
+        ):
+            with patch(
+                "pbn_import.utils.initial_setup.pobierz_instytucje_polon",
+                side_effect=RuntimeError("institutions failed"),
+            ):
+                with patch.object(setup, "handle_pbn_error") as handle_error:
+                    result = setup.run()
+
+    assert handle_error.call_count == 3
+    assert result["countries_integrated"] is True
+    assert result["disciplines_synced"] is True
+    assert result["institutions_fetched"] is True
+    assert "current_subtask" not in session.progress_data
+
+
+def test_auto_match_without_result_marks_manual_match_required(session, uczelnia):
+    setup = InitialSetup(session, client=MagicMock(), uczelnia=uczelnia)
+
+    with patch("pbn_import.utils.initial_setup.matchuj_uczelnie", return_value=None):
+        setup._auto_match_uczelnia(uczelnia)
+
+    session.refresh_from_db()
+    assert session.config["uczelnia_match_required"] is True
+    assert session.config["uczelnia_nazwa"] == uczelnia.nazwa
+    assert setup.errors == [
+        f"Uczelnia '{uczelnia.nazwa}' wymaga ręcznego wyboru PBN UID"
+    ]

--- a/src/pbn_import/tests/test_institution_import.py
+++ b/src/pbn_import/tests/test_institution_import.py
@@ -1,0 +1,154 @@
+"""Tests for PBN import institution setup helpers."""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Jednostka, Jednostka_Wydzial, Uczelnia, Wydzial
+from pbn_import.models import ImportLog, ImportSession
+from pbn_import.utils.institution_import import (
+    InstitutionImporter,
+    znajdz_lub_utworz_jednostke_domyslna,
+    znajdz_lub_utworz_wydzial_domyslny,
+    zrob_skrot,
+)
+
+
+@pytest.fixture
+def session(db, django_user_model):
+    user = baker.make(django_user_model)
+    return baker.make(ImportSession, user=user, config={})
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make(Uczelnia)
+
+
+def test_zrob_skrot_keeps_uppercase_and_punctuation_only():
+    assert zrob_skrot("Wydział Badań-Aplikacyjnych 2026!") == "WB-A!"
+
+
+def test_find_or_create_default_wydzial_reuses_uczelnia_scoped_match(uczelnia):
+    foreign = baker.make(Wydzial, nazwa="Wydział Domyślny Obcy")
+    existing = baker.make(
+        Wydzial,
+        nazwa="Wydział Domyślny Naukowy",
+        uczelnia=uczelnia,
+    )
+
+    wydzial, created = znajdz_lub_utworz_wydzial_domyslny(uczelnia)
+
+    assert wydzial == existing
+    assert wydzial != foreign
+    assert created is False
+
+
+def test_find_or_create_default_wydzial_creates_with_generated_short_name(uczelnia):
+    wydzial, created = znajdz_lub_utworz_wydzial_domyslny(
+        uczelnia,
+        "Wydział Testów-Jednostkowych",
+    )
+
+    assert created is True
+    assert wydzial.uczelnia == uczelnia
+    assert wydzial.skrot == "WT-J"
+
+
+def test_find_or_create_default_jednostka_reuses_uczelnia_scoped_match(uczelnia):
+    foreign = baker.make(Jednostka, nazwa="Jednostka Domyślna Obca")
+    existing = baker.make(
+        Jednostka,
+        nazwa="Jednostka Domyślna Testowa",
+        uczelnia=uczelnia,
+    )
+
+    jednostka, created = znajdz_lub_utworz_jednostke_domyslna(uczelnia)
+
+    assert jednostka == existing
+    assert jednostka != foreign
+    assert created is False
+
+
+def test_find_or_create_default_jednostka_creates_for_uczelnia(uczelnia):
+    jednostka, created = znajdz_lub_utworz_jednostke_domyslna(uczelnia)
+
+    assert created is True
+    assert jednostka.nazwa == "Jednostka Domyślna"
+    assert jednostka.skrot == "JD"
+    assert jednostka.uczelnia == uczelnia
+
+
+def test_institution_importer_requires_uczelnia(session):
+    importer = InstitutionImporter(session, uczelnia=None)
+
+    with pytest.raises(ValueError, match="Nie znaleziono domyślnej Uczelni"):
+        importer.run()
+
+
+def test_institution_importer_creates_defaults_links_and_session_config(
+    session,
+    uczelnia,
+):
+    importer = InstitutionImporter(
+        session,
+        uczelnia=uczelnia,
+        wydzial_domyslny="Wydział Testów",
+        wydzial_domyslny_skrot="WT",
+    )
+
+    result = importer.run()
+
+    session.refresh_from_db()
+    uczelnia.refresh_from_db()
+    wydzial = result["wydzial"]
+    jednostka = result["jednostka"]
+    obca_jednostka = result["obca_jednostka"]
+
+    assert wydzial.nazwa == "Wydział Testów"
+    assert jednostka.nazwa == "Jednostka Domyślna"
+    assert obca_jednostka.nazwa == "Obca jednostka"
+    assert obca_jednostka.skupia_pracownikow is False
+    assert uczelnia.obca_jednostka == obca_jednostka
+    assert Jednostka_Wydzial.objects.filter(
+        jednostka=jednostka,
+        wydzial=wydzial,
+    ).exists()
+    assert Jednostka_Wydzial.objects.filter(
+        jednostka=obca_jednostka,
+        wydzial=wydzial,
+    ).exists()
+    assert session.config == {
+        "default_jednostka_id": jednostka.id,
+        "obca_jednostka_id": obca_jednostka.id,
+        "wydzial_id": wydzial.id,
+    }
+    assert ImportLog.objects.filter(session=session, level="info").count() >= 4
+
+
+def test_institution_importer_reuses_existing_objects(session, uczelnia):
+    wydzial = baker.make(Wydzial, nazwa="Wydział Domyślny", uczelnia=uczelnia)
+    jednostka = baker.make(Jednostka, nazwa="Jednostka Domyślna", uczelnia=uczelnia)
+    obca = baker.make(
+        Jednostka,
+        nazwa="Obca jednostka",
+        uczelnia=uczelnia,
+        skupia_pracownikow=False,
+    )
+    uczelnia.obca_jednostka = obca
+    uczelnia.save(update_fields=["obca_jednostka"])
+    Jednostka_Wydzial.objects.create(jednostka=jednostka, wydzial=wydzial)
+    Jednostka_Wydzial.objects.create(jednostka=obca, wydzial=wydzial)
+
+    result = InstitutionImporter(session, uczelnia=uczelnia).run()
+
+    assert result == {
+        "wydzial": wydzial,
+        "jednostka": jednostka,
+        "obca_jednostka": obca,
+    }
+    assert Wydzial.objects.filter(uczelnia=uczelnia).count() == 1
+    assert Jednostka.objects.filter(uczelnia=uczelnia).count() == 2
+    assert ImportLog.objects.filter(
+        session=session,
+        message__contains="Using existing department",
+    ).exists()

--- a/src/pbn_import/tests/test_publication_import.py
+++ b/src/pbn_import/tests/test_publication_import.py
@@ -1,0 +1,227 @@
+"""Focused tests for publication import step behavior."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import (
+    Dyscyplina_Naukowa,
+    Jednostka,
+    Rodzaj_Zrodla,
+    Uczelnia,
+)
+from pbn_api.models import Institution, Publication
+from pbn_import.models import ImportSession
+from pbn_import.utils.base import CancelledException
+from pbn_import.utils.publication_import import PublicationImporter
+
+
+@pytest.fixture
+def session(db, django_user_model):
+    user = baker.make(django_user_model)
+    return baker.make(ImportSession, user=user, config={})
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make(Uczelnia, pbn_uid=baker.make(Institution))
+
+
+@pytest.fixture
+def importer(session, uczelnia):
+    imp = PublicationImporter(session, client=MagicMock(), uczelnia=uczelnia)
+    imp.default_jednostka = baker.make(Jednostka, nazwa="Default unit", uczelnia=uczelnia)
+    return imp
+
+
+def test_run_returns_reason_when_uczelnia_setup_is_missing(session):
+    importer = PublicationImporter(session, client=MagicMock(), uczelnia=None)
+
+    with patch.object(importer, "_setup_uczelnia_and_jednostka", return_value=None):
+        result = importer.run()
+
+    assert result == {"authors_imported": False, "reason": "No Uczelnia PBN UID"}
+
+
+def test_run_success_with_delete_existing_calls_steps_in_order(importer, uczelnia):
+    importer.delete_existing = True
+
+    with patch.object(
+        importer, "_setup_uczelnia_and_jednostka", return_value=uczelnia
+    ) as setup:
+        with patch.object(
+            importer, "_delete_existing_publications", return_value=None
+        ) as delete_existing:
+            with patch.object(
+                importer, "_download_publications", return_value=None
+            ) as download:
+                with patch.object(
+                    importer, "_download_publications_v2", return_value=None
+                ) as download_v2:
+                    with patch.object(
+                        importer, "_import_publications", return_value=None
+                    ) as import_publications:
+                        with patch.object(importer, "update_progress") as progress:
+                            result = importer.run()
+
+    setup.assert_called_once_with()
+    delete_existing.assert_called_once_with(0, 4)
+    download.assert_called_once_with(1, 4, uczelnia)
+    download_v2.assert_called_once_with(2, 4)
+    import_publications.assert_called_once_with(3, 4)
+    progress.assert_called_once_with(4, 4, "Zakończono import publikacji")
+    assert result == {
+        "publications_imported": True,
+        "default_jednostka": "Default unit",
+        "error_count": 0,
+    }
+
+
+def test_run_short_circuits_when_delete_existing_returns_result(importer, uczelnia):
+    importer.delete_existing = True
+
+    with patch.object(importer, "_setup_uczelnia_and_jednostka", return_value=uczelnia):
+        with patch.object(
+            importer, "_delete_existing_publications", return_value={"cancelled": True}
+        ):
+            with patch.object(importer, "_download_publications") as download:
+                result = importer.run()
+
+    assert result == {"cancelled": True}
+    download.assert_not_called()
+
+
+def test_delete_existing_returns_cancelled_before_deleting(importer):
+    with patch.object(importer, "check_cancelled", return_value=True):
+        with patch("pbn_import.utils.publication_import.Wydawnictwo_Zwarte") as zwarte:
+            result = importer._delete_existing_publications(0, 3)
+
+    assert result == {"cancelled": True}
+    zwarte.objects.exclude.assert_not_called()
+
+
+def test_download_publications_success_uses_progress_callback(importer, uczelnia):
+    callback = MagicMock()
+
+    with patch.object(importer, "check_cancelled", return_value=False):
+        with patch.object(importer, "create_subtask_progress", return_value=callback):
+            with patch(
+                "pbn_import.utils.publication_import.pobierz_publikacje_z_instytucji"
+            ) as download:
+                result = importer._download_publications(1, 3, uczelnia)
+
+    assert result is None
+    download.assert_called_once_with(importer.client, callback=callback)
+
+
+def test_download_publications_delegates_pbn_error(importer, uczelnia):
+    error = RuntimeError("pbn unavailable")
+
+    with patch.object(importer, "check_cancelled", return_value=False):
+        with patch(
+            "pbn_import.utils.publication_import.pobierz_publikacje_z_instytucji",
+            side_effect=error,
+        ):
+            with patch.object(importer, "handle_pbn_error") as handle_pbn_error:
+                importer._download_publications(1, 3, uczelnia)
+
+    handle_pbn_error.assert_called_once_with(
+        error, "Nie udało się pobrać publikacji"
+    )
+
+
+def test_download_publications_v2_clears_progress_even_on_error(importer):
+    error = RuntimeError("v2 failed")
+
+    with patch.object(importer, "check_cancelled", return_value=False):
+        with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+            with patch.object(
+                importer, "_download_publications_v2_with_callback", side_effect=error
+            ):
+                with patch.object(importer, "handle_pbn_error") as handle_pbn_error:
+                    with patch.object(importer, "clear_subtask_progress") as clear:
+                        importer._download_publications_v2(2, 3)
+
+    handle_pbn_error.assert_called_once_with(
+        error, "Nie udało się pobrać publikacji v2"
+    )
+    assert clear.call_count == 2
+
+
+def test_import_publications_success_calls_import_helper(importer):
+    with patch.object(importer, "check_cancelled", return_value=False):
+        with patch.object(importer, "_import_publications_with_cancellation") as helper:
+            result = importer._import_publications(2, 3)
+
+    assert result is None
+    helper.assert_called_once_with()
+
+
+def test_import_publications_logs_helper_error_and_continues(importer):
+    error = RuntimeError("broken publication")
+
+    with patch.object(importer, "check_cancelled", return_value=False):
+        with patch.object(
+            importer, "_import_publications_with_cancellation", side_effect=error
+        ):
+            with patch.object(importer, "handle_error") as handle_error:
+                result = importer._import_publications(2, 3)
+
+    assert result is None
+    handle_error.assert_called_once_with(error, "Nie udało się zaimportować publikacji")
+
+
+def test_import_publications_with_cancellation_imports_and_records_failures(importer):
+    rodzaj_periodyk, _ = Rodzaj_Zrodla.objects.get_or_create(nazwa="periodyk")
+    dyscyplina, _ = Dyscyplina_Naukowa.objects.get_or_create(
+        kod="2.3", defaults={"nazwa": "Informatyka"}
+    )
+    pub_ok = baker.make(Publication, mongoId="pub-ok")
+    pub_bad = baker.make(Publication, mongoId="pub-bad")
+
+    def passthrough_pbar(iterator, count, label, callback):
+        return iterator
+
+    def fake_import_one(pbn_uid, **kwargs):
+        if pbn_uid == pub_bad.mongoId:
+            raise RuntimeError("bad import")
+        return True
+
+    with patch("bpp.util.pbar", side_effect=passthrough_pbar):
+        with patch.object(importer, "check_cancelled", return_value=False):
+            with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
+                with patch.object(importer, "handle_error") as handle_error:
+                    with patch(
+                        "pbn_import.utils.publication_import."
+                        "importuj_publikacje_po_pbn_uid_id",
+                        side_effect=fake_import_one,
+                    ) as import_one:
+                        importer._import_publications_with_cancellation()
+
+    assert {args.args[0] for args in import_one.call_args_list} == {
+        pub_ok.mongoId,
+        pub_bad.mongoId,
+    }
+    for import_call in import_one.call_args_list:
+        assert import_call.kwargs == {
+            "client": importer.client,
+            "default_jednostka": importer.default_jednostka,
+            "rodzaj_periodyk": rodzaj_periodyk,
+            "dyscypliny_cache": {dyscyplina.nazwa: dyscyplina},
+        }
+    handle_error.assert_called_once()
+    assert "pub-bad" in handle_error.call_args.args[1]
+
+
+def test_import_publications_with_cancellation_raises_when_session_cancelled(importer):
+    Rodzaj_Zrodla.objects.get_or_create(nazwa="periodyk")
+    baker.make(Publication, mongoId="pub-cancelled")
+
+    def passthrough_pbar(iterator, count, label, callback):
+        return iterator
+
+    with patch("bpp.util.pbar", side_effect=passthrough_pbar):
+        with patch.object(importer, "check_cancelled", return_value=True):
+            with pytest.raises(CancelledException, match="Import został anulowany"):
+                importer._import_publications_with_cancellation()

--- a/src/pbn_import/tests/test_routing.py
+++ b/src/pbn_import/tests/test_routing.py
@@ -1,0 +1,11 @@
+"""Tests for PBN import websocket routing."""
+
+from pbn_import.routing import websocket_urlpatterns
+
+
+def test_websocket_route_points_to_import_session_progress():
+    pattern = websocket_urlpatterns[0]
+
+    assert len(websocket_urlpatterns) == 1
+    assert pattern.pattern.regex.pattern == r"ws/pbn-import/session/(?P<session_id>\w+)/$"
+    assert callable(pattern.callback)

--- a/src/pbn_import/tests/test_source_scoring_import.py
+++ b/src/pbn_import/tests/test_source_scoring_import.py
@@ -1,0 +1,252 @@
+"""Tests for source scoring synchronization."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Uczelnia
+from pbn_import.models import ImportLog, ImportSession
+from pbn_import.utils.source_scoring_import import (
+    SourceScoringImporter,
+    _import_disciplines_for_zrodlo,
+    _import_points_for_zrodlo,
+    _sync_single_source,
+)
+
+
+@pytest.fixture
+def session(db, django_user_model):
+    user = baker.make(django_user_model)
+    return baker.make(ImportSession, user=user, config={})
+
+
+class FakePbnUid:
+    def __init__(self, values):
+        self.values = values
+
+    def value(self, *path, return_none=False):
+        value = self.values
+        for elem in path:
+            value = value.get(elem)
+            if value is None:
+                return None if return_none else f"[brak {elem}]"
+        return value
+
+
+class FakePunktacjaManager:
+    def __init__(self, existing=None):
+        self.existing = existing
+        self.created = []
+
+    def get(self, rok):
+        if self.existing and self.existing.rok == rok:
+            return self.existing
+        from bpp.models import Punktacja_Zrodla
+
+        raise Punktacja_Zrodla.DoesNotExist
+
+    def create(self, **kwargs):
+        self.created.append(kwargs)
+        return SimpleNamespace(**kwargs)
+
+
+class FakeDyscyplinaManager:
+    def __init__(self):
+        self.deleted = False
+        self.created = []
+
+    def all(self):
+        return self
+
+    def delete(self):
+        self.deleted = True
+
+    def get_or_create(self, **kwargs):
+        self.created.append(kwargs)
+        return SimpleNamespace(**kwargs), True
+
+
+class FakeZrodlo:
+    def __init__(self, pbn_values, punktacja_manager=None):
+        self.pbn_uid = FakePbnUid(pbn_values)
+        self.punktacja_zrodla_set = punktacja_manager or FakePunktacjaManager()
+        self.dyscyplina_zrodla_set = FakeDyscyplinaManager()
+
+
+def test_import_points_creates_and_updates_points_from_min_year():
+    existing = SimpleNamespace(
+        rok="2020",
+        punkty_kbn=40,
+        save=MagicMock(),
+    )
+    punktacja = FakePunktacjaManager(existing=existing)
+    zrodlo = FakeZrodlo(
+        {
+            "object": {
+                "points": {
+                    "2016": {"points": 10},
+                    "2020": {"points": 70},
+                    "2021": {"points": 100},
+                    "2022": {},
+                }
+            }
+        },
+        punktacja_manager=punktacja,
+    )
+
+    last_year = _import_points_for_zrodlo(zrodlo, min_rok=2017)
+
+    assert last_year == 2022
+    assert existing.punkty_kbn == 70
+    existing.save.assert_called_once_with()
+    assert punktacja.created == [{"punkty_kbn": 100, "rok": "2021"}]
+
+
+def test_import_disciplines_replaces_known_disciplines_only():
+    zrodlo = FakeZrodlo(
+        {
+            "object": {
+                "disciplines": [
+                    {"code": "203"},
+                    {"code": ""},
+                    {"code": "999"},
+                    "301",
+                ]
+            }
+        }
+    )
+
+    _import_disciplines_for_zrodlo(
+        zrodlo,
+        ostatni_rok=2021,
+        dyscypliny_dict={"2.3": 10, "3.1": 20},
+    )
+
+    assert zrodlo.dyscyplina_zrodla_set.deleted is True
+    assert zrodlo.dyscyplina_zrodla_set.created == [
+        {"dyscyplina_id": 10, "rok": 2021},
+        {"dyscyplina_id": 20, "rok": 2021},
+    ]
+
+
+def test_import_disciplines_noops_without_year_or_payload():
+    zrodlo = FakeZrodlo({"object": {"disciplines": [{"code": "203"}]}})
+
+    _import_disciplines_for_zrodlo(zrodlo, ostatni_rok=None, dyscypliny_dict={})
+
+    assert zrodlo.dyscyplina_zrodla_set.deleted is False
+
+    zrodlo_no_disciplines = FakeZrodlo({"object": {"disciplines": []}})
+    _import_disciplines_for_zrodlo(
+        zrodlo_no_disciplines, ostatni_rok=2021, dyscypliny_dict={}
+    )
+
+    assert zrodlo_no_disciplines.dyscyplina_zrodla_set.deleted is False
+
+
+@pytest.mark.django_db
+def test_sync_single_source_reports_success_and_failure():
+    zrodlo = FakeZrodlo({"object": {"points": {}}})
+
+    with patch(
+        "pbn_import.utils.source_scoring_import.Zrodlo.objects"
+    ) as zrodlo_objects:
+        zrodlo_objects.select_related.return_value.get.return_value = zrodlo
+        with patch(
+            "pbn_import.utils.source_scoring_import._import_points_for_zrodlo",
+            return_value=2021,
+        ) as import_points:
+            with patch(
+                "pbn_import.utils.source_scoring_import."
+                "_import_disciplines_for_zrodlo"
+            ) as import_disciplines:
+                assert _sync_single_source(123, 2017, {"2.3": 10}) == (
+                    123,
+                    True,
+                    None,
+                )
+
+    import_points.assert_called_once_with(zrodlo, 2017)
+    import_disciplines.assert_called_once_with(zrodlo, 2021, {"2.3": 10})
+
+    with patch(
+        "pbn_import.utils.source_scoring_import.Zrodlo.objects"
+    ) as zrodlo_objects:
+        zrodlo_objects.select_related.return_value.get.side_effect = RuntimeError(
+            "db failed"
+        )
+
+        assert _sync_single_source(456, 2017, {}) == (456, False, "db failed")
+
+
+def test_run_returns_zero_when_no_sources(session):
+    importer = SourceScoringImporter(session, client=None, max_workers=1)
+
+    with patch(
+        "pbn_import.utils.source_scoring_import.Dyscyplina_Naukowa.objects"
+    ) as disciplines:
+        with patch(
+            "pbn_import.utils.source_scoring_import.Zrodlo.objects"
+        ) as sources:
+            disciplines.all.return_value = []
+            sources.exclude.return_value.values_list.return_value = []
+
+            result = importer.run()
+
+    assert result == {"synchronized": 0, "failed": 0}
+    assert ImportLog.objects.filter(
+        session=session,
+        level="info",
+        message="Brak źródeł z pbn_uid do synchronizacji",
+    ).exists()
+
+
+def test_run_synchronizes_sources_and_logs_first_errors(session):
+    importer = SourceScoringImporter(
+        session,
+        client=None,
+        max_workers=1,
+        uczelnia=baker.make(Uczelnia),
+    )
+    subtask = MagicMock()
+
+    with patch(
+        "pbn_import.utils.source_scoring_import.Dyscyplina_Naukowa.objects"
+    ) as disciplines:
+        with patch(
+            "pbn_import.utils.source_scoring_import.Zrodlo.objects"
+        ) as sources:
+            with patch(
+                "pbn_import.utils.source_scoring_import._sync_single_source",
+                side_effect=[(1, True, None), (2, False, "bad source")],
+            ) as sync_one:
+                with patch(
+                    "pbn_import.utils.source_scoring_import.tqdm",
+                    side_effect=lambda iterable, **kwargs: iterable,
+                ):
+                    with patch.object(
+                        importer, "create_subtask_progress", return_value=subtask
+                    ):
+                        disciplines.all.return_value = [
+                            SimpleNamespace(kod="2.3", pk=10)
+                        ]
+                        sources.exclude.return_value.values_list.return_value = [1, 2]
+
+                        result = importer.run()
+
+    assert result == {"synchronized": 1, "failed": 1}
+    assert sync_one.call_args_list == [
+        call(1, 2017, {"2.3": 10}),
+        call(2, 2017, {"2.3": 10}),
+    ]
+    assert subtask.update.call_count == 2
+    assert ImportLog.objects.filter(
+        session=session, level="warning", message__contains="bad source"
+    ).exists()
+    assert ImportLog.objects.filter(
+        session=session,
+        level="success",
+        message="Zsynchronizowano 1 źródeł, 1 błędów",
+    ).exists()

--- a/src/pbn_import/tests/test_templatetags.py
+++ b/src/pbn_import/tests/test_templatetags.py
@@ -1,0 +1,102 @@
+"""Tests for PBN import template tags."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+from bpp.models import Uczelnia
+from pbn_import.templatetags.pbn_import_tags import (
+    bpp_admin_url,
+    format_json,
+    is_error_log,
+    is_json,
+    pbn_publication_url,
+    truncate_message,
+)
+
+
+def test_pbn_publication_url_uses_public_pbn_root_without_request():
+    url = pbn_publication_url({}, "pub-1")
+
+    assert url == "https://pbn.nauka.gov.pl/core/#/publication/view/pub-1/current"
+
+
+@pytest.mark.django_db
+def test_pbn_publication_url_uses_request_uczelnia_root():
+    request = object()
+    uczelnia = Uczelnia(pbn_api_root="https://tenant.pbn.example/")
+
+    with patch.object(Uczelnia.objects, "get_for_request", return_value=uczelnia):
+        url = pbn_publication_url({"request": request}, "pub-1")
+
+    assert url == "https://tenant.pbn.example/core/#/publication/view/pub-1/current"
+
+
+def test_pbn_publication_url_returns_empty_for_missing_id():
+    assert pbn_publication_url({}, "") == ""
+    assert pbn_publication_url({}, None) == ""
+
+
+@pytest.mark.django_db
+def test_bpp_admin_url_builds_change_url(django_user_model):
+    content_type = ContentType.objects.get_for_model(django_user_model)
+    user = django_user_model.objects.create_user(username="admin-url-user")
+
+    assert bpp_admin_url(content_type, user.pk) == f"/admin/bpp/bppuser/{user.pk}/change/"
+
+
+def test_bpp_admin_url_returns_empty_for_missing_parts():
+    assert bpp_admin_url(None, 1) == ""
+    assert bpp_admin_url(SimpleNamespace(app_label="auth", model="user"), None) == ""
+
+
+def test_format_json_pretty_prints_and_escapes_json_values():
+    formatted = format_json({"key": "<script>"})
+
+    assert '<pre class="json-display">' in formatted
+    assert "&lt;script&gt;" in formatted
+    assert "&quot;key&quot;:" in formatted
+
+
+def test_format_json_parses_json_string_and_preserves_non_ascii():
+    formatted = format_json('{"name": "Łódź"}')
+
+    assert "Łódź" in formatted
+
+
+def test_format_json_wraps_invalid_json_string():
+    formatted = format_json("<not-json>")
+
+    assert formatted == '<pre class="json-display">&lt;not-json&gt;</pre>'
+
+
+def test_format_json_returns_empty_for_empty_value():
+    assert format_json({}) == ""
+    assert format_json("") == ""
+    assert format_json(None) == ""
+
+
+def test_is_json_accepts_only_valid_json_strings():
+    assert is_json('{"ok": true}') is True
+    assert is_json("[1, 2]") is True
+    assert is_json("{broken") is False
+    assert is_json({"ok": True}) is False
+    assert is_json("") is False
+
+
+@pytest.mark.parametrize("level", ["error", "critical", "warning"])
+def test_is_error_log_accepts_error_like_levels(level):
+    assert is_error_log(SimpleNamespace(level=level)) is True
+
+
+@pytest.mark.parametrize("level", ["info", "success", "debug"])
+def test_is_error_log_rejects_non_error_levels(level):
+    assert is_error_log(SimpleNamespace(level=level)) is False
+
+
+def test_truncate_message_handles_empty_short_and_long_values():
+    assert truncate_message("") == ""
+    assert truncate_message("short", length=10) == "short"
+    assert truncate_message("abcdefghij", length=5) == "abcde..."


### PR DESCRIPTION
## What changed

- Added focused tests for PBN import command helpers, websocket consumers, importer wrappers, initial setup, publication import, institution import, source scoring, routing, and template tags.
- Added regression coverage for CLI multi-hosted context propagation in `pbn_import`.
- Updated `pbn_import` so the command uses the `Uczelnia` resolved by `PBNBaseCommand` and passes it to `ImportManager`.
- Fixed `fix_missing_imported_pubs --type` handling by avoiding the `list.count()` zero-argument crash in `_prepare_missing_list`.
- Ignored named coverage JSON reports such as `coverage-pbn-import.json`.

## Findings

- The command path previously instantiated `ImportManager` without the resolved `Uczelnia`, while the Celery path already passed tenant context. That could let command imports lose multi-hosted scoping.
- The `fix_missing_imported_pubs` type-filter path returns a Python list; `_prepare_missing_list()` treated it like a QuerySet because lists also expose `count`, causing a runtime `TypeError`.
- Several earlier error-path tests were too mock-heavy and did not verify actual importer error accounting. The new tests assert `self.errors` and `ImportLog` behavior directly while only suppressing Rollbar.

## Validation

- `uv run ruff check src/pbn_import/management/commands/pbn_import.py src/pbn_import/management/commands/fix_missing_imported_pubs.py src/pbn_import/tests/test_command_helpers.py src/pbn_import/tests/test_command_pbn_import.py src/pbn_import/tests/test_consumers.py src/pbn_import/tests/test_error_handling.py src/pbn_import/tests/test_fix_commands.py src/pbn_import/tests/test_importer_wrappers.py src/pbn_import/tests/test_initial_setup.py src/pbn_import/tests/test_institution_import.py src/pbn_import/tests/test_publication_import.py src/pbn_import/tests/test_routing.py src/pbn_import/tests/test_source_scoring_import.py src/pbn_import/tests/test_templatetags.py`
- `uv run pytest src/pbn_import/tests --cov=src/pbn_import --cov-branch --cov-report=term-missing:skip-covered --cov-report=json:coverage-pbn-import.json`
- Result: `321 passed`, total coverage `81.47%`.
