### PR TITLE
fix(oidc): napraw logowanie OIDC + menu instytucjonalne per-uczelnia

### DIFF
--- a/docs/superpowers/specs/2026-06-05-oidc-login-fix-design.md
+++ b/docs/superpowers/specs/2026-06-05-oidc-login-fix-design.md
@@ -59,16 +59,40 @@ Logowanie OIDC (Keycloak, realm KA) nie działa. Z logów:
   odporne na wersje). Efekt: nieudane logowanie OAuth jest audytowane czysto,
   bez 500. Bez własnego widoku callbacka, bez `except KeyError`.
 
-### 3. Menu + routing — `top_bar.html`, `django_bpp/urls.py`, `registration/login.html`
-- `urls.py`: nowa gałąź gdy OIDC włączone (a Microsoft nie) — lustro gałęzi
-  Microsoftu: `local_login_form` (formularz BPP), `login_form` →
-  `RedirectView(pattern_name="oidc_authentication_init", query_string=True)`,
-  `logout` = `BppOIDCAwareLogoutView`.
-- `top_bar.html`: warunek `microsoft_login_enabled` → `microsoft_login_enabled
-  or oidc_login_enabled`; „logowanie instytucjonalne" celuje w
-  `bpp:microsoft_auth_redirect` albo `oidc_authentication_init` zależnie od
-  tego, co włączone; „logowanie BPP" → `local_login_form`.
+### 3. Menu + routing — PER-UCZELNIA (multi-hosted)
+
+Uzupełnienie po analizie: jeden proces obsługuje wiele uczelni po domenie
+(`SiteResolutionMiddleware` → `request._uczelnia`), ale OIDC to **jeden realm
+na proces** (mozilla czyta globalne `OIDC_RP_*`). Microsoft jest globalny i nie
+ma per-uczelnia bindingu. Decyzja usera: **gateuj OIDC po skrócie uczelni,
+Microsoft zostaw globalny**. Precedencja: OIDC (per-uczelnia) > Microsoft
+(globalny) > formularz BPP.
+
+- `oidc_integration/access.py` — `oidc_enabled_for_request(request)`: wspólne
+  źródło prawdy dla menu i routingu. OIDC wł. + brak skrótu → globalnie
+  (instalacja jedno-uczelniana); skrót ustawiony → tylko gdy
+  `request._uczelnia.skrot == OIDC_LOGIN_SKROT`.
+- `bpp/context_processors/oidc.py` — `oidc_login_enabled` liczone per-request
+  przez `oidc_enabled_for_request` (krótkie spięcie gdy OIDC wyłączone).
+- `django_bpp/views.py` — `InstitutionalLoginView` (używany jako `login_form`):
+  OIDC (jeśli dotyczy uczelni) → redirect na `oidc_authentication_init`
+  (z `?next`); inaczej Microsoft (jeśli zainstalowany, globalnie); inaczej
+  formularz BPP. Może współistnieć z `microsoft_auth` w jednym procesie.
+- `django_bpp/urls.py`: gdy `oidc_integration` zainstalowane → `login_form` =
+  `InstitutionalLoginView`, `local_login_form` = formularz BPP, `logout` =
+  `BppOIDCAwareLogoutView`. Gdy tylko `microsoft_auth` → gałąź Microsoft jak
+  dotąd. Gdy nic → tylko logowanie lokalne.
+- `top_bar.html`: warunek `microsoft_login_enabled or oidc_login_enabled`;
+  „logowanie instytucjonalne" celuje w `oidc_authentication_init` gdy
+  `oidc_login_enabled`, inaczej `bpp:microsoft_auth_redirect`; „logowanie BPP"
+  → `local_login_form`.
 - `registration/login.html`: usunąć przycisk OIDC spod formularza.
+
+Znane ograniczenie (poza zakresem): w procesie OIDC+Microsoft jednocześnie
+wylogowanie sesji Microsoft idzie standardowym Django logout (bez provider
+logout do Microsoftu). Guard easyaudit aktywny tylko gdy `oidc_integration`
+zainstalowane (czyli gdy OIDC skonfigurowane) — to wystarcza dla zgłoszonego
+buga OIDC.
 
 ### 4. Testy (TDD)
 - backend: `get_userinfo` normalizuje `mail`→`email`; `verify_claims`

