### PR TITLE
fix(sloty): redakcja monografii HST na poziomie 1 — mnożnik ×2 (Fixes Freshdesk FD#230)

### DIFF
--- a/src/bpp/models/sloty/wydawnictwo_zwarte.py
+++ b/src/bpp/models/sloty/wydawnictwo_zwarte.py
@@ -31,21 +31,27 @@ class SlotKalkulator_Wydawnictwo_Zwarte_Baza:
             #
             # Ta procedura da dobry wynik tak długo, jak długo punkty PK będą w "liczniku" czyli
             # całe działanie (zwracane przez super().punkty_pkd(dyscyplina) będzie możliwe do przemnożenia
-            # przez 1.5.  Do tego, podnosi tą wartość wyłącznie dla dyscyplin HST. Z wyłaczeniem rozdziału
-            # i redakcji monografii na poziomie 1, gdyż tam mnożnik wynosi 1.0
+            # przez mnożnik). Podnosi tą wartość wyłącznie dla dyscyplin HST.
+            #
+            # Mnożnik dla dyscyplin HST (rekord mieszany HST/nie-HST):
+            #   - poziom wydawcy 1, autorstwo monografii: 80 -> 120  (x1.5),
+            #   - poziom wydawcy 1, redakcja monografii:   20 -> 40   (x2.0),
+            #   - poziom wydawcy 1, rozdział:              20 -> 20   (x1.0),
+            #   - poziom wydawcy 2 oraz brak poziomu:                  x1.5.
+            #
+            # Uwaga: rozdział na poziomie 1 i tak nigdy tu nie trafia z wiele_hst,
+            # bo core.py wymusza dla niego wiele_hst=False (metoda kończy się
+            # wcześniej, bez mnożenia). Zostawiamy jednak jawne x1.0 jako
+            # czytelną dokumentację reguły.
             #
 
             mnoznik = Decimal("1.5")
 
-            if (
-                self.tryb_kalkulacji
-                in [
-                    const.TRYB_KALKULACJI.ROZDZIAL_W_MONOGRAFI,
-                    const.TRYB_KALKULACJI.REDAKCJA_MONOGRAFI,
-                ]
-                and self.poziom_wydawcy == 1
-            ):
-                mnoznik = Decimal("1.0")
+            if self.poziom_wydawcy == 1:
+                if self.tryb_kalkulacji == const.TRYB_KALKULACJI.REDAKCJA_MONOGRAFI:
+                    mnoznik = Decimal("2.0")
+                elif self.tryb_kalkulacji == const.TRYB_KALKULACJI.ROZDZIAL_W_MONOGRAFI:
+                    mnoznik = Decimal("1.0")
 
             return val * mnoznik
 

--- a/src/bpp/newsfragments/+fd230.bugfix.md
+++ b/src/bpp/newsfragments/+fd230.bugfix.md
@@ -1,0 +1,1 @@
+Redakcja monografii na poziomie 1 wydawcy dla autorów z dyscyplin HST (w rekordach mieszanych HST/nie-HST) jest punktowana poprawnie — z mnożnikiem ×2 (40 pkt zamiast 20) (FD#230).

--- a/src/bpp/tests/test_models/test_sloty/test_repro_fd230.py
+++ b/src/bpp/tests/test_models/test_sloty/test_repro_fd230.py
@@ -1,0 +1,56 @@
+"""Repro test dla FD#230 — złe naliczenie punktów dla redakcji monografii HST.
+
+Dla rekordu MIESZANEGO (autorzy z dyscyplin HST oraz nie-HST), redakcja
+monografii na poziomie 1 wydawcy musi naliczać autorowi HST mnożnik x2
+(40 pkt zamiast 20). Wcześniej kod stosował tu mnożnik x1.0, co było błędem.
+
+Patrz: src/bpp/models/sloty/wydawnictwo_zwarte.py, klasa Prog2 (poziom 1):
+    PK 20 + książka redakcja (HST 40).
+"""
+
+import pytest
+
+from bpp.models.sloty.core import ISlot
+from bpp.models.sloty.wydawnictwo_zwarte import (
+    SlotKalkulator_Wydawnictwo_Zwarte_Prog2,
+)
+
+
+@pytest.mark.django_db
+def test_fd230_redakcja_hst_oraz_nie_hst_prog_1_ze_zwiekszaniem(
+    zwarte_z_dyscyplinami_hst_oraz_nie_hst, rok, typ_odpowiedzialnosci_redaktor
+):
+    """Redakcja monografii, poziom wydawcy 1, rekord mieszany HST/nie-HST.
+
+    Autor z dyscypliny HST powinien dostać x2 bazy (40), autor nie-HST bazę.
+    """
+    from bpp.tests.test_models.test_sloty.test_sloty_wydawnictwo_zwarte import (
+        powiel_wpisy_dyscyplin_autorow,
+    )
+
+    wydawca = zwarte_z_dyscyplinami_hst_oraz_nie_hst.wydawca
+    wydawca.poziom_wydawcy_set.create(rok=2022, poziom=1)
+
+    zwarte_z_dyscyplinami_hst_oraz_nie_hst.rok = 2022
+    # punktacja bazowa dla redakcji na poziomie 1 (mieszany rekord)
+    zwarte_z_dyscyplinami_hst_oraz_nie_hst.punkty_kbn = 20
+    zwarte_z_dyscyplinami_hst_oraz_nie_hst.save()
+
+    # przypisania dyscyplin autorów na rok 2022
+    powiel_wpisy_dyscyplin_autorow(zwarte_z_dyscyplinami_hst_oraz_nie_hst, rok, 2022)
+
+    # redakcja monografii: oboje autorzy jako redaktorzy
+    for autor in zwarte_z_dyscyplinami_hst_oraz_nie_hst.autorzy_set.all():
+        autor.typ_odpowiedzialnosci = typ_odpowiedzialnosci_redaktor
+        autor.save()
+
+    i = ISlot(zwarte_z_dyscyplinami_hst_oraz_nie_hst)
+    assert isinstance(i, SlotKalkulator_Wydawnictwo_Zwarte_Prog2)
+
+    autorzy = list(zwarte_z_dyscyplinami_hst_oraz_nie_hst.autorzy_set.all())
+    # autorzy[0] = HST (dyscyplina1_hst), autorzy[1] = nie-HST (dyscyplina2)
+    pkd_hst = i.pkd_dla_autora(autorzy[0])
+    pkd_nie_hst = i.pkd_dla_autora(autorzy[1])
+
+    # autor HST: x2 bazy nie-HST
+    assert pkd_hst == pkd_nie_hst * 2


### PR DESCRIPTION
## Problem

Fixes Freshdesk FD#230 — „Złe naliczenie punktów - rozdział HST" (Akademia Pożarnicza).
Panel: https://iplweb.freshdesk.com/a/tickets/230

W rekordach **mieszanych** (autorzy z dyscyplin HST oraz nie-HST) **redakcja monografii** u wydawcy **poziomu 1** naliczała autorowi z dyscypliny HST mnożnik **×1.0** zamiast **×2.0** — czyli **20 pkt zamiast 40**. To zaniżało punktację ewaluacyjną.

Błąd był w `src/bpp/models/sloty/wydawnictwo_zwarte.py`, metoda `SlotKalkulator_Wydawnictwo_Zwarte_Baza.punkty_pkd`: zarówno `ROZDZIAL_W_MONOGRAFI`, jak i `REDAKCJA_MONOGRAFI` na poziomie 1 dostawały wspólny mnożnik `1.0`. Tymczasem docstring klasy `Prog2` mówi wprost: „PK 20 + książka redakcja (HST 40)" → ×2.0.

## Poprawiona tabela prawdy (dyscyplina HST, rekord mieszany)

| poziom wydawcy | autorstwo monografii | redakcja monografii | rozdział |
|---|---|---|---|
| **1** (Prog2) | ×1.5 (80→120) | **×2.0 (20→40)** ← poprawka | ×1.0 (20→20) |
| **2** (Prog1) | ×1.5 | ×1.5 | ×1.5 |
| **brak** (Prog3) | ×1.5 | ×1.5 | ×1.5 |

Poprawka jest zgodna z docstringami klas `Prog1`/`Prog2`/`Prog3` w `wydawnictwo_zwarte.py`.

## Zmiana

Rozdzielono przypadek poziomu 1: `REDAKCJA_MONOGRAFI` → ×2.0, `ROZDZIAL_W_MONOGRAFI` → ×1.0, autorstwo monografii pozostaje ×1.5. Poziom 2 oraz brak poziomu pozostają ×1.5 (tam `poziom_wydawcy` jest `None`, więc special-case się nie wykonuje).

```python
# przed:
if tryb in [ROZDZIAL_W_MONOGRAFI, REDAKCJA_MONOGRAFI] and poziom == 1:
    mnoznik = Decimal("1.0")

# po:
if self.poziom_wydawcy == 1:
    if self.tryb_kalkulacji == const.TRYB_KALKULACJI.REDAKCJA_MONOGRAFI:
        mnoznik = Decimal("2.0")
    elif self.tryb_kalkulacji == const.TRYB_KALKULACJI.ROZDZIAL_W_MONOGRAFI:
        mnoznik = Decimal("1.0")
```

Mechanizm `_wiele_hst=False` dla rozdziału@poziom1 w `core.py` pozostaje nietknięty (poza zakresem). Brak migracji — to czysta logika kalkulacji.

## Testy

- Nowy repro test (TDD): `test_repro_fd230.py::test_fd230_redakcja_hst_oraz_nie_hst_prog_1_ze_zwiekszaniem` — czerwony przed poprawką (HST=14.14 == nie-HST), zielony po (HST = nie-HST × 2).
- Cały moduł `src/bpp/tests/test_models/test_sloty/` — **61 passed**. Oba istniejące testy rozdziału (`..._prog_1_bez_zwiekszenia`, `..._prog_2_ze_zwiekszaniem`) nadal zielone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)