### PR TITLE
PBN import: rozdzielenie pobierania od przetwarzania

### DIFF
--- a/docs/superpowers/plans/2026-06-07-pbn-import-rozdziel-pobieranie.md
+++ b/docs/superpowers/plans/2026-06-07-pbn-import-rozdziel-pobieranie.md
@@ -1,0 +1,2375 @@
+# PBN Import — rozdzielenie pobierania od przetwarzania — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rozdzielić każdy rozdzielalny krok importu PBN na dwie niezależnie
+uruchamiane fazy — pobieranie (download → lustro `pbn_api.*`) i przetwarzanie
+(process → modele BPP) — z dwukolumnowym formularzem i zgodnością wsteczną.
+
+**Architecture:** `ImportStepBase` zyskuje metody `download()`/`process()`,
+a `run()` = obie po kolei. Sześć importerów (źródła, wydawcy, konferencje,
+autorzy, publikacje, oświadczenia) rozbijamy na te metody; reszta bez zmian.
+`step_definitions.py` przechodzi na model **faz** (każda faza ma własny
+`form_field`/`disable_key`/`method`), a `ImportManager` wykonuje fazy płasko,
+zachowując kolejność per-encja (download→process). Config to JSONField bez
+migracji; resolver zgodności wstecznej tłumaczy stary `disable_<encja>` na obie
+fazy. Dodajemy brakującą integrację konferencji (`integruj_konferencje`).
+
+**Tech Stack:** Django, pytest + model_bakery, pbn_integrator, Foundation CSS
+(panel admin importu), HTMX/JS w `dashboard.html`.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-pbn-import-rozdzielenie-pobierania-od-przetwarzania-design.md`
+
+---
+
+## Uwagi wykonawcze (przeczytaj przed startem)
+
+- **Wszystkie komendy Pythona przez `uv run`.** Nigdy gołe `python`/`pytest`.
+- **Max 88 znaków/linia** (ruff). Po każdym tasku z kodem: `ruff format <pliki>`
+  i `ruff check <pliki>` — naprawiaj ręcznie (NIE `--fix`).
+- **Nie modyfikuj istniejących migracji.** Tu i tak nie ma zmian w modelach.
+- Testy korzystają z testcontainers (wymagany Docker). Jeśli masz własne
+  usługi: `PYTEST_TESTCONTAINERS_DISABLE=1 uv run pytest …`.
+- Każdy task kończy się commitem. Wiadomości commitów po polsku, z trailerem
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- Pracujesz w worktree `~/Programowanie/bpp-pbn-import-split` na branchu
+  `feature/pbn-import-rozdziel-pobieranie`.
+
+---
+
+## Task 1: `ImportStepBase` — metody faz i wywołanie per-metoda
+
+Dodaje `download()`/`process()`/`run()` oraz `__call__(method=…)`, nie psując
+istniejących importerów (które wciąż mają własne `run()`).
+
+**Files:**
+- Modify: `src/pbn_import/utils/base.py`
+- Test: `src/pbn_import/tests/test_step_phase_dispatch.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/pbn_import/tests/test_step_phase_dispatch.py
+"""Testy dyspozytora faz w ImportStepBase (download/process/run/__call__)."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils.base import ImportStepBase
+
+
+class _DummyStep(ImportStepBase):
+    step_name = "dummy"
+    step_description = "Dummy"
+
+    def __init__(self, session):
+        super().__init__(session)
+        self.calls = []
+
+    def download(self):
+        self.calls.append("download")
+        return {"phase": "download"}
+
+    def process(self):
+        self.calls.append("process")
+        return {"phase": "process"}
+
+
+@pytest.fixture
+def session(db):
+    user = baker.make("auth.User")
+    return baker.make("pbn_import.ImportSession", user=user)
+
+
+def test_call_default_runs_both_phases(session):
+    step = _DummyStep(session)
+    result = step()  # default method="run"
+    assert step.calls == ["download", "process"]
+    assert result == {"phase": "process"}
+
+
+def test_call_download_only(session):
+    step = _DummyStep(session)
+    result = step(method="download")
+    assert step.calls == ["download"]
+    assert result == {"phase": "download"}
+
+
+def test_call_process_only(session):
+    step = _DummyStep(session)
+    result = step(method="process")
+    assert step.calls == ["process"]
+    assert result == {"phase": "process"}
+
+
+def test_base_download_process_not_implemented(session):
+    class _Bare(ImportStepBase):
+        step_name = "bare"
+
+    bare = _Bare(session)
+    with pytest.raises(NotImplementedError):
+        bare.download()
+    with pytest.raises(NotImplementedError):
+        bare.process()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_step_phase_dispatch.py -v`
+Expected: FAIL — `TypeError: __call__() got an unexpected keyword argument 'method'`
+(oraz brak `download`/`process` w bazie).
+
+- [ ] **Step 3: Implement in `base.py`**
+
+W `ImportStepBase` zastąp obecne `run()` i `__call__()` poniższym. Zostaw
+istniejący `run()` z `@transaction.atomic` jako `run()` domyślny, ale zmień
+jego ciało na sekwencję faz. Dodaj `download()`/`process()`.
+
+```python
+    def download(self):
+        """Faza pobierania danych z PBN do lustra. Nadpisz w podklasie."""
+        raise NotImplementedError("Krok nie implementuje fazy pobierania")
+
+    def process(self):
+        """Faza przetwarzania lustra do modeli BPP. Nadpisz w podklasie."""
+        raise NotImplementedError("Krok nie implementuje fazy przetwarzania")
+
+    @transaction.atomic
+    def run(self):
+        """Domyślnie: pobierz, potem przetwórz (zgodność wsteczna)."""
+        self.download()
+        return self.process()
+
+    def __call__(self, method: str = "run"):
+        """Uruchom wskazaną fazę (run/download/process) z obwiednią start/finish."""
+        self.start()
+        try:
+            result = getattr(self, method)()
+            self.finish()
+            return result
+        except Exception as e:
+            # handle_error robi raport do Rollbara + log; mark_failed robi ImportManager
+            self.handle_error(e, f"Krytyczny błąd w {self.step_name}")
+            raise
+```
+
+Uwaga: usuń poprzednią definicję `def run(self): raise NotImplementedError(...)`
+oraz poprzedni `def __call__(self):` — zastępujemy je powyższymi.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_step_phase_dispatch.py -v`
+Expected: PASS (4 testy).
+
+- [ ] **Step 5: Sanity — istniejące importery wciąż działają przez `run`**
+
+Run: `uv run pytest src/pbn_import/tests/test_importer_wrappers.py src/pbn_import/tests/test_step_constructor_contract.py -v`
+Expected: PASS (importery z własnym `run()` nadpisują bazowy — bez regresji).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+ruff format src/pbn_import/utils/base.py src/pbn_import/tests/test_step_phase_dispatch.py
+ruff check src/pbn_import/utils/base.py src/pbn_import/tests/test_step_phase_dispatch.py
+git add src/pbn_import/utils/base.py src/pbn_import/tests/test_step_phase_dispatch.py
+git commit -m "feat(pbn-import): ImportStepBase — fazy download/process i __call__(method)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `integruj_konferencje` — nowa integracja lustro → BPP
+
+Mapuje `pbn_api.Conference` na `bpp.Konferencja` (idempotentnie).
+
+**Files:**
+- Modify: `src/pbn_integrator/utils/conferences.py`
+- Modify: `src/pbn_integrator/utils/__init__.py` (eksport + `__all__`)
+- Test: `src/pbn_integrator/tests/test_integruj_konferencje.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/pbn_integrator/tests/test_integruj_konferencje.py
+"""Testy integracji konferencji PBN → BPP."""
+
+import datetime
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Konferencja
+from pbn_api.models import Conference
+from pbn_integrator.utils import integruj_konferencje
+
+
+def _make_conference(mongo_id, obj):
+    """Utwórz lustro Conference z podanym JSON-em 'object'."""
+    return baker.make(
+        Conference,
+        mongoId=mongo_id,
+        versions=[{"current": True, "object": obj}],
+        status="ACTIVE",
+    )
+
+
+@pytest.mark.django_db
+def test_tworzy_konferencje_z_lustra():
+    _make_conference(
+        "c1",
+        {
+            "fullName": "Międzynarodowa Konferencja XYZ",
+            "startDate": "2023-09-01",
+            "endDate": "2023-09-03",
+            "city": "Kraków",
+            "country": "Polska",
+            "abbreviation": "MKXYZ",
+        },
+    )
+
+    liczba = integruj_konferencje()
+
+    assert liczba == 1
+    k = Konferencja.objects.get()
+    assert k.nazwa == "Międzynarodowa Konferencja XYZ"
+    assert k.rozpoczecie == datetime.date(2023, 9, 1)
+    assert k.zakonczenie == datetime.date(2023, 9, 3)
+    assert k.miasto == "Kraków"
+    assert k.panstwo == "Polska"
+    assert k.skrocona_nazwa == "MKXYZ"
+    assert k.pbn_uid_id == "c1"
+
+
+@pytest.mark.django_db
+def test_idempotentne_po_pbn_uid():
+    _make_conference(
+        "c1", {"fullName": "Konf A", "startDate": "2022-01-01"}
+    )
+    integruj_konferencje()
+    integruj_konferencje()
+    assert Konferencja.objects.filter(pbn_uid_id="c1").count() == 1
+
+
+@pytest.mark.django_db
+def test_dowiazuje_istniejaca_po_nazwie_i_dacie():
+    # Konferencja wprowadzona ręcznie, bez pbn_uid
+    Konferencja.objects.create(
+        nazwa="Konf B", rozpoczecie=datetime.date(2021, 5, 5)
+    )
+    _make_conference(
+        "c2", {"fullName": "Konf B", "startDate": "2021-05-05", "city": "Łódź"}
+    )
+
+    integruj_konferencje()
+
+    assert Konferencja.objects.count() == 1
+    k = Konferencja.objects.get()
+    assert k.pbn_uid_id == "c2"
+    assert k.miasto == "Łódź"
+
+
+@pytest.mark.django_db
+def test_pomija_status_deleted():
+    baker.make(
+        Conference,
+        mongoId="c3",
+        versions=[{"current": True, "object": {"fullName": "Konf C"}}],
+        status="DELETED",
+    )
+    assert integruj_konferencje() == 0
+    assert Konferencja.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_zla_data_daje_none_bez_bledu():
+    _make_conference(
+        "c4", {"fullName": "Konf D", "startDate": "niepoprawna-data"}
+    )
+    assert integruj_konferencje() == 1
+    k = Konferencja.objects.get(pbn_uid_id="c4")
+    assert k.rozpoczecie is None
+
+
+@pytest.mark.django_db
+def test_pomija_rekord_bez_nazwy():
+    _make_conference("c5", {"startDate": "2020-01-01"})
+    assert integruj_konferencje() == 0
+    assert Konferencja.objects.count() == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_integrator/tests/test_integruj_konferencje.py -v`
+Expected: FAIL — `ImportError: cannot import name 'integruj_konferencje'`.
+
+- [ ] **Step 3: Implement `integruj_konferencje` w `conferences.py`**
+
+Dopisz na końcu `src/pbn_integrator/utils/conferences.py` (dołóż importy u góry):
+
+```python
+import datetime
+import logging
+
+from bpp.models import Konferencja
+
+logger = logging.getLogger("pbn_integrator")
+
+
+def _parse_pbn_date(value):
+    """Sparsuj 'YYYY-MM-DD' na date; None gdy brak/niepoprawne."""
+    if not value:
+        return None
+    try:
+        return datetime.date.fromisoformat(str(value)[:10])
+    except (ValueError, TypeError):
+        logger.debug("Niepoprawna data konferencji PBN: %r", value)
+        return None
+
+
+def integruj_konferencje(callback=None):
+    """Integruj lustro pbn_api.Conference → bpp.Konferencja.
+
+    Re-entrant: dopasowuje po pbn_uid, potem po (nazwa, rozpoczecie).
+    Aktualizuje pola pochodzące z PBN; nie nadpisuje pól, których PBN nie
+    dostarcza (typ_konferencji, bazy indeksujące). Zwraca liczbę
+    utworzonych/zaktualizowanych konferencji.
+    """
+    qs = Conference.objects.all()
+    total = qs.count()
+    przetworzone = 0
+
+    for i, conf in enumerate(qs.iterator(), 1):
+        if callback is not None:
+            callback.update(i, total, "Integracja konferencji")
+
+        if conf.status == "DELETED":
+            logger.info("Pomijam usuniętą konferencję PBN %s", conf.mongoId)
+            continue
+
+        nazwa = conf.fullName()
+        if not nazwa:
+            logger.info("Pomijam konferencję PBN %s bez nazwy", conf.mongoId)
+            continue
+
+        rozpoczecie = _parse_pbn_date(conf.startDate())
+        zakonczenie = _parse_pbn_date(conf.endDate())
+        miasto = conf.city() or None
+        panstwo = conf.country() or None
+        skrot = conf.value("object", "abbreviation", return_none=True)
+
+        konferencja = Konferencja.objects.filter(pbn_uid_id=conf.pk).first()
+        if konferencja is None:
+            konferencja = Konferencja.objects.filter(
+                nazwa=nazwa, rozpoczecie=rozpoczecie
+            ).first()
+
+        if konferencja is None:
+            konferencja = Konferencja(nazwa=nazwa, rozpoczecie=rozpoczecie)
+
+        konferencja.pbn_uid_id = conf.pk
+        konferencja.nazwa = nazwa
+        konferencja.rozpoczecie = rozpoczecie
+        konferencja.zakonczenie = zakonczenie
+        konferencja.miasto = miasto
+        konferencja.panstwo = panstwo
+        if skrot:
+            konferencja.skrocona_nazwa = skrot
+        konferencja.save()
+        przetworzone += 1
+
+    return przetworzone
+```
+
+- [ ] **Step 4: Eksportuj funkcję w `utils/__init__.py`**
+
+W `src/pbn_integrator/utils/__init__.py` rozszerz import konferencji i `__all__`:
+
+```python
+from pbn_integrator.utils.conferences import (  # noqa
+    integruj_konferencje,
+    pobierz_konferencje,
+)
+```
+
+oraz w liście `__all__` obok `"pobierz_konferencje"` dodaj:
+
+```python
+    "integruj_konferencje",
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_integrator/tests/test_integruj_konferencje.py -v`
+Expected: PASS (6 testów).
+
+Jeśli `versions`/`value("object", …)` w teście nie odwzorowuje realnego
+kształtu (sprawdź `src/pbn_api/models/base.py` metodę `value`), dostosuj
+`_make_conference` tak, by `conf.fullName()` zwracało wartość — kontrakt
+produkcyjny (`value("object", key)`) zostaje bez zmian.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+ruff format src/pbn_integrator/utils/conferences.py src/pbn_integrator/utils/__init__.py src/pbn_integrator/tests/test_integruj_konferencje.py
+ruff check src/pbn_integrator/utils/conferences.py src/pbn_integrator/utils/__init__.py src/pbn_integrator/tests/test_integruj_konferencje.py
+git add src/pbn_integrator/utils/conferences.py src/pbn_integrator/utils/__init__.py src/pbn_integrator/tests/test_integruj_konferencje.py
+git commit -m "feat(pbn-integrator): integruj_konferencje — lustro Conference → BPP Konferencja
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `ConferenceImporter` — split download/process
+
+**Files:**
+- Modify: `src/pbn_import/utils/conference_import.py`
+- Test: `src/pbn_import/tests/test_conference_importer_split.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/pbn_import/tests/test_conference_importer_split.py
+"""ConferenceImporter: download woła pobierz, process woła integruj."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import conference_import
+
+
+@pytest.fixture
+def step(db):
+    user = baker.make("auth.User")
+    session = baker.make("pbn_import.ImportSession", user=user)
+    return conference_import.ConferenceImporter(session, client=object())
+
+
+def test_download_calls_pobierz_not_integruj(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        conference_import, "pobierz_konferencje",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        conference_import, "integruj_konferencje",
+        lambda *a, **k: called.append("integruj"),
+    )
+    step.download()
+    assert called == ["pobierz"]
+
+
+def test_process_calls_integruj_not_pobierz(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        conference_import, "pobierz_konferencje",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        conference_import, "integruj_konferencje",
+        lambda *a, **k: called.append("integruj") or 3,
+    )
+    step.process()
+    assert called == ["integruj"]
+
+
+def test_process_warns_when_mirror_empty(step, monkeypatch):
+    monkeypatch.setattr(
+        conference_import, "integruj_konferencje", lambda *a, **k: 0
+    )
+    step.process()
+    warnings = step.session.logs.filter(level="warning")
+    assert warnings.exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_conference_importer_split.py -v`
+Expected: FAIL — `AttributeError: 'ConferenceImporter' object has no attribute 'download'`.
+
+- [ ] **Step 3: Rewrite `conference_import.py`**
+
+```python
+"""Conference import utilities"""
+
+from pbn_api.models import Conference
+from pbn_integrator.utils import integruj_konferencje, pobierz_konferencje
+
+from .base import ImportStepBase
+
+
+class ConferenceImporter(ImportStepBase):
+    """Import conferences from PBN"""
+
+    step_name = "conference_import"
+    step_description = "Import konferencji"
+
+    def download(self):
+        """Pobierz konferencje z PBN do lustra."""
+        self.update_progress(0, 1, "Pobieranie konferencji z PBN")
+        self.log("info", "Pobieranie konferencji z PBN")
+        subtask_callback = self.create_subtask_progress("Pobieranie konferencji")
+        try:
+            pobierz_konferencje(self.client, callback=subtask_callback)
+            self.log("success", "Konferencje pobrane pomyślnie")
+        except Exception as e:
+            self.handle_error(e, "Nie udało się pobrać konferencji")
+        finally:
+            self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono pobieranie konferencji")
+        return {"conferences_downloaded": True, "error_count": len(self.errors)}
+
+    def process(self):
+        """Zintegruj lustro konferencji do BPP."""
+        if not Conference.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych konferencji — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+        self.update_progress(0, 1, "Integracja konferencji")
+        subtask_callback = self.create_subtask_progress("Integracja konferencji")
+        try:
+            liczba = integruj_konferencje(callback=subtask_callback)
+            self.log("success", f"Zintegrowano {liczba} konferencji")
+        except Exception as e:
+            self.handle_error(e, "Nie udało się zintegrować konferencji")
+        finally:
+            self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono integrację konferencji")
+        return {"conferences_integrated": True, "error_count": len(self.errors)}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_conference_importer_split.py -v`
+Expected: PASS (3 testy).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff format src/pbn_import/utils/conference_import.py src/pbn_import/tests/test_conference_importer_split.py
+ruff check src/pbn_import/utils/conference_import.py src/pbn_import/tests/test_conference_importer_split.py
+git add src/pbn_import/utils/conference_import.py src/pbn_import/tests/test_conference_importer_split.py
+git commit -m "feat(pbn-import): ConferenceImporter — split download/process
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `SourceImporter` — split download/process
+
+**Files:**
+- Modify: `src/pbn_import/utils/source_import.py`
+- Test: `src/pbn_import/tests/test_source_importer_split.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/pbn_import/tests/test_source_importer_split.py
+"""SourceImporter: download woła pobierz, process woła importuj."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import source_import
+
+
+@pytest.fixture
+def step(db):
+    user = baker.make("auth.User")
+    session = baker.make("pbn_import.ImportSession", user=user)
+    return source_import.SourceImporter(session, client=object())
+
+
+def test_download_calls_pobierz_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        source_import, "pobierz_zrodla_mnisw",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        source_import.importer, "importuj_zrodla",
+        lambda *a, **k: called.append("importuj"),
+    )
+    step.download()
+    assert called == ["pobierz"]
+
+
+def test_process_calls_importuj_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        source_import, "pobierz_zrodla_mnisw",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        source_import.importer, "importuj_zrodla",
+        lambda *a, **k: called.append("importuj") or 5,
+    )
+    step.process()
+    assert called == ["importuj"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_source_importer_split.py -v`
+Expected: FAIL — brak metody `download`.
+
+- [ ] **Step 3: Rewrite `source_import.py`**
+
+```python
+"""Source (journal) import utilities"""
+
+from pbn_api.models import Journal
+from pbn_integrator import importer
+from pbn_integrator.utils import pobierz_zrodla_mnisw
+
+from .base import ImportStepBase
+
+
+class SourceImporter(ImportStepBase):
+    """Import sources/journals from PBN"""
+
+    step_name = "source_import"
+    step_description = "Import źródeł (czasopism)"
+
+    def download(self):
+        """Pobierz źródła z PBN (MNiSW) do lustra."""
+        self.update_progress(0, 1, "Pobieranie źródeł z PBN")
+        self.log("info", "Pobieranie źródeł z MNiSW")
+        subtask_callback = self.create_subtask_progress("Pobieranie źródeł MNiSW")
+        try:
+            pobierz_zrodla_mnisw(self.client, callback=subtask_callback)
+            self.log("success", "Źródła pobrane pomyślnie")
+        except Exception as e:
+            self.handle_pbn_error(e, "Nie udało się pobrać źródeł")
+            self.log("warning", "Kontynuacja z częściowymi danymi")
+        finally:
+            self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono pobieranie źródeł")
+        return {"sources_downloaded": True, "error_count": len(self.errors)}
+
+    def process(self):
+        """Zaimportuj źródła z lustra do BPP."""
+        if not Journal.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych źródeł — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+        self.update_progress(0, 1, "Importowanie źródeł do bazy danych")
+        self.log("info", "Importowanie źródeł do bazy danych")
+        try:
+            result = importer.importuj_zrodla()
+            if hasattr(self.session, "statistics") and isinstance(
+                result, (int, float)
+            ):
+                stats = self.session.statistics
+                stats.journals_imported = int(result)
+                stats.save()
+            self.log("success", "Źródła zaimportowane pomyślnie")
+        except Exception as e:
+            self.handle_error(e, "Nie udało się zaimportować źródeł")
+            raise
+        self.update_progress(1, 1, "Zakończono import źródeł")
+        return {"sources_imported": True, "error_count": len(self.errors)}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_source_importer_split.py src/pbn_import/tests/test_source_scoring_import.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff format src/pbn_import/utils/source_import.py src/pbn_import/tests/test_source_importer_split.py
+ruff check src/pbn_import/utils/source_import.py src/pbn_import/tests/test_source_importer_split.py
+git add src/pbn_import/utils/source_import.py src/pbn_import/tests/test_source_importer_split.py
+git commit -m "feat(pbn-import): SourceImporter — split download/process
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `PublisherImporter` — split download/process
+
+**Files:**
+- Modify: `src/pbn_import/utils/publisher_import.py`
+- Test: `src/pbn_import/tests/test_publisher_importer_split.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/pbn_import/tests/test_publisher_importer_split.py
+"""PublisherImporter: download woła pobierz, process woła importuj."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import publisher_import
+
+
+@pytest.fixture
+def step(db):
+    user = baker.make("auth.User")
+    session = baker.make("pbn_import.ImportSession", user=user)
+    return publisher_import.PublisherImporter(session, client=object())
+
+
+def test_download_calls_pobierz_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        publisher_import, "pobierz_wydawcow_mnisw",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        publisher_import.importer, "importuj_wydawcow",
+        lambda *a, **k: called.append("importuj"),
+    )
+    step.download()
+    assert called == ["pobierz"]
+
+
+def test_process_calls_importuj_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        publisher_import, "pobierz_wydawcow_mnisw",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        publisher_import.importer, "importuj_wydawcow",
+        lambda *a, **k: called.append("importuj") or 7,
+    )
+    step.process()
+    assert called == ["importuj"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_publisher_importer_split.py -v`
+Expected: FAIL — brak metody `download`.
+
+- [ ] **Step 3: Rewrite `publisher_import.py`**
+
+```python
+"""Publisher import utilities"""
+
+from pbn_api.models import Publisher
+from pbn_integrator import importer
+from pbn_integrator.utils import pobierz_wydawcow_mnisw
+
+from .base import ImportStepBase
+
+
+class PublisherImporter(ImportStepBase):
+    """Import publishers from PBN"""
+
+    step_name = "publisher_import"
+    step_description = "Import wydawców"
+
+    def download(self):
+        """Pobierz wydawców z PBN (MNiSW) do lustra."""
+        self.update_progress(0, 1, "Pobieranie wydawców z PBN")
+        self.log("info", "Pobieranie wydawców z MNiSW")
+        try:
+            pobierz_wydawcow_mnisw(self.client)
+            self.log("success", "Wydawcy pobrani pomyślnie")
+        except Exception as e:
+            self.handle_error(e, "Nie udało się pobrać wydawców")
+        self.update_progress(1, 1, "Zakończono pobieranie wydawców")
+        return {"publishers_downloaded": True, "error_count": len(self.errors)}
+
+    def process(self):
+        """Zaimportuj wydawców z lustra do BPP."""
+        if not Publisher.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych wydawców — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+        self.update_progress(0, 1, "Importowanie wydawców do bazy danych")
+        self.log("info", "Importowanie wydawców do bazy danych")
+        subtask_callback = self.create_subtask_progress("Importowanie wydawców")
+        try:
+            result = importer.importuj_wydawcow(callback=subtask_callback)
+            if hasattr(self.session, "statistics") and isinstance(
+                result, (int, float)
+            ):
+                stats = self.session.statistics
+                stats.publishers_imported = int(result)
+                stats.save()
+            self.log("success", "Wydawcy zaimportowani pomyślnie")
+        except Exception as e:
+            self.handle_error(e, "Nie udało się zaimportować wydawców")
+        finally:
+            self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono import wydawców")
+        return {"publishers_imported": True, "error_count": len(self.errors)}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_publisher_importer_split.py -v`
+Expected: PASS (2 testy).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff format src/pbn_import/utils/publisher_import.py src/pbn_import/tests/test_publisher_importer_split.py
+ruff check src/pbn_import/utils/publisher_import.py src/pbn_import/tests/test_publisher_importer_split.py
+git add src/pbn_import/utils/publisher_import.py src/pbn_import/tests/test_publisher_importer_split.py
+git commit -m "feat(pbn-import): PublisherImporter — split download/process
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `AuthorImporter` — split download/process
+
+**Files:**
+- Modify: `src/pbn_import/utils/author_import.py`
+- Test: `src/pbn_import/tests/test_author_importer_split.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/pbn_import/tests/test_author_importer_split.py
+"""AuthorImporter: download woła pobierz, process woła integruj."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import author_import
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make("bpp.Uczelnia", pbn_uid_id="INST-1")
+
+
+@pytest.fixture
+def step(db, uczelnia):
+    user = baker.make("auth.User")
+    session = baker.make("pbn_import.ImportSession", user=user)
+    return author_import.AuthorImporter(session, client=object(), uczelnia=uczelnia)
+
+
+def test_download_calls_pobierz_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        author_import, "pobierz_ludzi_z_uczelni",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        author_import, "integruj_autorow_z_uczelni",
+        lambda *a, **k: called.append("integruj"),
+    )
+    step.download()
+    assert called == ["pobierz"]
+
+
+def test_process_calls_integruj_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        author_import, "pobierz_ludzi_z_uczelni",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        author_import, "integruj_autorow_z_uczelni",
+        lambda *a, **k: called.append("integruj"),
+    )
+    step.process()
+    assert called == ["integruj"]
+
+
+def test_download_skips_without_pbn_uid(db, monkeypatch):
+    uczelnia = baker.make("bpp.Uczelnia", pbn_uid_id=None)
+    user = baker.make("auth.User")
+    session = baker.make("pbn_import.ImportSession", user=user)
+    step = author_import.AuthorImporter(session, client=object(), uczelnia=uczelnia)
+    called = []
+    monkeypatch.setattr(
+        author_import, "pobierz_ludzi_z_uczelni",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    result = step.download()
+    assert called == []
+    assert result["authors_imported"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_author_importer_split.py -v`
+Expected: FAIL — brak metody `download`.
+
+- [ ] **Step 3: Rewrite `author_import.py`**
+
+```python
+"""Author import utilities"""
+
+from pbn_api.models import Scientist
+from pbn_integrator.utils import integruj_autorow_z_uczelni, pobierz_ludzi_z_uczelni
+
+from .base import ImportStepBase
+
+
+class AuthorImporter(ImportStepBase):
+    """Import authors from PBN"""
+
+    step_name = "author_import"
+    step_description = "Import autorów"
+
+    def _resolve_uczelnia(self):
+        """Zwróć uczelnię kontekstu importu lub None (z logiem) gdy brak pbn_uid."""
+        uczelnia = self.uczelnia
+        if not uczelnia or not uczelnia.pbn_uid_id:
+            self.log(
+                "warning",
+                "Nie znaleziono Uczelni z PBN UID, pomijanie importu autorów",
+            )
+            return None
+        return uczelnia
+
+    def download(self):
+        """Pobierz autorów uczelni z PBN do lustra."""
+        uczelnia = self._resolve_uczelnia()
+        if uczelnia is None:
+            return {"authors_imported": False, "reason": "No Uczelnia PBN UID"}
+
+        self.update_progress(0, 1, "Pobieranie autorów z PBN")
+        self.log("info", f"Pobieranie autorów dla instytucji {uczelnia.pbn_uid_id}")
+        subtask_callback = self.create_subtask_progress("Pobieranie autorów")
+        try:
+            pobierz_ludzi_z_uczelni(
+                self.client, uczelnia.pbn_uid_id, callback=subtask_callback
+            )
+            self.log("success", "Autorzy pobrani pomyślnie")
+        except Exception as e:
+            self.handle_error(e, "Nie udało się pobrać autorów")
+        finally:
+            self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono pobieranie autorów")
+        return {"authors_downloaded": True, "error_count": len(self.errors)}
+
+    def process(self):
+        """Zintegruj autorów z lustra do BPP (z uczelnią)."""
+        uczelnia = self._resolve_uczelnia()
+        if uczelnia is None:
+            return {"authors_imported": False, "reason": "No Uczelnia PBN UID"}
+
+        if not Scientist.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych autorów — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+
+        self.update_progress(0, 1, "Integrowanie autorów")
+        self.log("info", "Integrating authors with university")
+        integration_callback = self.create_subtask_progress(
+            "Integrowanie autorów z uczelnią"
+        )
+        try:
+            integruj_autorow_z_uczelni(
+                self.client,
+                uczelnia.pbn_uid_id,
+                import_unexistent=True,
+                callback=integration_callback,
+            )
+            self.clear_subtask_progress()
+            if hasattr(self.session, "statistics"):
+                from bpp.models import Autor
+
+                stats = self.session.statistics
+                stats.authors_imported = Autor.objects.filter(
+                    pbn_uid_id__isnull=False
+                ).count()
+                stats.save()
+            self.log("success", "Autorzy zintegrowani pomyślnie")
+        except Exception as e:
+            self.handle_error(e, "Nie udało się zintegrować autorów")
+            if hasattr(self.session, "statistics"):
+                self.session.statistics.authors_failed += 1
+                self.session.statistics.save()
+        self.update_progress(1, 1, "Zakończono import autorów")
+        return {
+            "authors_imported": True,
+            "uczelnia_pbn_uid": uczelnia.pbn_uid_id,
+            "error_count": len(self.errors),
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_author_importer_split.py -v`
+Expected: PASS (3 testy).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff format src/pbn_import/utils/author_import.py src/pbn_import/tests/test_author_importer_split.py
+ruff check src/pbn_import/utils/author_import.py src/pbn_import/tests/test_author_importer_split.py
+git add src/pbn_import/utils/author_import.py src/pbn_import/tests/test_author_importer_split.py
+git commit -m "feat(pbn-import): AuthorImporter — split download/process
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `PublicationImporter` — split download/process
+
+`delete_existing` (kasowanie rekordów BPP) należy do fazy `process`.
+
+**Files:**
+- Modify: `src/pbn_import/utils/publication_import.py`
+- Test: `src/pbn_import/tests/test_publication_importer_split.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/pbn_import/tests/test_publication_importer_split.py
+"""PublicationImporter: rozdzielenie download (pobieranie) i process (import)."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import publication_import
+from pbn_import.utils.publication_import import PublicationImporter
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make("bpp.Uczelnia", pbn_uid_id="INST-1")
+
+
+@pytest.fixture
+def session(db):
+    user = baker.make("auth.User")
+    return baker.make("pbn_import.ImportSession", user=user)
+
+
+def _patch_setup(monkeypatch, importer_obj):
+    """Pomiń realny setup uczelni/jednostki — zwróć uczelnię ze stepu."""
+    monkeypatch.setattr(
+        importer_obj, "_setup_uczelnia_and_jednostka",
+        lambda *a, **k: importer_obj.uczelnia,
+    )
+
+
+def test_download_calls_only_download_helpers(session, uczelnia, monkeypatch):
+    step = PublicationImporter(session, client=object(), uczelnia=uczelnia)
+    _patch_setup(monkeypatch, step)
+    called = []
+    monkeypatch.setattr(
+        step, "_download_publications",
+        lambda *a, **k: called.append("dl") or None,
+    )
+    monkeypatch.setattr(
+        step, "_download_publications_v2",
+        lambda *a, **k: called.append("dl2") or None,
+    )
+    monkeypatch.setattr(
+        step, "_import_publications",
+        lambda *a, **k: called.append("import") or None,
+    )
+    step.download()
+    assert called == ["dl", "dl2"]
+
+
+def test_process_calls_only_import(session, uczelnia, monkeypatch):
+    step = PublicationImporter(session, client=object(), uczelnia=uczelnia)
+    _patch_setup(monkeypatch, step)
+    called = []
+    monkeypatch.setattr(
+        step, "_download_publications",
+        lambda *a, **k: called.append("dl") or None,
+    )
+    monkeypatch.setattr(
+        step, "_import_publications",
+        lambda *a, **k: called.append("import") or None,
+    )
+    step.process()
+    assert called == ["import"]
+
+
+def test_process_deletes_when_delete_existing(session, uczelnia, monkeypatch):
+    step = PublicationImporter(
+        session, client=object(), delete_existing=True, uczelnia=uczelnia
+    )
+    _patch_setup(monkeypatch, step)
+    called = []
+    monkeypatch.setattr(
+        step, "_delete_existing_publications",
+        lambda *a, **k: called.append("delete") or None,
+    )
+    monkeypatch.setattr(
+        step, "_import_publications",
+        lambda *a, **k: called.append("import") or None,
+    )
+    step.process()
+    assert called == ["delete", "import"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_publication_importer_split.py -v`
+Expected: FAIL — brak metody `download`.
+
+- [ ] **Step 3: Refaktor `publication_import.py`**
+
+Zastąp metodę `run()` (linie ~34–74) dwiema metodami. Pozostałe metody
+prywatne (`_setup_uczelnia_and_jednostka`, `_delete_existing_publications`,
+`_download_publications`, `_download_publications_v2`, `_import_publications`,
+`_import_publications_with_cancellation`, `import_single_publication`)
+ZOSTAJĄ bez zmian. Zmieniamy tylko sygnatury wewn. wywołań progresu na stałe
+liczniki (każda faza liczy własne kroki).
+
+```python
+    def download(self):
+        """Pobierz publikacje instytucji (v1 + v2) z PBN do lustra."""
+        uczelnia = self._setup_uczelnia_and_jednostka()
+        if uczelnia is None:
+            return {"publications_imported": False, "reason": "No Uczelnia PBN UID"}
+
+        result = self._download_publications(0, 2, uczelnia)
+        if result:
+            return result
+        result = self._download_publications_v2(1, 2)
+        if result:
+            return result
+
+        self.update_progress(2, 2, "Zakończono pobieranie publikacji")
+        return {"publications_downloaded": True, "error_count": len(self.errors)}
+
+    def process(self):
+        """Zaimportuj publikacje z lustra do BPP (opcjonalnie po skasowaniu)."""
+        from pbn_api.models import Publication
+
+        uczelnia = self._setup_uczelnia_and_jednostka()
+        if uczelnia is None:
+            return {"publications_imported": False, "reason": "No Uczelnia PBN UID"}
+
+        if not Publication.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych publikacji — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+
+        total_steps = 2 if self.delete_existing else 1
+        current_step = 0
+        if self.delete_existing:
+            result = self._delete_existing_publications(current_step, total_steps)
+            if result:
+                return result
+            current_step += 1
+
+        result = self._import_publications(current_step, total_steps)
+        if result:
+            return result
+
+        self.update_progress(total_steps, total_steps, "Zakończono import publikacji")
+        return {
+            "publications_imported": True,
+            "default_jednostka": self.default_jednostka.nazwa,
+            "error_count": len(self.errors),
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_publication_importer_split.py src/pbn_import/tests/test_publication_import.py -v`
+Expected: PASS (nowe + istniejące testy publikacji).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff format src/pbn_import/utils/publication_import.py src/pbn_import/tests/test_publication_importer_split.py
+ruff check src/pbn_import/utils/publication_import.py src/pbn_import/tests/test_publication_importer_split.py
+git add src/pbn_import/utils/publication_import.py src/pbn_import/tests/test_publication_importer_split.py
+git commit -m "feat(pbn-import): PublicationImporter — split download/process
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `StatementImporter` — split download/process
+
+`_download_missing_publications` to dociąg sterowany integracją → faza `process`.
+
+**Files:**
+- Modify: `src/pbn_import/utils/statement_import.py`
+- Test: `src/pbn_import/tests/test_statement_importer_split.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/pbn_import/tests/test_statement_importer_split.py
+"""StatementImporter: download = pobierz oświadczenia, process = integracja."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import statement_import
+from pbn_import.utils.statement_import import StatementImporter
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make("bpp.Uczelnia", pbn_uid_id="INST-1")
+
+
+@pytest.fixture
+def session(db):
+    user = baker.make("auth.User")
+    return baker.make("pbn_import.ImportSession", user=user)
+
+
+def test_download_calls_only_pobierz_oswiadczenia(session, uczelnia, monkeypatch):
+    step = StatementImporter(session, client=object(), uczelnia=uczelnia)
+    called = []
+    monkeypatch.setattr(
+        statement_import, "pobierz_oswiadczenia_z_instytucji",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        statement_import, "integruj_oswiadczenia_z_instytucji",
+        lambda *a, **k: called.append("integruj"),
+    )
+    step.download()
+    assert called == ["pobierz"]
+
+
+def test_process_integrates_without_redownloading_statements(
+    session, uczelnia, monkeypatch
+):
+    step = StatementImporter(session, client=object(), uczelnia=uczelnia)
+    called = []
+    monkeypatch.setattr(
+        statement_import, "pobierz_oswiadczenia_z_instytucji",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        statement_import, "integruj_oswiadczenia_z_instytucji",
+        lambda *a, **k: called.append("integruj"),
+    )
+    monkeypatch.setattr(
+        step.publication_importer, "_setup_uczelnia_and_jednostka",
+        lambda *a, **k: uczelnia,
+    )
+    step.publication_importer.default_jednostka = baker.make("bpp.Jednostka")
+    monkeypatch.setattr(
+        step, "_download_missing_publications", lambda *a, **k: None
+    )
+    step.process()
+    assert called == ["integruj"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_statement_importer_split.py -v`
+Expected: FAIL — brak metody `download`.
+
+- [ ] **Step 3: Refaktor `statement_import.py`**
+
+Zastąp `run()` (linie ~90–174) dwiema metodami. `_create_inconsistency_callback`,
+`_download_missing_publications` ZOSTAJĄ bez zmian.
+
+```python
+    def download(self):
+        """Pobierz oświadczenia instytucji z PBN do lustra."""
+        self.update_progress(0, 1, "Pobieranie oświadczeń z PBN")
+        self.log("info", "Pobieranie oświadczeń z instytucji")
+        subtask_callback = self.create_subtask_progress("Pobieranie oświadczeń")
+        try:
+            pobierz_oswiadczenia_z_instytucji(self.client, callback=subtask_callback)
+            self.log("success", "Oświadczenia pobrane pomyślnie")
+        except Exception as e:
+            self.handle_error(e, "Nie udało się pobrać oświadczeń")
+        finally:
+            self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono pobieranie oświadczeń")
+        return {"statements_downloaded": True, "error_count": len(self.errors)}
+
+    def process(self):
+        """Dociągnij brakujące publikacje i zintegruj oświadczenia."""
+        if not OswiadczenieInstytucji.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych oświadczeń — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+
+        uczelnia = self.publication_importer._setup_uczelnia_and_jednostka()
+        if not uczelnia:
+            self.log(
+                "warning", "Brak Uczelni z PBN UID, pomijanie integracji oświadczeń"
+            )
+            return {"statements_imported": False, "reason": "No Uczelnia PBN UID"}
+
+        default_jednostka = self.publication_importer.default_jednostka
+
+        self.update_progress(0, 2, "Pobieranie brakujących publikacji")
+        result = self._download_missing_publications(default_jednostka)
+        if result:
+            self.log(
+                "info",
+                f"Pobrano {result['downloaded']} brakujących publikacji "
+                f"({result['failed']} błędów)",
+            )
+
+        self.update_progress(1, 2, "Integrowanie oświadczeń")
+        self.log("info", "Integrowanie oświadczeń")
+        try:
+            inconsistency_callback = self._create_inconsistency_callback()
+            integruj_oswiadczenia_z_instytucji(
+                missing_publication_callback=None,
+                inconsistency_callback=inconsistency_callback,
+                default_jednostka=default_jednostka,
+                uczelnia=uczelnia,
+            )
+            inconsistency_count = self.session.inconsistencies.count()
+            if inconsistency_count > 0:
+                self.log(
+                    "warning",
+                    f"Znaleziono {inconsistency_count} nieścisłości podczas "
+                    f"integracji oświadczeń",
+                )
+            if hasattr(self.session, "statistics"):
+                stats = self.session.statistics
+                stats.statements_imported += 1
+                stats.save()
+            self.log("success", "Oświadczenia zintegrowane pomyślnie")
+        except Exception as e:
+            self.handle_error(e, "Nie udało się zintegrować oświadczeń")
+
+        self.update_progress(2, 2, "Zakończono import oświadczeń")
+        return {"statements_imported": True, "error_count": len(self.errors)}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_statement_importer_split.py -v`
+Expected: PASS (2 testy).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff format src/pbn_import/utils/statement_import.py src/pbn_import/tests/test_statement_importer_split.py
+ruff check src/pbn_import/utils/statement_import.py src/pbn_import/tests/test_statement_importer_split.py
+git add src/pbn_import/utils/statement_import.py src/pbn_import/tests/test_statement_importer_split.py
+git commit -m "feat(pbn-import): StatementImporter — split download/process
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Model faz w `step_definitions.py` + resolver zgodności wstecznej
+
+Przebudowa `ALL_STEP_DEFINITIONS` na fazy i przepisanie helperów. Po tym tasku
+`get_step_definitions` zwraca **płaską listę faz z `method` i `result_key`**.
+
+**Files:**
+- Modify: `src/pbn_import/utils/step_definitions.py`
+- Test: `src/pbn_import/tests/test_step_definitions.py` (rozszerz istniejący)
+
+- [ ] **Step 1: Write the failing tests** (dopisz do `test_step_definitions.py`)
+
+```python
+# --- dopisz na końcu src/pbn_import/tests/test_step_definitions.py ---
+from pbn_import.utils.step_definitions import (
+    get_all_disable_keys,
+    get_form_steps,
+    get_step_definitions,
+)
+
+
+def test_split_step_emits_two_phases_in_order():
+    # Wszystko włączone (pusty config)
+    defs = get_step_definitions({})
+    keys = [d["result_key"] for d in defs]
+    # download źródeł poprzedza process źródeł
+    assert keys.index("source_import:download") < keys.index("source_import:process")
+    # konferencje też rozdzielone
+    assert "conference_import:download" in keys
+    assert "conference_import:process" in keys
+
+
+def test_each_phase_carries_method():
+    defs = get_step_definitions({})
+    by_key = {d["result_key"]: d for d in defs}
+    assert by_key["source_import:download"]["method"] == "download"
+    assert by_key["source_import:process"]["method"] == "process"
+    # niepodzielny krok ma method "run"
+    assert by_key["fee_import"]["method"] == "run"
+
+
+def test_granular_disable_skips_one_phase_only():
+    defs = get_step_definitions({"disable_zrodla_download": True})
+    keys = [d["result_key"] for d in defs]
+    assert "source_import:download" not in keys
+    assert "source_import:process" in keys
+
+
+def test_legacy_key_disables_both_phases():
+    defs = get_step_definitions({"disable_zrodla": True})
+    keys = [d["result_key"] for d in defs]
+    assert "source_import:download" not in keys
+    assert "source_import:process" not in keys
+
+
+def test_granular_overrides_legacy():
+    # legacy mówi "wyłącz oba", granular mówi "włącz process"
+    defs = get_step_definitions(
+        {"disable_zrodla": True, "disable_zrodla_process": False}
+    )
+    keys = [d["result_key"] for d in defs]
+    assert "source_import:process" in keys
+    assert "source_import:download" not in keys
+
+
+def test_get_all_disable_keys_is_granular():
+    mapping = get_all_disable_keys()
+    assert mapping["zrodla_download"] == "disable_zrodla_download"
+    assert mapping["zrodla_process"] == "disable_zrodla_process"
+    # niepodzielny krok zachowuje stary klucz
+    assert mapping["oplaty"] == "disable_oplaty"
+
+
+def test_get_form_steps_returns_two_column_rows():
+    rows = get_form_steps()
+    by_name = {r["name"]: r for r in rows}
+    zrodla = by_name["source_import"]
+    assert zrodla["download"]["form_field"] == "zrodla_download"
+    assert zrodla["process"]["form_field"] == "zrodla_process"
+    # punktacja źródeł: tylko process
+    punktacja = by_name["source_scoring_import"]
+    assert punktacja["download"] is None
+    assert punktacja["process"] is not None
+    # opłaty: niepodzielne (single)
+    oplaty = by_name["fee_import"]
+    assert oplaty["single"] is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_step_definitions.py -v`
+Expected: FAIL — `result_key`/`method` brak, `get_form_steps` ma inny kształt.
+
+- [ ] **Step 3: Przepisz `step_definitions.py`**
+
+Zastąp całą zawartość pliku poniższą (importy klas bez zmian; dochodzi
+`integruj`-aware model faz). Zachowaj `STEP_ICONS`, `get_command_steps`,
+`get_icon_for_step`, `_get_step_args` — uzupełnione o fazy.
+
+```python
+"""PBN import step definitions and configuration (model faz)."""
+
+from .author_import import AuthorImporter
+from .conference_import import ConferenceImporter
+from .fee_import import FeeImporter
+from .initial_setup import InitialSetup
+from .institution_import import InstitutionImporter
+from .publication_import import PublicationImporter
+from .publisher_import import PublisherImporter
+from .source_import import SourceImporter
+from .source_scoring_import import SourceScoringImporter
+from .statement_import import StatementImporter
+
+
+def _split(entity, label):
+    """Zbuduj dwie fazy (download/process) dla rozdzielanej encji."""
+    return [
+        {
+            "phase": "download",
+            "method": "download",
+            "form_field": f"{entity}_download",
+            "disable_key": f"disable_{entity}_download",
+            "display": f"{label} — pobieranie",
+            "column": "download",
+            "legacy_key": f"disable_{entity}",
+        },
+        {
+            "phase": "process",
+            "method": "process",
+            "form_field": f"{entity}_process",
+            "disable_key": f"disable_{entity}_process",
+            "display": f"{label} — przetwarzanie",
+            "column": "process",
+            "legacy_key": f"disable_{entity}",
+        },
+    ]
+
+
+def _single(form_field, label, column):
+    """Zbuduj pojedynczą fazę dla kroku niepodzielnego/jednofazowego."""
+    return [
+        {
+            "phase": "single",
+            "method": "run",
+            "form_field": form_field,
+            "disable_key": f"disable_{form_field}",
+            "display": label,
+            "column": column,
+            "legacy_key": None,
+        }
+    ]
+
+
+# Pojedyncze źródło prawdy o krokach importu.
+ALL_STEP_DEFINITIONS = [
+    {
+        "name": "initial_setup",
+        "display": "Konfiguracja początkowa",
+        "class": InitialSetup,
+        "icon": "fi-wrench",
+        "required": True,
+        "show_in_form": True,
+        "phases": _single("initial", "Konfiguracja początkowa", "both"),
+    },
+    {
+        "name": "institution_setup",
+        "display": "Konfiguracja jednostek",
+        "class": InstitutionImporter,
+        "icon": "fi-home",
+        "required": True,
+        "show_in_form": True,
+        "phases": _single("institutions", "Konfiguracja jednostek", "both"),
+    },
+    {
+        "name": "source_import",
+        "display": "Źródła",
+        "class": SourceImporter,
+        "icon": "fi-book",
+        "required": False,
+        "show_in_form": True,
+        "phases": _split("zrodla", "Źródła"),
+    },
+    {
+        "name": "source_scoring_import",
+        "display": "Punktacja i dyscypliny źródeł",
+        "class": SourceScoringImporter,
+        "icon": "fi-graph-bar",
+        "required": False,
+        "show_in_form": True,
+        "phases": _single(
+            "punktacja_zrodel", "Synchronizacja punktów i dyscyplin źródeł", "process"
+        ),
+    },
+    {
+        "name": "publisher_import",
+        "display": "Wydawcy",
+        "class": PublisherImporter,
+        "icon": "fi-page-multiple",
+        "required": False,
+        "show_in_form": True,
+        "phases": _split("wydawcy", "Wydawcy"),
+    },
+    {
+        "name": "conference_import",
+        "display": "Konferencje",
+        "class": ConferenceImporter,
+        "icon": "fi-calendar",
+        "required": False,
+        "show_in_form": True,
+        "phases": _split("konferencje", "Konferencje"),
+    },
+    {
+        "name": "author_import",
+        "display": "Autorzy",
+        "class": AuthorImporter,
+        "icon": "fi-torsos-all",
+        "required": False,
+        "show_in_form": True,
+        "phases": _split("autorzy", "Autorzy"),
+    },
+    {
+        "name": "publication_import",
+        "display": "Publikacje",
+        "class": PublicationImporter,
+        "icon": "fi-page-copy",
+        "required": False,
+        "show_in_form": True,
+        "phases": _split("publikacje", "Publikacje"),
+    },
+    {
+        "name": "statement_import",
+        "display": "Oświadczenia",
+        "class": StatementImporter,
+        "icon": "fi-clipboard-pencil",
+        "required": False,
+        "show_in_form": True,
+        "phases": _split("oswiadczenia", "Oświadczenia"),
+    },
+    {
+        "name": "fee_import",
+        "display": "Opłaty",
+        "class": FeeImporter,
+        "icon": "fi-dollar",
+        "required": False,
+        "show_in_form": True,
+        "phases": _single("oplaty", "Import opłat", "both"),
+    },
+]
+
+STEP_ICONS = {step["name"]: step["icon"] for step in ALL_STEP_DEFINITIONS}
+
+
+def _iter_phases():
+    """Iteruj (step_def, phase_def) dla wszystkich kroków pokazywanych w formie."""
+    for step in ALL_STEP_DEFINITIONS:
+        if not step.get("show_in_form", True):
+            continue
+        for phase in step["phases"]:
+            yield step, phase
+
+
+def _phase_disabled(config, phase):
+    """Czy faza wyłączona? granular > legacy > domyślnie włączona."""
+    if phase["disable_key"] in config:
+        return bool(config[phase["disable_key"]])
+    legacy = phase.get("legacy_key")
+    if legacy and legacy in config:
+        return bool(config[legacy])
+    return False
+
+
+def get_form_steps():
+    """Wiersze formularza: encja + komórki download/process/single."""
+    rows = []
+    for step in ALL_STEP_DEFINITIONS:
+        if not step.get("show_in_form", True):
+            continue
+        row = {
+            "name": step["name"],
+            "display": step["display"],
+            "icon": step["icon"],
+            "required": step["required"],
+            "download": None,
+            "process": None,
+            "single": None,
+        }
+        for phase in step["phases"]:
+            cell = {"form_field": phase["form_field"], "display": phase["display"]}
+            if phase["phase"] == "single":
+                row["single"] = cell
+            else:
+                row[phase["phase"]] = cell
+        rows.append(row)
+    return rows
+
+
+def get_command_steps():
+    """Pary (form_field, display) dla CLI — jedna na fazę."""
+    return [(phase["form_field"], phase["display"]) for _, phase in _iter_phases()]
+
+
+def get_legacy_command_aliases():
+    """Mapa legacy form_field → lista granularnych disable_key (dla CLI alias)."""
+    aliases = {}
+    for step in ALL_STEP_DEFINITIONS:
+        phases = step["phases"]
+        if len(phases) == 2:  # krok rozdzielany
+            entity = phases[0]["form_field"].rsplit("_", 1)[0]
+            aliases[entity] = [p["disable_key"] for p in phases]
+    return aliases
+
+
+def get_all_disable_keys():
+    """Mapa form_field → disable_key (granularna, wszystkie fazy)."""
+    return {phase["form_field"]: phase["disable_key"] for _, phase in _iter_phases()}
+
+
+def _get_step_args(step_name, config):
+    """Dynamiczne argumenty konstruktora kroku na podstawie config."""
+    if step_name == "institution_setup":
+        return {
+            "wydzial_domyslny": config.get("wydzial_domyslny", "Wydział Domyślny"),
+            "wydzial_domyslny_skrot": config.get("wydzial_domyslny_skrot"),
+        }
+    elif step_name == "publication_import":
+        return {"delete_existing": config.get("delete_existing", False)}
+    return {}
+
+
+def get_step_definitions(config):
+    """Płaska, uporządkowana lista faz do wykonania (po odfiltrowaniu)."""
+    result = []
+    for step in ALL_STEP_DEFINITIONS:
+        for phase in step["phases"]:
+            if _phase_disabled(config, phase):
+                continue
+            phase_name = phase["phase"]
+            result_key = (
+                step["name"]
+                if phase_name == "single"
+                else f"{step['name']}:{phase_name}"
+            )
+            result.append(
+                {
+                    "name": step["name"],
+                    "phase": phase_name,
+                    "display": phase["display"],
+                    "class": step["class"],
+                    "method": phase["method"],
+                    "required": step["required"],
+                    "args": _get_step_args(step["name"], config),
+                    "result_key": result_key,
+                }
+            )
+    return result
+
+
+def get_icon_for_step(step_name):
+    """Zwróć klasę ikony Foundation dla kroku."""
+    return STEP_ICONS.get(step_name, "fi-download")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_step_definitions.py -v`
+Expected: PASS (istniejące + 7 nowych).
+
+Jeśli istniejące testy w tym pliku zakładały stary kształt `get_form_steps`
+(płaska lista z `form_field`), zaktualizuj je do nowego kontraktu (wiersze
+z `download`/`process`/`single`).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff format src/pbn_import/utils/step_definitions.py src/pbn_import/tests/test_step_definitions.py
+ruff check src/pbn_import/utils/step_definitions.py src/pbn_import/tests/test_step_definitions.py
+git add src/pbn_import/utils/step_definitions.py src/pbn_import/tests/test_step_definitions.py
+git commit -m "feat(pbn-import): model faz w step_definitions + resolver zgodnosci wstecznej
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: `ImportManager` — wykonanie per faza
+
+`get_step_definitions` zwraca teraz fazy; manager woła `step(method=…)` i
+kluczuje `results` po `result_key`.
+
+**Files:**
+- Modify: `src/pbn_import/utils/import_manager.py`
+- Test: `src/pbn_import/tests/test_import_manager.py` (rozszerz)
+
+- [ ] **Step 1: Write the failing test** (dopisz)
+
+```python
+# --- dopisz do src/pbn_import/tests/test_import_manager.py ---
+def test_manager_runs_only_download_phase(db, monkeypatch):
+    from model_bakery import baker
+
+    from pbn_import.utils import source_import
+    from pbn_import.utils.import_manager import ImportManager
+
+    called = []
+    monkeypatch.setattr(
+        source_import, "pobierz_zrodla_mnisw",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        source_import.importer, "importuj_zrodla",
+        lambda *a, **k: called.append("importuj"),
+    )
+
+    user = baker.make("auth.User")
+    session = baker.make("pbn_import.ImportSession", user=user)
+
+    class _Client:
+        def get_languages(self):
+            return []
+
+    manager = ImportManager(
+        session=session,
+        client=_Client(),
+        config={"disable_zrodla_process": True},  # tylko pobieranie źródeł
+    )
+    # Zostaw tylko fazę download źródeł
+    manager.steps = [
+        s for s in manager.steps if s["result_key"] == "source_import:download"
+    ]
+    manager.run()
+    assert "pobierz" in called
+    assert "importuj" not in called
+
+
+def test_results_keyed_by_phase(db, monkeypatch):
+    from pbn_import.utils.step_definitions import get_step_definitions
+
+    defs = get_step_definitions({})
+    keys = [d["result_key"] for d in defs]
+    # klucze unikalne (brak kolizji download/process tej samej encji)
+    assert len(keys) == len(set(keys))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_import_manager.py -v`
+Expected: FAIL — `_execute_step` nie przekazuje `method`; `results` po `name`.
+
+- [ ] **Step 3: Zmień `_execute_step` w `import_manager.py`**
+
+W metodzie `_execute_step` (linie ~232–259) zmień wywołanie kroku i klucz
+wyniku:
+
+```python
+    def _execute_step(
+        self, idx, step_config, results, has_errors, critical_error, tb_string
+    ):
+        """Execute a single import step (faza)."""
+        step_class = step_config["class"]
+        step = step_class(
+            session=self.session,
+            client=self.client,
+            uczelnia=self.uczelnia,
+            **step_config["args"],
+        )
+
+        logger.info(
+            f">>> Uruchamianie etapu {idx + 1}/{len(self.steps)}: "
+            f"{step_config['display']}"
+        )
+
+        try:
+            result = step(method=step_config["method"])
+            results[step_config["result_key"]] = result
+
+            if step_config["name"] == "initial_setup":
+                self._refresh_pbn_client_after_setup()
+
+            return has_errors, critical_error, tb_string, False, None
+
+        except CancelledException:
+            ImportLog.objects.create(
+                session=self.session,
+                level="warning",
+                step=step_config["display"],
+                message="Import został anulowany podczas wykonywania kroku",
+            )
+            logger.warning(
+                f"Import {self.session.id} anulowany podczas kroku "
+                f"{step_config['result_key']}"
+            )
+            return (
+                has_errors,
+                critical_error,
+                tb_string,
+                False,
+                {"success": False, "cancelled": True, "results": results},
+            )
+
+        except Exception as e:
+            return self._handle_step_error(
+                e, step_config, results, has_errors, critical_error, tb_string
+            )
+```
+
+W `_handle_step_error` (linie ~191–230) zmień zapisy do `results` z
+`step_config["name"]` na `step_config["result_key"]` (3 wystąpienia).
+
+W `_should_skip_step` (linie ~175–189) zmień zapis wyniku z
+`results[step_config["name"]]` na `results[step_config["result_key"]]`
+(zachowaj warunek po `step_config["name"]`, bo dotyczy on initial/institution).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_import_manager.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Regresja — pełny pakiet kroków/managera**
+
+Run: `uv run pytest src/pbn_import/tests/test_import_manager.py src/pbn_import/tests/test_tasks.py src/pbn_import/tests/test_step_definitions.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+ruff format src/pbn_import/utils/import_manager.py src/pbn_import/tests/test_import_manager.py
+ruff check src/pbn_import/utils/import_manager.py src/pbn_import/tests/test_import_manager.py
+git add src/pbn_import/utils/import_manager.py src/pbn_import/tests/test_import_manager.py
+git commit -m "feat(pbn-import): ImportManager wykonuje fazy per-metoda, results po result_key
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: CLI `pbn_import` — flagi granularne + legacy alias
+
+**Files:**
+- Modify: `src/pbn_import/management/commands/pbn_import.py`
+- Test: `src/pbn_import/tests/test_command_pbn_import.py` (rozszerz)
+
+- [ ] **Step 1: Write the failing tests** (dopisz)
+
+```python
+# --- dopisz do src/pbn_import/tests/test_command_pbn_import.py ---
+from pbn_import.management.commands.pbn_import import build_config_from_options
+
+
+def _base_options(**over):
+    opts = {
+        "app_id": None,
+        "base_url": None,
+        "delete_existing": False,
+        "wydzial_domyslny": "X",
+        "wydzial_domyslny_skrot": None,
+    }
+    opts.update(over)
+    return opts
+
+
+def test_granular_flag_disables_one_phase():
+    cfg = build_config_from_options(_base_options(disable_zrodla_download=True))
+    assert cfg["disable_zrodla_download"] is True
+    assert cfg.get("disable_zrodla_process", False) is False
+
+
+def test_legacy_flag_disables_both_phases():
+    cfg = build_config_from_options(_base_options(disable_zrodla=True))
+    assert cfg["disable_zrodla_download"] is True
+    assert cfg["disable_zrodla_process"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_command_pbn_import.py -v`
+Expected: FAIL — `build_config_from_options` nie zna legacy aliasów / granularnych kluczy.
+
+- [ ] **Step 3: Zmień command**
+
+W `pbn_import.py` zaktualizuj importy i logikę. `IMPORT_STEPS` = granularne
+fazy (`get_command_steps`). Dodaj legacy flagi i ich obsługę.
+
+W nagłówku:
+
+```python
+from pbn_import.utils.step_definitions import (
+    get_command_steps,
+    get_legacy_command_aliases,
+)
+
+IMPORT_STEPS = get_command_steps()
+LEGACY_ALIASES = get_legacy_command_aliases()
+```
+
+`build_config_from_options` — zamień ciało budujące disable na granularne +
+legacy:
+
+```python
+def build_config_from_options(options):
+    """Zbuduj config sesji z opcji CLI (fazy granularne + legacy aliasy)."""
+    config = {
+        "app_id": options.get("app_id"),
+        "base_url": options.get("base_url"),
+        "delete_existing": options.get("delete_existing", False),
+        "wydzial_domyslny": options.get("wydzial_domyslny"),
+        "wydzial_domyslny_skrot": options.get("wydzial_domyslny_skrot"),
+    }
+
+    # Granularne flagi: --disable-{form_field}
+    for form_field, _label in IMPORT_STEPS:
+        config[f"disable_{form_field}"] = options.get(f"disable_{form_field}", False)
+
+    # Legacy aliasy: --disable-{encja} wyłącza obie fazy encji
+    for entity, disable_keys in LEGACY_ALIASES.items():
+        if options.get(f"disable_{entity}"):
+            for dk in disable_keys:
+                config[dk] = True
+
+    return config
+```
+
+W `add_arguments` — zostaw pętlę po `IMPORT_STEPS` (granularne flagi) i DODAJ
+legacy flagi:
+
+```python
+        # Granularne flagi faz
+        for key, label in IMPORT_STEPS:
+            parser.add_argument(
+                f"--disable-{key}",
+                action="store_true",
+                help=f"Pomiń: {label}",
+            )
+        # Legacy aliasy (wyłączają obie fazy encji) — zgodność wsteczna
+        for entity in LEGACY_ALIASES:
+            parser.add_argument(
+                f"--disable-{entity}",
+                action="store_true",
+                help=f"Pomiń obie fazy: {entity}",
+            )
+```
+
+W `run_interactive` — `choices` już iterują po `IMPORT_STEPS` (teraz fazy),
+więc menu pokaże „Źródła — pobieranie" / „Źródła — przetwarzanie". Bez zmian
+strukturalnych, ale upewnij się, że pętle po `IMPORT_STEPS` używają
+`f"disable_{key}"` (klucz = granularny form_field) — tak jak teraz.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_command_pbn_import.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Smoke — komenda buduje parser bez błędu**
+
+Run: `uv run python src/manage.py pbn_import --help`
+Expected: lista flag zawiera `--disable-zrodla-download`, `--disable-zrodla-process`
+oraz legacy `--disable-zrodla`.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+ruff format src/pbn_import/management/commands/pbn_import.py src/pbn_import/tests/test_command_pbn_import.py
+ruff check src/pbn_import/management/commands/pbn_import.py src/pbn_import/tests/test_command_pbn_import.py
+git add src/pbn_import/management/commands/pbn_import.py src/pbn_import/tests/test_command_pbn_import.py
+git commit -m "feat(pbn-import): CLI — granularne flagi faz + legacy aliasy
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Presety — klucze granularne
+
+`ImportPresetsView` musi używać kluczy granularnych, bo resolver preferuje je
+nad legacy (inaczej `sources_only` zostawiłby źródła wyłączone).
+
+**Files:**
+- Modify: `src/pbn_import/views.py` (`ImportPresetsView`)
+- Test: `src/pbn_import/tests/test_views_dashboard.py` (rozszerz — lub nowy
+  `test_presets.py`)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# --- dopisz do src/pbn_import/tests/test_views_dashboard.py ---
+import json as _json
+
+
+def test_presets_sources_only_enables_both_source_phases(client, admin_user):
+    client.force_login(admin_user)
+    resp = client.get("/pbn_import/presets/")  # dostosuj URL do urls.py
+    assert resp.status_code == 200
+    presets = _json.loads(resp.content)["presets"]
+    sources_only = next(p for p in presets if p["id"] == "sources_only")
+    cfg = sources_only["config"]
+    # źródła (obie fazy) włączone
+    assert cfg.get("disable_zrodla_download", False) is False
+    assert cfg.get("disable_zrodla_process", False) is False
+    # a np. wydawcy (obie fazy) wyłączone
+    assert cfg["disable_wydawcy_download"] is True
+    assert cfg["disable_wydawcy_process"] is True
+```
+
+Uwaga: sprawdź realny URL presetów w `src/pbn_import/urls.py` (nazwa route
+`presets`) i podstaw poprawną ścieżkę / `reverse("pbn_import:presets")`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/pbn_import/tests/test_views_dashboard.py -k presets -v`
+Expected: FAIL — preset wciąż na legacy `disable_zrodla`.
+
+- [ ] **Step 3: Zaktualizuj `ImportPresetsView`**
+
+Zastąp słowniki `config` w presetach kluczami granularnymi. `all_disabled`
+zbudowane z `get_all_disable_keys()` jest już granularne, więc wystarczy
+nadpisać granularne klucze.
+
+```python
+        presets = [
+            {
+                "id": "full",
+                "name": "Wszystko",
+                "description": "Importuje wszystkie dane z PBN",
+                "icon": "fi-download",
+                "config": {},  # puste = wszystko włączone
+            },
+            {
+                "id": "update",
+                "name": "Aktualizacja",
+                "description": "Aktualizuje autorów, publikacje, oświadczenia i opłaty",
+                "icon": "fi-refresh",
+                "config": {
+                    "disable_initial": True,
+                    "disable_institutions": True,
+                    "disable_zrodla_download": True,
+                    "disable_zrodla_process": True,
+                    "disable_punktacja_zrodel": True,
+                    "disable_wydawcy_download": True,
+                    "disable_wydawcy_process": True,
+                    "disable_konferencje_download": True,
+                    "disable_konferencje_process": True,
+                    # autorzy, publikacje, oswiadczenia, oplaty pozostają włączone
+                    "delete_existing": False,
+                },
+            },
+            {
+                "id": "sources_only",
+                "name": "Tylko źródła",
+                "description": "Importuje i aktualizuje punktację źródeł",
+                "icon": "fi-book",
+                "config": {
+                    **all_disabled,
+                    "disable_zrodla_download": False,
+                    "disable_zrodla_process": False,
+                    "disable_punktacja_zrodel": False,
+                    "delete_existing": False,
+                },
+            },
+        ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/pbn_import/tests/test_views_dashboard.py -k presets -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff format src/pbn_import/views.py src/pbn_import/tests/test_views_dashboard.py
+ruff check src/pbn_import/views.py src/pbn_import/tests/test_views_dashboard.py
+git add src/pbn_import/views.py src/pbn_import/tests/test_views_dashboard.py
+git commit -m "feat(pbn-import): presety na kluczach granularnych faz
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Formularz dwukolumnowy (dashboard.html + JS)
+
+**Files:**
+- Modify: `src/pbn_import/templates/pbn_import/dashboard.html`
+- Test: ręczny smoke (frontend) + istniejący `test_views_dashboard.py`
+
+- [ ] **Step 1: Zamień blok checkboxów na tabelę**
+
+Zastąp blok (linie ~130–141, `<h4>Dane do importu</h4>` + pętla
+`{% for step in import_steps %}`) poniższym. Każda linia komentarza Django
+ma własne `{# #}`.
+
+```django
+            <h4>Dane do importu</h4>
+
+            {# Tabela: wiersz = encja, kolumny = Pobieranie / Przetwarzanie #}
+            <table class="pbn-import__steps-table">
+                <thead>
+                    <tr>
+                        <th>Etap</th>
+                        <th>Pobieranie</th>
+                        <th>Przetwarzanie</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for step in import_steps %}
+                    <tr>
+                        <td>
+                            <span class="{{ step.icon }}"></span> {{ step.display }}
+                            {% if step.required %}<small class="text-muted">(wymagane)</small>{% endif %}
+                        </td>
+                        {% if step.single %}
+                        {# Krok niepodzielny — jeden checkbox na obie kolumny #}
+                        <td colspan="2">
+                            <label>
+                                <input type="checkbox" name="{{ step.single.form_field }}" checked>
+                                {{ step.single.display }}
+                            </label>
+                        </td>
+                        {% else %}
+                        <td>
+                            {% if step.download %}
+                            <label>
+                                <input type="checkbox" name="{{ step.download.form_field }}" checked>
+                            </label>
+                            {% else %}—{% endif %}
+                        </td>
+                        <td>
+                            {% if step.process %}
+                            <label>
+                                <input type="checkbox" name="{{ step.process.form_field }}" checked>
+                            </label>
+                            {% else %}—{% endif %}
+                        </td>
+                        {% endif %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+
+            {# Pole ukryte — nigdy nie pokazujemy opcji kasowania #}
+            <input type="hidden" name="delete_existing" value="">
+```
+
+- [ ] **Step 2: Rozszerz `applyPresetConfig` o fallback legacy**
+
+W funkcji `applyPresetConfig` (linie ~361–369) zamień blok `disable_`:
+
+```javascript
+        if (key.startsWith('disable_')) {
+            const fieldName = key.replace('disable_', '');
+            const input = form.querySelector(`[name="${fieldName}"]`);
+            if (input && input.type === 'checkbox') {
+                input.checked = !config[key];
+            } else {
+                // Legacy: disable_<encja> dotyczy obu faz encji
+                ['_download', '_process'].forEach(suffix => {
+                    const phaseInput = form.querySelector(`[name="${fieldName}${suffix}"]`);
+                    if (phaseInput && phaseInput.type === 'checkbox') {
+                        phaseInput.checked = !config[key];
+                    }
+                });
+            }
+        } else if (key === 'delete_existing') {
+```
+
+- [ ] **Step 3: Zbuduj frontend i odpal smoke**
+
+```bash
+make assets
+uv run pytest src/pbn_import/tests/test_views_dashboard.py -v
+```
+Expected: testy dashboard PASS (kontekst `import_steps` to teraz wiersze).
+Jeśli test asercjonował stary kształt, zaktualizuj go do nowych pól wiersza.
+
+- [ ] **Step 4: Ręczny podgląd (zalecane)**
+
+```bash
+uv run run-site run --no-browser --no-celery
+```
+Otwórz dashboard importu PBN, kliknij „nowy import" — sprawdź tabelę
+dwukolumnową; przełącz presety i zweryfikuj zaznaczanie checkboxów.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+git add src/pbn_import/templates/pbn_import/dashboard.html
+git commit -m "feat(pbn-import): dwukolumnowy formularz importu (pobieranie/przetwarzanie)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: Styl tabeli (SCSS, opcjonalny ale zalecany)
+
+**Files:**
+- Modify: odpowiedni plik SCSS importu (znajdź:
+  `grep -rl "pbn-import__" src/bpp/static --include=*.scss`)
+
+- [ ] **Step 1: Dodaj minimalny styl (bez nadpisywania gridu Foundation)**
+
+```scss
+.pbn-import__steps-table {
+    width: 100%;
+
+    th, td {
+        text-align: left;
+        vertical-align: middle;
+    }
+
+    th:nth-child(2), th:nth-child(3),
+    td:nth-child(2), td:nth-child(3) {
+        text-align: center;
+        width: 7rem;
+    }
+
+    label {
+        margin: 0;
+    }
+}
+```
+
+- [ ] **Step 2: Zbuduj CSS**
+
+```bash
+grunt build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/bpp/static
+git commit -m "style(pbn-import): tabela kroków importu — wyrównanie kolumn faz
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: Regresja całości + sprzątanie wyświetlania wyników
+
+`result_key` zmienił klucze w `results`; sprawdź konsumentów (`_display_results`
+w CLI iteruje po `results.items()` — działa generycznie, ale klucze są teraz
+`name:phase`). Upewnij się, że nic nie zakłada starych kluczy.
+
+**Files:**
+- Sprawdź: `src/pbn_import/management/commands/pbn_import.py` (`_display_results`)
+- Sprawdź: `src/pbn_import/views.py`, `consumers.py`, szablony progresu
+
+- [ ] **Step 1: Wyszukaj twarde odwołania do starych kluczy results**
+
+```bash
+grep -rnE "results\[|\.get\(\"source_import\"|\.get\('source_import'" src/pbn_import
+```
+Expected: brak miejsc zakładających `results["source_import"]` itp. Jeśli są —
+zaktualizuj do `result_key` (`source_import:download`/`:process`).
+
+- [ ] **Step 2: Pełny pakiet pbn_import + pbn_integrator**
+
+Run:
+```bash
+uv run pytest src/pbn_import/ src/pbn_integrator/tests/test_integruj_konferencje.py -v
+```
+Expected: PASS w całości.
+
+- [ ] **Step 3: Lint changed-files względem bazy**
+
+```bash
+git fetch origin
+ruff check $(git diff --name-only origin/feature/multi-hosted-config...HEAD -- '*.py')
+ruff format --check $(git diff --name-only origin/feature/multi-hosted-config...HEAD -- '*.py')
+```
+Expected: brak błędów.
+
+- [ ] **Step 4: Commit (jeśli były poprawki)**
+
+```bash
+git add -A
+git commit -m "chore(pbn-import): regresja faz — spójność kluczy results
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: Szersza regresja (zalecane, do 10 min)**
+
+Run: `make tests-without-playwright`
+Expected: PASS. Przy błędach środowiskowych (Docker) — napraw warunki wstępne,
+nie pomijaj.
+
+---
+
+## Mapa pokrycia specyfikacji
+
+- Spec §4.2 (metody faz) → Task 1.
+- Spec §5 (integruj_konferencje) → Task 2; ConferenceImporter §5.3 → Task 3.
+- Spec §2.3 / §4.2 (6 splitów) → Tasks 3–8.
+- Spec §4.1, §4.6 (model faz + resolver) → Task 9.
+- Spec §4.3 (manager per faza, unikalne results) → Task 10.
+- Spec §4.5 (CLI granular + legacy) → Task 11.
+- Spec §4.4 (presety granularne) → Task 12; formularz dwukolumnowy + JS → Task 13–14.
+- Spec §4.7 (miękkie ostrzeżenie) → Tasks 3–8 (każdy `process()`).
+- Spec §8 (ryzyka: result_key, abbreviation, setup w obu fazach) → Tasks 10, 2, 6/7.
+- Zgodność wsteczna (stare presety/CLI/sesje) → Tasks 9, 11, 12, 13.

--- a/docs/superpowers/plans/2026-06-07-pbn-import-rozdziel-pobieranie.md
+++ b/docs/superpowers/plans/2026-06-07-pbn-import-rozdziel-pobieranie.md
@@ -311,6 +311,8 @@ Dopisz na końcu `src/pbn_integrator/utils/conferences.py` (dołóż importy u g
 import datetime
 import logging
 
+from django.db import IntegrityError, transaction
+
 from bpp.models import Konferencja
 
 logger = logging.getLogger("pbn_integrator")
@@ -334,6 +336,10 @@ def integruj_konferencje(callback=None):
     Aktualizuje pola pochodzące z PBN; nie nadpisuje pól, których PBN nie
     dostarcza (typ_konferencji, bazy indeksujące). Zwraca liczbę
     utworzonych/zaktualizowanych konferencji.
+
+    WAŻNE: czytamy przez ``value_or_none``, bo gołe ``value("object", k)``
+    zwraca STRING-sentinel ``"[brak k]"`` przy braku klucza (base.py:81-88),
+    co dawałoby śmieciowe ``nazwa="[brak fullName]"`` i omijało guard.
     """
     qs = Conference.objects.all()
     total = qs.count()
@@ -347,19 +353,21 @@ def integruj_konferencje(callback=None):
             logger.info("Pomijam usuniętą konferencję PBN %s", conf.mongoId)
             continue
 
-        nazwa = conf.fullName()
+        nazwa = conf.value_or_none("object", "fullName")
         if not nazwa:
             logger.info("Pomijam konferencję PBN %s bez nazwy", conf.mongoId)
             continue
 
-        rozpoczecie = _parse_pbn_date(conf.startDate())
-        zakonczenie = _parse_pbn_date(conf.endDate())
-        miasto = conf.city() or None
-        panstwo = conf.country() or None
-        skrot = conf.value("object", "abbreviation", return_none=True)
+        rozpoczecie = _parse_pbn_date(conf.value_or_none("object", "startDate"))
+        zakonczenie = _parse_pbn_date(conf.value_or_none("object", "endDate"))
+        miasto = conf.value_or_none("object", "city")
+        panstwo = conf.value_or_none("object", "country")
+        skrot = conf.value_or_none("object", "abbreviation")
 
         konferencja = Konferencja.objects.filter(pbn_uid_id=conf.pk).first()
         if konferencja is None:
+            # filter().first() (nie get()) — przy rozpoczecie=None i kilku
+            # ręcznych konferencjach o tej nazwie unikamy MultipleObjectsReturned.
             konferencja = Konferencja.objects.filter(
                 nazwa=nazwa, rozpoczecie=rozpoczecie
             ).first()
@@ -375,8 +383,23 @@ def integruj_konferencje(callback=None):
         konferencja.panstwo = panstwo
         if skrot:
             konferencja.skrocona_nazwa = skrot
-        konferencja.save()
-        przetworzone += 1
+
+        try:
+            # savepoint: IntegrityError bez atomic() zatruwa otaczającą
+            # transakcję (też tę pytestową) → TransactionManagementError.
+            with transaction.atomic():
+                konferencja.save()
+            przetworzone += 1
+        except IntegrityError:
+            # Dwie różne konferencje PBN dzielą (nazwa, rozpoczecie) i żadnej nie
+            # złapaliśmy po pbn_uid — nie przerywaj całej integracji.
+            logger.warning(
+                "Konflikt unikalności (nazwa, rozpoczecie) dla konferencji PBN "
+                "%s (%r, %r) — pomijam",
+                conf.mongoId,
+                nazwa,
+                rozpoczecie,
+            )
 
     return przetworzone
 ```
@@ -1055,10 +1078,16 @@ def session(db):
 
 
 def _patch_setup(monkeypatch, importer_obj):
-    """Pomiń realny setup uczelni/jednostki — zwróć uczelnię ze stepu."""
+    """Pomiń realny setup — ustaw default_jednostka i zwróć uczelnię ze stepu."""
+    importer_obj.default_jednostka = baker.make("bpp.Jednostka")
+
+    def _fake_setup(*a, **k):
+        # Odwzoruj realny kontrakt: setup ustawia default_jednostka na obiekcie.
+        importer_obj.default_jednostka = importer_obj.default_jednostka
+        return importer_obj.uczelnia
+
     monkeypatch.setattr(
-        importer_obj, "_setup_uczelnia_and_jednostka",
-        lambda *a, **k: importer_obj.uczelnia,
+        importer_obj, "_setup_uczelnia_and_jednostka", _fake_setup
     )
 
 
@@ -1177,7 +1206,9 @@ liczniki (każda faza liczy własne kroki).
         self.update_progress(total_steps, total_steps, "Zakończono import publikacji")
         return {
             "publications_imported": True,
-            "default_jednostka": self.default_jednostka.nazwa,
+            "default_jednostka": (
+                self.default_jednostka.nazwa if self.default_jednostka else None
+            ),
             "error_count": len(self.errors),
         }
 ```
@@ -1374,8 +1405,24 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ## Task 9: Model faz w `step_definitions.py` + resolver zgodności wstecznej
 
+> **⚠ BLOK MIGRACJI KONTRAKTU (Tasks 9–13).** Zmiana kształtu
+> `get_step_definitions` / `get_form_steps` / `get_command_steps` /
+> `get_all_disable_keys` pociąga za sobą konsumentów: `ImportManager` (Task 10),
+> CLI `pbn_import` (Task 11), presety (Task 12), szablon `dashboard.html`
+> (Task 13). **Pełny pakiet `src/pbn_import/` będzie przejściowo CZERWONY**
+> między Taskiem 9 a 13 (np. `test_command_pbn_import.py`,
+> `test_views_dashboard.py` zakładają stary kształt do czasu ich tasków).
+> To jest oczekiwane. Reguła: **każdy task utrzymuje ZIELONE swoje własne
+> nowe/zaktualizowane testy**, a skonsolidowany gate całego pakietu odpala się
+> na końcu Taska 13 oraz w Tasku 15. Nie używaj pełnego pakietu jako bramki
+> w środku bloku.
+
 Przebudowa `ALL_STEP_DEFINITIONS` na fazy i przepisanie helperów. Po tym tasku
 `get_step_definitions` zwraca **płaską listę faz z `method` i `result_key`**.
+
+**Liczność faz (wszystko włączone):** initial(1) + institution(1) + źródła(2)
++ punktacja(1) + wydawcy(2) + konferencje(2) + autorzy(2) + publikacje(2)
++ oświadczenia(2) + opłaty(1) = **16** pozycji.
 
 **Files:**
 - Modify: `src/pbn_import/utils/step_definitions.py`
@@ -1733,16 +1780,121 @@ def get_icon_for_step(step_name):
     return STEP_ICONS.get(step_name, "fi-download")
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Przepisz 4 istniejące testy złamane zmianą kształtu**
+
+Cztery testy w `test_step_definitions.py` zakładają stary wynik
+`get_step_definitions` (10 kroków, indeksowanie `ALL_STEP_DEFINITIONS[i]`).
+Zastąp je wersjami fazowymi. **Pozostałe testy** (dynamic_args, step_structure,
+get_icon, all_disabled) działają bez zmian — entry fazowe nadal mają
+`name`/`display`/`class`/`required`/`args`, a legacy klucze wyłączają obie fazy.
+
+Zastąp `test_get_step_definitions_default_config`:
+
+```python
+def test_get_step_definitions_default_config():
+    steps = get_step_definitions({})
+    # 6 encji rozdzielonych ×2 fazy + 4 kroki jednofazowe = 16
+    assert len(steps) == 16
+    keys = [s["result_key"] for s in steps]
+    assert keys == [
+        "initial_setup",
+        "institution_setup",
+        "source_import:download",
+        "source_import:process",
+        "source_scoring_import",
+        "publisher_import:download",
+        "publisher_import:process",
+        "conference_import:download",
+        "conference_import:process",
+        "author_import:download",
+        "author_import:process",
+        "publication_import:download",
+        "publication_import:process",
+        "statement_import:download",
+        "statement_import:process",
+        "fee_import",
+    ]
+```
+
+Zastąp `test_get_step_definitions_individual_disable_flags` (legacy klucz
+wyłącza obie fazy encji rozdzielonej; klucz jednofazowy — jedną):
+
+```python
+def test_get_step_definitions_individual_disable_flags():
+    # legacy disable_zrodla wyłącza OBIE fazy źródeł
+    keys = [s["result_key"] for s in get_step_definitions({"disable_zrodla": True})]
+    assert "source_import:download" not in keys
+    assert "source_import:process" not in keys
+    assert len(keys) == 14
+    # krok jednofazowy: jeden klucz znika
+    keys = [s["result_key"] for s in get_step_definitions({"disable_oplaty": True})]
+    assert "fee_import" not in keys
+    assert len(keys) == 15
+    # process-only: punktacja
+    keys = [
+        s["result_key"]
+        for s in get_step_definitions({"disable_punktacja_zrodel": True})
+    ]
+    assert "source_scoring_import" not in keys
+    assert len(keys) == 15
+```
+
+Zastąp `test_get_step_definitions_preserves_order` (kolejność: download danej
+encji przed jej process; kolejność encji jak w `ALL_STEP_DEFINITIONS`):
+
+```python
+def test_get_step_definitions_preserves_order():
+    keys = [s["result_key"] for s in get_step_definitions({})]
+    assert keys.index("source_import:download") < keys.index(
+        "source_import:process"
+    )
+    assert keys.index("source_import:process") < keys.index(
+        "publisher_import:download"
+    )
+    # kolejność encji zgodna z ALL_STEP_DEFINITIONS
+    entity_order = [
+        s["name"] for s in get_step_definitions({}) if s["phase"] != "process"
+    ]
+    expected = [d["name"] for d in ALL_STEP_DEFINITIONS]
+    # pierwsza pozycja każdej encji (single/download) w kolejności definicji
+    seen = []
+    for n in entity_order:
+        if n not in seen:
+            seen.append(n)
+    assert seen == expected
+```
+
+Zastąp `test_get_step_definitions_combination_of_flags` (wyłączone źródła,
+wydawcy, konferencje przez legacy → 16 − 6 = 10):
+
+```python
+def test_get_step_definitions_combination_of_flags():
+    config = {
+        "disable_zrodla": True,
+        "disable_wydawcy": True,
+        "disable_konferencje": True,
+    }
+    steps = get_step_definitions(config)
+    names = {s["name"] for s in steps}
+    assert len(steps) == 10
+    assert "source_import" not in names
+    assert "publisher_import" not in names
+    assert "conference_import" not in names
+    assert "initial_setup" in names
+    assert "institution_setup" in names
+    assert "source_scoring_import" in names
+    assert "author_import" in names
+    assert "publication_import" in names
+```
+
+- [ ] **Step 5: Run test to verify it passes**
 
 Run: `uv run pytest src/pbn_import/tests/test_step_definitions.py -v`
-Expected: PASS (istniejące + 7 nowych).
+Expected: PASS (przepisane 4 + niezmienione + 7 nowych z Kroku 1).
+(Pełny pakiet `src/pbn_import/` jest tu jeszcze CZERWONY — patrz nota bloku
+migracji; to OK, bramka pakietu jest na końcu Taska 13 i w Tasku 15.)
 
-Jeśli istniejące testy w tym pliku zakładały stary kształt `get_form_steps`
-(płaska lista z `form_field`), zaktualizuj je do nowego kontraktu (wiersze
-z `download`/`process`/`single`).
-
-- [ ] **Step 5: Lint + commit**
+- [ ] **Step 6: Lint + commit**
 
 ```bash
 ruff format src/pbn_import/utils/step_definitions.py src/pbn_import/tests/test_step_definitions.py
@@ -2057,10 +2209,12 @@ nad legacy (inaczej `sources_only` zostawiłby źródła wyłączone).
 # --- dopisz do src/pbn_import/tests/test_views_dashboard.py ---
 import json as _json
 
+from django.urls import reverse
+
 
 def test_presets_sources_only_enables_both_source_phases(client, admin_user):
     client.force_login(admin_user)
-    resp = client.get("/pbn_import/presets/")  # dostosuj URL do urls.py
+    resp = client.get(reverse("pbn_import:presets"))
     assert resp.status_code == 200
     presets = _json.loads(resp.content)["presets"]
     sources_only = next(p for p in presets if p["id"] == "sources_only")
@@ -2073,8 +2227,9 @@ def test_presets_sources_only_enables_both_source_phases(client, admin_user):
     assert cfg["disable_wydawcy_process"] is True
 ```
 
-Uwaga: sprawdź realny URL presetów w `src/pbn_import/urls.py` (nazwa route
-`presets`) i podstaw poprawną ścieżkę / `reverse("pbn_import:presets")`.
+Uwaga: nazwa route to `pbn_import:presets` (zweryfikowano w
+`src/pbn_import/urls.py`). Jeśli `admin_user` nie ma uprawnienia
+`ImportPermissionMixin`, nadaj je w teście lub użyj `superuser`.
 
 - [ ] **Step 2: Run test to verify it fails**
 

--- a/docs/superpowers/specs/2026-06-07-pbn-import-rozdzielenie-pobierania-od-przetwarzania-design.md
+++ b/docs/superpowers/specs/2026-06-07-pbn-import-rozdzielenie-pobierania-od-przetwarzania-design.md
@@ -1,0 +1,519 @@
+# PBN Import — rozdzielenie pobierania od przetwarzania
+
+**Data:** 2026-06-07
+**Branch:** `feature/pbn-import-rozdziel-pobieranie` (od `feature/multi-hosted-config`)
+**Status:** Design — do akceptacji przed implementacją
+
+---
+
+## 1. Cel
+
+W obecnym imporcie PBN każdy krok (np. „Źródła") wykonuje w jednym
+przebiegu **dwie różne operacje**:
+
+1. **Pobranie** danych z API PBN do lokalnych tabel-luster (`pbn_api.*`).
+2. **Przetworzenie** (integrację) tych luster do modeli BPP (`bpp.*`).
+
+Użytkownik chce móc uruchamiać te dwie operacje **niezależnie** — samo
+pobieranie, samo przetwarzanie, albo oba. Powody operacyjne:
+
+- pobranie jest powolne i zależne od API PBN; raz pobrane dane chcemy móc
+  przetwarzać wielokrotnie bez ponownego ruchu sieciowego,
+- przy debugowaniu integracji chcemy iterować na przetwarzaniu bez
+  czekania na re-download,
+- czasem chcemy tylko odświeżyć lustro (pobranie) bez dotykania danych BPP.
+
+Docelowy UX: w formularzu konfiguracji importu **dwie kolumny** —
+z lewej „Pobieranie", z prawej „Przetwarzanie" — z niezależnymi
+checkboxami per encja.
+
+## 2. Stan obecny (jak to działa dziś)
+
+### 2.1. Pojedyncze źródło prawdy o krokach
+
+`src/pbn_import/utils/step_definitions.py` zawiera `ALL_STEP_DEFINITIONS`
+— listę słowników, każdy opisuje jeden krok:
+
+```python
+{
+    "name": "source_import",
+    "display": "Import źródeł",
+    "class": SourceImporter,
+    "disable_key": "disable_zrodla",
+    "form_field": "zrodla",
+    "icon": "fi-book",
+    "required": False,
+    "show_in_form": True,
+}
+```
+
+Helpery czytane przez resztę systemu:
+
+- `get_form_steps()` → dane dla checkboxów formularza (HTML),
+- `get_command_steps()` → pary `(form_field, display)` dla CLI,
+- `get_all_disable_keys()` → mapa `form_field → disable_key`,
+- `get_step_definitions(config)` → lista kroków do wykonania,
+  odfiltrowana po `disable_key` (krok pominięty, gdy
+  `config[disable_key]` jest prawdziwe),
+- `_get_step_args(step_name, config)` → dynamiczne argumenty kroku.
+
+### 2.2. Wykonanie kroku
+
+Każdy importer dziedziczy po `ImportStepBase`
+(`src/pbn_import/utils/base.py`) i implementuje `run()`.
+`ImportStepBase.__call__()` woła `start()` → `run()` → `finish()`.
+
+`ImportManager` (`src/pbn_import/utils/import_manager.py`):
+
+- w `__init__` buduje `self.steps = get_step_definitions(self.config)`,
+- `_run_import_steps()` iteruje po krokach; `_execute_step()`
+  instancjonuje klasę kroku z `**step_config["args"]` i ją woła.
+
+### 2.3. Wewnętrzna struktura kroków (kluczowe)
+
+Każdy `pobierz_*` z `pbn_integrator` zapisuje surowy JSON PBN do tabel
+lustrzanych (`pbn_api.Journal`, `Publisher`, `Scientist`, `Publication`,
+`OswiadczenieInstytucji`, `Conference`). Każdy `integruj_*` / `importuj_*`
+czyta lustro i tworzy/aktualizuje modele BPP. **Pobranie persystuje w
+DB**, więc przetwarzanie może działać później, niezależnie.
+
+Klasyfikacja faz per krok (po analizie kodu):
+
+| Krok (`name`) | Pobieranie | Przetwarzanie | Uwagi |
+|---|---|---|---|
+| `initial_setup` | — | — | wymagany, fazy wymieszane → **poza zakresem**, bez zmian |
+| `institution_setup` | — | — | wymagany setup → **bez zmian** |
+| `source_import` | `pobierz_zrodla_mnisw` | `importuj_zrodla` | **rozdzielany** |
+| `source_scoring_import` | — | (cały) | **process-only**, działa na cache `pbn_uid`; bez zmian |
+| `publisher_import` | `pobierz_wydawcow_mnisw` | `importuj_wydawcow` | **rozdzielany** |
+| `conference_import` | `pobierz_konferencje` | **NOWY** `integruj_konferencje` | **rozdzielany** (patrz §5) |
+| `author_import` | `pobierz_ludzi_z_uczelni` | `integruj_autorow_z_uczelni` | **rozdzielany** |
+| `publication_import` | `_download_publications` + `_v2` | `_import_publications` | **rozdzielany** |
+| `statement_import` | `pobierz_oswiadczenia_z_instytucji` | `_download_missing_publications` + `integruj_oswiadczenia_z_instytucji` | **rozdzielany** |
+| `fee_import` | — | — | `get_publication_fees_batch` pobiera i zapisuje do BPP w tej samej pętli → **nierozdzielalny**, bez zmian |
+
+**Sześć kroków rozdzielanych:** Źródła, Wydawcy, Konferencje, Autorzy,
+Publikacje, Oświadczenia.
+
+### 2.4. Konfiguracja jest płaska (JSONField)
+
+`ImportSession.config` to `JSONField`. Konwencja: `config["disable_<x>"]`
+= `True` oznacza „pomiń krok". Brak migracji DB przy zmianie kształtu
+configu.
+
+- **Formularz** (`dashboard.html`, `StartImportView.post`): checkbox
+  `name="{form_field}"`; zaznaczony = NIE wyłączaj. Kod:
+  `disable_key: not request.POST.get(form_field)`.
+- **CLI** (`management/commands/pbn_import.py`): flagi
+  `--disable-{form_field}`; `build_config_from_options` mapuje na
+  `disable_key`.
+- **Presety** (`ImportPresetsView`): słowniki gotowych zestawów
+  `disable_*`.
+
+## 3. Decyzje projektowe (ustalone z użytkownikiem)
+
+1. **Zakres:** rozdzielamy wszystkie kroki, gdzie ma to sens (6 wyżej).
+   `initial_setup` NIE rozbijamy wewnętrznie.
+2. **Model UI:** dwa checkboxy na wiersz (Pobieranie | Przetwarzanie).
+3. **Brak danych przy samym przetwarzaniu:** **miękkie ostrzeżenie** —
+   `process()` loguje `warning` i kontynuuje (przetworzy 0 rekordów),
+   bez twardego błędu i bez walidacji blokującej w formularzu.
+4. **Zgodność wsteczna:** stary klucz `disable_<encja>` = obie podfazy;
+   nowe klucze granularne nadpisują, gdy obecne. Stare presety, sesje
+   i skrypty CLI działają bez zmian.
+5. **Konferencje:** dodajemy brakującą integrację (nowy kod, §5).
+
+## 4. Projekt techniczny
+
+### 4.1. Model fazy w `step_definitions.py`
+
+Każdy wpis `ALL_STEP_DEFINITIONS` zyskuje listę `phases`. Faza opisuje
+jedną wykonywalną jednostkę:
+
+```python
+{
+    "phase": "download",          # "download" | "process" | "single"
+    "method": "download",          # nazwa metody na klasie kroku
+    "form_field": "zrodla_download",
+    "disable_key": "disable_zrodla_download",
+    "display": "Źródła — pobieranie",
+    "column": "download",          # "download" | "process" | "both"
+    "legacy_key": "disable_zrodla",# stary klucz-alias (lub None)
+}
+```
+
+- Krok **rozdzielany** ma dwie fazy: `download` (column=download) i
+  `process` (column=process), obie z `legacy_key="disable_<encja>"`.
+- Krok **niepodzielny** (`initial_setup`, `institution_setup`,
+  `fee_import`) ma jedną fazę `single` (method=`run`, column=`both`),
+  z `disable_key` = dotychczasowym kluczem (bez `_download`/`_process`).
+- `source_scoring_import` → jedna faza `process` (column=process),
+  method=`run`, klucz bez zmian (`disable_punktacja_zrodel`).
+
+Konwencja nazw kluczy granularnych:
+`disable_<encja>_download`, `disable_<encja>_process` dla:
+`zrodla`, `wydawcy`, `konferencje`, `autorzy`, `publikacje`,
+`oswiadczenia`.
+
+Funkcje pomocnicze przepisane na fazy (zachowują nazwy i kontrakt
+zewnętrzny, ale operują na płaskiej liście faz):
+
+- `get_form_steps()` → struktura zgrupowana per encja, z polami
+  `column`, `form_field`, `display`, `required` dla każdej fazy
+  (formularz renderuje tabelę dwukolumnową — patrz §4.4).
+- `get_command_steps()` → pary `(form_field, display)` dla **każdej
+  fazy** (CLI dostaje granularne flagi) **plus** legacy aliasy (§4.5).
+- `get_all_disable_keys()` → mapa wszystkich `form_field → disable_key`
+  (granularnych).
+- `get_step_definitions(config)` → **płaska, uporządkowana lista faz do
+  wykonania** (patrz §4.3).
+
+### 4.2. Klasy importerów — dwie metody (Opcja A)
+
+Nie tworzymy osobnych klas per faza. `ImportStepBase` zyskuje:
+
+```python
+def download(self):
+    """Faza pobierania — nadpisz w podklasie rozdzielanej."""
+    raise NotImplementedError
+
+def process(self):
+    """Faza przetwarzania — nadpisz w podklasie rozdzielanej."""
+    raise NotImplementedError
+
+def run(self):
+    """Domyślnie: obie fazy po kolei (zgodność wsteczna)."""
+    # podklasy rozdzielane dziedziczą ten run(); niepodzielne nadpisują
+    self.download()
+    self.process()
+```
+
+`__call__` przyjmuje nazwę metody:
+
+```python
+def __call__(self, method: str = "run"):
+    self.start()
+    try:
+        result = getattr(self, method)()
+        self.finish()
+        return result
+    except Exception as e:
+        self.handle_error(e, f"Krytyczny błąd w {self.step_name}")
+        raise
+```
+
+Refaktor sześciu importerów rozdzielanych — `run()` rozbity na
+`download()` + `process()`; istniejące metody prywatne reużyte:
+
+- **SourceImporter:** `download()` = `pobierz_zrodla_mnisw`;
+  `process()` = `importuj_zrodla`.
+- **PublisherImporter:** `download()` = `pobierz_wydawcow_mnisw`;
+  `process()` = `importuj_wydawcow`.
+- **AuthorImporter:** `download()` = `pobierz_ludzi_z_uczelni`;
+  `process()` = `integruj_autorow_z_uczelni`. (Setup uczelni potrzebny w
+  obu — wspólny helper wywoływany w każdej fazie.)
+- **PublicationImporter:** `download()` = `_setup_…` +
+  `_download_publications` + `_download_publications_v2`;
+  `process()` = `_setup_…` + (opcjonalny `_delete_existing_publications`,
+  gdy `delete_existing`) + `_import_publications`.
+  Uwaga: `delete_existing` jest operacją po stronie BPP → należy do
+  `process()`.
+- **StatementImporter:** `download()` = `pobierz_oswiadczenia_z_instytucji`;
+  `process()` = `_setup_…` + `_download_missing_publications` +
+  `integruj_oswiadczenia_z_instytucji`.
+  Uwaga: `_download_missing_publications` to dociąg brakujących publikacji
+  sterowany tym, czego brakuje w BPP względem już-pobranych oświadczeń —
+  jest częścią integracji, więc klasyfikujemy go jako `process`.
+- **ConferenceImporter:** `download()` = `pobierz_konferencje`;
+  `process()` = **nowa** `integruj_konferencje` (§5).
+
+Importery niepodzielne (`InitialSetup`, `InstitutionImporter`,
+`FeeImporter`) i `SourceScoringImporter` **zostawiają `run()`** bez zmian;
+nie dostają `download()`/`process()`.
+
+### 4.3. ImportManager — wykonanie per faza
+
+`get_step_definitions(config)` zwraca płaską listę pozycji do wykonania,
+zachowując **kolejność**: dla kroku rozdzielanego najpierw `download`,
+potem `process`; kolejność kroków jak w `ALL_STEP_DEFINITIONS`. Czyli
+realna kolejność wykonania to: download Źródeł → process Źródeł →
+download Wydawców → process Wydawców → … (semantyka jak dziś — każda
+encja pobiera i przetwarza po sobie). Dwukolumnowy UI to grupowanie
+**wizualne**, nie kolejność wykonania.
+
+Każda pozycja niesie `method` (`download`/`process`/`run`). Manager:
+
+```python
+step = step_class(session=…, client=…, uczelnia=…, **args)
+result = step(method=phase["method"])
+```
+
+Klucz wyniku w `results` musi być unikalny per faza, np.
+`"source_import:download"` / `"source_import:process"`, żeby `results`
+nie nadpisywał się między fazami tej samej encji.
+
+Reszta `ImportManager` (autoryzacja, anulowanie, obsługa błędów,
+`_run_post_import_commands`, refresh klienta po `initial_setup`) działa
+bez zmian — operuje na `step_config["name"]`, który zostaje nazwą
+**kroku** (nie fazy); fazę trzymamy w osobnym polu.
+
+### 4.4. Formularz (dashboard.html + StartImportView)
+
+Renderujemy **tabelę** zamiast płaskiej listy checkboxów:
+
+```
+                         Pobieranie     Przetwarzanie
+ Konfiguracja początk.   [ wymagane — pełna szerokość, 1 checkbox ]
+ Konfiguracja jednostek  [ wymagane — pełna szerokość, 1 checkbox ]
+ Źródła                      [x]             [x]
+ Punktacja źródeł             —              [x]
+ Wydawcy                     [x]             [x]
+ Konferencje                 [x]             [x]
+ Autorzy                     [x]             [x]
+ Publikacje                  [x]             [x]
+ Oświadczenia                [x]             [x]
+ Opłaty                   [ nierozdzielne — pełna szerokość, 1 checkbox ]
+```
+
+- Komórka z checkboxem: `name="{phase.form_field}"`, domyślnie `checked`.
+- Komórka pusta (faza nie istnieje): renderujemy „—".
+- Kroki niepodzielne (`initial_setup`, `institution_setup`,
+  `fee_import`): jeden checkbox `name="{single.form_field}"` w wierszu
+  rozciągniętym na obie kolumny (osobna grupa „Operacje niepodzielne"
+  albo wiersz `colspan=2`).
+- `StartImportView.post`: bez zmian co do logiki — iteruje po
+  `get_all_disable_keys()` i ustawia `disable_key = not POST.get(form_field)`
+  dla **każdej fazy**. Dochodzą tylko nowe `form_field`.
+- JS presetów (dashboard.html, sekcja ~355–370): obecnie ustawia
+  wszystkie checkboxy `checked`, potem odznacza te, których `disable_xxx`
+  jest `True`. Logika działa dalej dla kluczy granularnych; dla
+  zgodności wstecznej JS dodatkowo: jeśli preset niesie stary
+  `disable_<encja>`, zastosuj go do obu checkboxów encji
+  (`{encja}_download` i `{encja}_process`).
+
+Styl: zwykła tabela Foundation (`<table>`), checkboxy bez nadpisywania
+klas gridu. Ikony Foundation jak dziś (frontend publiczny/admin-mixed —
+to widok importu w panelu, ikony `fi-*` zostają).
+
+### 4.5. CLI (`management/commands/pbn_import.py`)
+
+- Dla każdej fazy generujemy flagę `--disable-{phase.form_field}`
+  (np. `--disable-zrodla-download`, `--disable-zrodla-process`).
+- **Legacy alias:** zostają flagi `--disable-{encja}` (np.
+  `--disable-zrodla`); gdy podana, ustawia obie podfazy encji na
+  wyłączone. Implementacja: po sparsowaniu, w `build_config_from_options`,
+  jeśli legacy flaga `True`, ustaw `disable_<encja>_download = True` i
+  `disable_<encja>_process = True` (o ile granularna nie ustawiona
+  jawnie).
+- Menu interaktywne (`run_interactive`): lista wyboru pokazuje fazy jako
+  osobne pozycje, pogrupowane czytelnie, np.
+  „Źródła — pobieranie", „Źródła — przetwarzanie".
+
+### 4.6. Rozwiązywanie configu — zgodność wsteczna
+
+Centralna funkcja (w `step_definitions.py`) ustala, czy faza jest
+wyłączona, w kolejności:
+
+1. jeśli `config` zawiera klucz granularny fazy (`disable_<encja>_<faza>`)
+   → użyj go,
+2. wpp. jeśli `config` zawiera `legacy_key` (`disable_<encja>`)
+   → użyj go (dotyczy obu faz encji),
+3. wpp. faza włączona (domyślnie `not disabled`).
+
+`get_step_definitions(config)` używa tej funkcji do filtrowania. Dzięki
+temu:
+- stare sesje/presety z `disable_zrodla=False` → pobranie i
+  przetwarzanie Źródeł włączone (jak dziś),
+- stare CLI `--disable-zrodla` → obie fazy pominięte,
+- nowy formularz/CLI z kluczami granularnymi → pełna kontrola.
+
+### 4.7. Miękkie ostrzeżenie przy pustym lustrze
+
+Każda metoda `process()` rozdzielanego kroku na starcie sprawdza, czy
+jej tabela lustrzana ma rekordy; jeśli pusta, loguje `warning` i
+kontynuuje (istniejące pętle i tak przejdą po 0 rekordach):
+
+| Krok | sprawdzane lustro |
+|---|---|
+| source | `pbn_api.Journal` |
+| publisher | `pbn_api.Publisher` |
+| author | `pbn_api.Scientist` |
+| publication | `pbn_api.Publication` |
+| statement | `pbn_api.OswiadczenieInstytucji` |
+| conference | `pbn_api.Conference` |
+
+Komunikat: „Brak pobranych danych dla kroku X — przetwarzam to, co jest
+w lokalnym lustrze (0 rekordów). Uruchom fazę pobierania, jeśli to nie
+zamierzone." Bez `error`, bez przerwania importu.
+
+## 5. Nowa integracja konferencji
+
+### 5.1. Stan obecny
+
+- `pobierz_konferencje` (`pbn_integrator/utils/conferences.py`) pobiera
+  konferencje do lustra `pbn_api.Conference`.
+- Lustro `Conference` udostępnia: `fullName()`, `startDate()`,
+  `endDate()`, `city()`, `country()`, `website` (widoczne w
+  `pbn_api/admin/conference.py`).
+- BPP **ma** model `bpp.models.Konferencja` (`src/bpp/models/konferencja.py`)
+  z FK `pbn_uid → pbn_api.Conference`, polami `nazwa`, `skrocona_nazwa`,
+  `rozpoczecie`, `zakonczenie`, `miasto`, `panstwo`, `typ_konferencji`,
+  `baza_scopus/wos/inna`, oraz `unique_together = ("nazwa", "rozpoczecie")`.
+- **Brak** funkcji `integruj_konferencje` — konferencje nie są dziś
+  mapowane do BPP (metadane lądują tylko w `adnotacje` publikacji).
+
+### 5.2. Nowa funkcja `integruj_konferencje`
+
+Lokalizacja: `pbn_integrator/utils/conferences.py` (obok
+`pobierz_konferencje`), spójnie z `importuj_zrodla`/`importuj_wydawcow`.
+
+Sygnatura (wzorowana na innych integratorach):
+
+```python
+def integruj_konferencje(callback=None):
+    """Integruj lustro pbn_api.Conference → bpp.Konferencja.
+
+    Re-entrant: dopasowuje najpierw po pbn_uid, potem po
+    (nazwa, rozpoczecie). Aktualizuje pola z PBN, nie nadpisuje
+    danych BPP, których PBN nie dostarcza (typ_konferencji, bazy).
+    """
+```
+
+Mapowanie pól:
+
+| `pbn_api.Conference` | `bpp.Konferencja` | uwagi |
+|---|---|---|
+| obiekt lustra | `pbn_uid` | FK |
+| `fullName()` | `nazwa` | wymagane; pomiń rekord, gdy puste + log warning |
+| `startDate()` | `rozpoczecie` | parse ISO `YYYY-MM-DD`; `None` gdy brak/niepoprawny |
+| `endDate()` | `zakonczenie` | jw. |
+| `city()` | `miasto` | |
+| `country()` | `panstwo` | |
+| `value("object","abbreviation")` *(jeśli klucz istnieje)* | `skrocona_nazwa` | best-effort |
+
+Pola **nieustawiane** (PBN nie dostarcza jednoznacznie):
+`typ_konferencji`, `baza_scopus`, `baza_wos`, `baza_inna` — zostawiamy
+wartości BPP (lub domyślne przy tworzeniu).
+
+Logika dopasowania (idempotencja):
+
+1. Konferencja z `pbn_uid == <to lustro>` istnieje → aktualizuj pola PBN.
+2. Wpp. spróbuj dopasować po `unique_together (nazwa, rozpoczecie)` →
+   jeśli istnieje rekord bez `pbn_uid` (wprowadzony ręcznie), **dowiąż**
+   `pbn_uid` i zaktualizuj pola.
+3. Wpp. utwórz nową `Konferencja`.
+
+Pomijamy rekordy lustra ze `status == "DELETED"` (analogicznie do
+istniejących integratorów — log `info`, bez tworzenia).
+
+Obsługa błędów: parsowanie dat w `try/except` na wąskim `ValueError`
+(niepoprawny format → `None` + log `debug`), zgodnie z regułą projektu
+(brak gołych `except: pass`). Postęp przez `callback` jak w innych
+krokach.
+
+### 5.3. `ConferenceImporter.process()`
+
+```python
+def process(self):
+    if not Conference.objects.exists():
+        self.log("warning", "Brak pobranych konferencji — przetwarzam 0…")
+    cb = self.create_subtask_progress("Integracja konferencji")
+    try:
+        wynik = integruj_konferencje(callback=cb)
+        self.log("success", f"Zintegrowano {wynik} konferencji")
+    except Exception as e:
+        self.handle_error(e, "Nie udało się zintegrować konferencji")
+    finally:
+        self.clear_subtask_progress()
+    return {"conferences_integrated": True, "error_count": len(self.errors)}
+```
+
+`download()` = dotychczasowa treść `run()` (samo `pobierz_konferencje`).
+
+## 6. Pliki do zmiany / utworzenia
+
+**Zmiana:**
+
+- `src/pbn_import/utils/step_definitions.py` — model `phases`, przepisane
+  helpery, funkcja rozwiązywania configu (§4.1, §4.6).
+- `src/pbn_import/utils/base.py` — `download()`/`process()`/`run()` +
+  `__call__(method=…)` (§4.2).
+- `src/pbn_import/utils/import_manager.py` — wykonanie per faza,
+  unikalne klucze `results` (§4.3).
+- `src/pbn_import/utils/source_import.py` — split (§4.2).
+- `src/pbn_import/utils/publisher_import.py` — split.
+- `src/pbn_import/utils/author_import.py` — split.
+- `src/pbn_import/utils/publication_import.py` — split (delete_existing
+  po stronie process).
+- `src/pbn_import/utils/statement_import.py` — split.
+- `src/pbn_import/utils/conference_import.py` — split + wywołanie nowej
+  integracji (§5.3).
+- `src/pbn_integrator/utils/conferences.py` — **nowa**
+  `integruj_konferencje` (§5.2).
+- `src/pbn_import/templates/pbn_import/dashboard.html` — tabela
+  dwukolumnowa + JS presetów (§4.4).
+- `src/pbn_import/views.py` — `ImportPresetsView` (granularne klucze;
+  legacy honorowane przez resolver) — drobne.
+- `src/pbn_import/management/commands/pbn_import.py` — flagi granularne +
+  legacy aliasy + menu (§4.5).
+
+**Bez zmian (świadomie):** `initial_setup.py`, `institution_import.py`,
+`fee_import.py`, `source_scoring_import.py`, modele
+(`pbn_import/models.py`), migracje.
+
+## 7. Testy
+
+Pakiet: `src/pbn_import/tests/` (pytest, bez `unittest.TestCase`,
+`model_bakery`, `@pytest.mark.django_db`).
+
+**Nowe / rozszerzone:**
+
+- `test_step_definitions.py`: model `phases`; `get_step_definitions`
+  zwraca poprawną płaską listę i kolejność (download przed process per
+  encja); resolver zgodności wstecznej (granularny vs legacy vs domyślny)
+  — tabela przypadków.
+- `test_importer_wrappers.py` / `test_step_constructor_contract.py`:
+  `__call__(method=…)` woła właściwą metodę; `run()` woła obie;
+  niepodzielne kroki nadal działają przez `run`.
+- Split per importer: dla każdego z 6 — `download()` woła `pobierz_*` i
+  NIE woła integracji; `process()` woła integrację i NIE woła `pobierz_*`
+  (mock `pbn_integrator`); miękkie ostrzeżenie przy pustym lustrze.
+- `test_import_manager.py`: sesja z samym pobieraniem; sama integracja;
+  oba; klucze `results` unikalne per faza.
+- **`integruj_konferencje`** (nowy plik testu, np.
+  `test_conference_integration.py`): tworzenie z lustra, idempotencja po
+  `pbn_uid`, dowiązanie istniejącego rekordu po `(nazwa, rozpoczecie)`,
+  parsowanie/braki dat, pominięcie `DELETED`, mapowanie pól.
+- `test_command_pbn_import.py`: flagi granularne; legacy alias
+  `--disable-zrodla` wyłącza obie fazy.
+- Render formularza: `get_form_steps` daje strukturę dwukolumnową;
+  smoke-test widoku dashboard (kontekst `import_steps`).
+
+**Regresja:** istniejące testy używające `disable_zrodla` itd. oraz
+`SourceImporter().run()` mają przechodzić bez zmian (zgodność wsteczna).
+
+Uruchomienie lokalnie (zgodnie z CLAUDE.md):
+
+```bash
+uv run pytest src/pbn_import/tests/
+uv run pytest src/pbn_integrator/  # testy integracji konferencji
+```
+
+## 8. Ryzyka i uwagi
+
+- **Kolejność wykonania** pozostaje per-encja (download→process danej
+  encji), nie „wszystkie pobrania, potem wszystkie integracje". To
+  świadome — zachowuje obecną semantykę i zależności (np. publikacje
+  przed oświadczeniami). Dwukolumnowy UI jest czysto wizualny.
+- **`results` keys**: zmiana z `name` na `name:phase` może dotykać
+  konsumentów `results` (`_display_results` w CLI, ewentualne odczyty w
+  widokach). Przejrzeć i dostosować wyświetlanie.
+- **`abbreviation` konferencji**: klucz niepotwierdzony w API (admin go
+  nie pokazuje). Mapujemy best-effort — tylko gdy obecny; brak nie jest
+  błędem.
+- **PublicationImporter.process** wymaga `default_jednostka` /
+  `default_jezyk` (setup uczelni). Setup jest idempotentny i tani, więc
+  wołamy go w obu fazach niezależnie — to umożliwia samodzielny
+  `process` później.
+- **Brak migracji DB** — `config` to JSONField; stare rekordy czytane
+  przez resolver zgodności wstecznej.

--- a/docs/superpowers/specs/2026-06-07-pbn-import-rozdzielenie-pobierania-od-przetwarzania-design.md
+++ b/docs/superpowers/specs/2026-06-07-pbn-import-rozdzielenie-pobierania-od-przetwarzania-design.md
@@ -352,9 +352,13 @@ zamierzone." Bez `error`, bez przerwania importu.
 
 - `pobierz_konferencje` (`pbn_integrator/utils/conferences.py`) pobiera
   konferencje do lustra `pbn_api.Conference`.
-- Lustro `Conference` udostępnia: `fullName()`, `startDate()`,
-  `endDate()`, `city()`, `country()`, `website` (widoczne w
-  `pbn_api/admin/conference.py`).
+- Lustro `Conference` udostępnia metody `fullName()`, `startDate()`,
+  `endDate()`, `city()`, `country()`, `website()` (widoczne w
+  `pbn_api/admin/conference.py`). **Uwaga:** to metody na bazowym
+  `value("object", k)`, które przy braku klucza zwraca STRING-sentinel
+  `"[brak k]"`, a NIE `None`. Integracja MUSI czytać przez
+  `value_or_none("object", k)` (base.py:90), inaczej powstaną śmieci typu
+  `nazwa="[brak fullName]"`.
 - BPP **ma** model `bpp.models.Konferencja` (`src/bpp/models/konferencja.py`)
   z FK `pbn_uid → pbn_api.Conference`, polami `nazwa`, `skrocona_nazwa`,
   `rozpoczecie`, `zakonczenie`, `miasto`, `panstwo`, `typ_konferencji`,
@@ -381,15 +385,15 @@ def integruj_konferencje(callback=None):
 
 Mapowanie pól:
 
-| `pbn_api.Conference` | `bpp.Konferencja` | uwagi |
+| `pbn_api.Conference` (przez `value_or_none`) | `bpp.Konferencja` | uwagi |
 |---|---|---|
 | obiekt lustra | `pbn_uid` | FK |
-| `fullName()` | `nazwa` | wymagane; pomiń rekord, gdy puste + log warning |
-| `startDate()` | `rozpoczecie` | parse ISO `YYYY-MM-DD`; `None` gdy brak/niepoprawny |
-| `endDate()` | `zakonczenie` | jw. |
-| `city()` | `miasto` | |
-| `country()` | `panstwo` | |
-| `value("object","abbreviation")` *(jeśli klucz istnieje)* | `skrocona_nazwa` | best-effort |
+| `value_or_none("object","fullName")` | `nazwa` | wymagane; pomiń rekord, gdy `None` + log info |
+| `value_or_none("object","startDate")` | `rozpoczecie` | parse ISO `YYYY-MM-DD`; `None` gdy brak/niepoprawny |
+| `value_or_none("object","endDate")` | `zakonczenie` | jw. |
+| `value_or_none("object","city")` | `miasto` | |
+| `value_or_none("object","country")` | `panstwo` | |
+| `value_or_none("object","abbreviation")` | `skrocona_nazwa` | best-effort, tylko gdy nie-`None` |
 
 Pola **nieustawiane** (PBN nie dostarcza jednoznacznie):
 `typ_konferencji`, `baza_scopus`, `baza_wos`, `baza_inna` — zostawiamy
@@ -398,10 +402,17 @@ wartości BPP (lub domyślne przy tworzeniu).
 Logika dopasowania (idempotencja):
 
 1. Konferencja z `pbn_uid == <to lustro>` istnieje → aktualizuj pola PBN.
-2. Wpp. spróbuj dopasować po `unique_together (nazwa, rozpoczecie)` →
-   jeśli istnieje rekord bez `pbn_uid` (wprowadzony ręcznie), **dowiąż**
-   `pbn_uid` i zaktualizuj pola.
+2. Wpp. spróbuj dopasować po `unique_together (nazwa, rozpoczecie)` przez
+   `filter(...).first()` (NIE `get()` — przy `rozpoczecie=None` i kilku
+   ręcznych konferencjach o tej nazwie `get()` rzuciłby
+   `MultipleObjectsReturned`); jeśli istnieje rekord bez `pbn_uid`
+   (wprowadzony ręcznie), **dowiąż** `pbn_uid` i zaktualizuj pola.
 3. Wpp. utwórz nową `Konferencja`.
+
+`save()` opakowany w `transaction.atomic()` (savepoint) + `except
+IntegrityError` z logiem `warning`: dwie różne konferencje PBN mogą dzielić
+`(nazwa, rozpoczecie)` — wtedy pomijamy drugą zamiast wywracać całą integrację
+(savepoint chroni też transakcję testową pytest przed zatruciem).
 
 Pomijamy rekordy lustra ze `status == "DELETED"` (analogicznie do
 istniejących integratorów — log `info`, bez tworzenia).
@@ -452,8 +463,13 @@ def process(self):
   `integruj_konferencje` (§5.2).
 - `src/pbn_import/templates/pbn_import/dashboard.html` — tabela
   dwukolumnowa + JS presetów (§4.4).
-- `src/pbn_import/views.py` — `ImportPresetsView` (granularne klucze;
-  legacy honorowane przez resolver) — drobne.
+- `src/pbn_import/views.py` — `ImportPresetsView` **musi** używać kluczy
+  granularnych. `all_disabled` budowane z `get_all_disable_keys()` jest już
+  granularne, więc preset, który robi `{**all_disabled, "disable_zrodla": False}`
+  (legacy) NIE zadziała — resolver woli granularny (tu: `True`) nad legacy,
+  zostawiając źródła wyłączone. Presety przepisać na granular
+  (`disable_zrodla_download`/`_process`). To NIE jest drobne — bez tego preset
+  „Tylko źródła" wyłącza źródła.
 - `src/pbn_import/management/commands/pbn_import.py` — flagi granularne +
   legacy aliasy + menu (§4.5).
 
@@ -505,9 +521,12 @@ uv run pytest src/pbn_integrator/  # testy integracji konferencji
   encji), nie „wszystkie pobrania, potem wszystkie integracje". To
   świadome — zachowuje obecną semantykę i zależności (np. publikacje
   przed oświadczeniami). Dwukolumnowy UI jest czysto wizualny.
-- **`results` keys**: zmiana z `name` na `name:phase` może dotykać
-  konsumentów `results` (`_display_results` w CLI, ewentualne odczyty w
-  widokach). Przejrzeć i dostosować wyświetlanie.
+- **`results` keys**: zmiana z `name` na `name:phase`. Jedyny konsument
+  `results` poza `ImportManager` to `_display_results` w CLI
+  (`pbn_import.py`) — iteruje `.items()` i sprawdza `"error" in result`,
+  więc klucze `name:phase` nie psują logiki, zmieniają tylko etykiety
+  wyświetlania. Brak innych czytelników w widokach/WS/szablonach
+  (zweryfikowane gretem w Tasku 15). Dostosować tylko wyświetlanie.
 - **`abbreviation` konferencji**: klucz niepotwierdzony w API (admin go
   nie pokazuje). Mapujemy best-effort — tylko gdy obecny; brak nie jest
   błędem.

--- a/src/pbn_import/management/commands/pbn_import.py
+++ b/src/pbn_import/management/commands/pbn_import.py
@@ -7,22 +7,19 @@ from pbn_api.management.commands.util import PBNBaseCommand
 from pbn_import.models import ImportSession
 from pbn_import.utils import ImportManager
 from pbn_import.utils.step_definitions import (
-    ALL_STEP_DEFINITIONS,
     get_command_steps,
+    get_legacy_command_aliases,
 )
 
 User = get_user_model()
 
 # Import steps from single source of truth (step_definitions.py)
 IMPORT_STEPS = get_command_steps()
+LEGACY_ALIASES = get_legacy_command_aliases()
 
 
 def build_config_from_options(options):
-    """Build session config dict from command line options.
-
-    Maps form_field options (e.g., --disable-zrodla) to disable_key config
-    (e.g., disable_zrodla) using step_definitions as the source of truth.
-    """
+    """Zbuduj config sesji z opcji CLI (fazy granularne + legacy aliasy)."""
     config = {
         "app_id": options.get("app_id"),
         "base_url": options.get("base_url"),
@@ -31,12 +28,15 @@ def build_config_from_options(options):
         "wydzial_domyslny_skrot": options.get("wydzial_domyslny_skrot"),
     }
 
-    # Map form_field to disable_key from step_definitions
-    for step in ALL_STEP_DEFINITIONS:
-        form_field = step["form_field"]
-        disable_key = step["disable_key"]
-        # Get option value using form_field name (from CLI --disable-{form_field})
-        config[disable_key] = options.get(f"disable_{form_field}", False)
+    # Granularne flagi: --disable-{form_field}
+    for form_field, _label in IMPORT_STEPS:
+        config[f"disable_{form_field}"] = options.get(f"disable_{form_field}", False)
+
+    # Legacy aliasy: --disable-{encja} wyłącza obie fazy encji
+    for entity, disable_keys in LEGACY_ALIASES.items():
+        if options.get(f"disable_{entity}"):
+            for dk in disable_keys:
+                config[dk] = True
 
     return config
 
@@ -53,12 +53,19 @@ class Command(PBNBaseCommand):
             help="Bez interaktywnego menu (dla skryptów/automatyzacji)",
         )
 
-        # Opcje disable-* dla kompatybilności wstecznej i trybu batch
+        # Granularne flagi faz
         for key, label in IMPORT_STEPS:
             parser.add_argument(
                 f"--disable-{key}",
                 action="store_true",
                 help=f"Pomiń: {label}",
+            )
+        # Legacy aliasy (wyłączają obie fazy encji) — zgodność wsteczna
+        for entity in LEGACY_ALIASES:
+            parser.add_argument(
+                f"--disable-{entity}",
+                action="store_true",
+                help=f"Pomiń obie fazy: {entity}",
             )
 
         # Dodatkowe opcje

--- a/src/pbn_import/management/commands/pbn_import.py
+++ b/src/pbn_import/management/commands/pbn_import.py
@@ -53,10 +53,12 @@ class Command(PBNBaseCommand):
             help="Bez interaktywnego menu (dla skryptów/automatyzacji)",
         )
 
-        # Granularne flagi faz
+        # Granularne flagi faz. Myślniki w nazwie flagi (konwencja POSIX,
+        # spójna z --base-url itd.); argparse i tak mapuje dest na podkreślenia,
+        # więc dest = disable_<form_field>, dokładnie jak czyta build_config.
         for key, label in IMPORT_STEPS:
             parser.add_argument(
-                f"--disable-{key}",
+                f"--disable-{key.replace('_', '-')}",
                 action="store_true",
                 help=f"Pomiń: {label}",
             )

--- a/src/pbn_import/static/pbn_import/scss/pbn_import.scss
+++ b/src/pbn_import/static/pbn_import/scss/pbn_import.scss
@@ -1148,3 +1148,26 @@ a.pbn-import__session-item {
     padding-top: 15px;
     border-top: 1px solid #e2e8f0;
 }
+
+// Steps table (new-import modal)
+.pbn-import__steps-table {
+    width: 100%;
+
+    th,
+    td {
+        text-align: left;
+        vertical-align: middle;
+    }
+
+    th:nth-child(2),
+    th:nth-child(3),
+    td:nth-child(2),
+    td:nth-child(3) {
+        text-align: center;
+        width: 7rem;
+    }
+
+    label {
+        margin: 0;
+    }
+}

--- a/src/pbn_import/templates/pbn_import/dashboard.html
+++ b/src/pbn_import/templates/pbn_import/dashboard.html
@@ -129,15 +129,52 @@
         <div class="pbn-import__modal-content">
             <h4>Dane do importu</h4>
 
-            {% for step in import_steps %}
-            <label>
-                <input type="checkbox" name="{{ step.form_field }}" checked>
-                <span class="{{ step.icon }}"></span> {{ step.display }}
-                {% if step.required %}<small class="text-muted">(wymagane)</small>{% endif %}
-            </label>
-            {% endfor %}
+            {# Tabela: wiersz = encja, kolumny = Pobieranie / Przetwarzanie #}
+            <table class="pbn-import__steps-table">
+                <thead>
+                    <tr>
+                        <th>Etap</th>
+                        <th>Pobieranie</th>
+                        <th>Przetwarzanie</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for step in import_steps %}
+                    <tr>
+                        <td>
+                            <span class="{{ step.icon }}"></span> {{ step.display }}
+                            {% if step.required %}<small class="text-muted">(wymagane)</small>{% endif %}
+                        </td>
+                        {% if step.single %}
+                        {# Krok niepodzielny — jeden checkbox na obie kolumny #}
+                        <td colspan="2">
+                            <label>
+                                <input type="checkbox" name="{{ step.single.form_field }}" checked>
+                                {{ step.single.display }}
+                            </label>
+                        </td>
+                        {% else %}
+                        <td>
+                            {% if step.download %}
+                            <label>
+                                <input type="checkbox" name="{{ step.download.form_field }}" checked>
+                            </label>
+                            {% else %}—{% endif %}
+                        </td>
+                        <td>
+                            {% if step.process %}
+                            <label>
+                                <input type="checkbox" name="{{ step.process.form_field }}" checked>
+                            </label>
+                            {% else %}—{% endif %}
+                        </td>
+                        {% endif %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
 
-            <!-- Hidden field - never show delete existing option -->
+            {# Pole ukryte — nigdy nie pokazujemy opcji kasowania #}
             <input type="hidden" name="delete_existing" value="">
 
             {% if uzywaj_wydzialow %}
@@ -360,12 +397,18 @@ function applyPresetConfig(config) {
     // Now apply the preset configuration
     Object.keys(config).forEach(key => {
         if (key.startsWith('disable_')) {
-            // Extract the field name from disable_xxx
             const fieldName = key.replace('disable_', '');
             const input = form.querySelector(`[name="${fieldName}"]`);
             if (input && input.type === 'checkbox') {
-                // If disable_xxx is true, uncheck the checkbox
                 input.checked = !config[key];
+            } else {
+                // Legacy: disable_<encja> dotyczy obu faz encji
+                ['_download', '_process'].forEach(suffix => {
+                    const phaseInput = form.querySelector(`[name="${fieldName}${suffix}"]`);
+                    if (phaseInput && phaseInput.type === 'checkbox') {
+                        phaseInput.checked = !config[key];
+                    }
+                });
             }
         } else if (key === 'delete_existing') {
             const input = form.querySelector('[name="delete_existing"]');

--- a/src/pbn_import/tests/test_author_importer_split.py
+++ b/src/pbn_import/tests/test_author_importer_split.py
@@ -1,0 +1,66 @@
+"""AuthorImporter: download woła pobierz, process woła integruj."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import author_import
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make("bpp.Uczelnia", pbn_uid=baker.make("pbn_api.Institution"))
+
+
+@pytest.fixture
+def step(db, django_user_model, uczelnia):
+    user = baker.make(django_user_model)
+    session = baker.make("pbn_import.ImportSession", user=user)
+    return author_import.AuthorImporter(session, client=object(), uczelnia=uczelnia)
+
+
+def test_download_calls_pobierz_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        author_import,
+        "pobierz_ludzi_z_uczelni",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        author_import,
+        "integruj_autorow_z_uczelni",
+        lambda *a, **k: called.append("integruj"),
+    )
+    step.download()
+    assert called == ["pobierz"]
+
+
+def test_process_calls_integruj_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        author_import,
+        "pobierz_ludzi_z_uczelni",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        author_import,
+        "integruj_autorow_z_uczelni",
+        lambda *a, **k: called.append("integruj"),
+    )
+    step.process()
+    assert called == ["integruj"]
+
+
+def test_download_skips_without_pbn_uid(db, django_user_model, monkeypatch):
+    uczelnia = baker.make("bpp.Uczelnia", pbn_uid=None)
+    user = baker.make(django_user_model)
+    session = baker.make("pbn_import.ImportSession", user=user)
+    step = author_import.AuthorImporter(session, client=object(), uczelnia=uczelnia)
+    called = []
+    monkeypatch.setattr(
+        author_import,
+        "pobierz_ludzi_z_uczelni",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    result = step.download()
+    assert called == []
+    assert result["authors_imported"] is False

--- a/src/pbn_import/tests/test_command_pbn_import.py
+++ b/src/pbn_import/tests/test_command_pbn_import.py
@@ -9,14 +9,16 @@ from model_bakery import baker
 
 from bpp.models import Uczelnia
 from pbn_import.management.commands.pbn_import import (
+    IMPORT_STEPS,
+    LEGACY_ALIASES,
     Command,
     build_config_from_options,
 )
 from pbn_import.models import ImportSession
-from pbn_import.utils.step_definitions import ALL_STEP_DEFINITIONS
 
 
 def command_options(**overrides):
+    """Buduj słownik opcji CLI odpowiadający nowemu modelowi faz granularnych."""
     options = {
         "app_id": "app-id",
         "app_token": "app-token",
@@ -28,8 +30,12 @@ def command_options(**overrides):
         "username": None,
         "noinput": True,
     }
-    for step in ALL_STEP_DEFINITIONS:
-        options[f"disable_{step['form_field']}"] = False
+    # Granularne flagi faz (disable_<form_field> = False domyślnie)
+    for form_field, _label in IMPORT_STEPS:
+        options[f"disable_{form_field}"] = False
+    # Legacy aliasy (disable_<entity> = False domyślnie)
+    for entity in LEGACY_ALIASES:
+        options[f"disable_{entity}"] = False
     options.update(overrides)
     return options
 
@@ -42,10 +48,14 @@ def make_command():
 
 
 def test_build_config_from_options_maps_all_step_disable_keys():
+    """Granularne disable_<form_field> trafiają do config.
+
+    Sprawdzamy też że legacy alias disable_zrodla=True ustawia obie fazy
+    oraz że config zawiera klucz dla każdej granularnej fazy.
+    """
     options = command_options(
         delete_existing=True,
         disable_zrodla=True,
-        disable_publikacje=True,
     )
 
     config = build_config_from_options(options)
@@ -53,11 +63,14 @@ def test_build_config_from_options_maps_all_step_disable_keys():
     assert config["app_id"] == "app-id"
     assert config["base_url"] == "https://pbn.example.test"
     assert config["delete_existing"] is True
-    assert config["disable_zrodla"] is True
-    assert config["disable_publikacje"] is True
 
-    for step in ALL_STEP_DEFINITIONS:
-        assert step["disable_key"] in config
+    # Legacy alias disable_zrodla=True → obie fazy wyłączone
+    assert config["disable_zrodla_download"] is True
+    assert config["disable_zrodla_process"] is True
+
+    # Każda granularna faza ma swój klucz w config
+    for form_field, _label in IMPORT_STEPS:
+        assert f"disable_{form_field}" in config
 
 
 @pytest.mark.django_db
@@ -207,8 +220,16 @@ def test_run_interactive_cancel_on_step_selection():
 
 
 def test_run_interactive_applies_selected_steps_and_delete_choice():
+    """run_interactive ustawia granularne flagi faz na podstawie wyboru.
+
+    W modelu faz granularnych `selected` zawiera form_field poszczególnych faz
+    (np. "initial", "publikacje_download", "publikacje_process").
+    Fazy nieznajdujące się w `selected` mają disable_<form_field>=True.
+    """
     command = make_command()
-    selected = ["initial", "publikacje"]
+    # Wybieramy tylko fazę "initial" i obie fazy publikacji;
+    # fazy zrodla_download/zrodla_process są NIEwybrane → disable=True.
+    selected = ["initial", "publikacje_download", "publikacje_process"]
 
     with patch(
         "pbn_import.management.commands.pbn_import.questionary.checkbox"
@@ -222,6 +243,37 @@ def test_run_interactive_applies_selected_steps_and_delete_choice():
             options = command.run_interactive(command_options(noinput=False))
 
     assert options["delete_existing"] is True
+    # Wybrane fazy → nie wyłączone
     assert options["disable_initial"] is False
-    assert options["disable_publikacje"] is False
-    assert options["disable_zrodla"] is True
+    assert options["disable_publikacje_download"] is False
+    assert options["disable_publikacje_process"] is False
+    # Niewybrane fazy źródeł → wyłączone
+    assert options["disable_zrodla_download"] is True
+    assert options["disable_zrodla_process"] is True
+
+
+# --- Task 11: granularne flagi faz + legacy aliasy ---
+
+
+def _base_options(**over):
+    opts = {
+        "app_id": None,
+        "base_url": None,
+        "delete_existing": False,
+        "wydzial_domyslny": "X",
+        "wydzial_domyslny_skrot": None,
+    }
+    opts.update(over)
+    return opts
+
+
+def test_granular_flag_disables_one_phase():
+    cfg = build_config_from_options(_base_options(disable_zrodla_download=True))
+    assert cfg["disable_zrodla_download"] is True
+    assert cfg.get("disable_zrodla_process", False) is False
+
+
+def test_legacy_flag_disables_both_phases():
+    cfg = build_config_from_options(_base_options(disable_zrodla=True))
+    assert cfg["disable_zrodla_download"] is True
+    assert cfg["disable_zrodla_process"] is True

--- a/src/pbn_import/tests/test_conference_importer_split.py
+++ b/src/pbn_import/tests/test_conference_importer_split.py
@@ -1,0 +1,52 @@
+"""ConferenceImporter: download woła pobierz, process woła integruj."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import conference_import
+
+
+@pytest.fixture
+def step(db, django_user_model):
+    user = baker.make(django_user_model)
+    session = baker.make("pbn_import.ImportSession", user=user)
+    return conference_import.ConferenceImporter(session, client=object())
+
+
+def test_download_calls_pobierz_not_integruj(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        conference_import,
+        "pobierz_konferencje",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        conference_import,
+        "integruj_konferencje",
+        lambda *a, **k: called.append("integruj"),
+    )
+    step.download()
+    assert called == ["pobierz"]
+
+
+def test_process_calls_integruj_not_pobierz(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        conference_import,
+        "pobierz_konferencje",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        conference_import,
+        "integruj_konferencje",
+        lambda *a, **k: called.append("integruj") or 3,
+    )
+    step.process()
+    assert called == ["integruj"]
+
+
+def test_process_warns_when_mirror_empty(step, monkeypatch):
+    monkeypatch.setattr(conference_import, "integruj_konferencje", lambda *a, **k: 0)
+    step.process()
+    warnings = step.session.logs.filter(level="warning")
+    assert warnings.exists()

--- a/src/pbn_import/tests/test_import_manager.py
+++ b/src/pbn_import/tests/test_import_manager.py
@@ -42,7 +42,7 @@ class _SuccessStep:
     def __init__(self, session, client, uczelnia=None, **kwargs):
         self.session = session
 
-    def __call__(self):
+    def __call__(self, method="run"):
         return {"ok": True}
 
 
@@ -50,17 +50,20 @@ class _RaisingStep:
     def __init__(self, session, client, uczelnia=None, **kwargs):
         self.session = session
 
-    def __call__(self):
+    def __call__(self, method="run"):
         raise ValueError("krok się wywalił")
 
 
-def step_cfg(klass, name="zrodla", display="Źródła", required=False):
+def step_cfg(klass, name="zrodla", display="Źródła", required=False, result_key=None):
     return {
         "name": name,
+        "phase": "single",
         "display": display,
         "class": klass,
+        "method": "run",
         "args": {},
         "required": required,
+        "result_key": result_key if result_key is not None else name,
     }
 
 
@@ -283,3 +286,54 @@ def test_pause_resume_cancel_set_status(session):
     session.refresh_from_db()
     assert session.status == "cancelled"
     assert session.completed_at is not None
+
+
+# ===========================================================================
+# Fazy (Task 10): result_key + method dispatch
+# ===========================================================================
+
+
+def test_manager_runs_only_download_phase(db, django_user_model, monkeypatch):
+    from model_bakery import baker
+
+    from pbn_import.utils import source_import
+    from pbn_import.utils.import_manager import ImportManager
+
+    called = []
+    monkeypatch.setattr(
+        source_import,
+        "pobierz_zrodla_mnisw",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        source_import.importer,
+        "importuj_zrodla",
+        lambda *a, **k: called.append("importuj"),
+    )
+
+    user = baker.make(django_user_model)
+    session = baker.make("pbn_import.ImportSession", user=user)
+
+    class _Client:
+        def get_languages(self):
+            return []
+
+    manager = ImportManager(
+        session=session,
+        client=_Client(),
+        config={"disable_zrodla_process": True},
+    )
+    manager.steps = [
+        s for s in manager.steps if s["result_key"] == "source_import:download"
+    ]
+    manager.run()
+    assert "pobierz" in called
+    assert "importuj" not in called
+
+
+def test_results_keyed_by_phase(db):
+    from pbn_import.utils.step_definitions import get_step_definitions
+
+    defs = get_step_definitions({})
+    keys = [d["result_key"] for d in defs]
+    assert len(keys) == len(set(keys))

--- a/src/pbn_import/tests/test_importer_wrappers.py
+++ b/src/pbn_import/tests/test_importer_wrappers.py
@@ -189,9 +189,14 @@ def test_conference_importer_success_and_error_paths(session):
 
     with patch.object(importer, "create_subtask_progress", return_value=MagicMock()):
         with patch("pbn_import.utils.conference_import.pobierz_konferencje") as dl:
-            result = importer.run()
+            with patch(
+                "pbn_import.utils.conference_import.integruj_konferencje",
+                return_value=0,
+            ) as integrate:
+                result = importer.run()
 
     dl.assert_called_once()
+    integrate.assert_called_once()
     assert result == {"conferences_imported": True, "error_count": 0}
 
     failing = ConferenceImporter(session, client=MagicMock())
@@ -200,8 +205,12 @@ def test_conference_importer_success_and_error_paths(session):
             "pbn_import.utils.conference_import.pobierz_konferencje",
             side_effect=RuntimeError("conference failed"),
         ):
-            with patch.object(failing, "handle_error") as handle_error:
-                result = failing.run()
+            with patch(
+                "pbn_import.utils.conference_import.integruj_konferencje",
+                return_value=0,
+            ):
+                with patch.object(failing, "handle_error") as handle_error:
+                    result = failing.run()
 
     handle_error.assert_called_once()
     assert result["conferences_imported"] is True

--- a/src/pbn_import/tests/test_publication_import.py
+++ b/src/pbn_import/tests/test_publication_import.py
@@ -50,16 +50,25 @@ def test_setup_wires_default_jezyk_from_resolver(importer):
     assert importer.default_jezyk == Jezyk.objects.get(skrot="pol.")
 
 
-def test_run_returns_reason_when_uczelnia_setup_is_missing(session):
+def test_download_returns_reason_when_uczelnia_setup_is_missing(session):
     importer = PublicationImporter(session, client=MagicMock(), uczelnia=None)
 
     with patch.object(importer, "_setup_uczelnia_and_jednostka", return_value=None):
-        result = importer.run()
+        result = importer.download()
 
-    assert result == {"authors_imported": False, "reason": "No Uczelnia PBN UID"}
+    assert result == {"publications_imported": False, "reason": "No Uczelnia PBN UID"}
 
 
-def test_run_success_with_delete_existing_calls_steps_in_order(importer, uczelnia):
+def test_process_returns_reason_when_uczelnia_setup_is_missing(session):
+    importer = PublicationImporter(session, client=MagicMock(), uczelnia=None)
+
+    with patch.object(importer, "_setup_uczelnia_and_jednostka", return_value=None):
+        result = importer.process()
+
+    assert result == {"publications_imported": False, "reason": "No Uczelnia PBN UID"}
+
+
+def test_process_success_with_delete_existing_calls_steps_in_order(importer, uczelnia):
     importer.delete_existing = True
 
     with patch.object(
@@ -69,23 +78,15 @@ def test_run_success_with_delete_existing_calls_steps_in_order(importer, uczelni
             importer, "_delete_existing_publications", return_value=None
         ) as delete_existing:
             with patch.object(
-                importer, "_download_publications", return_value=None
-            ) as download:
-                with patch.object(
-                    importer, "_download_publications_v2", return_value=None
-                ) as download_v2:
-                    with patch.object(
-                        importer, "_import_publications", return_value=None
-                    ) as import_publications:
-                        with patch.object(importer, "update_progress") as progress:
-                            result = importer.run()
+                importer, "_import_publications", return_value=None
+            ) as import_publications:
+                with patch.object(importer, "update_progress") as progress:
+                    result = importer.process()
 
     setup.assert_called_once_with()
-    delete_existing.assert_called_once_with(0, 4)
-    download.assert_called_once_with(1, 4, uczelnia)
-    download_v2.assert_called_once_with(2, 4)
-    import_publications.assert_called_once_with(3, 4)
-    progress.assert_called_once_with(4, 4, "Zakończono import publikacji")
+    delete_existing.assert_called_once_with(0, 2)
+    import_publications.assert_called_once_with(1, 2)
+    progress.assert_called_once_with(2, 2, "Zakończono import publikacji")
     assert result == {
         "publications_imported": True,
         "default_jednostka": "Default unit",
@@ -93,18 +94,38 @@ def test_run_success_with_delete_existing_calls_steps_in_order(importer, uczelni
     }
 
 
-def test_run_short_circuits_when_delete_existing_returns_result(importer, uczelnia):
+def test_download_success_calls_download_steps_in_order(importer, uczelnia):
+    with patch.object(
+        importer, "_setup_uczelnia_and_jednostka", return_value=uczelnia
+    ) as setup:
+        with patch.object(
+            importer, "_download_publications", return_value=None
+        ) as download:
+            with patch.object(
+                importer, "_download_publications_v2", return_value=None
+            ) as download_v2:
+                with patch.object(importer, "update_progress") as progress:
+                    result = importer.download()
+
+    setup.assert_called_once_with()
+    download.assert_called_once_with(0, 2, uczelnia)
+    download_v2.assert_called_once_with(1, 2)
+    progress.assert_called_once_with(2, 2, "Zakończono pobieranie publikacji")
+    assert result == {"publications_downloaded": True, "error_count": 0}
+
+
+def test_process_short_circuits_when_delete_existing_returns_result(importer, uczelnia):
     importer.delete_existing = True
 
     with patch.object(importer, "_setup_uczelnia_and_jednostka", return_value=uczelnia):
         with patch.object(
             importer, "_delete_existing_publications", return_value={"cancelled": True}
         ):
-            with patch.object(importer, "_download_publications") as download:
-                result = importer.run()
+            with patch.object(importer, "_import_publications") as import_publications:
+                result = importer.process()
 
     assert result == {"cancelled": True}
-    download.assert_not_called()
+    import_publications.assert_not_called()
 
 
 def test_delete_existing_returns_cancelled_before_deleting(importer):

--- a/src/pbn_import/tests/test_publication_importer_split.py
+++ b/src/pbn_import/tests/test_publication_importer_split.py
@@ -1,0 +1,88 @@
+"""PublicationImporter: rozdzielenie download (pobieranie) i process (import)."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils.publication_import import PublicationImporter
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make("bpp.Uczelnia")
+
+
+@pytest.fixture
+def session(db, django_user_model):
+    user = baker.make(django_user_model)
+    return baker.make("pbn_import.ImportSession", user=user)
+
+
+def _patch_setup(monkeypatch, importer_obj):
+    """Pomiń realny setup — ustaw default_jednostka i zwróć uczelnię ze stepu."""
+    importer_obj.default_jednostka = baker.make("bpp.Jednostka")
+    monkeypatch.setattr(
+        importer_obj,
+        "_setup_uczelnia_and_jednostka",
+        lambda *a, **k: importer_obj.uczelnia,
+    )
+
+
+def test_download_calls_only_download_helpers(session, uczelnia, monkeypatch):
+    step = PublicationImporter(session, client=object(), uczelnia=uczelnia)
+    _patch_setup(monkeypatch, step)
+    called = []
+    monkeypatch.setattr(
+        step,
+        "_download_publications",
+        lambda *a, **k: called.append("dl") or None,
+    )
+    monkeypatch.setattr(
+        step,
+        "_download_publications_v2",
+        lambda *a, **k: called.append("dl2") or None,
+    )
+    monkeypatch.setattr(
+        step,
+        "_import_publications",
+        lambda *a, **k: called.append("import") or None,
+    )
+    step.download()
+    assert called == ["dl", "dl2"]
+
+
+def test_process_calls_only_import(session, uczelnia, monkeypatch):
+    step = PublicationImporter(session, client=object(), uczelnia=uczelnia)
+    _patch_setup(monkeypatch, step)
+    called = []
+    monkeypatch.setattr(
+        step,
+        "_download_publications",
+        lambda *a, **k: called.append("dl") or None,
+    )
+    monkeypatch.setattr(
+        step,
+        "_import_publications",
+        lambda *a, **k: called.append("import") or None,
+    )
+    step.process()
+    assert called == ["import"]
+
+
+def test_process_deletes_when_delete_existing(session, uczelnia, monkeypatch):
+    step = PublicationImporter(
+        session, client=object(), delete_existing=True, uczelnia=uczelnia
+    )
+    _patch_setup(monkeypatch, step)
+    called = []
+    monkeypatch.setattr(
+        step,
+        "_delete_existing_publications",
+        lambda *a, **k: called.append("delete") or None,
+    )
+    monkeypatch.setattr(
+        step,
+        "_import_publications",
+        lambda *a, **k: called.append("import") or None,
+    )
+    step.process()
+    assert called == ["delete", "import"]

--- a/src/pbn_import/tests/test_publisher_importer_split.py
+++ b/src/pbn_import/tests/test_publisher_importer_split.py
@@ -1,0 +1,45 @@
+"""PublisherImporter: download woła pobierz, process woła importuj."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import publisher_import
+
+
+@pytest.fixture
+def step(db, django_user_model):
+    user = baker.make(django_user_model)
+    session = baker.make("pbn_import.ImportSession", user=user)
+    return publisher_import.PublisherImporter(session, client=object())
+
+
+def test_download_calls_pobierz_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        publisher_import,
+        "pobierz_wydawcow_mnisw",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        publisher_import.importer,
+        "importuj_wydawcow",
+        lambda *a, **k: called.append("importuj"),
+    )
+    step.download()
+    assert called == ["pobierz"]
+
+
+def test_process_calls_importuj_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        publisher_import,
+        "pobierz_wydawcow_mnisw",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        publisher_import.importer,
+        "importuj_wydawcow",
+        lambda *a, **k: called.append("importuj") or 7,
+    )
+    step.process()
+    assert called == ["importuj"]

--- a/src/pbn_import/tests/test_source_importer_split.py
+++ b/src/pbn_import/tests/test_source_importer_split.py
@@ -1,0 +1,45 @@
+"""SourceImporter: download woła pobierz, process woła importuj."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import source_import
+
+
+@pytest.fixture
+def step(db, django_user_model):
+    user = baker.make(django_user_model)
+    session = baker.make("pbn_import.ImportSession", user=user)
+    return source_import.SourceImporter(session, client=object())
+
+
+def test_download_calls_pobierz_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        source_import,
+        "pobierz_zrodla_mnisw",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        source_import.importer,
+        "importuj_zrodla",
+        lambda *a, **k: called.append("importuj"),
+    )
+    step.download()
+    assert called == ["pobierz"]
+
+
+def test_process_calls_importuj_only(step, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        source_import,
+        "pobierz_zrodla_mnisw",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        source_import.importer,
+        "importuj_zrodla",
+        lambda *a, **k: called.append("importuj") or 5,
+    )
+    step.process()
+    assert called == ["importuj"]

--- a/src/pbn_import/tests/test_statement_importer_split.py
+++ b/src/pbn_import/tests/test_statement_importer_split.py
@@ -1,0 +1,61 @@
+"""StatementImporter: download = pobierz oświadczenia, process = integracja."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils import statement_import
+from pbn_import.utils.statement_import import StatementImporter
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make("bpp.Uczelnia")
+
+
+@pytest.fixture
+def session(db, django_user_model):
+    user = baker.make(django_user_model)
+    return baker.make("pbn_import.ImportSession", user=user)
+
+
+def test_download_calls_only_pobierz_oswiadczenia(session, uczelnia, monkeypatch):
+    step = StatementImporter(session, client=object(), uczelnia=uczelnia)
+    called = []
+    monkeypatch.setattr(
+        statement_import,
+        "pobierz_oswiadczenia_z_instytucji",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        statement_import,
+        "integruj_oswiadczenia_z_instytucji",
+        lambda *a, **k: called.append("integruj"),
+    )
+    step.download()
+    assert called == ["pobierz"]
+
+
+def test_process_integrates_without_redownloading_statements(
+    session, uczelnia, monkeypatch
+):
+    step = StatementImporter(session, client=object(), uczelnia=uczelnia)
+    called = []
+    monkeypatch.setattr(
+        statement_import,
+        "pobierz_oswiadczenia_z_instytucji",
+        lambda *a, **k: called.append("pobierz"),
+    )
+    monkeypatch.setattr(
+        statement_import,
+        "integruj_oswiadczenia_z_instytucji",
+        lambda *a, **k: called.append("integruj"),
+    )
+    monkeypatch.setattr(
+        step.publication_importer,
+        "_setup_uczelnia_and_jednostka",
+        lambda *a, **k: uczelnia,
+    )
+    step.publication_importer.default_jednostka = baker.make("bpp.Jednostka")
+    monkeypatch.setattr(step, "_download_missing_publications", lambda *a, **k: None)
+    step.process()
+    assert called == ["integruj"]

--- a/src/pbn_import/tests/test_step_definitions.py
+++ b/src/pbn_import/tests/test_step_definitions.py
@@ -4,6 +4,8 @@ import pytest
 
 from pbn_import.utils.step_definitions import (
     ALL_STEP_DEFINITIONS,
+    get_all_disable_keys,
+    get_form_steps,
     get_icon_for_step,
     get_step_definitions,
 )
@@ -11,30 +13,27 @@ from pbn_import.utils.step_definitions import (
 
 @pytest.mark.django_db
 def test_get_step_definitions_default_config():
-    """Test that all steps are enabled with empty/default config"""
-    config = {}
-    steps = get_step_definitions(config)
-
-    # Should return all 10 steps when nothing is disabled
-    # (data_integration was removed as redundant - publications are created
-    # with pbn_uid_id already set, and statement integration is done in statement_import)
-    assert len(steps) == 10
-
-    # Verify step names in order
-    expected_names = [
+    steps = get_step_definitions({})
+    assert len(steps) == 16
+    keys = [s["result_key"] for s in steps]
+    assert keys == [
         "initial_setup",
         "institution_setup",
-        "source_import",
+        "source_import:download",
+        "source_import:process",
         "source_scoring_import",
-        "publisher_import",
-        "conference_import",
-        "author_import",
-        "publication_import",
-        "statement_import",
+        "publisher_import:download",
+        "publisher_import:process",
+        "conference_import:download",
+        "conference_import:process",
+        "author_import:download",
+        "author_import:process",
+        "publication_import:download",
+        "publication_import:process",
+        "statement_import:download",
+        "statement_import:process",
         "fee_import",
     ]
-    actual_names = [step["name"] for step in steps]
-    assert actual_names == expected_names
 
 
 @pytest.mark.django_db
@@ -60,90 +59,35 @@ def test_get_step_definitions_all_disabled():
 
 @pytest.mark.django_db
 def test_get_step_definitions_individual_disable_flags():
-    """Test that each disable flag works correctly"""
-    # Test disabling initial_setup
-    config = {"disable_initial": True}
-    steps = get_step_definitions(config)
-    step_names = [step["name"] for step in steps]
-    assert "initial_setup" not in step_names
-    assert len(steps) == 9
-
-    # Test disabling institutions
-    config = {"disable_institutions": True}
-    steps = get_step_definitions(config)
-    step_names = [step["name"] for step in steps]
-    assert "institution_setup" not in step_names
-    assert len(steps) == 9
-
-    # Test disabling sources
-    config = {"disable_zrodla": True}
-    steps = get_step_definitions(config)
-    step_names = [step["name"] for step in steps]
-    assert "source_import" not in step_names
-    assert len(steps) == 9
-
-    # Test disabling source scoring
-    config = {"disable_punktacja_zrodel": True}
-    steps = get_step_definitions(config)
-    step_names = [step["name"] for step in steps]
-    assert "source_scoring_import" not in step_names
-    assert len(steps) == 9
-
-    # Test disabling publishers
-    config = {"disable_wydawcy": True}
-    steps = get_step_definitions(config)
-    step_names = [step["name"] for step in steps]
-    assert "publisher_import" not in step_names
-    assert len(steps) == 9
-
-    # Test disabling conferences
-    config = {"disable_konferencje": True}
-    steps = get_step_definitions(config)
-    step_names = [step["name"] for step in steps]
-    assert "conference_import" not in step_names
-    assert len(steps) == 9
-
-    # Test disabling authors
-    config = {"disable_autorzy": True}
-    steps = get_step_definitions(config)
-    step_names = [step["name"] for step in steps]
-    assert "author_import" not in step_names
-    assert len(steps) == 9
-
-    # Test disabling publications
-    config = {"disable_publikacje": True}
-    steps = get_step_definitions(config)
-    step_names = [step["name"] for step in steps]
-    assert "publication_import" not in step_names
-    assert len(steps) == 9
-
-    # Test disabling statements
-    config = {"disable_oswiadczenia": True}
-    steps = get_step_definitions(config)
-    step_names = [step["name"] for step in steps]
-    assert "statement_import" not in step_names
-    assert len(steps) == 9
-
-    # Test disabling fees
-    config = {"disable_oplaty": True}
-    steps = get_step_definitions(config)
-    step_names = [step["name"] for step in steps]
-    assert "fee_import" not in step_names
-    assert len(steps) == 9
+    keys = [s["result_key"] for s in get_step_definitions({"disable_zrodla": True})]
+    assert "source_import:download" not in keys
+    assert "source_import:process" not in keys
+    assert len(keys) == 14
+    keys = [s["result_key"] for s in get_step_definitions({"disable_oplaty": True})]
+    assert "fee_import" not in keys
+    assert len(keys) == 15
+    keys = [
+        s["result_key"]
+        for s in get_step_definitions({"disable_punktacja_zrodel": True})
+    ]
+    assert "source_scoring_import" not in keys
+    assert len(keys) == 15
 
 
 @pytest.mark.django_db
 def test_get_step_definitions_preserves_order():
-    """Test that step order matches ALL_STEP_DEFINITIONS"""
-    config = {}
-    steps = get_step_definitions(config)
-
-    # Verify order matches ALL_STEP_DEFINITIONS
-    for i, step in enumerate(steps):
-        assert step["name"] == ALL_STEP_DEFINITIONS[i]["name"]
-        assert step["display"] == ALL_STEP_DEFINITIONS[i]["display"]
-        assert step["class"] == ALL_STEP_DEFINITIONS[i]["class"]
-        assert step["required"] == ALL_STEP_DEFINITIONS[i]["required"]
+    keys = [s["result_key"] for s in get_step_definitions({})]
+    assert keys.index("source_import:download") < keys.index("source_import:process")
+    assert keys.index("source_import:process") < keys.index("publisher_import:download")
+    entity_order = [
+        s["name"] for s in get_step_definitions({}) if s["phase"] != "process"
+    ]
+    expected = [d["name"] for d in ALL_STEP_DEFINITIONS]
+    seen = []
+    for n in entity_order:
+        if n not in seen:
+            seen.append(n)
+    assert seen == expected
 
 
 @pytest.mark.django_db
@@ -238,28 +182,22 @@ def test_get_step_definitions_step_structure():
 
 @pytest.mark.django_db
 def test_get_step_definitions_combination_of_flags():
-    """Test that combination of disable flags works correctly"""
     config = {
         "disable_zrodla": True,
         "disable_wydawcy": True,
         "disable_konferencje": True,
     }
     steps = get_step_definitions(config)
-
-    # Should have 7 steps (10 - 3 disabled)
-    assert len(steps) == 7
-
-    step_names = [step["name"] for step in steps]
-    assert "source_import" not in step_names
-    assert "publisher_import" not in step_names
-    assert "conference_import" not in step_names
-
-    # These should still be present
-    assert "initial_setup" in step_names
-    assert "institution_setup" in step_names
-    assert "source_scoring_import" in step_names
-    assert "author_import" in step_names
-    assert "publication_import" in step_names
+    names = {s["name"] for s in steps}
+    assert len(steps) == 10
+    assert "source_import" not in names
+    assert "publisher_import" not in names
+    assert "conference_import" not in names
+    assert "initial_setup" in names
+    assert "institution_setup" in names
+    assert "source_scoring_import" in names
+    assert "author_import" in names
+    assert "publication_import" in names
 
 
 @pytest.mark.django_db
@@ -287,7 +225,8 @@ def test_get_step_definitions_steps_with_empty_args():
     config = {}
     steps = get_step_definitions(config)
 
-    # Steps without dynamic args
+    # Steps without dynamic args — with phase model, steps appear per-phase;
+    # use name match (first occurrence covers both download & process phases)
     steps_without_args = [
         "initial_setup",
         "source_import",
@@ -303,3 +242,65 @@ def test_get_step_definitions_steps_with_empty_args():
         step = next((s for s in steps if s["name"] == step_name), None)
         assert step is not None
         assert step["args"] == {}
+
+
+# --- nowe testy (Task 9: model faz) ---
+
+
+def test_split_step_emits_two_phases_in_order():
+    defs = get_step_definitions({})
+    keys = [d["result_key"] for d in defs]
+    assert keys.index("source_import:download") < keys.index("source_import:process")
+    assert "conference_import:download" in keys
+    assert "conference_import:process" in keys
+
+
+def test_each_phase_carries_method():
+    defs = get_step_definitions({})
+    by_key = {d["result_key"]: d for d in defs}
+    assert by_key["source_import:download"]["method"] == "download"
+    assert by_key["source_import:process"]["method"] == "process"
+    assert by_key["fee_import"]["method"] == "run"
+
+
+def test_granular_disable_skips_one_phase_only():
+    defs = get_step_definitions({"disable_zrodla_download": True})
+    keys = [d["result_key"] for d in defs]
+    assert "source_import:download" not in keys
+    assert "source_import:process" in keys
+
+
+def test_legacy_key_disables_both_phases():
+    defs = get_step_definitions({"disable_zrodla": True})
+    keys = [d["result_key"] for d in defs]
+    assert "source_import:download" not in keys
+    assert "source_import:process" not in keys
+
+
+def test_granular_overrides_legacy():
+    defs = get_step_definitions(
+        {"disable_zrodla": True, "disable_zrodla_process": False}
+    )
+    keys = [d["result_key"] for d in defs]
+    assert "source_import:process" in keys
+    assert "source_import:download" not in keys
+
+
+def test_get_all_disable_keys_is_granular():
+    mapping = get_all_disable_keys()
+    assert mapping["zrodla_download"] == "disable_zrodla_download"
+    assert mapping["zrodla_process"] == "disable_zrodla_process"
+    assert mapping["oplaty"] == "disable_oplaty"
+
+
+def test_get_form_steps_returns_two_column_rows():
+    rows = get_form_steps()
+    by_name = {r["name"]: r for r in rows}
+    zrodla = by_name["source_import"]
+    assert zrodla["download"]["form_field"] == "zrodla_download"
+    assert zrodla["process"]["form_field"] == "zrodla_process"
+    punktacja = by_name["source_scoring_import"]
+    assert punktacja["download"] is None
+    assert punktacja["process"] is not None
+    oplaty = by_name["fee_import"]
+    assert oplaty["single"] is not None

--- a/src/pbn_import/tests/test_step_phase_dispatch.py
+++ b/src/pbn_import/tests/test_step_phase_dispatch.py
@@ -59,3 +59,9 @@ def test_base_download_process_not_implemented(session):
         bare.download()
     with pytest.raises(NotImplementedError):
         bare.process()
+
+
+def test_call_unknown_method_raises_valueerror(session):
+    step = _DummyStep(session)
+    with pytest.raises(ValueError):
+        step(method="nope")

--- a/src/pbn_import/tests/test_step_phase_dispatch.py
+++ b/src/pbn_import/tests/test_step_phase_dispatch.py
@@ -1,0 +1,61 @@
+"""Testy dyspozytora faz w ImportStepBase (download/process/run/__call__)."""
+
+import pytest
+from model_bakery import baker
+
+from pbn_import.utils.base import ImportStepBase
+
+
+class _DummyStep(ImportStepBase):
+    step_name = "dummy"
+    step_description = "Dummy"
+
+    def __init__(self, session):
+        super().__init__(session)
+        self.calls = []
+
+    def download(self):
+        self.calls.append("download")
+        return {"phase": "download"}
+
+    def process(self):
+        self.calls.append("process")
+        return {"phase": "process"}
+
+
+@pytest.fixture
+def session(db, django_user_model):
+    user = baker.make(django_user_model)
+    return baker.make("pbn_import.ImportSession", user=user)
+
+
+def test_call_default_runs_both_phases(session):
+    step = _DummyStep(session)
+    result = step()  # default method="run"
+    assert step.calls == ["download", "process"]
+    assert result == {"phase": "process"}
+
+
+def test_call_download_only(session):
+    step = _DummyStep(session)
+    result = step(method="download")
+    assert step.calls == ["download"]
+    assert result == {"phase": "download"}
+
+
+def test_call_process_only(session):
+    step = _DummyStep(session)
+    result = step(method="process")
+    assert step.calls == ["process"]
+    assert result == {"phase": "process"}
+
+
+def test_base_download_process_not_implemented(session):
+    class _Bare(ImportStepBase):
+        step_name = "bare"
+
+    bare = _Bare(session)
+    with pytest.raises(NotImplementedError):
+        bare.download()
+    with pytest.raises(NotImplementedError):
+        bare.process()

--- a/src/pbn_import/tests/test_views_dashboard.py
+++ b/src/pbn_import/tests/test_views_dashboard.py
@@ -1,5 +1,6 @@
 """Unit tests for pbn_import dashboard and start views"""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -721,3 +722,22 @@ class TestCancelImportView:
         response = client.post(reverse("pbn_import:cancel", args=[session.id]))
 
         assert response.status_code == 404
+
+
+# ============================================================================
+# PRESETS VIEW TESTS
+# ============================================================================
+
+
+@pytest.mark.django_db
+def test_presets_sources_only_enables_both_source_phases(client, admin_user):
+    client.force_login(admin_user)
+    resp = client.get(reverse("pbn_import:presets"))
+    assert resp.status_code == 200
+    presets = json.loads(resp.content)["presets"]
+    sources_only = next(p for p in presets if p["id"] == "sources_only")
+    cfg = sources_only["config"]
+    assert cfg.get("disable_zrodla_download", False) is False
+    assert cfg.get("disable_zrodla_process", False) is False
+    assert cfg["disable_wydawcy_download"] is True
+    assert cfg["disable_wydawcy_process"] is True

--- a/src/pbn_import/utils/author_import.py
+++ b/src/pbn_import/utils/author_import.py
@@ -1,5 +1,6 @@
 """Author import utilities"""
 
+from pbn_api.models import Scientist
 from pbn_integrator.utils import integruj_autorow_z_uczelni, pobierz_ludzi_z_uczelni
 
 from .base import ImportStepBase
@@ -11,43 +12,56 @@ class AuthorImporter(ImportStepBase):
     step_name = "author_import"
     step_description = "Import autorów"
 
-    def run(self, uczelnia=None):
-        """Import authors"""
-        if uczelnia is None:
-            uczelnia = self.uczelnia
-
+    def _resolve_uczelnia(self):
+        """Zwróć uczelnię kontekstu importu lub None (z logiem) gdy brak pbn_uid."""
+        uczelnia = self.uczelnia
         if not uczelnia or not uczelnia.pbn_uid_id:
             self.log(
-                "warning", "Nie znaleziono Uczelni z PBN UID, pomijanie importu autorów"
+                "warning",
+                "Nie znaleziono Uczelni z PBN UID, pomijanie importu autorów",
             )
+            return None
+        return uczelnia
+
+    def download(self):
+        """Pobierz autorów uczelni z PBN do lustra."""
+        uczelnia = self._resolve_uczelnia()
+        if uczelnia is None:
             return {"authors_imported": False, "reason": "No Uczelnia PBN UID"}
 
-        # Download authors from PBN
-        self.update_progress(0, 2, "Pobieranie autorów z PBN")
+        self.update_progress(0, 1, "Pobieranie autorów z PBN")
         self.log("info", f"Pobieranie autorów dla instytucji {uczelnia.pbn_uid_id}")
-
-        # Create progress callback
         subtask_callback = self.create_subtask_progress("Pobieranie autorów")
-
         try:
             pobierz_ludzi_z_uczelni(
                 self.client, uczelnia.pbn_uid_id, callback=subtask_callback
             )
-            self.log("info", "Authors downloaded successfully")
+            self.log("success", "Autorzy pobrani pomyślnie")
         except Exception as e:
             self.handle_error(e, "Nie udało się pobrać autorów")
         finally:
             self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono pobieranie autorów")
+        return {"authors_downloaded": True, "error_count": len(self.errors)}
 
-        # Integrate authors
-        self.update_progress(1, 2, "Integrowanie autorów")
+    def process(self):
+        """Zintegruj autorów z lustra do BPP (z uczelnią)."""
+        uczelnia = self._resolve_uczelnia()
+        if uczelnia is None:
+            return {"authors_imported": False, "reason": "No Uczelnia PBN UID"}
+
+        if not Scientist.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych autorów — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+
+        self.update_progress(0, 1, "Integrowanie autorów")
         self.log("info", "Integrating authors with university")
-
-        # Create progress callback for integration phase
         integration_callback = self.create_subtask_progress(
             "Integrowanie autorów z uczelnią"
         )
-
         try:
             integruj_autorow_z_uczelni(
                 self.client,
@@ -55,13 +69,8 @@ class AuthorImporter(ImportStepBase):
                 import_unexistent=True,
                 callback=integration_callback,
             )
-
-            # Clear the integration subtask progress
             self.clear_subtask_progress()
-
-            # Update statistics if available
             if hasattr(self.session, "statistics"):
-                # We could query the database for actual count
                 from bpp.models import Autor
 
                 stats = self.session.statistics
@@ -69,17 +78,13 @@ class AuthorImporter(ImportStepBase):
                     pbn_uid_id__isnull=False
                 ).count()
                 stats.save()
-
-            self.log("success", "Authors integrated successfully")
-
+            self.log("success", "Autorzy zintegrowani pomyślnie")
         except Exception as e:
             self.handle_error(e, "Nie udało się zintegrować autorów")
             if hasattr(self.session, "statistics"):
                 self.session.statistics.authors_failed += 1
                 self.session.statistics.save()
-
-        self.update_progress(2, 2, "Zakończono import autorów")
-
+        self.update_progress(1, 1, "Zakończono import autorów")
         return {
             "authors_imported": True,
             "uczelnia_pbn_uid": uczelnia.pbn_uid_id,

--- a/src/pbn_import/utils/base.py
+++ b/src/pbn_import/utils/base.py
@@ -280,20 +280,27 @@ class ImportStepBase:
             or "autoryzacja" in error_msg.lower()
         )
 
+    def download(self):
+        """Faza pobierania danych z PBN do lustra. Nadpisz w podklasie."""
+        raise NotImplementedError("Krok nie implementuje fazy pobierania")
+
+    def process(self):
+        """Faza przetwarzania lustra do modeli BPP. Nadpisz w podklasie."""
+        raise NotImplementedError("Krok nie implementuje fazy przetwarzania")
+
     @transaction.atomic
     def run(self):
-        """Execute the import step - override in subclasses"""
-        raise NotImplementedError("Subclasses must implement run()")
+        """Domyślnie: pobierz, potem przetwórz (zgodność wsteczna)."""
+        self.download()
+        return self.process()
 
-    def __call__(self):
-        """Make the class callable for easier use"""
+    def __call__(self, method: str = "run"):
+        """Uruchom wskazaną fazę (run/download/process) z obwiednią start/finish."""
         self.start()
         try:
-            result = self.run()
+            result = getattr(self, method)()
             self.finish()
             return result
         except Exception as e:
-            # handle_error now does Rollbar reporting and logging
             self.handle_error(e, f"Krytyczny błąd w {self.step_name}")
-            # Note: Don't mark_failed here - let ImportManager handle it
             raise

--- a/src/pbn_import/utils/base.py
+++ b/src/pbn_import/utils/base.py
@@ -280,6 +280,10 @@ class ImportStepBase:
             or "autoryzacja" in error_msg.lower()
         )
 
+    # Uwaga: fazy download()/process() NIE są opakowane w transakcję — gdy
+    # ImportManager woła je osobno (method=), atomowość per faza jest
+    # odpowiedzialnością podklasy. Tylko legacy run() (obie fazy) jest atomic.
+
     def download(self):
         """Faza pobierania danych z PBN do lustra. Nadpisz w podklasie."""
         raise NotImplementedError("Krok nie implementuje fazy pobierania")
@@ -296,6 +300,8 @@ class ImportStepBase:
 
     def __call__(self, method: str = "run"):
         """Uruchom wskazaną fazę (run/download/process) z obwiednią start/finish."""
+        if method not in ("run", "download", "process"):
+            raise ValueError(f"Nieznana metoda kroku importu: {method!r}")
         self.start()
         try:
             result = getattr(self, method)()

--- a/src/pbn_import/utils/conference_import.py
+++ b/src/pbn_import/utils/conference_import.py
@@ -1,6 +1,7 @@
 """Conference import utilities"""
 
-from pbn_integrator.utils import pobierz_konferencje
+from pbn_api.models import Conference
+from pbn_integrator.utils import integruj_konferencje, pobierz_konferencje
 
 from .base import ImportStepBase
 
@@ -11,30 +12,37 @@ class ConferenceImporter(ImportStepBase):
     step_name = "conference_import"
     step_description = "Import konferencji"
 
-    def run(self):
-        """Import conferences"""
+    def download(self):
+        """Pobierz konferencje z PBN do lustra."""
         self.update_progress(0, 1, "Pobieranie konferencji z PBN")
         self.log("info", "Pobieranie konferencji z PBN")
-
-        # Create progress callback
         subtask_callback = self.create_subtask_progress("Pobieranie konferencji")
-
         try:
             pobierz_konferencje(self.client, callback=subtask_callback)
-
-            # Update statistics if available
-            if hasattr(self.session, "statistics"):
-                stats = self.session.statistics
-                stats.conferences_imported += 1  # Increment counter
-                stats.save()
-
-            self.log("success", "Conferences imported successfully")
-
+            self.log("success", "Konferencje pobrane pomyślnie")
         except Exception as e:
-            self.handle_error(e, "Nie udało się zaimportować konferencji")
+            self.handle_error(e, "Nie udało się pobrać konferencji")
         finally:
             self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono pobieranie konferencji")
+        return {"conferences_downloaded": True, "error_count": len(self.errors)}
 
-        self.update_progress(1, 1, "Zakończono import konferencji")
-
-        return {"conferences_imported": True, "error_count": len(self.errors)}
+    def process(self):
+        """Zintegruj lustro konferencji do BPP."""
+        if not Conference.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych konferencji — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+        self.update_progress(0, 1, "Integracja konferencji")
+        subtask_callback = self.create_subtask_progress("Integracja konferencji")
+        try:
+            liczba = integruj_konferencje(callback=subtask_callback)
+            self.log("success", f"Zintegrowano {liczba} konferencji")
+        except Exception as e:
+            self.handle_error(e, "Nie udało się zintegrować konferencji")
+        finally:
+            self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono integrację konferencji")
+        return {"conferences_integrated": True, "error_count": len(self.errors)}

--- a/src/pbn_import/utils/conference_import.py
+++ b/src/pbn_import/utils/conference_import.py
@@ -45,4 +45,4 @@ class ConferenceImporter(ImportStepBase):
         finally:
             self.clear_subtask_progress()
         self.update_progress(1, 1, "Zakończono integrację konferencji")
-        return {"conferences_integrated": True, "error_count": len(self.errors)}
+        return {"conferences_imported": True, "error_count": len(self.errors)}

--- a/src/pbn_import/utils/import_manager.py
+++ b/src/pbn_import/utils/import_manager.py
@@ -181,7 +181,7 @@ class ImportManager:
             logger.warning(
                 f"Pomijanie kroku {step_config['display']} - brak autoryzacji PBN"
             )
-            results[step_config["name"]] = {
+            results[step_config["result_key"]] = {
                 "error": "Brak autoryzacji PBN",
                 "skipped": True,
             }
@@ -210,7 +210,7 @@ class ImportManager:
         if hasattr(e, "content") or "403" in str(e) or "Forbidden" in error_msg:
             has_errors = True
             critical_error = error_msg
-            results[step_config["name"]] = {
+            results[step_config["result_key"]] = {
                 "error": error_msg,
                 "skipped": False,
                 "critical": True,
@@ -223,7 +223,7 @@ class ImportManager:
             return has_errors, critical_error, tb_string, False, None
 
         has_errors = True
-        results[step_config["name"]] = {
+        results[step_config["result_key"]] = {
             "error": error_msg,
             "skipped": False,
         }
@@ -247,8 +247,8 @@ class ImportManager:
         )
 
         try:
-            result = step()
-            results[step_config["name"]] = result
+            result = step(method=step_config["method"])
+            results[step_config["result_key"]] = result
 
             # After initial_setup, refresh the client and authorization
             # This is critical for clean database imports where pbn_uid_id
@@ -266,7 +266,8 @@ class ImportManager:
                 message="Import został anulowany podczas wykonywania kroku",
             )
             logger.warning(
-                f"Import {self.session.id} anulowany podczas kroku {step_config['name']}"
+                f"Import {self.session.id} anulowany podczas kroku "
+                f"{step_config['result_key']}"
             )
             return (
                 has_errors,

--- a/src/pbn_import/utils/publication_import.py
+++ b/src/pbn_import/utils/publication_import.py
@@ -31,45 +31,55 @@ class PublicationImporter(ImportStepBase):
         self.default_jednostka = None
         self.default_jezyk = None
 
-    def run(self):
-        """Import publications"""
-        # Setup uczelnia and jednostka
+    def download(self):
+        """Pobierz publikacje instytucji (v1 + v2) z PBN do lustra."""
         uczelnia = self._setup_uczelnia_and_jednostka()
         if uczelnia is None:
-            return {"authors_imported": False, "reason": "No Uczelnia PBN UID"}
+            return {"publications_imported": False, "reason": "No Uczelnia PBN UID"}
 
-        total_steps = 4 if self.delete_existing else 3
+        result = self._download_publications(0, 2, uczelnia)
+        if result:
+            return result
+        result = self._download_publications_v2(1, 2)
+        if result:
+            return result
+
+        self.update_progress(2, 2, "Zakończono pobieranie publikacji")
+        return {"publications_downloaded": True, "error_count": len(self.errors)}
+
+    def process(self):
+        """Zaimportuj publikacje z lustra do BPP (opcjonalnie po skasowaniu)."""
+        from pbn_api.models import Publication
+
+        uczelnia = self._setup_uczelnia_and_jednostka()
+        if uczelnia is None:
+            return {"publications_imported": False, "reason": "No Uczelnia PBN UID"}
+
+        if not Publication.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych publikacji — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+
+        total_steps = 2 if self.delete_existing else 1
         current_step = 0
-
-        # Delete existing if requested
         if self.delete_existing:
             result = self._delete_existing_publications(current_step, total_steps)
             if result:
                 return result
             current_step += 1
 
-        # Download publications
-        result = self._download_publications(current_step, total_steps, uczelnia)
-        if result:
-            return result
-        current_step += 1
-
-        # Download publications v2
-        result = self._download_publications_v2(current_step, total_steps)
-        if result:
-            return result
-        current_step += 1
-
-        # Import publications
         result = self._import_publications(current_step, total_steps)
         if result:
             return result
 
         self.update_progress(total_steps, total_steps, "Zakończono import publikacji")
-
         return {
             "publications_imported": True,
-            "default_jednostka": self.default_jednostka.nazwa,
+            "default_jednostka": (
+                self.default_jednostka.nazwa if self.default_jednostka else None
+            ),
             "error_count": len(self.errors),
         }
 

--- a/src/pbn_import/utils/publication_import.py
+++ b/src/pbn_import/utils/publication_import.py
@@ -49,8 +49,6 @@ class PublicationImporter(ImportStepBase):
 
     def process(self):
         """Zaimportuj publikacje z lustra do BPP (opcjonalnie po skasowaniu)."""
-        from pbn_api.models import Publication
-
         uczelnia = self._setup_uczelnia_and_jednostka()
         if uczelnia is None:
             return {"publications_imported": False, "reason": "No Uczelnia PBN UID"}

--- a/src/pbn_import/utils/publisher_import.py
+++ b/src/pbn_import/utils/publisher_import.py
@@ -1,5 +1,6 @@
 """Publisher import utilities"""
 
+from pbn_api.models import Publisher
 from pbn_integrator import importer
 from pbn_integrator.utils import pobierz_wydawcow_mnisw
 
@@ -12,41 +13,39 @@ class PublisherImporter(ImportStepBase):
     step_name = "publisher_import"
     step_description = "Import wydawców"
 
-    def run(self):
-        """Import publishers"""
-        # Download publishers from PBN
-        self.update_progress(0, 2, "Pobieranie wydawców z PBN")
+    def download(self):
+        """Pobierz wydawców z PBN (MNiSW) do lustra."""
+        self.update_progress(0, 1, "Pobieranie wydawców z PBN")
         self.log("info", "Pobieranie wydawców z MNiSW")
-
         try:
             pobierz_wydawcow_mnisw(self.client)
-            self.log("info", "Publishers downloaded successfully")
+            self.log("success", "Wydawcy pobrani pomyślnie")
         except Exception as e:
             self.handle_error(e, "Nie udało się pobrać wydawców")
-            # Continue anyway - might have partial data
+        self.update_progress(1, 1, "Zakończono pobieranie wydawców")
+        return {"publishers_downloaded": True, "error_count": len(self.errors)}
 
-        # Import publishers to database
-        self.update_progress(1, 2, "Importowanie wydawców do bazy danych")
-        self.log("info", "Importing publishers to database")
-
+    def process(self):
+        """Zaimportuj wydawców z lustra do BPP."""
+        if not Publisher.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych wydawców — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+        self.update_progress(0, 1, "Importowanie wydawców do bazy danych")
+        self.log("info", "Importowanie wydawców do bazy danych")
         subtask_callback = self.create_subtask_progress("Importowanie wydawców")
         try:
             result = importer.importuj_wydawcow(callback=subtask_callback)
-
-            # Update statistics if available
-            if hasattr(self.session, "statistics"):
+            if hasattr(self.session, "statistics") and isinstance(result, (int, float)):
                 stats = self.session.statistics
-                if isinstance(result, (int, float)):
-                    stats.publishers_imported = int(result)
-                    stats.save()
-
-            self.log("success", "Publishers imported successfully")
-
+                stats.publishers_imported = int(result)
+                stats.save()
+            self.log("success", "Wydawcy zaimportowani pomyślnie")
         except Exception as e:
             self.handle_error(e, "Nie udało się zaimportować wydawców")
         finally:
             self.clear_subtask_progress()
-
-        self.update_progress(2, 2, "Zakończono import wydawców")
-
+        self.update_progress(1, 1, "Zakończono import wydawców")
         return {"publishers_imported": True, "error_count": len(self.errors)}

--- a/src/pbn_import/utils/source_import.py
+++ b/src/pbn_import/utils/source_import.py
@@ -1,5 +1,6 @@
 """Source (journal) import utilities"""
 
+from pbn_api.models import Journal
 from pbn_integrator import importer
 from pbn_integrator.utils import pobierz_zrodla_mnisw
 
@@ -12,49 +13,41 @@ class SourceImporter(ImportStepBase):
     step_name = "source_import"
     step_description = "Import źródeł (czasopism)"
 
-    def run(self):
-        """Import sources"""
-        # Download sources from PBN
-        self.update_progress(0, 2, "Pobieranie źródeł z PBN")
+    def download(self):
+        """Pobierz źródła z PBN (MNiSW) do lustra."""
+        self.update_progress(0, 1, "Pobieranie źródeł z PBN")
         self.log("info", "Pobieranie źródeł z MNiSW")
-
-        # Create progress callback for sub-task tracking
         subtask_callback = self.create_subtask_progress("Pobieranie źródeł MNiSW")
-
         try:
             pobierz_zrodla_mnisw(self.client, callback=subtask_callback)
-            self.log("info", "Źródła pobrane pomyślnie")
+            self.log("success", "Źródła pobrane pomyślnie")
         except Exception as e:
-            # Use the new method that handles authorization errors properly
             self.handle_pbn_error(e, "Nie udało się pobrać źródeł")
-            # If we're here, it's not an authorization error
             self.log("warning", "Kontynuacja z częściowymi danymi")
         finally:
-            # Clear subtask progress when done
             self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono pobieranie źródeł")
+        return {"sources_downloaded": True, "error_count": len(self.errors)}
 
-        # Import sources to database
-        self.update_progress(1, 2, "Importowanie źródeł do bazy danych")
+    def process(self):
+        """Zaimportuj źródła z lustra do BPP."""
+        if not Journal.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych źródeł — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+        self.update_progress(0, 1, "Importowanie źródeł do bazy danych")
         self.log("info", "Importowanie źródeł do bazy danych")
-
         try:
             result = importer.importuj_zrodla()
-
-            # Get statistics if available
-            if hasattr(self.session, "statistics"):
+            if hasattr(self.session, "statistics") and isinstance(result, (int, float)):
                 stats = self.session.statistics
-                # Assuming result contains count
-                if isinstance(result, (int, float)):
-                    stats.journals_imported = int(result)
-                    stats.save()
-
+                stats.journals_imported = int(result)
+                stats.save()
             self.log("success", "Źródła zaimportowane pomyślnie")
-
         except Exception as e:
             self.handle_error(e, "Nie udało się zaimportować źródeł")
-            # This is also critical, so raise
             raise
-
-        self.update_progress(2, 2, "Zakończono import źródeł")
-
+        self.update_progress(1, 1, "Zakończono import źródeł")
         return {"sources_imported": True, "error_count": len(self.errors)}

--- a/src/pbn_import/utils/statement_import.py
+++ b/src/pbn_import/utils/statement_import.py
@@ -87,40 +87,40 @@ class StatementImporter(ImportStepBase):
 
         return inconsistency_callback
 
-    def run(self):
-        """Import statements"""
-        # Step 1: Download statements
-        self.update_progress(0, 3, "Pobieranie oświadczeń z PBN")
+    def download(self):
+        """Pobierz oświadczenia instytucji z PBN do lustra."""
+        self.update_progress(0, 1, "Pobieranie oświadczeń z PBN")
         self.log("info", "Pobieranie oświadczeń z instytucji")
-
-        # Create progress callback for sub-task tracking
         subtask_callback = self.create_subtask_progress("Pobieranie oświadczeń")
-
         try:
             pobierz_oswiadczenia_z_instytucji(self.client, callback=subtask_callback)
-            self.log("info", "Oświadczenia pobrane pomyślnie")
+            self.log("success", "Oświadczenia pobrane pomyślnie")
         except Exception as e:
             self.handle_error(e, "Nie udało się pobrać oświadczeń")
         finally:
             self.clear_subtask_progress()
+        self.update_progress(1, 1, "Zakończono pobieranie oświadczeń")
+        return {"statements_downloaded": True, "error_count": len(self.errors)}
 
-        # Setup publication importer for any missing publications
+    def process(self):
+        """Dociągnij brakujące publikacje i zintegruj oświadczenia."""
+        if not OswiadczenieInstytucji.objects.exists():
+            self.log(
+                "warning",
+                "Brak pobranych oświadczeń — przetwarzam 0. Uruchom fazę "
+                "pobierania, jeśli to nie zamierzone.",
+            )
+
         uczelnia = self.publication_importer._setup_uczelnia_and_jednostka()
         if not uczelnia:
             self.log(
-                "warning",
-                "Brak Uczelni z PBN UID, pomijanie integracji oświadczeń",
+                "warning", "Brak Uczelni z PBN UID, pomijanie integracji oświadczeń"
             )
             return {"statements_imported": False, "reason": "No Uczelnia PBN UID"}
 
-        # Domyślną jednostkę ustalił już resolver wywołany przez
-        # ``_setup_uczelnia_and_jednostka`` powyżej — reużywamy jej zamiast
-        # czytać config drugi raz (czytanie wyłącznie ``default_jednostka_id``
-        # gubiło wybór z formularza zapisany pod ``jednostka_domyslna_id``).
         default_jednostka = self.publication_importer.default_jednostka
 
-        # Step 2: Download missing publications in batch (NEW STEP)
-        self.update_progress(1, 3, "Pobieranie brakujących publikacji")
+        self.update_progress(0, 2, "Pobieranie brakujących publikacji")
         result = self._download_missing_publications(default_jednostka)
         if result:
             self.log(
@@ -129,27 +129,16 @@ class StatementImporter(ImportStepBase):
                 f"({result['failed']} błędów)",
             )
 
-        # Step 3: Integrate statements (no longer needs missing publication callback)
-        self.update_progress(2, 3, "Integrowanie oświadczeń")
+        self.update_progress(1, 2, "Integrowanie oświadczeń")
         self.log("info", "Integrowanie oświadczeń")
-
         try:
-            # Create inconsistency callback to log issues found during integration
             inconsistency_callback = self._create_inconsistency_callback()
-
-            # Pass None for missing_publication_callback - publications already downloaded
-            # Multi-hosted (Track 7a): integrujemy TYLKO oświadczenia uczelni
-            # kontekstu importu (institutionId == uczelnia.pbn_uid). ``uczelnia``
-            # to lokalna, zweryfikowana (ma pbn_uid) Uczelnia z
-            # _setup_uczelnia_and_jednostka powyżej.
             integruj_oswiadczenia_z_instytucji(
                 missing_publication_callback=None,
                 inconsistency_callback=inconsistency_callback,
                 default_jednostka=default_jednostka,
                 uczelnia=uczelnia,
             )
-
-            # Log inconsistency summary
             inconsistency_count = self.session.inconsistencies.count()
             if inconsistency_count > 0:
                 self.log(
@@ -157,20 +146,15 @@ class StatementImporter(ImportStepBase):
                     f"Znaleziono {inconsistency_count} nieścisłości podczas "
                     f"integracji oświadczeń",
                 )
-
-            # Update statistics
             if hasattr(self.session, "statistics"):
                 stats = self.session.statistics
                 stats.statements_imported += 1
                 stats.save()
-
             self.log("success", "Oświadczenia zintegrowane pomyślnie")
-
         except Exception as e:
             self.handle_error(e, "Nie udało się zintegrować oświadczeń")
 
-        self.update_progress(3, 3, "Zakończono import oświadczeń")
-
+        self.update_progress(2, 2, "Zakończono import oświadczeń")
         return {"statements_imported": True, "error_count": len(self.errors)}
 
     def _download_missing_publications(self, default_jednostka):

--- a/src/pbn_import/utils/step_definitions.py
+++ b/src/pbn_import/utils/step_definitions.py
@@ -1,4 +1,4 @@
-"""PBN import step definitions and configuration"""
+"""PBN import step definitions and configuration (model faz)."""
 
 from .author_import import AuthorImporter
 from .conference_import import ConferenceImporter
@@ -11,158 +11,221 @@ from .source_import import SourceImporter
 from .source_scoring_import import SourceScoringImporter
 from .statement_import import StatementImporter
 
-# All possible import steps with their configuration
-# This is the single source of truth for import steps
+
+def _split(entity, label):
+    """Zbuduj dwie fazy (download/process) dla rozdzielanej encji."""
+    return [
+        {
+            "phase": "download",
+            "method": "download",
+            "form_field": f"{entity}_download",
+            "disable_key": f"disable_{entity}_download",
+            "display": f"{label} — pobieranie",
+            "column": "download",
+            "legacy_key": f"disable_{entity}",
+        },
+        {
+            "phase": "process",
+            "method": "process",
+            "form_field": f"{entity}_process",
+            "disable_key": f"disable_{entity}_process",
+            "display": f"{label} — przetwarzanie",
+            "column": "process",
+            "legacy_key": f"disable_{entity}",
+        },
+    ]
+
+
+def _single(form_field, label, column):
+    """Zbuduj pojedynczą fazę dla kroku niepodzielnego/jednofazowego."""
+    return [
+        {
+            "phase": "single",
+            "method": "run",
+            "form_field": form_field,
+            "disable_key": f"disable_{form_field}",
+            "display": label,
+            "column": column,
+            "legacy_key": None,
+        }
+    ]
+
+
+# Pojedyncze źródło prawdy o krokach importu.
 ALL_STEP_DEFINITIONS = [
     {
         "name": "initial_setup",
         "display": "Konfiguracja początkowa",
         "class": InitialSetup,
-        "disable_key": "disable_initial",
-        "form_field": "initial",
         "icon": "fi-wrench",
         "required": True,
         "show_in_form": True,
+        "phases": _single("initial", "Konfiguracja początkowa", "both"),
     },
     {
         "name": "institution_setup",
         "display": "Konfiguracja jednostek",
         "class": InstitutionImporter,
-        "disable_key": "disable_institutions",
-        "form_field": "institutions",
         "icon": "fi-home",
         "required": True,
         "show_in_form": True,
+        "phases": _single("institutions", "Konfiguracja jednostek", "both"),
     },
     {
         "name": "source_import",
-        "display": "Import źródeł",
+        "display": "Źródła",
         "class": SourceImporter,
-        "disable_key": "disable_zrodla",
-        "form_field": "zrodla",
         "icon": "fi-book",
         "required": False,
         "show_in_form": True,
+        "phases": _split("zrodla", "Źródła"),
     },
     {
         "name": "source_scoring_import",
-        "display": "Synchronizacja punktów i dyscyplin źródeł",
+        "display": "Punktacja i dyscypliny źródeł",
         "class": SourceScoringImporter,
-        "disable_key": "disable_punktacja_zrodel",
-        "form_field": "punktacja_zrodel",
         "icon": "fi-graph-bar",
         "required": False,
         "show_in_form": True,
+        "phases": _single(
+            "punktacja_zrodel", "Synchronizacja punktów i dyscyplin źródeł", "process"
+        ),
     },
     {
         "name": "publisher_import",
-        "display": "Import wydawców",
+        "display": "Wydawcy",
         "class": PublisherImporter,
-        "disable_key": "disable_wydawcy",
-        "form_field": "wydawcy",
         "icon": "fi-page-multiple",
         "required": False,
         "show_in_form": True,
+        "phases": _split("wydawcy", "Wydawcy"),
     },
     {
         "name": "conference_import",
-        "display": "Import konferencji",
+        "display": "Konferencje",
         "class": ConferenceImporter,
-        "disable_key": "disable_konferencje",
-        "form_field": "konferencje",
         "icon": "fi-calendar",
         "required": False,
         "show_in_form": True,
+        "phases": _split("konferencje", "Konferencje"),
     },
     {
         "name": "author_import",
-        "display": "Import autorów",
+        "display": "Autorzy",
         "class": AuthorImporter,
-        "disable_key": "disable_autorzy",
-        "form_field": "autorzy",
         "icon": "fi-torsos-all",
         "required": False,
         "show_in_form": True,
+        "phases": _split("autorzy", "Autorzy"),
     },
     {
         "name": "publication_import",
-        "display": "Import publikacji",
+        "display": "Publikacje",
         "class": PublicationImporter,
-        "disable_key": "disable_publikacje",
-        "form_field": "publikacje",
         "icon": "fi-page-copy",
         "required": False,
         "show_in_form": True,
+        "phases": _split("publikacje", "Publikacje"),
     },
     {
         "name": "statement_import",
-        "display": "Import oświadczeń",
+        "display": "Oświadczenia",
         "class": StatementImporter,
-        "disable_key": "disable_oswiadczenia",
-        "form_field": "oswiadczenia",
         "icon": "fi-clipboard-pencil",
         "required": False,
         "show_in_form": True,
+        "phases": _split("oswiadczenia", "Oświadczenia"),
     },
     {
         "name": "fee_import",
-        "display": "Import opłat",
+        "display": "Opłaty",
         "class": FeeImporter,
-        "disable_key": "disable_oplaty",
-        "form_field": "oplaty",
         "icon": "fi-dollar",
         "required": False,
         "show_in_form": True,
+        "phases": _single("oplaty", "Import opłat", "both"),
     },
 ]
 
-# Legacy STEP_ICONS dict for backwards compatibility
 STEP_ICONS = {step["name"]: step["icon"] for step in ALL_STEP_DEFINITIONS}
 
 
-def get_form_steps():
-    """Get import steps formatted for form display.
+def _iter_phases():
+    """Iteruj (step_def, phase_def) dla wszystkich kroków pokazywanych w formie."""
+    for step in ALL_STEP_DEFINITIONS:
+        if not step.get("show_in_form", True):
+            continue
+        for phase in step["phases"]:
+            yield step, phase
 
-    Returns list of dicts with:
-    - form_field: name for form checkbox
-    - display: Polish label
-    - icon: Foundation icon class
-    - required: whether step is required
+
+def _phase_disabled(config, phase):
+    """Czy faza wyłączona? granular > legacy > domyślnie włączona."""
+    if phase["disable_key"] in config:
+        return bool(config[phase["disable_key"]])
+    legacy = phase.get("legacy_key")
+    if legacy and legacy in config:
+        return bool(config[legacy])
+    return False
+
+
+def get_form_steps():
+    """Wiersze formularza: encja + komórki download/process/single.
+
+    Dla kroków podzielonych (split): komórki "download" i "process".
+    Dla kroków jednofazowych (single): komórka wyznaczona przez pole "column":
+      - "both"    → "single"
+      - "process" → "process"
+      - "download"→ "download"
     """
-    return [
-        {
-            "form_field": step["form_field"],
+    rows = []
+    for step in ALL_STEP_DEFINITIONS:
+        if not step.get("show_in_form", True):
+            continue
+        row = {
+            "name": step["name"],
             "display": step["display"],
             "icon": step["icon"],
             "required": step["required"],
+            "download": None,
+            "process": None,
+            "single": None,
         }
-        for step in ALL_STEP_DEFINITIONS
-        if step.get("show_in_form", True)
-    ]
+        for phase in step["phases"]:
+            cell = {"form_field": phase["form_field"], "display": phase["display"]}
+            if phase["phase"] == "single":
+                column = phase.get("column", "both")
+                target = column if column in ("download", "process") else "single"
+                row[target] = cell
+            else:
+                row[phase["phase"]] = cell
+        rows.append(row)
+    return rows
 
 
 def get_command_steps():
-    """Get import steps formatted for management command.
+    """Pary (form_field, display) dla CLI — jedna na fazę."""
+    return [(phase["form_field"], phase["display"]) for _, phase in _iter_phases()]
 
-    Returns list of tuples (form_field, display) for building CLI arguments.
-    """
-    return [
-        (step["form_field"], step["display"])
-        for step in ALL_STEP_DEFINITIONS
-        if step.get("show_in_form", True)
-    ]
+
+def get_legacy_command_aliases():
+    """Mapa legacy form_field → lista granularnych disable_key (dla CLI alias)."""
+    aliases = {}
+    for step in ALL_STEP_DEFINITIONS:
+        phases = step["phases"]
+        if len(phases) == 2:  # krok rozdzielany
+            entity = phases[0]["form_field"].rsplit("_", 1)[0]
+            aliases[entity] = [p["disable_key"] for p in phases]
+    return aliases
 
 
 def get_all_disable_keys():
-    """Get all disable_key values from step definitions.
-
-    Returns dict mapping form_field to disable_key.
-    """
-    return {step["form_field"]: step["disable_key"] for step in ALL_STEP_DEFINITIONS}
+    """Mapa form_field → disable_key (granularna, wszystkie fazy)."""
+    return {phase["form_field"]: phase["disable_key"] for _, phase in _iter_phases()}
 
 
 def _get_step_args(step_name, config):
-    """Get dynamic args for a specific step based on config"""
+    """Dynamiczne argumenty konstruktora kroku na podstawie config."""
     if step_name == "institution_setup":
         return {
             "wydzial_domyslny": config.get("wydzial_domyslny", "Wydział Domyślny"),
@@ -174,20 +237,33 @@ def _get_step_args(step_name, config):
 
 
 def get_step_definitions(config):
-    """Get list of import step definitions based on config"""
-    return [
-        {
-            "name": step_def["name"],
-            "display": step_def["display"],
-            "class": step_def["class"],
-            "required": step_def["required"],
-            "args": _get_step_args(step_def["name"], config),
-        }
-        for step_def in ALL_STEP_DEFINITIONS
-        if not config.get(step_def["disable_key"])
-    ]
+    """Płaska, uporządkowana lista faz do wykonania (po odfiltrowaniu)."""
+    result = []
+    for step in ALL_STEP_DEFINITIONS:
+        for phase in step["phases"]:
+            if _phase_disabled(config, phase):
+                continue
+            phase_name = phase["phase"]
+            result_key = (
+                step["name"]
+                if phase_name == "single"
+                else f"{step['name']}:{phase_name}"
+            )
+            result.append(
+                {
+                    "name": step["name"],
+                    "phase": phase_name,
+                    "display": phase["display"],
+                    "class": step["class"],
+                    "method": phase["method"],
+                    "required": step["required"],
+                    "args": _get_step_args(step["name"], config),
+                    "result_key": result_key,
+                }
+            )
+    return result
 
 
 def get_icon_for_step(step_name):
-    """Get Foundation icon class for step"""
+    """Zwróć klasę ikony Foundation dla kroku."""
     return STEP_ICONS.get(step_name, "fi-download")

--- a/src/pbn_import/views.py
+++ b/src/pbn_import/views.py
@@ -452,11 +452,14 @@ class ImportPresetsView(LoginRequiredMixin, ImportPermissionMixin, View):
                 "config": {
                     "disable_initial": True,
                     "disable_institutions": True,
-                    "disable_zrodla": True,
+                    "disable_zrodla_download": True,
+                    "disable_zrodla_process": True,
                     "disable_punktacja_zrodel": True,
-                    "disable_wydawcy": True,
-                    "disable_konferencje": True,
-                    # autorzy, publikacje, oswiadczenia, oplaty remain enabled
+                    "disable_wydawcy_download": True,
+                    "disable_wydawcy_process": True,
+                    "disable_konferencje_download": True,
+                    "disable_konferencje_process": True,
+                    # autorzy, publikacje, oswiadczenia, oplaty pozostają włączone
                     "delete_existing": False,
                 },
             },
@@ -467,7 +470,8 @@ class ImportPresetsView(LoginRequiredMixin, ImportPermissionMixin, View):
                 "icon": "fi-book",
                 "config": {
                     **all_disabled,
-                    "disable_zrodla": False,
+                    "disable_zrodla_download": False,
+                    "disable_zrodla_process": False,
                     "disable_punktacja_zrodel": False,
                     "delete_existing": False,
                 },

--- a/src/pbn_integrator/tests/test_integruj_konferencje.py
+++ b/src/pbn_integrator/tests/test_integruj_konferencje.py
@@ -95,3 +95,23 @@ def test_pomija_rekord_bez_nazwy():
     _make_conference("c5", {"startDate": "2020-01-01"})
     assert integruj_konferencje() == 0
     assert Konferencja.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_przycina_zbyt_dlugie_pola():
+    _make_conference(
+        "c6",
+        {
+            "fullName": "x" * 600,
+            "abbreviation": "y" * 300,
+            "city": "z" * 150,
+            "country": "w" * 150,
+            "startDate": "2020-01-01",
+        },
+    )
+    assert integruj_konferencje() == 1
+    k = Konferencja.objects.get(pbn_uid_id="c6")
+    assert len(k.nazwa) == 512
+    assert len(k.skrocona_nazwa) == 250
+    assert len(k.miasto) == 100
+    assert len(k.panstwo) == 100

--- a/src/pbn_integrator/tests/test_integruj_konferencje.py
+++ b/src/pbn_integrator/tests/test_integruj_konferencje.py
@@ -1,0 +1,97 @@
+"""Testy integracji konferencji PBN → BPP."""
+
+import datetime
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Konferencja
+from pbn_api.models import Conference
+from pbn_integrator.utils import integruj_konferencje
+
+
+def _make_conference(mongo_id, obj):
+    """Utwórz lustro Conference z podanym JSON-em 'object'."""
+    return baker.make(
+        Conference,
+        mongoId=mongo_id,
+        versions=[{"current": True, "object": obj}],
+        status="ACTIVE",
+    )
+
+
+@pytest.mark.django_db
+def test_tworzy_konferencje_z_lustra():
+    _make_conference(
+        "c1",
+        {
+            "fullName": "Międzynarodowa Konferencja XYZ",
+            "startDate": "2023-09-01",
+            "endDate": "2023-09-03",
+            "city": "Kraków",
+            "country": "Polska",
+            "abbreviation": "MKXYZ",
+        },
+    )
+
+    liczba = integruj_konferencje()
+
+    assert liczba == 1
+    k = Konferencja.objects.get()
+    assert k.nazwa == "Międzynarodowa Konferencja XYZ"
+    assert k.rozpoczecie == datetime.date(2023, 9, 1)
+    assert k.zakonczenie == datetime.date(2023, 9, 3)
+    assert k.miasto == "Kraków"
+    assert k.panstwo == "Polska"
+    assert k.skrocona_nazwa == "MKXYZ"
+    assert k.pbn_uid_id == "c1"
+
+
+@pytest.mark.django_db
+def test_idempotentne_po_pbn_uid():
+    _make_conference("c1", {"fullName": "Konf A", "startDate": "2022-01-01"})
+    integruj_konferencje()
+    integruj_konferencje()
+    assert Konferencja.objects.filter(pbn_uid_id="c1").count() == 1
+
+
+@pytest.mark.django_db
+def test_dowiazuje_istniejaca_po_nazwie_i_dacie():
+    Konferencja.objects.create(nazwa="Konf B", rozpoczecie=datetime.date(2021, 5, 5))
+    _make_conference(
+        "c2", {"fullName": "Konf B", "startDate": "2021-05-05", "city": "Łódź"}
+    )
+
+    integruj_konferencje()
+
+    assert Konferencja.objects.count() == 1
+    k = Konferencja.objects.get()
+    assert k.pbn_uid_id == "c2"
+    assert k.miasto == "Łódź"
+
+
+@pytest.mark.django_db
+def test_pomija_status_deleted():
+    baker.make(
+        Conference,
+        mongoId="c3",
+        versions=[{"current": True, "object": {"fullName": "Konf C"}}],
+        status="DELETED",
+    )
+    assert integruj_konferencje() == 0
+    assert Konferencja.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_zla_data_daje_none_bez_bledu():
+    _make_conference("c4", {"fullName": "Konf D", "startDate": "niepoprawna-data"})
+    assert integruj_konferencje() == 1
+    k = Konferencja.objects.get(pbn_uid_id="c4")
+    assert k.rozpoczecie is None
+
+
+@pytest.mark.django_db
+def test_pomija_rekord_bez_nazwy():
+    _make_conference("c5", {"startDate": "2020-01-01"})
+    assert integruj_konferencje() == 0
+    assert Konferencja.objects.count() == 0

--- a/src/pbn_integrator/utils/__init__.py
+++ b/src/pbn_integrator/utils/__init__.py
@@ -35,7 +35,10 @@ from pbn_integrator.utils.cleanup import (  # noqa
 )
 
 # Conferences
-from pbn_integrator.utils.conferences import pobierz_konferencje  # noqa
+from pbn_integrator.utils.conferences import (  # noqa
+    integruj_konferencje,
+    pobierz_konferencje,
+)
 
 # Constants
 from pbn_integrator.utils.constants import (  # noqa
@@ -230,6 +233,7 @@ __all__ = [
     "pobierz_instytucje",
     "pobierz_instytucje_polon",
     # Conferences
+    "integruj_konferencje",
     "pobierz_konferencje",
     # Journals
     "ZrodlaGetter",

--- a/src/pbn_integrator/utils/conferences.py
+++ b/src/pbn_integrator/utils/conferences.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import datetime
+import logging
 from typing import TYPE_CHECKING
 
+from django.db import IntegrityError, transaction
+
+from bpp.models import Konferencja
 from pbn_api.models import Conference
 from pbn_integrator.utils.mongodb_ops import pobierz_mongodb
 
 if TYPE_CHECKING:
     from pbn_api.client import PBNClient
+
+logger = logging.getLogger("pbn_integrator")
 
 
 def pobierz_konferencje(client: PBNClient, callback=None):
@@ -24,3 +31,82 @@ def pobierz_konferencje(client: PBNClient, callback=None):
         pbar_label="Pobieranie konferencji",
         callback=callback,
     )
+
+
+def _parse_pbn_date(value):
+    """Sparsuj 'YYYY-MM-DD' na date; None gdy brak/niepoprawne."""
+    if not value:
+        return None
+    try:
+        return datetime.date.fromisoformat(str(value)[:10])
+    except (ValueError, TypeError):
+        logger.debug("Niepoprawna data konferencji PBN: %r", value)
+        return None
+
+
+def integruj_konferencje(callback=None):
+    """Integruj lustro pbn_api.Conference → bpp.Konferencja.
+
+    Re-entrant: dopasowuje po pbn_uid, potem po (nazwa, rozpoczecie).
+    Aktualizuje pola pochodzące z PBN; nie nadpisuje pól, których PBN nie
+    dostarcza (typ_konferencji, bazy indeksujące). Zwraca liczbę
+    utworzonych/zaktualizowanych konferencji.
+
+    WAŻNE: czytamy przez ``value_or_none``, bo gołe ``value("object", k)``
+    zwraca STRING-sentinel ``"[brak k]"`` przy braku klucza (base.py:81-88).
+    """
+    qs = Conference.objects.all()
+    total = qs.count()
+    przetworzone = 0
+
+    for i, conf in enumerate(qs.iterator(), 1):
+        if callback is not None:
+            callback.update(i, total, "Integracja konferencji")
+
+        if conf.status == "DELETED":
+            logger.info("Pomijam usuniętą konferencję PBN %s", conf.mongoId)
+            continue
+
+        nazwa = conf.value_or_none("object", "fullName")
+        if not nazwa:
+            logger.info("Pomijam konferencję PBN %s bez nazwy", conf.mongoId)
+            continue
+
+        rozpoczecie = _parse_pbn_date(conf.value_or_none("object", "startDate"))
+        zakonczenie = _parse_pbn_date(conf.value_or_none("object", "endDate"))
+        miasto = conf.value_or_none("object", "city")
+        panstwo = conf.value_or_none("object", "country")
+        skrot = conf.value_or_none("object", "abbreviation")
+
+        konferencja = Konferencja.objects.filter(pbn_uid_id=conf.pk).first()
+        if konferencja is None:
+            konferencja = Konferencja.objects.filter(
+                nazwa=nazwa, rozpoczecie=rozpoczecie
+            ).first()
+
+        if konferencja is None:
+            konferencja = Konferencja(nazwa=nazwa, rozpoczecie=rozpoczecie)
+
+        konferencja.pbn_uid_id = conf.pk
+        konferencja.nazwa = nazwa
+        konferencja.rozpoczecie = rozpoczecie
+        konferencja.zakonczenie = zakonczenie
+        konferencja.miasto = miasto
+        konferencja.panstwo = panstwo
+        if skrot:
+            konferencja.skrocona_nazwa = skrot
+
+        try:
+            with transaction.atomic():
+                konferencja.save()
+            przetworzone += 1
+        except IntegrityError:
+            logger.warning(
+                "Konflikt unikalności (nazwa, rozpoczecie) dla konferencji PBN "
+                "%s (%r, %r) — pomijam",
+                conf.mongoId,
+                nazwa,
+                rozpoczecie,
+            )
+
+    return przetworzone

--- a/src/pbn_integrator/utils/conferences.py
+++ b/src/pbn_integrator/utils/conferences.py
@@ -44,6 +44,13 @@ def _parse_pbn_date(value):
         return None
 
 
+def _truncate(value, max_length):
+    """Przytnij string do limitu pola modelu; None zostaje None."""
+    if value is None:
+        return None
+    return str(value)[:max_length]
+
+
 def integruj_konferencje(callback=None):
     """Integruj lustro pbn_api.Conference → bpp.Konferencja.
 
@@ -63,16 +70,16 @@ def integruj_konferencje(callback=None):
         if callback is not None:
             callback.update(i, total, "Integracja konferencji")
 
-        nazwa = conf.value_or_none("object", "fullName")
+        nazwa = _truncate(conf.value_or_none("object", "fullName"), 512)
         if not nazwa:
             logger.info("Pomijam konferencję PBN %s bez nazwy", conf.mongoId)
             continue
 
         rozpoczecie = _parse_pbn_date(conf.value_or_none("object", "startDate"))
         zakonczenie = _parse_pbn_date(conf.value_or_none("object", "endDate"))
-        miasto = conf.value_or_none("object", "city")
-        panstwo = conf.value_or_none("object", "country")
-        skrot = conf.value_or_none("object", "abbreviation")
+        miasto = _truncate(conf.value_or_none("object", "city"), 100)
+        panstwo = _truncate(conf.value_or_none("object", "country"), 100)
+        skrot = _truncate(conf.value_or_none("object", "abbreviation"), 250)
 
         konferencja = Konferencja.objects.filter(pbn_uid_id=conf.pk).first()
         if konferencja is None:

--- a/src/pbn_integrator/utils/conferences.py
+++ b/src/pbn_integrator/utils/conferences.py
@@ -55,17 +55,13 @@ def integruj_konferencje(callback=None):
     WAŻNE: czytamy przez ``value_or_none``, bo gołe ``value("object", k)``
     zwraca STRING-sentinel ``"[brak k]"`` przy braku klucza (base.py:81-88).
     """
-    qs = Conference.objects.all()
+    qs = Conference.objects.exclude(status="DELETED")
     total = qs.count()
     przetworzone = 0
 
     for i, conf in enumerate(qs.iterator(), 1):
         if callback is not None:
             callback.update(i, total, "Integracja konferencji")
-
-        if conf.status == "DELETED":
-            logger.info("Pomijam usuniętą konferencję PBN %s", conf.mongoId)
-            continue
 
         nazwa = conf.value_or_none("object", "fullName")
         if not nazwa:
@@ -80,6 +76,10 @@ def integruj_konferencje(callback=None):
 
         konferencja = Konferencja.objects.filter(pbn_uid_id=conf.pk).first()
         if konferencja is None:
+            # Uwaga: przy rozpoczecie=None i dwóch konferencjach PBN o tej samej
+            # nazwie bez daty zadziała "last-writer-wins" na pbn_uid (NULL=NULL w
+            # filtrze to IS NULL i dopasuje istniejący rekord). Zdarzenie skrajnie
+            # rzadkie; konflikt na (nazwa, rozpoczecie) i tak łapie IntegrityError.
             konferencja = Konferencja.objects.filter(
                 nazwa=nazwa, rozpoczecie=rozpoczecie
             ).first()
@@ -91,6 +91,8 @@ def integruj_konferencje(callback=None):
         konferencja.nazwa = nazwa
         konferencja.rozpoczecie = rozpoczecie
         konferencja.zakonczenie = zakonczenie
+        # Pola mirror-fidelity: nadpisujemy też None (gdy PBN przestał je
+        # dostarczać). Inaczej skrocona_nazwa, która jest guardowana niżej.
         konferencja.miasto = miasto
         konferencja.panstwo = panstwo
         if skrot:


### PR DESCRIPTION
## Cel

Rozbicie kroków importu PBN (`src/pbn_import`) na dwie **niezależnie uruchamiane fazy**: **pobieranie** (PBN → tabele-lustra `pbn_api.*`) i **przetwarzanie/integracja** (lustro → modele `bpp.*`). Można teraz uruchomić samo pobieranie, samo przetwarzanie albo oba — niezależnie per encja.

## Co się zmienia

- **`ImportStepBase`**: nowe metody `download()` / `process()`, `run()` = obie po kolei, `__call__(method=…)` z walidacją.
- **6 importerów rozdzielonych** (download/process): Źródła, Wydawcy, Konferencje, Autorzy, Publikacje, Oświadczenia. Każdy `process()` ostrzega miękko przy pustym lustrze i kontynuuje.
- **Nowa integracja konferencji** `integruj_konferencje()` — wcześniej konferencje były tylko pobierane do lustra, nigdy nie trafiały do `bpp.Konferencja`. Idempotentna (po `pbn_uid`, potem `(nazwa, rozpoczecie)`), odporna (`value_or_none`, savepoint+`IntegrityError`, przycinanie zbyt długich pól).
- **Model faz w `step_definitions.py`** + resolver zgodności wstecznej: stary klucz `disable_<encja>` wyłącza obie fazy; nowe klucze granularne (`disable_<encja>_download/_process`) nadpisują. Bez migracji DB (JSONField).
- **`ImportManager`** wykonuje fazy per-metoda, `results` kluczowane po `result_key` (`encja:faza`).
- **Formularz**: dwukolumnowa tabela (Pobieranie | Przetwarzanie); kroki niepodzielne (initial/institution/opłaty) na pełną szerokość; punktacja źródeł tylko w kolumnie przetwarzania.
- **CLI**: granularne flagi `--disable-<encja>-<faza>` + legacy aliasy `--disable-<encja>` (obie fazy).
- **Presety** przepisane na klucze granularne (legacy + `**all_disabled` dawałyby zły wynik przez resolver).

Kroki niepodzielne świadomie zostają bez zmian: `initial_setup`/`institution_setup` (setup), `fee_import` (pobiera i zapisuje w jednej pętli — nierozdzielalne), `source_scoring_import` (process-only na cache).

## Zgodność wsteczna

Stare sesje, presety i skrypty CLI (`disable_zrodla` itd.) działają bez zmian — resolver tłumaczy legacy na obie fazy. Brak migracji bazy.

## Dokumentacja

- Spec: `docs/superpowers/specs/2026-06-07-pbn-import-rozdzielenie-pobierania-od-przetwarzania-design.md`
- Plan: `docs/superpowers/plans/2026-06-07-pbn-import-rozdziel-pobieranie.md`

## Testy

- 487 testów zielonych w `src/pbn_import/` + `src/pbn_integrator/` lokalnie.
- TDD: każdy z 15 tasków z testami; review spec + jakość per task; finalny review całości.
- Nowe pliki testów: split per importer, `integruj_konferencje`, model faz, manager per faza, CLI granular/legacy, presety granularne.

## Plan testów (do weryfikacji)

- [ ] CI: `Build test-runner image` + `Tests (sharded)` zielone
- [ ] Ręcznie: nowy import z zaznaczonym tylko „Pobieranie" dla Źródeł → lustro `Journal` pełne, `Zrodlo` nietknięte; potem tylko „Przetwarzanie" → źródła w BPP
- [ ] Stary preset / `--disable-zrodla` nadal pomija oba podkroki

🤖 Generated with [Claude Code](https://claude.com/claude-code)