### PR TITLE
feat(generate_500_page): strony 500 per-domena (multi-hosted) + hardening DisallowedHost

### DIFF
--- a/src/bpp/management/commands/generate_500_page.py
+++ b/src/bpp/management/commands/generate_500_page.py
@@ -1,7 +1,11 @@
+import traceback
 from datetime import datetime
 from pathlib import Path
 
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.sites.models import Site
+from django.core.cache import cache
 from django.core.management import BaseCommand
 from django.template import loader
 from django.test import RequestFactory
@@ -12,51 +16,11 @@ from bpp.context_processors.global_nav import user as global_nav_user
 from bpp.context_processors.google_analytics import google_analytics
 from bpp.context_processors.microsoft_auth import microsoft_auth_status
 from bpp.context_processors.testing import testing
+from bpp.models import Uczelnia
 
-
-class Command(BaseCommand):
-    help = "Generuje statyczny plik 500.html dla nginx"
-
-    def handle(self, *args, **options):
-        # Create fake request with anonymous user
-        factory = RequestFactory()
-        request = factory.get("/")
-        request.user = AnonymousUser()
-        request.session = {}
-
-        # Create fake Uczelnia object for 500 error page
-        class FakeUczelnia:
-            skrot = "Strona główna"
-            nazwa = "Błąd 500"
-
-            def sprawdz_uprawnienie(self, attr, request, ignoruj_grupe=None):
-                # For 500 error page, don't show any permission-restricted content
-                return False
-
-        uczelnia_context = {"uczelnia": FakeUczelnia()}
-
-        # Build context from all context processors
-        context = {}
-        context.update(uczelnia_context)
-        context.update(bpp_configuration(request))
-        context.update(global_nav_user(request))
-        context.update(google_analytics(request))
-        context.update(microsoft_auth_status(request))
-        context.update(testing(request))
-
-        # Add any additional required context
-        context["messages"] = []
-        context["password_change_required"] = False
-
-        # Set cookielaw to accepted to avoid showing cookie banner on 500 page
-        context["cookielaw"] = {"notset": False, "accepted": True, "rejected": False}
-
-        # Render the template
-        template = loader.get_template("50x.html")
-        rendered_html = template.render(context, request)
-
-        # Add JavaScript to remove login menu from the rendered page
-        cleanup_script = """
+# JavaScript usuwający z wygenerowanej strony 500 wpisy menu logowania/raportów/
+# ewaluacji (statyczny plik nie zna stanu zalogowania użytkownika).
+CLEANUP_SCRIPT = """
 <script type="text/javascript">
     // Remove login, raporty and ewaluacja menus from 500 error page (added by generate_500_page command)
     $(document).ready(function() {
@@ -69,10 +33,95 @@ class Command(BaseCommand):
     });
 </script>
 """
-        # Insert the script before </body> tag
-        rendered_html = rendered_html.replace("</body>", cleanup_script + "</body>")
 
-        # Add warning comment at the top
+
+class Command(BaseCommand):
+    help = "Generuje statyczne pliki 500.html dla nginx (generyczny + per-domena)"
+
+    def handle(self, *args, **options):
+        static_root = Path(settings.STATIC_ROOT)
+
+        # 1. Generyczny fallback — pojedyncza uczelnia (single-site) albo
+        #    neutralna „niezdefiniowana uczelnia" (multi-site bez dopasowania
+        #    domeny). nginx serwuje go przez `try_files ... /static/500.html`,
+        #    gdy brak strony per-domena. Host z ALLOWED_HOSTS, by jakikolwiek
+        #    procesor/template wołający get_host() nie wywalił DisallowedHost.
+        generic_html = self._render_500(
+            Uczelnia.objects.get_single_uczelnia_or_none(), self._valid_host()
+        )
+        # Source-dir (gitignored) — zbierany przez collectstatic na buildzie,
+        # zachowuje wsteczny kontrakt z obrazami pre-multi-hosted.
+        bpp_app_dir = Path(__file__).parent.parent.parent
+        self._write(bpp_app_dir / "static" / "500.html", generic_html)
+        # $STATIC_ROOT — autorytatywne miejsce serwowane przez nginx w runtime.
+        self._write(static_root / "500.html", generic_html)
+
+        # 2. Per-domena — każdy Site dostaje stronę z brandingiem swojej
+        #    uczelni w `$STATIC_ROOT/500/<domena>.html`.
+        count = 0
+        for site in Site.objects.all():
+            try:
+                uczelnia = Uczelnia.objects.get_for_site(site)
+                html = self._render_500(uczelnia, site.domain)
+                self._write(static_root / "500" / f"{site.domain}.html", html)
+                count += 1
+            except Exception:
+                # Best-effort artefakt: jedna wadliwa domena nie może wywalić
+                # generacji pozostałych. Loguj pełny traceback i kontynuuj.
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Nie udało się wygenerować strony 500 dla domeny "
+                        f"{site.domain!r}:"
+                    )
+                )
+                traceback.print_exc()
+                continue
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Wygenerowano stronę 500: generyczną + {count} per-domena "
+                f"w {static_root}"
+            )
+        )
+
+    def _render_500(self, uczelnia, host):
+        """Wyrenderuj finalny HTML strony 500 dla danej uczelni i hosta.
+
+        ``uczelnia`` może być ``None`` (→ neutralna „niezdefiniowana uczelnia").
+        ``host`` trafia do ``SERVER_NAME`` fałszywego requestu — musi być w
+        ALLOWED_HOSTS, bo procesory/template mogą wołać ``get_host()``.
+        """
+        factory = RequestFactory()
+        request = factory.get("/", SERVER_NAME=host)
+        request.user = AnonymousUser()
+        request.session = {}
+        # KLUCZ: ustaw uczelnię z góry. ``Uczelnia.objects.get_for_request``
+        # zwraca ``request._uczelnia`` ZANIM sięgnie po ``get_host()`` w
+        # ``_site_dla_requestu`` — to jednocześnie wymusza właściwy branding
+        # per-domena i uodparnia command na DisallowedHost (testserver).
+        request._uczelnia = uczelnia
+
+        context = {}
+        context.update(bpp_configuration(request))
+        context.update(global_nav_user(request))
+        context.update(google_analytics(request))
+        context.update(microsoft_auth_status(request))
+        context.update(testing(request))
+        context["messages"] = []
+        context["password_change_required"] = False
+        # Ustaw cookielaw na zaakceptowane, by nie pokazywać bannera cookies.
+        context["cookielaw"] = {"notset": False, "accepted": True, "rejected": False}
+
+        # Context processor ``uczelnia`` trzyma globalny cache ``b"bpp_uczelnia"``
+        # NIE rozróżniający domen — przy seryjnym renderowaniu per-domena
+        # pierwsza uczelnia „zatrułaby" kolejne strony. Czyść przed każdym
+        # renderem, by processor policzył uczelnię z ``request._uczelnia``.
+        cache.delete(b"bpp_uczelnia")
+
+        template = loader.get_template("50x.html")
+        rendered_html = template.render(context, request)
+        rendered_html = rendered_html.replace("</body>", CLEANUP_SCRIPT + "</body>")
+
         warning = f"""<!--
 This file was automatically generated by: python src/manage.py generate_500_page
 Generated on: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
@@ -84,8 +133,8 @@ To modify this page, edit src/bpp/templates/50x.html and run the generate_500_pa
 """
         final_html = warning + rendered_html
 
-        # Minify HTML to remove unnecessary whitespace
-        final_html = html_minify(
+        # Minify HTML, usuwając zbędne białe znaki.
+        return html_minify(
             final_html,
             keep_comments=True,
             keep_closing_tags=True,
@@ -93,13 +142,19 @@ To modify this page, edit src/bpp/templates/50x.html and run the generate_500_pa
             keep_input_type_text_attr=True,
         )
 
-        # Save to bpp app's static directory
-        # Find bpp app directory by going up from this file's location
-        bpp_app_dir = Path(__file__).parent.parent.parent
-        output_path = bpp_app_dir / "static" / "500.html"
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(final_html, encoding="utf-8")
+    @staticmethod
+    def _write(path, html):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(html, encoding="utf-8")
 
-        self.stdout.write(
-            self.style.SUCCESS(f"Successfully generated 500.html at {output_path}")
-        )
+    @staticmethod
+    def _valid_host():
+        """Pierwszy konkretny host z ALLOWED_HOSTS (get_host() go waliduje).
+
+        Pomija wildcardy: ``"*"`` oraz subdomenowe ``".example.com"`` nie są
+        poprawną wartością nagłówka ``Host:``.
+        """
+        for h in settings.ALLOWED_HOSTS:
+            if h and h != "*" and not h.startswith(".") and "*" not in h:
+                return h
+        return "localhost"

--- a/src/bpp/tests/test_management_commands_generate_500_page.py
+++ b/src/bpp/tests/test_management_commands_generate_500_page.py
@@ -1,0 +1,80 @@
+"""Testy dla `generate_500_page` w trybie multi-hosted (per-domena).
+
+Command renderuje statyczną stronę 500 dla nginx. W instalacji multi-hosted
+(jedna baza, wiele `Site`/`Uczelnia` mapowanych po domenie) potrzebujemy
+osobnej strony 500 per domena — `$STATIC_ROOT/500/<domena>.html` — plus
+generyczny fallback `$STATIC_ROOT/500.html`.
+"""
+
+import pytest
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+
+from bpp.models import Uczelnia
+
+
+def _make_uczelnia(domain, skrot, nazwa):
+    site = Site.objects.create(domain=domain, name=nazwa)
+    return Uczelnia.objects.create(skrot=skrot, nazwa=nazwa, site=site)
+
+
+@pytest.mark.django_db
+def test_generate_500_page_writes_per_domain_files(settings, tmp_path):
+    """Każda domena dostaje własną stronę 500 z brandingiem swojej uczelni."""
+    settings.STATIC_ROOT = str(tmp_path)
+    _make_uczelnia("alfa.example.test", "ALFAUNIQ", "Alfa Uczelnia")
+    _make_uczelnia("beta.example.test", "BETAUNIQ", "Beta Uczelnia")
+
+    call_command("generate_500_page")
+
+    html_alfa = (tmp_path / "500" / "alfa.example.test.html").read_text("utf-8")
+    html_beta = (tmp_path / "500" / "beta.example.test.html").read_text("utf-8")
+
+    # Górny pasek base.html renderuje {{ uczelnia.skrot }} — każda strona
+    # musi nieść skrót SWOJEJ uczelni i nie zawierać skrótu drugiej.
+    assert "ALFAUNIQ" in html_alfa and "BETAUNIQ" not in html_alfa
+    assert "BETAUNIQ" in html_beta and "ALFAUNIQ" not in html_beta
+
+
+@pytest.mark.django_db
+def test_generate_500_page_writes_generic_fallback(settings, tmp_path):
+    """Generyczny `$STATIC_ROOT/500.html` powstaje (fallback dla nginx)."""
+    settings.STATIC_ROOT = str(tmp_path)
+    _make_uczelnia("alfa.example.test", "ALFAUNIQ", "Alfa Uczelnia")
+    _make_uczelnia("beta.example.test", "BETAUNIQ", "Beta Uczelnia")
+
+    call_command("generate_500_page")
+
+    generic = tmp_path / "500.html"
+    assert generic.exists()
+    assert "Wystąpił błąd serwera" in generic.read_text("utf-8")
+
+
+@pytest.mark.django_db
+def test_generate_500_page_robust_against_disallowed_host(settings, tmp_path):
+    """Command nie wywala się DisallowedHost gdy `testserver` nie jest w
+    ALLOWED_HOSTS — fałszywy request nigdy nie używa hosta `testserver`."""
+    settings.STATIC_ROOT = str(tmp_path)
+    settings.ALLOWED_HOSTS = ["alfa.example.test"]  # bez "testserver"
+    _make_uczelnia("alfa.example.test", "ALFAUNIQ", "Alfa Uczelnia")
+
+    # Nie może rzucić django.core.exceptions.DisallowedHost.
+    call_command("generate_500_page")
+
+    assert (tmp_path / "500" / "alfa.example.test.html").exists()
+
+
+@pytest.mark.django_db
+def test_generate_500_page_succeeds_with_no_uczelnia(settings, tmp_path):
+    """Świeża instalacja: ZERO obiektów Uczelnia — generacja musi się udać
+    (neutralna strona), bez wyjątku. Entrypoint woła to po `migrate` na pustej
+    bazie, zanim setup wizard utworzy uczelnię."""
+    settings.STATIC_ROOT = str(tmp_path)
+    assert not Uczelnia.objects.exists()
+
+    call_command("generate_500_page")
+
+    generic = tmp_path / "500.html"
+    assert generic.exists()
+    # Neutralna „niezdefiniowana uczelnia" — strona renderuje się poprawnie.
+    assert "Wystąpił błąd serwera" in generic.read_text("utf-8")


### PR DESCRIPTION
## Co i dlaczego

Na `feature/multi-hosted-config` jeden stack obsługuje N domen (Site→Uczelnia). Dotychczasowy `generate_500_page`:

1. **Wywalał się** `DisallowedHost: 'testserver'` — renderował przez `RequestFactory().get("/")` (host `testserver`), a context processor `uczelnia` → `get_for_request` → `_site_dla_requestu` → `request.get_host()` waliduje `ALLOWED_HOSTS`. Widoczne w logach przy starcie appservera.
2. Generował **jedną** stronę 500 dla wszystkich domen — brak brandingu per-uczelnia.

## Zmiany

- Renderuje osobną stronę per `Site` → `$STATIC_ROOT/500/<domena>.html` z brandingiem przypisanej uczelni + generyczny `$STATIC_ROOT/500.html` (fallback dla nginx).
- **Hardening:** `request._uczelnia` ustawiane z góry → `get_for_request` zwraca je ZANIM sięgnie po `get_host()`. Koniec `DisallowedHost`; jednocześnie wymusza właściwą uczelnię per-domena.
- **Fix cache-poison:** czyści globalny `b"bpp_uczelnia"` przed każdym renderem — bez tego pierwsza uczelnia „zatruwałaby" kolejne domeny (cache nie rozróżnia hostów).
- Pisze do `$STATIC_ROOT` (autorytatywne miejsce serwowane przez nginx w runtime), zachowując zapis do gitignored `src/bpp/static/500.html` (collectstatic na buildzie, wsteczny kontrakt).

## Testy (4, zielone)

- per-domena z izolacją brandingu (uczelnia A nie wycieka na stronę B),
- generyczny fallback,
- regresja `DisallowedHost` (`ALLOWED_HOSTS` bez `testserver`),
- **zero obiektów Uczelnia** (świeża instalacja po `migrate`) — generacja się udaje, neutralna strona.

## Strona deploy

Parę nginx: iplweb/bpp-deploy `feat/per-domain-500-page` (`error_page 500` per-`${VHOST_NAME}` z fallbackiem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)