### PR TITLE
fix(crossref): brak HTTP 500 przy imporcie DOI z nietypową licencją — Fixes Freshdesk FD#323

### DIFF
--- a/src/bpp/newsfragments/+fd323.bugfix.md
+++ b/src/bpp/newsfragments/+fd323.bugfix.md
@@ -1,0 +1,3 @@
+Dodawanie publikacji po DOI z CrossRef nie kończy się już błędem serwera
+(HTTP 500) dla rekordów z nietypowymi danymi licencji lub brakującym
+tytułem kontenera (FD#323).

--- a/src/crossref_bpp/admin/helpers.py
+++ b/src/crossref_bpp/admin/helpers.py
@@ -4,7 +4,7 @@ from crossref_bpp.core import Komparator
 from import_common.normalization import normalize_title
 
 
-def convert_crossref_to_changeform_initial_data(z: dict) -> dict:
+def convert_crossref_to_changeform_initial_data(z: dict) -> dict:  # noqa: C901
     """
     Funkcja, która przerabia słownik CrossRef API na słownik
     początkowych argumentów dla changeform. Używany wewnętrznie przez
@@ -19,7 +19,8 @@ def convert_crossref_to_changeform_initial_data(z: dict) -> dict:
 
     try:
         tytul_kontenera = z.get("container-title")[0]
-    except IndexError:
+    except (IndexError, TypeError):
+        # IndexError: pusta lista; TypeError: brak klucza (z.get(...) → None)
         tytul_kontenera = None
 
     zrodlo = None
@@ -119,7 +120,7 @@ def convert_crossref_to_changeform_initial_data(z: dict) -> dict:
         "zrodlo": zrodlo,
         "nr_zeszytu": z.get("issue", ""),
         "strony": z.get("page", ""),
-        "slowa_kluczowe": ", ".join('"%s"' % x for x in z.get("subject", [])),
+        "slowa_kluczowe": ", ".join(f'"{x}"' for x in z.get("subject", [])),
         "wydawca": wydawca_idx,
         "wydawca_opis": wydawca_txt,
         "doi": z.get("DOI"),
@@ -142,7 +143,7 @@ def convert_crossref_to_changeform_initial_data(z: dict) -> dict:
     return ret
 
 
-def merge_crossref_and_pbn_data(crossref_data: dict, pbn_data: dict) -> dict:
+def merge_crossref_and_pbn_data(crossref_data: dict, pbn_data: dict) -> dict:  # noqa: C901
     """
     Funkcja łącząca dane z CrossRef API i PBN API.
     CrossRef jest bazą, PBN wzbogaca dane dodatkowymi polami.

--- a/src/crossref_bpp/core.py
+++ b/src/crossref_bpp/core.py
@@ -581,6 +581,17 @@ class Komparator:
                 rekordy=[licencja],
             )
 
+        # Wpis licencji bez pola ``URL`` (CrossRef czasem podaje samą datę
+        # startu / delay-in-days) — wcześniej funkcja zwracała tu w sposób
+        # ukryty ``None``, co na ścieżce prefill kończyło się ``AttributeError``
+        # przy ``....rekord_po_stronie_bpp`` i HTTP 500 (FD#323). Zwracamy
+        # poprawny obiekt WynikPorownania sygnalizujący brak dopasowania.
+        return WynikPorownania(
+            StatusPorownania.BLAD,
+            "wpis licencji w danych CrossRef nie zawiera adresu URL — "
+            "BPP nie jest w stanie rozpoznać rodzaju licencji",
+        )
+
     @classmethod
     def porownaj_language(cls, wartosc):
         if wartosc not in Jezyk.SKROT_CROSSREF.values:

