### PR TITLE
perf(multiseek): cache agregatów wyników — stronicowanie bez powtarzania COUNT

### DIFF
--- a/docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md
+++ b/docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md
@@ -219,6 +219,15 @@ zawyżone przez duplikację z joina.
 **Status: ✅ zrobione** (branch `perf/orm-quick-wins`,
 `test_views/test_mymultiseek_query_count.py`).
 
+**Etap 2 — cache agregatów (✅, branch `perf/multiseek-count-cache`):**
+stronicowanie tych samych wyników nie powtarza skanu — agregaty
+(count + sumy) cache'owane 30 min pod kluczem
+sha256(formularz, removed, print-removed, zalogowanie, uczelnia).
+Decyzja użytkownika 2026-06: implementacja w BPP (nie w pakiecie
+django-multiseek — upstream nawet nie wykonuje tego COUNT-a, a klucz
+zależy od BPP-specyficznych wejść). W dev/local default cache to
+DummyCache — cache działa na produkcji (Redis).
+
 ### 2.3. Browse: zbędne zapytania (PRIORYTET 7)
 
 `src/bpp/views/browse.py` (zweryfikowane):

--- a/src/bpp/newsfragments/+multiseek-count-cache.feature.rst
+++ b/src/bpp/newsfragments/+multiseek-count-cache.feature.rst
@@ -1,0 +1,4 @@
+Przeglądanie kolejnych stron wyników multiwyszukiwarki jest szybsze:
+liczba rekordów i sumy punktacji są liczone raz na zapytanie
+(cache 30 min), a nie od nowa przy każdej stronie. Zmiana formularza,
+wyrzucenie rekordu z wyników lub zalogowanie przelicza od razu.

