### PR TITLE
perf(css): selektywne @include Foundation — wspólna lista, −9 martwych komponentów

### DIFF
--- a/docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md
+++ b/docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md
@@ -307,6 +307,22 @@ include'ami, import w 6 motywach. Po zmianie `grunt build`
 **Weryfikacja.** Rozmiar `app-*.css` przed/po; wizualna regresja
 kluczowych stron (multiseek, strona autora, rekord) przez `run-site`.
 
+**Status: ✅ zrobione** (branch `perf/foundation-diet`) — z ważną
+korektą szacunku: audyt wykazał tylko **9** komponentów bez użycia
+(accordion-menu, drilldown-menu, responsive-embed, media-object,
+off-canvas, orbit, slider, switch, thumbnail); ciężkie komponenty
+(gridy, forms, typography, button) są używane. Realny zysk:
+**−16,5 KB/motyw (−5,4%)**, nie ~150 KB. Lista include'ów wydzielona
+do wspólnego `_foundation-includes.scss` (1 plik zamiast 6 kopii).
+Weryfikacja wizualna (run-site + Playwright, screenshoty): top-bar,
+breadcrumbs, callout, formularz multiseek — bez regresji.
+
+**Follow-up (zmierzony, świadomie odłożony):** `foundation-grid`
+(float) i `foundation-flex-grid` emitują nakładające się reguły
+`.row/.columns`; usunięcie float-grida dałoby kolejne **−17,7 KB**
+(289,7 → 272,0 KB), ale zmienia kaskadę (clearfixy) i wymaga
+pełnej regresji wizualnej — osobny PR, jeśli warto.
+
 ### 3.4. Nie robić (świadomie odrzucone)
 
 - **Wymiana Grunta na webpack/Vite** — pipeline jest już szybki

--- a/src/bpp/newsfragments/+foundation-selective-includes.feature.rst
+++ b/src/bpp/newsfragments/+foundation-selective-includes.feature.rst
@@ -1,0 +1,5 @@
+Arkusze CSS motywów są mniejsze (−5%, ok. 16 KB na motyw) po
+usunięciu dziewięciu nieużywanych komponentów Foundation (m.in.
+karuzela orbit, suwak slider, przełącznik switch, menu off-canvas).
+Lista komponentów jest teraz wspólna dla wszystkich sześciu motywów
+(jeden plik zamiast sześciu kopii), z udokumentowanym audytem użycia.

--- a/src/bpp/static/scss/_foundation-includes.scss
+++ b/src/bpp/static/scss/_foundation-includes.scss
@@ -1,0 +1,59 @@
+// Wspólny, SELEKTYWNY zestaw komponentów Foundation dla wszystkich motywów
+// (app-blue, app-green, app-orange, app-vizja, app-mwsl, app-uafm).
+//
+// Importować PO załadowaniu ustawień motywu (zmienne $primary-color itd.
+// muszą być w zasięgu przed @import 'foundation').
+//
+// Audyt użycia (2026-06, spec-optymalizacje-wydajnosci-2026-06.md pkt 3.3):
+// grep selektorów każdego komponentu po templates + JS w src/ oraz
+// templates pakietów renderowanych przez BPP (multiseek, dal,
+// channels_broadcast, cookielaw, session_security).
+//
+// Komponenty USUNIĘTE (0 wystąpień w templates/JS):
+//   foundation-accordion-menu, foundation-drilldown-menu,
+//   foundation-responsive-embed, foundation-media-object,
+//   foundation-off-canvas, foundation-orbit, foundation-slider,
+//   foundation-switch, foundation-thumbnail
+// Jeśli któryś będzie potrzebny (nowy widok, customizacja per-uczelnia,
+// szablon w dbtemplates) — dopisz @include niżej i przebuduj CSS
+// (grunt build); patrz docs/deweloper/budowanie-css.md.
+//
+// UWAGA (follow-up, świadomie NIE ruszone w tym przebiegu):
+// foundation-grid (float) i foundation-flex-grid emitują nakładające się
+// reguły .row/.columns — flex-grid nadpisuje większość, ale usunięcie
+// float-grida zmienia kaskadę (clearfixy itd.) i wymaga osobnej weryfikacji
+// wizualnej.
+
+@import 'foundation';
+@include foundation-global-styles;
+@include foundation-xy-grid-classes;
+@include foundation-grid;
+@include foundation-flex-grid;
+@include foundation-flex-classes;
+@include foundation-typography;
+@include foundation-forms;
+@include foundation-button;
+@include foundation-accordion;
+@include foundation-badge;
+@include foundation-breadcrumbs;
+@include foundation-button-group;
+@include foundation-callout;
+@include foundation-card;
+@include foundation-close-button;
+@include foundation-menu;
+@include foundation-menu-icon;
+@include foundation-dropdown;
+@include foundation-dropdown-menu;
+@include foundation-label;
+@include foundation-pagination;
+@include foundation-progress-bar;
+@include foundation-sticky;
+@include foundation-reveal;
+@include foundation-table;
+@include foundation-tabs;
+@include foundation-title-bar;
+@include foundation-tooltip;
+@include foundation-top-bar;
+@include foundation-visibility-classes;
+@include foundation-float-classes;
+@include foundation-print-styles;

