### PR TITLE
fix(multiseek): liczbowe warunki nie są już „nieprzekładalne" przy konwersji do DjangoQL

### DIFF
--- a/src/bpp/multiseek_registry/djangoql_export.py
+++ b/src/bpp/multiseek_registry/djangoql_export.py
@@ -10,7 +10,7 @@ jest walidowany przeciw BppQLSchema(Rekord) — niepoprawne -> warning.
 import logging
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from urllib.parse import urlencode
 
 from django.urls import reverse
@@ -20,11 +20,13 @@ from multiseek.logic import (
     ANDNOT,
     AUTOCOMPLETE,
     CONTAINS,
+    DECIMAL,
     DIFFERENT_ALL,
     EQUALITY_OPS_ALL,
     GREATER_OPS_ALL,
     GREATER_OR_EQUAL_OPS_ALL,
     IN_RANGE,
+    INTEGER,
     LESSER_OPS_ALL,
     LESSER_OR_EQUAL_OPS_ALL,
     NOT_CONTAINS,
@@ -192,13 +194,56 @@ def _value_list_leaf(field, value, operation):
     return frag
 
 
+def _coerce_range_bound(value):
+    """Granica zakresu (rok) -> int, albo None gdy nie-liczbowa.
+
+    Multiseek serializuje granice jako stringi ("2000"), a
+    ``RangeQueryObject.value_from_web`` wymusza na nich ``int()``. Robimy to
+    samo przy renderowaniu, by goly literal liczbowy przeszedl walidacje
+    schematu (np. ``rok`` to IntegerField) — bez tego wychodzil cudzyslowiony
+    ``rok >= "2000"``, ktorego DjangoQL nie przyjmuje. None -> lisc pomijany,
+    spojnie z multiseek (ktory tez zwraca None dla nie-liczbowej granicy).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value).strip())
+    except (ValueError, TypeError):
+        return None
+
+
+def _render_scalar(field, value):
+    """Literal DjangoQL dla skalarnego porownania, z normalizacja liczb.
+
+    Multiseek trzyma wartosci formularza jako stringi ("5", "0.5"); renderowane
+    doslownie trafialyby w cudzyslow ('impact_factor > "5"'), co DjangoQL
+    odrzuca dla liczbowych pol modelu. Dla pol INTEGER/DECIMAL przepuszczamy
+    wartosc przez ``value_from_web`` (tak jak ``real_query``), wiec wychodzi goly
+    literal liczbowy. None -> lisc nieprzekladalny (spojnie z tym, ze multiseek
+    tez by go nie dopasowal, np. pusta/niepoprawna liczba).
+    """
+    if getattr(field, "type", None) in (INTEGER, DECIMAL):
+        try:
+            coerced = field.value_from_web(value)
+        except (ValueError, TypeError, InvalidOperation):
+            return None
+        if coerced is None:
+            return None
+        return render_value(coerced)
+    return render_value(value)
+
+
 def _range_leaf(name, value, operation):
     """IN_RANGE/NOT_IN_RANGE: value to [low, high]."""
     if not (isinstance(value, (list, tuple)) and len(value) == 2):
         return None
     if str(operation) == str(NOT_IN_RANGE):
         return None  # brak unary not(...) w DjangoQL -> warning (Task 5/6)
-    low, high = value
+    low, high = _coerce_range_bound(value[0]), _coerce_range_bound(value[1])
+    if low is None or high is None:
+        return None
     path = _orm_path_to_djangoql(name)
     return f"({path} >= {render_value(low)} and {path} <= {render_value(high)})"
 
@@ -217,7 +262,10 @@ def _default_leaf(field, value, operation):
     dql_op = scalar_operator_to_djangoql(op)
     if dql_op is None:
         return None
-    return f"{_orm_path_to_djangoql(name)} {dql_op} {render_value(value)}"
+    rendered = _render_scalar(field, value)
+    if rendered is None:
+        return None
+    return f"{_orm_path_to_djangoql(name)} {dql_op} {rendered}"
 
 
 def leaf_to_djangoql(registry, leaf, warnings=None):

--- a/src/bpp/tests/test_multiseek_djangoql_numeric.py
+++ b/src/bpp/tests/test_multiseek_djangoql_numeric.py
@@ -1,0 +1,52 @@
+"""Konwersja Multiseek -> DjangoQL dla pól liczbowych.
+
+Multiseek serializuje wartości formularza jako stringi ("5", "0.5",
+["2000","2010"]). Renderowane dosłownie trafiałyby w cudzysłów
+('impact_factor > "5"'), co DjangoQL odrzuca dla liczbowych pól modelu —
+i lić był pomijany jako „nieprzekładalny". Te testy pilnują, że wartości
+liczbowe renderują się jako gołe literały i przechodzą walidację schematu.
+"""
+
+import pytest
+from multiseek.logic import GREATER, GREATER_OR_EQUAL, IN_RANGE, LESSER
+
+from bpp.multiseek_registry import registry
+from bpp.multiseek_registry.djangoql_export import leaf_to_djangoql
+
+pytestmark = pytest.mark.serial
+
+
+def _leaf(field, operator, value):
+    return leaf_to_djangoql(
+        registry, {"field": field, "operator": str(operator), "value": value}
+    )
+
+
+def test_impact_factor_greater_string_value():
+    # Tak jak realny formularz: wartość to string.
+    assert _leaf("Impact factor", GREATER, "0") == "impact_factor > 0"
+
+
+def test_impact_factor_decimal_string_value():
+    assert _leaf("Impact factor", GREATER_OR_EQUAL, "2.5") == "impact_factor >= 2.5"
+
+
+def test_impact_factor_numeric_value_unchanged():
+    assert _leaf("Impact factor", GREATER, 0) == "impact_factor > 0"
+
+
+def test_integer_field_string_value():
+    assert _leaf("Liczba cytowań", LESSER, "5") == "liczba_cytowan < 5"
+
+
+def test_blank_numeric_value_is_untranslatable():
+    # Pusta/niepoprawna liczba: multiseek też by nie dopasował -> None.
+    assert _leaf("Impact factor", GREATER, "") is None
+    assert _leaf("Impact factor", GREATER, "abc") is None
+
+
+def test_year_range_string_bounds():
+    assert (
+        _leaf("Zakres lat", IN_RANGE, ["2000", "2010"])
+        == "(rok >= 2000 and rok <= 2010)"
+    )


### PR DESCRIPTION
## Problem

Konwersja formularza Multiseek → DjangoQL pomijała warunki liczbowe, raportując np.:

> Pominięto warunek: Impact factor większy, niż (nieprzekładalny)

Mimo że `impact_factor > 0` jest w DjangoQL trywialne.

## Przyczyna źródłowa

Multiseek serializuje wartości formularza jako **stringi** (`"0"`, `"2.5"`, zakres jako `["2000","2010"]`). Ścieżka skalarna (`_default_leaf`) i zakresowa (`_range_leaf`) konwertera renderowały je dosłownie przez `render_value`, które **owija stringi w cudzysłów** → `impact_factor > "0"`.

Bramka `is_valid_rekord_djangoql()` waliduje fragment względem `BppQLSchema(Rekord)`, a DjangoQL **odrzuca porównanie liczbowego pola modelu do literału stringowego** → fragment niepoprawny → `leaf_to_djangoql` zwraca `None` → „Pominięto warunek (nieprzekładalny)".

Sam multiseek działa, bo w `real_query` przepuszcza string przez `value_from_web` (→ `Decimal`/`int`) **zanim** zbuduje ORM-owe `Q`. Konwerter pomijał ten krok.

To samo dotyczyło **zakresu lat** — `(rok >= "2000" and rok <= "2010")` też był odrzucany.

## Naprawa

Odwzorowanie tego, co robi `multiseek.real_query`:

- `_render_scalar` — wartości pól typu `INTEGER`/`DECIMAL` przepuszczane przez `value_from_web` (→ `int`/`Decimal`) i renderowane jako gołe literały liczbowe. Pola stringowe bez zmian.
- `_coerce_range_bound` — granice zakresu coercowane przez `int()` (jak `RangeQueryObject.value_from_web`).
- Pusta/niepoprawna liczba (`""`, `"abc"`, NaN) → `None` (nieprzekładalny), spójnie z multiseek.

Naprawia oba przypadki: skalarne porównania liczbowe (Impact factor, Liczba cytowań, Punkty KBN, …) oraz zakres lat.

## Testy

- Nowy plik `src/bpp/tests/test_multiseek_djangoql_numeric.py` (6 testów, red → green).
- Cała suita `multiseek_djangoql`: **66 passed** (w tym roundtrip + Playwright).
- ruff check + format: czysto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)