### PR TITLE
refactor(db): port 7 funkcji PL/Python → PL/pgSQL + eliminacja trigger_tytul_sort

### DIFF
--- a/src/bpp/migrations/0440_port_plpython_to_plpgsql.py
+++ b/src/bpp/migrations/0440_port_plpython_to_plpgsql.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from django.db import connection, migrations
+
+
+def _exec_sql_file(filename):
+    sql_file = Path(__file__).parent / filename
+    with open(sql_file) as f:
+        sql = f.read()
+    # connection.cursor() zamiast schema_editor.execute() — w ciele funkcji
+    # (format('...%I...'), a w reverse plpython3u znaki `%`) PostgreSQL/psycopg
+    # przez schema_editor probowalby interpretowac `%` jako placeholdery.
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+
+
+def load_sql(apps, schema_editor):
+    _exec_sql_file("0440_port_plpython_to_plpgsql.sql")
+
+
+def unload_sql(apps, schema_editor):
+    # Reverse: przywroc wersje plpython3u (wymaga rozszerzenia plpython3u,
+    # ktore jest jeszcze obecne az do osobnego DROP EXTENSION w finalnym PR).
+    _exec_sql_file("0440_port_plpython_to_plpgsql_reverse.sql")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0431_search_index_gin"),
+    ]
+
+    operations = [
+        migrations.RunPython(load_sql, unload_sql),
+    ]

