### PR TITLE
feat(beatserver): lekki healthcheck celerybeat przez heartbeat

### DIFF
--- a/docker/beatserver/Dockerfile
+++ b/docker/beatserver/Dockerfile
@@ -2,8 +2,13 @@ ARG BPP_BASE_TAG=latest
 FROM iplweb/bpp_base:${BPP_BASE_TAG}
 
 COPY docker/beatserver/entrypoint-beatserver.sh /app/entrypoint-beatserver.sh
+# healthcheck_broker.py zostaje dla wstecznej zgodnosci: stary docker-compose w
+# bpp-deploy moze go jeszcze wywolywac. Domyslny HEALTHCHECK uzywa juz lekkiej sondy.
 COPY docker/beatserver/healthcheck_broker.py /app/healthcheck_broker.py
+COPY docker/beatserver/healthcheck_beat.py /app/healthcheck_beat.py
 
 ENTRYPOINT ["/app/entrypoint-beatserver.sh"]
 
-HEALTHCHECK --interval=10s --timeout=10s --start-period=40s --retries=3 CMD ["python", "/app/healthcheck_broker.py"]
+# Lekka sonda: tylko swiezosc pliku-heartbeatu (HeartbeatScheduler dotyka go na kazdym
+# ticku), bez cold-importu Django. ~30-50 ms zamiast 4-10 s -> szybki start kontenera.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --retries=3 CMD ["python", "/app/healthcheck_beat.py"]

--- a/docker/beatserver/entrypoint-beatserver.sh
+++ b/docker/beatserver/entrypoint-beatserver.sh
@@ -4,7 +4,7 @@ cd /app
 
 if [ "$ENABLE_AUTORELOAD_ON_CODE_CHANGE" = "1" ] || [ "$ENABLE_AUTORELOAD_ON_CODE_CHANGE" = "true" ]; then
     echo "Auto-reload ENABLED for beat"
-    exec watchmedo auto-restart --directory=/app/src --pattern=*.py --recursive --ignore-patterns '__pycache__/*;*.pyc' -- celery -A django_bpp.celery_tasks beat --pidfile=/celerybeat.pid -s /celerybeat-schedule
+    exec watchmedo auto-restart --directory=/app/src --pattern=*.py --recursive --ignore-patterns '__pycache__/*;*.pyc' -- celery -A django_bpp.celery_tasks beat -S django_bpp.beat_heartbeat:HeartbeatScheduler --pidfile=/celerybeat.pid -s /celerybeat-schedule
 else
-    exec celery -A django_bpp.celery_tasks beat --pidfile=/celerybeat.pid -s /celerybeat-schedule
+    exec celery -A django_bpp.celery_tasks beat -S django_bpp.beat_heartbeat:HeartbeatScheduler --pidfile=/celerybeat.pid -s /celerybeat-schedule
 fi

