### PR TITLE
feat(rollbar): login użytkownika w polu custom (anonim oznaczony)

### DIFF
--- a/src/bpp/middleware.py
+++ b/src/bpp/middleware.py
@@ -272,6 +272,20 @@ class CustomRollbarNotifierMiddleware(RollbarNotifierMiddleware):
                     "username": request.user.username,
                     "email": request.user.email,
                 },
+                # Login także w `custom`, by był widoczny wprost na evencie
+                # (sekcja `person` nie zawsze jest pokazywana na liście itemów).
+                "custom": {
+                    "login": request.user.username,
+                    "zalogowany": True,
+                },
+            }
+        else:
+            # Anonim nie ma `person` (brak id), więc oznaczamy go w `custom`.
+            payload_data = {
+                "custom": {
+                    "login": "<użytkownik anonimowy / niezalogowany>",
+                    "zalogowany": False,
+                },
             }
 
         return payload_data

--- a/src/bpp/newsfragments/+rollbar-login-custom.feature.rst
+++ b/src/bpp/newsfragments/+rollbar-login-custom.feature.rst
@@ -1,0 +1,3 @@
+Zgłoszenia błędów w Rollbarze zawierają teraz w polu ``custom`` login
+zalogowanego użytkownika (a dla ruchu niezalogowanego — wyraźne oznaczenie
+użytkownika anonimowego), co ułatwia powiązanie błędu z konkretną osobą.

--- a/src/bpp/tests/test_middleware/test_rollbar_middleware.py
+++ b/src/bpp/tests/test_middleware/test_rollbar_middleware.py
@@ -1,0 +1,41 @@
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from model_bakery import baker
+
+from bpp.middleware import CustomRollbarNotifierMiddleware
+
+
+@pytest.fixture
+def middleware(settings):
+    # Bez access_token RollbarNotifierMiddleware.__init__ rzuca
+    # MiddlewareNotUsed; podajemy atrapę, by powołać obiekt w teście.
+    settings.ROLLBAR = {"access_token": "test-token", "environment": "test"}
+    return CustomRollbarNotifierMiddleware(get_response=lambda request: None)
+
+
+@pytest.mark.django_db
+def test_get_payload_data_zalogowany_login_w_custom(middleware, rf):
+    """Zalogowany użytkownik: jego login trafia do pola `custom`."""
+    user = baker.make("bpp.BppUser", username="jkowalski")
+    request = rf.get("/")
+    request.user = user
+
+    payload = middleware.get_payload_data(request, None)
+
+    assert payload["custom"]["login"] == "jkowalski"
+    assert payload["custom"]["zalogowany"] is True
+    # person nadal wypełnione dla dashboardu "users affected"
+    assert payload["person"]["username"] == "jkowalski"
+
+
+def test_get_payload_data_anonimowy_oznaczony_w_custom(middleware, rf):
+    """Niezalogowany użytkownik: pole `custom` oznacza go jako anonimowego."""
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    payload = middleware.get_payload_data(request, None)
+
+    assert payload["custom"]["zalogowany"] is False
+    assert "anonim" in payload["custom"]["login"].lower()
+    # brak sekcji person — anonim nie ma id
+    assert "person" not in payload


### PR DESCRIPTION
## Co i po co

Rollbar dostaje teraz w payloadzie sekcję `custom`, dzięki czemu w każdym evencie widać **kto** go wywołał:

- **zalogowany** → `custom.login = <username>`, `custom.zalogowany = true` (sekcja `person` zostaje bez zmian, dla dashboardu „users affected");
- **niezalogowany** → `custom.login = "<użytkownik anonimowy / niezalogowany>"`, `custom.zalogowany = false` (anonim nie ma `person`, bo nie ma `id`).

Login w `custom` jest widoczny wprost na liście itemów, gdzie sekcja `person` nie zawsze się pokazuje.

## Zmiany

- `src/bpp/middleware.py` — `CustomRollbarNotifierMiddleware.get_payload_data` dokłada `custom`.
- `src/bpp/tests/test_middleware/test_rollbar_middleware.py` — nowe testy (TDD): zalogowany → login w `custom`; anonim → oznaczenie anonimowości, brak `person`.
- newsfragment (feature).

## Testy

```
uv run pytest src/bpp/tests/test_middleware/test_rollbar_middleware.py
2 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)