--- a/src/bpp/migrations/0440_port_plpython_to_plpgsql.sql
+++ b/src/bpp/migrations/0440_port_plpython_to_plpgsql.sql
@@ -1,0 +1,368 @@
+-- Port 7 funkcji PL/Python -> PL/pgSQL (pożegnanie z plpython3u, §1 spec).
+--
+-- Wszystkie 7 jest GD-free (stanu sesyjnego GD używały tylko bpp_refresh_cache
+-- i trigger_tytul_sort). Tu: 2 dirty-markery dyscyplin, 2 settery "aktualna",
+-- 3 walidatory. CREATE OR REPLACE — triggery (CREATE TRIGGER) pozostają bez
+-- zmian, zmienia się tylko ciało + LANGUAGE.
+--
+-- Uwaga semantyczna: wszędzie gdzie oryginał używał Pythonowego `==`
+-- (które dla None==None zwraca True), stosujemy `IS NOT DISTINCT FROM`,
+-- żeby NULL=NULL traktować jak równość — wierna kalka zachowania plpython.
+
+
+-- =====================================================================
+-- 1a. Dirty-markery denorm (filtr rok + dyscyplina + ten autor)
+-- =====================================================================
+
+-- bpp_autor_dyscyplina_change: AFTER UPDATE na bpp_autor_dyscyplina.
+-- Gdy autorowi zmienia się przypisana dyscyplina/subdyscyplina na dany rok,
+-- przemapowuje wiersze *_autor (tego autora, tego roku) ze starej wartości
+-- dyscypliny na nową i oznacza dotknięte rekordy jako dirty dla denorm.
+--
+-- KRYTYCZNE: dwufazowość (snapshot ID-ków OBU zbiorów PRZED jakimkolwiek
+-- UPDATE). W najgorszym przypadku — zamianie dyscypliny z subdyscypliną —
+-- sekwencyjny UPDATE f1 wpadłby w selekcję f2 (read-after-write) i cofnął
+-- zmianę. Dlatego najpierw array_agg ID-ków obu zbiorów, potem dopiero
+-- UPDATE-y. Wierna kalka oryginalnego two-temp-table podejścia.
+CREATE OR REPLACE FUNCTION public.bpp_autor_dyscyplina_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_rok           integer;
+    v_autor_id      integer;
+    v_f1_old        integer;
+    v_f1_new        integer;
+    v_f2_old        integer;
+    v_f2_new        integer;
+    v_diff_f1       boolean;
+    v_diff_f2       boolean;
+    v_table         text;
+    v_ct_id         integer;
+    v_dys_ids       integer[];
+    v_dys_rekordy   integer[];
+    v_subdys_ids    integer[];
+    v_subdys_rekordy integer[];
+BEGIN
+    -- Guard: zmiana roku / ID autora nie jest obsługiwana (jak w oryginale).
+    IF NEW.rok IS DISTINCT FROM OLD.rok THEN
+        RAISE EXCEPTION 'Zmiana roku NIE jest obsługiwana';
+    END IF;
+    IF NEW.autor_id IS DISTINCT FROM OLD.autor_id THEN
+        RAISE EXCEPTION 'Zmiana ID autora nie jest obsługiwana';
+    END IF;
+
+    v_rok      := NEW.rok;
+    v_autor_id := NEW.autor_id;
+
+    v_f1_old := OLD.dyscyplina_naukowa_id;
+    v_f1_new := NEW.dyscyplina_naukowa_id;
+    v_f2_old := OLD.subdyscyplina_naukowa_id;
+    v_f2_new := NEW.subdyscyplina_naukowa_id;
+
+    v_diff_f1 := v_f1_old IS DISTINCT FROM v_f1_new;
+    v_diff_f2 := v_f2_old IS DISTINCT FROM v_f2_new;
+
+    -- Brak zmian dyscyplin — wróć.
+    IF NOT v_diff_f1 AND NOT v_diff_f2 THEN
+        RETURN NEW;
+    END IF;
+
+    FOREACH v_table IN ARRAY
+        ARRAY['bpp_wydawnictwo_ciagle', 'bpp_wydawnictwo_zwarte', 'bpp_patent']
+    LOOP
+        SELECT id INTO v_ct_id
+        FROM django_content_type
+        WHERE app_label = 'bpp' AND model = substr(v_table, 5);
+
+        v_dys_ids := NULL;
+        v_dys_rekordy := NULL;
+        v_subdys_ids := NULL;
+        v_subdys_rekordy := NULL;
+
+        -- FAZA 1: snapshot ID-ków zanim cokolwiek zaktualizujemy.
+        IF v_diff_f1 AND v_f1_old IS NOT NULL THEN
+            EXECUTE format(
+                'SELECT array_agg(a.id), array_agg(a.rekord_id)
+                   FROM %I a, %I p
+                  WHERE a.dyscyplina_naukowa_id = $1
+                    AND p.rok = $2
+                    AND p.id = a.rekord_id
+                    AND a.autor_id = $3',
+                v_table || '_autor', v_table)
+            INTO v_dys_ids, v_dys_rekordy
+            USING v_f1_old, v_rok, v_autor_id;
+        END IF;
+
+        IF v_diff_f2 AND v_f2_old IS NOT NULL THEN
+            EXECUTE format(
+                'SELECT array_agg(a.id), array_agg(a.rekord_id)
+                   FROM %I a, %I p
+                  WHERE a.dyscyplina_naukowa_id = $1
+                    AND p.rok = $2
+                    AND p.id = a.rekord_id
+                    AND a.autor_id = $3',
+                v_table || '_autor', v_table)
+            INTO v_subdys_ids, v_subdys_rekordy
+            USING v_f2_old, v_rok, v_autor_id;
+        END IF;
+
+        -- FAZA 2: dopiero teraz UPDATE-y + oznaczanie dirty.
+        IF v_dys_ids IS NOT NULL THEN
+            EXECUTE format(
+                'UPDATE %I SET dyscyplina_naukowa_id = $1 WHERE id = ANY($2)',
+                v_table || '_autor')
+            USING v_f1_new, v_dys_ids;
+
+            INSERT INTO denorm_dirtyinstance(content_type_id, object_id)
+            SELECT v_ct_id, r FROM unnest(v_dys_rekordy) AS r
+            ON CONFLICT DO NOTHING;
+        END IF;
+
+        IF v_subdys_ids IS NOT NULL THEN
+            -- subdyscyplina_naukowa autora -> kolumna dyscyplina_naukowa_id
+            -- wiersza *_autor (te tabele mają tylko jedno pole dyscypliny);
+            -- nowa wartość może być NULL (gdy subdyscyplinę skasowano).
+            EXECUTE format(
+                'UPDATE %I SET dyscyplina_naukowa_id = $1 WHERE id = ANY($2)',
+                v_table || '_autor')
+            USING v_f2_new, v_subdys_ids;
+
+            INSERT INTO denorm_dirtyinstance(content_type_id, object_id)
+            SELECT v_ct_id, r FROM unnest(v_subdys_rekordy) AS r
+            ON CONFLICT DO NOTHING;
+        END IF;
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$;
+
+
+-- bpp_autor_dyscyplina_delete: AFTER DELETE na bpp_autor_dyscyplina.
+-- Gdy kasowane jest przypisanie dyscypliny dla roku — wszystkim wierszom
+-- *_autor tego autora w tym roku zeruje dyscyplinę i oznacza rekordy dirty.
+-- Filtr: rok + autor (jak w oryginale). Oryginał iterował po polach
+-- [dyscyplina, subdyscyplina] robiąc to samo dwa razy gdy oba były != NULL;
+-- wynik (zbiór NULL-owanych wierszy i dirtyinstance) jest identyczny przy
+-- jednym przebiegu, więc upraszczamy do jednego — z gardą "któraś != NULL".
+CREATE OR REPLACE FUNCTION public.bpp_autor_dyscyplina_delete() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_autor_id integer := OLD.autor_id;
+    v_rok      integer := OLD.rok;
+    v_table    text;
+    v_ct_id    integer;
+BEGIN
+    IF OLD.dyscyplina_naukowa_id IS NULL
+       AND OLD.subdyscyplina_naukowa_id IS NULL THEN
+        RETURN OLD;
+    END IF;
+
+    FOREACH v_table IN ARRAY
+        ARRAY['bpp_wydawnictwo_ciagle', 'bpp_wydawnictwo_zwarte', 'bpp_patent']
+    LOOP
+        SELECT id INTO v_ct_id
+        FROM django_content_type
+        WHERE app_label = 'bpp' AND model = substr(v_table, 5);
+
+        EXECUTE format(
+            'WITH dys AS (
+                 UPDATE %I a SET dyscyplina_naukowa_id = NULL
+                   FROM %I p
+                  WHERE p.id = a.rekord_id
+                    AND p.rok = $1
+                    AND a.autor_id = $2
+              RETURNING a.rekord_id
+             )
+             INSERT INTO denorm_dirtyinstance(content_type_id, object_id)
+             SELECT $3, rekord_id FROM dys
+             ON CONFLICT DO NOTHING',
+            v_table || '_autor', v_table)
+        USING v_rok, v_autor_id, v_ct_id;
+    END LOOP;
+
+    RETURN OLD;
+END;
+$$;
+
+
+-- =====================================================================
+-- 1c. Walidatory (assert -> RAISE EXCEPTION)
+-- =====================================================================
+
+-- bpp_autor_dyscyplina_rozne: dyscyplina != subdyscyplina.
+-- IS NOT DISTINCT FROM kalkuje Pythonowe `==` (None==None -> True).
+CREATE OR REPLACE FUNCTION public.bpp_autor_dyscyplina_rozne() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF NEW.dyscyplina_naukowa_id
+       IS NOT DISTINCT FROM NEW.subdyscyplina_naukowa_id THEN
+        RAISE EXCEPTION 'Dyscypliny muszą być różne';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+-- bpp_jednostka_sprawdz_uczelnia_id: uczelnia jednostki == uczelnia jej wydziału.
+CREATE OR REPLACE FUNCTION public.bpp_jednostka_sprawdz_uczelnia_id() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_wydzial_uczelnia integer;
+BEGIN
+    IF NEW.wydzial_id IS NOT NULL THEN
+        SELECT uczelnia_id INTO v_wydzial_uczelnia
+        FROM bpp_wydzial WHERE id = NEW.wydzial_id;
+
+        IF v_wydzial_uczelnia IS DISTINCT FROM NEW.uczelnia_id THEN
+            RAISE EXCEPTION 'Uczelnia jednostki i wydzialu musi byc identyczna';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+-- bpp_jednostka_wydzial_sprawdz_uczelnia_id: uczelnia wydziału == uczelnia
+-- jednostki (po stronie tabeli M2M bpp_jednostka_wydzial).
+CREATE OR REPLACE FUNCTION public.bpp_jednostka_wydzial_sprawdz_uczelnia_id()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_uczelnia_wydzialu  integer;
+    v_uczelnia_jednostki integer;
+BEGIN
+    IF NEW.wydzial_id IS NOT NULL THEN
+        SELECT uczelnia_id INTO v_uczelnia_wydzialu
+        FROM bpp_wydzial WHERE id = NEW.wydzial_id;
+
+        SELECT uczelnia_id INTO v_uczelnia_jednostki
+        FROM bpp_jednostka WHERE id = NEW.jednostka_id;
+
+        IF v_uczelnia_wydzialu IS DISTINCT FROM v_uczelnia_jednostki THEN
+            RAISE EXCEPTION 'Uczelnia jednostki i wydzialu musi byc identyczna';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+-- =====================================================================
+-- 1b. Settery "aktualna jednostka" / "aktualny wydział"
+-- =====================================================================
+
+-- bpp_autor_ustaw_jednostka_aktualna: AFTER INS/DEL/UPD na bpp_autor_jednostka.
+-- Wylicza aktualną jednostkę/funkcję autora (najświeższe, niezakończone
+-- zatrudnienie, preferując podstawowe miejsce pracy) i zapisuje na bpp_autor.
+CREATE OR REPLACE FUNCTION public.bpp_autor_ustaw_jednostka_aktualna()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_autor_id    integer;
+    v_jednostka_id integer;
+    v_funkcja_id  integer;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        IF NEW.autor_id IS DISTINCT FROM OLD.autor_id THEN
+            RAISE EXCEPTION
+                'zmiana ID autora nie jest obsługiwana przez trigger';
+        END IF;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+        v_autor_id := OLD.autor_id;
+    ELSE
+        v_autor_id := NEW.autor_id;
+    END IF;
+
+    SELECT jednostka_id, funkcja_id
+    INTO v_jednostka_id, v_funkcja_id
+    FROM bpp_autor_jednostka
+    WHERE autor_id = v_autor_id
+      AND coalesce(zakonczyl_prace, '9999-12-31'::date) > NOW()::date
+    ORDER BY
+        coalesce(podstawowe_miejsce_pracy, false) DESC,
+        coalesce(rozpoczal_prace, '0001-01-01'::date) DESC,
+        coalesce(zakonczyl_prace, '9999-12-31'::date) DESC,
+        id DESC
+    LIMIT 1;
+
+    IF FOUND THEN
+        UPDATE bpp_autor
+           SET aktualna_jednostka_id = v_jednostka_id,
+               aktualna_funkcja_id = v_funkcja_id
+         WHERE id = v_autor_id;
+    ELSE
+        -- Brak wpisów -> wyzeruj aktualną jednostkę/funkcję.
+        UPDATE bpp_autor
+           SET aktualna_jednostka_id = NULL,
+               aktualna_funkcja_id = NULL
+         WHERE id = v_autor_id;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+-- bpp_jednostka_ustaw_wydzial_aktualna: AFTER INS/DEL/UPD na
+-- bpp_jednostka_wydzial. Wylicza aktualny wydział jednostki (najświeższe
+-- przypisanie wg daty "od") i zapisuje na bpp_jednostka.
+CREATE OR REPLACE FUNCTION public.bpp_jednostka_ustaw_wydzial_aktualna()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_jednostka_id integer;
+    v_wydzial_id   integer;
+    v_aktualna     boolean;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        IF NEW.jednostka_id IS DISTINCT FROM OLD.jednostka_id THEN
+            RAISE EXCEPTION
+                'zmiana ID jednostki nie jest obsługiwana przez trigger';
+        END IF;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+        v_jednostka_id := OLD.jednostka_id;
+    ELSE
+        v_jednostka_id := NEW.jednostka_id;
+    END IF;
+
+    SELECT wydzial_id,
+           (coalesce("do", '9999-12-31'::date) > NOW()::date)
+    INTO v_wydzial_id, v_aktualna
+    FROM bpp_jednostka_wydzial
+    WHERE jednostka_id = v_jednostka_id
+    ORDER BY coalesce("od", '0001-01-01'::date) DESC
+    LIMIT 1;
+
+    IF FOUND THEN
+        UPDATE bpp_jednostka
+           SET wydzial_id = v_wydzial_id,
+               aktualna = v_aktualna
+         WHERE id = v_jednostka_id;
+    ELSE
+        -- Brak wpisów -> wydział NULL, aktualna = false.
+        UPDATE bpp_jednostka
+           SET wydzial_id = NULL,
+               aktualna = false
+         WHERE id = v_jednostka_id;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/src/bpp/migrations/0440_port_plpython_to_plpgsql_reverse.sql
+++ b/src/bpp/migrations/0440_port_plpython_to_plpgsql_reverse.sql
@@ -1,0 +1,263 @@
+-- Reverse migracji 0440 — przywraca oryginalne wersje plpython3u 7 funkcji.
+-- Skopiowane 1:1 z baseline.sql (stan sprzed portu). Wymaga rozszerzenia
+-- plpython3u w bazie (jeszcze obecne aż do osobnego DROP EXTENSION w Spec/PR3).
+
+CREATE OR REPLACE FUNCTION public.bpp_autor_dyscyplina_change() RETURNS trigger
+    LANGUAGE plpython3u
+    AS $$
+  # Uruchamiane w przypadku zmiany dyscypliny obiektu Autor_Dyscyplina
+  # (tabela bpp_autor_dyscyplina)
+
+  # Ta funkcja wygląda jak wygląda, bo w przypadku zmiany dwóch pól tzn dyscyplina_naukowa
+  # oraz subdyscyplina_naukowa, w najgorszym możliwym przypadku -- zamiany jednego z drugim
+  # będzie potrzebne właśnie takie przemapowanie rzeczy:
+
+  if TD['new']['rok'] != TD['old']['rok']:
+    plpy.error("Zmiana roku NIE jest obsługiwana")
+    return
+
+  if TD['new']['autor_id'] != TD['old']['autor_id']:
+    plpy.error("Zmiana ID autora nie jest obsługiwana")
+    return
+
+  rok = TD['new']['rok']
+  autor_id = TD['new']['autor_id']
+
+  f1 = 'dyscyplina_naukowa_id'
+  f2 = 'subdyscyplina_naukowa_id'
+
+  val_f1_old = TD['old'][f1]
+  val_f1_new = TD['new'][f1]
+
+  val_f2_old = TD['old'][f2]
+  val_f2_new = TD['new'][f2]
+
+  diff_f1 = val_f1_old != val_f1_new
+  diff_f2 = val_f2_old != val_f2_new
+
+  # Brak zmian dyscyplin, wróć
+  if not diff_f1 and not diff_f2:
+    return
+
+  qry = """
+    CREATE TEMP TABLE %(temp_table)s AS
+    SELECT %(table)s_autor.id, %(table)s_autor.rekord_id FROM %(table)s, %(table)s_autor
+    WHERE dyscyplina_naukowa_id = %(dyscyplina_id)s
+      AND %(table)s.rok = %(rok)i
+      AND %(table)s.id = %(table)s_autor.rekord_id
+      AND %(table)s_autor.autor_id = %(autor_id)i
+  """
+
+  cqueue = """
+  INSERT INTO denorm_dirtyinstance(content_type_id, object_id) SELECT %(content_type_id)s, rekord_id FROM %(table)s ON CONFLICT DO NOTHING
+  """
+
+  for table in ['bpp_wydawnictwo_ciagle',
+                'bpp_wydawnictwo_zwarte',
+                'bpp_patent']:
+
+    rv = plpy.execute("SELECT id FROM django_content_type WHERE app_label = 'bpp' AND model = '%s'" % table[4:], 1)
+    content_type_id = rv[0]['id']
+
+    if diff_f1 and (val_f1_old != None):
+      plpy.execute(qry % dict(temp_table="dys", table=table, dyscyplina_id=val_f1_old, rok=rok, autor_id=autor_id))
+
+    if diff_f2 and (val_f2_old != None):
+      plpy.execute(qry % dict(temp_table="subdys", table=table, dyscyplina_id=val_f2_old, rok=rok, autor_id=autor_id))
+
+    if diff_f1 and (val_f1_old != None):
+      plpy.execute("UPDATE %s_autor SET dyscyplina_naukowa_id = %s WHERE id IN (SELECT id FROM dys)" % (table, val_f1_new))
+      plpy.execute(cqueue % dict(table="dys", content_type_id=content_type_id))
+      plpy.execute("DROP TABLE dys")
+
+    if diff_f2 and (val_f2_old != None):
+      plpy.execute("UPDATE %s_autor SET dyscyplina_naukowa_id = %s WHERE id IN (SELECT id FROM subdys)" % (table, val_f2_new or "NULL"))
+      plpy.execute(cqueue % dict(table="subdys", content_type_id=content_type_id))
+      plpy.execute("DROP TABLE subdys")
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.bpp_autor_dyscyplina_delete() RETURNS trigger
+    LANGUAGE plpython3u
+    AS $$
+  # Uruchamiane w przypadku skasowania wpisu dla roku czyli obiektu Autor_Dyscyplina
+  # (tabela bpp_autor_dyscyplina)
+
+  cqueue = """
+  INSERT INTO denorm_dirtyinstance(content_type_id, object_id) SELECT %(content_type_id)s, rekord_id FROM %(table)s ON CONFLICT DO NOTHING
+  """
+
+  autor_id = TD['old']['autor_id']
+  rok = TD['old']['rok']
+
+  for field in ['dyscyplina_naukowa_id', 'subdyscyplina_naukowa_id']:
+    if TD['old'][field] is None:
+      continue
+
+    for table in ['bpp_wydawnictwo_ciagle',
+                  'bpp_wydawnictwo_zwarte',
+                  'bpp_patent']:
+      rv = plpy.execute("SELECT id FROM django_content_type WHERE app_label = 'bpp' AND model = '%s'" % table[4:], 1)
+      content_type_id = rv[0]['id']
+
+      plpy.execute("""
+      CREATE TEMP TABLE dys AS
+      SELECT %(table)s_autor.id, %(table)s_autor.rekord_id
+      FROM %(table)s, %(table)s_autor
+      WHERE %(table)s.rok = %(rok)i
+        AND %(table)s.id = %(table)s_autor.rekord_id
+        AND %(table)s_autor.autor_id = %(autor_id)i
+      """ % dict(table=table, autor_id=autor_id, rok=rok))
+      plpy.execute("UPDATE %(table)s_autor SET dyscyplina_naukowa_id = NULL WHERE id IN (SELECT id FROM dys)" % dict(table=table))
+      plpy.execute(cqueue % dict(content_type_id=content_type_id, table="dys"))
+      plpy.execute("DROP TABLE dys")
+
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.bpp_autor_dyscyplina_rozne() RETURNS trigger
+    LANGUAGE plpython3u
+    AS $$
+  # Sprawdz czy dyscyplina_naukowa i subdyscyplina_naukowa sa rozne
+  if TD['new']['dyscyplina_naukowa_id'] == TD['new']['subdyscyplina_naukowa_id']:
+    plpy.error("Dyscypliny muszą być różne")
+
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.bpp_autor_ustaw_jednostka_aktualna() RETURNS trigger
+    LANGUAGE plpython3u
+    AS $_$
+
+    action = "new"
+    if TD["event"] == "DELETE":
+        action = "old"
+
+    if TD["event"] == "UPDATE":
+        if TD["new"]["autor_id"] != TD["old"]["autor_id"]:
+            raise Exception("zmiana ID autora nie jest obsługiwana przez trigger")
+
+    autor_id = TD[action]["autor_id"]
+    q1 = """
+    SELECT
+        jednostka_id,
+        funkcja_id,
+        (coalesce("podstawowe_miejsce_pracy", false)) AS podstawowe_miejsce_pracy,
+        (coalesce("rozpoczal_prace", '0001-01-01'::date)) AS data_rozpoczecia,
+        (coalesce("zakonczyl_prace", '9999-12-31'::date)) AS data_zakonczenia
+    FROM
+        bpp_autor_jednostka
+    WHERE
+        autor_id = $1 AND
+        coalesce("zakonczyl_prace", '9999-12-31'::date) > NOW()::date
+    ORDER BY
+        podstawowe_miejsce_pracy DESC,
+        data_rozpoczecia DESC,
+        data_zakonczenia DESC,
+        bpp_autor_jednostka.id DESC
+    LIMIT
+        1
+    """
+
+    p1 = plpy.prepare(q1, ["int"])
+    rv = plpy.execute(p1, [autor_id])
+
+    q2 = """
+    UPDATE
+        bpp_autor
+    SET
+        aktualna_jednostka_id = $1,
+        aktualna_funkcja_id = $2
+    WHERE
+        id = $3
+    """
+    p2 = plpy.prepare(q2, ["int", "int", "int"])
+
+    if len(rv) == 1:
+        plpy.execute(p2, [rv[0]["jednostka_id"], rv[0]["funkcja_id"], autor_id])
+    else:
+        # Ustaw aktualna_jednostka=NULL, aktualna_funkcja=NULL i aktualny=False jeżeli nie ma żadnych wpisów
+        plpy.execute(p2, [None, None, autor_id])
+
+$_$;
+
+
+CREATE OR REPLACE FUNCTION public.bpp_jednostka_sprawdz_uczelnia_id() RETURNS trigger
+    LANGUAGE plpython3u
+    AS $$
+    uczelnia_id = TD["new"]["uczelnia_id"]
+    wydzial_id = TD["new"]["wydzial_id"]
+
+    if wydzial_id is not None:
+        q = "SELECT uczelnia_id FROM bpp_wydzial WHERE id = %i" % wydzial_id
+        r = plpy.execute(q)
+        assert r[0]["uczelnia_id"] == uczelnia_id, "Uczelnia jednostki i wydzialu musi byc identyczna"
+
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.bpp_jednostka_ustaw_wydzial_aktualna() RETURNS trigger
+    LANGUAGE plpython3u
+    AS $_$
+    action = "new"
+    if TD["event"] == "DELETE":
+        action = "old"
+
+    if TD["event"] == "UPDATE":
+        if TD["new"]["jednostka_id"] != TD["old"]["jednostka_id"]:
+            raise Exception("zmiana ID jednostki nie jest obsługiwana przez trigger")
+
+    jednostka_id = TD[action]["jednostka_id"]
+    q1 = """
+    SELECT
+        wydzial_id,
+        (coalesce("do", '9999-12-31'::date) > NOW()::date) AS "aktualna"
+    FROM
+        bpp_jednostka_wydzial
+    WHERE
+        jednostka_id = $1
+    ORDER BY
+        (coalesce("od", '0001-01-01'::date)) DESC
+    LIMIT
+        1
+    """
+
+    p1 = plpy.prepare(q1, ["int"])
+    rv = plpy.execute(p1, [jednostka_id])
+
+    q2 = """
+    UPDATE
+        bpp_jednostka
+    SET
+        wydzial_id = $1,
+        aktualna = $2
+    WHERE
+        id = $3
+    """
+    p2 = plpy.prepare(q2, ["int", "bool", "int"])
+
+    if len(rv) == 1:
+        plpy.execute(p2, [rv[0]["wydzial_id"], rv[0]["aktualna"], jednostka_id])
+    else:
+        # Ustaw wydział=NULL i aktualna=False jeżeli nie ma żadnych wpisów
+        plpy.execute(p2, [None, False, jednostka_id])
+
+$_$;
+
+
+CREATE OR REPLACE FUNCTION public.bpp_jednostka_wydzial_sprawdz_uczelnia_id() RETURNS trigger
+    LANGUAGE plpython3u
+    AS $$
+    jednostka_id = TD["new"]["jednostka_id"]
+    wydzial_id = TD["new"]["wydzial_id"]
+
+    if wydzial_id is not None:
+      q1 = "SELECT uczelnia_id FROM bpp_wydzial WHERE id = %i" % wydzial_id
+      q2 = "SELECT uczelnia_id FROM bpp_jednostka WHERE id = %i" % jednostka_id
+
+      r1 = plpy.execute(q1)
+      r2 = plpy.execute(q2)
+
+      assert r1[0]["uczelnia_id"] == r2[0]["uczelnia_id"], "Uczelnia jednostki i wydzialu musi byc identyczna"
+
+$$;