--- a/docker/beatserver/healthcheck_beat.py
+++ b/docker/beatserver/healthcheck_beat.py
@@ -1,0 +1,46 @@
+"""Lekki healthcheck celerybeat: swiezosc pliku-heartbeatu (bez importu Django).
+
+Beat dziala z HeartbeatScheduler (src/django_bpp/beat_heartbeat.py), ktory dotyka
+HEARTBEAT_FILE przy kazdym ticku. Ten skrypt tylko sprawdza, czy plik jest swiezy -
+bez importu django_bpp.celery_tasks i bez laczenia z brokerem (redis ma wlasny
+healthcheck). Dzieki temu sonda trwa ~30-50 ms zamiast 4-10 s (cold-import calego
+stacku), wiec nie wydluza startu kontenera ani nie obciaza limitu CPU beata.
+
+Celowo bez zaleznosci poza stdlib - import celery/Django zniwelowalby cala oszczednosc.
+"""
+
+import os
+import sys
+import time
+
+#: MUSI byc zgodne z HEARTBEAT_FILE w src/django_bpp/beat_heartbeat.py.
+HEARTBEAT_FILE = "/tmp/celerybeat-heartbeat"
+
+#: Maks. akceptowalny wiek heartbeatu. > 2x HEARTBEAT_INTERVAL (30 s) = zapas na
+#: wariancje petli beata; ponizej tego beat na pewno tyka.
+MAX_AGE_SECONDS = 90
+
+
+def main() -> int:
+    try:
+        age = time.time() - os.path.getmtime(HEARTBEAT_FILE)
+    except OSError as exc:
+        print(
+            f"celerybeat: brak/niedostepny heartbeat {HEARTBEAT_FILE}: {exc!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if age > MAX_AGE_SECONDS:
+        print(
+            f"celerybeat: heartbeat przestarzaly ({age:.0f}s > {MAX_AGE_SECONDS}s) "
+            "- beat moze nie tykac",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/django_bpp/beat_heartbeat.py
+++ b/src/django_bpp/beat_heartbeat.py
@@ -1,0 +1,56 @@
+"""Heartbeat-owy scheduler dla celerybeat -> tani healthcheck bez importu Django.
+
+Domyslny PersistentScheduler nie daje zadnego sygnalu "beat zyje i tyka", a
+poprzednia sonda (docker/beatserver/healthcheck_broker.py) cold-importowala caly
+stack Django (config_from_object + autodiscover_tasks po calym INSTALLED_APPS) co
+interval, tylko po to by otworzyc polaczenie do brokera. Pod limitem CPU kontenera
+zajmowalo to 4-10 s i wydluzalo start celerybeat do ~218 s.
+
+`HeartbeatScheduler` dotyka pliku-heartbeatu przy kazdym ticku, a sonda Dockera
+(docker/beatserver/healthcheck_beat.py) sprawdza tylko swiezosc mtime tego pliku -
+bez importu Django i bez sprawdzania redisa (redis ma wlasny healthcheck, a beat i
+tak zalezy od redis: service_healthy, wiec ponowne sprawdzanie go z beata jest
+redundantne). `tick()` jest dodatkowo capowany do HEARTBEAT_INTERVAL, zeby plik
+odswiezal sie nawet gdy zadne zadanie nie jest bliskie (domyslny max_interval to 300 s).
+"""
+
+import logging
+import pathlib
+
+from celery.beat import PersistentScheduler
+
+logger = logging.getLogger(__name__)
+
+#: Plik dotykany przy kazdym ticku; healthcheck_beat.py sprawdza jego mtime.
+#: Sciezka MUSI byc zgodna z HEARTBEAT_FILE w docker/beatserver/healthcheck_beat.py.
+HEARTBEAT_FILE = pathlib.Path("/tmp/celerybeat-heartbeat")
+
+#: Gorny limit snu petli beata (s) -> heartbeat odswieza sie co najwyzej co tyle,
+#: nawet przy braku bliskich zadan. Sonda toleruje wiek do ~3x tej wartosci.
+HEARTBEAT_INTERVAL = 30
+
+
+def write_heartbeat(path):
+    """Dotknij plik-heartbeat. Loguje i NIE wywraca beata gdy zapis sie nie uda.
+
+    Zwraca True przy sukcesie, False przy bledzie I/O.
+    """
+    try:
+        path.touch()
+    except OSError as exc:
+        logger.warning("celerybeat: nie udalo sie zapisac heartbeatu %s: %r", path, exc)
+        return False
+    return True
+
+
+def cap_interval(interval, maximum=HEARTBEAT_INTERVAL):
+    """Ogranicz sen petli beata, by heartbeat nie zestarzal sie przy braku zadan."""
+    return min(interval, maximum)
+
+
+class HeartbeatScheduler(PersistentScheduler):
+    """PersistentScheduler dotykajacy pliku-heartbeatu na kazdym ticku."""
+
+    def tick(self, *args, **kwargs):
+        write_heartbeat(HEARTBEAT_FILE)
+        return cap_interval(super().tick(*args, **kwargs))

--- a/src/django_bpp/tests/test_beat_heartbeat.py
+++ b/src/django_bpp/tests/test_beat_heartbeat.py
@@ -1,0 +1,46 @@
+import os
+from unittest import mock
+
+from django_bpp import beat_heartbeat
+
+
+def test_write_heartbeat_creates_file(tmp_path):
+    f = tmp_path / "beat.alive"
+    assert beat_heartbeat.write_heartbeat(f) is True
+    assert f.exists()
+
+
+def test_write_heartbeat_refreshes_mtime(tmp_path):
+    f = tmp_path / "beat.alive"
+    f.touch()
+    os.utime(f, (1000, 1000))  # cofnij mtime daleko w przeszlosc
+    beat_heartbeat.write_heartbeat(f)
+    assert f.stat().st_mtime > 1000
+
+
+def test_write_heartbeat_returns_false_on_error(tmp_path):
+    # rodzic nie istnieje -> touch rzuca OSError, ma byc zalogowane i False (beat zyje)
+    f = tmp_path / "nie-ma-katalogu" / "beat.alive"
+    assert beat_heartbeat.write_heartbeat(f) is False
+
+
+def test_cap_interval_limits_long_idle_sleep():
+    assert beat_heartbeat.cap_interval(300) == beat_heartbeat.HEARTBEAT_INTERVAL
+
+
+def test_cap_interval_keeps_short_interval():
+    assert beat_heartbeat.cap_interval(2) == 2
+
+
+def test_tick_touches_heartbeat_and_caps_interval(tmp_path, monkeypatch):
+    f = tmp_path / "beat.alive"
+    monkeypatch.setattr(beat_heartbeat, "HEARTBEAT_FILE", f)
+    # __new__ pomija __init__ (wymagajacy aplikacji celery) - testujemy sam tick().
+    sched = beat_heartbeat.HeartbeatScheduler.__new__(beat_heartbeat.HeartbeatScheduler)
+    with mock.patch(
+        "celery.beat.PersistentScheduler.tick", return_value=300
+    ) as super_tick:
+        interval = sched.tick()
+    super_tick.assert_called_once()
+    assert f.exists()
+    assert interval == beat_heartbeat.HEARTBEAT_INTERVAL


### PR DESCRIPTION
## Problem
Healthcheck celerybeat (`healthcheck_broker.py`) cold-importował cały stack Django (`config_from_object` + `autodiscover_tasks` po całym `INSTALLED_APPS`) co interval, tylko by otworzyć połączenie do brokera. Pod limitem CPU kontenera import trwał **4–10 s** (zmierzone na produkcji: 4.1 / 6.3 / 9.8 s), wpadał w 10 s timeout przy zimnym starcie → celerybeat zostawał `starting` do **~218 s** (gating `compose up --wait`). Sonda sprawdzała też redisa — redundantnie (redis ma własny healthcheck, a beat i tak `depend_on redis: service_healthy`).

## Rozwiązanie
- **`HeartbeatScheduler`** (`src/django_bpp/beat_heartbeat.py`) — `PersistentScheduler` dotykający `/tmp/celerybeat-heartbeat` na każdym `tick()`, z capem pętli do 30 s (heartbeat odświeża się nawet bez bliskich zadań; domyślny `max_interval` to 300 s).
- **`healthcheck_beat.py`** — lekka sonda: sama świeżość `mtime` (okno 90 s), bez importu Django, bez redisa. ~30–50 ms.
- **entrypoint** — `-S django_bpp.beat_heartbeat:HeartbeatScheduler` (oba branche, też watchmedo).
- **Dockerfile** — domyślny `HEALTHCHECK` → `healthcheck_beat.py`. `healthcheck_broker.py` **zostaje** (fallback wstecznej zgodności: stary `docker-compose` w bpp-deploy może go jeszcze wołać).

## Testy
`src/django_bpp/tests/test_beat_heartbeat.py` — 6 testów (czyste funkcje, bez fixture'ów celery). Lokalnie: 6 passed, ruff clean, `symbol_by_name('django_bpp.beat_heartbeat:HeartbeatScheduler')` rozwiązuje się i nadpisuje `tick`.

## Powiązane
Strona deploy: iplweb/bpp-deploy#12 — dyspozytor w compose używa nowej sondy gdy obraz ją ma, inaczej spada na `healthcheck_broker.py`. Bezpieczne do mergowania niezależnie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)