### PR TITLE
test(dspace): napraw flake izolacji test_adapter_patent (Jezyk.DoesNotExist)

### DIFF
--- a/src/dspace_api/tests/test_adapter_patent.py
+++ b/src/dspace_api/tests/test_adapter_patent.py
@@ -1,10 +1,20 @@
 import pytest
 from model_bakery import baker
 
+from bpp.models.system import Jezyk
+
 
 @pytest.mark.django_db
 def test_adapter_patent():
     from dspace_api.adapters.patent import PatentDSpaceAdapter
+
+    # Patent.jezyk to @cached_property: Jezyk.objects.get(nazwa__icontains="polski").
+    # Test nie może polegać na danych referencyjnych baseline — inny test
+    # transakcyjny potrafi je wyczyścić, co daje order-zależny flake przy
+    # przetasowaniu shardów (pytest-split). Zapewnij dokładnie jeden "polski"
+    # Jezyk: dotwórz TYLKO gdy brak (inaczej baseline + nowy => MultipleObjectsReturned).
+    if not Jezyk.objects.filter(nazwa__icontains="polski").exists():
+        baker.make(Jezyk, nazwa="polski")
 
     rec = baker.make(
         "bpp.Patent",


### PR DESCRIPTION
## Fix: order-zależny flake `test_adapter_patent` (`Jezyk.DoesNotExist`)

Ujawnił się przy **#364** (usunięcie testu przetasowało shardy `pytest-split`). **NIE** związany z `DROP EXTENSION` — to pre-existing dług izolacji testów.

### Przyczyna
`Patent.jezyk` to `@cached_property` → `Jezyk.objects.get(nazwa__icontains="polski")`, czytana przez `PatentDSpaceAdapter(...).to_dspace_dict()`. Test polegał na języku „polski" z **danych referencyjnych baseline**. Gdy wcześniejszy test transakcyjny wyczyści `bpp_jezyk` i shard ustawi go przed tym testem → `Jezyk.DoesNotExist`.

### Fix
Test sam zapewnia „polski" `Jezyk` — dotwarza **tylko gdy brak** (bez dublowania → bez `MultipleObjectsReturned`, gdy baseline go ma):
```python
if not Jezyk.objects.filter(nazwa__icontains="polski").exists():
    baker.make(Jezyk, nazwa="polski")
```

### Weryfikacja (lokalnie, testcontainer)
- ✅ przechodzi z danymi referencyjnymi baseline (gałąź „nie dubluj"),
- ✅ przechodzi po **symulowanym wyczyszczeniu** `bpp_jezyk` (gałąź „dotwórz" — czyli realny scenariusz buga).

### Poza tym PR-em
Szersze rozwiązanie (autouse-fixtura na dane referencyjne / namierzenie testu „wycieracza" truncującego `bpp_jezyk`) — ten punktowy fix usuwa konkretny flake, nie cały wzorzec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)