--- a/src/bpp/migrations/0441_drop_trigger_tytul_sort.py
+++ b/src/bpp/migrations/0441_drop_trigger_tytul_sort.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from django.db import connection, migrations
+
+
+def _exec_sql_file(filename):
+    sql_file = Path(__file__).parent / filename
+    with open(sql_file) as f:
+        sql = f.read()
+    # connection.cursor() — w reverse plpython3u sa znaki `%`, ktore
+    # schema_editor probowalby interpretowac jako placeholdery parametrow.
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+
+
+def drop_trigger(apps, schema_editor):
+    _exec_sql_file("0441_drop_trigger_tytul_sort.sql")
+
+
+def restore_trigger(apps, schema_editor):
+    # Reverse: przywroc funkcje + triggery plpython3u (wymaga plpython3u).
+    _exec_sql_file("0441_drop_trigger_tytul_sort_reverse.sql")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0440_port_plpython_to_plpgsql"),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_trigger, restore_trigger),
+    ]

--- a/src/bpp/migrations/0441_drop_trigger_tytul_sort.sql
+++ b/src/bpp/migrations/0441_drop_trigger_tytul_sort.sql
@@ -1,0 +1,14 @@
+-- Eliminacja trigger_tytul_sort (§2 spec). Klucz sortu tytułu liczy teraz
+-- ModelPrzeszukiwalny.save() (bpp/models/abstract/search.py). Wszystkie zapisy
+-- tytul_oryginalny idą przez ORM, więc gwarancja triggera DB jest zbędna.
+--
+-- Usuwamy 5 triggerów BEFORE INSERT/UPDATE + samą funkcję plpython3u
+-- (jedyną — obok bpp_refresh_cache ze Spec 1 — używającą stanu GD).
+
+DROP TRIGGER IF EXISTS bpp_patent_tytul_oryginalny_sort_trigger ON public.bpp_patent;
+DROP TRIGGER IF EXISTS bpp_praca_doktorska_tytul_oryginalny_sort_trigger ON public.bpp_praca_doktorska;
+DROP TRIGGER IF EXISTS bpp_praca_habilitacyjna_tytul_oryginalny_sort_trigger ON public.bpp_praca_habilitacyjna;
+DROP TRIGGER IF EXISTS bpp_wydawnictwo_ciagle_tytul_oryginalny_sort_trigger ON public.bpp_wydawnictwo_ciagle;
+DROP TRIGGER IF EXISTS bpp_wydawnictwo_zwarte_tytul_oryginalny_sort_trigger ON public.bpp_wydawnictwo_zwarte;
+
+DROP FUNCTION IF EXISTS public.trigger_tytul_sort();