--- a/docs/superpowers/specs/2026-06-05-oidc-login-fix-design.md
+++ b/docs/superpowers/specs/2026-06-05-oidc-login-fix-design.md
@@ -1,0 +1,85 @@
+# OIDC: naprawa logowania + menu „logowanie instytucjonalne"
+
+Data: 2026-06-05
+Branch: `feature/oidc-login` → PR do `feature/multi-hosted-config`
+
+## Problem
+
+Logowanie OIDC (Keycloak, realm KA) nie działa. Z logów:
+
+1. **„Claims verification failed"** — `mozilla_django_oidc.verify_claims`
+   sprawdza `"email" in claims`, bo scope zawiera `email`. Keycloak wysyła
+   klucz **`mail`**, nie `email`. Poprawne logowanie jest odrzucane.
+   Te same `filter_users_by_claims` (dopasowanie po e-mailu) i `create_user`
+   czytają `email`, więc nawet po przejściu konto miałoby pusty e-mail.
+
+2. **`KeyError: 'username'`** — przy nieudanym logowaniu Django wysyła sygnał
+   `user_login_failed`, a handler `easyaudit` robi twardy `credentials['username']`
+   (a nie `.get(...)`). Callback mozilli woła `auth.authenticate(request,
+   nonce=…, code_verifier=…)` — bez `username`. Przy
+   `DJANGO_EASY_AUDIT_PROPAGATE_EXCEPTIONS = True` ten `KeyError` wybucha jako
+   HTTP 500. Uwaga: `credentials` to NIE są claimy — w tym miejscu
+   `preferred_username` fizycznie nie istnieje (claimy pobierane są dopiero
+   wewnątrz backendu).
+
+3. **Brak menu** — OIDC istnieje dziś tylko jako przycisk pod formularzem
+   logowania (`registration/login.html`). User chce parytetu z Microsoftem:
+   w menu „logowanie instytucjonalne" (→ OIDC) i „logowanie BPP" (→ lokalne),
+   bez formularza z przyciskiem pod spodem.
+
+## Decyzje (potwierdzone z userem)
+
+- Dopasowanie/tworzenie konta **po e-mailu** (`mail`→`email`); `username` z
+  `preferred_username` (→ `email` → `sub`); imię/nazwisko z
+  `given_name`/`family_name`. **Bez** `person_id`.
+- Domyślne logowanie **jak Microsoft**: `login_form` → redirect na OIDC;
+  „logowanie BPP" osobno w menu (`local_login_form`).
+- **Gating bez zmian**: każdy z realmu dostaje zwykłe konto bez `is_staff`.
+- Banner `[OIDC]` z claimami: ścisz do `logger.debug` (koniec stderr).
+
+## Rozwiązanie
+
+### 1. Normalizacja claimów — `src/oidc_integration/backends.py`
+- Nadpisać `get_userinfo()`: jeśli brak `email`, a jest `mail`, ustaw
+  `claims["email"] = claims["mail"]`. Jeden chokepoint — `verify_claims`,
+  `filter_users_by_claims` (domyślny) i `create_user` dostają znormalizowany
+  słownik.
+- `create_user` bez zmian merytorycznych (username `preferred_username`→
+  `email`→`sub`, imię/nazwisko z claimów) — teraz z niepustym e-mailem.
+- `_dump_claims_to_stderr` → `logger.debug` (bez bannera na stderr).
+
+### 2. Odporność easyaudit — `src/oidc_integration/apps.py` (+ moduł compat)
+- W `AppConfig.ready()`, tylko gdy `easyaudit` zainstalowany: zaimportuj
+  `easyaudit.signals.auth_signals` (gwarancja, że easyaudit już się podłączył),
+  rozłącz jego `user_login_failed` (`dispatch_uid="easy_audit_signals_login_failed"`),
+  podłącz cienki wrapper z tym samym `dispatch_uid`.
+- Wrapper: jeśli w `credentials` brak `USERNAME_FIELD`, dołóż go
+  (`credentials.get("preferred_username")` lub `""`), a potem **deleguj do
+  oryginalnej funkcji easyaudit** (reużycie logiki audytu; brak duplikacji,
+  odporne na wersje). Efekt: nieudane logowanie OAuth jest audytowane czysto,
+  bez 500. Bez własnego widoku callbacka, bez `except KeyError`.
+
+### 3. Menu + routing — `top_bar.html`, `django_bpp/urls.py`, `registration/login.html`
+- `urls.py`: nowa gałąź gdy OIDC włączone (a Microsoft nie) — lustro gałęzi
+  Microsoftu: `local_login_form` (formularz BPP), `login_form` →
+  `RedirectView(pattern_name="oidc_authentication_init", query_string=True)`,
+  `logout` = `BppOIDCAwareLogoutView`.
+- `top_bar.html`: warunek `microsoft_login_enabled` → `microsoft_login_enabled
+  or oidc_login_enabled`; „logowanie instytucjonalne" celuje w
+  `bpp:microsoft_auth_redirect` albo `oidc_authentication_init` zależnie od
+  tego, co włączone; „logowanie BPP" → `local_login_form`.
+- `registration/login.html`: usunąć przycisk OIDC spod formularza.
+
+### 4. Testy (TDD)
+- backend: `get_userinfo` normalizuje `mail`→`email`; `verify_claims`
+  przechodzi z `mail`; `create_user` bierze username z `preferred_username`,
+  e-mail z `mail`, ustawia imię/nazwisko; re-login dopasowuje po e-mailu.
+- easyaudit compat: wrapper dokłada brakujący `username` i deleguje; przy
+  obecnym `username` nie rusza credentials.
+- urls/settings: w trybie OIDC istnieje `local_login_form`, a `login_form`
+  redirectuje na OIDC.
+
+## Poza zakresem
+- Powiązanie konta z `Autor` (po `person_id` czy inaczej).
+- Gating po rolach/grupach Keycloaka.
+- Mapowanie ról → grupy/uprawnienia.

--- a/src/bpp/context_processors/oidc.py
+++ b/src/bpp/context_processors/oidc.py
@@ -4,11 +4,18 @@ from django.conf import settings
 def oidc_auth_status(request):
     """Udostępnia szablonom status logowania OIDC (bez ruchu sieciowego).
 
-    Flagi ustawia ``settings/base.py`` tylko gdy konfiguracja OIDC jest
-    obecna w środowisku; w przeciwnym razie zwracamy wartości domyślne
-    (wyłączone), jak robią to context processory ORCID/Microsoft.
+    ``oidc_login_enabled`` jest **per-uczelnia**: w instalacji wielouczelnianej
+    OIDC to jeden realm na proces, więc przycisk pokazujemy tylko na domenie
+    uczelni o skrócie == ``OIDC_LOGIN_SKROT`` (patrz
+    ``oidc_integration.access.oidc_enabled_for_request``). Gdy OIDC jest w
+    procesie wyłączone, krótkie spięcie bez importu apki.
     """
+    if not getattr(settings, "OIDC_LOGIN_ENABLED", False):
+        return {"oidc_login_enabled": False, "oidc_login_skrot": ""}
+
+    from oidc_integration.access import oidc_enabled_for_request
+
     return {
-        "oidc_login_enabled": getattr(settings, "OIDC_LOGIN_ENABLED", False),
+        "oidc_login_enabled": oidc_enabled_for_request(request),
         "oidc_login_skrot": getattr(settings, "OIDC_LOGIN_SKROT", ""),
     }

--- a/src/django_bpp/templates/registration/login.html
+++ b/src/django_bpp/templates/registration/login.html
@@ -24,14 +24,6 @@
                     </a>
                 </div>
                 {% endif %}