--- a/src/bpp/static/scss/app-blue.scss
+++ b/src/bpp/static/scss/app-blue.scss
@@ -10,51 +10,7 @@
 @import "pagination";
 @import "wizard_forms";
 
-@import 'foundation';
-@include foundation-global-styles;
-@include foundation-xy-grid-classes;
-@include foundation-grid;
-@include foundation-flex-grid;
-@include foundation-flex-classes;
-@include foundation-typography;
-@include foundation-forms;
-@include foundation-button;
-@include foundation-accordion;
-@include foundation-accordion-menu;
-@include foundation-badge;
-@include foundation-breadcrumbs;
-@include foundation-button-group;
-@include foundation-callout;
-@include foundation-card;
-@include foundation-close-button;
-@include foundation-menu;
-@include foundation-menu-icon;
-@include foundation-drilldown-menu;
-@include foundation-dropdown;
-@include foundation-dropdown-menu;
-@include foundation-responsive-embed;
-@include foundation-label;
-@include foundation-media-object;
-@include foundation-off-canvas;
-@include foundation-orbit;
-@include foundation-pagination;
-@include foundation-progress-bar;
-@include foundation-slider;
-@include foundation-sticky;
-@include foundation-reveal;
-@include foundation-switch;
-@include foundation-table;
-@include foundation-tabs;
-@include foundation-thumbnail;
-@include foundation-title-bar;
-@include foundation-tooltip;
-@include foundation-top-bar;
-@include foundation-visibility-classes;
-@include foundation-float-classes;
-@include foundation-print-styles;
-
-
-
+@import "foundation-includes";
 /* Blue theme checkbox and radio button accent color */
 /* Using Foundation's primary color (#1779ba) for the blue theme */
 input[type=checkbox],

--- a/src/bpp/static/scss/app-green.scss
+++ b/src/bpp/static/scss/app-green.scss
@@ -13,50 +13,7 @@
 @import "pagination";
 @import "wizard_forms";
 
-@import 'foundation';
-
-@include foundation-global-styles;
-@include foundation-xy-grid-classes;
-@include foundation-grid;
-@include foundation-flex-grid;
-@include foundation-flex-classes;
-@include foundation-typography;
-@include foundation-forms;
-@include foundation-button;
-@include foundation-accordion;
-@include foundation-accordion-menu;
-@include foundation-badge;
-@include foundation-breadcrumbs;
-@include foundation-button-group;
-@include foundation-callout;
-@include foundation-card;
-@include foundation-close-button;
-@include foundation-menu;
-@include foundation-menu-icon;
-@include foundation-drilldown-menu;
-@include foundation-dropdown;
-@include foundation-dropdown-menu;
-@include foundation-responsive-embed;
-@include foundation-label;
-@include foundation-media-object;
-@include foundation-off-canvas;
-@include foundation-orbit;
-@include foundation-pagination;
-@include foundation-progress-bar;
-@include foundation-slider;
-@include foundation-sticky;
-@include foundation-reveal;
-@include foundation-switch;
-@include foundation-table;
-@include foundation-tabs;
-@include foundation-thumbnail;
-@include foundation-title-bar;
-@include foundation-tooltip;
-@include foundation-top-bar;
-@include foundation-visibility-classes;
-@include foundation-float-classes;
-@include foundation-print-styles;
-
+@import "foundation-includes";
 $info-color: #DEF3B6;
 
 /* Green theme checkbox and radio button accent color */

--- a/src/bpp/static/scss/app-mwsl.scss
+++ b/src/bpp/static/scss/app-mwsl.scss
@@ -12,50 +12,7 @@
 @import "pagination";
 @import "wizard_forms";
 
