### PR TITLE
perf(frontend): usuń martwy Tone.js z bundle (−598 KB, −39%) + bez re-minifikacji JS

### DIFF
--- a/docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md
+++ b/docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md
@@ -83,6 +83,10 @@ kilku tysiącach wierszy przed/po + `pg_stat_user_tables.n_dead_tup`
 dla obu tabel mat. Testy: istniejące testy triggera + nowy test
 „edycja publikacji nie zmienia zawartości bpp_autorzy_mat".
 
+**Status: ✅ zrobione** (PR #352, migracja `0429_cache_trigger_v3`;
+benchmark syntetyczny: bulk UPDATE 100 pub × 10 aut. 1.7× szybciej,
+50 pub × 30 aut. 2.8× szybciej).
+
 ### 1.2. `plpy.subtransaction()` per wiersz (PRIORYTET 3)
 
 **Problem.** Linia 558 — każde odpalenie triggera otwiera
@@ -99,6 +103,8 @@ testem; w obecnej formie wyjątek i tak propaguje i wywala transakcję.
 
 **Weryfikacja.** Benchmark jak w 1.1 (szczególnie pojedyncza
 transakcja z >64 zmienionymi wierszami).
+
+**Status: ✅ zrobione** (PR #352, migracja `0429_cache_trigger_v3`).
 
 ### 1.3. `liczba_autorow` — eventual consistency przez denorm (DOKUMENTACJA)
 
@@ -121,6 +127,13 @@ dotknięcia rekordu.
 (`rekord_id`, `autor_id`); gdy różne — odświeżyć obie. Najpierw test
 reprodukujący (UPDATE `autor_id` przez ORM/SQL + asercja na zawartość
 `bpp_autorzy_mat`).
+
+**Status: ✅ zrobione** (PR #352) — bug potwierdzony czerwonym testem;
+v3 czyta `TD["new"]`, a upsert po stabilnym `id = ARRAY[ct,
+pk-wiersza-through]` aktualizuje wiersz w miejscu. Przy okazji wykryty
+i naprawiony DRUGI bug v2: DELETE jednej z dwóch ról autora
+(aut. + red.) kasował z `bpp_autorzy_mat` oba wiersze (DELETE po
+`(rekord_id, autor_id)` zamiast po id wiersza mat).
 
 ### 1.5. Indeksy na tabelach mat — follow-up po 1.1
 
@@ -270,6 +283,16 @@ referencję) i kod powiadomień w `notifications`.
 **Weryfikacja.** Rozmiar `bundle.js` przed/po; smoke-test dźwięku
 powiadomienia (test Playwright lub ręcznie przez `run-site`).
 
+**Status: ✅ zrobione** (branch `perf/frontend-bundle`) — okazało się
+LEPIEJ niż w spec: Tone.js to był martwy kod. Jedyny konsument
+(`notifications-chime.js` z channels_broadcast) nie jest w ogóle
+ładowany, `enableChime()` nigdzie nie jest wołane, a komunikaty idą
+z `sound: false`. Usunięty import + zależność `tone` z package.json.
+Bundle: 1 541 543 B → 943 122 B (**−598 KB, −39%**). Smoke-test
+przeglądarkowy (run-site + Playwright): strony działają,
+channelsBroadcast/Mustache/htmx/jQuery/Foundation obecne, zero błędów
+konsoli związanych z bundle.
+
 ### 3.2. `COMPRESS_JS_FILTERS = []` (PRIORYTET 6)
 
 **Problem.** `src/django_bpp/settings/base.py:585` —
@@ -290,6 +313,11 @@ pliki spoza SCSS pipeline'u (jqueryui, select2 itd., `bare.html:45-58`)
 
 **Weryfikacja.** Czas `manage.py compress --force` przed/po; diff
 rozmiarów plików w `CACHE-*/`.
+
+**Status: ✅ zrobione** (branch `perf/frontend-bundle`) —
+`COMPRESS_JS_FILTERS = []`, filtry CSS zostają (CssAbsoluteFilter
+przepisuje względne `url()` przy konkatenacji — load-bearing;
+CSSMinFilter potrzebny dla nie-zminifikowanych wejść spoza SCSS).
 
 ### 3.3. Selektywna kompilacja Foundation (PRIORYTET 8)
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
         "select2-foundation-theme": "https://github.com/mpasternak/select2-foundation.git#modernize-foundation-6.9",
         "sigma": "^3.0.2",
         "three-spritetext": "^1.10.0",
-        "tone": "^15.1.22",
         "what-input": "^5.0.5"
     },
     "optionalDependencies": {

--- a/src/bpp/newsfragments/+frontend-bundle-diet.feature.rst
+++ b/src/bpp/newsfragments/+frontend-bundle-diet.feature.rst
@@ -1,0 +1,5 @@
+Strony ładują się szybciej: główny pakiet JavaScript (``bundle.js``)
+schudł o ~600 KB (−39%) po usunięciu nieużywanej biblioteki Tone.js
+(dźwięki powiadomień nigdy nie były włączone), a start kontenera nie
+traci już czasu na ponowną minifikację zminifikowanego wcześniej
+JavaScriptu (``COMPRESS_JS_FILTERS``).

--- a/src/bpp/static/bpp/js/bundle-entry.js
+++ b/src/bpp/static/bpp/js/bundle-entry.js
@@ -36,12 +36,14 @@ select2(window.jQuery);
 // Set Polish language for Select2
 window.jQuery.fn.select2.defaults.set('language', window.select2PlLanguage);
 
-// ===== 7. MUSTACHE + TONE (for notifications) =====
+// ===== 7. MUSTACHE (for notifications) =====
+// NOTE: Tone.js was removed from the bundle (~450 KB minified). It was only
+// ever consumed by channels_broadcast's optional notifications-chime.js,
+// which BPP does not load (enableChime() is never called; messages are sent
+// with sound: false). If the chime is ever wanted, load Tone.js +
+// notifications-chime.js as separate scripts per channels_broadcast docs.
 import * as Mustache from '../../../../../.venv/lib/python/site-packages/channels_broadcast/static/channels_broadcast/js/mustache.js';
 window.Mustache = Mustache;
-
-import * as Tone from 'tone';
-window.Tone = Tone;
 
 // ===== 8. DJANGO LIBRARIES (from .venv) =====
 // Paths relative to site-packages
@@ -71,4 +73,3 @@ import '../../../../../.venv/lib/python/site-packages/channels_broadcast/static/
 // These are used in HTML templates, so we need to prevent tree-shaking
 void window.channelsBroadcast;
 void window.Mustache;
-void window.Tone;

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -582,7 +582,13 @@ COMPRESS_CSS_FILTERS = [
     "compressor.filters.css_default.CssAbsoluteFilter",
     "compressor.filters.cssmin.CSSMinFilter",
 ]
-COMPRESS_JS_FILTERS = ["compressor.filters.jsmin.rJSMinFilter"]
+# Bez filtra JS: wszystkie nietrywialne wejscia (bundle.js itd.) sa juz
+# zminifikowane przez esbuild na etapie grunt build. rJSMinFilter
+# re-minifikowal 1,5 MB bundle'a przy `manage.py compress` na starcie
+# kontenera (zysk ~0 bajtow), a regexowe minifikatory potrafia zepsuc
+# nowoczesna skladnie emitowana przez AST-owy esbuild. {% compress js %}
+# zostaje — daje konkatenacje + hashowane nazwy plikow (cache-busting).
+COMPRESS_JS_FILTERS = []
 
 COMPRESS_ROOT = STATIC_ROOT
 COMPRESS_OFFLINE_CONTEXT = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,11 +32,6 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
   integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
-"@babel/runtime@^7.25.6", "@babel/runtime@^7.29.2":
-  version "7.29.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
-  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
-
 "@choojs/findup@^0.2.0":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@choojs/findup/-/findup-0.2.1.tgz#ac13c59ae7be6e1da64de0779a0a7f03d75615a3"
@@ -669,14 +664,6 @@ async@^3.1.0, async@~3.2.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
   integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
-
-automation-events@^7.0.9:
-  version "7.1.19"
-  resolved "https://registry.yarnpkg.com/automation-events/-/automation-events-7.1.19.tgz#9323849f1f8d0e6019b4658dc7a1592346197b08"
-  integrity sha512-cD+TLhJTI0q4AI3ktd353lrGZiVa9AchowSDzQzzGjSoYe22js4vlS32VUtWuaulghi1Yq0KYNWKk9wWuGymPA==
-  dependencies:
-    "@babel/runtime" "^7.29.2"
-    tslib "^2.8.1"
 
 b4a@^1.6.4:
   version "1.8.0"
@@ -3757,15 +3744,6 @@ stack-trace@0.0.9:
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
   integrity sha512-vjUc6sfgtgY0dxCdnc40mK6Oftjo9+2K8H/NG81TMhgL392FtiPA9tn9RLyTxXmTLPJPjF3VyzFp6bsWFLisMQ==
 
-standardized-audio-context@^25.3.70:
-  version "25.3.77"
-  resolved "https://registry.yarnpkg.com/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz#9502c40f3860f0877ce5c53a161f819f23c978f4"
-  integrity sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==
-  dependencies:
-    "@babel/runtime" "^7.25.6"
-    automation-events "^7.0.9"
-    tslib "^2.7.0"
-
 static-eval@^2.0.5:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.1.1.tgz#71ac6a13aa32b9e14c5b5f063c362176b0d584ba"
@@ -4050,14 +4028,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tone@^15.1.22:
-  version "15.1.22"
-  resolved "https://registry.yarnpkg.com/tone/-/tone-15.1.22.tgz#77581c7e8347a969872ca4f90f3532cd1e307dc8"
-  integrity sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==
-  dependencies:
-    standardized-audio-context "^25.3.70"
-    tslib "^2.3.1"
-
 topojson-client@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/topojson-client/-/topojson-client-3.1.0.tgz#22e8b1ed08a2b922feeb4af6f53b6ef09a467b99"
@@ -4065,7 +4035,7 @@ topojson-client@^3.1.0:
   dependencies:
     commander "2"
 
-tslib@^2.0.1, tslib@^2.3.1, tslib@^2.7.0, tslib@^2.8.1:
+tslib@^2.0.1, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Co i po co

Trzeci PR z planu w `docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md` (punkty 3.1 + 3.2).

## Tone.js był martwym kodem (3.1)

Spec zakładał lazy-load — audyt wykazał coś lepszego: **Tone.js w bundle nie ma żadnego konsumenta**.

- Jedyny kod używający `window.Tone` to opcjonalny `notifications-chime.js` z channels_broadcast — **nigdy nie ładowany** w BPP.
- `channelsBroadcast.enableChime()` nie jest wołane w żadnym szablonie/JS.
- Komunikaty w `base.html` idą z `sound: false`.
- Sam plugin jest defensywny (`typeof Tone === "undefined"` → no-op) i zaprojektowany pod Tone ładowany osobnym `<script>` — jeśli chime kiedyś wróci, instrukcja jest w docstringu pluginu.

Usunięty import z `bundle-entry.js` + zależność `tone` z `package.json`/`yarn.lock`.

**`bundle.js`: 1 541 543 B → 943 122 B (−598 KB, −39%)** — na każdej stronie, dla każdego odwiedzającego.

## Bez podwójnej minifikacji JS (3.2)

`COMPRESS_JS_FILTERS = []` — wejścia JS są już zminifikowane przez esbuild na etapie `grunt build`; `rJSMinFilter` re-minifikował 1,5 MB bundle'a przy `manage.py compress` na starcie kontenera (zysk ~0 B), a regexowe minifikatory potrafią psuć składnię emitowaną przez AST-owy esbuild. `{% compress js %}` zostaje (konkatenacja + hashowane nazwy = cache-busting). Filtry CSS celowo **bez zmian**: `CssAbsoluteFilter` przepisuje względne `url()` (load-bearing), `CSSMinFilter` potrzebny dla nie-zminifikowanych wejść spoza SCSS (jqueryui, select2 itd.).

## Weryfikacja

- `grep -c Tone dist/bundle.js` → 0; rozmiary jak wyżej.
- Smoke-test przeglądarkowy (run-site + Playwright chromium): strona główna + multiseek renderują się, `channelsBroadcast` / `Mustache` / `htmx` / `jQuery` / `Foundation` obecne, `window.Tone === undefined`, zero błędów konsoli pochodzących z bundle (jedyne błędy to środowiskowe COOP/userway przy HTTP-origin).
- `src/bpp/tests/test_views/` + `test_html_minify_integrity.py`: **155 passed**.
- Spec zaktualizowany: statusy 1.1/1.2/1.4 (po merge #352) oraz 3.1/3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)