### PR TITLE
perf(browse): AutorzyView — Exists zamiast Count/anti-joinów + fix ukrywania autorów obcych

### DIFF
--- a/docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md
+++ b/docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md
@@ -278,6 +278,27 @@ HOT-friendly UPDATE-y, a slug zmienia się rzadko.
 `enable_seqscan = off` potwierdza Index Scan;
 `test_cache/test_rekord_perf.py`.
 
+### 2.7. AutorzyView: filtr „autorów obcych" (znalezione po audycie)
+
+**Problem.** `_apply_uczelnia_filters`: (a) `annotate(Count("autor_jednostka"))`
+wymuszał GROUP BY po liście autorów × przypisania na każdej stronie
+przeglądarki autorów; (b) `.exclude(autorzyview=None)` („bez prac")
+anti-joinował NIEzmaterializowany widok `bpp_autorzy` — unię 5 tabel
+`*_autor`; (c) zapis `Q(pk=-1) & Q(pk=obca_id) & Q(count<=2)` w exclude()
+ukrywał tylko autorów w OBU sztucznych jednostkach naraz (exclude daje
+warunkom wielowartościowym osobne joiny) — autor wyłącznie w jednej
+sztucznej (np. tylko pk=-1) pozostawał widoczny.
+
+**Fix.** Trzy `Exists()` zamiast Count (w tym trik `EXISTS(... OFFSET 1)`
+na „co najmniej dwa przypisania"); „bez prac" jako `Exists` po
+`bpp_autorzy_mat` (indeks po autor_id); semantyka reguły (decyzja
+użytkownika 2026-06): ukryj autora, gdy KAŻDE jego przypisanie wskazuje
+jednostkę sztuczną (obca_jednostka lub pk=-1).
+
+**Status: ✅ zrobione** (branch `perf/autorzy-view-filters`,
+`test_views/test_browse/test_autorzy_view_filters.py` — 8 testów,
+w tym czerwony na starym kodzie dowód luki „tylko pk=-1").
+
 ---
 
 ## Warstwa 3: pipeline CSS/JS (Grunt + dart-sass + esbuild)

--- a/src/bpp/newsfragments/+autorzy-view-filters.feature.rst
+++ b/src/bpp/newsfragments/+autorzy-view-filters.feature.rst
@@ -1,0 +1,6 @@
+Przeglądanie autorów działa szybciej i poprawniej ukrywa autorów
+obcych: lista nie buduje już GROUP BY po wszystkich przypisaniach
+autorów, filtr „autorzy bez prac" korzysta ze zmaterializowanej tabeli
+cache zamiast skanować pięć tabel źródłowych, a autor przypisany
+wyłącznie do jednostki sztucznej (Obca / „Błędna") jest teraz ukrywany
+także wtedy, gdy figuruje tylko w jednej z nich.

--- a/src/bpp/tests/test_cache/test_cache_pk_filter.py
+++ b/src/bpp/tests/test_cache/test_cache_pk_filter.py
@@ -42,12 +42,18 @@ def test_object_id_raw_daje_index_seek_na_pk():
     nie do Seq Scan (sedno optymalizacji)."""
     wc = baker.make(Wydawnictwo_Ciagle)
     with connection.cursor() as c:
+        # enable_seqscan=off: na malej tabeli planner potrafi wybrac
+        # Seq Scan mimo indeksu (zalezne od statystyk => flaky w CI);
+        # wylaczenie wymusza indeks JESLI ISTNIEJE - a o jego uzycie
+        # przez widok tu chodzi.
+        c.execute("SET enable_seqscan = off")
         c.execute(
             "EXPLAIN SELECT * FROM bpp_wydawnictwo_ciagle_view "
             "WHERE object_id_raw = %s",
             [wc.pk],
         )
         plan = "\n".join(row[0] for row in c.fetchall())
+        c.execute("RESET enable_seqscan")
     assert "Index Cond" in plan, plan
     assert "Seq Scan on bpp_wydawnictwo_ciagle " not in plan, plan
 

--- a/src/bpp/tests/test_views/test_browse/test_autorzy_view_filters.py
+++ b/src/bpp/tests/test_views/test_browse/test_autorzy_view_filters.py
@@ -1,0 +1,144 @@
+"""Testy filtrów AutorzyView._apply_uczelnia_filters (przeglądanie autorów).
+
+Reguła „ukryj autorów obcych": ukryci mają być autorzy, których WSZYSTKIE
+przypisania wskazują jednostki sztuczne — skonfigurowaną obca_jednostka
+LUB jednostkę pk=-1 („Błędna/Obca" z konwencji starych wdrożeń).
+
+Historyczny zapis `Q(jednostka__pk=-1) & Q(jednostka__pk=obca_id)
+& Q(count__lte=2)` w exclude() dostawał OSOBNE joiny per warunek
+(semantyka exclude dla relacji wielowartościowych), więc ukrywał tylko
+autorów przypisanych do OBU sztucznych jednostek naraz; autor wyłącznie
+w jednej z nich (np. tylko pk=-1) pozostawał widoczny — potwierdzone
+czerwonym testem na starym kodzie. Nowa semantyka (decyzja 2026-06):
+ukryj, gdy KAŻDE przypisanie jest sztuczne.
+"""
+
+import pytest
+from django.test import RequestFactory
+from model_bakery import baker
+
+from bpp.models import Autor_Jednostka, Jednostka
+from bpp.models.autor import Autor
+from bpp.views.browse import AutorzyView
+
+
+def _widoczni_autorzy(uczelnia):
+    view = AutorzyView()
+    view.request = RequestFactory().get("/autorzy/")
+    view.kwargs = {}
+    return set(view.get_queryset().values_list("pk", flat=True))
+
+
+@pytest.fixture
+def uczelnia_ukrywa_obcych(uczelnia):
+    obca = baker.make(
+        Jednostka, nazwa="Obca jednostka", skupia_pracownikow=False, uczelnia=uczelnia
+    )
+    uczelnia.obca_jednostka = obca
+    uczelnia.pokazuj_autorow_obcych_w_przegladaniu_danych = False
+    uczelnia.save()
+    return uczelnia
+
+
+def _jednostka_bledna(uczelnia):
+    # Jednostka.save() z jawnym pk=-1 wpada w forced-update (hooki save);
+    # tworzymy normalnie i przenumerowujemy queryset-owym update().
+    j = baker.make(Jednostka, nazwa="Błędna", uczelnia=uczelnia)
+    Jednostka.objects.filter(pk=j.pk).update(id=-1)
+    return Jednostka.objects.get(pk=-1)
+
+
+def _autor(nazwisko, *jednostki, aktualna=None):
+    a = baker.make(Autor, imiona="Jan", nazwisko=nazwisko, pokazuj=True)
+    for j in jednostki:
+        Autor_Jednostka.objects.create(autor=a, jednostka=j)
+    Autor.objects.filter(pk=a.pk).update(aktualna_jednostka=aktualna)
+    return a
+
+
+@pytest.mark.django_db
+def test_ukryty_autor_tylko_w_jednostce_minus_jeden(uczelnia_ukrywa_obcych):
+    """Autor przypisany WYŁĄCZNIE do jednostki pk=-1 ma być ukryty."""
+    bledna = _jednostka_bledna(uczelnia_ukrywa_obcych)
+    a = _autor("TylkoBledna", bledna, aktualna=bledna)
+
+    assert a.pk not in _widoczni_autorzy(uczelnia_ukrywa_obcych)
+
+
+@pytest.mark.django_db
+def test_ukryty_autor_w_obu_sztucznych_jednostkach(uczelnia_ukrywa_obcych):
+    """Autor przypisany do pk=-1 ORAZ obca_jednostka (i nic poza tym)
+    ma być ukryty."""
+    bledna = _jednostka_bledna(uczelnia_ukrywa_obcych)
+    obca = uczelnia_ukrywa_obcych.obca_jednostka
+    a = _autor("ObieSztuczne", bledna, obca, aktualna=obca)
+
+    assert a.pk not in _widoczni_autorzy(uczelnia_ukrywa_obcych)
+
+
+@pytest.mark.django_db
+def test_ukryty_autor_tylko_w_obcej(uczelnia_ukrywa_obcych):
+    obca = uczelnia_ukrywa_obcych.obca_jednostka
+    a = _autor("TylkoObca", obca, aktualna=obca)
+
+    assert a.pk not in _widoczni_autorzy(uczelnia_ukrywa_obcych)
+
+
+@pytest.mark.django_db
+def test_widoczny_autor_z_prawdziwa_jednostka(uczelnia_ukrywa_obcych, jednostka):
+    a = _autor("Prawdziwy", jednostka, aktualna=jednostka)
+
+    assert a.pk in _widoczni_autorzy(uczelnia_ukrywa_obcych)
+
+
+@pytest.mark.django_db
+def test_widoczny_autor_prawdziwa_plus_obca(uczelnia_ukrywa_obcych, jednostka):
+    """Autor z prawdziwą jednostką + obcą NIE może zostać ukryty."""
+    obca = uczelnia_ukrywa_obcych.obca_jednostka
+    a = _autor("Mieszany", jednostka, obca, aktualna=jednostka)
+
+    assert a.pk in _widoczni_autorzy(uczelnia_ukrywa_obcych)
+
+
+@pytest.mark.django_db
+def test_pokazuj_obcych_wylacza_filtr(uczelnia_ukrywa_obcych):
+    """Z flagą pokazuj_autorow_obcych=True nikt nie jest ukrywany."""
+    uczelnia_ukrywa_obcych.pokazuj_autorow_obcych_w_przegladaniu_danych = True
+    uczelnia_ukrywa_obcych.save()
+
+    obca = uczelnia_ukrywa_obcych.obca_jednostka
+    a = _autor("ObcyWidoczny", obca, aktualna=obca)
+
+    assert a.pk in _widoczni_autorzy(uczelnia_ukrywa_obcych)
+
+
+@pytest.mark.django_db
+def test_bez_grupowania_w_sql(uczelnia_ukrywa_obcych):
+    """Filtr nie może budować GROUP BY po całej liście autorów
+    (poprzednio: annotate(Count(autor_jednostka)))."""
+    view = AutorzyView()
+    view.request = RequestFactory().get("/autorzy/")
+    view.kwargs = {}
+    sql = str(view.get_queryset().query)
+    assert "GROUP BY" not in sql.upper(), sql
+
+
+@pytest.mark.django_db
+def test_filtr_bez_prac(uczelnia_ukrywa_obcych, jednostka, standard_data, denorms):
+    """pokazuj_autorow_bez_prac=False ukrywa autora bez publikacji,
+    pokazuje autora z publikacją."""
+    from bpp.tests.util import any_ciagle
+
+    uczelnia_ukrywa_obcych.pokazuj_autorow_bez_prac_w_przegladaniu_danych = False
+    uczelnia_ukrywa_obcych.save()
+
+    a_z_praca = _autor("ZPraca", jednostka, aktualna=jednostka)
+    a_bez_pracy = _autor("BezPracy", jednostka, aktualna=jednostka)
+
+    wc = any_ciagle(tytul_oryginalny="Praca autora")
+    wc.dodaj_autora(a_z_praca, jednostka)
+    denorms.flush()
+
+    widoczni = _widoczni_autorzy(uczelnia_ukrywa_obcych)
+    assert a_z_praca.pk in widoczni
+    assert a_bez_pracy.pk not in widoczni

--- a/src/bpp/views/browse.py
+++ b/src/bpp/views/browse.py
@@ -6,7 +6,7 @@ from cacheops import cached
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Count
+from django.db.models import Count, Exists, OuterRef
 from django.db.models.functions import Substr
 from django.http import JsonResponse
 from django.utils import timezone
@@ -311,23 +311,54 @@ class AutorzyView(Browser):
             return queryset
 
         if not uczelnia.pokazuj_autorow_obcych_w_przegladaniu_danych:
-            queryset = queryset.annotate(Count("autor_jednostka"))
-            # Wyrzuć autorów przypisanych do Obca + Błędna
+            from bpp.models import Autor_Jednostka
+
+            sztuczne_jednostki = [-1]
+            if uczelnia.obca_jednostka_id is not None:
+                sztuczne_jednostki.append(uczelnia.obca_jednostka_id)
+
+            przypisania = Autor_Jednostka.objects.filter(autor=OuterRef("pk"))
+
+            queryset = queryset.annotate(
+                _ma_przypisania=Exists(przypisania),
+                _ma_prawdziwa_jednostke=Exists(
+                    przypisania.exclude(jednostka_id__in=sztuczne_jednostki)
+                ),
+                # EXISTS(... OFFSET 1) == "ma co najmniej dwa przypisania"
+                _ma_wiele_przypisan=Exists(przypisania.values("pk")[1:]),
+            )
+
+            # Wyrzuć autorów, których WSZYSTKIE przypisania to jednostki
+            # sztuczne: skonfigurowana obca_jednostka lub pk=-1 ("Błędna"
+            # z konwencji starych wdrożeń). Wcześniejszy zapis
+            # Q(pk=-1) & Q(pk=obca_id) & Q(count<=2) w exclude() ukrywał
+            # tylko autorów w OBU sztucznych naraz (exclude daje warunkom
+            # wielowartościowym osobne joiny); autor wyłącznie w jednej
+            # sztucznej jednostce pozostawał widoczny.
             queryset = queryset.exclude(
-                Q(autor_jednostka__jednostka__pk=-1)
-                & Q(autor_jednostka__jednostka__pk=uczelnia.obca_jednostka_id)
-                & Q(autor_jednostka__count__lte=2)
+                _ma_przypisania=True, _ma_prawdziwa_jednostke=False
             )
             queryset = queryset.exclude(
-                aktualna_jednostka=None, autor_jednostka__count=1
+                aktualna_jednostka=None,
+                _ma_przypisania=True,
+                _ma_wiele_przypisan=False,
             )
             queryset = queryset.exclude(
                 aktualna_jednostka_id=uczelnia.obca_jednostka_id,
-                autor_jednostka__count=1,
+                _ma_przypisania=True,
+                _ma_wiele_przypisan=False,
             )
 
         if not uczelnia.pokazuj_autorow_bez_prac_w_przegladaniu_danych:
-            queryset = queryset.exclude(autorzyview=None)
+            from bpp.models.cache import Autorzy
+
+            # Exists po zmaterializowanej bpp_autorzy_mat (indeks po
+            # autor_id) zamiast anti-joina po bpp_autorzy — to widok-unia
+            # 5 tabel *_autor, nie zmaterializowany, wiec kazde zapytanie
+            # skanowalo wszystkie tabele zrodlowe.
+            queryset = queryset.filter(
+                Exists(Autorzy.objects.filter(autor=OuterRef("pk")))
+            )
 
         return queryset
 


### PR DESCRIPTION
## Co i po co

PR 6 z planu wydajnościowego (`docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md`, nowy punkt 2.7). Przeglądarka autorów (`/autorzy/`) — trzy zmiany w `_apply_uczelnia_filters`:

## 1. Bez GROUP BY po liście autorów

`annotate(Count("autor_jednostka"))` wymuszał GROUP BY po autorach × przypisaniach na każdej stronie listy. Zastąpione trzema skorelowanymi `Exists()` — w tym trik `EXISTS(... OFFSET 1)` jako tani test „ma co najmniej dwa przypisania". Test pilnuje, że w SQL nie ma `GROUP BY`.

## 2. Filtr „autorzy bez prac" po tabeli zmaterializowanej

`.exclude(autorzyview=None)` anti-joinował **niezmaterializowany** widok `bpp_autorzy` — unię pięciu tabel `*_autor`, więc każde zapytanie listy skanowało wszystkie tabele źródłowe. Teraz `Exists` po `bpp_autorzy_mat` (indeks po `autor_id`).

## 3. Fix semantyki „ukryj autorów obcych" (decyzja użytkownika: miał być OR)

Stary zapis `Q(jednostka__pk=-1) & Q(jednostka__pk=obca_id) & Q(count<=2)` w `exclude()` dostaje **osobne joiny per warunek** (semantyka exclude dla relacji wielowartościowych) — ukrywał więc tylko autorów przypisanych do OBU sztucznych jednostek naraz. Autor wyłącznie w jednej z nich (np. tylko `pk=-1`) **pozostawał widoczny** — dowiedzione czerwonym testem na starym kodzie. Nowa reguła: ukryj autora, gdy **każde** jego przypisanie wskazuje jednostkę sztuczną (skonfigurowana `obca_jednostka` lub `pk=-1`).

Ciekawostka procesowa: pierwotna hipoteza z audytu („warunek niespełnialny") okazała się błędna właśnie dzięki TDD — test-strażnik „autor w obu sztucznych" przeszedł na starym kodzie, ujawniając prawdziwą semantykę exclude(); opisy w kodzie i spec zostały skorygowane do stanu faktycznego.

## Testy

- 8 testów (`test_autorzy_view_filters.py`): luka „tylko pk=-1" (RED na starym kodzie), strażniki zachowań dotychczasowych (oba-sztuczne ukryty, tylko-obca ukryty, autor z prawdziwą jednostką widoczny, mieszany widoczny, flaga `pokazuj_autorow_obcych` wyłącza filtr), brak GROUP BY, filtr „bez prac".
- Regresja: `test_views/` + `test_multiseek/` — **246 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)