### PR TITLE
perf(cache): port bpp_refresh_cache PL/Python → PL/pgSQL + bramka WHEN

### DIFF
--- a/src/bpp/migrations/0432_cache_trigger_plpgsql.py
+++ b/src/bpp/migrations/0432_cache_trigger_plpgsql.py
@@ -1,0 +1,256 @@
+"""Port bpp_refresh_cache PL/Python -> statyczny PL/pgSQL.
+
+Spec: docs/deweloper/spec-bpp-refresh-cache-plpgsql-2026-06.md (Zmiana 1).
+
+Zamiast JEDNEJ dynamicznej funkcji PL/Python (introspekcja kolumn na KAZDYM
+odpaleniu) generujemy per-tabela statyczne funkcje PL/pgSQL z wklejonymi na
+sztywno listami kolumn. Introspekcja idzie z hot-path do migrate-path; runtime
+dostaje SQL z cache'owanym planem.
+
+8 funkcji refresh (5 rekord + 3 through) + 8 funkcji delete. Triggery sa
+rozbite na INSERT / DELETE / UPDATE (UPDATE jeszcze bezwarunkowy -- bramka WHEN
+to migracja 0433).
+
+Zachowana DOKLADNIE semantyka v3 (0429):
+- through-table odswieza tylko JEDEN wiersz autora (object_id_raw + autor_id);
+- doktorat/habilitacja: DELETE + INSERT na bpp_autorzy_mat (widok *_autorzy ma
+  INNER JOIN do bpp_autor -- wiersz moze wypasc ze zrodla);
+- DELETE to OSOBNA funkcja (NEW jest NULL na DELETE -> upsert by nic nie
+  skasowal); kasuje po id = ARRAY[ct, OLD.id];
+- advisory lock przez SELECT ... INTO STRICT (pg_advisory_xact_lock jest STRICT;
+  goly podselect z NULL cicho nie zablokowalby -- #309);
+- mapowanie kolumn POZYCYJNE (widok *_autorzy nazywa kolumne-tablice 'array' lub
+  'id' niespojnie; INSERT(mat) SELECT(widok) zgadza sie po kolejnosci).
+"""
+
+from pathlib import Path
+
+from django.db import connection, migrations
+
+# (tabela bazowa, model content_type, czy autor lezy na wierszu publikacji)
+REKORD_SITES = [
+    ("bpp_wydawnictwo_ciagle", "wydawnictwo_ciagle", False),
+    ("bpp_wydawnictwo_zwarte", "wydawnictwo_zwarte", False),
+    ("bpp_patent", "patent", False),
+    ("bpp_praca_doktorska", "praca_doktorska", True),
+    ("bpp_praca_habilitacyjna", "praca_habilitacyjna", True),
+]
+
+# (tabela through *_autor, model content_type publikacji)
+THROUGH_SITES = [
+    ("bpp_wydawnictwo_ciagle_autor", "wydawnictwo_ciagle"),
+    ("bpp_wydawnictwo_zwarte_autor", "wydawnictwo_zwarte"),
+    ("bpp_patent_autor", "patent"),
+]
+
+# Stare zlaczone triggery (v3 / 0400) do usuniecia.
+OLD_TRIGGERS = [
+    ("bpp_wydawnictwo_ciagle", "bpp_wydawnictwo_ciagle_cache_trigger"),
+    ("bpp_wydawnictwo_ciagle_autor", "bpp_wydawnictwo_ciagle_autor_cache_trigger"),
+    ("bpp_wydawnictwo_zwarte", "bpp_wydawnictwo_zwarte_cache_trigger"),
+    ("bpp_wydawnictwo_zwarte_autor", "bpp_wydawnictwo_zwarte_autor_cache_trigger"),
+    ("bpp_patent", "bpp_patent_cache_trigger"),
+    ("bpp_patent_autor", "bpp_patent_autor_cache_trigger"),
+    ("bpp_praca_doktorska", "bpp_praca_doktorska_cache_trigger"),
+    ("bpp_praca_habilitacyjna", "bpp_praca_habilitacyjna_cache_trigger"),
+]
+
+
+def _q(c):
+    return '"' + c + '"'
+
+
+def _cols(cur, relname):
+    cur.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema='public' AND table_name=%s ORDER BY ordinal_position",
+        [relname],
+    )
+    return [r[0] for r in cur.fetchall()]
+
+
+def _upsert_sql(cur, mat_table, source_view, source_where):
+    """INSERT(mat_cols) SELECT(view_cols bez object_id_raw) ON CONFLICT (id)
+    DO UPDATE SET. Mapowanie POZYCYJNE (patrz docstring modulu)."""
+    mat_cols = _cols(cur, mat_table)
+    src_cols = [c for c in _cols(cur, source_view) if c != "object_id_raw"]
+    set_clause = ", ".join(f"{_q(c)} = EXCLUDED.{_q(c)}" for c in mat_cols if c != "id")
+    return (
+        f"INSERT INTO {mat_table} ({', '.join(_q(c) for c in mat_cols)})\n"
+        f"      SELECT {', '.join(_q(c) for c in src_cols)} FROM {source_view}\n"
+        f"      WHERE {source_where}\n"
+        f"      ON CONFLICT (id) DO UPDATE SET {set_clause}"
+    )
+
+
+def _ct_lookup(model):
+    # SELECT ... INTO STRICT -> glosny NO_DATA_FOUND zamiast cichego no-op locka.
+    return (
+        "SELECT id INTO STRICT ct FROM django_content_type "
+        f"WHERE app_label='bpp' AND model='{model}';"
+    )
+
+
+def _create_rekord_function(cur, table, model, autor_na_wierszu):
+    autorzy_view = table + "_autorzy"
+    body_autorzy = ""
+    if autor_na_wierszu:
+        upsert_autorzy = _upsert_sql(
+            cur, "bpp_autorzy_mat", autorzy_view, "object_id_raw = NEW.id"
+        )
+        body_autorzy = (
+            "\n      DELETE FROM bpp_autorzy_mat "
+            "WHERE rekord_id = ARRAY[ct, NEW.id]::integer[];\n"
+            f"      {upsert_autorzy};"
+        )
+    upsert_rekord = _upsert_sql(
+        cur, "bpp_rekord_mat", table + "_view", "object_id_raw = NEW.id"
+    )
+    return f"""
+CREATE OR REPLACE FUNCTION bpp_refresh_rekord_{model}() RETURNS trigger
+LANGUAGE plpgsql AS $bpp_body$
+DECLARE ct integer;
+BEGIN
+      {_ct_lookup(model)}
+      PERFORM pg_advisory_xact_lock(ct, NEW.id);
+      {upsert_rekord};{body_autorzy}
+      RETURN NULL;
+END $bpp_body$;
+"""
+
+
+def _create_delete_rekord_function(model):
+    return f"""
+CREATE OR REPLACE FUNCTION bpp_delete_rekord_{model}() RETURNS trigger
+LANGUAGE plpgsql AS $bpp_body$
+DECLARE ct integer;
+BEGIN
+      {_ct_lookup(model)}
+      PERFORM pg_advisory_xact_lock(ct, OLD.id);
+      DELETE FROM bpp_rekord_mat WHERE id = ARRAY[ct, OLD.id]::integer[];
+      RETURN NULL;
+END $bpp_body$;
+"""
+
+
+def _create_through_function(cur, table, model):
+    autorzy_view = table[: -len("_autor")] + "_autorzy"
+    upsert = _upsert_sql(
+        cur,
+        "bpp_autorzy_mat",
+        autorzy_view,
+        "object_id_raw = NEW.rekord_id AND autor_id = NEW.autor_id",
+    )
+    return f"""
+CREATE OR REPLACE FUNCTION bpp_refresh_autor_{model}() RETURNS trigger
+LANGUAGE plpgsql AS $bpp_body$
+DECLARE ct integer;
+BEGIN
+      {_ct_lookup(model)}
+      PERFORM pg_advisory_xact_lock(ct, NEW.rekord_id);
+      {upsert};
+      RETURN NULL;
+END $bpp_body$;
+"""
+
+
+def _create_delete_through_function(model):
+    return f"""
+CREATE OR REPLACE FUNCTION bpp_delete_autor_{model}() RETURNS trigger
+LANGUAGE plpgsql AS $bpp_body$
+DECLARE ct integer;
+BEGIN
+      {_ct_lookup(model)}
+      PERFORM pg_advisory_xact_lock(ct, OLD.rekord_id);
+      DELETE FROM bpp_autorzy_mat WHERE id = ARRAY[ct, OLD.id]::integer[];
+      RETURN NULL;
+END $bpp_body$;
+"""
+
+
+def _triggers(table, refresh_fn, delete_fn):
+    # INSERT / DELETE bezwarunkowe; UPDATE w 0432 jeszcze bezwarunkowy
+    # (bramka WHEN dochodzi w 0433).
+    return [
+        f"DROP TRIGGER IF EXISTS {table}_cache_ins ON {table};",
+        f"DROP TRIGGER IF EXISTS {table}_cache_del ON {table};",
+        f"DROP TRIGGER IF EXISTS {table}_cache_upd ON {table};",
+        f"CREATE TRIGGER {table}_cache_ins AFTER INSERT ON {table} "
+        f"FOR EACH ROW EXECUTE PROCEDURE {refresh_fn}();",
+        f"CREATE TRIGGER {table}_cache_del AFTER DELETE ON {table} "
+        f"FOR EACH ROW EXECUTE PROCEDURE {delete_fn}();",
+        f"CREATE TRIGGER {table}_cache_upd AFTER UPDATE ON {table} "
+        f"FOR EACH ROW EXECUTE PROCEDURE {refresh_fn}();",
+    ]
+
+
+def forward(apps, schema_editor):
+    with connection.cursor() as cur:
+        # 1) Usun stare zlaczone triggery PL/Python.
+        for table, trig in OLD_TRIGGERS:
+            cur.execute(f"DROP TRIGGER IF EXISTS {trig} ON {table};")
+
+        stmts = []
+        # 2) Funkcje + triggery rekord.
+        for table, model, autor_na_wierszu in REKORD_SITES:
+            stmts.append(_create_rekord_function(cur, table, model, autor_na_wierszu))
+            stmts.append(_create_delete_rekord_function(model))
+            stmts += _triggers(
+                table,
+                f"bpp_refresh_rekord_{model}",
+                f"bpp_delete_rekord_{model}",
+            )
+        # 3) Funkcje + triggery through.
+        for table, model in THROUGH_SITES:
+            stmts.append(_create_through_function(cur, table, model))
+            stmts.append(_create_delete_through_function(model))
+            stmts += _triggers(
+                table,
+                f"bpp_refresh_autor_{model}",
+                f"bpp_delete_autor_{model}",
+            )
+
+        for s in stmts:
+            cur.execute(s)
+
+        # 4) Stara dynamiczna funkcja PL/Python jest juz nieuzywana (zaden
+        #    trigger jej nie wola). Usuwamy ja -- to 9. (ostatnia w tym
+        #    porcie) funkcja plpython3u; reszta + DROP EXTENSION to osobny
+        #    spec (pozegnanie-z-plpython).
+        cur.execute("DROP FUNCTION IF EXISTS bpp_refresh_cache();")
+
+
+def backward(apps, schema_editor):
+    with connection.cursor() as cur:
+        # 1) Usun nowe rozbite triggery + funkcje PL/pgSQL.
+        for table, _model, _x in REKORD_SITES:
+            for suffix in ("ins", "del", "upd"):
+                cur.execute(
+                    f"DROP TRIGGER IF EXISTS {table}_cache_{suffix} ON {table};"
+                )
+        for table, _model in THROUGH_SITES:
+            for suffix in ("ins", "del", "upd"):
+                cur.execute(
+                    f"DROP TRIGGER IF EXISTS {table}_cache_{suffix} ON {table};"
+                )
+        for _table, model, _x in REKORD_SITES:
+            cur.execute(f"DROP FUNCTION IF EXISTS bpp_refresh_rekord_{model}();")
+            cur.execute(f"DROP FUNCTION IF EXISTS bpp_delete_rekord_{model}();")
+        for _table, model in THROUGH_SITES:
+            cur.execute(f"DROP FUNCTION IF EXISTS bpp_refresh_autor_{model}();")
+            cur.execute(f"DROP FUNCTION IF EXISTS bpp_delete_autor_{model}();")
+
+        # 2) Odtworz funkcje PL/Python v3 (0429) i zlaczone triggery (0400).
+        for fname in ("0429_cache_trigger_v3.sql", "0400_restore_cache_triggers.sql"):
+            sql = (Path(__file__).parent / fname).read_text()
+            cur.execute(sql)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0431_search_index_gin"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, backward),
+    ]

