### PR TITLE
perf(cache): trigger bpp_refresh_cache() v3 — upsert bez kaskady FK + 2 bugfixy

### DIFF
--- a/src/bpp/migrations/0429_cache_trigger_v3.py
+++ b/src/bpp/migrations/0429_cache_trigger_v3.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from django.db import connection, migrations
+
+
+def load_sql(apps, schema_editor):
+    sql_file = Path(__file__).parent / "0429_cache_trigger_v3.sql"
+    with open(sql_file) as f:
+        sql = f.read()
+    # connection.cursor() zamiast schema_editor.execute() — w ciele funkcji
+    # plpython3u sa znaki `%`, ktore schema_editor probowalby interpretowac
+    # jako placeholdery parametrow.
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+
+
+def unload_sql(apps, schema_editor):
+    # Revert: przywroc funkcje v2 (plik 0421 zawiera widoki + funkcje;
+    # widoki sa identyczne, wiec ponowne CREATE OR REPLACE jest neutralne).
+    sql_file = Path(__file__).parent / "0421_cache_trigger_pk_filter.sql"
+    with open(sql_file) as f:
+        sql = f.read()
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0428_weighted_publication_fulltext"),
+    ]
+
+    operations = [
+        migrations.RunPython(load_sql, unload_sql),
+    ]

