### PR TITLE
fix(multiseek): przywróć zapisywanie formularzy (CSRF token missing, #378)

### DIFF
--- a/src/bpp/tests/test_multiseek/test_multiseek_views.py
+++ b/src/bpp/tests/test_multiseek/test_multiseek_views.py
@@ -1,3 +1,4 @@
+import re
 
 try:
     from django.core.urlresolvers import reverse
@@ -5,6 +6,13 @@ except ImportError:
     from django.urls import reverse
 
 import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from model_bakery import baker
+
+#: To, czego saveForm() z multiseek.js szuka w stronie, zeby wstawic token
+#: CSRF do POST-a na ./save_form/ (pole ``csrfmiddlewaretoken``).
+MULTISEEK_CSRF_TOKEN_RE = re.compile(r"multiseekCSRFToken\s*=\s*'([^']*)'")
 
 
 @pytest.mark.django_db
@@ -21,3 +29,65 @@ def test_multiseek_logged_in(logged_in_client):
     res = logged_in_client.get(reverse("multiseek:index"))
     assert res.status_code == 200
     assert b"Adnotacje" in res.content
+
+
+@pytest.mark.django_db
+def test_multiseek_index_renders_multiseek_csrf_token(logged_in_client):
+    """Strona multiseek MUSI ustawiac window.multiseekCSRFToken na realny token.
+
+    Vendorowany multiseek.js (saveForm/submitEvent) czyta
+    ``window.multiseekCSRFToken`` i wstawia go jako pole ``csrfmiddlewaretoken``
+    do POST-a na ``./save_form/``. Jesli token jest pusty (albo go w ogole nie ma
+    w szablonie), Django odrzuca zapis z bledem CSRF. To wprost regresja z
+    FreshDesk #378 — nasz override ``multiseek/index.html`` zgubil te linie,
+    ktora upstreamowy ``multiseek_head.html`` renderuje.
+    """
+    res = logged_in_client.get(reverse("multiseek:index"))
+    assert res.status_code == 200
+
+    match = MULTISEEK_CSRF_TOKEN_RE.search(res.content.decode("utf-8"))
+    assert match is not None, (
+        "Strona multiseek nie ustawia window.multiseekCSRFToken — saveForm() "
+        "wysle pusty token i zapis formularza padnie na CSRF (FreshDesk #378)."
+    )
+    assert match.group(1).strip(), (
+        "window.multiseekCSRFToken jest pusty — POST do save_form/ dostanie "
+        "pusty csrfmiddlewaretoken i Django zwroci 403 (FreshDesk #378)."
+    )
+
+
+@pytest.mark.django_db
+def test_save_form_post_using_page_rendered_token_is_allowed():
+    """Reprodukcja FreshDesk #378 na poziomie HTTP, tak jak robi to przegladarka.
+
+    Kluczowe: ``CSRF_COOKIE_HTTPONLY = True`` w BPP sprawia, ze JS NIE moze
+    odczytac ciasteczka ``csrftoken``. Dlatego saveForm() polega wylacznie na
+    tokenie wyrenderowanym server-side w ``window.multiseekCSRFToken`` — i to
+    jego tu wyciagamy ze strony (a NIE z ciasteczka, jak robi to test
+    upstreamu, ktory wlasnie dlatego nie wykryl tego buga w naszym szablonie).
+
+    Z ``enforce_csrf_checks=True`` (jak prawdziwa przegladarka) brak tokenu
+    konczy sie 403. Po naprawie szablonu token jest obecny i zapis przechodzi.
+    """
+    staff = baker.make(get_user_model(), is_staff=True)
+    csrf_client = Client(enforce_csrf_checks=True)
+    csrf_client.force_login(staff)
+
+    page = csrf_client.get(reverse("multiseek:index"))
+    assert page.status_code == 200
+    match = MULTISEEK_CSRF_TOKEN_RE.search(page.content.decode("utf-8"))
+    token = match.group(1) if match else ""
+
+    res = csrf_client.post(
+        reverse("multiseek:save_form"),
+        data={
+            "json": '{"form_data": [null]}',
+            "name": "formularz testowy #378",
+            "csrfmiddlewaretoken": token,
+        },
+    )
+
+    assert res.status_code != 403, (
+        "save_form zwrocil 403 — token CSRF ze strony (window.multiseekCSRFToken) "
+        "nie dotarl do POST-a. To bug z FreshDesk #378."
+    )

--- a/src/bpp/tests/test_playwright/test_multiseek.py
+++ b/src/bpp/tests/test_playwright/test_multiseek.py
@@ -1,8 +1,18 @@
 import pytest
+from django.test import Client
 from django.urls.base import reverse
+from model_bakery import baker
 from playwright.sync_api import Page, expect
 
+from bpp.models import BppUser
 from bpp.models.cache import Rekord
+
+
+def _login_cookie(user):
+    """Zaloguj usera Clientem i zwróć ciasteczko sesji (dla kontekstu Playwright)."""
+    client = Client()
+    client.force_login(user)
+    return client.cookies["sessionid"].value
 
 
 @pytest.mark.django_db
@@ -127,3 +137,52 @@ def test_index_copernicus_widoczny(page: Page, live_server, uczelnia):
     page.wait_for_load_state("domcontentloaded")
 
     assert "Index Copernicus" in page.content()
+
+
+@pytest.mark.django_db
+def test_save_form_csrf(page: Page, live_server):
+    """Reprodukcja FreshDesk #378: zalogowany staff zapisuje formularz.
+
+    saveForm() z multiseek.js czyta ``window.multiseekCSRFToken`` i POST-uje go
+    jako ``csrfmiddlewaretoken`` na ``./save_form/``. Gdy szablon nie renderuje
+    tego tokenu, POST konczy sie 403 (CSRF), a uzytkownik dostaje alert o bledzie
+    serwera ("formularz NIE zostal zapisany"). Ten test przechodzi caly flow w
+    przegladarce: prompt o nazwe -> confirm o publicznosci -> POST i sprawdza, ze
+    serwer NIE odrzucil zapisu oraz ze formularz faktycznie zostal zapisany.
+    """
+    admin = baker.make(BppUser, is_superuser=True, is_staff=True)
+    sid = _login_cookie(admin)
+    page.context.add_cookies(
+        [{"name": "sessionid", "value": sid, "url": live_server.url}]
+    )
+
+    # saveForm() pyta o nazwe (prompt) i o publicznosc (confirm), a na koncu
+    # pokazuje alert. Obslugujemy dialogi automatycznie, zeby flow doszedl do
+    # POST-a na ./save_form/.
+    def handle_dialog(dialog):
+        if dialog.type == "prompt":
+            dialog.accept("formularz #378")
+        else:
+            dialog.accept()
+
+    page.on("dialog", handle_dialog)
+
+    page.goto(live_server.url + reverse("multiseek:index"))
+    page.evaluate("Cookielaw.accept()")
+    page.wait_for_selector("#saveFormButton", state="visible")
+
+    # saveForm odpala POST po dwoch setTimeout(500ms), wiec czekamy na response.
+    with page.expect_response(
+        lambda r: r.url.endswith("/save_form/") and r.request.method == "POST",
+        timeout=15000,
+    ) as resp_info:
+        page.click("#saveFormButton")
+
+    response = resp_info.value
+    assert response.status != 403, (
+        "POST /save_form/ zwrocil 403 — token CSRF (window.multiseekCSRFToken) "
+        "nie dotarl do POST-a. Regresja FreshDesk #378."
+    )
+    assert "saved" in response.text(), (
+        f"Zapis formularza nie powiodl sie, odpowiedz serwera: {response.text()}"
+    )

--- a/src/django_bpp/templates/multiseek/index.html
+++ b/src/django_bpp/templates/multiseek/index.html
@@ -16,6 +16,12 @@
         var djangoLanguageCode = '{{ LANGUAGE_CODE }}';
         var multiseekDateFormat = 'yyyy-mm-dd';
         var multiseekDateWeekStart = 1;
+
+        {# saveForm()/submitEvent() z multiseek.js czytaja window.multiseekCSRFToken #}
+        {# i wstawiaja go jako pole csrfmiddlewaretoken do POST-a (np. ./save_form/). #}
+        {# Renderowanie {{ csrf_token }} ustawia tez ciasteczko csrftoken. Bez tej #}
+        {# linii zapis formularza zwraca 403 CSRF — patrz FreshDesk #378. #}
+        var multiseekCSRFToken = '{{ csrf_token }}';
     </script>
     <script src="{% static 'multiseek/js/multiseek.js' %}"></script>
 


### PR DESCRIPTION
## Problem (FreshDesk #378)

Zapisywanie formularzy zapytań multiseek kończyło się błędem
`Forbidden (CSRF token missing.)` na `POST /multiseek/save_form/`.
Użytkownicy nie mogli utworzyć i zapisać formularza na później.

## Root cause

Override BPP `src/django_bpp/templates/multiseek/index.html` zgubił linię,
którą upstreamowy `multiseek/multiseek_head.html` renderuje:

```js
var multiseekCSRFToken = '{{ csrf_token }}';
```

Vendorowany `multiseek.js` (`saveForm()`/`submitEvent()`) czyta
`window.multiseekCSRFToken` i wstawia go jako pole `csrfmiddlewaretoken`
do POST-a. Bez tej zmiennej token był pusty → Django odrzucał zapis (403).
BPP ma `CSRF_COOKIE_HTTPONLY = True`, więc JS nie może sięgnąć po ciasteczko
— token renderowany server-side jest jedynym źródłem. Renderowanie
`{{ csrf_token }}` przy okazji ustawia ciasteczko `csrftoken`.

## Fix

6 linii w bloku `extrahead` — przywrócenie `multiseekCSRFToken`.

## Dlaczego testy tego nie złapały

- Django `Client` domyślnie ma `enforce_csrf_checks=False` → każdy POST na
  `save_form` przechodził niezależnie od tokenu.
- BPP nie miało **żadnego** testu dotykającego ścieżki zapisu formularza.
- Test upstreamu czyta token z **ciasteczka** (`cookies["csrftoken"]`), które
  bywa ustawione przez formularz wylogowania w `base.html` — więc przechodzi
  mimo buga. Wierny test musi czytać token z `window.multiseekCSRFToken`,
  dokładnie tak jak robi to przeglądarka.

## Testy (TDD — każdy oglądany RED→GREEN)

- `test_multiseek_index_renders_multiseek_csrf_token` — szybki lock na render.
- `test_save_form_post_using_page_rendered_token_is_allowed` — reprodukcja 403
  na poziomie HTTP z `enforce_csrf_checks=True`.
- `test_save_form_csrf` (Playwright) — pełny flow w przeglądarce: prompt o
  nazwę → confirm o publiczności → POST; sprawdza brak 403 i faktyczny zapis.

Pełna suita multiseek + playwright na świeżym kontenerze: **98 passed, 0 failures**.

Fixes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)