--- a/src/bpp/migrations/0433_cache_trigger_when_gate.py
+++ b/src/bpp/migrations/0433_cache_trigger_when_gate.py
@@ -1,0 +1,145 @@
+"""Bramka WHEN (lista kolumn) na UPDATE triggerach cache.
+
+Spec: docs/deweloper/spec-bpp-refresh-cache-plpgsql-2026-06.md (Zmiana 2).
+
+INSERT/DELETE zostaja bezwarunkowe (z 0432). UPDATE dostaje
+``WHEN (OLD.col IS DISTINCT FROM NEW.col OR ...)`` gdzie lista = kolumny bazowe
+faktycznie zasilajace wyjscie widoku(-ow) danej tabeli. Trigger nie wchodzi, gdy
+zaden istotny atrybut sie nie zmienil (jalowy churn -- np. wsadowe zapisy
+opl_pub_* nie bumpujace auto_now).
+
+Lista kolumn idzie z pg_depend (poziom kolumn, regula _RETURN), NIE z dopasowania
+nazw -- widok przemianowuje kolumny (wydawca_opis -> wydawnictwo w
+zwarte/doktorat/habilitacja), wiec dopasowanie po nazwie gubiloby zrodlo i dawalo
+cichy staleness. Odejmujemy {id, search_index, tytul_oryginalny_sort} (klucz;
+pochodne, ktorych zrodla i tak sa w zbiorze). Doktorat/habilitacja: ∪ kolumny
+zasilajace widok *_autorzy (autor_id, jednostka_id) -- bo autor lezy na wierszu
+publikacji.
+
+Kolejnosc termow OR: tanie/staloszerokie typy najpierw (short-circuit), drogie
+(tekst/varchar/tablice/tsvector) na koniec.
+
+Funkcje triggera sie NIE zmieniaja (to 0432) -- bramka siedzi na definicji
+triggera, nie w ciele funkcji.
+"""
+
+from django.db import connection, migrations
+
+# tabela -> (funkcja refresh, [widoki ktore tabela zasila])
+GATED = [
+    (
+        "bpp_wydawnictwo_ciagle",
+        "bpp_refresh_rekord_wydawnictwo_ciagle",
+        ["bpp_wydawnictwo_ciagle_view"],
+    ),
+    (
+        "bpp_wydawnictwo_zwarte",
+        "bpp_refresh_rekord_wydawnictwo_zwarte",
+        ["bpp_wydawnictwo_zwarte_view"],
+    ),
+    (
+        "bpp_patent",
+        "bpp_refresh_rekord_patent",
+        ["bpp_patent_view"],
+    ),
+    (
+        "bpp_praca_doktorska",
+        "bpp_refresh_rekord_praca_doktorska",
+        ["bpp_praca_doktorska_view", "bpp_praca_doktorska_autorzy"],
+    ),
+    (
+        "bpp_praca_habilitacyjna",
+        "bpp_refresh_rekord_praca_habilitacyjna",
+        ["bpp_praca_habilitacyjna_view", "bpp_praca_habilitacyjna_autorzy"],
+    ),
+    (
+        "bpp_wydawnictwo_ciagle_autor",
+        "bpp_refresh_autor_wydawnictwo_ciagle",
+        ["bpp_wydawnictwo_ciagle_autorzy"],
+    ),
+    (
+        "bpp_wydawnictwo_zwarte_autor",
+        "bpp_refresh_autor_wydawnictwo_zwarte",
+        ["bpp_wydawnictwo_zwarte_autorzy"],
+    ),
+    (
+        "bpp_patent_autor",
+        "bpp_refresh_autor_patent",
+        ["bpp_patent_autorzy"],
+    ),
+]
+
+EXCLUDED = ("id", "search_index", "tytul_oryginalny_sort")
+
+
+def _gate_columns(cur, table, views):
+    """Kolumny bazowe ``table`` referowane przez ``views`` (pg_depend, poziom
+    kolumn), bez {id, search_index, tytul_oryginalny_sort}, posortowane
+    tanie-typy-pierwsze, potem attnum."""
+    cur.execute(
+        """
+        SELECT a.attname
+        FROM (
+            SELECT DISTINCT a.attname, a.attnum,
+                   (t.typcategory IN ('S','A')
+                    OR a.atttypid = 'pg_catalog.tsvector'::regtype)::int AS expensive
+            FROM pg_depend d
+            JOIN pg_rewrite r ON r.oid = d.objid
+            JOIN pg_class   v ON v.oid = r.ev_class AND v.relname = ANY(%s)
+            JOIN pg_attribute a ON a.attrelid = d.refobjid
+                                AND a.attnum = d.refobjsubid
+            JOIN pg_type    t ON t.oid = a.atttypid
+            WHERE d.refobjid = %s::regclass
+              AND d.classid = 'pg_rewrite'::regclass
+              AND d.refclassid = 'pg_class'::regclass
+              AND d.refobjsubid > 0
+              AND a.attname <> ALL(%s)
+        ) a
+        ORDER BY a.expensive, a.attnum
+        """,
+        [list(views), table, list(EXCLUDED)],
+    )
+    return [r[0] for r in cur.fetchall()]
+
+
+def _when_clause(columns):
+    return " OR ".join(f'OLD."{c}" IS DISTINCT FROM NEW."{c}"' for c in columns)
+
+
+def forward(apps, schema_editor):
+    with connection.cursor() as cur:
+        for table, refresh_fn, views in GATED:
+            columns = _gate_columns(cur, table, views)
+            if not columns:
+                raise RuntimeError(
+                    f"bramka dla {table}: pg_depend nie zwrocil zadnej kolumny "
+                    f"(widoki={views}) -- nie tworze niezbramkowanego UPDATE"
+                )
+            when = _when_clause(columns)
+            cur.execute(f"DROP TRIGGER IF EXISTS {table}_cache_upd ON {table};")
+            cur.execute(
+                f"CREATE TRIGGER {table}_cache_upd AFTER UPDATE ON {table} "
+                f"FOR EACH ROW WHEN ({when}) "
+                f"EXECUTE PROCEDURE {refresh_fn}();"
+            )
+
+
+def backward(apps, schema_editor):
+    # Z powrotem do bezwarunkowego UPDATE (stan po 0432).
+    with connection.cursor() as cur:
+        for table, refresh_fn, _views in GATED:
+            cur.execute(f"DROP TRIGGER IF EXISTS {table}_cache_upd ON {table};")
+            cur.execute(
+                f"CREATE TRIGGER {table}_cache_upd AFTER UPDATE ON {table} "
+                f"FOR EACH ROW EXECUTE PROCEDURE {refresh_fn}();"
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0432_cache_trigger_plpgsql"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, backward),
+    ]