--- a/src/bpp/migrations/0429_cache_trigger_v3.sql
+++ b/src/bpp/migrations/0429_cache_trigger_v3.sql
@@ -1,0 +1,166 @@
+-- Trigger cache v3 (spec docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md,
+-- pkt 1.1 / 1.2 / 1.4). Widoki per-typ bez zmian (stan po 0421) — podmieniamy
+-- wylacznie funkcje bpp_refresh_cache().
+--
+-- Zmiany wzgledem v2 (0421):
+--
+-- 1. INSERT/UPDATE bez wstepnego DELETE — wiersz tabeli bazowej nigdy nie
+--    znika z wlasnego widoku per-typ (widoki *_view to czyste SELECT-y
+--    z GROUP BY po PK), wiec ON CONFLICT (id) DO UPDATE wystarcza.
+--    Poprzednio DELETE na bpp_rekord_mat kaskadowal (FK) na bpp_autorzy_mat,
+--    wymuszajac wipe + re-insert WSZYSTKICH autorow przy kazdej edycji
+--    publikacji; czysty upsert to zwykly UPDATE (HOT-friendly, bez churnu
+--    indeksow przy niezmienionych kolumnach indeksowanych).
+--
+-- 2. Edycje publikacji ciagle/zwarte/patent NIE odswiezaja bpp_autorzy_mat —
+--    wiersze autorow pochodza wylacznie z tabel *_autor (widoki *_autorzy
+--    to SELECT bez WHERE z tabeli through). Praca_doktorska/habilitacyjna:
+--    autor lezy na wierszu publikacji, a widok *_autorzy ma INNER JOIN do
+--    bpp_autor — wiersz moze "wypasc" ze zrodla, wiec tam zostaje
+--    DELETE + INSERT (dokladnie 1 wiersz, tanio).
+--
+-- 3. UPDATE czyta TD["new"] (nie TD["old"]) — zmiana autor_id / rekord_id
+--    in-place na wierszu *_autor aktualizuje wiersz mat przez ON CONFLICT
+--    po stabilnym id = ARRAY[ct, pk-wiersza-through], zamiast go gubic
+--    (v2 filtrowala widok po STARYM autor_id -> pusty SELECT).
+--
+-- 4. DELETE wiersza *_autor kasuje precyzyjnie po id wiersza mat
+--    (ARRAY[ct, pk-wiersza-through]) — v2 kasowala po (rekord_id, autor_id),
+--    co przy autorze w dwoch rolach (aut. + red.) usuwalo OBA wiersze.
+--
+-- 5. Bez plpy.subtransaction() — kazde odpalenie zuzywalo subxact (XID);
+--    >64 subxactow w jednej transakcji (masowy import, rebuildall) to spill
+--    do SLRU pg_subtrans i ostry spadek wydajnosci sprawdzania widocznosci.
+--    Subtransakcja niczego tu nie lapala (brak try/except) — blad i tak
+--    propaguje i wycofuje transakcje.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION bpp_refresh_cache()
+  RETURNS TRIGGER
+  LANGUAGE plpython3u
+  AS $$
+    # Odswieza bpp_rekord_mat / bpp_autorzy_mat dla POJEDYNCZEGO rekordu.
+    # v3 — patrz naglowek pliku 0429_cache_trigger_v3.sql.
+
+    table_name = TD["table_name"]
+    event = TD["event"]
+    # DELETE: tozsamosc ze starego wiersza. INSERT/UPDATE: z nowego —
+    # dzieki temu zmiana autor_id/rekord_id in-place trafia w aktualne dane.
+    field = "old" if event == "DELETE" else "new"
+
+    # Routing: tabela triggera -> (bazowa tabela publikacji, czy to through-table autorow)
+    ROUTING = {
+        "bpp_wydawnictwo_ciagle":       ("bpp_wydawnictwo_ciagle", False),
+        "bpp_wydawnictwo_ciagle_autor": ("bpp_wydawnictwo_ciagle", True),
+        "bpp_wydawnictwo_zwarte":       ("bpp_wydawnictwo_zwarte", False),
+        "bpp_wydawnictwo_zwarte_autor": ("bpp_wydawnictwo_zwarte", True),
+        "bpp_patent":                   ("bpp_patent", False),
+        "bpp_patent_autor":             ("bpp_patent", True),
+        "bpp_praca_doktorska":          ("bpp_praca_doktorska", False),
+        "bpp_praca_habilitacyjna":      ("bpp_praca_habilitacyjna", False),
+    }
+    pub_base, is_through = ROUTING[table_name]
+    app_name, model_name = pub_base.split("_", 1)
+
+    # Publikacje, ktorych dane autora leza na wierszu publikacji (widok
+    # *_autorzy z INNER JOIN do bpp_autor — wiersz moze wypasc ze zrodla).
+    AUTOR_NA_WIERSZU_PUBLIKACJI = ("bpp_praca_doktorska", "bpp_praca_habilitacyjna")
+
+    # object_id = PK publikacji (dla through-table jest w rekord_id, inaczej w id)
+    object_id = TD[field]["rekord_id"] if is_through else TD[field]["id"]
+
+    # cache content_type_id oraz listy kolumn w GD (per-backend, na czas polaczenia)
+    cache_key = "django_content_type_ver_2"
+    columns_cache_key = "table_columns_ver_2"
+    if GD.get(cache_key) is None:
+        GD[cache_key] = {}
+    if GD.get(columns_cache_key) is None:
+        GD[columns_cache_key] = {}
+
+    if pub_base not in GD[cache_key]:
+        res = plpy.execute(
+            "SELECT id FROM django_content_type "
+            "WHERE app_label = '%s' AND model = '%s'" % (app_name, model_name))
+        GD[cache_key][pub_base] = res[0]["id"]
+    content_type_id = GD[cache_key][pub_base]
+
+    rekord_view = pub_base + "_view"
+    autorzy_view = pub_base + "_autorzy"
+
+    mat_arr = "ARRAY[%s, %s]::INTEGER[2]" % (content_type_id, object_id)
+
+    def get_table_columns(mat_table):
+        if mat_table not in GD[columns_cache_key]:
+            res = plpy.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = 'public' AND table_name = '%s' "
+                "ORDER BY ordinal_position" % mat_table)
+            GD[columns_cache_key][mat_table] = [r["column_name"] for r in res]
+        return GD[columns_cache_key][mat_table]
+
+    def upsert(mat_table, source_view, source_where):
+        # INSERT ... SELECT ... ON CONFLICT (id) DO UPDATE — bez wstepnego
+        # DELETE (patrz naglowek pliku, pkt 1).
+        # INSERT po nazwach kolumn tabeli mat, SELECT po nazwach kolumn widoku.
+        # Odpowiadaja sobie POZYCYJNIE: widok to zrodlo tabeli mat + dorzucone
+        # na koncu object_id_raw. Mapowanie pozycyjne (a nie po nazwie) jest
+        # odporne na to, ze pojedynczy widok moze nazwac kolumne-tablice inaczej
+        # niz tabela mat — np. bpp_praca_doktorska_autorzy ma 'array' zamiast
+        # 'id' (nieaaliasowane ARRAY[...]); unia normalizowala nazwe z pierwszej
+        # galezi, ale pojedynczy widok juz nie.
+        # Cytujemy identyfikatory ("...") — niektore kolumny widokow nazywaja
+        # sie jak slowa zarezerwowane (np. 'array').
+        def q(c):
+            return '"' + c + '"'
+
+        mat_cols = get_table_columns(mat_table)
+        src_cols = [c for c in get_table_columns(source_view) if c != "object_id_raw"]
+        set_clause = ", ".join(
+            "%s = EXCLUDED.%s" % (q(c), q(c)) for c in mat_cols if c != "id")
+        plpy.execute(
+            "INSERT INTO " + mat_table +
+            " (" + ", ".join(q(c) for c in mat_cols) + ") "
+            "SELECT " + ", ".join(q(c) for c in src_cols) + " FROM " + source_view +
+            " WHERE " + source_where +
+            " ON CONFLICT (id) DO UPDATE SET " + set_clause)
+
+    # Deterministyczny advisory lock (#309): para int4 (ct, obj).
+    plpy.execute("SELECT pg_advisory_xact_lock(%s, %s)" % (content_type_id, object_id))
+
+    if event == "DELETE":
+        if is_through:
+            # Precyzyjnie po id wiersza mat = ARRAY[ct, pk-wiersza-through].
+            # NIE po (rekord_id, autor_id) — autor w dwoch rolach ma dwa
+            # wiersze i skasowalibysmy oba (patrz naglowek, pkt 4).
+            plpy.execute(
+                "DELETE FROM bpp_autorzy_mat "
+                "WHERE id = ARRAY[%s, %s]::INTEGER[2]"
+                % (content_type_id, TD["old"]["id"]))
+        else:
+            # DELETE bpp_rekord_mat kaskaduje (FK) na bpp_autorzy_mat.
+            plpy.execute("DELETE FROM bpp_rekord_mat WHERE id = " + mat_arr)
+        return
+
+    # INSERT / UPDATE
+    if is_through:
+        # Tylko ten jeden autor; filtr po NOWYCH wartosciach (pkt 3).
+        upsert(
+            "bpp_autorzy_mat",
+            autorzy_view,
+            "object_id_raw = %s AND autor_id = %s"
+            % (object_id, TD["new"]["autor_id"]))
+        return
+
+    upsert("bpp_rekord_mat", rekord_view, "object_id_raw = %s" % object_id)
+
+    if pub_base in AUTOR_NA_WIERSZU_PUBLIKACJI:
+        # Widok *_autorzy ma INNER JOIN do bpp_autor — czysty upsert nie
+        # usunalby wiersza, gdy zrodlo nie zwraca nic. DELETE + INSERT,
+        # dokladnie 1 wiersz autora.
+        plpy.execute("DELETE FROM bpp_autorzy_mat WHERE rekord_id = " + mat_arr)
+        upsert("bpp_autorzy_mat", autorzy_view, "object_id_raw = %s" % object_id)
+    # Dla ciagle/zwarte/patent NIE ruszamy bpp_autorzy_mat: wiersze autorow
+    # pochodza wylacznie z tabel *_autor (pkt 2).
+$$;
+
+COMMIT;

