### PR TITLE
build(deps): bump django-channels-broadcast 0.2.0 -> 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ dependencies = [
     "gunicorn>=26.0.0", # authserver WSGI runner (moved from docker/authserver build-time uv pip install)
     "watchdog>=5.0.3", # --reload mode dla uvicorn/celery w dev compose (moved from entrypoint `uv pip install`)
     "sqlparse>=0.5.4", # Dependabot: transitive via Django, bumped to fix DoS in format_list_of_tuples
-    "django-channels-broadcast>=0.2.0",
+    "django-channels-broadcast>=0.2.1",
     "django-countdown>=0.2.0",
     "django-formdefaults>=0.6.2",
     # django-pg-baseline: zewnetrzny pakiet zarzadzajacy baseline.sql + monkey-patch

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ requires-dist = [
     { name = "django-cacheops", specifier = ">=7.2,<8" },
     { name = "django-celery-email", specifier = ">=3.0.0" },
     { name = "django-celery-results", specifier = "==2.6.0" },
-    { name = "django-channels-broadcast", specifier = ">=0.2.0" },
+    { name = "django-channels-broadcast", specifier = ">=0.2.1" },
     { name = "django-classy-tags", specifier = "==4.1.0" },
     { name = "django-columns", specifier = "==0.1.0" },
     { name = "django-compressor", specifier = "==4.6.0" },
@@ -1574,7 +1574,7 @@ wheels = [
 
 [[package]]
 name = "django-channels-broadcast"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref", marker = "platform_python_implementation != 'PyPy'" },
@@ -1582,9 +1582,9 @@ dependencies = [
     { name = "django", marker = "platform_python_implementation != 'PyPy'" },
     { name = "nest-asyncio", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/5c/feb9208d8f0b8301835bbed481979ddee3895dd17869c6b6fa806601cb5d/django_channels_broadcast-0.2.0.tar.gz", hash = "sha256:57894ec2efe4f50977d297d88d3122d99fe4b62b6344190e682560e1c72dda1d", size = 70372, upload-time = "2026-05-13T17:07:31.794Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/f6/5b81cb57c400db1c47a5e07035bfa00c87b0aa647580134ee5ad4709d4b2/django_channels_broadcast-0.2.1.tar.gz", hash = "sha256:c6f969bdd4cf1967944eb591a46431a6117421c00acc13857a9223c5a0485cc7", size = 70791, upload-time = "2026-06-18T10:49:22.938259Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/e5/e45b643695a701e2ab4ed150006fce887d96e3e725baa2706d81804ca21c/django_channels_broadcast-0.2.0-py3-none-any.whl", hash = "sha256:a791d06d9c3afc6d6626c48ce5b2afa2b2db97d58c1b5c2c7dc8f24ad9b44828", size = 43997, upload-time = "2026-05-13T17:07:33.19Z" },
+    { url = "https://files.pythonhosted.org/packages/31/02/8d3bdd947d51c5c12fdadcbd44b425afc41a73d57d561379122234563ac2/django_channels_broadcast-0.2.1-py3-none-any.whl", hash = "sha256:b3d6f972fc56a52605b23a8eb0436eb83621b84cb4fe8539ad7b0de0febe14e4", size = 44403, upload-time = "2026-06-18T10:49:21.306391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Co i po co

Podbija `django-channels-broadcast` `0.2.0 → 0.2.1`, który naprawia
otwieranie websocketu powiadomień jako
`/asgi/notifications/?extraChannels=%22%22` na **każdej** zalogowanej
stronie.

`%22%22` to `""` — `json.dumps('')` z `{{ extraChannels|json_script }}`,
gdy zmienna `extraChannels` jest niezdefiniowana (a jest na większości
stron — ustawiają ją tylko widoki per-obiekt). Poprawka w bibliotece
(`normalizeExtraChannels`) odrzuca puste / nie-tablicowe payloady, więc
param znika całkowicie. Po deployu połączenia będą czyste:
`/asgi/notifications/`.

Upstream: iplweb/django-channels-broadcast#1 (opublikowane na PyPI jako 0.2.1).

## Zmiany

- `pyproject.toml`: `django-channels-broadcast>=0.2.1`
- `uv.lock`: bump pojedynczego wpisu pakietu do 0.2.1

## Uwaga o uv.lock

`uv.lock` podbity **chirurgicznie** (sam wpis pakietu + specifier), nie
przez `uv lock --upgrade-package`. Pełna re-rezolucja odsłania
**wcześniej istniejący, latentny** konflikt `django-autocomplete-light==4.0.1`
w splicie python-3.14/win32 (istniejący lock jest „zagrandfatherowany" —
`uv lock --check` go akceptuje, ale przeliczenie grafu od zera pada).
`uv lock --check` po tej zmianie pozostaje zielony. Konflikt autocomplete
to osobny temat (rozważyć zawężenie `requires-python` < 3.14 lub
wykluczenie win32 w `[tool.uv].environments`).

## Statyki

`bundle.js` jest gitignorowanym artefaktem — produkcyjny obraz odtwarza
go z pakietu 0.2.1 na etapie build (kontrakt statyków), więc PR nie
commit-uje przebudowanych assetów. Zweryfikowano lokalnie: po `grunt build`
poprawiona logika jest w `bundle.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)