--- a/src/bpp/tests/test_cache/test_cache_plpgsql_benchmark.py
+++ b/src/bpp/tests/test_cache/test_cache_plpgsql_benchmark.py
@@ -1,0 +1,142 @@
+"""Benchmark VC (PL/pgSQL) vs V0 (PL/Python) + dowod semantycznej neutralnosci.
+
+Spec: docs/deweloper/spec-bpp-refresh-cache-plpgsql-2026-06.md (sek. 1, Zalacznik A).
+
+Dwa twierdzenia:
+
+1. SEMANTYKA (twardy gejt): ``bpp_rekord_mat`` policzony przez port PL/pgSQL jest
+   BAJTOWO identyczny z policzonym przez stara funkcje PL/Python (agregat md5 po
+   calej tabeli). To jest wlasciwy dowod poprawnosci portu.
+
+2. WYDAJNOSC (informacyjnie + sanity): serwerowy czas bulk-UPDATE (min z prob,
+   1 warm-up odrzucony) -- port ma byc szybszy od PL/Python (spec: ~2,2-2,3x na
+   czystych komorkach). Na malym zbiorze w CI margines jest skromniejszy, wiec
+   asercja jest konserwatywna (port nie wolniejszy), a liczby ida do stdout.
+
+Mechanika: zbior testowy jest staly; mierzymy ten sam bulk-UPDATE raz na porcie
+(stan biezacy), raz po przelaczeniu na funkcje V0 (plpython3u + zlaczone
+triggery, odtworzone z 0429/0400 bez BEGIN/COMMIT). DDL jest transakcyjne, wiec
+przelaczenie zyje tylko w transakcji testu.
+"""
+
+from pathlib import Path
+
+import pytest
+from django.db import connection
+from model_bakery import baker
+
+from bpp.models import Autor, Jednostka, Wydawnictwo_Ciagle
+
+N = 120
+REPS = 5  # 1 warm-up odrzucony, min z reszty
+
+_MIGR = Path(__file__).resolve().parents[3] / "bpp" / "migrations"
+
+BENCH_FN = """
+CREATE OR REPLACE FUNCTION bench_update(setclause text, n int)
+RETURNS TABLE(ms numeric, mat_writes bigint) LANGUAGE plpgsql AS $$
+DECLARE t0 timestamptz;
+BEGIN
+  t0 := clock_timestamp();
+  EXECUTE format('UPDATE bpp_wydawnictwo_ciagle SET %s WHERE id IN '
+    '(SELECT id FROM bpp_wydawnictwo_ciagle ORDER BY id LIMIT %s)', setclause, n);
+  ms := round(extract(epoch from clock_timestamp()-t0)*1000,1);
+  SELECT COALESCE(sum(n_tup_ins+n_tup_upd),0) INTO mat_writes
+    FROM pg_stat_xact_user_tables WHERE relname='bpp_rekord_mat';
+  RETURN NEXT;
+END $$;
+"""
+
+
+def _strip_tx(sql):
+    # 0429 owija sie w BEGIN; ... COMMIT; -- w transakcji testu COMMIT zerwalby
+    # izolacje (rollback). Wytnij sterowanie transakcja, zostaw DDL.
+    lines = []
+    for line in sql.splitlines():
+        if line.strip().upper() in ("BEGIN;", "COMMIT;"):
+            continue
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _swap_to_v0(cur):
+    """Przelacz na V0: usun rozbite triggery, odtworz plpython bpp_refresh_cache
+    (0429) + zlaczone triggery (0400)."""
+    for table in (
+        "bpp_wydawnictwo_ciagle",
+        "bpp_wydawnictwo_ciagle_autor",
+        "bpp_wydawnictwo_zwarte",
+        "bpp_wydawnictwo_zwarte_autor",
+        "bpp_patent",
+        "bpp_patent_autor",
+        "bpp_praca_doktorska",
+        "bpp_praca_habilitacyjna",
+    ):
+        for suffix in ("ins", "del", "upd"):
+            cur.execute(f"DROP TRIGGER IF EXISTS {table}_cache_{suffix} ON {table};")
+    cur.execute(_strip_tx((_MIGR / "0429_cache_trigger_v3.sql").read_text()))
+    cur.execute((_MIGR / "0400_restore_cache_triggers.sql").read_text())
+
+
+def _md5_mat(cur):
+    cur.execute(
+        "SELECT md5(string_agg(x, ',' ORDER BY x)) "
+        "FROM (SELECT bpp_rekord_mat::text AS x FROM bpp_rekord_mat) t"
+    )
+    return cur.fetchone()[0]
+
+
+def _bench(cur, setclause):
+    best = None
+    writes = 0
+    for i in range(REPS):
+        cur.execute("SELECT ms, mat_writes FROM bench_update(%s, %s)", [setclause, N])
+        ms, writes = cur.fetchone()
+        if i == 0:
+            continue  # warm-up
+        best = ms if best is None else min(best, ms)
+    return best, writes
+
+
+@pytest.mark.django_db
+def test_plpgsql_port_identical_and_not_slower(standard_data, denorms):
+    j = baker.make(Jednostka)
+    for i in range(N):
+        wc = baker.make(Wydawnictwo_Ciagle, tytul_oryginalny=f"Bench {i}", punkty_kbn=5)
+        wc.dodaj_autora(baker.make(Autor, imiona="Jan", nazwisko=f"Aut{i}"), j)
+    denorms.flush()
+
+    with connection.cursor() as cur:
+        cur.execute(BENCH_FN)
+
+        # --- VC (port PL/pgSQL, stan biezacy 0433) ---
+        # (fire/skip bramki dowodza osobne testy: test_gate_skips + kanarki;
+        # pg_stat_xact_user_tables jest kumulatywne w transakcji, wiec tu sie
+        # do liczenia fire'ow nie nadaje.)
+        t_vc, _ = _bench(cur, "punkty_kbn = punkty_kbn + 1")
+        md5_vc = _md5_mat(cur)
+
+        # --- V0 (PL/Python, odtworzony) ---
+        _swap_to_v0(cur)
+        # Wymus pelne odswiezenie tego samego stanu danych bez ich zmiany:
+        # plpython odpala bezwarunkowo, wiec mat zostaje przeliczony 1:1.
+        cur.execute("UPDATE bpp_wydawnictwo_ciagle SET punkty_kbn = punkty_kbn")
+        md5_v0 = _md5_mat(cur)
+
+        # 1) SEMANTYKA: identyczny bajtowo wynik obu silnikow dla tego stanu.
+        assert md5_v0 == md5_vc, (
+            "port PL/pgSQL liczy bpp_rekord_mat INACZEJ niz PL/Python "
+            f"(md5 V0={md5_v0} != VC={md5_vc})"
+        )
+
+        # 2) WYDAJNOSC: ten sam bulk-UPDATE na silniku V0.
+        t_v0, _ = _bench(cur, "punkty_kbn = punkty_kbn + 1")
+
+    speedup = t_v0 / t_vc if t_vc else float("inf")
+    print(
+        f"\nBENCH (N={N}, min z {REPS - 1} prob): "
+        f"VC={t_vc} ms  V0={t_v0} ms  speedup={speedup:.2f}x"
+    )
+    # Konserwatywnie: port nie moze byc wolniejszy (oczekiwane ~2x na czystych
+    # komorkach; na malym zbiorze margines mniejszy, ale kierunek pewny).
+    assert t_vc < t_v0, f"port NIE szybszy: VC={t_vc} >= V0={t_v0} ms"