--- a/src/bpp/newsfragments/+cache-trigger-v3.feature.rst
+++ b/src/bpp/newsfragments/+cache-trigger-v3.feature.rst
@@ -1,0 +1,8 @@
+Trigger odświeżający tabele cache (``bpp_rekord_mat`` /
+``bpp_autorzy_mat``) działa wydajniej i poprawniej: edycja publikacji
+nie kasuje już i nie wstawia od nowa wszystkich wierszy autorów
+(czysty upsert zamiast DELETE z kaskadą FK), masowe operacje nie
+zużywają subtransakcji per wiersz, zmiana autora wpisu „in-place"
+poprawnie aktualizuje cache, a usunięcie jednej z dwóch ról tego
+samego autora (np. autor + redaktor) nie usuwa już obu wierszy
+z cache autorów.

--- a/src/bpp/tests/test_cache/test_cache_trigger_v3.py
+++ b/src/bpp/tests/test_cache/test_cache_trigger_v3.py
@@ -1,0 +1,136 @@
+"""Testy triggera bpp_refresh_cache() v3 (spec-optymalizacje-wydajnosci-2026-06).
+
+Trzy zachowania:
+
+1. UPDATE publikacji NIE przepisuje wierszy bpp_autorzy_mat (poprzednio
+   DELETE na bpp_rekord_mat kaskadował przez FK i wymuszał wipe + re-insert
+   wszystkich autorów; v3 robi czysty upsert ON CONFLICT). Sprawdzane po
+   xmin — przepisany wiersz dostaje nowe xmin.
+
+2. UPDATE wiersza *_autor zmieniający autor_id in-place aktualizuje
+   bpp_autorzy_mat (poprzednio trigger czytał TD["old"] i filtrował widok
+   po STARYM autor_id — pusty SELECT, wiersz mat ginął bez następcy).
+
+3. DELETE jednego z dwóch wierszy *_autor tego samego autora (dwie role,
+   np. aut. + red.) usuwa z bpp_autorzy_mat tylko ten jeden wiersz
+   (poprzednio DELETE po (rekord_id, autor_id) kasował OBA).
+"""
+
+import pytest
+from django.db import connection
+from model_bakery import baker
+
+from bpp.models import (
+    Autor,
+    Jednostka,
+    Praca_Doktorska,
+    Rekord,
+    Wydawnictwo_Ciagle,
+)
+
+
+def _xmin_autorzy_mat(rekord):
+    """Mapa {id_wiersza_mat: xmin} dla wszystkich autorów rekordu."""
+    with connection.cursor() as c:
+        c.execute(
+            "SELECT id, xmin::text FROM bpp_autorzy_mat WHERE rekord_id = %s",
+            [list(rekord.pk)],
+        )
+        return {tuple(row[0]): row[1] for row in c.fetchall()}
+
+
+@pytest.mark.django_db
+def test_update_publikacji_nie_przepisuje_wierszy_autorzy_mat(standard_data, denorms):
+    wc = baker.make(
+        Wydawnictwo_Ciagle, tytul_oryginalny="STARY", szczegoly="sz", uwagi="u"
+    )
+    j = baker.make(Jednostka)
+    wc.dodaj_autora(baker.make(Autor, imiona="Jan", nazwisko="Pierwszy"), j)
+    wc.dodaj_autora(baker.make(Autor, imiona="Jan", nazwisko="Drugi"), j)
+    denorms.flush()
+
+    rekord = Rekord.objects.get_for_model(wc)
+    przed = _xmin_autorzy_mat(rekord)
+    assert len(przed) == 2
+
+    # surowy UPDATE — izoluje sam trigger (bez denorm / sygnałów Django)
+    with connection.cursor() as c:
+        c.execute(
+            "UPDATE bpp_wydawnictwo_ciagle SET tytul_oryginalny = 'NOWY' WHERE id = %s",
+            [wc.pk],
+        )
+
+    assert Rekord.objects.get_for_model(wc).tytul_oryginalny == "NOWY"
+
+    po = _xmin_autorzy_mat(rekord)
+    assert po == przed, (
+        "edycja publikacji przepisała wiersze bpp_autorzy_mat "
+        f"(xmin przed={przed}, po={po})"
+    )
+
+
+@pytest.mark.django_db
+def test_zmiana_autor_id_in_place_aktualizuje_autorzy_mat(standard_data, denorms):
+    wc = baker.make(Wydawnictwo_Ciagle, tytul_oryginalny="T", szczegoly="sz", uwagi="u")
+    j = baker.make(Jednostka)
+    a = baker.make(Autor, imiona="Jan", nazwisko="Stary")
+    b = baker.make(Autor, imiona="Jan", nazwisko="Nowy")
+    wca = wc.dodaj_autora(a, j)
+    denorms.flush()
+
+    rekord = Rekord.objects.get_for_model(wc)
+    assert rekord.autorzy_set.filter(autor=a).exists()
+
+    with connection.cursor() as c:
+        c.execute(
+            "UPDATE bpp_wydawnictwo_ciagle_autor SET autor_id = %s WHERE id = %s",
+            [b.pk, wca.pk],
+        )
+
+    assert rekord.autorzy_set.filter(autor=b).exists(), (
+        "po zmianie autor_id in-place wiersz bpp_autorzy_mat nie wskazuje nowego autora"
+    )
+    assert not rekord.autorzy_set.filter(autor=a).exists()
+
+
+@pytest.mark.django_db
+def test_usuniecie_jednej_z_dwoch_rol_autora_zostawia_druga(standard_data, denorms):
+    wc = baker.make(Wydawnictwo_Ciagle, tytul_oryginalny="T", szczegoly="sz", uwagi="u")
+    j = baker.make(Jednostka)
+    a = baker.make(Autor, imiona="Jan", nazwisko="Dwurolowy")
+    wca_aut = wc.dodaj_autora(a, j, typ_odpowiedzialnosci_skrot="aut.", kolejnosc=0)
+    wca_red = wc.dodaj_autora(a, j, typ_odpowiedzialnosci_skrot="red.", kolejnosc=1)
+    denorms.flush()
+
+    rekord = Rekord.objects.get_for_model(wc)
+    assert rekord.autorzy_set.filter(autor=a).count() == 2
+
+    wca_red.delete()
+
+    pozostale = rekord.autorzy_set.filter(autor=a)
+    assert pozostale.count() == 1, (
+        "usunięcie jednej roli autora skasowało z bpp_autorzy_mat oba wiersze"
+    )
+    assert tuple(pozostale.get().pk) == (rekord.pk[0], wca_aut.pk)
+
+
+@pytest.mark.django_db
+def test_doktorska_zmiana_autora_aktualizuje_autorzy_mat(standard_data, denorms):
+    """Strażnik: dla prac doktorskich autor leży na wierszu publikacji
+    (widok autorzy z INNER JOIN do bpp_autor) — edycja publikacji musi
+    nadal odświeżać bpp_autorzy_mat."""
+    j = baker.make(Jednostka)
+    a = baker.make(Autor, imiona="Jan", nazwisko="Doktorant")
+    b = baker.make(Autor, imiona="Jan", nazwisko="Inny")
+    pd = baker.make(Praca_Doktorska, autor=a, jednostka=j, tytul_oryginalny="Dr")
+    denorms.flush()
+
+    rekord = Rekord.objects.get_for_model(pd)
+    assert rekord.autorzy_set.filter(autor=a).exists()
+
+    pd.autor = b
+    pd.save()
+    denorms.flush()
+
+    assert rekord.autorzy_set.filter(autor=b).exists()
+    assert not rekord.autorzy_set.filter(autor=a).exists()


