### PR TITLE
fix(pbn): leniwe rozwiązywanie uczelni w PBNBaseCommand + Rollbar dla błędów post-importu

### DIFF
--- a/src/pbn_api/management/commands/util.py
+++ b/src/pbn_api/management/commands/util.py
@@ -29,7 +29,18 @@ class PBNBaseCommand(BaseCommand):
         parser.add_argument("--user-token", default=None)
 
     def execute(self, *args, **options):
-        self._fill_pbn_credentials(options)
+        # Uczelnię i credentiale PBN rozwiązujemy LENIWIE — dopiero w
+        # get_client() (gdy komenda realnie buduje klienta PBN), a nie tutaj,
+        # dla każdego uruchomienia. Dzięki temu komendy dziedziczące
+        # PBNBaseCommand, które PBN-a w ogóle nie używają (np. ustawianie
+        # punktów po imporcie czy przypisywanie rekordów do jednostek), NIE
+        # wymagają --uczelnia-id i nie wywalają się przy >1 uczelni. Komendy
+        # PBN-owe nadal dostają twardy CommandError — ale w get_client().
+        self._pbn_uczelnia_id = options.get("uczelnia_id")
+        # Inwariant: atrybut istnieje już po execute() (komendy czytają go
+        # wprost, np. WydawnictwoPBNAdapter(uczelnia=self._resolved_uczelnia)).
+        # Leniwe get_client() nadpisze go realną uczelnią, gdy zbuduje klienta.
+        self._resolved_uczelnia = None
         return super().execute(*args, **options)
 
     def _resolve_uczelnia(self, uczelnia_id):
@@ -93,7 +104,27 @@ class PBNBaseCommand(BaseCommand):
                 user = BppUser.objects.first()
                 options["user_token"] = user.pbn_token if user is not None else None
 
