### PR TITLE
fix(multihosted): wyplenij Uczelnia.objects.first() z runtime + walidacja site

### DIFF
--- a/src/bpp/admin/core.py
+++ b/src/bpp/admin/core.py
@@ -190,9 +190,12 @@ def generuj_formularz_dla_autorow(  # noqa
         def __init__(self, *args, **kwargs):  # noqa
             super().__init__(*args, **kwargs)
 
-            # Ustaw inicjalną wartość dla pola 'afiliuje'
+            # Ustaw inicjalną wartość dla pola 'afiliuje'. Formularz inline nie
+            # dysponuje requestem (świadomie — to UI-default nowego wiersza),
+            # więc czytamy JEDYNĄ uczelnię (single → ona; 0/>1 → None →
+            # neutralny default True). NIE zgadujemy pierwszej-z-brzegu.
             domyslnie_afiliuje = True
-            uczelnia = Uczelnia.objects.first()
+            uczelnia = Uczelnia.objects.get_single_uczelnia_or_none()
             if uczelnia is not None:
                 domyslnie_afiliuje = uczelnia.domyslnie_afiliuje
             self.fields["afiliuje"].initial = domyslnie_afiliuje

--- a/src/bpp/admin/helpers/pbn_api/common.py
+++ b/src/bpp/admin/helpers/pbn_api/common.py
@@ -142,9 +142,7 @@ def sprobuj_wyslac_do_pbn(  # noqa: C901
 
     open_in_pbn_link = ""
     if obj.pbn_uid_id:
-        open_in_pbn_link = (
-            f'<a target=_blank href="{obj.link_do_pbn()}">Otwórz w PBN</a>. '
-        )
+        open_in_pbn_link = f'<a target=_blank href="{obj.link_do_pbn(uczelnia=uczelnia)}">Otwórz w PBN</a>. '
 
     open_in_pi_link = obj.link_do_pi(uczelnia=uczelnia) or ""
     if open_in_pi_link:
@@ -165,7 +163,7 @@ def sprobuj_wyslac_do_pbn(  # noqa: C901
 
         # Być moze obj.pbn_uid_id uległ zmianie. Jeżeli tak -- zregeneruj link:
         if obj.pbn_uid_id:
-            open_in_pbn_link = f'<a target=_blank href="{obj.link_do_pbn()}">Kliknij tutaj, aby otworzyć w PBN</a>. '
+            open_in_pbn_link = f'<a target=_blank href="{obj.link_do_pbn(uczelnia=uczelnia)}">Kliknij tutaj, aby otworzyć w PBN</a>. '
         open_in_pi_link = obj.link_do_pi(uczelnia=uczelnia) or ""
         if open_in_pi_link:
             open_in_pi_link = f'<a target=_blank href="{open_in_pi_link}">Otwórz w Profilu Instytucji</a>. '

--- a/src/bpp/admin/helpers/pbn_api/gui.py
+++ b/src/bpp/admin/helpers/pbn_api/gui.py
@@ -83,8 +83,15 @@ def sprobuj_utworzyc_zlecenie_eksportu_do_PBN_gui(request, obj):
         messages.error(request, "Wysyłka do PBN nie skonfigurowana w obiektu Uczelnia.")
         return
 
+    # Multi-hosted: wpis kolejki niesie uczelnię z requestu (jak batch path),
+    # żeby wysyłka w tle użyła właściwej konfiguracji PBN zamiast zgadywać.
+    from bpp.models.uczelnia import Uczelnia
+
+    uczelnia = Uczelnia.objects.get_for_request(request)
     try:
-        ret = PBN_Export_Queue.objects.sprobuj_utowrzyc_wpis(request.user, obj)
+        ret = PBN_Export_Queue.objects.sprobuj_utowrzyc_wpis(
+            request.user, obj, uczelnia=uczelnia
+        )
     except AlreadyEnqueuedError:
         messages.warning(
             request, f"Rekord {obj} jest już w kolejce do eksportu do PBN."

--- a/src/bpp/admin/uczelnia.py
+++ b/src/bpp/admin/uczelnia.py
@@ -81,6 +81,18 @@ class UczelniaAdminForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields["theme_name"].choices = list(settings.BPP_THEMES)
 
+        # Multi-hosted: ``site`` jest na poziomie DB NOT NULL (migracja 0417),
+        # ale to admin musi je wskazać JAWNIE — to Site wiąże uczelnię z
+        # domeną (host → Site → Uczelnia), nie ma „uczelni domyślnej". Damy
+        # komunikat dziedzinowy zamiast generycznego „To pole jest wymagane.".
+        if "site" in self.fields:
+            self.fields["site"].required = True
+            self.fields["site"].error_messages["required"] = (
+                "Wskaż stronę (domenę / obiekt Site) dla tej uczelni. W trybie "
+                "multi-hosted to powiązanie z domeną wiąże uczelnię z jej "
+                "adresem — nie istnieje „uczelnia domyślna”."
+            )
+
 
 class UczelniaAdmin(
     SiteFilteredAdminMixin,

--- a/src/bpp/models/autor.py
+++ b/src/bpp/models/autor.py
@@ -57,17 +57,25 @@ class AutorManager(FulltextSearchMixin, models.Manager):
     # Nie włączaj websearch gdy podano minus (podwójne nazwiska z myślnikiem)
     fts_enable_websearch_on_minus_or_quote = False
 
-    def create_from_string(self, text):
+    def create_from_string(self, text, uczelnia=None):
         """Tworzy rekord autora z ciągu znaków. Używane, gdy dysponujemy
         wpisanym ciągiem znaków z np AutorAutocomplete i chcemy utworzyć
-        autora z nazwiskiem i imieniem w poprawny sposób."""
+        autora z nazwiskiem i imieniem w poprawny sposób.
+
+        ``uczelnia`` (multi-hosted): uczelnia z requestu wołającego — z niej
+        czytamy ``nowy_autor_z_formularza_pokazuj``. Bez niej próbujemy
+        JEDYNEJ w systemie (single → ona; 0/>1 → None → ``pokazuj=False``).
+        NIE zgadujemy pierwszej-z-brzegu (dawny footgun ``.first()`` na
+        managerze Uczelni).
+        """
 
         text = autor_split_string(text)
 
         # Sprawdź ustawienie w modelu Uczelnia, czy nowy autor ma być widoczny
         from bpp.models.uczelnia import Uczelnia
 
-        uczelnia = Uczelnia.objects.first()
+        if uczelnia is None:
+            uczelnia = Uczelnia.objects.get_single_uczelnia_or_none()
         pokazuj = uczelnia.nowy_autor_z_formularza_pokazuj if uczelnia else False
 
         return self.create(

--- a/src/bpp/multiseek_registry/fields/numeric_fields.py
+++ b/src/bpp/multiseek_registry/fields/numeric_fields.py
@@ -68,12 +68,13 @@ class IndexCopernicusQueryObject(BppMultiseekVisibilityMixin, SafeDecimalQueryOb
     label = "Index Copernicus"
     field_name = "index_copernicus"
 
-    def option_enabled(self, uczelnia=None):
-        # Multi-hosted: odczyt ustawienia widoczności pola. Bez przekazanej
-        # uczelni próbujemy JEDYNEJ w systemie (single → jej ustawienie; 0/>1
-        # → None → pole widoczne, default True). NIE ma „uczelni domyślnej".
-        if uczelnia is None:
-            uczelnia = Uczelnia.objects.get_single_uczelnia_or_none()
+    def option_enabled(self, request=None):
+        # Multi-hosted: odczyt ustawienia widoczności pola dla uczelni Z
+        # REQUESTU (host). ``get_for_request`` sam degraduje przy braku
+        # requestu/dopasowania domeny do JEDYNEJ w systemie (single → jej
+        # ustawienie; 0/>1 → None → pole widoczne, default True). NIE ma
+        # „uczelni domyślnej" i nie zgadujemy pierwszej-z-brzegu.
+        uczelnia = Uczelnia.objects.get_for_request(request)
         if uczelnia is not None:
             return uczelnia.pokazuj_index_copernicus
         return True

--- a/src/bpp/multiseek_registry/mixins.py
+++ b/src/bpp/multiseek_registry/mixins.py
@@ -39,7 +39,7 @@ class BppMultiseekVisibilityMixin:
     def visibility_options(self):
         return self._get_or_create()
 
-    def option_enabled(self):
+    def option_enabled(self, request=None):
         return True
 
     @property
@@ -47,7 +47,9 @@ class BppMultiseekVisibilityMixin:
         return self.visibility_options.sort_order
 
     def enabled(self, request=None):
-        if not self.option_enabled():
+        # Multi-hosted: przekazujemy request niżej, żeby option_enabled mogło
+        # ustalić uczelnię z hosta (np. IndexCopernicus → pokazuj_index_copernicus).
+        if not self.option_enabled(request):
             return False
 
         vis = self.visibility_options

--- a/src/bpp/tests/test_admin/test_autor_form_afiliuje_per_uczelnia.py
+++ b/src/bpp/tests/test_admin/test_autor_form_afiliuje_per_uczelnia.py
@@ -1,0 +1,41 @@
+"""Multi-hosted: domyślna wartość pola ``afiliuje`` w admin-owym formularzu
+inline autora (``generuj_formularz_dla_autorow``).
+
+Formularz inline NIE dostaje requestu (świadoma, minimalna decyzja — to tylko
+UI-default nowego wiersza). Zamiast zgadywać pierwszą-z-brzegu uczelnię
+(``Uczelnia.objects.first()``) używa ``get_single_uczelnia_or_none``:
+- single-install → czyta ``domyslnie_afiliuje`` z tej jednej uczelni,
+- >1 uczelnia → None → neutralny hardcoded default (True), bez zgadywania.
+"""
+
+import pytest
+
+from bpp.admin.core import generuj_formularz_dla_autorow
+from bpp.models import Wydawnictwo_Ciagle_Autor
+
+
+def _form_class():
+    return generuj_formularz_dla_autorow(
+        Wydawnictwo_Ciagle_Autor, include_rekord=True
+    )
+
+
+@pytest.mark.django_db
+def test_afiliuje_default_wiele_uczelni_neutralny(uczelnia1, uczelnia2):
+    """>1 uczelnia: bez requestu nie da się ustalić uczelni → neutralny
+    default True, NIE ``domyslnie_afiliuje`` pierwszej-z-brzegu (uczelnia1)."""
+    uczelnia1.domyslnie_afiliuje = False  # to jest first() (niższy pk)
+    uczelnia1.save()
+
+    form = _form_class()()
+    assert form.fields["afiliuje"].initial is True
+
+
+@pytest.mark.django_db
+def test_afiliuje_default_single_install_czyta_uczelnie(uczelnia):
+    """Single-install: czyta ``domyslnie_afiliuje`` z jedynej uczelni."""
+    uczelnia.domyslnie_afiliuje = False
+    uczelnia.save()
+
+    form = _form_class()()
+    assert form.fields["afiliuje"].initial is False

--- a/src/bpp/tests/test_admin/test_uczelnia_site_required.py
+++ b/src/bpp/tests/test_admin/test_uczelnia_site_required.py
@@ -1,0 +1,32 @@
+"""Multi-hosted: admin-owy formularz Uczelni wymaga jawnie pola ``site``
+(domena), z przyjaznym komunikatem.
+
+Na poziomie DB ``site`` jest już NOT NULL (migracja 0417), ale domyślny
+komunikat Django ("To pole jest wymagane.") nie tłumaczy, DLACZEGO — w trybie
+multi-hosted to Site wiąże uczelnię z domeną. Forma dostarcza komunikat
+dziedzinowy.
+"""
+
+import pytest
+from django.forms import modelform_factory
+
+from bpp.admin.uczelnia import UczelniaAdminForm
+from bpp.models import Uczelnia
+
+
+def _form_with_site():
+    return modelform_factory(
+        Uczelnia,
+        form=UczelniaAdminForm,
+        fields=["nazwa", "skrot", "site", "theme_name"],
+    )
+
+
+@pytest.mark.django_db
+def test_uczelnia_form_site_wymagany_przyjazny_komunikat():
+    """Brak ``site`` → forma niewalidna, a komunikat wspomina o domenie/Site."""
+    form = _form_with_site()(data={"nazwa": "Testowa", "skrot": "T"})
+
+    assert not form.is_valid()
+    assert "site" in form.errors
+    assert "domen" in " ".join(form.errors["site"]).lower()

--- a/src/bpp/tests/test_multihosted_get_default_guard.py
+++ b/src/bpp/tests/test_multihosted_get_default_guard.py
@@ -40,10 +40,8 @@ SRC = Path(__file__).resolve().parents[2]  # .../src
 # Whitelist dla ``Uczelnia.objects.first()``. Każdy wpis to ŚWIADOMY fallback
 # bez requestu (warstwa modelu / UI default / demo / debug / komentarz).
 APPROVED_FIRST: dict[str, int] = {
-    "bpp/admin/core.py": 1,  # admin form __init__: default pola 'afiliuje', None-tolerant UI
     "bpp/demo_data/generators/uczelnia.py": 1,  # demo/seed, CLI bez requestu
     "bpp/management/commands/debug_setup_initial_data.py": 1,  # debug command, None-tolerant
-    "bpp/models/autor.py": 1,  # warstwa modelu: domyślne 'pokazuj' nowego autora, None-tolerant
     "bpp/models/jednostka.py": 1,  # KOMENTARZ (nie kod) — zakomentowany default=lambda
 }
 

--- a/src/bpp/tests/test_multiseek/test_index_copernicus_per_uczelnia.py
+++ b/src/bpp/tests/test_multiseek/test_index_copernicus_per_uczelnia.py
@@ -1,0 +1,54 @@
+"""Multi-hosted: pole multiseek „Index Copernicus" respektuje ustawienie
+``pokazuj_index_copernicus`` uczelni Z REQUESTU (host), a nie zgaduje
+jedynej/pierwszej-z-brzegu.
+
+Bug: bazowy ``BppMultiseekVisibilityMixin.enabled(request)`` wołał
+``option_enabled()`` bez argumentów, więc ``IndexCopernicusQueryObject``
+nigdy nie dostawał requestu → przy >1 uczelni zawsze ``True`` (widoczne),
+niezależnie od ustawienia oglądanej uczelni.
+"""
+
+import pytest
+
+from bpp.models import BppUser
+from bpp.multiseek_registry.fields.numeric_fields import IndexCopernicusQueryObject
+from fixtures.conftest_multisite import make_request_for_site
+
+
+def _staff_request(site):
+    user = BppUser.objects.create_user(
+        username=f"ic_staff_{site.pk}", is_staff=True
+    )
+    return make_request_for_site(site, user=user)
+
+
+@pytest.mark.django_db
+def test_index_copernicus_ukryty_dla_uczelni_z_requestu(
+    uczelnia1, uczelnia2, site1, settings
+):
+    """U1.pokazuj_index_copernicus=False + request na host U1 → pole ukryte,
+    mimo że w systemie jest druga uczelnia (get_single_uczelnia_or_none → None
+    nie może o tym decydować)."""
+    settings.ALLOWED_HOSTS = ["*"]
+    uczelnia1.pokazuj_index_copernicus = False
+    uczelnia1.save()
+    uczelnia2.pokazuj_index_copernicus = True
+    uczelnia2.save()
+
+    field = IndexCopernicusQueryObject()
+    assert field.enabled(_staff_request(site1)) is False
+
+
+@pytest.mark.django_db
+def test_index_copernicus_widoczny_dla_uczelni_z_requestu(
+    uczelnia1, uczelnia2, site2, settings
+):
+    """U2.pokazuj_index_copernicus=True + request na host U2 → pole widoczne."""
+    settings.ALLOWED_HOSTS = ["*"]
+    uczelnia1.pokazuj_index_copernicus = False
+    uczelnia1.save()
+    uczelnia2.pokazuj_index_copernicus = True
+    uczelnia2.save()
+
+    field = IndexCopernicusQueryObject()
+    assert field.enabled(_staff_request(site2)) is True

--- a/src/bpp/tests/test_multiseek/test_mixins.py
+++ b/src/bpp/tests/test_multiseek/test_mixins.py
@@ -20,7 +20,7 @@ class TestQueryObjectDisabled(BppMultiseekVisibilityMixin, StringQueryObject):
     field_name = "bar"
     public = True
 
-    def option_enabled(self):
+    def option_enabled(self, request=None):
         return False
 
 

--- a/src/bpp/tests/test_views/test_autocomplete_per_uczelnia.py
+++ b/src/bpp/tests/test_views/test_autocomplete_per_uczelnia.py
@@ -235,6 +235,67 @@ def test_autor_aktualnie_zatrudniony_tylko_aktualna_jednostka(
 
 
 @pytest.mark.django_db
+def test_create_from_string_honoruje_podana_uczelnie(uczelnia1, uczelnia2):
+    """``AutorManager.create_from_string`` czyta ``nowy_autor_z_formularza_pokazuj``
+    z PODANEJ uczelni, nie z pierwszej-z-brzegu (``Uczelnia.objects.first()``).
+    """
+    from bpp.models import Autor
+
+    uczelnia1.nowy_autor_z_formularza_pokazuj = False
+    uczelnia1.save()
+    uczelnia2.nowy_autor_z_formularza_pokazuj = True
+    uczelnia2.save()
+
+    # uczelnia2 (wyższy pk) NIE jest first() — first() to uczelnia1 (False).
+    autor = Autor.objects.create_from_string("Kowalski Jan", uczelnia=uczelnia2)
+    assert autor.pokazuj is True
+
+    autor2 = Autor.objects.create_from_string("Nowak Anna", uczelnia=uczelnia1)
+    assert autor2.pokazuj is False
+
+
+@pytest.mark.django_db
+def test_create_from_string_bez_uczelni_wiele_uczelni_nie_zgaduje(uczelnia1, uczelnia2):
+    """Bez podanej uczelni i przy >1 uczelni: get_single_uczelnia_or_none → None
+    → ``pokazuj=False`` (bezpieczny default), bez zgadywania pierwszej-z-brzegu.
+    """
+    from bpp.models import Autor
+
+    uczelnia1.nowy_autor_z_formularza_pokazuj = True  # first(), gdyby zgadywał
+    uczelnia1.save()
+
+    autor = Autor.objects.create_from_string("Bezuczelni Ktos")
+    assert autor.pokazuj is False
+
+
+@pytest.mark.django_db
+def test_autor_autocomplete_create_object_uzywa_uczelni_z_requestu(
+    uczelnia1, uczelnia2, site2, settings
+):
+    """``AutorAutocomplete.create_object`` ustala ``pokazuj`` nowego autora z
+    uczelni Z REQUESTU (host), nie z pierwszej-z-brzegu.
+    """
+    settings.ALLOWED_HOSTS = ["*"]
+    from bpp.models import Autor, BppUser
+    from bpp.views.autocomplete.authors import AutorAutocomplete
+
+    uczelnia1.nowy_autor_z_formularza_pokazuj = False  # first()
+    uczelnia1.save()
+    uczelnia2.nowy_autor_z_formularza_pokazuj = True
+    uczelnia2.save()
+
+    user = BppUser.objects.create_user(username="ac_creator", is_staff=True)
+
+    view = AutorAutocomplete()
+    view.request = make_request_for_site(site2, user=user)  # → uczelnia2
+
+    obj = view.create_object("Iksinski Piotr")
+
+    assert isinstance(obj, Autor)
+    assert obj.pokazuj is True  # z uczelni2 (request), nie z first()=uczelnia1
+
+
+@pytest.mark.django_db
 def test_autocomplete_get_queryset_bez_requestu_nie_wywala(uczelnia1, uczelnia2):
     """Mixin toleruje brak self.request (no-op) — kontrakt defensywny bazy.
 

--- a/src/bpp/views/autocomplete/authors.py
+++ b/src/bpp/views/autocomplete/authors.py
@@ -169,8 +169,13 @@ class AutorAutocomplete(GroupRequiredMixin, AutorAutocompleteBase):
     )
 
     def create_object(self, text):
+        # Multi-hosted: nowy autor dziedziczy widoczność (``pokazuj``) z uczelni
+        # Z REQUESTU (host), nie z pierwszej-z-brzegu.
+        from bpp.models.uczelnia import Uczelnia
+
+        uczelnia = Uczelnia.objects.get_for_request(getattr(self, "request", None))
         try:
-            obj = Autor.objects.create_from_string(text)
+            obj = Autor.objects.create_from_string(text, uczelnia=uczelnia)
         except ValueError:
             return self.err
 

--- a/src/pbn_api/models/publikacja_instytucji.py
+++ b/src/pbn_api/models/publikacja_instytucji.py
@@ -72,7 +72,12 @@ class PublikacjaInstytucji_V2(models.Model):
         from bpp import const
         from bpp.models import Uczelnia
 
-        uczelnia = self.uczelnia or Uczelnia.objects.get()
+        # Multi-hosted: wiersz lustrzany nie ma requestu. Gdy brak własnego
+        # taga uczelni, próbujemy JEDYNEJ w systemie (single → ona; 0/>1 →
+        # None → link się nie wyrenderuje). NIE ma „uczelni domyślnej" i nie
+        # zgadujemy pierwszej-z-brzegu (dawne ``Uczelnia.objects.get()``
+        # wybuchało MultipleObjectsReturned przy >1 uczelni).
+        uczelnia = self.uczelnia or Uczelnia.objects.get_single_uczelnia_or_none()
         if uczelnia is not None:
             return const.LINK_PI_ADD_STATEMENTS.format(
                 pbn_api_root=uczelnia.pbn_api_root, pbn_uid_id=pbn_uid_id, uuid=uuid

--- a/src/pbn_api/tests/test_bpp_admin_helpers.py
+++ b/src/pbn_api/tests/test_bpp_admin_helpers.py
@@ -225,6 +225,67 @@ def test_sprobuj_wyslac_do_pbn_z_oswiadczeniami(
 
 
 @pytest.mark.django_db
+def test_sprobuj_wyslac_do_pbn_link_uzywa_uczelni_z_requestu(
+    pbn_wydawnictwo_zwarte_z_charakterem, pbn_client, rf, pbn_uczelnia
+):
+    """Multi-hosted: link „Otwórz w PBN" w komunikacie sukcesu używa
+    pbn_api_root uczelni Z REQUESTU, a nie zgaduje pierwszej-z-brzegu.
+
+    Przy >1 uczelni ``link_do_pbn()`` bez argumentu degradowałby do None
+    (get_single_uczelnia_or_none → None) → ``href="None"``. Po fixie link
+    dostaje jawnie uczelnię z requestu.
+    """
+    from bpp.models import Uczelnia
+
+    req = rf.get("/")
+    # SiteResolutionMiddleware w produkcji ustawia request._uczelnia; tu
+    # ustawiamy jawnie, żeby resolucja była deterministyczna mimo >1 uczelni.
+    req._uczelnia = pbn_uczelnia
+
+    pbn_uczelnia.pbn_api_root = "https://pbn-zrequestu.example.com"
+    pbn_uczelnia.pbn_wysylaj_bez_oswiadczen = True
+    pbn_uczelnia.save()
+
+    # Druga uczelnia → get_single_uczelnia_or_none() zwróci None (>1).
+    inne_site = baker.make("sites.Site", domain="inna-pbn.example.com")
+    baker.make(
+        Uczelnia,
+        skrot="INNA",
+        nazwa="Inna uczelnia",
+        site=inne_site,
+        pbn_api_root="https://pbn-inna.example.com",
+    )
+
+    pbn_client.transport.return_values[PBN_POST_PUBLICATION_NO_STATEMENTS_URL] = [
+        {"id": "123"}
+    ]
+    pbn_client.transport.return_values[
+        PBN_GET_PUBLICATION_BY_ID_URL.format(id="123")
+    ] = MOCK_RETURNED_MONGODB_DATA
+    pbn_client.transport.return_values[PBN_GET_PUBLICATION_BY_ID_URL.format(id=456)] = (
+        MOCK_RETURNED_MONGODB_DATA
+    )
+    pbn_client.transport.return_values[
+        PBN_GET_INSTITUTION_PUBLICATIONS_V2 + "?publicationId=123&size=10"
+    ] = pbn_pageable_json(MOCK_RETURNED_INSTITUTION_PUBLICATION_V2_DATA)
+    pbn_client.transport.return_values[
+        PBN_GET_INSTITUTION_STATEMENTS + "?publicationId=123&size=5120"
+    ] = pbn_pageable_json([])
+
+    with middleware(req):
+        sprobuj_wyslac_do_pbn_gui(
+            req, pbn_wydawnictwo_zwarte_z_charakterem, pbn_client=pbn_client
+        )
+
+    msg = list(get_messages(req))
+    # Asercja CELOWO na URL publikacji (link_do_pbn), NIE na sam host — host
+    # występuje też w link_do_pi (Profil Instytucji), które uczelnię już
+    # dostaje. Pre-fix link_do_pbn() → None → ten fragment z hostem znika.
+    oczekiwany = "pbn-zrequestu.example.com/core/#/publication/view/"
+    assert any(oczekiwany in m.message for m in msg), [m.message for m in msg]
+
+
+@pytest.mark.django_db
 def test_sprobuj_wyslac_do_pbn_bez_oswiadczen_sukces(
     pbn_wydawnictwo_zwarte_z_charakterem, pbn_client, rf, pbn_uczelnia
 ):

--- a/src/pbn_api/tests/test_bpp_admin_helpers_gui.py
+++ b/src/pbn_api/tests/test_bpp_admin_helpers_gui.py
@@ -1,17 +1,15 @@
 from unittest.mock import patch
 
 import pytest
+from django.contrib.messages import get_messages
 from django.urls import reverse
 from model_bakery import baker
-
-from pbn_api.tests.utils import middleware
-from pbn_export_queue.models import PBN_Export_Queue
-
-from django.contrib.messages import get_messages
 
 from bpp.admin.helpers.pbn_api.gui import sprobuj_utworzyc_zlecenie_eksportu_do_PBN_gui
 from bpp.const import RODZAJ_PBN_ARTYKUL
 from bpp.models import Charakter_Formalny
+from pbn_api.tests.utils import middleware
+from pbn_export_queue.models import PBN_Export_Queue
 
 
 @pytest.mark.django_db
@@ -63,6 +61,36 @@ def test_sprobuj_utworzyc_zlecenie_eksportu_do_PBN_gui_success(
     assert expected_link in message
     assert f"Utworzono zlecenie wysyłki rekordu {wydawnictwo_ciagle}" in message
     assert "Kliknij tutaj, aby śledzić stan" in message
+
+
+@pytest.mark.django_db
+def test_sprobuj_utworzyc_zlecenie_eksportu_do_PBN_gui_stores_uczelnia(
+    rf, wydawnictwo_ciagle, admin_user, uczelnia
+):
+    """Multi-hosted: pojedyncza ścieżka GUI zapisuje uczelnię (z requestu) na
+    wpisie kolejki — tak jak batch — żeby wysyłka w tle nie zgadywała PBN."""
+    req = rf.get("/")
+    req.user = admin_user
+
+    wydawnictwo_ciagle.charakter_formalny = baker.make(
+        Charakter_Formalny, rodzaj_pbn=RODZAJ_PBN_ARTYKUL
+    )
+    wydawnictwo_ciagle.save()
+
+    uczelnia.pbn_integracja = True
+    uczelnia.pbn_aktualizuj_na_biezaco = True
+    uczelnia.save()
+
+    with middleware(req):
+        with patch("pbn_export_queue.tasks.task_sprobuj_wyslac_do_pbn.delay_on_commit"):
+            sprobuj_utworzyc_zlecenie_eksportu_do_PBN_gui(req, wydawnictwo_ciagle)
+
+    queue_entry = PBN_Export_Queue.objects.get(
+        content_type__model="wydawnictwo_ciagle",
+        object_id=wydawnictwo_ciagle.pk,
+        zamowil=admin_user,
+    )
+    assert queue_entry.uczelnia == uczelnia
 
 
 @pytest.mark.django_db

--- a/src/pbn_api/tests/test_link_do_pi_per_uczelnia.py
+++ b/src/pbn_api/tests/test_link_do_pi_per_uczelnia.py
@@ -159,6 +159,58 @@ def test_filtr_link_do_pi_przekazuje_uczelnia(uczelnia):
     assert str(v.pk) in link
 
 
+def _make_v2_z_uuid(objectId, uczelnia=None):
+    """Wiersz _V2 z ``uuid`` w json_data — żeby ``link_do_pi`` przeszedł
+    poza wczesny ``return`` (linia: ``if not uuid``)."""
+    return PublikacjaInstytucji_V2.objects.create(
+        uuid=uuid_module.uuid4(),
+        objectId=objectId,
+        json_data={
+            "title": "Test",
+            "objectId": objectId.pk,
+            "uuid": str(uuid_module.uuid4()),
+        },
+        uczelnia=uczelnia,
+    )
+
+
+@pytest.mark.django_db
+def test_v2_link_do_pi_wiele_uczelni_bez_taga_nie_crashuje(uczelnia):
+    """``PublikacjaInstytucji_V2.link_do_pi()``: wiersz bez taga uczelni przy
+    >1 uczelni w systemie NIE rzuca MultipleObjectsReturned — degraduje do
+    None (brak get_default / Uczelnia.objects.get() pierwszej-z-brzegu)."""
+    site2 = baker.make("sites.Site", domain="v2multi.example.com")
+    baker.make(Uczelnia, skrot="V2M", nazwa="Druga", site=site2)
+    assert Uczelnia.objects.count() >= 2
+
+    objectId = _make_publication()
+    v = _make_v2_z_uuid(objectId, uczelnia=None)
+
+    # Pre-fix: Uczelnia.objects.get() → MultipleObjectsReturned.
+    assert v.link_do_pi() is None
+
+
+@pytest.mark.django_db
+def test_v2_link_do_pi_uzywa_self_uczelnia(uczelnia):
+    """``PublikacjaInstytucji_V2.link_do_pi()`` z otagowaną uczelnią buduje
+    link z JEJ pbn_api_root, niezależnie od liczby uczelni w systemie."""
+    site2 = baker.make("sites.Site", domain="v2self.example.com")
+    u2 = baker.make(
+        Uczelnia,
+        skrot="V2S",
+        nazwa="Druga",
+        site=site2,
+        pbn_api_root="https://pbn-v2self.example.com",
+    )
+
+    objectId = _make_publication()
+    v = _make_v2_z_uuid(objectId, uczelnia=u2)
+
+    link = v.link_do_pi()
+    assert link is not None
+    assert urlparse(link).hostname == "pbn-v2self.example.com"
+
+
 @pytest.mark.django_db
 def test_backfill_single_install_taguje_null(uczelnia):
     """Single-install: backfill taguje wiersze NULL jedyną uczelnią."""


### PR DESCRIPTION
Naprawia uwagi z review dot. pozostałych runtime'owych `Uczelnia.objects.first()` / `Uczelnia.objects.get()` (footgun „pierwszej-z-brzegu uczelni") w trybie multi-hosted. Każda zmiana z testem (TDD: czerwony → zielony).

## Punkty review

| # | Plik | Fix |
|---|------|-----|
| 1 | `models/autor.py`, `views/autocomplete/authors.py` | `create_from_string(uczelnia=)`; `create_object` przekazuje `get_for_request` |
| 2 | `admin/core.py` | inline AutorForm: `get_single_uczelnia_or_none()` zamiast `first()` (UI-default bez requestu) |
| 3 | `multiseek_registry/{mixins,fields/numeric_fields}.py` | ujednolicone `option_enabled(request=None)`; IndexCopernicus respektuje uczelnię z requestu |
| 4 | `admin/helpers/pbn_api/gui.py` | single GUI path kolejki PBN zapisuje `uczelnia` z requestu (jak batch) |
| 5 | `admin/helpers/pbn_api/common.py` | `link_do_pbn(uczelnia=uczelnia)` (linie 146, 168) |
| 6 | `pbn_api/models/publikacja_instytucji.py` | `link_do_pi`: `get_single_uczelnia_or_none()` — koniec `MultipleObjectsReturned` przy >1 uczelni |
| 7 | `admin/uczelnia.py` | `UczelniaAdminForm`: przyjazny komunikat wymogu `site` (NOT NULL od migracji 0417) |

**Punkt 7 — ustalenie:** auto-linkowanie z review (`Uczelnia.save()`) było już zrealizowane przez migracje `0412`+`0417` (`site` jest NOT NULL, single-install 1+1 linkuje się automatycznie). Zamiast redundantnej migracji dodano walidację UX w formularzu admina.

## Cleanup
- Usunięto nieaktualne wpisy `bpp/admin/core.py` i `bpp/models/autor.py` z `APPROVED_FIRST` (guard-test `test_multihosted_get_default_guard`).
- Pozostałe runtime `first()` (whitelistowane, bez requestu): demo generator, debug command, komentarz w `jednostka.py`.

## Testy
- 7 nowych/rozszerzonych plików testowych, wszystkie dotknięte moduły zielone lokalnie (pbn_api admin/link helpers, autocomplete, multiseek, admin Uczelni, guard).
- ruff check + format czyste na zmienionych plikach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)