### PR TITLE
fix(pbn-import): odporny openAccess + round-trip originalLanguage

### DIFF
--- a/src/pbn_integrator/importer/__init__.py
+++ b/src/pbn_integrator/importer/__init__.py
@@ -31,6 +31,7 @@ from .helpers import (
     przetworz_metadane_konferencji,
     przetworz_slowa_kluczowe,
     przetworz_tytuly,
+    ustaw_jezyk_oryginalny,
 )
 
 # Re-export publisher handling
@@ -187,6 +188,7 @@ __all__ = [
     "przetworz_metadane_konferencji",
     "przetworz_slowa_kluczowe",
     "przetworz_tytuly",
+    "ustaw_jezyk_oryginalny",
     # Publication imports
     "importuj_artykul",
     "importuj_ksiazke",

--- a/src/pbn_integrator/importer/articles.py
+++ b/src/pbn_integrator/importer/articles.py
@@ -32,6 +32,7 @@ from .helpers import (
     przetworz_metadane_konferencji,
     przetworz_slowa_kluczowe,
     przetworz_tytuly,
+    ustaw_jezyk_oryginalny,
 )
 
 
@@ -100,6 +101,7 @@ def importuj_artykul(
     importuj_openaccess(
         ret, pbn_json, klasa_bazowa_tryb_dostepu=Tryb_OpenAccess_Wydawnictwo_Ciagle
     )
+    ustaw_jezyk_oryginalny(ret, pbn_json)
     try:
         ret.punkty_kbn = zrodlo.punktacja_zrodla_set.get(rok=ret.rok).punkty_kbn
     except Punktacja_Zrodla.DoesNotExist:

--- a/src/pbn_integrator/importer/books.py
+++ b/src/pbn_integrator/importer/books.py
@@ -18,7 +18,12 @@ from .cache import (
     get_status_korekty_przed,
     get_typ_kbn_inne,
 )
-from .helpers import get_or_download_publication, importuj_openaccess, pobierz_jezyk
+from .helpers import (
+    get_or_download_publication,
+    importuj_openaccess,
+    pobierz_jezyk,
+    ustaw_jezyk_oryginalny,
+)
 from .publishers import sciagnij_i_zapisz_wydawce
 
 
@@ -84,6 +89,7 @@ def importuj_ksiazke(
     )
 
     importuj_openaccess(ret, pbn_json)
+    ustaw_jezyk_oryginalny(ret, pbn_json)
 
     ret.save()
 

--- a/src/pbn_integrator/importer/helpers.py
+++ b/src/pbn_integrator/importer/helpers.py
@@ -298,6 +298,23 @@ def pobierz_jezyk(mainLanguage, pbn_json_title=None, domyslny_jezyk=None):
     return domyslny_jezyk
 
 
+def ustaw_jezyk_oryginalny(ret, pbn_json):
+    """Mapuje ``originalLanguage`` z PBN na ``ret.jezyk_orig`` (round-trip eksportu).
+
+    Adapter eksportu (``_build_language_data``) zapisuje ``originalLanguage`` z
+    ``jezyk_orig`` rekordu (język oryginału dla tłumaczeń). Import musi ten klucz
+    skonsumować — inaczej ``assert_dictionary_empty`` wywala cały import na
+    leftoverze ``{'originalLanguage': ...}``.
+
+    ``jezyk_orig`` jest nullable i dotyczy tylko tłumaczeń, więc gdy kodu nie ma
+    w słowniku ``Jezyk`` zostawiamy ``None`` (NIE język domyślny — inaczej niż
+    ``mainLanguage`` → ``jezyk``). Klucz konsumujemy zawsze, gdy jest obecny.
+    """
+    kod_jezyka = pbn_json.pop("originalLanguage", None)
+    if kod_jezyka:
+        ret.jezyk_orig = _dopasuj_jezyk(kod_jezyka)
+
+
 def przetworz_journal_issue(pbn_json, ret, zrodlo):
     """Process journalIssue data and add to annotations if needed."""
     journalIssue = pbn_json.pop("journalIssue", {})
@@ -379,78 +396,103 @@ def importuj_openaccess(
     oa_json = pbn_json.pop("openAccess", None)
     orig_oa_json = copy.deepcopy(oa_json)  # noqa
     if oa_json is not None:
-        pbn_licencja = oa_json.pop("license").replace("_", "-")
-        try:
-            ret.openaccess_licencja = Licencja_OpenAccess.objects.get(
-                skrot=pbn_licencja
-            )
-        except Licencja_OpenAccess.DoesNotExist as err:
-            raise ValueError(f"W BPP nie istnieje licancja {pbn_licencja=}") from err
-        ret.openaccess_tryb_dostepu = klasa_bazowa_tryb_dostepu.objects.get(
-            skrot=oa_json.pop("mode")
-        )
-        ret.openaccess_czas_publikacji = Czas_Udostepnienia_OpenAccess.objects.get(
-            skrot=oa_json.pop("releaseDateMode")
-        )
-
-        pbn_wersja_tekstu = oa_json.pop("textVersion")
-        try:
-            ret.openaccess_wersja_tekstu = Wersja_Tekstu_OpenAccess.objects.get(
-                skrot=pbn_wersja_tekstu
-            )
-        except Wersja_Tekstu_OpenAccess.DoesNotExist as err:
-            raise NotImplementedError(
-                f"W BPP nie istnieje wersja tekstu openaccess {pbn_wersja_tekstu=}"
-            ) from err
-
-        months = oa_json.pop("months", None)
-        if months:
-            ret.openaccess_ilosc_miesiecy = months
-
-        reldate = oa_json.pop("releaseDate", None)
-        if reldate:
-            reldate = reldate.split("T")[0]
-            ret.openaccess_data_opublikowania = date.fromisoformat(reldate)
-
-            oa_json.pop("releaseDateYear", None)
-            oa_json.pop("releaseDateMonth", None)
-        else:
-            if "releaseDateYear" in oa_json and "releaseDateMonth" in oa_json:
-                strMonth = {
-                    "JANUARY": 1,
-                    "FEBRUARY": 2,
-                    "MARCH": 3,
-                    "APRIL": 4,
-                    "MAY": 5,
-                    "JUNE": 6,
-                    "JULY": 7,
-                    "AUGUST": 8,
-                    "SEPTEMBER": 9,
-                    "OCTOBER": 10,
-                    "NOVEMBER": 11,
-                    "DECEMBER": 12,
-                }
-
-                assert ret.openaccess_data_opublikowania is None
-
-                reldate_year = oa_json.pop("releaseDateYear")
-                if reldate_year is None:
-                    logger.info("bez zartow BLAD DDATY")
-                else:
-                    ret.openaccess_data_opublikowania = date(
-                        int(reldate_year),
-                        strMonth.get(oa_json.pop("releaseDateMonth")),
-                        1,
-                    )
-
-            if "releaseDateYear" in oa_json:  # sam rok
-                ret.openaccess_data_opublikowania = date(
-                    int(oa_json.pop("releaseDateYear")),
-                    1,
-                    1,
+        # Blok openAccess z PBN bywa niekompletny — potrafi nie zawierać
+        # license/mode/releaseDateMode/textVersion. Wszystkie docelowe pola FK
+        # są nullable, więc brak klucza zostawia pole puste, a nie wywala import
+        # KeyError-em. Wartość OBECNA, ale nieznana w słowniku BPP, to realna
+        # luka konfiguracji — wtedy zgłaszamy błąd (jak dotychczas).
+        pbn_licencja = oa_json.pop("license", None)
+        if pbn_licencja:
+            pbn_licencja = pbn_licencja.replace("_", "-")
+            try:
+                ret.openaccess_licencja = Licencja_OpenAccess.objects.get(
+                    skrot=pbn_licencja
                 )
+            except Licencja_OpenAccess.DoesNotExist as err:
+                raise ValueError(
+                    f"W BPP nie istnieje licancja {pbn_licencja=}"
+                ) from err
 
+        pbn_tryb = oa_json.pop("mode", None)
+        if pbn_tryb:
+            ret.openaccess_tryb_dostepu = klasa_bazowa_tryb_dostepu.objects.get(
+                skrot=pbn_tryb
+            )
+
+        pbn_czas = oa_json.pop("releaseDateMode", None)
+        if pbn_czas:
+            ret.openaccess_czas_publikacji = Czas_Udostepnienia_OpenAccess.objects.get(
+                skrot=pbn_czas
+            )
+
+        pbn_wersja_tekstu = oa_json.pop("textVersion", None)
+        if pbn_wersja_tekstu:
+            try:
+                ret.openaccess_wersja_tekstu = Wersja_Tekstu_OpenAccess.objects.get(
+                    skrot=pbn_wersja_tekstu
+                )
+            except Wersja_Tekstu_OpenAccess.DoesNotExist as err:
+                raise NotImplementedError(
+                    f"W BPP nie istnieje wersja tekstu openaccess {pbn_wersja_tekstu=}"
+                ) from err
+
+        _importuj_openaccess_daty(ret, oa_json)
         assert_dictionary_empty(oa_json)
+
+
+def _importuj_openaccess_daty(ret, oa_json):
+    """Ustawia pola dat/miesięcy Open Access z (potencjalnie niekompletnego) bloku.
+
+    Wydzielone z ``importuj_openaccess`` dla czytelności i utrzymania złożoności
+    cyklomatycznej w ryzach. Klucze ``releaseDate*`` konsumujemy w miarę użycia,
+    by ``assert_dictionary_empty`` nie wywalił importu na resztkach.
+    """
+    months = oa_json.pop("months", None)
+    if months:
+        ret.openaccess_ilosc_miesiecy = months
+
+    reldate = oa_json.pop("releaseDate", None)
+    if reldate:
+        reldate = reldate.split("T")[0]
+        ret.openaccess_data_opublikowania = date.fromisoformat(reldate)
+        oa_json.pop("releaseDateYear", None)
+        oa_json.pop("releaseDateMonth", None)
+        return
+
+    if "releaseDateYear" in oa_json and "releaseDateMonth" in oa_json:
+        strMonth = {
+            "JANUARY": 1,
+            "FEBRUARY": 2,
+            "MARCH": 3,
+            "APRIL": 4,
+            "MAY": 5,
+            "JUNE": 6,
+            "JULY": 7,
+            "AUGUST": 8,
+            "SEPTEMBER": 9,
+            "OCTOBER": 10,
+            "NOVEMBER": 11,
+            "DECEMBER": 12,
+        }
+
+        assert ret.openaccess_data_opublikowania is None
+
+        reldate_year = oa_json.pop("releaseDateYear")
+        if reldate_year is None:
+            logger.info("bez zartow BLAD DDATY")
+        else:
+            ret.openaccess_data_opublikowania = date(
+                int(reldate_year),
+                strMonth.get(oa_json.pop("releaseDateMonth")),
+                1,
+            )
+
+    if "releaseDateYear" in oa_json:  # sam rok
+        ret.openaccess_data_opublikowania = date(
+            int(oa_json.pop("releaseDateYear")),
+            1,
+            1,
+        )
 
 
 def get_or_download_publication(mongoId, client):

--- a/src/pbn_integrator/tests/test_openaccess_i_jezyk_orig.py
+++ b/src/pbn_integrator/tests/test_openaccess_i_jezyk_orig.py
@@ -1,0 +1,171 @@
+"""Odporność importera PBN na niekompletne dane Open Access oraz round-trip
+języka oryginalnego (``originalLanguage`` → ``jezyk_orig``).
+
+- ``importuj_openaccess`` — blok ``openAccess`` z PBN bywa niekompletny (potrafi
+  nie zawierać ``mode``/``license``/``releaseDateMode``/``textVersion``).
+  Wszystkie docelowe pola FK są nullable, więc brak klucza ma zostawić pole
+  puste, a nie wywalić import ``KeyError``-em.
+- ``ustaw_jezyk_oryginalny`` — adapter eksportu zapisuje ``originalLanguage`` z
+  ``jezyk_orig``; importer musi go odczytać z powrotem (inaczej leftover wywala
+  ``assert_dictionary_empty``).
+"""
+
+from datetime import date
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Tryb_OpenAccess_Wydawnictwo_Ciagle
+from pbn_integrator.importer.helpers import (
+    importuj_openaccess,
+    ustaw_jezyk_oryginalny,
+)
+
+
+@pytest.fixture
+def wydawnictwo_ciagle(db):
+    return baker.make("bpp.Wydawnictwo_Ciagle", adnotacje="", tytul="")
+
+
+class TestImportujOpenaccess:
+    def test_komplet_ustawia_wszystkie_pola(self, wydawnictwo_ciagle):
+        # Skróty syntetyczne (nieobecne w baseline), by nie kolidować z
+        # ograniczeniem unikalności słowników OA.
+        baker.make("bpp.Licencja_OpenAccess", skrot="TST-LIC")
+        baker.make("bpp.Tryb_OpenAccess_Wydawnictwo_Ciagle", skrot="TST_TRYB")
+        baker.make("bpp.Czas_Udostepnienia_OpenAccess", skrot="TST_CZAS")
+        baker.make("bpp.Wersja_Tekstu_OpenAccess", skrot="TST_WERSJA")
+
+        pbn_json = {
+            "openAccess": {
+                "license": "TST_LIC",
+                "mode": "TST_TRYB",
+                "releaseDateMode": "TST_CZAS",
+                "textVersion": "TST_WERSJA",
+            }
+        }
+
+        importuj_openaccess(
+            wydawnictwo_ciagle,
+            pbn_json,
+            klasa_bazowa_tryb_dostepu=Tryb_OpenAccess_Wydawnictwo_Ciagle,
+        )
+
+        assert wydawnictwo_ciagle.openaccess_licencja.skrot == "TST-LIC"
+        assert wydawnictwo_ciagle.openaccess_tryb_dostepu.skrot == "TST_TRYB"
+        assert wydawnictwo_ciagle.openaccess_czas_publikacji.skrot == "TST_CZAS"
+        assert wydawnictwo_ciagle.openaccess_wersja_tekstu.skrot == "TST_WERSJA"
+        assert pbn_json == {}
+
+    def test_bez_mode_nie_wywala_importu(self, wydawnictwo_ciagle):
+        # wcześniej: KeyError 'mode'
+        baker.make("bpp.Licencja_OpenAccess", skrot="TST-LIC")
+
+        pbn_json = {"openAccess": {"license": "TST_LIC"}}
+
+        importuj_openaccess(
+            wydawnictwo_ciagle,
+            pbn_json,
+            klasa_bazowa_tryb_dostepu=Tryb_OpenAccess_Wydawnictwo_Ciagle,
+        )
+
+        assert wydawnictwo_ciagle.openaccess_licencja.skrot == "TST-LIC"
+        assert wydawnictwo_ciagle.openaccess_tryb_dostepu is None
+        assert wydawnictwo_ciagle.openaccess_czas_publikacji is None
+        assert wydawnictwo_ciagle.openaccess_wersja_tekstu is None
+        assert pbn_json == {}
+
+    def test_pusty_blok_nie_wywala_importu(self, wydawnictwo_ciagle):
+        pbn_json = {"openAccess": {}}
+
+        importuj_openaccess(
+            wydawnictwo_ciagle,
+            pbn_json,
+            klasa_bazowa_tryb_dostepu=Tryb_OpenAccess_Wydawnictwo_Ciagle,
+        )
+
+        assert wydawnictwo_ciagle.openaccess_licencja is None
+        assert wydawnictwo_ciagle.openaccess_tryb_dostepu is None
+        assert pbn_json == {}
+
+    def test_brak_openaccess_to_noop(self, wydawnictwo_ciagle):
+        pbn_json = {"inne": "dane"}
+
+        importuj_openaccess(
+            wydawnictwo_ciagle,
+            pbn_json,
+            klasa_bazowa_tryb_dostepu=Tryb_OpenAccess_Wydawnictwo_Ciagle,
+        )
+
+        assert wydawnictwo_ciagle.openaccess_licencja is None
+        assert pbn_json == {"inne": "dane"}
+
+    def test_release_date_iso_z_miesiacami(self, wydawnictwo_ciagle):
+        pbn_json = {
+            "openAccess": {"releaseDate": "2021-05-10T00:00:00", "months": 6}
+        }
+
+        importuj_openaccess(
+            wydawnictwo_ciagle,
+            pbn_json,
+            klasa_bazowa_tryb_dostepu=Tryb_OpenAccess_Wydawnictwo_Ciagle,
+        )
+
+        assert wydawnictwo_ciagle.openaccess_data_opublikowania == date(2021, 5, 10)
+        assert wydawnictwo_ciagle.openaccess_ilosc_miesiecy == 6
+        assert pbn_json == {}
+
+    def test_release_date_rok_i_miesiac(self, wydawnictwo_ciagle):
+        pbn_json = {
+            "openAccess": {"releaseDateYear": "2020", "releaseDateMonth": "MARCH"}
+        }
+
+        importuj_openaccess(
+            wydawnictwo_ciagle,
+            pbn_json,
+            klasa_bazowa_tryb_dostepu=Tryb_OpenAccess_Wydawnictwo_Ciagle,
+        )
+
+        assert wydawnictwo_ciagle.openaccess_data_opublikowania == date(2020, 3, 1)
+        assert pbn_json == {}
+
+    def test_brak_licencji_w_slowniku_zglasza_blad(self, wydawnictwo_ciagle):
+        # license obecne, ale nieznane w BPP — to realna luka konfiguracji,
+        # nie cichy no-op (zachowanie sprzed fixa).
+        pbn_json = {"openAccess": {"license": "NIEISTNIEJACA"}}
+
+        with pytest.raises(ValueError):
+            importuj_openaccess(
+                wydawnictwo_ciagle,
+                pbn_json,
+                klasa_bazowa_tryb_dostepu=Tryb_OpenAccess_Wydawnictwo_Ciagle,
+            )
+
+
+class TestUstawJezykOryginalny:
+    def test_mapuje_kod_na_jezyk_orig(self, wydawnictwo_ciagle):
+        # synthetyczny kod, którego nie ma w baseline
+        baker.make("pbn_api.Language", code="qaa")
+        jezyk = baker.make("bpp.Jezyk", pbn_uid_id="qaa")
+
+        pbn_json = {"originalLanguage": "qaa"}
+        ustaw_jezyk_oryginalny(wydawnictwo_ciagle, pbn_json)
+
+        assert wydawnictwo_ciagle.jezyk_orig_id == jezyk.pk
+        assert pbn_json == {}
+
+    def test_nieznany_kod_zostawia_none(self, wydawnictwo_ciagle):
+        # język oryginalny jest dla tłumaczeń i nullable — brak dopasowania to
+        # None, a NIE język domyślny (inaczej niż mainLanguage → jezyk).
+        pbn_json = {"originalLanguage": "qzz"}
+        ustaw_jezyk_oryginalny(wydawnictwo_ciagle, pbn_json)
+
+        assert wydawnictwo_ciagle.jezyk_orig is None
+        assert pbn_json == {}
+
+    def test_brak_klucza_to_noop(self, wydawnictwo_ciagle):
+        pbn_json = {"inne": "dane"}
+        ustaw_jezyk_oryginalny(wydawnictwo_ciagle, pbn_json)
+
+        assert wydawnictwo_ciagle.jezyk_orig is None
+        assert pbn_json == {"inne": "dane"}


### PR DESCRIPTION
## Problem

Sesja importu PBN (log #10) zatrzymywała się na pierwszym błędzie — trzy publikacje wywalały cały przebieg:

- `KeyError: 'mode'` (książka `60f58d35…`, artykuł `5e717b08…`)
- `AssertionError: some data still left in dictionary dct={'originalLanguage': 'pol'}` (artykuł `5e71843e…`)

## Root cause

1. **`importuj_openaccess`** popował `license`/`mode`/`releaseDateMode`/`textVersion` **bez wartości domyślnej**, zakładając że obecny blok `openAccess` jest zawsze kompletny. PBN bywa niekompletny — część bloków ma `license`, ale nie `mode`. Pola docelowe to **nullable FK**, więc „brak klucza" to stan dopuszczalny.
2. **`importuj_artykul`** — adapter eksportu (`_build_language_data`) zapisuje `originalLanguage` z `jezyk_orig`, ale importer nigdy tego klucza nie odczytywał → leftover wywalał `assert_dictionary_empty`.

## Fix

- `importuj_openaccess`: każdy lookup OA toleruje brak klucza (`pop(key, None)` + guard) → zostawia puste nullable FK zamiast `KeyError`. Wartość **obecna, lecz nieznana** w słowniku BPP nadal zgłasza błąd (realna luka konfiguracji — zachowanie zachowane).
- Nowy helper **`ustaw_jezyk_oryginalny`** mapuje `originalLanguage` → `ret.jezyk_orig` (round-trip eksportu), wpięty w import artykułów **i** książek. Nieznany kod → `None` (pole nullable, dotyczy tłumaczeń — inaczej niż `mainLanguage` → `jezyk`, które ma fallback na domyślny).
- Refactor: blok dat OA wydzielony do `_importuj_openaccess_daty` (zachowanie identyczne), by `importuj_openaccess` zmieścił się w limicie ruff C901.

## Decyzja do akceptacji

`originalLanguage` jest **zachowywane** do `jezyk_orig` (wierny round-trip), a nie odrzucane jak w `chapters.py`. Efekt uboczny: rekordy, gdzie PBN wysyła `originalLanguage == mainLanguage`, dostaną `jezyk_orig` (UI czyta to jako „tłumaczenie z…"). Jeśli wolicie odrzucać dla prac nietłumaczonych — to zmiana jednolinijkowa.

## Testy

- Nowy `test_openaccess_i_jezyk_orig.py` — **10 testów** (komplet pól, brak `mode`, pusty blok, brak `openAccess`, nieznana licencja → `ValueError`, daty ISO i rok+miesiąc, mapowanie/nieznany kod/brak `originalLanguage`).
- Pełna suita `pbn_integrator`: **131 passed**, bez regresji.
- ruff check + format: czysto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)