### PR TITLE
fix(browse): rekord nie wysadza się, gdy autorzy nadrzędnego z PBN to dict UID→dane

### DIFF
--- a/src/bpp/templates/browse/praca_tabela_mono.html
+++ b/src/bpp/templates/browse/praca_tabela_mono.html
@@ -151,7 +151,7 @@
                                         /
                                         {% for typ, lista in praca.wydawnictwo_nadrzedne_w_pbn.autorzy.items %}
                                             {% for autor in lista %}
-                                                {{ autor.lastName }} {{ autor.firstName|default:autor.givenNames|default:"" }}{% if not forloop.last %}, {% endif %}
+                                                {{ autor.lastName }} {{ autor.firstName }}{% if not forloop.last %}, {% endif %}
                                             {% endfor %}
                                             {% if not forloop.last %}, {% endif %}
                                         {% endfor %}

--- a/src/pbn_api/models/publication.py
+++ b/src/pbn_api/models/publication.py
@@ -86,13 +86,44 @@ class Publication(LinkDoPBNMixin, BasePBNMongoDBModel):
             ret += len(self.autorzy[elem])
         return ret
 
+    @staticmethod
+    def _normalizuj_autora(autor):
+        """Sprowadza pojedynczego autora z PBN do ``{lastName, firstName}``.
+
+        PBN podaje imię raz jako ``firstName``, raz jako ``givenNames``,
+        a w danych zaciągniętych z API instytucji jako ``name``. Czasem
+        zamiast słownika dostajemy goły UID (string) — wtedy nie mamy
+        danych osobowych i zwracamy puste pola (zamiast wysadzać szablon).
+        """
+        if not isinstance(autor, dict):
+            return {"lastName": "", "firstName": ""}
+        return {
+            "lastName": autor.get("lastName") or "",
+            "firstName": (
+                autor.get("firstName")
+                or autor.get("givenNames")
+                or autor.get("name")
+                or ""
+            ),
+        }
+
     @cached_property
     def autorzy(self):
+        """Autorzy/redaktorzy pogrupowani wg roli, jako listy słowników.
+
+        PBN przechowuje te kolekcje niespójnie: raz jako *dict* kluczowany
+        PBN UID-em autora (``{"<uid>": {...}}``), a raz jako *listę*
+        słowników. Normalizujemy oba kształty do listy znormalizowanych
+        słowników ``{lastName, firstName}``, żeby konsumenci (szablony,
+        ``policz_autorow``) nie musieli znać surowych wariantów PBN.
+        """
         ret = {}
         for elem in ["authors", "editors", "translators", "translationEditors"]:
             elem_dct = self.value_or_none("object", elem)
-            if elem_dct:
-                ret[elem] = elem_dct
+            if not elem_dct:
+                continue
+            kolekcja = elem_dct.values() if isinstance(elem_dct, dict) else elem_dct
+            ret[elem] = [self._normalizuj_autora(autor) for autor in kolekcja]
         return ret
 
     @cached_property

