### PR TITLE
feat(admin): wyszukiwanie prac po search_index w globalnej nawigacji admina

### DIFF
--- a/src/bpp/tests/test_views/test_global_nav.py
+++ b/src/bpp/tests/test_views/test_global_nav.py
@@ -1,11 +1,11 @@
 import json
 
 import pytest
+from django.contrib.contenttypes.models import ContentType
 from django.http.response import HttpResponseNotAllowed, HttpResponseRedirect
 from django.urls import reverse
+from django.utils.http import urlencode
 from model_bakery import baker
-
-from django.contrib.contenttypes.models import ContentType
 
 from bpp.models.autor import Autor
 from bpp.models.cache import Rekord
@@ -63,6 +63,31 @@ def test_global_nav_redir(model, source, typy_odpowiedzialnosci):
     )
 
     assert isinstance(res, HttpResponseRedirect)
+
+
+@pytest.mark.django_db
+def test_admin_nav_znajduje_prace_po_slowie_z_tytulu_i_nazwisku_autora(
+    admin_client, jednostka, typy_odpowiedzialnosci
+):
+    """Adminowy widget globalnej nawigacji (id_global_nav_value) ma znajdować
+    pracę, gdy wpisze się słowo z TYTUŁU oraz słowo z NAZWISKA autora naraz —
+    tak jak publiczna wyszukiwarka spod "/". Wymaga full-textu po search_index,
+    nie icontains po samym tytule."""
+    praca = baker.make(
+        Wydawnictwo_Ciagle,
+        tytul_oryginalny="Teleportacja kwantowa peptydow",
+    )
+    autor = baker.make(Autor, nazwisko="Kowalczykiewicz", imiona="Jan")
+    praca.dodaj_autora(autor, jednostka, zapisany_jako="Kowalczykiewicz Jan")
+
+    Rekord.objects.full_refresh()
+
+    url = reverse("bpp:admin-navigation-autocomplete")
+    url += "?" + urlencode({"q": "Teleportacja Kowalczykiewicz"})
+    res = admin_client.get(url)
+
+    assert res.status_code == 200
+    assert b"Teleportacja" in res.content
 
 
 def test_global_nav_ukrywanie_statusow_przed_korekta_praca_schowana(

--- a/src/bpp/util/orm.py
+++ b/src/bpp/util/orm.py
@@ -12,6 +12,55 @@ from django.utils import timezone
 from bpp.util.text import fulltext_tokenize
 
 
+def build_fulltext_search_query(qstr, enable_websearch_on_minus_or_quote=True):
+    """Zbuduj ``SearchQuery`` dla pełnotekstowego wyszukiwania w polu typu
+    ``tsvector`` (np. ``search_index``).
+
+    Wspólna logika dla ``FulltextSearchMixin.fulltext_filter`` oraz adminowego
+    autocomplete (``AdminNavigationAutocomplete``) — żeby admin szukał prac
+    identycznie jak publiczna wyszukiwarka spod „/".
+
+    Zwraca ``SearchQuery`` albo ``None``, gdy z zapytania nie da się wyciągnąć
+    żadnych słów (wtedy wołający decyduje, co zrobić z pustym wynikiem).
+    """
+    if qstr is None:
+        return None
+
+    if isinstance(qstr, bytes):
+        qstr = qstr.decode("utf-8")
+
+    # Remove " - " (space-dash-space) from the query string
+    qstr = qstr.replace(" - ", " ")
+
+    words = fulltext_tokenize(qstr)
+    if not words:
+        return None
+
+    if (
+        qstr.find("-") >= 0 or qstr.find('"') >= 0
+    ) and enable_websearch_on_minus_or_quote:
+        # Jezeli użytkownik podał cudzysłów lub minus w zapytaniu i dozwolone jest
+        # przełączenie się na websearch, to skorzystaj z trybu zapytania
+        # ``websearch``:
+        return SearchQuery(qstr, search_type="websearch", config="bpp_nazwy_wlasne")
+
+    # Jeżeli nie ma minusów, cudzysłowów to możesz odpalić dodatkowo tryb
+    # wyszukiwania 'phrase' żeby znaleźć wyrazy w kolejności, tak jak zostały
+    # podane
+
+    q1 = reduce(
+        operator.__and__,
+        [
+            SearchQuery(word + ":*", search_type="raw", config="bpp_nazwy_wlasne")
+            for word in words
+        ],
+    )
+
+    q3 = SearchQuery(qstr, search_type="phrase", config="bpp_nazwy_wlasne")
+
+    return q1 | q3
+
+
 class FulltextSearchMixin:
     fts_field = "search"
 
@@ -30,46 +79,11 @@ class FulltextSearchMixin:
         }
 
     def fulltext_filter(self, qstr, normalization=None):