--- a/src/bpp/migrations/0441_drop_trigger_tytul_sort_reverse.sql
+++ b/src/bpp/migrations/0441_drop_trigger_tytul_sort_reverse.sql
@@ -1,0 +1,72 @@
+-- Reverse migracji 0441 — przywraca funkcję plpython3u trigger_tytul_sort
+-- oraz 5 triggerów BEFORE INSERT/UPDATE (stan z baseline.sql).
+-- Wymaga rozszerzenia plpython3u (obecne aż do finalnego DROP EXTENSION).
+
+CREATE OR REPLACE FUNCTION public.trigger_tytul_sort() RETURNS trigger
+    LANGUAGE plpython3u
+    AS $$
+    if TD["new"]["tytul_oryginalny_sort"]:
+      # Jeżeli jest coś w tym polu, to sprawdź, może nie warto go zmieniać
+      # jeżeli nie, to uzupełnij je.
+      if TD["event"] == "UPDATE":
+          if TD["new"]["tytul_oryginalny"] == TD["old"]["tytul_oryginalny"]:
+              if TD["new"].get("jezyk_id") == TD["old"].get("jezyk_id"):
+                return
+
+    version = "get_tytul_sort_ver_6_initialized"
+    cache = version + "_cache"
+
+    jezyk_id = TD["new"].get("jezyk_id", None)
+
+    if jezyk_id is not None:
+        # ma jezyk_id
+
+        if GD.get(cache) is None:
+            # utwórz słownik CACHE
+            GD[cache] = {}
+
+        if GD[cache].get(jezyk_id) is None:
+            query = "SELECT skrot FROM bpp_jezyk WHERE id = %s" % TD["new"]["jezyk_id"]
+            res = plpy.execute(query)
+            GD[cache][jezyk_id] = res[0]["skrot"]
+
+        jezyk = GD[cache].get(jezyk_id)
+
+    else:
+        jezyk = "pol."
+
+
+    tytul_oryginalny = TD["new"]["tytul_oryginalny"]
+
+    if not GD.get(version, None):
+      GD[version] = {
+        'ang.': ["the ", "a "],
+        'niem.': ["der ", "die ", "das ", ],
+        'fr.': ["la ", "le ", "en "],
+        'wł.': ["la ", "en "],
+        'hiszp.': ["de ", "la ", "en "]
+      }
+
+    replaces = GD.get(version).get(jezyk, [" ", "\t"])
+
+    ret = tytul_oryginalny.lower().strip()
+
+    for elem in replaces:
+      while True:
+        if ret.startswith(elem):
+          ret = ret[len(elem):]
+          continue
+        break
+
+    ret = ret.replace("'", "").replace('"', '')
+
+    TD["new"]["tytul_oryginalny_sort"] = ret
+
+    return "modify"
+$$;
+
+CREATE TRIGGER bpp_patent_tytul_oryginalny_sort_trigger BEFORE INSERT OR UPDATE ON public.bpp_patent FOR EACH ROW EXECUTE FUNCTION public.trigger_tytul_sort();
+CREATE TRIGGER bpp_praca_doktorska_tytul_oryginalny_sort_trigger BEFORE INSERT OR UPDATE ON public.bpp_praca_doktorska FOR EACH ROW EXECUTE FUNCTION public.trigger_tytul_sort();
+CREATE TRIGGER bpp_praca_habilitacyjna_tytul_oryginalny_sort_trigger BEFORE INSERT OR UPDATE ON public.bpp_praca_habilitacyjna FOR EACH ROW EXECUTE FUNCTION public.trigger_tytul_sort();
+CREATE TRIGGER bpp_wydawnictwo_ciagle_tytul_oryginalny_sort_trigger BEFORE INSERT OR UPDATE ON public.bpp_wydawnictwo_ciagle FOR EACH ROW EXECUTE FUNCTION public.trigger_tytul_sort();
+CREATE TRIGGER bpp_wydawnictwo_zwarte_tytul_oryginalny_sort_trigger BEFORE INSERT OR UPDATE ON public.bpp_wydawnictwo_zwarte FOR EACH ROW EXECUTE FUNCTION public.trigger_tytul_sort();