--- a/src/pbn_api/tests/test_publication_autorzy.py
+++ b/src/pbn_api/tests/test_publication_autorzy.py
@@ -1,0 +1,95 @@
+"""Testy property ``Publication.autorzy``.
+
+PBN przechowuje kolekcje autorów/redaktorów niespójnie: raz jako *dict*
+kluczowany PBN UID-em autora (``{"<uid>": {"lastName": ..., "name": ...}}``),
+a raz jako *listę* słowników. Szablon rekordu (``praca_tabela_mono.html``)
+iterował po tej kolekcji zakładając listę słowników — przy dict-cie
+``{% for autor in lista %}`` zwracał gołe klucze (UID-y, stringi), przez co
+``autor.givenNames`` jako argument filtra ``default`` wysadzał stronę
+(``VariableDoesNotExist``). Te testy pilnują, że ``autorzy`` zwraca zawsze
+listę znormalizowanych słowników z polami ``lastName``/``firstName``.
+"""
+
+import pytest
+from model_bakery import baker
+
+from pbn_api.models import Publication
+
+
+def _publikacja(object_dict):
+    return baker.make(
+        Publication,
+        versions=[{"current": True, "object": object_dict}],
+    )
+
+
+@pytest.mark.django_db
+def test_autorzy_dict_kluczowany_uidem_normalizuje_do_listy_slownikow():
+    """Regresja: kształt z produkcji (rekord 3,306) — dict UID→dane."""
+    pub = _publikacja(
+        {
+            "authors": {
+                "5e709321878c28a0473a33f9": {
+                    "lastName": "Windyga",
+                    "name": "Jerzy",
+                }
+            }
+        }
+    )
+    autorzy = pub.autorzy["authors"]
+    assert isinstance(autorzy, list)
+    assert autorzy[0]["lastName"] == "Windyga"
+    assert autorzy[0]["firstName"] == "Jerzy"
+
+
+@pytest.mark.django_db
+def test_autorzy_lista_slownikow_z_givenNames():
+    pub = _publikacja({"authors": [{"lastName": "Kowalski", "givenNames": "Jan"}]})
+    autorzy = pub.autorzy["authors"]
+    assert autorzy[0]["lastName"] == "Kowalski"
+    assert autorzy[0]["firstName"] == "Jan"
+
+
+@pytest.mark.django_db
+def test_autorzy_lista_slownikow_z_firstName():
+    pub = _publikacja({"editors": [{"lastName": "Nowak", "firstName": "Anna"}]})
+    assert pub.autorzy["editors"][0]["firstName"] == "Anna"
+
+
+@pytest.mark.django_db
+def test_policz_autorow_dziala_dla_dict_kluczowanego_uidem():
+    pub = _publikacja(
+        {
+            "authors": {"uid1": {"lastName": "A", "name": "B"}},
+            "editors": {"uid2": {"lastName": "C", "name": "D"}},
+        }
+    )
+    assert pub.policz_autorow() == 2
+
+
+@pytest.mark.django_db
+def test_autorzy_goly_uid_bez_danych_osobowych_nie_wybucha():
+    """Defensywnie: gdyby PBN podał listę samych UID-ów (stringów),
+    nie wysadzamy się — zwracamy puste pola zamiast crashować szablon."""
+    pub = _publikacja({"authors": ["5e709321878c28a0473a33f9"]})
+    autorzy = pub.autorzy["authors"]
+    assert autorzy[0]["lastName"] == ""
+    assert autorzy[0]["firstName"] == ""
+
+
+@pytest.mark.django_db
+def test_szablon_rekordu_nie_wybucha_na_dict_kluczowanym_uidem():
+    """End-to-end odwzorowanie pętli z praca_tabela_mono.html."""
+    from django.template import Context, Template
+
+    pub = _publikacja({"authors": {"5e70": {"lastName": "Windyga", "name": "Jerzy"}}})
+    tmpl = Template(
+        "{% for typ, lista in pub.autorzy.items %}"
+        "{% for autor in lista %}"
+        "{{ autor.lastName }} {{ autor.firstName }}"
+        "{% if not forloop.last %}, {% endif %}"
+        "{% endfor %}{% endfor %}"
+    )
+    out = tmpl.render(Context({"pub": pub}))
+    assert "Windyga" in out
+    assert "Jerzy" in out


### PR DESCRIPTION
## Problem

Strona rekordu (`/bpp/rekord/3,306/`) zwracała **HTTP 500**:

```
VariableDoesNotExist: Failed lookup for key [givenNames] in '5e709321878c28a0473a33f9'
```

`5e709321878c28a0473a33f9` to PBN UID autora.

## Analiza (root cause)

`praca_tabela_mono.html` wyświetla autorów *wydawnictwa nadrzędnego z PBN*:

```django
{% for typ, lista in praca.wydawnictwo_nadrzedne_w_pbn.autorzy.items %}
    {% for autor in lista %}
        {{ autor.lastName }} {{ autor.firstName|default:autor.givenNames|default:"" }}
```

PBN przechowuje `object.authors`/`editors` **niespójnie**:

- raz jako **dict kluczowany PBN UID-em** autora: `{"5e70…": {"lastName": …, "name": …}}` (potwierdza to importer `utworz_autorow`, który iteruje `.items()`),
- raz jako **listę słowników** (m.in. wyjście adaptera wysyłki do PBN).

Przy dict-cie `{% for autor in lista %}` w Django iteruje po **kluczach** → `autor` to goły UID (string). Wtedy `autor.givenNames`:

- jako **zmienna główna** `{{ }}` byłaby po cichu pusta (Django zwraca `string_if_invalid`),
- ale tu jest **argumentem filtra** `|default:autor.givenNames` — a `FilterExpression.resolve` **nie tłumi** `VariableDoesNotExist` dla argumentów filtrów, więc wyjątek leci w górę i wywala stronę.

Dodatkowo imię w kształcie dict-owym jest pod kluczem `name`, nie `givenNames`/`firstName`.

## Poprawka

`Publication.autorzy` normalizuje teraz **oba** kształty do listy słowników `{lastName, firstName}` (imię z `firstName` → `givenNames` → `name`). Goły UID bez danych osobowych degraduje do pustych pól zamiast crashować szablon. Szablon używa już tylko gwarantowanych kluczy (`{{ autor.firstName }}`), bez kruchego `default:`-argumentu.

`policz_autorow` (liczy przez `len()`) działa bez zmian — normalizacja zachowuje liczność.

## Testy

Nowy `src/pbn_api/tests/test_publication_autorzy.py` (6 testów): kształt dict-keyed (regresja z produkcji), lista z `givenNames`/`firstName`, `policz_autorow` dla dict-a, defensywny goły UID, oraz end-to-end render pętli z szablonu. Czerwone przed poprawką, zielone po.

🤖 Generated with [Claude Code](https://claude.com/claude-code)