### PR TITLE
fix(crossref): dopasowanie czasopisma z encją HTML w tytule (Fixes Freshdesk FD#321)

### DIFF
--- a/src/bpp/newsfragments/+fd321.bugfix.md
+++ b/src/bpp/newsfragments/+fd321.bugfix.md
@@ -1,0 +1,1 @@
+Import z CrossRef poprawnie dopasowuje czasopismo, którego tytuł zawiera znak „&" lub inne encje HTML (np. „Leukemia & Lymphoma") — pole źródła nie zostaje już puste (FD#321).

--- a/src/crossref_bpp/tests/test_repro_fd321.py
+++ b/src/crossref_bpp/tests/test_repro_fd321.py
@@ -1,0 +1,63 @@
+"""Repro dla FD#321 — import z CrossRef czasopisma z encją HTML w tytule.
+
+CrossRef REST API zwraca ``container-title`` / ``short-container-title``
+z encjami HTML (np. ``Leukemia &amp; Lymphoma``). Wartość ta przepływała
+dosłownie przez normalizację i dopasowanie trygramowe, więc nie
+dopasowywała się do zapisanego w bazie źródła o nazwie
+``Leukemia & Lymphoma`` — w kroku 3 "Dopasowanie źródła" pole „źródło
+(czasopismo)" zostawało puste.
+
+DOI z repro: 10.3109/10428194.2014.985672.
+
+Encja ``&amp;`` w środku napisu dokłada 4 dodatkowe znaki, które
+zaburzają podobieństwo trygramowe. Dla krótkich tytułów (np. „R&D")
+podobieństwo spada poniżej progu 0.6 i dopasowanie znika całkowicie;
+dla dłuższych tytułów wynik jest zafałszowany. Naprawą jest
+``html.unescape`` zastosowany do wartości z CrossRef *przed*
+normalizacją do porównania z bazą.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Zrodlo
+from crossref_bpp.core import Komparator
+from import_common.core import (
+    normalize_zrodlo_nazwa_for_db_lookup,
+    normalize_zrodlo_skrot_for_db_lookup,
+)
+
+
+def test_normalize_zrodlo_nazwa_unescapes_html_entities():
+    # Wartość z CrossRef (z encją) po normalizacji musi być identyczna jak
+    # znormalizowana wartość zapisana w bazie (z gołym znakiem &).
+    assert normalize_zrodlo_nazwa_for_db_lookup(
+        "Leukemia &amp; Lymphoma"
+    ) == normalize_zrodlo_nazwa_for_db_lookup("Leukemia & Lymphoma")
+
+
+def test_normalize_zrodlo_skrot_unescapes_html_entities():
+    assert normalize_zrodlo_skrot_for_db_lookup(
+        "Leuk. &amp; Lymphoma"
+    ) == normalize_zrodlo_skrot_for_db_lookup("Leuk. & Lymphoma")
+
+
+@pytest.mark.django_db
+def test_porownaj_container_title_short_title_with_entity():
+    # Krótki tytuł z & — bez unescape encja zabija podobieństwo trygramowe
+    # (sim ~0.50 < próg 0.60), więc źródło nie zostaje dopasowane.
+    zrodlo = baker.make(Zrodlo, nazwa="R&D")
+
+    wynik = Komparator.porownaj_container_title("R&amp;D")
+
+    assert wynik.rekord_po_stronie_bpp == zrodlo
+
+
+@pytest.mark.django_db
+def test_porownaj_container_title_leukemia_lymphoma():
+    # Tytuł z oryginalnego zgłoszenia FD#321.
+    zrodlo = baker.make(Zrodlo, nazwa="Leukemia & Lymphoma")
+
+    wynik = Komparator.porownaj_container_title("Leukemia &amp; Lymphoma")
+
+    assert wynik.rekord_po_stronie_bpp == zrodlo

--- a/src/import_common/core/normalize_db.py
+++ b/src/import_common/core/normalize_db.py
@@ -5,6 +5,8 @@ wartości w bazie z wartościami pochodzącymi z importu, oraz odpowiadające
 im funkcje pythonowe normalizujące napis tak samo jak ORM-owy odpowiednik.
 """
 
+import html
+
 import dateutil
 from django.db.models import Value
 from django.db.models.functions import Lower, Replace, Trim
@@ -35,6 +37,11 @@ normalized_db_zrodlo_skrot = Trim(
 
 
 def normalize_zrodlo_skrot_for_db_lookup(s):
+    # html.unescape: CrossRef API zwraca tytuły z encjami HTML (np.
+    # "Leuk. &amp; Lymphoma"), a w bazie zapisany jest goły znak
+    # ("Leuk. & Lymphoma"). Bez dekodowania encja zaburza podobieństwo
+    # trygramowe i dopasowanie źródła znika (FD#321).
+    s = html.unescape(s)
     return s.lower().replace(" ", "").strip().replace("-", "").replace(".", "")
 
 
@@ -60,6 +67,11 @@ normalized_db_zrodlo_nazwa = Trim(
 
 
 def normalize_zrodlo_nazwa_for_db_lookup(s):
+    # html.unescape: CrossRef API zwraca tytuły z encjami HTML (np.
+    # "Leukemia &amp; Lymphoma"), a w bazie zapisana jest goła nazwa
+    # ("Leukemia & Lymphoma"). Bez dekodowania encja zaburza podobieństwo
+    # trygramowe i dopasowanie źródła znika (FD#321).
+    s = html.unescape(s)
     return s.lower().replace(" ", "").strip()
 
 


### PR DESCRIPTION
## Problem

Fixes Freshdesk FD#321 — https://iplweb.freshdesk.com/a/tickets/321
(klient: IHiT). Import publikacji po DOI z CrossRef dla czasopisma,
którego tytuł zawiera znak „&" (np. „Leukemia & Lymphoma"), w kroku 3
„Dopasowanie źródła" zostawiał pole „źródło (czasopismo)" PUSTE — także
ręczny autocomplete nie trafiał. Repro DOI: `10.3109/10428194.2014.985672`.

## Przyczyna

CrossRef REST API zwraca `container-title` / `short-container-title`
z encjami HTML, np. `Leukemia &amp; Lymphoma`. Wartość przepływała
dosłownie przez normalizację i dopasowanie trygramowe, podczas gdy w
bazie zapisany jest goły znak (`Leukemia & Lymphoma`). Encja `&amp;`
dokłada 4 dodatkowe znaki, które psują podobieństwo trygramowe — dla
krótkich tytułów (np. `R&D`) podobieństwo spada poniżej progu 0.6
i dopasowanie znika całkowicie; dla dłuższych wynik jest zafałszowany.
Nigdzie w `src/crossref_bpp/` ani `src/import_common/` nie było
`html.unescape`.

## Naprawa

`html.unescape` zastosowany w pojedynczym chokepoincie —
`normalize_zrodlo_nazwa_for_db_lookup` i
`normalize_zrodlo_skrot_for_db_lookup` w
`src/import_common/core/normalize_db.py`. Te funkcje normalizują
wyłącznie wartość przychodzącą z CrossRef przed porównaniem trygramowym
z bazą, więc poprawka obejmuje zarówno dopasowanie do bazy, jak i
prefill changeformu (przez
`Komparator.porownaj_container_title(...).rekord_po_stronie_bpp`).
Obsługuje `&amp;`, `&lt;`, encje numeryczne itd.

## Testy (TDD)

Nowy `src/crossref_bpp/tests/test_repro_fd321.py`:
- przed naprawą: 3 failed, 1 passed (krótki tytuł `R&D` + dwa testy
  normalizacji szły na czerwono; `Leukemia & Lymphoma` przechodził
  trygramem „rzutem na taśmę"),
- po naprawie: 4 passed.

Pełne suity `src/crossref_bpp/` + `src/import_common/`: 271 passed,
bez regresji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)