### PR TITLE
feat(importer): tworzenie nowego autora z "Edytuj" wiersza (Freshdesk #383)

### DIFF
--- a/src/importer_publikacji/templates/importer_publikacji/partials/author_row.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/author_row.html
@@ -71,6 +71,11 @@
         {% endif %}
     </td>
     <td>
+        {% if row_error %}
+            <div class="callout alert" style="padding:0.4rem;margin-bottom:0.4rem">
+                <small>{{ row_error }}</small>
+            </div>
+        {% endif %}
         <button type="button"
                 class="button small secondary btn-edit-author">
             <span class="fi-pencil"></span>

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_authors.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_authors.html
@@ -245,6 +245,7 @@
      data-close-on-click="false"
      data-author-info-base="/importer_publikacji/{{ session.pk }}/authors/"
      data-candidates-modal-base="/importer_publikacji/{{ session.pk }}/authors/"
+     data-create-new-base="/importer_publikacji/{{ session.pk }}/authors/"
      style="height:auto;max-height:90vh;overflow-y:auto;top:5vh;bottom:auto">
     <h5 id="modal-author-title"></h5>
 
@@ -302,6 +303,24 @@
                        id="modal-zapisany-jako"
                        style="width:100%">
             </div>
+        </div>
+
+        {# Tworzenie NOWEGO autora bezpośrednio z tego wiersza (Freshdesk #}
+        {# #383) — rozwiązuje niedopasowany wiersz bez wracania do #}
+        {# zbiorczego żółtego przycisku na górze listy. #}
+        <div class="callout secondary"
+             style="margin-top:1rem;padding:0.75rem">
+            <p class="help-text" style="margin-bottom:0.5rem">
+                Brak pasującego autora w BPP? Utwórz nowego z danych
+                dostawcy (nazwisko/imiona powyżej). Zostanie przypisany
+                do obcej jednostki.
+            </p>
+            <button type="button"
+                    class="button warning"
+                    id="modal-create-new-author">
+                <span class="fi-torsos-all"></span>
+                Utwórz nowego autora
+            </button>
         </div>
 
         <div class="text-right"
@@ -898,6 +917,27 @@ $(document).ready(function() {
             );
         }
     );
+
+    // "Utwórz nowego autora" w modalu — POST do per-wierszowego
+    // endpointu create-new, swap wiersza, zamknij modal. Reużywa ten
+    // sam mechanizm co zbiorczy żółty przycisk (Freshdesk #383).
+    $('#modal-create-new-author').on('click', function() {
+        var importedId = $('#modal-author-id').val();
+        if (!importedId) return;
+        var base = $modal.data('create-new-base');
+        var url = base + importedId + '/create-new/';
+        htmx.ajax('POST', url, {
+            target: '#author-row-' + importedId,
+            swap: 'outerHTML',
+            values: {
+                csrfmiddlewaretoken: $modal.find(
+                    '[name=csrfmiddlewaretoken]'
+                ).val(),
+                zapisany_jako: $('#modal-zapisany-jako').val() || ''
+            }
+        });
+        $modal.foundation('close');
+    });
 
     // Submit modal form via HTMX and close
     $('#modal-author-form').on('submit', function(e) {

--- a/src/importer_publikacji/tests/test_views_authors.py
+++ b/src/importer_publikacji/tests/test_views_authors.py
@@ -141,6 +141,143 @@ def test_create_unmatched_orcid_matches_existing(
 
 
 @pytest.mark.django_db
+def test_author_create_new_single_row(
+    importer_client,
+    importer_user,
+    uczelnia_z_obca_jednostka,
+):
+    """Per-wierszowe "Utwórz nowego autora" z modala edycji (Freshdesk
+    #383) tworzy Autora dla jednego niedopasowanego wiersza i przypisuje
+    go do obcej jednostki, nie ruszając pozostałych wierszy."""
+    obca = uczelnia_z_obca_jednostka.obca_jednostka
+    session = _make_session_with_unmatched(importer_user, count=2)
+    first, second = list(session.authors.order_by("order"))
+
+    url = reverse(
+        "importer_publikacji:author-create-new",
+        kwargs={"session_id": session.pk, "author_id": first.pk},
+    )
+    response = importer_client.post(url)
+    assert response.status_code == 200
+
+    first.refresh_from_db()
+    assert first.match_status == ImportedAuthor.MatchStatus.MANUAL
+    assert first.matched_autor is not None
+    assert first.matched_autor.nazwisko == "Testowy0"
+    assert first.matched_autor.imiona == "Autor0"
+    assert first.matched_jednostka == obca
+    assert Autor_Jednostka.objects.filter(
+        autor=first.matched_autor,
+        jednostka=obca,
+    ).exists()
+
+    # Drugi wiersz nietknięty — to akcja per-wierszowa.
+    second.refresh_from_db()
+    assert second.match_status == ImportedAuthor.MatchStatus.UNMATCHED
+    assert second.matched_autor is None
+
+
+@pytest.mark.django_db
+def test_author_create_new_with_corrections(
+    importer_client,
+    importer_user,
+    uczelnia_z_obca_jednostka,
+):
+    """Korekta nazwiska/imion/zapisany_jako w POST przed utworzeniem."""
+    session = _make_session_with_unmatched(importer_user, count=1)
+    imported = session.authors.first()
+
+    url = reverse(
+        "importer_publikacji:author-create-new",
+        kwargs={"session_id": session.pk, "author_id": imported.pk},
+    )
+    response = importer_client.post(
+        url,
+        {
+            "nazwisko": "Poprawiony",
+            "imiona": "Jan",
+            "zapisany_jako": "Poprawiony J.",
+        },
+    )
+    assert response.status_code == 200
+
+    imported.refresh_from_db()
+    assert imported.matched_autor.nazwisko == "Poprawiony"
+    assert imported.matched_autor.imiona == "Jan"
+    assert imported.zapisany_jako == "Poprawiony J."
+
+
+@pytest.mark.django_db
+def test_author_create_new_orcid_matches_existing(
+    importer_client,
+    importer_user,
+    uczelnia_z_obca_jednostka,
+):
+    """Per-wierszowe tworzenie z ORCID istniejącego Autora dopasowuje
+    istniejącego zamiast tworzyć duplikat."""
+    obca = uczelnia_z_obca_jednostka.obca_jednostka
+    existing = baker.make(
+        Autor,
+        imiona="Jan",
+        nazwisko="Kowalski",
+        orcid="0000-0002-1111-2222",
+    )
+    session = ImportSession.objects.create(
+        created_by=importer_user,
+        provider_name="CrossRef",
+        identifier="10.1234/row-orcid",
+        raw_data={},
+        normalized_data={},
+    )
+    imported = ImportedAuthor.objects.create(
+        session=session,
+        order=0,
+        family_name="Kowalski",
+        given_name="Jan",
+        orcid="0000-0002-1111-2222",
+        match_status=ImportedAuthor.MatchStatus.UNMATCHED,
+    )
+
+    url = reverse(
+        "importer_publikacji:author-create-new",
+        kwargs={"session_id": session.pk, "author_id": imported.pk},
+    )
+    response = importer_client.post(url)
+    assert response.status_code == 200
+
+    imported.refresh_from_db()
+    assert imported.matched_autor == existing
+    assert imported.matched_jednostka == obca
+    assert imported.match_status == ImportedAuthor.MatchStatus.MANUAL
+    assert Autor.objects.filter(orcid="0000-0002-1111-2222").count() == 1
+
+
+@pytest.mark.django_db
+def test_author_create_new_no_obca_jednostka(
+    importer_client,
+    importer_user,
+    uczelnia,
+):
+    """Brak obcej jednostki -> komunikat błędu w wierszu, autor
+    pozostaje niedopasowany."""
+    assert uczelnia.obca_jednostka is None
+    session = _make_session_with_unmatched(importer_user, count=1)
+    imported = session.authors.first()
+
+    url = reverse(
+        "importer_publikacji:author-create-new",
+        kwargs={"session_id": session.pk, "author_id": imported.pk},
+    )
+    response = importer_client.post(url)
+    assert response.status_code == 200
+    assert "obcej jednostki" in response.content.decode()
+
+    imported.refresh_from_db()
+    assert imported.match_status == ImportedAuthor.MatchStatus.UNMATCHED
+    assert imported.matched_autor is None
+
+
+@pytest.mark.django_db
 def test_create_unmatched_noop_when_all_matched(
     importer_client,
     importer_user,

--- a/src/importer_publikacji/urls.py
+++ b/src/importer_publikacji/urls.py
@@ -48,6 +48,11 @@ urlpatterns = [
         name="author-info",
     ),
     path(
+        "<int:session_id>/authors/<int:author_id>/create-new/",
+        views.AuthorCreateNewView.as_view(),
+        name="author-create-new",
+    ),
+    path(
         "<int:session_id>/authors/<int:author_id>/candidates-modal/",
         views.AuthorCandidatesModalView.as_view(),
         name="author-candidates-modal",

--- a/src/importer_publikacji/views/__init__.py
+++ b/src/importer_publikacji/views/__init__.py
@@ -93,6 +93,7 @@ from .steps import (
 )
 from .wizard import (
     AuthorCandidatesModalView,
+    AuthorCreateNewView,
     AuthorInfoView,
     AuthorMatchView,
     AuthorsConfirmView,
@@ -130,6 +131,7 @@ __all__ = [
     "STEP_VERIFY",
     # Class-based views
     "AuthorCandidatesModalView",
+    "AuthorCreateNewView",
     "AuthorInfoView",
     "AuthorMatchView",
     "AuthorSetOrcidView",

--- a/src/importer_publikacji/views/authors.py
+++ b/src/importer_publikacji/views/authors.py
@@ -220,6 +220,45 @@ def _prefill_dyscypliny_z_zgloszen(session):
 
 
 @transaction.atomic
+def _create_single_author(imported, obca):
+    """Utwórz (lub dopasuj po ORCID) rekord ``Autor`` dla pojedynczego
+    ``ImportedAuthor`` i przypisz go do obcej jednostki.
+
+    Wspólny rdzeń dla masowego ``_create_unmatched_authors`` oraz
+    per-wierszowego ``AuthorCreateNewView`` ("Utwórz nowego" z modala
+    edycji). Trzymane w jednym miejscu, żeby logika dedupowania po ORCID
+    nie rozjechała się między ścieżkami.
+
+    Jeśli dostawca podał ORCID i istnieje już ``Autor`` z tym ORCID-em,
+    dopasowuje istniejącego zamiast tworzyć duplikat.
+    """
+    orcid = imported.orcid.strip() or None
+
+    if orcid:
+        existing = Autor.objects.filter(orcid=orcid).first()
+        if existing:
+            existing.dodaj_jednostke(obca)
+            imported.matched_autor = existing
+            imported.matched_jednostka = obca
+            imported.match_status = ImportedAuthor.MatchStatus.MANUAL
+            imported.save()
+            return existing
+
+    autor = Autor.objects.create(
+        imiona=imported.given_name,
+        nazwisko=imported.family_name,
+        orcid=orcid,
+    )
+    autor.dodaj_jednostke(obca)
+
+    imported.matched_autor = autor
+    imported.matched_jednostka = obca
+    imported.match_status = ImportedAuthor.MatchStatus.MANUAL
+    imported.save()
+    return autor
+
+
+@transaction.atomic
 def _create_unmatched_authors(session, obca):
     """Utwórz rekordy Autor dla niedopasowanych
     autorów i przypisz do obcej jednostki."""
@@ -227,28 +266,4 @@ def _create_unmatched_authors(session, obca):
         match_status=(ImportedAuthor.MatchStatus.UNMATCHED)
     )
     for imported in unmatched:
-        orcid = imported.orcid.strip() or None
-
-        # Jeśli ORCID podany i istnieje Autor
-        # z takim ORCID -- dopasuj istniejącego
-        if orcid:
-            existing = Autor.objects.filter(orcid=orcid).first()
-            if existing:
-                imported.matched_autor = existing
-                imported.matched_jednostka = obca
-                imported.match_status = ImportedAuthor.MatchStatus.MANUAL
-                existing.dodaj_jednostke(obca)
-                imported.save()
-                continue
-
-        autor = Autor.objects.create(
-            imiona=imported.given_name,
-            nazwisko=imported.family_name,
-            orcid=orcid,
-        )
-        autor.dodaj_jednostke(obca)
-
-        imported.matched_autor = autor
-        imported.matched_jednostka = obca
-        imported.match_status = ImportedAuthor.MatchStatus.MANUAL
-        imported.save()
+        _create_single_author(imported, obca)

--- a/src/importer_publikacji/views/wizard.py
+++ b/src/importer_publikacji/views/wizard.py
@@ -24,6 +24,7 @@ from ..permissions import ImporterPermissionMixin
 from ..providers import InputMode, get_provider
 from ..tasks import create_publication_task, fetch_session_task
 from .authors import (
+    _create_single_author,
     _create_unmatched_authors,
     _orcid_settable_qs,
 )
@@ -407,6 +408,69 @@ class AuthorMatchView(ImporterPermissionMixin, View):
             imported_author.dyscyplina_source = ""
 
         imported_author.save()
+
+        return render(
+            request,
+            "importer_publikacji/partials/author_row.html",
+            {
+                "session": session,
+                "author": imported_author,
+            },
+        )
+
+
+class AuthorCreateNewView(ImporterPermissionMixin, View):
+    """Utwórz NOWEGO autora dla pojedynczego wiersza ("Edytuj" → "Utwórz
+    nowego autora").
+
+    Pozwala rozwiązać niedopasowany wiersz bezpośrednio z modala edycji,
+    bez wracania do zbiorczego żółtego przycisku na górze listy. Tworzy
+    (lub dopasowuje po ORCID) rekord ``Autor`` z danych dostawcy
+    i przypisuje go do obcej jednostki — reużywa ``_create_single_author``,
+    czyli ten sam rdzeń co masowy ``CreateUnmatchedAuthorsView``.
+
+    Opcjonalne pola POST ``nazwisko`` / ``imiona`` / ``zapisany_jako``
+    pozwalają skorygować dane przed utworzeniem (np. literówka w danych
+    dostawcy). Puste pola → użycie wartości z ``ImportedAuthor``.
+    """
+
+    def post(self, request, session_id, author_id):
+        session = get_object_or_404(ImportSession, pk=session_id)
+        imported_author = get_object_or_404(
+            ImportedAuthor,
+            pk=author_id,
+            session=session,
+        )
+
+        uczelnia = Uczelnia.objects.get_for_request(request)
+        obca = uczelnia.obca_jednostka if uczelnia else None
+        if not obca:
+            return render(
+                request,
+                "importer_publikacji/partials/author_row.html",
+                {
+                    "session": session,
+                    "author": imported_author,
+                    "row_error": (
+                        "Brak skonfigurowanej obcej jednostki w "
+                        "ustawieniach uczelni. Skontaktuj się z "
+                        "administratorem."
+                    ),
+                },
+            )
+
+        # Korekta danych przed utworzeniem (opcjonalna).
+        nazwisko = (request.POST.get("nazwisko") or "").strip()
+        imiona = (request.POST.get("imiona") or "").strip()
+        zapisany_jako = (request.POST.get("zapisany_jako") or "").strip()
+        if nazwisko:
+            imported_author.family_name = nazwisko
+        if imiona:
+            imported_author.given_name = imiona
+        if zapisany_jako:
+            imported_author.zapisany_jako = zapisany_jako
+
+        _create_single_author(imported_author, obca)
 
         return render(
             request,


### PR DESCRIPTION
## Co

Na ekranie dopasowania autorów importera publikacji (Krok 4) przycisk
**„Edytuj"** przy wierszu autora pozwala teraz **utworzyć nowego autora**
bezpośrednio z modala edycji — bez wracania do zbiorczego żółtego
przycisku na górze listy.

W modalu edycji autora pojawia się sekcja „Utwórz nowego autora"
(żółty przycisk). Kliknięcie tworzy (lub dopasowuje po ORCID) rekord
`Autor` z danych dostawcy, przypisuje go do obcej jednostki i odświeża
wiersz w miejscu (HTMX `outerHTML` swap).

## Dlaczego

Freshdesk #383: dotąd nowego autora dla wierszy „niedopasowanych" dało
się utworzyć **wyłącznie** zbiorczym żółtym przyciskiem, który tworzył
od razu wszystkich brakujących. Z poziomu „Edytuj" pojedynczego wiersza
można było tylko wybrać istniejącego autora BPP. To zmusza do akcji
zbiorczej nawet gdy chce się rozwiązać jeden konkretny wiersz.

## Jak

- Nowy widok `AuthorCreateNewView` (POST `.../authors/<id>/create-new/`,
  URL `author-create-new`) tworzy/dopasowuje pojedynczego autora
  i zwraca odświeżony partial wiersza — spójnie z `AuthorMatchView`.
- Rdzeń tworzenia wyciągnięty do `_create_single_author()` w `authors.py`
  i reużyty przez masowy `CreateUnmatchedAuthorsView` oraz nowy widok —
  logika dedupowania po ORCID jest w jednym miejscu (DRY).
- W modalu (`step_authors.html`) przycisk + handler JS POST-ujący do
  nowego endpointu, swap wiersza, zamknięcie modala.
- Opcjonalne pola POST `nazwisko`/`imiona`/`zapisany_jako` pozwalają
  skorygować dane przed utworzeniem; `zapisany_jako` wysyłane z modala.
- Brak obcej jednostki → komunikat błędu renderowany w wierszu, autor
  pozostaje niedopasowany (bez wyjątku).

## Jak testowano

`src/importer_publikacji/tests/test_views_authors.py` — 4 nowe testy
(per-wierszowe tworzenie, korekty danych, dopasowanie po ORCID, brak
obcej jednostki) + 4 istniejące: **8 passed**. `ruff` czysty,
`manage.py check` bez uwag.

## Co odłożono

- Zachowano lokalny zasięg zmian (ścieżka create-from-Edytuj), by
  zminimalizować konflikty z równoległym ticketem #332 (usuwanie
  wierszy na tym samym ekranie). Bez refaktoru całego ekranu.
- Pola korekty `nazwisko`/`imiona` są obsługiwane server-side, ale nie
  dodano dla nich osobnych inputów w modalu (modal pokazuje dane
  dostawcy w nagłówku); można dołożyć w razie potrzeby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)