-                {% if oidc_login_enabled %}
-                <div style="margin-top: 1rem;">
-                    <a href="{% url "oidc_authentication_init" %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}"
-                       class="button expanded">
-                        Zaloguj się przez {{ oidc_login_skrot|default:"OpenID" }}
-                    </a>
-                </div>
-                {% endif %}
                 {% if not microsoft_login_enabled %}
                 <a href="{% url "password_reset" %}">Zapomniałem/am hasła.</a>
                 {% endif %}

--- a/src/django_bpp/templates/top_bar.html
+++ b/src/django_bpp/templates/top_bar.html
@@ -461,13 +461,18 @@
             {% endif %}
 
             {% if request.user.is_anonymous %}
-                {% if microsoft_login_enabled %}
+                {% if microsoft_login_enabled or oidc_login_enabled %}
                     <li>
                         <a href="#" aria-haspopup="menu"><i class="fi-lock" aria-hidden="true"></i>
                         zaloguj</a>
                         <ul class="menu vertical" role="menu">
+                            {% if oidc_login_enabled %}
+                            <li><a href="{% url "oidc_authentication_init" %}?next={{ request.get_full_path|urlencode }}">
+                                <i class="fi-cloud"></i> logowanie instytucjonalne</a></li>
+                            {% else %}
                             <li><a href="{% url "bpp:microsoft_auth_redirect" %}?next={{ request.get_full_path|urlencode }}">
                                 <i class="fi-cloud"></i> logowanie instytucjonalne</a></li>
+                            {% endif %}
                             {% if orcid_login_enabled %}
                             <li><a href="{% url "orcid_integration:login" %}?next={{ request.get_full_path|urlencode }}">
                                 <span class="fi-torso"></span> logowanie ORCID</a></li>

--- a/src/django_bpp/urls.py
+++ b/src/django_bpp/urls.py
@@ -395,28 +395,42 @@ if settings.DEBUG and settings.DEBUG_TOOLBAR:
     urlpatterns += debug_toolbar_urls()
 
 
-if not apps.is_installed("microsoft_auth"):
+if apps.is_installed("oidc_integration"):
     #
-    # Jeżeli NIE ma włączonej aplikacji microsoft_auth, to obsługuj
-    # własne logowanie hasłem z front-endu:
+    # Logowanie instytucjonalne przez OIDC (Keycloak). apps.is_installed(
+    # "oidc_integration") jest prawdą tylko gdy OIDC jest skonfigurowane (apka
+    # dokładana warunkowo w settings). OIDC to jeden realm na proces, więc
+    # logowanie jest wybierane PER-UCZELNIA: InstitutionalLoginView odbija na
+    # Keycloaka tylko dla domeny uczelni o skrócie == OIDC_LOGIN_SKROT, dla
+    # pozostałych domen używa Microsoftu (jeśli włączony, globalnie) albo
+    # formularza BPP. Może współistnieć z microsoft_auth w jednym procesie.
+    # Formularz BPP osobno pod local_login_form. Logout świadomy OIDC.
     #
-    # Logout świadomy OIDC: sesja OIDC → wyloguj też z Keycloaka; reszta →
-    # standardowy LogoutView. Bezpieczny nadzbiór, więc używamy go zawsze gdy
-    # apka OIDC jest aktywna.
-    if apps.is_installed("oidc_integration"):
-        from oidc_integration.views import BppOIDCAwareLogoutView as _LogoutView
-    else:
-        _LogoutView = LogoutView
+    from django_bpp.views import InstitutionalLoginView
+    from oidc_integration.views import BppOIDCAwareLogoutView
 
     urlpatterns += [
         url(
-            r"^accounts/login/$",
+            r"^accounts/login/local/$",
             HTMXAwareLoginView.as_view(authentication_form=MyAuthenticationForm),
+            name="local_login_form",
+        ),
+        url(
+            r"^accounts/login/$",
+            InstitutionalLoginView.as_view(),
             name="login_form",
         ),
-        url(r"^logout/$", login_required(_LogoutView.as_view()), name="logout"),
+        url(
+            r"^logout/$",
+            login_required(BppOIDCAwareLogoutView.as_view()),
+            name="logout",
+        ),
     ]
-else:
+elif apps.is_installed("microsoft_auth"):
+    #
+    # Logowanie instytucjonalne przez Microsoft (globalne, jak dotąd): domyślne
+    # logowanie odbija na Microsoft, formularz BPP osobno pod local_login_form.
+    #
     from django_bpp.views import MicrosoftLogoutView
 
     urlpatterns += [
@@ -437,6 +451,18 @@ else:
             MicrosoftLogoutView.as_view(),
             name="logout",
         ),
+    ]
+else:
+    #
+    # Brak logowania instytucjonalnego — własne logowanie hasłem z front-endu.
+    #
+    urlpatterns += [
+        url(
+            r"^accounts/login/$",
+            HTMXAwareLoginView.as_view(authentication_form=MyAuthenticationForm),
+            name="login_form",
+        ),
+        url(r"^logout/$", login_required(LogoutView.as_view()), name="logout"),
     ]
 
 if apps.is_installed("password_policies"):

--- a/src/django_bpp/views.py
+++ b/src/django_bpp/views.py
@@ -1,6 +1,7 @@
 import logging
 from urllib.parse import urlencode
 
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import BACKEND_SESSION_KEY, logout
 from django.contrib.auth.views import LoginView
@@ -42,6 +43,46 @@ class HTMXAwareLoginView(LoginView):
             return response
 
         return super().get(request, *args, **kwargs)
