### PR TITLE
perf(rekord): indeks na bpp_rekord_mat.slug + ma_punktacje_sloty jednym zapytaniem

### DIFF
--- a/docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md
+++ b/docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md
@@ -114,6 +114,10 @@ denorm dotknie wiersza publikacji. Zamierzone, ale nieudokumentowane —
 przy opóźnionej kolejce denorm listy pokazują przestarzałą liczbę
 autorów. Akcja: komentarz w SQL + nota w mapa-kodu.md.
 
+**Status: ✅ zrobione** (branch `perf/slug-index`) — komentarz przy polu
+`liczba_autorow` w `src/bpp/models/cache/rekord.py` (mapa-kodu.md jest
+generowana maszynowo, więc nota poszła do kodu).
+
 ### 1.4. Bug poprawności: `UPDATE` z `TD["old"]` (PRIORYTET 9)
 
 **Problem.** Dla `UPDATE` trigger czyta tylko `TD["old"]` (linia 467).
@@ -253,9 +257,26 @@ zapytanie), ale:
 
 - `Rekord.ma_punktacje_sloty` (`rekord.py:302-310`) — dwa `.exists()`;
   da się jednym (`Exists`/union). Tylko strona szczegółów.
+  **✅ zrobione** (branch `perf/slug-index`) — UNION ALL + LIMIT 1.
 - Strona autora (`autor.html` + `Autor.prace_w_latach`,
   `autor.py:366`) — kilka osobnych zapytań DISTINCT per render;
   łączyć tylko, jeśli pojawi się w slow logach.
+
+### 2.6. Brak indeksu na `bpp_rekord_mat.slug` (znalezione po audycie)
+
+**Problem.** `PracaViewBySlug` — kanoniczny publiczny URL rekordu —
+robi `Rekord.objects.get(slug=...)`, a kolumna `slug` (dodana w 0253)
+**nigdy nie miała indeksu**. Każde wejście na stronę rekordu po slug
+= Seq Scan po całej, szerokiej tabeli mat (tsvector itd.).
+
+**Fix.** Migracja `0430_rekord_mat_slug_idx`:
+`CREATE INDEX CONCURRENTLY IF NOT EXISTS bpp_rekord_mat_slug_idx`
+(`atomic = False`). Koszt zapisu mały — po triggerze v3 odświeżenia to
+HOT-friendly UPDATE-y, a slug zmienia się rzadko.
+
+**Status: ✅ zrobione** (branch `perf/slug-index`) — test z
+`enable_seqscan = off` potwierdza Index Scan;
+`test_cache/test_rekord_perf.py`.
 
 ---
 

--- a/src/bpp/migrations/0430_rekord_mat_slug_idx.py
+++ b/src/bpp/migrations/0430_rekord_mat_slug_idx.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    # CREATE INDEX CONCURRENTLY nie może działać w bloku transakcji —
+    # stąd atomic = False. CONCURRENTLY: tabela mat bywa duża, a zwykły
+    # CREATE INDEX trzymałby write-lock na czas budowy (triggery cache
+    # piszą do niej przy każdej edycji publikacji).
+    atomic = False
+
+    dependencies = [
+        ("bpp", "0429_cache_trigger_v3"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            # PracaViewBySlug (kanoniczny publiczny URL rekordu) robi
+            # Rekord.objects.get(slug=...) — bez indeksu to Seq Scan
+            # po całej, szerokiej tabeli przy każdym wejściu na stronę
+            # rekordu. Kolumna slug istnieje od 0253, indeksu nigdy
+            # nie było (audyt: spec-optymalizacje-wydajnosci-2026-06).
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS bpp_rekord_mat_slug_idx "
+            "ON bpp_rekord_mat (slug)",
+            "DROP INDEX CONCURRENTLY IF EXISTS bpp_rekord_mat_slug_idx",
+        ),
+    ]

