### PR TITLE
feat(frontend): nazwiska "naszych" autorów w kolorze akcentu motywu

### DIFF
--- a/src/bpp/static/scss/praca_detail.scss
+++ b/src/bpp/static/scss/praca_detail.scss
@@ -1182,12 +1182,14 @@
 
 // "Nasz" autor (pracownik jednostki skupiającej pracowników) — wyróżniony,
 // żeby od razu rzucał się w oczy na długiej liście autorów obcych.
+// Kolor (i poświata) bierze się z $primary-color, więc nazwiska trzymają
+// się koloru akcentu aktualnego motywu (app-blue, app-orange, app-green…),
+// zamiast zahardkodowanej zieleni. Autorzy obcy są w tym samym akcencie
+// przez $anchor-color; "naszych" odróżnia pogrubienie + delikatny glow.
 .praca-mono__author-name--nasz {
     font-weight: 700;
-    color: #1f6f3c;
-    background: #eaf6ee;
-    border-radius: 3px;
-    padding: 0 2px;
+    color: $primary-color;
+    text-shadow: 0 0 6px rgba($primary-color, 0.45);
 }
 
 // Numer pozycji autora na liście, np. "(264.)" — mały, wyszarzony.


### PR DESCRIPTION
## Problem

Na `praca_tabela_mono.html` (i innych stronach z listą autorów) nazwiska
„naszych" autorów były **zielone niezależnie od motywu**. Reguła
`.praca-mono__author-name--nasz` miała zahardkodowaną zieleń
(`color:#1f6f3c` na tle `#eaf6ee`), więc w motywach o niebieskim
(app-blue), pomarańczowym (app-orange), bursztynowym (app-vizja) itd.
akcencie zieleń gryzła się z resztą kolorystyki tematu.

## Rozwiązanie

Kolor i poświatę nazwisk bierzemy z `$primary-color`, dzięki czemu
trzymają się **koloru akcentu aktualnego motywu**. Każdy motyw kompiluje
się jako osobny bundle z własnym `$primary-color`, więc wystarczy zmienna
SCSS — bez `var(--…)` i bez logiki w szablonie.

Zmiana w `src/bpp/static/scss/praca_detail.scss`, reguła
`.praca-mono__author-name--nasz`:

- `color: #1f6f3c` → `color: $primary-color`
- usunięte zielone tło `#eaf6ee`, `border-radius`, `padding`
- dodany delikatny glow: `text-shadow: 0 0 6px rgba($primary-color, .45)`
- `font-weight: 700` zostaje → różnica „nasz"/obcy nadal czytelna
  (pogrubienie + poświata)

Autorzy obcy już są w kolorze akcentu przez `$anchor-color`, więc nie
wymagali zmian. Żadnych zmian w HTML/szablonach.

## Weryfikacja

Skompilowane bundle (`grunt sass`) — reguła `--nasz` rozwiązuje się na
akcent per-motyw:

| motyw | color | glow |
|-------|-------|------|
| app-blue | `#1779ba` | `rgba(23,121,186,.45)` |
| app-orange | `#f26621` | `rgba(242,102,33,.45)` |
| app-vizja | `#efa402` | `rgba(239,164,2,.45)` |
| app-green | `green` | `rgba(0,128,0,.45)` |

W motywie green akcent *jest* zielony, więc nazwiska pozostają zielone —
to poprawne (kolor tego motywu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)