+
+
+def _redirect_preserving_next(request, base_url):
+    nxt = request.GET.get("next")
+    if nxt:
+        return HttpResponseRedirect(f"{base_url}?{urlencode({'next': nxt})}")
+    return HttpResponseRedirect(base_url)
+
+
+class InstitutionalLoginView(View):
+    """Per-uczelnia dyspozytor logowania (używany jako ``login_form``).
+
+    Precedencja: OIDC (gateowany po skrócie uczelni) > Microsoft (globalny) >
+    formularz BPP. Dzięki temu w instalacji wielouczelnianej domena uczelni z
+    OIDC odbija na Keycloaka, domeny pod Microsoftem na Microsoft, a reszta
+    dostaje lokalny formularz — wszystko z jednego procesu, decydowane na
+    podstawie ``request._uczelnia``.
+
+    ``oidc_enabled_for_request`` to wspólne źródło prawdy z context processorem
+    rysującym menu, więc to, co widać, zgadza się z tym, dokąd kieruje login.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        from oidc_integration.access import oidc_enabled_for_request
+
+        if oidc_enabled_for_request(request):
+            return _redirect_preserving_next(
+                request, reverse("oidc_authentication_init")
+            )
+        if apps.is_installed("microsoft_auth"):
+            return _redirect_preserving_next(
+                request, reverse("microsoft_auth:to-auth-redirect")
+            )
+
+        # Brak logowania instytucjonalnego dla tej uczelni — formularz BPP.
+        from bpp.forms import MyAuthenticationForm
+
+        return HTMXAwareLoginView.as_view(authentication_form=MyAuthenticationForm)(
+            request, *args, **kwargs
+        )
 
 
 class MicrosoftLogoutView(View):

--- a/src/oidc_integration/access.py
+++ b/src/oidc_integration/access.py
@@ -1,0 +1,38 @@
+"""Reguła: czy bieżący request ma używać logowania OIDC.
+
+W instalacji wielouczelnianej jeden proces obsługuje wiele uczelni (po
+domenie), ale OIDC to **jeden realm na proces** (``mozilla-django-oidc`` czyta
+globalne ``OIDC_RP_*``). Dlatego logowanie OIDC pokazujemy/uruchamiamy tylko na
+domenie uczelni, do której ten realm należy — identyfikowanej przez
+``OIDC_LOGIN_SKROT`` (== ``Uczelnia.skrot``).
+
+Jedna funkcja (`oidc_enabled_for_request`) jest wspólnym źródłem prawdy dla
+menu (context processor) i routingu (`login_form`), żeby nie rozjechało się to,
+co widać, z tym, dokąd faktycznie kieruje logowanie.
+"""
+
+from django.conf import settings
+
+
+def oidc_enabled_for_request(request):
+    """Czy ``request`` (jego uczelnia) ma używać logowania OIDC.
+
+    * OIDC wyłączone w procesie → ``False``.
+    * Brak ``OIDC_LOGIN_SKROT`` (konfiguracja bez skrótu = instalacja
+      jedno-uczelniana) → ``True`` globalnie, jak dawniej.
+    * Skrót ustawiony → ``True`` tylko gdy uczelnia z requestu ma ten skrót.
+    """
+    if not getattr(settings, "OIDC_LOGIN_ENABLED", False):
+        return False
+
+    skrot = (getattr(settings, "OIDC_LOGIN_SKROT", "") or "").strip()
+    if not skrot:
+        # Brak per-uczelnia bindingu — pojedyncza uczelnia, OIDC globalnie.
+        return True
+
+    from bpp.models import Uczelnia
+
+    uczelnia = Uczelnia.objects.get_for_request(request)
+    if uczelnia is None:
+        return False
+    return (uczelnia.skrot or "").strip().upper() == skrot.upper()

--- a/src/oidc_integration/apps.py
+++ b/src/oidc_integration/apps.py
@@ -1,6 +1,18 @@
-from django.apps import AppConfig
+from django.apps import AppConfig, apps
 
 
 class OidcIntegrationConfig(AppConfig):
     name = "oidc_integration"
     verbose_name = "Integracja z OpenID Connect (Keycloak)"
+
+    def ready(self):
+        # Gdy easyaudit jest aktywny, jego receiver user_login_failed wywala
+        # KeyError('username') na nieudanym logowaniu OAuth (callback OIDC nie
+        # podaje username w credentials) — podmieniamy go na odporny wariant.
+        if not apps.is_installed("easyaudit"):
+            return
+        from oidc_integration.easyaudit_compat import (
+            install_easyaudit_login_failed_guard,
+        )
+
+        install_easyaudit_login_failed_guard()

--- a/src/oidc_integration/backends.py
+++ b/src/oidc_integration/backends.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 from django.conf import settings
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
@@ -7,34 +6,39 @@ from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 logger = logging.getLogger(__name__)
 
 
-def _dump_claims_to_stderr(claims):
-    """Wypisz na stderr klucze i wartości claimów z Keycloaka.
+def _log_claims_debug(claims):
+    """Zaloguj klucze i wartości claimów z Keycloaka na poziomie DEBUG.
 
-    Cel discovery: zobaczyć, co realnie wystawia realm KA, bez interaktywnego
-    klikania — wynik ląduje w konsoli runservera / logu serwera. Banner ułatwia
-    wyłowienie tego w hałasie logów (`grep '\\[OIDC\\]'`).
+    Po fazie discovery nie zaśmiecamy już stderr bannerem — podgląd claimów
+    zostaje dostępny przez ``logging`` na DEBUG (np. do diagnostyki realmu),
+    ale domyślnie milczy. Guard na ``isEnabledFor`` unika składania stringów,
+    gdy DEBUG i tak jest wyłączony.
     """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
     keys = sorted(claims.keys())
-    banner = "=" * 70
-    print(banner, file=sys.stderr)
-    print("[OIDC] Claimy otrzymane z Keycloaka (userinfo):", file=sys.stderr)
-    print(f"[OIDC] Klucze ({len(keys)}): {', '.join(keys)}", file=sys.stderr)
+    logger.debug("OIDC: otrzymane claimy (%d): %s", len(keys), ", ".join(keys))
     for key in keys:
