### PR TITLE
feat(zrodlo): pokazuj dyscypliny najnowszego roku z bazy na podstronie źródła (Freshdesk 296)

### DIFF
--- a/src/bpp/models/zrodlo.py
+++ b/src/bpp/models/zrodlo.py
@@ -229,12 +229,15 @@ class Zrodlo(LinkDoPBNMixin, ModelZAdnotacjami, ModelZISSN):
     def dyscypliny_aktualna_ewaluacja(
         self,
         min_year=const.PBN_AKTUALNA_EWALUACJA_START,
-        max_year=const.PBN_AKTUALNA_EWALUACJA_STOP,
+        max_year=None,
     ):
-        return (
-            self.dyscyplina_zrodla_set.filter(
-                rok__gte=min_year, rok__lte=max_year, dyscyplina__widoczna=True
-            )
-            .select_related()
-            .order_by("rok", "dyscyplina__kod")
+        # max_year=None => bez górnego ograniczenia: pokazujemy dyscypliny aż
+        # do najnowszego roku obecnego w bazie (Freshdesk 296). Wcześniej górną
+        # granicą był na sztywno const.PBN_AKTUALNA_EWALUACJA_STOP, przez co
+        # świeżo wgrane lata (np. 2026) nie pojawiały się na podstronie źródła.
+        qs = self.dyscyplina_zrodla_set.filter(
+            rok__gte=min_year, dyscyplina__widoczna=True
         )
+        if max_year is not None:
+            qs = qs.filter(rok__lte=max_year)
+        return qs.select_related().order_by("rok", "dyscyplina__kod")

--- a/src/bpp/newsfragments/+dyscypliny-zrodla-najnowszy-rok.feature.rst
+++ b/src/bpp/newsfragments/+dyscypliny-zrodla-najnowszy-rok.feature.rst
@@ -1,0 +1,6 @@
+Na podstronie źródła panel „Dyscypliny naukowe w ewaluacji” pokazuje
+teraz dyscypliny aż do najnowszego roku obecnego w bazie danych i to
+właśnie ten najnowszy rok jest domyślnie rozwinięty. Wcześniej zakres
+prezentowanych lat oraz domyślnie otwarty rok były ustawione na sztywno,
+przez co świeżo wgrane dyscypliny (np. za kolejny rok ewaluacji) nie były
+widoczne bez zmiany w kodzie (Freshdesk 296).

--- a/src/bpp/templates/browse/zrodlo.html
+++ b/src/bpp/templates/browse/zrodlo.html
@@ -200,7 +200,9 @@
                     <ul class="accordion" data-accordion data-allow-all-closed="false">
                         {% regroup zrodlo.dyscypliny_aktualna_ewaluacja by rok as disciplines_by_year %}
                         {% for year_group in disciplines_by_year reversed %}
-                            <li class="accordion-item{% if year_group.grouper == 2025 %} is-active{% endif %}" data-accordion-item>
+                            {# Pętla idzie od najnowszego roku (reversed) — domyślnie #}
+                            {# rozwijamy pierwszy, czyli najnowszy rok w bazie (Freshdesk 296). #}
+                            <li class="accordion-item{% if forloop.first %} is-active{% endif %}" data-accordion-item>
                                 <a href="#" class="accordion-title">
                                     <i class="fi-calendar"></i>
                                     Rok {{ year_group.grouper }}

--- a/src/bpp/tests/test_models/test_zrodlo.py
+++ b/src/bpp/tests/test_models/test_zrodlo.py
@@ -1,3 +1,5 @@
+import pytest
+
 from bpp.models import Dyscyplina_Zrodla
 
 
@@ -9,3 +11,28 @@ def test_Dyscyplina_Zrodla___str__(zrodlo, dyscyplina1):
         str(dz)
         == 'Przypisanie dyscypliny "memetyka stosowana (3.1)" do źródła "Testowe Źródło" dla roku 2017'
     )
+
+
+@pytest.mark.django_db
+def test_dyscypliny_aktualna_ewaluacja_pokazuje_najnowszy_rok(zrodlo, dyscyplina1):
+    """Najnowszy rok obecny w bazie musi się pojawić, nawet gdy jest nowszy
+    niż dawny twardy limit PBN_AKTUALNA_EWALUACJA_STOP (Freshdesk 296)."""
+    for rok in (2024, 2025, 2026):
+        Dyscyplina_Zrodla.objects.create(zrodlo=zrodlo, dyscyplina=dyscyplina1, rok=rok)
+
+    lata = list(zrodlo.dyscypliny_aktualna_ewaluacja().values_list("rok", flat=True))
+
+    assert 2026 in lata
+    assert max(lata) == 2026
+
+
+@pytest.mark.django_db
+def test_dyscypliny_aktualna_ewaluacja_pomija_lata_przed_oknem(zrodlo, dyscyplina1):
+    """Dolna granica okna ewaluacji jest zachowana — stare lata się nie pokazują."""
+    Dyscyplina_Zrodla.objects.create(zrodlo=zrodlo, dyscyplina=dyscyplina1, rok=2018)
+    Dyscyplina_Zrodla.objects.create(zrodlo=zrodlo, dyscyplina=dyscyplina1, rok=2024)
+
+    lata = list(zrodlo.dyscypliny_aktualna_ewaluacja().values_list("rok", flat=True))
+
+    assert 2018 not in lata
+    assert 2024 in lata

--- a/src/bpp/tests/test_views/test_browse/test_zrodlo_zrodla.py
+++ b/src/bpp/tests/test_views/test_browse/test_zrodlo_zrodla.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from django.urls import reverse
 from model_bakery import baker
@@ -42,3 +44,37 @@ def test_zrodlo_view_no_banner_when_has_publications(client, zrodlo):
     assert res.status_code == 200
     assert "Brak publikacji" not in res.rendered_content
     assert "To źródło nie zawiera jeszcze żadnych prac" not in res.rendered_content
+
+
+def _accordion_items_with_years(content):
+    """Zwraca listę krotek (klasa <li>, rok) dla panelu dyscyplin."""
+    return re.findall(
+        r'<li class="(accordion-item[^"]*)"[^>]*>.*?Rok\s+(\d+)',
+        content,
+        re.DOTALL,
+    )
+
+
+@pytest.mark.django_db
+def test_zrodlo_view_pokazuje_dyscypliny_najnowszego_roku_z_bazy(
+    client, zrodlo, dyscyplina1
+):
+    """Rok nowszy niż dawny twardy limit (2025) musi się pojawić na podstronie
+    źródła i być domyślnie rozwinięty (Freshdesk 296)."""
+    from bpp.models import Dyscyplina_Zrodla
+
+    for rok in (2024, 2025, 2026):
+        Dyscyplina_Zrodla.objects.create(zrodlo=zrodlo, dyscyplina=dyscyplina1, rok=rok)
+
+    res = client.get(reverse("bpp:browse_zrodlo", args=(zrodlo.slug,)))
+    assert res.status_code == 200
+
+    content = res.rendered_content
+    assert "Rok 2026" in content
+
+    items = dict((rok, klasa) for klasa, rok in _accordion_items_with_years(content))
+    # Najnowszy rok (2026) rozwinięty domyślnie...
+    assert "is-active" in items["2026"]
+    # ...a poprzednie lata zwinięte (brak twardego dowiązania do 2025).
+    assert "is-active" not in items["2025"]
+    assert "is-active" not in items["2024"]


### PR DESCRIPTION
## Cel (Freshdesk 296)

Zgłoszenie: prośba o wyświetlanie dyscyplin czasopism za rok 2026 na podstronach źródeł (lista dyscyplin została już wgrana). Modyfikacja względem zgłoszenia: zamiast wpisywać konkretny rok na sztywno, podstrona źródła **zawsze pokazuje dyscypliny aż do najnowszego roku obecnego w bazie** i to ten najnowszy rok jest domyślnie rozwinięty.

## Problem

Panel „Dyscypliny naukowe w ewaluacji” na podstronie źródła (`/bpp/zrodlo/<nazwa>/`):

- **ograniczał prezentowane lata** do `PBN_AKTUALNA_EWALUACJA_STOP` (2025) — przez `max_year` w `Zrodlo.dyscypliny_aktualna_ewaluacja`, więc świeżo wgrane dyscypliny np. za 2026 w ogóle się nie pokazywały;
- **rozwijał domyślnie zahardkodowany rok 2025** — w szablonie `zrodlo.html` było `{% if year_group.grouper == 2025 %}`.

Oba miejsca wymagałyby ręcznej zmiany w kodzie co rok.

## Zmiana

- `src/bpp/models/zrodlo.py`: `dyscypliny_aktualna_ewaluacja` nie nakłada już górnej granicy roku (`max_year=None` → brak `rok__lte`), więc pokazuje dyscypliny aż do najnowszego roku w bazie. Dolna granica okna ewaluacji (`PBN_AKTUALNA_EWALUACJA_START`) bez zmian. Metoda jest używana wyłącznie na podstronie źródła, więc zmiana jest tam zamknięta.
- `src/bpp/templates/browse/zrodlo.html`: domyślnie rozwijany jest pierwszy element pętli (`forloop.first`) — a ponieważ lata iterowane są `reversed`, jest to najnowszy rok.

## Testy

- `test_dyscypliny_aktualna_ewaluacja_pokazuje_najnowszy_rok` — rok nowszy niż dawny limit (2026) pojawia się w wynikach.
- `test_dyscypliny_aktualna_ewaluacja_pomija_lata_przed_oknem` — dolna granica okna nadal odcina stare lata.
- `test_zrodlo_view_pokazuje_dyscypliny_najnowszego_roku_z_bazy` — end-to-end render podstrony: „Rok 2026” jest widoczny i ma klasę `is-active`, a poprzednie lata są zwinięte.

Wszystkie przechodzą; ruff + pre-commit czyste. Dodano fragment changelogu (towncrier, `Usprawnienie`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)