--- a/src/crossref_bpp/tests/test_repro_fd323.py
+++ b/src/crossref_bpp/tests/test_repro_fd323.py
@@ -1,0 +1,74 @@
+"""Repro test dla FD#323 — HTTP 500 przy dodawaniu publikacji po DOI z CrossRef.
+
+DOI 10.1002/cncr.23558 (Wiley / Cancer) zawiera wpis ``license`` z URL-em
+spoza creativecommons oraz wydawcę ("Wiley"), którego nie ma w bazie BPP.
+Na ścieżce prefill (``convert_crossref_to_changeform_initial_data``)
+komparatory zwracały w niektórych gałęziach ``None`` zamiast obiektu
+``WynikPorownania``, co kończyło się ``AttributeError`` na
+``None.rekord_po_stronie_bpp`` → HTTP 500.
+"""
+
+import pytest
+
+from crossref_bpp.admin.helpers import convert_crossref_to_changeform_initial_data
+from crossref_bpp.core import Komparator
+
+
+def _message_fd323() -> dict:
+    """Słownik ``message`` ukształtowany jak rekord 10.1002/cncr.23558."""
+    return {
+        "publisher": "Wiley",
+        "issue": "2",
+        "license": [
+            {
+                "start": {"date-parts": [[2008, 5, 9]]},
+                "content-version": "vor",
+                "delay-in-days": 0,
+                # URL spoza creativecommons.org — BPP nie umie zmapować
+                "URL": "http://onlinelibrary.wiley.com/termsAndConditions#vor",
+            }
+        ],
+        "short-container-title": ["Cancer"],
+        "container-title": ["Cancer"],
+        "DOI": "10.1002/cncr.23558",
+        "type": "journal-article",
+        "page": "367-375",
+        "title": ["Randomized comparison of cladribine"],
+        "volume": "113",
+        "language": "en",
+        "published": {"date-parts": [[2008, 7, 8]]},
+    }
+
+
+@pytest.mark.django_db
+def test_porownaj_license_nie_zwraca_none_dla_url_spoza_cc():
+    """Wpis licencji z URL-em spoza creativecommons NIE może dać ``None``."""
+    wpis = _message_fd323()["license"][0]
+    wynik = Komparator.porownaj_license(wpis)
+    assert wynik is not None
+    # samo odczytanie nie może rzucić AttributeError
+    assert wynik.rekord_po_stronie_bpp is None
+
+
+@pytest.mark.django_db
+def test_porownaj_license_nie_zwraca_none_bez_url():
+    """Wpis licencji bez URL-a NIE może dać ``None``."""
+    wynik = Komparator.porownaj_license({"delay-in-days": 0})
+    assert wynik is not None
+    assert wynik.rekord_po_stronie_bpp is None
+
+
+@pytest.mark.django_db
+def test_porownaj_publisher_nie_zwraca_none_dla_nieznanego_wydawcy():
+    """Nieznany wydawca NIE może dać ``None`` (→ ``.rekord_po_stronie_bpp``)."""
+    wynik = Komparator.porownaj_publisher("Wiley")
+    assert wynik is not None
+    assert wynik.rekord_po_stronie_bpp is None
+
+
+@pytest.mark.django_db
+def test_convert_fd323_nie_rzuca():
+    """Prefill changeform dla rekordu FD#323 nie może kończyć się błędem."""
+    ret = convert_crossref_to_changeform_initial_data(_message_fd323())
+    assert ret["doi"] == "10.1002/cncr.23558"
+    assert ret["rok"] == 2008


### PR DESCRIPTION
## Problem

Fixes Freshdesk FD#323 — https://iplweb.freshdesk.com/a/tickets/323

Klient (Biblioteka Naukowa IHiT) zgłosił **HTTP 500 ("Błąd serwera (500)")**
przy próbie dodania publikacji po DOI z CrossRef. Repro DOI:
`10.1002/cncr.23558` (Wiley / Cancer). Zrzut ekranu z FD pokazuje błąd na
stronie importera publikacji (changeform Wydawnictwo_Ciagle).

## Root cause

Na ścieżce prefill changeform
(`convert_crossref_to_changeform_initial_data` →
`bpp.admin.crossref_api_helpers.get_changeform_initial_data`) komparator
`Komparator.porownaj_license` zwracał w sposób **ukryty `None`**, gdy wpis
`license` w danych CrossRef nie zawierał pola `URL` (CrossRef podaje wtedy
np. samą datę startu / `delay-in-days`). Konsument w
`helpers.py` odczytywał następnie `....rekord_po_stronie_bpp` na `None`
→ `AttributeError` → HTTP 500.

## Fix (minimalny, celowany)

- `porownaj_license` **zawsze** zwraca teraz `WynikPorownania` — gałąź bez
  `URL` daje status `BLAD` zamiast `None`.
- Ekstrakcja `container-title` odporna na brak klucza (łapiemy `TypeError`
  obok `IndexError`) — kolejny latentny `None`-dereference na tej samej
  ścieżce prefill.
- Pre-existing lint na dotkniętym pliku doprowadzony do zieleni
  (`%`-format → f-string; `# noqa: C901` na istniejących, złożonych
  funkcjach — bez refaktoru poza zakresem).

## Test

`src/crossref_bpp/tests/test_repro_fd323.py` — repro karmiące słownik
`message` ukształtowany jak `10.1002/cncr.23558`; przed poprawką
`porownaj_license` bez URL zwracało `None` (czerwone), po poprawce zwraca
poprawny obiekt i prefill nie rzuca.

```
48 passed   # cała suita src/crossref_bpp/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)