### PR TITLE
fix(toz): kopiowanie „toż" nie zeruje pbn_uid → HTTP 500 (Fixes Freshdesk FD#328)

### DIFF
--- a/src/bpp/newsfragments/+fd328.bugfix.md
+++ b/src/bpp/newsfragments/+fd328.bugfix.md
@@ -1,0 +1,1 @@
+Kopiowanie rekordu przyciskiem „toż" nie kończy się już błędem serwera dla rekordów powiązanych z PBN — kopia powstaje bez przeniesienia unikalnego identyfikatora PBN (FD#328).

--- a/src/bpp/tests/test_repro_fd328.py
+++ b/src/bpp/tests/test_repro_fd328.py
@@ -1,0 +1,44 @@
+"""Repro dla FD#328 — kopiowanie rekordu przyciskiem „toż".
+
+Klikniecie „toż" na rekordzie powiazanym z PBN (ustawione pbn_uid)
+konczylo sie HTTP 500, bo kopia probowala zachowac ten sam pbn_uid
+(OneToOneField, unique=True) -> IntegrityError przy save().
+
+https://iplweb.freshdesk.com/a/tickets/328
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models.wydawnictwo_ciagle import Wydawnictwo_Ciagle
+from bpp.models.wydawnictwo_zwarte import Wydawnictwo_Zwarte
+from bpp.views.admin import WydawnictwoCiagleTozView, WydawnictwoZwarteTozView
+from pbn_api.models.publication import Publication
+
+
+@pytest.mark.django_db
+def test_toz_zwarte_z_pbn_uid_nie_rzuca_integrity_error():
+    pub = baker.make(Publication, mongoId="fd328-zwarte-pub")
+    z1 = baker.make(Wydawnictwo_Zwarte, pbn_uid=pub)
+    assert Wydawnictwo_Zwarte.objects.count() == 1
+
+    url = WydawnictwoZwarteTozView().get_redirect_url(z1.pk)
+
+    assert Wydawnictwo_Zwarte.objects.count() == 2
+    z2 = Wydawnictwo_Zwarte.objects.exclude(pk=z1.pk).get()
+    assert z2.pbn_uid_id is None
+    assert str(z2.pk) in url
+
+
+@pytest.mark.django_db
+def test_toz_ciagle_z_pbn_uid_nie_rzuca_integrity_error():
+    pub = baker.make(Publication, mongoId="fd328-ciagle-pub")
+    c1 = baker.make(Wydawnictwo_Ciagle, pbn_uid=pub)
+    assert Wydawnictwo_Ciagle.objects.count() == 1
+
+    url = WydawnictwoCiagleTozView().get_redirect_url(c1.pk)
+
+    assert Wydawnictwo_Ciagle.objects.count() == 2
+    c2 = Wydawnictwo_Ciagle.objects.exclude(pk=c1.pk).get()
+    assert c2.pbn_uid_id is None
+    assert str(c2.pk) in url

--- a/src/bpp/views/admin.py
+++ b/src/bpp/views/admin.py
@@ -20,12 +20,17 @@ class TozView(RedirectView):
         try:
             w = self.klass.objects.get(pk=pk)
         except self.klass.DoesNotExist:
-            raise Http404
+            raise Http404 from None
 
         w_copy = copy.copy(w)
         w_copy.id = None
         w_copy.tytul_oryginalny = "[ ** KOPIA ** ]" + w_copy.tytul_oryginalny
         w_copy.slug = None
+        if hasattr(w_copy, "pbn_uid_id"):
+            # pbn_uid to OneToOneField (unique=True) — kopia nie moze
+            # wspoldzielic identyfikatora PBN z oryginalem, bo save()
+            # rzuciłby IntegrityError (FD#328).
+            w_copy.pbn_uid_id = None
         w_copy.save()
 
         for wca in self.klass_autor.objects.filter(rekord=w):
@@ -34,7 +39,7 @@ class TozView(RedirectView):
             wca_copy.rekord = w_copy
             wca_copy.save()
 
-        return reverse("admin:bpp_%s_change" % self.klass_name, args=(w_copy.pk,))
+        return reverse(f"admin:bpp_{self.klass_name}_change", args=(w_copy.pk,))
 
 
 class WydawnictwoCiagleTozView(TozView):


### PR DESCRIPTION
## Problem

Klikniecie przycisku „toż" (kopiuj/duplikuj rekord) na rekordzie
powiazanym z PBN konczylo sie **HTTP 500**. Zgloszone przez IHiT dla
rekordu „Raport : wiedza, determinacja, współpraca : cancer moonshot".

Fixes Freshdesk FD#328 — https://iplweb.freshdesk.com/a/tickets/328

## Przyczyna

`TozView.get_redirect_url` w `src/bpp/views/admin.py` robil
`copy.copy(obj)`, zerowal tylko `id`/`slug` i prefiksowal
`tytul_oryginalny`, po czym `save()`. Pole `pbn_uid` to
`OneToOneField(unique=True)` — kopia probowala zapisac ten sam
`pbn_uid_id` co oryginal, co dawalo `IntegrityError`
(`UniqueViolation` na `bpp_wydawnictwo_*_pbn_uid_id_*_uniq`) → 500.

## Poprawka

Przed `save()` kopii zerujemy `pbn_uid_id`, gdy model je posiada
(`hasattr`-guard). Dotyczy `Wydawnictwo_Ciagle` i `Wydawnictwo_Zwarte`
(oba dziedzicza `ModelZPBN_UID`); `Patent` nie ma `pbn_uid`, wiec jest
pomijany. Kopia nadal nie jest powiazana z zadnym rekordem PBN — to
poprawne zachowanie (kopia to nowy, jeszcze niezsynchronizowany rekord).

Przy okazji domkniete dwa preexistujace lint-errory w tym samym pliku
(`B904` raise-from, `UP031` percent-format), zeby pre-commit przeszedl.

## Test

Repro `src/bpp/tests/test_repro_fd328.py` (TDD): tworzy
`Wydawnictwo_Zwarte`/`Wydawnictwo_Ciagle` z ustawionym `pbn_uid`,
wola `TozView.get_redirect_url`, asercja: kopia powstaje, `pbn_uid_id`
jest `None`, brak `IntegrityError`. RED przed fixem (UniqueViolation),
GREEN po. Istniejacy `test_wydawnictwociagletozview` dalej zielony.

🤖 Generated with [Claude Code](https://claude.com/claude-code)