### PR TITLE
[codex] Improve weighted publication fulltext search

### DIFF
--- a/src/bpp/migrations/0428_weighted_publication_fulltext.py
+++ b/src/bpp/migrations/0428_weighted_publication_fulltext.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from django.db import connection, migrations
+
+
+def load_sql(apps, schema_editor):
+    sql_file = Path(__file__).parent / "0428_weighted_publication_fulltext.sql"
+    with open(sql_file) as f:
+        sql = f.read()
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0427_merge_20260604_1838"),
+    ]
+
+    operations = [
+        migrations.RunPython(load_sql, migrations.RunPython.noop),
+    ]

--- a/src/bpp/migrations/0428_weighted_publication_fulltext.sql
+++ b/src/bpp/migrations/0428_weighted_publication_fulltext.sql
@@ -1,0 +1,162 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION bpp_publication_weighted_search_vector(
+    p_tytul_oryginalny TEXT,
+    p_tytul TEXT,
+    p_autorzy TEXT,
+    p_rok INTEGER,
+    p_doi TEXT,
+    p_opis_bibliograficzny TEXT
+) RETURNS tsvector AS $$
+    SELECT
+        setweight(
+            to_tsvector(
+                'bpp_nazwy_wlasne',
+                strip_tags(COALESCE(p_tytul_oryginalny, ''))
+            ),
+            'A'
+        ) ||
+        setweight(
+            to_tsvector(
+                'bpp_nazwy_wlasne',
+                strip_tags(COALESCE(p_tytul, ''))
+            ),
+            'A'
+        ) ||
+        setweight(
+            to_tsvector(
+                'bpp_nazwy_wlasne',
+                strip_tags(COALESCE(p_autorzy, ''))
+            ),
+            'B'
+        ) ||
+        setweight(
+            to_tsvector(
+                'bpp_nazwy_wlasne',
+                COALESCE(p_doi, '') || ' ' ||
+                regexp_replace(COALESCE(p_doi, ''), '[^[:alnum:]]+', '', 'g')
+            ),
+            'B'
+        ) ||
+        setweight(
+            to_tsvector('bpp_nazwy_wlasne', COALESCE(p_rok::TEXT, '')),
+            'C'
+        ) ||
+        setweight(
+            to_tsvector(
+                'bpp_nazwy_wlasne',
+                strip_tags(COALESCE(p_opis_bibliograficzny, ''))
+            ),
+            'D'
+        );
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION bpp_publication_author_search_text(
+    p_zapisani_autorzy TEXT,
+    p_autorzy TEXT[]
+) RETURNS TEXT AS $$
+    SELECT concat_ws(' ', p_zapisani_autorzy, array_to_string(p_autorzy, ' '));
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION ts_post_bpp_wydawnictwo_ciagle_search()
+RETURNS trigger AS $$
+BEGIN
+    NEW.search_index := bpp_publication_weighted_search_vector(
+        NEW.tytul_oryginalny,
+        NEW.tytul,
+        bpp_publication_author_search_text(
+            NEW.opis_bibliograficzny_zapisani_autorzy_cache,
+            NEW.opis_bibliograficzny_autorzy_cache
+        ),
+        NEW.rok,
+        NEW.doi,
+        NEW.opis_bibliograficzny_cache
+    );
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ts_post_bpp_wydawnictwo_zwarte_search()
+RETURNS trigger AS $$
+BEGIN
+    NEW.search_index := bpp_publication_weighted_search_vector(
+        NEW.tytul_oryginalny,
+        NEW.tytul,
+        bpp_publication_author_search_text(
+            NEW.opis_bibliograficzny_zapisani_autorzy_cache,
+            NEW.opis_bibliograficzny_autorzy_cache
+        ),
+        NEW.rok,
+        NEW.doi,
+        NEW.opis_bibliograficzny_cache
+    );
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ts_post_bpp_praca_doktorska_search()
+RETURNS trigger AS $$
+BEGIN
+    NEW.search_index := bpp_publication_weighted_search_vector(
+        NEW.tytul_oryginalny,
+        NEW.tytul,
+        bpp_publication_author_search_text(
+            NEW.opis_bibliograficzny_zapisani_autorzy_cache,
+            NEW.opis_bibliograficzny_autorzy_cache
+        ),
+        NEW.rok,
+        NEW.doi,
+        NEW.opis_bibliograficzny_cache
+    );
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ts_post_bpp_praca_habilitacyjna_search()
+RETURNS trigger AS $$
+BEGIN
+    NEW.search_index := bpp_publication_weighted_search_vector(
+        NEW.tytul_oryginalny,
+        NEW.tytul,
+        bpp_publication_author_search_text(
+            NEW.opis_bibliograficzny_zapisani_autorzy_cache,
+            NEW.opis_bibliograficzny_autorzy_cache
+        ),
+        NEW.rok,
+        NEW.doi,
+        NEW.opis_bibliograficzny_cache
+    );
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ts_post_bpp_patent_search()
+RETURNS trigger AS $$
+BEGIN
+    NEW.search_index := bpp_publication_weighted_search_vector(
+        NEW.tytul_oryginalny,
+        NULL,
+        bpp_publication_author_search_text(
+            NEW.opis_bibliograficzny_zapisani_autorzy_cache,
+            NEW.opis_bibliograficzny_autorzy_cache
+        ),
+        NEW.rok,
+        NULL,
+        NEW.opis_bibliograficzny_cache
+    );
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+UPDATE bpp_wydawnictwo_ciagle SET id = id;
+UPDATE bpp_wydawnictwo_zwarte SET id = id;
+UPDATE bpp_praca_doktorska SET id = id;
+UPDATE bpp_praca_habilitacyjna SET id = id;
+UPDATE bpp_patent SET id = id;
+
+COMMIT;