-        print(f"[OIDC]   {key} = {claims[key]!r}", file=sys.stderr)
-    print(banner, file=sys.stderr, flush=True)
+        logger.debug("OIDC:   %s = %r", key, claims[key])
 
 
 class BppOIDCBackend(OIDCAuthenticationBackend):
     """Backend logowania OpenID Connect (Keycloak) dla BPP.
 
-    Faza 2a (discovery, obecna): zakładaj konto KAŻDEMU zalogowanemu —
-    zwykłe konto, **bez** ``is_staff``/``is_superuser`` — i wypisz na stderr
-    klucze claimów, żeby zobaczyć, co wystawia realm. To krok poznawczy: na
-    podstawie realnych kluczy zaprojektujemy właściwe reguły.
+    Zachowanie: zakładaj konto KAŻDEMU zalogowanemu z realmu — zwykłe konto,
+    **bez** ``is_staff``/``is_superuser``. Dopasowanie istniejących kont i
+    tworzenie nowych odbywa się po e-mailu; ``username`` bierzemy z
+    ``preferred_username``.
 
     ⚠️ „Konto każdemu" oznacza, że dowolna osoba z realmu KA (potencjalnie też
     studenci — patrz scope ``kierunek-oidc``) dostanie konto BPP. Bezpieczne o
-    tyle, że bez ``is_staff`` nie ma dostępu do panelu/edycji. To stan tymczasowy.
+    tyle, że bez ``is_staff`` nie ma dostępu do panelu/edycji.
+
+    Normalizacja claimów: realm KA wystawia adres pod kluczem ``mail``, a
+    ``mozilla-django-oidc`` (``verify_claims``/``filter_users_by_claims``/
+    ``create_user``) oczekuje ``email``. Uzupełniamy ``email`` z ``mail`` w
+    jednym miejscu — ``get_userinfo`` — przez które przechodzą wszystkie te
+    metody (``get_or_create_user`` woła je na wyniku ``get_userinfo``).
 
     Przypisanie uczelni: konto dostaje ``accessible_uczelnie`` (M2M z PR #189)
     z uczelnią o ``skrot`` == skrótowi z konfiguracji OIDC. Ten sam skrót
@@ -42,18 +46,31 @@ class BppOIDCBackend(OIDCAuthenticationBackend):
     ``Uczelnia.skrot`` — dzięki czemu docelowe „3 backendy = 3 uczelnie" same
     przypisują właściwą uczelnię, bez dodatkowej konfiguracji.
 
-    Faza 2b (po obejrzeniu kluczy) — TU wejdą reguły:
-      * gating po rolach/grupach (``realm_access.roles``): „kogo nie wpuszczamy"
-        → ``verify_claims`` zwraca ``False``;
-      * „komu nie tworzymy konta" → warunek w ``create_user``;
-      * mapowanie ról Keycloaka na grupy/uprawnienia → ``update_user``;
-      * powiązanie z istniejącym ``Autor`` przez claim ``person_id`` →
-        ``filter_users_by_claims``.
+    Możliwe rozszerzenia (poza zakresem): gating po rolach/grupach
+    (``realm_access.roles``) w ``verify_claims``; mapowanie ról na grupy/
+    uprawnienia w ``update_user``.
     """
 
+    @staticmethod
+    def _normalized(claims):
+        """Zwróć claimy z uzupełnionym ``email`` z ``mail`` (jeśli trzeba).
+
+        Gdy ``email`` już jest albo nie ma ``mail`` — zwraca wejście bez zmian.
+        W przeciwnym razie zwraca **kopię** z dorobionym ``email`` (oryginalny
+        ``mail`` zostaje zachowany).
+        """
+        if claims.get("email") or not claims.get("mail"):
+            return claims
+        return {**claims, "email": claims["mail"]}
+
+    def get_userinfo(self, access_token, id_token, payload):
+        # Jedyny chokepoint: znormalizuj claimy z userinfo, zanim trafią do
+        # verify_claims / filter_users_by_claims / create_user.
+        claims = super().get_userinfo(access_token, id_token, payload)
+        return self._normalized(claims)
+
     def verify_claims(self, claims):
-        _dump_claims_to_stderr(claims)
-        logger.info("OIDC: otrzymane claimy: %r", claims)
+        _log_claims_debug(claims)
         return super().verify_claims(claims)
 
     def _assign_uczelnia(self, user):

--- a/src/oidc_integration/easyaudit_compat.py
+++ b/src/oidc_integration/easyaudit_compat.py
@@ -1,0 +1,68 @@
+"""Uodpornienie handlera ``user_login_failed`` z django-easy-audit.
+
+easyaudit audytuje nieudane logowania robiąc twardo
+``credentials[USERNAME_FIELD]`` (a nie ``.get(...)``). Backendy OAuth
+(OIDC/Microsoft/ORCID) wołają ``auth.authenticate()`` bez ``username`` w
+credentials — wtedy handler rzuca ``KeyError``, a przy
+``DJANGO_EASY_AUDIT_PROPAGATE_EXCEPTIONS = True`` zamienia się to w HTTP 500
+na ścieżce *nieudanego* logowania (m.in. callback OIDC).
+
+Tu podmieniamy receiver easyaudit na cienki wrapper: gdy w ``credentials``
+brakuje klucza username, dokładamy go (best-effort), a potem delegujemy do
+**oryginalnej** funkcji easyaudit — reużywamy ich logikę zapisu audytu, więc
+jest to odporne na zmiany wersji biblioteki.
+"""
+
+import logging
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.signals import user_login_failed
+
+logger = logging.getLogger(__name__)
+
+# Ten sam dispatch_uid, którego używa easyaudit przy connect() — dzięki temu
+# rozłączamy dokładnie jego receiver i podstawiamy nasz w to miejsce.
+EASYAUDIT_DISPATCH_UID = "easy_audit_signals_login_failed"
+
+
+def _ensure_username(credentials):
+    """Zwróć ``credentials`` z gwarantowanym kluczem ``USERNAME_FIELD``.
+
+    Gdy klucz jest — zwraca wejście bez zmian. Gdy go brak (typowe dla OAuth) —
+    zwraca kopię z dorobionym username: ``preferred_username`` jeśli akurat
+    jest w credentials, inaczej pusty string.
+    """
+    username_field = get_user_model().USERNAME_FIELD
+    if username_field in credentials:
+        return credentials
+    return {
+        **credentials,
+        username_field: credentials.get("preferred_username") or "",
+    }
+
+
+def _make_guard(original):
+    """Zbuduj receiver opakowujący ``original`` o sanityzację credentials."""
+
+    def guarded_user_login_failed(sender, credentials, **kwargs):
+        return original(
+            sender=sender, credentials=_ensure_username(credentials), **kwargs
+        )
+
+    return guarded_user_login_failed
+
+
+def install_easyaudit_login_failed_guard():
+    """Podmień kruchy receiver easyaudit na odporny na brak ``username``.
+
+    Import ``easyaudit.signals.auth_signals`` gwarantuje, że easyaudit zdążył
+    podłączyć swój receiver, zanim go rozłączymy — niezależnie od kolejności
+    ``INSTALLED_APPS``. Idempotentne: ponowne wywołanie podstawia świeży guard.
+    """
+    from easyaudit.signals import auth_signals
+
+    guard = _make_guard(auth_signals.user_login_failed)
+    user_login_failed.disconnect(dispatch_uid=EASYAUDIT_DISPATCH_UID)
+    user_login_failed.connect(guard, dispatch_uid=EASYAUDIT_DISPATCH_UID)
+    logger.debug("easyaudit user_login_failed guard zainstalowany")
+    return guard