-@import 'foundation';
-
-@include foundation-global-styles;
-@include foundation-xy-grid-classes;
-@include foundation-grid;
-@include foundation-flex-grid;
-@include foundation-flex-classes;
-@include foundation-typography;
-@include foundation-forms;
-@include foundation-button;
-@include foundation-accordion;
-@include foundation-accordion-menu;
-@include foundation-badge;
-@include foundation-breadcrumbs;
-@include foundation-button-group;
-@include foundation-callout;
-@include foundation-card;
-@include foundation-close-button;
-@include foundation-menu;
-@include foundation-menu-icon;
-@include foundation-drilldown-menu;
-@include foundation-dropdown;
-@include foundation-dropdown-menu;
-@include foundation-responsive-embed;
-@include foundation-label;
-@include foundation-media-object;
-@include foundation-off-canvas;
-@include foundation-orbit;
-@include foundation-pagination;
-@include foundation-progress-bar;
-@include foundation-slider;
-@include foundation-sticky;
-@include foundation-reveal;
-@include foundation-switch;
-@include foundation-table;
-@include foundation-tabs;
-@include foundation-thumbnail;
-@include foundation-title-bar;
-@include foundation-tooltip;
-@include foundation-top-bar;
-@include foundation-visibility-classes;
-@include foundation-float-classes;
-@include foundation-print-styles;
-
+@import "foundation-includes";
 $info-color: #fff0e8;
 
 /* MWSL University theme checkbox and radio button accent color */

--- a/src/bpp/static/scss/app-orange.scss
+++ b/src/bpp/static/scss/app-orange.scss
@@ -12,50 +12,7 @@
 @import "pagination";
 @import "wizard_forms";
 
-@import 'foundation';
-
-@include foundation-global-styles;
-@include foundation-xy-grid-classes;
-@include foundation-grid;
-@include foundation-flex-grid;
-@include foundation-flex-classes;
-@include foundation-typography;
-@include foundation-forms;
-@include foundation-button;
-@include foundation-accordion;
-@include foundation-accordion-menu;
-@include foundation-badge;
-@include foundation-breadcrumbs;
-@include foundation-button-group;
-@include foundation-callout;
-@include foundation-card;
-@include foundation-close-button;
-@include foundation-menu;
-@include foundation-menu-icon;
-@include foundation-drilldown-menu;
-@include foundation-dropdown;
-@include foundation-dropdown-menu;
-@include foundation-responsive-embed;
-@include foundation-label;
-@include foundation-media-object;
-@include foundation-off-canvas;
-@include foundation-orbit;
-@include foundation-pagination;
-@include foundation-progress-bar;
-@include foundation-slider;
-@include foundation-sticky;
-@include foundation-reveal;
-@include foundation-switch;
-@include foundation-table;
-@include foundation-tabs;
-@include foundation-thumbnail;
-@include foundation-title-bar;
-@include foundation-tooltip;
-@include foundation-top-bar;
-@include foundation-visibility-classes;
-@include foundation-float-classes;
-@include foundation-print-styles;
-
+@import "foundation-includes";
 $info-color: #DEF3B6;
 
 /* Orange theme checkbox and radio button accent color */

--- a/src/bpp/static/scss/app-uafm.scss
+++ b/src/bpp/static/scss/app-uafm.scss
@@ -12,50 +12,7 @@
 @import "pagination";
 @import "wizard_forms";
 
-@import 'foundation';
-
-@include foundation-global-styles;
-@include foundation-xy-grid-classes;
-@include foundation-grid;
-@include foundation-flex-grid;
-@include foundation-flex-classes;
-@include foundation-typography;
-@include foundation-forms;
-@include foundation-button;
-@include foundation-accordion;
-@include foundation-accordion-menu;
-@include foundation-badge;
-@include foundation-breadcrumbs;
-@include foundation-button-group;
-@include foundation-callout;
-@include foundation-card;
-@include foundation-close-button;
-@include foundation-menu;
-@include foundation-menu-icon;
-@include foundation-drilldown-menu;
-@include foundation-dropdown;
-@include foundation-dropdown-menu;
-@include foundation-responsive-embed;
-@include foundation-label;
-@include foundation-media-object;
-@include foundation-off-canvas;
-@include foundation-orbit;
-@include foundation-pagination;
-@include foundation-progress-bar;
-@include foundation-slider;
-@include foundation-sticky;
-@include foundation-reveal;
-@include foundation-switch;
-@include foundation-table;
-@include foundation-tabs;
-@include foundation-thumbnail;
-@include foundation-title-bar;
-@include foundation-tooltip;
-@include foundation-top-bar;
-@include foundation-visibility-classes;
-@include foundation-float-classes;
-@include foundation-print-styles;
-
+@import "foundation-includes";
 $info-color: #f0f8ff;
 
 /* UFAM University theme checkbox and radio button accent color */