--- a/src/bpp/newsfragments/+weighted-publication-fulltext.feature.rst
+++ b/src/bpp/newsfragments/+weighted-publication-fulltext.feature.rst
@@ -1,0 +1,2 @@
+Ulepszono pełnotekstowe wyszukiwanie publikacji przez ważenie tytułów,
+autorów, DOI, roku oraz opisu bibliograficznego w cache'owanym indeksie.

--- a/src/bpp/tests/test_fulltext_search.py
+++ b/src/bpp/tests/test_fulltext_search.py
@@ -1,8 +1,9 @@
 import pytest
 from django.urls.base import reverse
-
 from django.utils.http import urlencode
+from model_bakery import baker
 
+from bpp.models import Rekord, Wydawnictwo_Ciagle
 from bpp.models.autor import Autor
 
 
@@ -28,6 +29,40 @@ def test_tokenizer_minus(wydawnictwo_zwarte, client):
 def test_fulltext_search_mixin(autor_jan_kowalski):
     res = Autor.objects.fulltext_filter("kowalski jan")
     assert autor_jan_kowalski in res
+
+
+@pytest.mark.django_db
+def test_publication_fulltext_search_uses_weighted_cached_fields(
+    autor_jan_kowalski, jednostka
+):
+    publication = baker.make(
+        Wydawnictwo_Ciagle,
+        tytul_oryginalny="Neurokognitywny atlas markerowy",
+        tytul="Neurocognitive marker atlas",
+        rok=2031,
+        doi="10.1234/BPP.FULLTEXT-ATLAS",
+        szczegoly="Opis zawiera fraze neurodetektor",
+    )
+    publication.dodaj_autora(
+        autor_jan_kowalski,
+        jednostka,
+        zapisany_jako="Kowalski Jan",
+    )
+
+    Rekord.objects.full_refresh()
+    record = Rekord.objects.get_for_model(publication)
+
+    queries = [
+        "Neurokognitywny",
+        "Neurokognitywny Kowalski",
+        "Neurokognitywny 2031",
+        "10.1234/BPP.FULLTEXT-ATLAS",
+        "101234BPPFULLTEXTATLAS",
+        "neurodetektor",
+    ]
+
+    for query in queries:
+        assert record in Rekord.objects.fulltext_filter(query)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- Add a SQL migration that builds weighted fulltext vectors for publication records.
- Include titles, author cache, DOI plus normalized DOI, year, and bibliographic description in the cached search index.
- Add regression coverage for publication fulltext queries across those cached fields.
- Add a towncrier feature fragment.

## Tests

- `uv run pytest src/bpp/tests/test_fulltext_search.py -q`