--- a/src/oidc_integration/tests/test_access.py
+++ b/src/oidc_integration/tests/test_access.py
@@ -1,0 +1,71 @@
+"""Testy per-uczelnia gatingu OIDC (`oidc_enabled_for_request`) i context
+processora menu (`oidc_auth_status`).
+"""
+
+import pytest
+from django.test import override_settings
+from model_bakery import baker
+
+from bpp.context_processors.oidc import oidc_auth_status
+from oidc_integration.access import oidc_enabled_for_request
+
+
+class _Req:
+    """Lekki request: get_for_request czyta tylko atrybut ``_uczelnia``."""
+
+    def __init__(self, uczelnia):
+        self._uczelnia = uczelnia
+
+
+@override_settings(OIDC_LOGIN_ENABLED=False)
+def test_wylaczone_oidc_zwraca_false():
+    assert oidc_enabled_for_request(_Req(None)) is False
+
+
+@override_settings(OIDC_LOGIN_ENABLED=True, OIDC_LOGIN_SKROT="")
+def test_bez_skrotu_dziala_globalnie():
+    # Konfiguracja bez skrótu = instalacja jedno-uczelniana → OIDC globalnie.
+    assert oidc_enabled_for_request(_Req(None)) is True
+
+
+@pytest.mark.django_db
+@override_settings(OIDC_LOGIN_ENABLED=True, OIDC_LOGIN_SKROT="UAFM")
+def test_dopasowanie_skrotu_uczelni_true():
+    uczelnia = baker.make("bpp.Uczelnia", skrot="UAFM")
+    assert oidc_enabled_for_request(_Req(uczelnia)) is True
+
+
+@pytest.mark.django_db
+@override_settings(OIDC_LOGIN_ENABLED=True, OIDC_LOGIN_SKROT="uafm")
+def test_dopasowanie_skrotu_ignoruje_wielkosc_liter():
+    uczelnia = baker.make("bpp.Uczelnia", skrot="UAFM")
+    assert oidc_enabled_for_request(_Req(uczelnia)) is True
+
+
+@pytest.mark.django_db
+@override_settings(OIDC_LOGIN_ENABLED=True, OIDC_LOGIN_SKROT="UAFM")
+def test_inna_uczelnia_nie_widzi_oidc():
+    uczelnia = baker.make("bpp.Uczelnia", skrot="INNA")
+    assert oidc_enabled_for_request(_Req(uczelnia)) is False
+
+
+@override_settings(OIDC_LOGIN_ENABLED=True, OIDC_LOGIN_SKROT="UAFM")
+def test_brak_uczelni_w_requescie_false():
+    assert oidc_enabled_for_request(_Req(None)) is False
+
+
+@override_settings(OIDC_LOGIN_ENABLED=False)
+def test_context_processor_krotkie_spiecie_gdy_wylaczone():
+    out = oidc_auth_status(_Req(None))
+    assert out == {"oidc_login_enabled": False, "oidc_login_skrot": ""}
+
+
+@pytest.mark.django_db
+@override_settings(OIDC_LOGIN_ENABLED=True, OIDC_LOGIN_SKROT="UAFM")
+def test_context_processor_per_uczelnia():
+    uafm = baker.make("bpp.Uczelnia", skrot="UAFM")
+    inna = baker.make("bpp.Uczelnia", skrot="INNA")
+
+    assert oidc_auth_status(_Req(uafm))["oidc_login_enabled"] is True
+    assert oidc_auth_status(_Req(inna))["oidc_login_enabled"] is False
+    assert oidc_auth_status(_Req(uafm))["oidc_login_skrot"] == "UAFM"

--- a/src/oidc_integration/tests/test_backends.py
+++ b/src/oidc_integration/tests/test_backends.py
@@ -30,21 +30,46 @@ def test_verify_claims_odrzuca_bez_emaila():
     assert _backend().verify_claims({"sub": "123"}) is False
 
 