--- a/src/bpp/tests/test_views/test_mymultiseek_count_cache.py
+++ b/src/bpp/tests/test_views/test_mymultiseek_count_cache.py
@@ -1,0 +1,138 @@
+"""Cache agregatów strony wyników multiseek (count + sumy).
+
+Stronicowanie wyników nie może powtarzać drogiego COUNT (DISTINCT przy
+joinie do bpp_autorzy_mat) przy każdej stronie tego samego zapytania —
+agregaty są cache'owane per (formularz, removed, print-removed,
+zalogowanie, uczelnia). Zmiana któregokolwiek z tych wejść przelicza.
+
+Uwaga: settings testowe mają DummyCache — testy podmieniają default na
+LocMemCache fixture'em `settings`.
+"""
+
+import json
+from decimal import Decimal
+
+import pytest
+from django.conf import settings as django_settings
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from django.utils import translation
+from multiseek.logic import STARTS_WITH
+from multiseek.views import MULTISEEK_SESSION_KEY, MULTISEEK_SESSION_KEY_REMOVED
+
+from bpp.models import Rekord
+from bpp.tests.util import any_ciagle
+
+TYTUL_PREFIX = "CCache multiseek"
+TABLE_REPORT_TYPE = "1"
+
+
+def _ustaw_filtr(client, value, report_type=TABLE_REPORT_TYPE):
+    with translation.override(django_settings.LANGUAGE_CODE):
+        operator = str(STARTS_WITH)
+
+    session = client.session
+    session[MULTISEEK_SESSION_KEY] = json.dumps(
+        {
+            "form_data": [
+                None,
+                {
+                    "field": "Tytuł pracy",
+                    "operator": operator,
+                    "value": value,
+                    "prev_op": None,
+                },
+            ],
+            "ordering": {},
+            "report_type": report_type,
+        }
+    )
+    session.save()
+
+
+def _agregaty_sql(ctx):
+    return [
+        q["sql"]
+        for q in ctx.captured_queries
+        if "bpp_rekord_mat" in q["sql"]
+        and ("COUNT(" in q["sql"].upper() or "SUM(" in q["sql"].upper())
+    ]
+
+
+@pytest.fixture
+def locmem_cache(settings):
+    # Podmień tylko alias "default" (testowo DummyCache); constance_cache
+    # zostaje bez zmian (django-constance odrzuca backendy lokalne).
+    caches = dict(settings.CACHES)
+    caches["default"] = {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
+    settings.CACHES = caches
+    from django.core.cache import cache
+
+    cache.clear()
+    yield cache
+    cache.clear()
+
+
+@pytest.fixture
+def dwa_rekordy(standard_data):
+    a = any_ciagle(
+        tytul_oryginalny=f"{TYTUL_PREFIX} alfa",
+        rok=2024,
+        impact_factor=Decimal("1.500"),
+    )
+    b = any_ciagle(
+        tytul_oryginalny=f"{TYTUL_PREFIX} beta",
+        rok=2023,
+        impact_factor=Decimal("2.500"),
+    )
+    return a, b
+
+
+@pytest.mark.django_db
+def test_drugie_wejscie_nie_liczy_agregatow_ponownie(client, dwa_rekordy, locmem_cache):
+    _ustaw_filtr(client, TYTUL_PREFIX)
+
+    res1 = client.get(reverse("multiseek:results"))
+    assert res1.context["paginator_count"] == 2
+
+    with CaptureQueriesContext(connection) as ctx:
+        res2 = client.get(reverse("multiseek:results"))
+
+    assert res2.context["paginator_count"] == 2
+    assert res2.context["sumy"]["impact_factor__sum"] == Decimal("4.000")
+    assert _agregaty_sql(ctx) == []
+
+
+@pytest.mark.django_db
+def test_zmiana_formularza_przelicza(client, dwa_rekordy, locmem_cache):
+    _ustaw_filtr(client, TYTUL_PREFIX)
+    assert client.get(reverse("multiseek:results")).context["paginator_count"] == 2
+
+    _ustaw_filtr(client, f"{TYTUL_PREFIX} beta")
+    assert client.get(reverse("multiseek:results")).context["paginator_count"] == 1
+
+
+@pytest.mark.django_db
+def test_wyrzucenie_rekordu_przelicza(client, dwa_rekordy, locmem_cache):
+    _ustaw_filtr(client, TYTUL_PREFIX)
+    assert client.get(reverse("multiseek:results")).context["paginator_count"] == 2
+
+    rekord = Rekord.objects.get_original(dwa_rekordy[0])
+    session = client.session
+    session[MULTISEEK_SESSION_KEY_REMOVED] = [list(rekord.pk)]
+    session.save()
+
+    assert client.get(reverse("multiseek:results")).context["paginator_count"] == 1
+
+
+@pytest.mark.django_db
+def test_zalogowanie_ma_osobny_cache(client, admin_client, dwa_rekordy, locmem_cache):
+    """Anonim i zalogowany mają osobne klucze (ukryte statusy zależą od
+    zalogowania) — wpis anonima nie może obsłużyć admina."""
+    _ustaw_filtr(client, TYTUL_PREFIX)
+    assert client.get(reverse("multiseek:results")).context["paginator_count"] == 2
+
+    _ustaw_filtr(admin_client, TYTUL_PREFIX)
+    res = admin_client.get(reverse("multiseek:results"))
+    assert res.context["paginator_count"] == 2

--- a/src/bpp/views/mymultiseek.py
+++ b/src/bpp/views/mymultiseek.py
@@ -1,4 +1,5 @@
 import csv
+import hashlib
 import html
 import io
 import json
@@ -6,6 +7,7 @@ import logging
 import re
 
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.cache import cache
 from django.db.models import Count, Sum
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.urls import reverse
@@ -32,6 +34,9 @@ PKT_WEWN = "pkt_wewn"
 PKT_WEWN_BEZ = "pkt_wewn_bez"
 TABLE = "table"
 MULTISEEK_EXPORT_MAX_ROWS = 5000
+
+# TTL cache agregatów wyników (count + sumy) — patrz get_context_data.
+MULTISEEK_AGGREGATE_CACHE_TIMEOUT = 30 * 60
 MULTISEEK_REPORT_TITLE_SESSION_KEY = "MULTISEEK_TITLE"
 MULTISEEK_DEFAULT_REPORT_TITLE = "Rezultat wyszukiwania"
 XLSX_WORKSHEET_TITLE_MAX_LENGTH = 31
@@ -159,6 +164,25 @@ class MyMultiseekResults(MultiseekResults):
             only_those_ids=self.request.session.get(MULTISEEK_SESSION_KEY_REMOVED, [])
         )
 
+    def _aggregate_cache_key(self):
+        """Klucz cache agregatów wyników (count + sumy) — wszystkie wejścia
+        wpływające na wynik: formularz multiseek (z report_type
+        i ordering), lista wyrzuconych rekordów, tryb print-removed,
+        zalogowanie (ukryte statusy) i uczelnia."""
+        uczelnia = Uczelnia.objects.get_for_request(self.request)
+        payload = json.dumps(
+            [
+                self.get_multiseek_data(),
+                sorted(str(x) for x in self.get_removed_records()),
+                bool(self.request.GET.get("print-removed", False)),
+                bool(self.request.user.is_authenticated),
+                getattr(uczelnia, "pk", None),
+            ],
+            sort_keys=True,
+            default=str,
+        )
+        return "multiseek_agregaty:" + hashlib.sha256(payload.encode()).hexdigest()
+
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data()
 
@@ -167,21 +191,32 @@ class MyMultiseekResults(MultiseekResults):
             ctx["object_list"] = qset
             ctx["print_removed"] = True
 