--- a/src/bpp/models/cache/rekord.py
+++ b/src/bpp/models/cache/rekord.py
@@ -232,6 +232,12 @@ class RekordBase(
 
     tytul_oryginalny_sort = models.TextField()
 
+    # UWAGA eventual consistency: trigger bpp_refresh_cache() odświeża
+    # liczba_autorow tylko przy zdarzeniach na wierszu PUBLIKACJI. Edycja
+    # tabeli *_autor sama w sobie nie przelicza tej kolumny — aktualizacja
+    # przychodzi dopiero, gdy flush denorm (opis_bibliograficzny_cache
+    # zależy od *_autor) dotknie wiersza publikacji. Przy opóźnionej
+    # kolejce denorm wartość bywa chwilowo nieaktualna.
     liczba_autorow = models.SmallIntegerField()
 
     liczba_cytowan = models.SmallIntegerField()
@@ -302,13 +308,18 @@ class RekordBase(
 
     @cached_property
     def ma_punktacje_sloty(self):
+        # Jedno zapytanie (UNION ALL + LIMIT 1) zamiast dwóch osobnych EXISTS.
+        pk = [self.id[0], self.id[1]]
         return (
-            Cache_Punktacja_Autora.objects.filter(
-                rekord_id=[self.id[0], self.id[1]]
-            ).exists()
-            or Cache_Punktacja_Dyscypliny.objects.filter(
-                rekord_id=[self.id[0], self.id[1]]
-            ).exists()
+            Cache_Punktacja_Autora.objects.filter(rekord_id=pk)
+            .values_list("pk")
+            .union(
+                Cache_Punktacja_Dyscypliny.objects.filter(rekord_id=pk).values_list(
+                    "pk"
+                ),
+                all=True,
+            )
+            .exists()
         )
 
     @cached_property

--- a/src/bpp/newsfragments/+rekord-slug-index.feature.rst
+++ b/src/bpp/newsfragments/+rekord-slug-index.feature.rst
@@ -1,0 +1,5 @@
+Strona pojedynczego rekordu (adres ze slugiem) ładuje się szybciej:
+kolumna ``slug`` w tabeli cache ``bpp_rekord_mat`` dostała indeks —
+wcześniej każde wejście na stronę rekordu skanowało całą tabelę.
+Dodatkowo sprawdzenie „czy rekord ma punktację/sloty" na stronie
+szczegółów kosztuje jedno zapytanie zamiast dwóch.

--- a/src/bpp/tests/test_cache/test_rekord_perf.py
+++ b/src/bpp/tests/test_cache/test_rekord_perf.py
@@ -1,0 +1,54 @@
+"""Testy wydajnościowe Rekord (spec-optymalizacje-wydajnosci-2026-06).
+
+1. Wyszukanie po slug (PracaViewBySlug — kanoniczny publiczny URL rekordu)
+   musi używać indeksu — bez niego każde wejście na stronę rekordu robi
+   Seq Scan po całej, szerokiej tabeli bpp_rekord_mat.
+
+2. ma_punktacje_sloty ma kosztować jedno zapytanie, nie dwa osobne EXISTS.
+"""
+
+import pytest
+from django.db import connection
+from model_bakery import baker
+
+from bpp.models import Rekord
+from bpp.models.cache import Cache_Punktacja_Dyscypliny
+from bpp.tests.util import any_ciagle
+
+
+@pytest.mark.django_db
+def test_wyszukanie_po_slug_uzywa_indeksu():
+    any_ciagle(tytul_oryginalny="Praca ze slugiem")
+    with connection.cursor() as c:
+        # enable_seqscan=off: przy małej tabeli planner i tak wybrałby
+        # Seq Scan; wyłączenie wymusza indeks JEŚLI ISTNIEJE — a o jego
+        # istnienie tu chodzi.
+        c.execute("SET enable_seqscan = off")
+        c.execute("EXPLAIN SELECT id FROM bpp_rekord_mat WHERE slug = 'nie-ma-takiego'")
+        plan = "\n".join(row[0] for row in c.fetchall())
+        c.execute("RESET enable_seqscan")
+    assert "Seq Scan on bpp_rekord_mat" not in plan, plan
+
+
+@pytest.mark.django_db
+def test_ma_punktacje_sloty_jedno_zapytanie(django_assert_num_queries):
+    wc = any_ciagle()
+    rekord = Rekord.objects.get_original(wc)
+    with django_assert_num_queries(1):
+        assert rekord.ma_punktacje_sloty is False
+
+
+@pytest.mark.django_db
+def test_ma_punktacje_sloty_wykrywa_punktacje_dyscypliny():
+    """Strażnik: punktacja TYLKO w Cache_Punktacja_Dyscypliny (bez wpisu
+    per-autor) nadal daje True — pojedyncze zapytanie musi pokrywać
+    obie tabele."""
+    wc = any_ciagle()
+    rekord = Rekord.objects.get_original(wc)
+    baker.make(
+        Cache_Punktacja_Dyscypliny,
+        rekord_id=list(rekord.pk),
+        pkd=10,
+        slot=1,
+    )
+    assert rekord.ma_punktacje_sloty is True


### PR DESCRIPTION
## Co i po co

Piąty PR z planu w `docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md` (nowy punkt 2.6 + dokończenie 2.5 i 1.3).

## Brak indeksu na `bpp_rekord_mat.slug` (główne znalezisko)

`PracaViewBySlug` — **kanoniczny publiczny URL każdego rekordu** (ten sam, który rozdaje API ostatnich publikacji) — robi `Rekord.objects.get(slug=...)`. Kolumna `slug` istnieje od migracji 0253, ale **indeksu nigdy nie miała** (zweryfikowane po wszystkich `CREATE INDEX` w migracjach SQL + audycie indeksów). Efekt: każde wejście na stronę rekordu po slug = Seq Scan po całej, szerokiej tabeli mat (z tsvectorem).

Migracja **0430**: `CREATE INDEX CONCURRENTLY IF NOT EXISTS bpp_rekord_mat_slug_idx` (`atomic = False` — CONCURRENTLY nie może działać w transakcji; bez blokady zapisu na czas budowy, bo triggery cache piszą do tej tabeli na bieżąco). Koszt utrzymania mały: po triggerze v3 (#352) odświeżenia to HOT-friendly UPDATE-y, a slug zmienia się rzadko.

## Mniejsze

- `Rekord.ma_punktacje_sloty`: UNION ALL + LIMIT 1 (1 zapytanie) zamiast dwóch osobnych `.exists()` (strona szczegółów rekordu).
- Komentarz o eventual consistency `liczba_autorow` przy polu modelu (spec 1.3; trafił do kodu, bo `mapa-kodu.md` jest generowana maszynowo).

## Testy (TDD)

- Indeks: test z `enable_seqscan = off` — RED na v2 pokazywał Seq Scan **mimo kary plannera 10^10** (dowód braku indeksu), GREEN: Index Scan.
- `ma_punktacje_sloty`: RED „Expected 1 queries but 2 were done" → GREEN; + strażnik, że punktacja obecna tylko w `Cache_Punktacja_Dyscypliny` nadal daje `True`.
- Regresja: `test_cache/` + `test_views/` — **202 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)