--- a/src/bpp/models/abstract/search.py
+++ b/src/bpp/models/abstract/search.py
@@ -6,6 +6,40 @@ from django.contrib.postgres.fields import HStoreField
 from django.contrib.postgres.search import SearchVectorField as VectorField
 from django.db import models
 
+# Rodzajniki obcinane z początku tytułu przy budowaniu klucza sortowania,
+# per skrót języka. Domyślnie (m.in. polski) nic nie obcinamy — sam strip
+# białych znaków. Dawniej tablica `GD` w triggerze plpython `trigger_tytul_sort`;
+# po pożegnaniu z plpython3u klucz liczymy w warstwie modelu (patrz save()).
+#
+# PostgreSQL nie ma kolacji "ignoruj rodzajnik" (to katalogowe *nonfiling
+# characters*, spoza Unicode Collation Algorithm), więc osobna kolumna-klucz
+# `tytul_oryginalny_sort` to właściwy, standardowy wzorzec.
+PRZEDROSTKI_DO_OBCIECIA = {
+    "ang.": ["the ", "a "],
+    "niem.": ["der ", "die ", "das "],
+    "fr.": ["la ", "le ", "en "],
+    "wł.": ["la ", "en "],
+    "hiszp.": ["de ", "la ", "en "],
+}
+
+# Pola, których zmiana wymusza przeliczenie klucza sortu. Gdy save() dostaje
+# update_fields rozłączne z tym zbiorem — klucz się nie zmienia, więc pomijamy
+# (odpowiednik bramki "nic się nie zmieniło" z dawnego triggera).
+_POLA_ZRODLOWE_TYTUL_SORT = frozenset({"tytul_oryginalny", "jezyk", "jezyk_id"})
+
+
+def oblicz_tytul_oryginalny_sort(tytul_oryginalny, jezyk_skrot):
+    """Klucz sortowania tytułu: lowercase + strip, obcięcie rodzajników
+    właściwych dla języka, usunięcie cudzysłowów.
+
+    Wierna kalka dawnego triggera DB `trigger_tytul_sort` (plpython3u)."""
+    przedrostki = PRZEDROSTKI_DO_OBCIECIA.get(jezyk_skrot, [" ", "\t"])
+    ret = (tytul_oryginalny or "").lower().strip()
+    for przedrostek in przedrostki:
+        while ret.startswith(przedrostek):
+            ret = ret[len(przedrostek) :]
+    return ret.replace("'", "").replace('"', "")
+
 
 class ModelPrzeszukiwalny(models.Model):
     """Model zawierający pole pełnotekstowego przeszukiwania
@@ -16,6 +50,31 @@ class ModelPrzeszukiwalny(models.Model):
 
     class Meta:
         abstract = True
+
+    def save(self, *args, update_fields=None, **kwargs):
+        # Liczymy tytul_oryginalny_sort w modelu (dawniej BEFORE-trigger
+        # plpython `trigger_tytul_sort`). Gotcha update_fields: gdy zapis jest
+        # częściowy i dotyka tytułu/języka — dorzucamy klucz do update_fields,
+        # inaczej policzona wartość nie trafiłaby do bazy.
+        if update_fields is None or _POLA_ZRODLOWE_TYTUL_SORT.intersection(
+            update_fields
+        ):
+            self.tytul_oryginalny_sort = oblicz_tytul_oryginalny_sort(
+                getattr(self, "tytul_oryginalny", "") or "",
+                self._jezyk_skrot_dla_sortu(),
+            )
+            if update_fields is not None:
+                update_fields = set(update_fields) | {"tytul_oryginalny_sort"}
+        return super().save(*args, update_fields=update_fields, **kwargs)
+
+    def _jezyk_skrot_dla_sortu(self):
+        # Patent nie ma kolumny jezyk_id (język to stała cached_property),
+        # więc — jak dawny trigger czytający TD["new"].get("jezyk_id") — gdy
+        # brak jezyk_id przyjmujemy domyślnie polski (bez obcinania rodzajnika).
+        jezyk_id = getattr(self, "jezyk_id", None)
+        if jezyk_id is None:
+            return "pol."
+        return self.jezyk.skrot
 
 
 class ModelZLegacyData(models.Model):

--- a/src/bpp/tests/test_models/test_tytul_oryginalny_sort.py
+++ b/src/bpp/tests/test_models/test_tytul_oryginalny_sort.py
@@ -1,0 +1,101 @@
+"""Testy klucza sortowania tytułu (`tytul_oryginalny_sort`).
+
+Po pożegnaniu z plpython3u logikę dawnego triggera `trigger_tytul_sort`
+liczy `ModelPrzeszukiwalny.save()` (bpp/models/abstract/search.py). Tu:
+1. czysta funkcja `oblicz_tytul_oryginalny_sort` (wszystkie języki + edge),
+2. integracja przez ORM dla Patentu (brak jezyk_id -> "pol.") oraz
+   gotcha `update_fields`.
+"""
+
+import pytest
+
+from bpp.models.abstract.search import oblicz_tytul_oryginalny_sort
+
+
+@pytest.mark.parametrize(
+    "tytul,jezyk_skrot,oczekiwany",
+    [
+        # angielski: obcina "the "/"a "
+        ("The 'APPROACH'", "ang.", "approach"),
+        ("A House", "ang.", "house"),
+        ("the the end", "ang.", "end"),  # obcina powtórzony rodzajnik
+        # francuski: "la "/"le "/"en "
+        ("le 'test'", "fr.", "test"),
+        ("La Vie", "fr.", "vie"),
+        # niemiecki
+        ("Der Spiegel", "niem.", "spiegel"),
+        ("Die Welt", "niem.", "welt"),
+        ("Das Boot", "niem.", "boot"),
+        # włoski / hiszpański
+        ("La Strada", "wł.", "strada"),
+        ("De La Cosa", "hiszp.", "cosa"),
+        # polski (i nieznany język) — bez obcinania rodzajnika
+        ("Pełna Treść", "pol.", "pełna treść"),
+        ("The Title", "pol.", "the title"),  # po polsku NIE obcinamy "the"
+        ("Tytuł", "nieznany", "tytuł"),
+        # usuwanie cudzysłowów + strip + lower
+        ('  "Cudzysłów"  ', "pol.", "cudzysłów"),
+        # edge: pusty / None
+        ("", "ang.", ""),
+        (None, "ang.", ""),
+    ],
+)
+def test_oblicz_tytul_oryginalny_sort(tytul, jezyk_skrot, oczekiwany):
+    assert oblicz_tytul_oryginalny_sort(tytul, jezyk_skrot) == oczekiwany
+
+
+@pytest.mark.django_db
+def test_save_hook_patent_bez_jezyka(patent):
+    """Patent nie ma kolumny jezyk_id — klucz liczony jak dla 'pol.'
+    (bez obcinania rodzajnika), wiernie jak dawny trigger."""
+    patent.tytul_oryginalny = "The Invention"
+    patent.save()
+    patent.refresh_from_db()
+    # 'pol.' -> bez obcinania "the"
+    assert patent.tytul_oryginalny_sort == "the invention"
+
+
+@pytest.mark.django_db
+def test_save_hook_wydawnictwo_ciagle_z_jezykiem(wydawnictwo_ciagle, jezyki):
+    """Dla rekordu z jezyk_id klucz uwzględnia rodzajniki języka."""
+    wydawnictwo_ciagle.tytul_oryginalny = "The Best Paper"
+    wydawnictwo_ciagle.jezyk = jezyki["ang."]
+    wydawnictwo_ciagle.save()
+    wydawnictwo_ciagle.refresh_from_db()
+    assert wydawnictwo_ciagle.tytul_oryginalny_sort == "best paper"
+
+
+@pytest.mark.django_db
+def test_save_hook_update_fields_gotcha(wydawnictwo_ciagle, jezyki):
+    """Gdy update_fields zawiera tytul_oryginalny, policzony klucz MUSI
+    trafić do bazy (save() dorzuca tytul_oryginalny_sort do update_fields)."""
+    wydawnictwo_ciagle.jezyk = jezyki["ang."]
+    wydawnictwo_ciagle.tytul_oryginalny = "The First"
+    wydawnictwo_ciagle.save()
+    wydawnictwo_ciagle.refresh_from_db()
+    assert wydawnictwo_ciagle.tytul_oryginalny_sort == "first"
+
+    wydawnictwo_ciagle.tytul_oryginalny = "A Second"
+    wydawnictwo_ciagle.save(update_fields=["tytul_oryginalny"])
+    wydawnictwo_ciagle.refresh_from_db()
+    assert wydawnictwo_ciagle.tytul_oryginalny == "A Second"
+    assert wydawnictwo_ciagle.tytul_oryginalny_sort == "second"
+
+
+@pytest.mark.django_db
+def test_save_hook_update_fields_niezwiazane_nie_przelicza(wydawnictwo_ciagle, jezyki):
+    """Częściowy zapis nieruszający tytułu/języka nie przelicza klucza
+    (odpowiednik bramki 'nic się nie zmieniło' dawnego triggera)."""
+    wydawnictwo_ciagle.jezyk = jezyki["ang."]
+    wydawnictwo_ciagle.tytul_oryginalny = "The Stable"
+    wydawnictwo_ciagle.save()
+    wydawnictwo_ciagle.refresh_from_db()
+    assert wydawnictwo_ciagle.tytul_oryginalny_sort == "stable"
+
+    # zmieniamy tytuł w pamięci, ale zapisujemy TYLKO inne pole:
+    wydawnictwo_ciagle.tytul_oryginalny = "A Different In Memory"
+    wydawnictwo_ciagle.szczegoly = "x"
+    wydawnictwo_ciagle.save(update_fields=["szczegoly"])
+    wydawnictwo_ciagle.refresh_from_db()
+    # klucz w bazie pozostał z poprzedniego zapisu:
+    assert wydawnictwo_ciagle.tytul_oryginalny_sort == "stable"


### PR DESCRIPTION
## Cel

Pożegnanie z `plpython3u` — **§1 + §2** spec [`spec-pozegnanie-z-plpython-2026-06`](docs/deweloper/spec-pozegnanie-z-plpython-2026-06.md). **Bez** finalnego `DROP EXTENSION` (§3) — to osobny PR po wdrożeniu Spec 1 (`bpp_refresh_cache`). `baseline.sql` **nietknięty**.

## Zmiany

### `0440` — port 7 funkcji PL/Python → PL/pgSQL
`CREATE OR REPLACE` (triggery nietknięte, zmienia się tylko ciało + `LANGUAGE`):

- **2 dirty-markery** (`bpp_autor_dyscyplina_change`/`_delete`) — zachowany **filtr rok+dyscyplina** + **guard zmiany `rok`/`autor_id`**. W `_change` odtworzony **dwufazowy snapshot** ID-ków (`array_agg` OBU zbiorów *przed* UPDATE-ami) — bez tego najgorszy przypadek (zamiana dyscyplina↔subdyscyplina) cofałby się przez read-after-write.
- **2 settery** „aktualna jednostka/wydział" (`plpy.prepare` → natywne zapytania).
- **3 walidatory** (`assert`/`plpy.error` → `RAISE EXCEPTION`) z `IS [NOT] DISTINCT FROM` jako wierną kalką Pythonowego `==` na NULL-ach.

### `0441` — eliminacja `trigger_tytul_sort`
`DROP` 5 triggerów + funkcji. Klucz sortu tytułu liczy teraz `ModelPrzeszukiwalny.save()` (`oblicz_tytul_oryginalny_sort`). Umieszczone na `ModelPrzeszukiwalny` (nie `DwaTytuly`/naming.py wg litery spec) — bo **jest właścicielem pola** `tytul_oryginalny_sort` i **obejmuje Patent**, który omija `DwaTytuly`. Obsłużony gotcha `update_fields`.

Obie migracje **w pełni odwracalne** (reverse `.sql` przywraca wersje plpython3u).

## Testy

- `uv run pytest` (pełna suita, czysty kontener): **4718 passed, 3 skipped, 1 xfailed, 0 failed**.
- Nowy `test_tytul_oryginalny_sort.py`: wszystkie języki + edge + ścieżka Patent + gotcha `update_fields`.
- Ryzyka spec pokryte istniejącymi testami reprodukującymi: swap (`regula_2/4`), guardy (`zmiana_roku`/`zmiana_autora`), walidatory `uczelnia_id` (`*_before_insert` rzucają wyjątek).
- `ruff` czysto; `makemigrations --check`: *No changes detected*.

## Koordynacja (nie w tym PR)

- Gałąź startuje od `0440` (z `0431`); Spec 1 używa `0432+` → przy mergu obu do `dev` powstaną dwa dzieci `0431`, potrzebna migracja `merge`.
- `DROP EXTENSION plpython3u` + refresh `baseline.sql` + zmiana obrazu `bpp-dbserver` — finalny PR po zmergowaniu obu (Spec 1 + ten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)