--- a/src/bpp/static/scss/app-vizja.scss
+++ b/src/bpp/static/scss/app-vizja.scss
@@ -12,50 +12,7 @@
 @import "pagination";
 @import "wizard_forms";
 
-@import 'foundation';
-
-@include foundation-global-styles;
-@include foundation-xy-grid-classes;
-@include foundation-grid;
-@include foundation-flex-grid;
-@include foundation-flex-classes;
-@include foundation-typography;
-@include foundation-forms;
-@include foundation-button;
-@include foundation-accordion;
-@include foundation-accordion-menu;
-@include foundation-badge;
-@include foundation-breadcrumbs;
-@include foundation-button-group;
-@include foundation-callout;
-@include foundation-card;
-@include foundation-close-button;
-@include foundation-menu;
-@include foundation-menu-icon;
-@include foundation-drilldown-menu;
-@include foundation-dropdown;
-@include foundation-dropdown-menu;
-@include foundation-responsive-embed;
-@include foundation-label;
-@include foundation-media-object;
-@include foundation-off-canvas;
-@include foundation-orbit;
-@include foundation-pagination;
-@include foundation-progress-bar;
-@include foundation-slider;
-@include foundation-sticky;
-@include foundation-reveal;
-@include foundation-switch;
-@include foundation-table;
-@include foundation-tabs;
-@include foundation-thumbnail;
-@include foundation-title-bar;
-@include foundation-tooltip;
-@include foundation-top-bar;
-@include foundation-visibility-classes;
-@include foundation-float-classes;
-@include foundation-print-styles;
-
+@import "foundation-includes";
 $info-color: #fff8e0;
 
 /* Vizja University theme checkbox and radio button accent color */


### PR DESCRIPTION
## Co i po co

Czwarty PR z planu w `docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md` (punkt 3.3, „Foundation diet").

## Audyt

Grep selektorów każdego z 41 komponentów Foundation po templates + JS w `src/` **oraz** templates pakietów renderowanych przez BPP (multiseek, dal, channels_broadcast, cookielaw, session_security). Wynik: **9 komponentów bez ani jednego użycia**:

`accordion-menu`, `drilldown-menu`, `responsive-embed`, `media-object`, `off-canvas`, `orbit`, `slider`, `switch`, `thumbnail`

## Zmiany

- Nowy **`_foundation-includes.scss`** — wspólna, udokumentowana lista include'ów dla wszystkich 6 motywów (wcześniej 6 identycznych kopii po 41 linii; weryfikowane md5). Przyszłe zmiany w jednym miejscu; w pliku komentarz z audytem i instrukcją przywrócenia komponentu.
- 9 martwych `@include` usuniętych.

## Liczby (uczciwie)

- `app-*.css`: **~306 KB → ~290 KB na motyw (−16,5 KB, −5,4%)**.
- To mniej niż szacunek ze spec (~150 KB) — ciężkie komponenty (gridy ×3, forms, typography, button) są realnie używane; spec zaktualizowany.
- **Zmierzony follow-up** (świadomie odłożony): `foundation-grid` (float) i `foundation-flex-grid` emitują nakładające się reguły `.row/.columns` — usunięcie float-grida dałoby kolejne **−17,7 KB** (zmierzony test-compile), ale zmienia kaskadę (clearfixy) i wymaga pełnej regresji wizualnej.

## Weryfikacja

- Kompilowany CSS: wszystkie używane selektory obecne (`.top-bar`, `.callout`, `.reveal`, `.pagination`, `.sticky`, `.tabs`, `.badge`), wszystkie usunięte nieobecne (`.orbit`, `.off-canvas`, `.switch-paddle`, `.drilldown`, ...).
- Wizualny smoke-test (run-site + Playwright chromium, screenshoty): strona główna, multiseek (formularz + wyniki), przeglądanie lat — top-bar, dropdowny, breadcrumbs, callouty, przyciski, layout bez regresji; zero błędów JS.
- Ryzyko dbtemplates / customizacji per-uczelnia: usunięte komponenty to widgety layoutowe, których szablony w dbtemplates (opisy bibliograficzne — poziom tekstu) nie używają; gdyby któryś był potrzebny, przywrócenie = 1 linia w `_foundation-includes.scss` + `grunt build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)