-        if qstr is None:
+        search_query = build_fulltext_search_query(
+            qstr, self.fts_enable_websearch_on_minus_or_quote
+        )
+        if search_query is None:
             return self.fulltext_empty()
-
-        if isinstance(qstr, bytes):
-            qstr = qstr.decode("utf-8")
-
-        # Remove " - " (space-dash-space) from the query string
-        qstr = qstr.replace(" - ", " ")
-
-        words = fulltext_tokenize(qstr)
-        if not words:
-            return self.fulltext_empty()
-
-        if (
-            qstr.find("-") >= 0 or qstr.find('"') >= 0
-        ) and self.fts_enable_websearch_on_minus_or_quote:
-            # Jezeli użytkownik podał cudzysłów lub minus w zapytaniu i dozwolone jest
-            # przełączenie się na websearch (parametr ``self.fts_enable_websearch_on_minus``,
-            # to skorzystaj z trybu zapytania ``websearch``:
-
-            search_query = SearchQuery(
-                qstr, search_type="websearch", config="bpp_nazwy_wlasne"
-            )
-        else:
-            # Jeżeli nie ma minusów, cudzysłowów to możesz odpalić dodatkowo tryb wyszukiwania
-            # 'phrase' żeby znaleźć wyrazy w kolejności, tak jak zostały podane
-
-            q1 = reduce(
-                operator.__and__,
-                [
-                    SearchQuery(
-                        word + ":*", search_type="raw", config="bpp_nazwy_wlasne"
-                    )
-                    for word in words
-                ],
-            )
-
-            q3 = SearchQuery(qstr, search_type="phrase", config="bpp_nazwy_wlasne")
-
-            search_query = q1 | q3
 
         query = (
             self.filter(**{self.fts_field: search_query})

--- a/src/bpp/views/autocomplete/navigation.py
+++ b/src/bpp/views/autocomplete/navigation.py
@@ -20,6 +20,7 @@ from bpp.models.praca_habilitacyjna import Praca_Habilitacyjna
 from bpp.models.profile import BppUser
 from bpp.models.wydawnictwo_ciagle import Wydawnictwo_Ciagle
 from bpp.models.wydawnictwo_zwarte import Wydawnictwo_Zwarte
+from bpp.util.orm import build_fulltext_search_query
 from import_common.core import normalized_db_isbn
 from import_common.normalization import normalize_isbn
 
@@ -442,6 +443,16 @@ class AdminNavigationAutocomplete(
     def _build_publication_filter(self, klass):
         """Build filter for publication models."""
         query_filter = Q(tytul_oryginalny__icontains=self.q)
+
+        # Pełnotekstowe wyszukiwanie po ``search_index`` (tytuł waga A,
+        # autorzy waga B, rok, opis bibliograficzny) — identyczne z publiczną
+        # wyszukiwarką spod „/". Dzięki temu wpisanie słowa z TYTUŁU oraz
+        # słowa z NAZWISKA autora naraz odnajduje pracę, czego sam
+        # ``tytul_oryginalny__icontains`` (cały ciąg jako jeden ILIKE) nie
+        # potrafił. Kolumna i indeks GIN już istnieją — bez migracji.
+        search_query = build_fulltext_search_query(self.q)
+        if search_query is not None:
+            query_filter |= Q(search_index=search_query)
 
         # Try to add primary key filter if q is an integer
         try:

--- a/src/dspace_api/tests/test_selectors.py
+++ b/src/dspace_api/tests/test_selectors.py
@@ -19,7 +19,13 @@ def test_uczelnie_z_autorzy_set():
 
 
 @pytest.mark.django_db
-def test_uczelnie_z_jednostki_rekordu_doktorat():
+def test_uczelnie_z_jednostki_rekordu_doktorat(typ_odpowiedzialnosci_autor):
+    # ``Praca_Doktorska.autorzy_set`` sięga do modułowego cache
+    # ``_Praca_Doktorska_PropertyCache.typ_odpowiedzialnosci_autor``, który
+    # robi ``Typ_Odpowiedzialnosci.objects.get(skrot="aut.")``. Ten wiersz
+    # musi istnieć w trakcie testu — sam baseline nie wystarcza, bo test
+    # transakcyjny (live_server/playwright) w tym samym workerze potrafi
+    # zflushować dane referencyjne. Fixture gwarantuje obecność "aut.".
     from dspace_api.selectors import uczelnie_rekordu
 
     u = baker.make("bpp.Uczelnia")


### PR DESCRIPTION
## Problem

Adminowy widget globalnej nawigacji na górze stron `/admin/` (`id_global_nav_value`, placeholder „Wpisz, aby wyszukać... lub wciśnij /") szukał publikacji **wyłącznie** przez `tytul_oryginalny__icontains` — cały ciąg zapytania jako jeden `ILIKE` po samym tytule. Wpisanie słowa z tytułu **oraz** nazwiska autora naraz (np. „teleportacja kowalski") nie znajdowało nic, mimo że publiczna wyszukiwarka spod „/" to potrafi.

Przyczyna: publiczna „/" szuka prac przez `Rekord.objects.fulltext_filter()` (pełnotekstowy `search_index`: tytuł=waga A, **autorzy=waga B**, rok=C, opis=D), a adminowy `AdminNavigationAutocomplete` w ogóle nie dotykał `search_index`.

## Rozwiązanie

W `AdminNavigationAutocomplete._build_publication_filter` dokładam pełnotekstowy warunek `Q(search_index=search_query)` obok dotychczasowego `icontains`, dla **wszystkich pięciu** typów prac (ciągłe, zwarte, patenty, doktoraty, habilitacje). Oba warunki są komplementarne: full-text łapie po tokenach (w tym autorów), `icontains` łapie fragmenty wewnątrz słowa.

**Bez migracji / bez przebudowy bazy** — kolumna `search_index` i indeks GIN już istnieją na każdym modelu pracy i są utrzymywane triggerami. Admin po prostu z nich nie korzystał.

Logikę budowania `SearchQuery` (prefix `word:*` AND + tryb `phrase`; `websearch` przy `-`/`"`) wydzieliłem z `FulltextSearchMixin.fulltext_filter` do współdzielonej funkcji `build_fulltext_search_query()` w `bpp/util/orm.py`, żeby admin i „/" budowały **identyczne** zapytanie bez duplikacji logiki.

Uwaga: `SearchRank`/sortowanie po trafności **nie** jest dokładane (świadoma decyzja — liczy się znajdowanie po tytule i `search_index`).

## Testy

- Nowy test `test_admin_nav_znajduje_prace_po_slowie_z_tytulu_i_nazwisku_autora` (TDD — najpierw padał, że nie znajduje).
- `test_fulltext_search.py` + `test_views/test_global_nav.py`: 40 passed (potwierdza, że refaktor `fulltext_filter` jest behawioralnie identyczny).
- `test_autocomplete/test_autocomplete_publications.py`: 15 passed.
- `ruff check` + `ruff format --check`: czysto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)