### PR TITLE
Importer Krok 1: podpowiedź, że CrossRef oznacza wyszukiwanie po DOI (Freshdesk #381)

### DIFF
--- a/src/importer_publikacji/forms.py
+++ b/src/importer_publikacji/forms.py
@@ -57,7 +57,10 @@ class FetchForm(forms.Form):
         super().__init__(*args, **kwargs)
         providers = get_available_providers()
         self.providers_metadata = get_providers_metadata()
-        self.fields["provider"].choices = [(p, p) for p in providers]
+        self.fields["provider"].choices = [
+            (p, self.providers_metadata.get(p, {}).get("choice_label", p))
+            for p in providers
+        ]
         if last_provider and last_provider in providers:
             self.fields["provider"].initial = last_provider
         elif providers:

--- a/src/importer_publikacji/providers/__init__.py
+++ b/src/importer_publikacji/providers/__init__.py
@@ -49,6 +49,17 @@ class DataProvider(ABC):
         """Etykieta pola identyfikatora, np. 'DOI'."""
 
     @property
+    def choice_label(self) -> str:
+        """Etykieta opcji na liście wyboru źródła danych.
+
+        Domyślnie identyczna z ``name``, ale provider może ją nadpisać,
+        żeby od razu podpowiedzieć operatorowi, czego dane źródło wymaga
+        (np. „CrossRef — wyszukiwanie po numerze DOI"). Wartość opcji
+        (``value`` radia) pozostaje równa ``name`` — zmienia się tylko
+        tekst widoczny dla użytkownika."""
+        return self.name
+
+    @property
     def input_mode(self) -> str:
         return InputMode.IDENTIFIER
 
@@ -98,6 +109,7 @@ def get_providers_metadata() -> dict[str, dict]:
         instance = cls()
         result[name] = {
             "name": name,
+            "choice_label": instance.choice_label,
             "identifier_label": instance.identifier_label,
             "input_mode": instance.input_mode,
             "input_placeholder": instance.input_placeholder,

--- a/src/importer_publikacji/providers/crossref.py
+++ b/src/importer_publikacji/providers/crossref.py
@@ -11,6 +11,10 @@ class CrossRefProvider(DataProvider):
         return "CrossRef"
 
     @property
+    def choice_label(self) -> str:
+        return "CrossRef — wyszukiwanie po numerze DOI"
+
+    @property
     def identifier_label(self) -> str:
         return "Identyfikator DOI"
 

--- a/src/importer_publikacji/tests/test_providers.py
+++ b/src/importer_publikacji/tests/test_providers.py
@@ -2,6 +2,7 @@ from importer_publikacji.providers import (
     FetchedPublication,
     get_available_providers,
     get_provider,
+    get_providers_metadata,
 )
 from importer_publikacji.providers.crossref import (
     CrossRefProvider,
@@ -21,6 +22,24 @@ def test_crossref_provider_name():
     provider = CrossRefProvider()
     assert provider.name == "CrossRef"
     assert provider.identifier_label == "Identyfikator DOI"
+
+
+def test_crossref_choice_label_mentions_doi():
+    """Etykieta opcji CrossRef ma jasno wskazywać wymóg numeru DOI
+    (Freshdesk #381) — operator nie powinien tego wiedzieć z góry."""
+    provider = CrossRefProvider()
+    assert provider.choice_label == "CrossRef — wyszukiwanie po numerze DOI"
+    assert "DOI" in provider.choice_label
+
+
+def test_providers_metadata_exposes_choice_label():
+    """Metadane przekazywane do formularza zawierają choice_label."""
+    meta = get_providers_metadata()
+    assert meta["CrossRef"]["choice_label"] == (
+        "CrossRef — wyszukiwanie po numerze DOI"
+    )
+    # Provider bez nadpisania choice_label spada do nazwy.
+    assert meta["BibTeX"]["choice_label"] == "BibTeX"
 
 
 def test_crossref_validate_identifier_valid():

--- a/src/importer_publikacji/tests/test_views.py
+++ b/src/importer_publikacji/tests/test_views.py
@@ -65,6 +65,17 @@ def test_index_denied_for_staff_user(db, client):
 
 
 @pytest.mark.django_db
+def test_step1_shows_crossref_doi_hint(importer_client):
+    """Krok 1 powinien jasno informować, że CrossRef oznacza wyszukiwanie
+    po numerze DOI (Freshdesk #381). Wartość radia pozostaje 'CrossRef'."""
+    url = reverse("importer_publikacji:index")
+    response = importer_client.get(url)
+    content = response.content.decode()
+    assert "CrossRef — wyszukiwanie po numerze DOI" in content
+    assert 'value="CrossRef"' in content
+
+
+@pytest.mark.django_db
 def test_fetch_empty_identifier(importer_client):
     url = reverse("importer_publikacji:fetch")
     response = importer_client.post(


### PR DESCRIPTION
## Co

W „Krok 1: Podaj dane publikacji" importera, na liście źródeł danych
opcja „CrossRef" zyskuje czytelną etykietę: **„CrossRef — wyszukiwanie
po numerze DOI"**.

## Dlaczego

Freshdesk #381: operatorowi nie było oczywiste, że wybór źródła
„CrossRef" wymaga podania numeru DOI. Etykieta opcji od razu to
podpowiada, bez potrzeby wcześniejszej wiedzy.

## Jak

- Bazowa klasa `DataProvider` dostaje opcjonalną właściwość
  `choice_label` (domyślnie równą `name`), eksponowaną w
  `get_providers_metadata()`.
- `CrossRefProvider` nadpisuje `choice_label` na „CrossRef —
  wyszukiwanie po numerze DOI".
- `FetchForm` buduje `choices` radia jako `(name, choice_label)` —
  **wartość radia pozostaje `"CrossRef"`**, więc walidacja formularza,
  JS przełączający pola identyfikatora/tekstu oraz istniejące sesje
  importu działają bez zmian. Pozostałe providery (BibTeX, DSpace, PBN,
  Pozostałe strony WWW) bez zmian — spadają do `name`.

Zmiana minimalna, bez migracji.

## Jak testowano

- `uv run python src/manage.py check` — bez uwag.
- `ruff format` + `ruff check` — czysto.
- Nowe testy:
  - `test_crossref_choice_label_mentions_doi`
  - `test_providers_metadata_exposes_choice_label`
  - `test_step1_shows_crossref_doi_hint` (renderowany Krok 1 zawiera
    podpowiedź, a `value="CrossRef"` nadal obecne).
- `pytest` na `test_providers.py`, `test_views.py`, `test_source_form.py`
  — wszystko zielone (regresja choices sprawdzona).

🤖 Generated with [Claude Code](https://claude.com/claude-code)