### PR DESCRIPTION
## Co i po co

Drugi PR z planu w `docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md` (plik spec jedzie w #351; punkty 1.1 / 1.2 / 1.4). Migracja **0429** podmienia wyłącznie funkcję `bpp_refresh_cache()` — widoki per-typ zostają jak po 0421.

## Zmiany wydajnościowe

1. **INSERT/UPDATE bez wstępnego `DELETE`.** Wiersz tabeli bazowej nigdy nie znika z własnego widoku per-typ (widoki `*_view` to czyste SELECT-y z GROUP BY po PK), więc `ON CONFLICT (id) DO UPDATE` wystarcza. Poprzednio `DELETE` na `bpp_rekord_mat` kaskadował (FK) na `bpp_autorzy_mat` — edycja publikacji z N autorami = wipe + re-insert N wierszy + churn wszystkich indeksów. Teraz to zwykły UPDATE (HOT-friendly).
2. **Edycje publikacji ciagle/zwarte/patent nie dotykają `bpp_autorzy_mat`** — wiersze autorów pochodzą wyłącznie z tabel `*_autor`. Wyjątek: doktorska/habilitacyjna (autor na wierszu publikacji, widok `*_autorzy` z INNER JOIN do `bpp_autor` może nie zwrócić wiersza) — tam zostaje DELETE+INSERT dokładnie 1 wiersza.
3. **Bez `plpy.subtransaction()`** — subxact per odpalenie triggera; >64 subxactów w jednej transakcji (masowy import, `denorm.rebuildall`) = spill do SLRU `pg_subtrans` i ostry spadek wydajności. Subtransakcja niczego nie łapała (brak try/except).

## Bugfixy (oba potwierdzone czerwonym testem na v2)

4. **Zmiana `autor_id` in-place na wierszu `*_autor` gubiła autora w cache** — v2 czytała `TD["old"]` i filtrowała widok po starym `autor_id` (pusty SELECT → wiersz mat ginął bez następcy). v3 czyta `TD["new"]`; upsert po stabilnym `id = ARRAY[ct, pk-wiersza-through]` aktualizuje wiersz w miejscu.
5. **Autor w dwóch rolach (aut. + red.) tracił OBA wiersze** przy usunięciu jednej roli — v2 kasowała po `(rekord_id, autor_id)`. v3 kasuje precyzyjnie po id wiersza mat.

## Benchmark (syntetyczny, testcontainers, min z 3 powtórzeń)

| scenariusz | v2 (0421) | v3 (0429) | speedup |
|---|---|---|---|
| bulk UPDATE 100 publikacji × 10 autorów | 0.062s | 0.036s | **1.7×** |
| bulk UPDATE 50 publikacji × 30 autorów | 0.047s | 0.017s | **2.8×** |

Zysk rośnie z liczbą autorów na publikacji (to dokładnie koszt kaskady). Nieuwzględnione w pomiarze: mniej dead tuples / pracy autovacuum, brak ryzyka subxact-overflow.

## Testy

- `src/bpp/tests/test_cache/test_cache_trigger_v3.py` — 4 testy (TDD; 3 czerwone na v2: przepisywanie xmin wierszy autorów, zgubiony autor po UPDATE in-place, skasowane obie role) + strażnik ścieżki doktorskiej.
- Pełna suita bez Playwright na v3: **4534 passed, 2 skipped, 1 xfailed**.
- Rollback migracji przywraca funkcję v2 (re-aplikacja pliku 0421).

🤖 Generated with [Claude Code](https://claude.com/claude-code)