--- a/src/bpp/tests/test_cache/test_cache_plpgsql_port.py
+++ b/src/bpp/tests/test_cache/test_cache_plpgsql_port.py
@@ -1,0 +1,258 @@
+"""Kanarki portu bpp_refresh_cache PL/Python -> PL/pgSQL + bramki WHEN.
+
+Spec: docs/deweloper/spec-bpp-refresh-cache-plpgsql-2026-06.md
+
+Trzy klasy testow:
+
+1. ``test_cache_functions_are_plpgsql`` -- po porcie (migracja 0432) funkcje
+   triggera musza byc statycznym PL/pgSQL, nie dynamicznym PL/Python.
+   RED dopoki port nie istnieje.
+
+2. ``test_view_feeding_column_keeps_mat_fresh`` / ``..._autorzy_mat_fresh``
+   -- KANAREK STALENESS (spec sec. 3, obowiazkowy). Dla kolumny bazowej
+   zasilajacej widok: surowy UPDATE -> ``mat`` musi byc == swiezo policzony
+   widok. Brak kolumny w bramce WHEN = cichy staleness = ten test na czerwono.
+   Pokrywa pulapke przemianowania (``wydawca_opis`` -> ``wydawnictwo`` w
+   zwarte) i kolumne through-table.
+
+3. ``test_gate_skips_non_view_column`` -- bramka WHEN (migracja 0433) pomija
+   jalowe odswiezenie: surowy UPDATE kolumny SPOZA widoku
+   (``weryfikacja_punktacji``) NIE przepisuje wiersza ``bpp_rekord_mat``
+   (ctid bez zmian). RED dopoki trigger jest bezwarunkowy.
+
+Wszystkie testy uzywaja SUROWEGO SQL-a, by izolowac sam trigger bazodanowy
+(bez denorm / sygnalow Django).
+"""
+
+import pytest
+from django.db import connection
+from model_bakery import baker
+
+from bpp.models import Autor, Jednostka, Wydawnictwo_Ciagle
+from bpp.tests.util import any_ciagle, any_zwarte
+
+
+def _cols(cur, relname):
+    cur.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema='public' AND table_name=%s ORDER BY ordinal_position",
+        [relname],
+    )
+    return [r[0] for r in cur.fetchall()]
+
+
+def _ct(cur, model):
+    cur.execute(
+        "SELECT id FROM django_content_type WHERE app_label='bpp' AND model=%s",
+        [model],
+    )
+    return cur.fetchone()[0]
+
+
+def _q(c):
+    return '"' + c + '"'
+
+
+def _rekord_mat_row(cur, ct, pk):
+    cols = _cols(cur, "bpp_rekord_mat")
+    cur.execute(
+        f"SELECT {', '.join(_q(c) for c in cols)} FROM bpp_rekord_mat "
+        f"WHERE id = ARRAY[%s, %s]::integer[]",
+        [ct, pk],
+    )
+    return cur.fetchone()
+
+
+def _rekord_view_row(cur, view, pk):
+    src = [c for c in _cols(cur, view) if c != "object_id_raw"]
+    cur.execute(
+        f"SELECT {', '.join(_q(c) for c in src)} FROM {view} WHERE object_id_raw = %s",
+        [pk],
+    )
+    return cur.fetchone()
+
+
+def _autorzy_mat_row(cur, ct, through_pk):
+    cols = _cols(cur, "bpp_autorzy_mat")
+    cur.execute(
+        f"SELECT {', '.join(_q(c) for c in cols)} FROM bpp_autorzy_mat "
+        f"WHERE id = ARRAY[%s, %s]::integer[]",
+        [ct, through_pk],
+    )
+    return cur.fetchone()
+
+
+def _autorzy_view_row(cur, view, object_id_raw, autor_id):
+    src = [c for c in _cols(cur, view) if c != "object_id_raw"]
+    cur.execute(
+        f"SELECT {', '.join(_q(c) for c in src)} FROM {view} "
+        f"WHERE object_id_raw = %s AND autor_id = %s",
+        [object_id_raw, autor_id],
+    )
+    return cur.fetchone()
+
+
+# ---------------------------------------------------------------------------
+# 1. Port: funkcje sa PL/pgSQL
+# ---------------------------------------------------------------------------
+
+EXPECTED_FUNCTIONS = [
+    "bpp_refresh_rekord_wydawnictwo_ciagle",
+    "bpp_refresh_rekord_wydawnictwo_zwarte",
+    "bpp_refresh_rekord_patent",
+    "bpp_refresh_rekord_praca_doktorska",
+    "bpp_refresh_rekord_praca_habilitacyjna",
+    "bpp_refresh_autor_wydawnictwo_ciagle",
+    "bpp_refresh_autor_wydawnictwo_zwarte",
+    "bpp_refresh_autor_patent",
+    "bpp_delete_rekord_wydawnictwo_ciagle",
+    "bpp_delete_rekord_wydawnictwo_zwarte",
+    "bpp_delete_rekord_patent",
+    "bpp_delete_rekord_praca_doktorska",
+    "bpp_delete_rekord_praca_habilitacyjna",
+    "bpp_delete_autor_wydawnictwo_ciagle",
+    "bpp_delete_autor_wydawnictwo_zwarte",
+    "bpp_delete_autor_patent",
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("fn", EXPECTED_FUNCTIONS)
+def test_cache_functions_are_plpgsql(fn):
+    with connection.cursor() as cur:
+        cur.execute(
+            "SELECT l.lanname FROM pg_proc p JOIN pg_language l ON l.oid=p.prolang "
+            "WHERE p.proname=%s",
+            [fn],
+        )
+        row = cur.fetchone()
+    assert row is not None, f"funkcja {fn} nie istnieje (port nie zrobiony)"
+    assert row[0] == "plpgsql", f"{fn} jest w jezyku {row[0]}, oczekiwano plpgsql"
+
+
+# ---------------------------------------------------------------------------
+# 2. Kanarek staleness: mat == widok dla kazdej zasilajacej kolumny
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "model,table,view,column,perturb",
+    [
+        # ciagle: kolumny tekstowe, nazwa = nazwa kolumny mat
+        (
+            "wydawnictwo_ciagle",
+            "bpp_wydawnictwo_ciagle",
+            "bpp_wydawnictwo_ciagle_view",
+            "tytul_oryginalny",
+            "COALESCE(tytul_oryginalny, '') || 'KANAREK'",
+        ),
+        (
+            "wydawnictwo_ciagle",
+            "bpp_wydawnictwo_ciagle",
+            "bpp_wydawnictwo_ciagle_view",
+            "uwagi",
+            "COALESCE(uwagi, '') || 'KANAREK'",
+        ),
+        # zwarte: PULAPKA PRZEMIANOWANIA -- wydawca_opis zasila widokowa
+        # kolumne 'wydawnictwo'. Dopasowanie po nazwie zgubiloby ja.
+        (
+            "wydawnictwo_zwarte",
+            "bpp_wydawnictwo_zwarte",
+            "bpp_wydawnictwo_zwarte_view",
+            "wydawca_opis",
+            "COALESCE(wydawca_opis, '') || 'KANAREK'",
+        ),
+    ],
+)
+def test_view_feeding_column_keeps_mat_fresh(model, table, view, column, perturb):
+    if table == "bpp_wydawnictwo_ciagle":
+        rec = any_ciagle(tytul_oryginalny="Kanarkowa", uwagi="u")
+    else:
+        rec = any_zwarte(tytul_oryginalny="Kanarkowa", uwagi="u")
+    pk = rec.pk
+
+    with connection.cursor() as cur:
+        ct = _ct(cur, model)
+        cur.execute(f"UPDATE {table} SET {column} = {perturb} WHERE id = %s", [pk])
+
+        mat = _rekord_mat_row(cur, ct, pk)
+        widok = _rekord_view_row(cur, view, pk)
+
+    assert mat == widok, (
+        f"po zmianie {table}.{column} wiersz bpp_rekord_mat != widok "
+        f"(kolumna zgubiona w bramce? cichy staleness)"
+    )
+
+
+@pytest.mark.django_db
+def test_through_feeding_column_keeps_autorzy_mat_fresh(standard_data, denorms):
+    wc = baker.make(
+        Wydawnictwo_Ciagle,
+        tytul_oryginalny="Kanarek through",
+        szczegoly="sz",
+        uwagi="u",
+    )
+    j = baker.make(Jednostka)
+    a = baker.make(Autor, imiona="Jan", nazwisko="Kanarek")
+    wca = wc.dodaj_autora(a, j, zapisany_jako="Jan Kanarek")
+    denorms.flush()
+
+    with connection.cursor() as cur:
+        ct = _ct(cur, "wydawnictwo_ciagle")
+        cur.execute(
+            "UPDATE bpp_wydawnictwo_ciagle_autor "
+            "SET zapisany_jako = zapisany_jako || 'KANAREK' WHERE id = %s",
+            [wca.pk],
+        )
+        mat = _autorzy_mat_row(cur, ct, wca.pk)
+        widok = _autorzy_view_row(cur, "bpp_wydawnictwo_ciagle_autorzy", wc.pk, a.pk)
+
+    assert mat == widok, (
+        "po zmianie bpp_wydawnictwo_ciagle_autor.zapisany_jako "
+        "wiersz bpp_autorzy_mat != widok (cichy staleness)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Bramka WHEN: skip jalowego odswiezenia na kolumnie spoza widoku
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_gate_skips_non_view_column():
+    """weryfikacja_punktacji nie zasila zadnego widoku -> bramka WHEN ma
+    pominac UPDATE: bpp_rekord_mat NIE przepisany (ctid bez zmian).
+
+    ctid (fizyczne polozenie krotki), nie xmin: w obrebie jednej transakcji
+    testowej kazdy zapis ma to samo xid, wiec xmin sie nie rusza nawet przy
+    przepisaniu; ctid zmienia sie na KAZDYM UPDATE krotki.
+
+    RED dopoki trigger UPDATE jest bezwarunkowy (przepisuje zawsze)."""
+    wc = any_ciagle(tytul_oryginalny="Bramka")
+    pk = wc.pk
+
+    with connection.cursor() as cur:
+        ct = _ct(cur, "wydawnictwo_ciagle")
+
+        def ctid():
+            cur.execute(
+                "SELECT ctid::text FROM bpp_rekord_mat "
+                "WHERE id = ARRAY[%s, %s]::integer[]",
+                [ct, pk],
+            )
+            return cur.fetchone()[0]
+
+        przed = ctid()
+        cur.execute(
+            "UPDATE bpp_wydawnictwo_ciagle "
+            "SET weryfikacja_punktacji = NOT COALESCE(weryfikacja_punktacji, false) "
+            "WHERE id = %s",
+            [pk],
+        )
+        po = ctid()
+
+    assert po == przed, (
+        "UPDATE kolumny spoza widoku (weryfikacja_punktacji) przepisal "
+        f"bpp_rekord_mat (ctid {przed} -> {po}) -- bramka WHEN nie dziala"
+    )


### PR DESCRIPTION
Follow-up do triggera cache **v3** (migracje 0421+0429). Wdraża
[spec-bpp-refresh-cache-plpgsql-2026-06](docs/deweloper/spec-bpp-refresh-cache-plpgsql-2026-06.md) —
dwie **ortogonalne** dźwignie wydajności triggera materializującego
`bpp_rekord_mat` / `bpp_autorzy_mat`.

## Zmiana 1 — port PL/Python → PL/pgSQL (migracja `0432`)

Introspekcja kolumn przeniesiona z **hot-path do migrate-path**: zamiast jednej
dynamicznej funkcji PL/Python (marshaling `TD["old"]`/`TD["new"]`, brak cache'u
planu) — per-tabela **statyczne** funkcje PL/pgSQL z wklejonymi na sztywno
listami `INSERT/SELECT/ON CONFLICT … SET`. 16 funkcji (8 refresh + 8 delete;
5 rekord + 3 through).

Semantyka v3 zachowana **dokładnie** (pułapki §2 spec-u):
- **mapowanie pozycyjne** dla widoków `*_autorzy` (`bpp_praca_doktorska_autorzy`
  nazywa kolumnę-tablicę `"array"`, habilitacja — `id`);
- **osobna ścieżka DELETE** (`NEW` jest `NULL` na DELETE → upsert by cicho nic
  nie skasował); kasowanie po `id = ARRAY[ct, OLD.id]`;
- advisory lock przez `SELECT … INTO STRICT ct` (`pg_advisory_xact_lock` jest
  STRICT — gołe podzapytanie z NULL cicho nie blokuje, #309);
- doktorat/habilitacja: `DELETE + INSERT` na `bpp_autorzy_mat` (widok `*_autorzy`
  ma INNER JOIN do `bpp_autor`).

Usuwa nieużywaną już funkcję `plpython3u` `bpp_refresh_cache` (ostatnią z tego
portu; `DROP EXTENSION` to osobny spec *pożegnanie-z-plpython*).

## Zmiana 2 — bramka `WHEN` listą kolumn na UPDATE (migracja `0433`)

`INSERT`/`DELETE` bezwarunkowe; `UPDATE` dostaje
`WHEN (OLD.col IS DISTINCT FROM NEW.col OR …)`. Lista kolumn z **`pg_depend`**
(poziom kolumn, reguła `_RETURN`) — **nie** z dopasowania nazw, które gubiłoby
przemianowania (`wydawca_opis → wydawnictwo` na 3 z 5 typów → cichy staleness).
Minus `{id, search_index, tytul_oryginalny_sort}`; tanie typy pierwsze
(short-circuit). Pomija jałowe odświeżenia `mat` na ścieżkach nie-bumpujących
`auto_now` (wsadowe `opl_pub_*`).

## Dowód

- **Wydajność:** benchmark VC vs V0 (bulk UPDATE, `min` z prób, czas serwerowy) —
  **~2,2–2,7× szybciej**, zgodnie ze spec-em (2,2–2,3× na czystych komórkach).
- **Semantyka:** agregat `md5` całej `bpp_rekord_mat` po VC vs V0 — **bajtowo
  identyczny**.

## TDD

1. **Czerwone kanarki** (`test_cache_plpgsql_port.py`): funkcje muszą być
   `plpgsql`; **brak kolumny w bramce → staleness** (`mat == widok`, pokrywa
   pułapkę przemianowania `wydawca_opis` i kolumnę through-table); **skip**
   kolumny spoza widoku (`weryfikacja_punktacji`) wykrywany przez `ctid`
   (w obrębie jednej transakcji testu `xmin` się nie rusza — `ctid` widzi
   przepisanie krotki).
2. Migracje `0432` + `0433` (round-trip forward→reverse→forward zweryfikowany).
3. Benchmark (`test_cache_plpgsql_benchmark.py`).

## Zakres / uwagi

- Through-table `UPDATE` też zbramkowane (jednolity mechanizm `pg_depend` —
  pomija jałowe rewrite'y `autorzy_mat`); spec rozpisywał bramkę dla 5 tabel
  bazowych, ale mechanizm jest identyczny i ściśle lepszy.
- **`baseline.sql` nietknięty** — odświeżenie po merge (zgodnie z planem
  parallelizacji; jednoczesne edycje baseline-u = nierozwiązywalny konflikt).
- 93 testy zielone (cache + browse + multiseek + API + raporty); brak driftu
  modeli (`makemigrations --check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)