-    def get_client(self, app_id, app_token, base_url, user_token, verbose=False):
+    def get_client(
+        self, app_id=None, app_token=None, base_url=None, user_token=None, verbose=False
+    ):
+        # Tu rozwiązujemy uczelnię i uzupełniamy credentiale (leniwie). To
+        # jedyne miejsce, w którym PBN jest faktycznie potrzebny — i jedyne,
+        # w którym może paść CommandError o >1 uczelni bez --uczelnia-id.
+        # Wartości jawnie podane na CLI (app_id itd.) mają priorytet; resztę
+        # bierzemy z wybranej uczelni, a w ostateczności z settings.
+        options = {
+            "uczelnia_id": getattr(self, "_pbn_uczelnia_id", None),
+            "app_id": app_id,
+            "app_token": app_token,
+            "base_url": base_url,
+            "user_token": user_token,
+        }
+        self._fill_pbn_credentials(options)
+        app_id = options["app_id"]
+        app_token = options["app_token"]
+        base_url = options["base_url"]
+        user_token = options["user_token"]
+
         if user_token is None:
             warnings.warn(
                 "user_token not set, expect authorisation problems", stacklevel=2

--- a/src/pbn_api/tests/test_pbn_base_command.py
+++ b/src/pbn_api/tests/test_pbn_base_command.py
@@ -9,7 +9,7 @@ Reguła multi-hosted dla komend CLI:
 """
 
 import pytest
-from django.core.management import CommandError
+from django.core.management import CommandError, call_command
 
 from bpp.models import Uczelnia
 from pbn_api.management.commands.util import PBNBaseCommand
@@ -82,3 +82,28 @@ def test_explicit_uczelnia_id_selects_it(uczelnia):
 def test_unknown_uczelnia_id_raises(uczelnia):
     with pytest.raises(CommandError):
         PBNBaseCommand()._fill_pbn_credentials(_blank_options(uczelnia_id=999999))
+
+
+@pytest.mark.django_db
+def test_command_without_pbn_client_runs_with_multiple_uczelnie(uczelnia):
+    """Komenda dziedzicząca PBNBaseCommand, ale NIE wołająca get_client()
+    (np. ustawianie punktów po imporcie), musi działać przy wielu uczelniach
+    bez --uczelnia-id — credentiale PBN rozwiązujemy leniwie, dopiero gdy
+    realnie powstaje klient."""
+    _second_uczelnia()
+
+    # Nie powinno rzucić CommandError o ">1 uczelni" — komenda nie tyka PBN.
+    call_command("ustaw_zwrotnie_punkty_zwartych")
+
+
+@pytest.mark.django_db
+def test_get_client_still_requires_uczelnia_id_with_multiple(uczelnia):
+    """Gwarancja, że leniwość nie osłabia multi-hosted: komendy PBN-owe
+    nadal dostają twardy CommandError przy >1 uczelni bez --uczelnia-id —
+    tyle że dopiero przy budowie klienta, nie na starcie każdej komendy."""
+    _second_uczelnia()
+
+    cmd = PBNBaseCommand()
+    cmd._pbn_uczelnia_id = None
+    with pytest.raises(CommandError):
+        cmd.get_client()

--- a/src/pbn_import/tests/test_post_import_commands.py
+++ b/src/pbn_import/tests/test_post_import_commands.py
@@ -1,0 +1,78 @@
+"""Testy pipeline'u post-importu (`ImportManager._run_post_import_commands`).
+
+Reguła: błąd komendy post-importu (np. `ustaw_zwrotnie_punkty_ciaglych`)
+NIE może zniknąć po cichu. Ma:
+- trafić do Rollbara (`rollbar.report_exc_info`),
+- zostać zapisany jako `ImportLog` (poziom "error") widoczny w UI importu,
+- a mimo to NIE wywalać całego importu — pozostałe komendy lecą dalej.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import CommandError
+
+from pbn_import.models import ImportLog, ImportSession
+from pbn_import.utils.import_manager import ImportManager
+
+
+def _manager():
+    user = get_user_model().objects.create_user(username="testuser")
+    session = ImportSession.objects.create(user=user)
+    return ImportManager(session, client=None, config={})
+
+
+@pytest.mark.django_db
+def test_failing_post_import_command_is_reported_not_swallowed():
+    manager = _manager()
+
+    def fake_call_command(cmd, *a, **kw):
+        if cmd == "ustaw_zwrotnie_punkty_ciaglych":
+            raise CommandError("W systemie jest więcej niż jedna uczelnia")
+        return None
+
+    with (
+        patch(
+            "pbn_import.utils.import_manager.call_command",
+            side_effect=fake_call_command,
+        ),
+        patch(
+            "pbn_import.utils.import_manager.rollbar.report_exc_info"
+        ) as mock_rollbar,
+    ):
+        manager._run_post_import_commands()
+
+    # Błąd komendy MUSI trafić do Rollbara — nie do nikąd.
+    assert mock_rollbar.called
+
+    # ...i zostać zapisany jako log sesji widoczny w UI importu.
+    error_logs = ImportLog.objects.filter(session=manager.session, level="error")
+    assert error_logs.filter(
+        message__icontains="ustaw_zwrotnie_punkty_ciaglych"
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_failing_post_import_command_does_not_abort_remaining():
+    manager = _manager()
+    attempted = []
+
+    def fake_call_command(cmd, *a, **kw):
+        attempted.append(cmd)
+        if cmd == "ustaw_zwrotnie_punkty_zwartych":
+            raise CommandError("boom")
+        return None
+
+    with (
+        patch(
+            "pbn_import.utils.import_manager.call_command",
+            side_effect=fake_call_command,
+        ),
+        patch("pbn_import.utils.import_manager.rollbar.report_exc_info"),
+    ):
+        manager._run_post_import_commands()
+
+    # Mimo błędu pierwszej komendy, kolejne nadal są uruchamiane.
+    assert "ustaw_zwrotnie_punkty_ciaglych" in attempted
+    assert "przypisz_rekordy_aktualnym_jednostkom_autorow" in attempted

--- a/src/pbn_import/utils/import_manager.py
+++ b/src/pbn_import/utils/import_manager.py
@@ -488,8 +488,27 @@ class ImportManager:
                 call_command(cmd)
 
             except Exception as e:
-                logger.error(f"Komenda {cmd} nie powiodła się: {e}")
-                # Don't fail the entire import for post-processing errors
+                # Błąd komendy post-importu NIE może zniknąć po cichu (kiedyś
+                # samo logger.error → niewidoczne w UI, punkty się nie ustawiały
+                # bez śladu). Zgłaszamy do Rollbara i zapisujemy jako ImportLog
+                # widoczny w logu sesji importu. Mimo to NIE wywalamy całego
+                # importu — pozostałe komendy post-importu lecą dalej (awaria
+                # jednego typu punktacji nie powinna blokować reszty).
+                logger.exception(f"Komenda post-importu {cmd} nie powiodła się")
+                rollbar.report_exc_info(
+                    sys.exc_info(),
+                    extra_data={
+                        "session_id": self.session.id,
+                        "post_import_command": cmd,
+                    },
+                )
+                ImportLog.objects.create(
+                    session=self.session,
+                    level="error",
+                    step=description,
+                    message=f"Komenda post-importu {cmd} nie powiodła się: {e}",
+                    details={"traceback": traceback.format_exc()},
+                )
 
         # Uruchom denorm_flush po zacommitowaniu transakcji, aby uniknąć deadlocka
         self.session.current_step = "Odświeżanie denormalizacji"


### PR DESCRIPTION
## Problem

Na multi-hosted (>1 uczelnia) **cały pipeline ustawiania punktów po imporcie z PBN cicho padał** — prace importowane przez WebUI nie dostawały punktacji bez żadnego śladu w logu importu.

Przyczyna to złożenie dwóch bugów:

1. **Catch-22 w `PBNBaseCommand`.** Komendy post-importu (`ustaw_zwrotnie_punkty_zwartych`, `ustaw_zwrotnie_punkty_ciaglych`, `przypisz_rekordy_aktualnym_jednostkom_autorow`) dziedziczą `PBNBaseCommand`, ale **nie używają klienta PBN**. Eager rozwiązywanie uczelni w `execute()` wywalało je przy >1 uczelni komunikatem „podaj `--uczelnia-id`", którego te komendy nawet nie rejestrują (`add_arguments` bez `super()`). Bez flagi → `CommandError`; z flagą → `unrecognized arguments`. Komenda kompletnie nieuruchamialna.

2. **Cichy `except`.** `import_manager._run_post_import_commands` łapał wyjątek i robił tylko `logger.error` (komentarz „Don't fail the entire import"). Błąd nie trafiał ani do Rollbara, ani do logu sesji widocznego w UI → import raportował sukces, a punktów nie było.

## Rozwiązanie

- **`PBNBaseCommand`**: rozwiązywanie uczelni/credentiali przeniesione z `execute()` (eager, dla każdej komendy) do `get_client()` (**lazy**, tylko gdy realnie powstaje klient PBN). Komendy NO-PBN działają przy >1 uczelni bez `--uczelnia-id`; komendy PBN-owe nadal dostają twardy `CommandError`. Inwariant `self._resolved_uczelnia` zachowany (init w `execute()`). Jeden punkt zmiany naprawia **8 komend NO-PBN**.
- **`import_manager._run_post_import_commands`**: błąd komendy post-importu → `rollbar.report_exc_info()` + `ImportLog(level="error")` widoczny w logu sesji. Import nadal nie wywala się w całości.

## Testy (TDD, RED→GREEN)

- `test_pbn_base_command`: komenda NO-PBN działa przy 2 uczelniach; `get_client` nadal failuje przy 2 uczelniach bez `--uczelnia-id`.
- `test_post_import_commands`: błąd post-importu → Rollbar + ImportLog; nie przerywa pozostałych komend.
- Regresja: **645 testów** `pbn_api` + `pbn_import` zielone, ruff czysty.

## Po wdrożeniu

Prace już zaimportowane (bez punktów) trzeba uzupełnić — po deployu odpalić ręcznie (już bez `--uczelnia-id`):

```
python src/manage.py ustaw_zwrotnie_punkty_zwartych
python src/manage.py ustaw_zwrotnie_punkty_ciaglych
python src/manage.py przypisz_rekordy_aktualnym_jednostkom_autorow
```

> ⚠️ Uwaga zakresu: te komendy nie mają filtra po uczelni (model `Wydawnictwo_*` nie ma pola uczelnia) — działają globalnie na wszystkich rekordach. `--uczelnia-id` nigdy nie zawężał danych, tylko config PBN. Punkty są tenant-niezależne (poziom wydawcy / lista ministerialna), więc wartość jest poprawna, ale to globalny przelot (łagodzony domyślnym brakiem `--overwrite`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)