+        # Agregaty (COUNT + sumy) sa cache'owane, zeby stronicowanie tych
+        # samych wynikow nie powtarzalo drogiego skanu (DISTINCT + join do
+        # bpp_autorzy_mat) przy kazdej stronie. Staleness ograniczone TTL;
+        # kazda zmiana formularza / wyrzucenie rekordu zmienia klucz.
+        cache_key = self._aggregate_cache_key()
+        agregaty = cache.get(cache_key)
+        if agregaty is None:
+            if ctx["report_type"] in EXTRA_TYPES:
+                # Licznik i sumy jednym skanem — przy DISTINCT + join do
+                # bpp_autorzy_mat osobny COUNT podwajalby najdrozsza czesc.
+                agregaty = qset.aggregate(
+                    Sum("impact_factor"),
+                    Sum("liczba_cytowan"),
+                    Sum("punkty_kbn"),
+                    Sum("index_copernicus"),
+                    Sum("punktacja_wewnetrzna"),
+                    paginator_count=Count("pk"),
+                )
+            else:
+                agregaty = {"paginator_count": qset.count()}
+            cache.set(cache_key, agregaty, MULTISEEK_AGGREGATE_CACHE_TIMEOUT)
+
+        agregaty = dict(agregaty)
+        ctx["paginator_count"] = agregaty.pop("paginator_count")
         if ctx["report_type"] in EXTRA_TYPES:
-            # Licznik i sumy jednym skanem — przy DISTINCT + join do
-            # bpp_autorzy_mat osobny COUNT podwajalby najdrozsza czesc.
-            agregaty = qset.aggregate(
-                Sum("impact_factor"),
-                Sum("liczba_cytowan"),
-                Sum("punkty_kbn"),
-                Sum("index_copernicus"),
-                Sum("punktacja_wewnetrzna"),
-                paginator_count=Count("pk"),
-            )
-            ctx["paginator_count"] = agregaty.pop("paginator_count")
             ctx["sumy"] = agregaty
-        else:
-            ctx["paginator_count"] = qset.count()
 
         ctx["multiseek_export_max_rows"] = MULTISEEK_EXPORT_MAX_ROWS
         object_list = ctx["object_list"]


### PR DESCRIPTION
## Co i po co

PR 7 z planu wydajnościowego (`docs/deweloper/spec-optymalizacje-wydajnosci-2026-06.md`, pkt 2.2 etap 2). Strona wyników multiseek liczyła `paginator_count` (+ sumy punktacji dla raportów tabelarycznych) **od nowa przy każdej stronie** tych samych wyników — a przy `DISTINCT` + join do `bpp_autorzy_mat` ten agregat to najdroższa część zapytania. Klikanie po stronach dużego wyniku = wielokrotne pełne skany.

## Jak

Agregaty (count + sumy razem, jak po #351) są cache'owane w default cache (Redis na produkcji), **TTL 30 min**, pod kluczem sha256 ze **wszystkich** wejść wpływających na wynik:

- formularz multiseek z sesji (w tym `report_type` i `ordering`),
- lista wyrzuconych rekordów („Wyrzuć" → upstream filtruje je z wyników → nowy klucz → przeliczenie),
- tryb `print-removed`,
- zalogowanie (ukryte statusy dla anonimów),
- uczelnia.

Zmiana czegokolwiek z powyższych = inny klucz = natychmiastowe przeliczenie. Staleness ograniczone do TTL dotyczy tylko równoległych zmian w danych podczas przeglądania tych samych wyników — akceptowalne dla licznika/sum.

Decyzja użytkownika (2026-06): implementacja **w BPP**, nie w pakiecie django-multiseek — upstream `MultiseekResults` nawet nie wykonuje tego COUNT-a (to nadpisanie BPP), a klucz zależy od BPP-specyficznych wejść. Jeśli mechanizm się sprawdzi, generyczny hook można upstreamować później.

Uwaga: na dev/local default cache to `DummyCache` → cache jest no-opem (każde wejście liczy od nowa) — działa wyłącznie na produkcji, gdzie jest Redis.

## Testy (TDD)

- RED: „drugie wejście na wyniki wykonuje agregat ponownie" (CaptureQueriesContext, zero zapytań COUNT/SUM po bpp_rekord_mat przy drugim GET) → GREEN po implementacji.
- Strażniki: zmiana formularza przelicza; wyrzucenie rekordu przelicza; anonim i zalogowany mają osobne wpisy; `Decimal` przeżywa round-trip przez cache.
- Testy podmieniają default cache na LocMemCache (testowo jest DummyCache); `constance_cache` zostaje (django-constance odrzuca backendy lokalne).
- Regresja: `test_views/` + `test_multiseek/` + `nowe_raporty/` — **302 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)