-def test_verify_claims_loguje_claimy(caplog):
-    with caplog.at_level(logging.INFO, logger="oidc_integration.backends"):
-        _backend().verify_claims({"email": "jan@uafm.edu.pl", "sub": "123"})
-    assert any("otrzymane claimy" in rec.message for rec in caplog.records)
+def test_verify_claims_przepuszcza_znormalizowane_claimy_z_mail():
+    # Keycloak realmu KA wystawia `mail`; po normalizacji (get_userinfo)
+    # claimy mają `email` i weryfikacja przechodzi.
+    backend = _backend()
+    claims = backend._normalized({"mail": "jan@uafm.edu.pl", "sub": "123"})
+    assert backend.verify_claims(claims) is True
 
 
-def test_verify_claims_zrzuca_klucze_na_stderr(capsys):
-    _backend().verify_claims(
-        {"email": "jan@uafm.edu.pl", "sub": "123", "person_id": "999"}
+def test_verify_claims_loguje_klucze_na_debug(caplog):
+    with caplog.at_level(logging.DEBUG, logger="oidc_integration.backends"):
+        _backend().verify_claims(
+            {"email": "jan@uafm.edu.pl", "sub": "123", "person_id": "999"}
+        )
+    debug = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    joined = " ".join(r.getMessage() for r in debug)
+    assert "email" in joined and "person_id" in joined and "sub" in joined
+
+
+def test_verify_claims_nie_pisze_bannera_na_stderr(capsys):
+    _backend().verify_claims({"email": "jan@uafm.edu.pl", "sub": "123"})
+    assert "[OIDC]" not in capsys.readouterr().err
+
+
+def test_normalized_uzupelnia_email_z_mail():
+    out = _backend()._normalized({"mail": "jan@uafm.edu.pl", "sub": "1"})
+    assert out["email"] == "jan@uafm.edu.pl"
+    # oryginalny `mail` zachowany
+    assert out["mail"] == "jan@uafm.edu.pl"
+
+
+def test_normalized_nie_nadpisuje_istniejacego_email():
+    out = _backend()._normalized(
+        {"email": "wlasny@uafm.edu.pl", "mail": "inny@uafm.edu.pl"}
     )
-    err = capsys.readouterr().err
-    assert "[OIDC]" in err
-    assert "Klucze (3)" in err
-    # klucze wypisane alfabetycznie
-    assert "email" in err and "person_id" in err and "sub" in err
+    assert out["email"] == "wlasny@uafm.edu.pl"
+
+
+def test_normalized_bez_mail_nie_dorabia_email():
+    out = _backend()._normalized({"sub": "123"})
+    assert "email" not in out
 
 
 @pytest.mark.django_db
@@ -71,6 +96,44 @@ def test_create_user_zaklada_zwykle_konto_bez_is_staff():
     assert user.is_active is True
     # logowanie wyłącznie przez OIDC — brak używalnego hasła lokalnego
     assert not user.has_usable_password()
+
+
+@pytest.mark.django_db
+def test_create_user_email_z_mail_po_normalizacji():
+    # Pełna ścieżka: claimy z Keycloaka (`mail`, `preferred_username`) →
+    # normalizacja → create_user. Konto dostaje username z preferred_username
+    # i e-mail z mail.
+    backend = _backend()
+    backend.UserModel = get_user_model()
+
+    user = backend.create_user(
+        backend._normalized(
+            {
+                "preferred_username": "99999@student-afm.edu.pl",
+                "mail": "99999@student-afm.edu.pl",
+                "given_name": "Test",
+                "family_name": "Testowy",
+                "sub": "66662961",
+            }
+        )
+    )
+
+    assert user.username == "99999@student-afm.edu.pl"
+    assert user.email == "99999@student-afm.edu.pl"
+    assert user.first_name == "Test"
+    assert user.last_name == "Testowy"
+    assert user.is_staff is False
+
+
+def test_get_userinfo_normalizuje_mail_na_email(mocker):
+    backend = _backend()
+    mocker.patch.object(
+        BppOIDCBackend.__bases__[0],
+        "get_userinfo",
+        return_value={"mail": "jan@uafm.edu.pl", "sub": "1"},
+    )
+    out = backend.get_userinfo("acc", "id", {"payload": True})
+    assert out["email"] == "jan@uafm.edu.pl"
 
 
 @pytest.mark.django_db

--- a/src/oidc_integration/tests/test_easyaudit_compat.py
+++ b/src/oidc_integration/tests/test_easyaudit_compat.py
@@ -1,0 +1,55 @@
+"""Testy guarda kompatybilności z django-easy-audit.
+
+easyaudit zapisuje nieudane logowania robiąc twardo
+``credentials[USERNAME_FIELD]``. Backendy OAuth (OIDC/Microsoft) wołają
+``auth.authenticate()`` bez ``username`` w credentials — bez guarda handler
+rzuca ``KeyError`` (a przy ``PROPAGATE_EXCEPTIONS=True`` → HTTP 500).
+"""
+
+from oidc_integration import easyaudit_compat
+
+
+def test_ensure_username_dorabia_z_preferred_username():
+    out = easyaudit_compat._ensure_username(
+        {"nonce": "x", "preferred_username": "jkowalski@uafm.edu.pl"}
+    )
+    assert out["username"] == "jkowalski@uafm.edu.pl"
+    # oryginalne klucze zachowane
+    assert out["nonce"] == "x"
+
+
+def test_ensure_username_pusty_gdy_brak_preferred_username():
+    # Realny przypadek OIDC: credentials = {nonce, code_verifier}.
+    out = easyaudit_compat._ensure_username({"nonce": "x", "code_verifier": "y"})
+    assert out["username"] == ""
+
+
+def test_ensure_username_nie_rusza_gdy_username_jest():
+    src = {"username": "admin", "password": "tajne"}
+    out = easyaudit_compat._ensure_username(src)
+    # bez zmian — formularzowe logowanie ma już username
+    assert out is src
+
+
+def test_guard_dokłada_username_i_deleguje_do_oryginalu():
+    captured = {}
+
+    def fake_original(sender, credentials, **kwargs):
+        captured["sender"] = sender
+        captured["credentials"] = credentials
+
+    guard = easyaudit_compat._make_guard(fake_original)
+    guard(
+        sender="bpp",
+        credentials={"nonce": "x", "preferred_username": "u@uafm.edu.pl"},
+    )
+
+    assert captured["sender"] == "bpp"
+    assert captured["credentials"]["username"] == "u@uafm.edu.pl"
+
+
+def test_install_zwraca_callable_i_nie_wybucha():
+    # easyaudit jest zależnością (w venv), więc import auth_signals działa
+    # niezależnie od tego, czy easyaudit jest w INSTALLED_APPS.
+    guard = easyaudit_compat.install_easyaudit_login_failed_guard()
+    assert callable(guard)

--- a/src/oidc_integration/tests/test_login_dispatch.py
+++ b/src/oidc_integration/tests/test_login_dispatch.py
@@ -1,0 +1,46 @@
+"""Testy InstitutionalLoginView — per-uczelnia dyspozytora logowania.
+
+Precedencja: OIDC (gateowany po skrócie) > Microsoft (globalny) > formularz BPP.
+Reverse'y prowadzą do tras, których w ustawieniach testowych nie ma (OIDC/
+Microsoft niezainstalowane), więc mockujemy `reverse` i `apps.is_installed`.
+"""
+
+from django.apps import apps
+from django.http import HttpResponse
+
+from django_bpp.views import InstitutionalLoginView
+
+
+def test_dispatch_oidc_redirect_z_next(rf, mocker):
+    mocker.patch("oidc_integration.access.oidc_enabled_for_request", return_value=True)
+    mocker.patch("django_bpp.views.reverse", return_value="/oidc/authenticate/")
+
+    resp = InstitutionalLoginView.as_view()(rf.get("/accounts/login/?next=/foo/"))
+
+    assert resp.status_code == 302
+    assert resp.url == "/oidc/authenticate/?next=%2Ffoo%2F"
+
+
+def test_dispatch_microsoft_gdy_oidc_nie_dotyczy(rf, mocker):
+    mocker.patch("oidc_integration.access.oidc_enabled_for_request", return_value=False)
+    mocker.patch.object(apps, "is_installed", return_value=True)  # microsoft_auth
+    mocker.patch("django_bpp.views.reverse", return_value="/microsoft/redirect/")
+
+    resp = InstitutionalLoginView.as_view()(rf.get("/accounts/login/"))
+
+    assert resp.status_code == 302
+    assert resp.url == "/microsoft/redirect/"
+
+
+def test_dispatch_formularz_bpp_gdy_brak_instytucjonalnego(rf, mocker):
+    mocker.patch("oidc_integration.access.oidc_enabled_for_request", return_value=False)
+    mocker.patch.object(apps, "is_installed", return_value=False)
+    sentinel = HttpResponse("LOCAL")
+    mocker.patch(
+        "django_bpp.views.HTMXAwareLoginView.as_view",
+        return_value=lambda *a, **k: sentinel,
+    )
+
+    resp = InstitutionalLoginView.as_view()(rf.get("/accounts/login/"))
+
+    assert resp is sentinel


### PR DESCRIPTION
## Co i dlaczego

Naprawa logowania OpenID Connect (Keycloak, realm KA) — z logów wynikały dwie awarie i brakowało integracji z menu.

### 1. „Claims verification failed" (logowanie odrzucane)
Realm KA wystawia adres e-mail pod kluczem **`mail`**, a `mozilla-django-oidc` w `verify_claims`/`filter_users_by_claims`/`create_user` oczekuje **`email`**. Poprawne logowanie było odrzucane, a konto powstałoby z pustym e-mailem.

**Fix:** normalizacja w jednym chokepoincie — `BppOIDCBackend.get_userinfo()` uzupełnia `email` z `mail`. `get_or_create_user` woła wszystkie trzy metody na wyniku `get_userinfo`, więc jedno nadpisanie naprawia całość. Username z `preferred_username`, imię/nazwisko z `given_name`/`family_name`.

### 2. `KeyError: 'username'` → HTTP 500 (easyaudit)
Przy nieudanym logowaniu Django wysyła sygnał `user_login_failed`; handler easyaudit robi twardo `credentials['username']`. Callback OIDC woła `auth.authenticate(request, nonce=…, code_verifier=…)` — bez `username` (claimy są pobierane dopiero wewnątrz backendu, więc na tym etapie `preferred_username` fizycznie nie istnieje w `credentials`). Przy `DJANGO_EASY_AUDIT_PROPAGATE_EXCEPTIONS=True` → 500.

**Fix:** guard w `OidcIntegrationConfig.ready()` (gdy easyaudit zainstalowany) podmienia kruchy receiver easyaudit na cienki wrapper, który dokłada brakujący `username` i **deleguje do oryginalnej funkcji easyaudit** (reużycie logiki audytu, odporne na wersje). Po naprawie #1 happy-path i tak nie wpada w ten błąd — guard chroni ścieżkę realnej porażki.

### 3. Menu „logowanie instytucjonalne" jak Microsoft — ale PER-UCZELNIA
Instalacja multi-hosted: jeden proces obsługuje wiele uczelni po domenie (`request._uczelnia`), ale OIDC to **jeden realm na proces**. Microsoft jest globalny, bez per-uczelnia bindingu. Decyzja: **gateuj OIDC po skrócie uczelni, Microsoft zostaw globalny**. Precedencja: **OIDC (per-uczelnia) > Microsoft (globalny) > formularz BPP**.

- `oidc_integration/access.py` — `oidc_enabled_for_request(request)`: wspólne źródło prawdy dla menu i routingu. Skrót ustawiony → OIDC tylko na domenie uczelni o `skrot == OIDC_LOGIN_SKROT`; brak skrótu = instalacja jedno-uczelniana → globalnie.
- `InstitutionalLoginView` jako `login_form`; `local_login_form` = formularz BPP.
- `top_bar.html`: „logowanie instytucjonalne" (OIDC/Microsoft) + „logowanie BPP".
- `registration/login.html`: usunięty przycisk OIDC spod formularza (zgodnie z prośbą — bez „formularz + przycisk pod spodem").
- Banner `[OIDC]` z claimami: `stderr` → `logger.debug`.

## Testy
- `test_backends.py`: normalizacja `mail`→`email`, debug log zamiast stderr, `create_user` z `preferred_username`/`mail`.
- `test_easyaudit_compat.py`: guard dokłada `username` i deleguje.
- `test_access.py`: per-uczelnia gating + context processor.
- `test_login_dispatch.py`: `InstitutionalLoginView` (OIDC/Microsoft/lokalny).

Lokalnie: 46 passed w `src/oidc_integration/tests/`, `test_views/test_auth.py` zielony, `manage.py check` czysty, pre-commit czysty.

## Znane ograniczenia (poza zakresem)
- W procesie z OIDC **i** Microsoftem jednocześnie wylogowanie sesji Microsoft idzie standardowym Django logout (bez provider-logout do Microsoftu).
- Guard easyaudit aktywny tylko gdy `oidc_integration` zainstalowane (czyli gdy OIDC skonfigurowane) — wystarcza dla zgłoszonego buga.

Spec: `docs/superpowers/specs/2026-06-05-oidc-login-fix-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)