### PR TITLE
feat(importer): autodetekcja języka pracy także spoza {en,es,pl} (FD#389)

### DIFF
--- a/src/bpp/newsfragments/+fd389.feature.md
+++ b/src/bpp/newsfragments/+fd389.feature.md
@@ -1,0 +1,5 @@
+Importer publikacji: autodetekcja języka pracy przypisuje teraz język także
+dla pozycji w językach spoza pary polski/angielski (np. niemiecki, francuski,
+rosyjski, ukraiński) — o ile w Danych systemowych istnieje odpowiedni język z
+ustawionym skrótem CrossRef. Wcześniej taki rekord bywał wykrywany, ale język
+pozostawał pusty (FD#389).

--- a/src/importer_publikacji/tasks.py
+++ b/src/importer_publikacji/tasks.py
@@ -143,6 +143,7 @@ def _auto_match_type_and_language(session, result):
     from crossref_bpp.core import Komparator
 
     from .views.helpers import _detect_language, _get_crossref_mapper
+    from .views.publikacja import _resolve_jezyk
 
     mapper = _get_crossref_mapper(result.publication_type)
     if mapper and mapper.charakter_formalny_bpp_id:
@@ -156,6 +157,17 @@ def _auto_match_type_and_language(session, result):
         lang_result = Komparator.porownaj_language(language_code)
         if lang_result.rekord_po_stronie_bpp:
             session.jezyk = lang_result.rekord_po_stronie_bpp
+        else:
+            # Komparator akceptuje tylko kody z enuma Jezyk.SKROT_CROSSREF
+            # ({en, es, pl}). Dla pozostałych kodów (de, fr, ru, uk…),
+            # wykrytych przez langdetect lub zwróconych przez źródło,
+            # dopasuj bezpośrednio po skrot_crossref — tak samo jak robi
+            # to ścieżka języka streszczeń (_resolve_jezyk). Dzięki temu
+            # autodetekcja przypisuje język, gdy instalacja ma pasujący
+            # rekord Jezyk, zamiast cicho zostawiać pole puste (FD#389).
+            jezyk = _resolve_jezyk(language_code)
+            if jezyk:
+                session.jezyk = jezyk
 
 
 @shared_task(bind=True)

--- a/src/importer_publikacji/tests/test_repro_fd389.py
+++ b/src/importer_publikacji/tests/test_repro_fd389.py
@@ -1,0 +1,109 @@
+"""Repro dla FD#389 — autodetekcja języka pracy w importerze publikacji.
+
+Wykrywanie języka (``_detect_language``) już istnieje, ale przypisanie
+wykrytego/podanego kodu do obiektu ``Jezyk`` w
+``_auto_match_type_and_language`` szło wyłącznie przez
+``Komparator.porownaj_language``, które twardo odrzuca każdy kod spoza
+statycznego enuma ``Jezyk.SKROT_CROSSREF`` = {en, es, pl}
+(crossref_bpp/core.py). W efekcie publikacja niemiecka/francuska/rosyjska
+/ukraińska była poprawnie wykrywana, ale jej język NIE był przypisywany —
+mimo że instalacja miała pasujący rekord ``Jezyk``.
+
+Te testy pinują oczekiwanie: jeśli istnieje ``Jezyk`` z danym
+``skrot_crossref``, autodetekcja przypisuje go do sesji — także dla kodów
+spoza {en, es, pl}.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from importer_publikacji.providers import FetchedPublication
+from importer_publikacji.tasks import _auto_match_type_and_language
+
+
+def _jezyk(skrot_crossref, nazwa, skrot):
+    """Pobierz/utwórz Jezyk o danym skrot_crossref.
+
+    Baseline bazy ma już rekordy języków (z reguły bez skrot_crossref),
+    więc dopasowujemy po unikalnym skrot_crossref i nie kolidujemy z
+    nazwą/skrótem rekordów referencyjnych.
+    """
+    from bpp.models import Jezyk
+
+    obj, _ = Jezyk.objects.get_or_create(
+        skrot_crossref=skrot_crossref,
+        defaults={"nazwa": nazwa, "skrot": skrot},
+    )
+    return obj
+
+
+def _session(importer_user):
+    from importer_publikacji.models import ImportSession
+
+    return ImportSession.objects.create(
+        created_by=importer_user,
+        provider_name="BibTeX",
+        identifier="repro-fd389",
+        raw_data={},
+        normalized_data={"title": "x"},
+    )
+
+
+@pytest.mark.django_db
+def test_jezyk_podany_przez_zrodlo_spoza_enum_zostaje_przypisany(importer_user):
+    """Źródło podaje język "de" (spoza {en, es, pl}); istnieje Jezyk z
+    skrot_crossref="de" → po dopasowaniu session.jezyk == ten Jezyk.
+    """
+    jez_de = _jezyk("de", "TEST-niemiecki-fd389", "tde389")
+    session = _session(importer_user)
+    result = FetchedPublication(
+        raw_data={},
+        title="Der Einfluss von Umweltfaktoren auf die Gesundheit",
+        language="de",
+    )
+
+    _auto_match_type_and_language(session, result)
+
+    assert session.jezyk == jez_de
+
+
+@pytest.mark.django_db
+def test_jezyk_wykryty_heurystycznie_spoza_enum_zostaje_przypisany(importer_user):
+    """Źródło NIE podaje języka; wykrywanie zwraca "de"; istnieje Jezyk z
+    skrot_crossref="de" → session.jezyk == ten Jezyk.
+
+    Wykrywanie patchujemy, by test był deterministyczny niezależnie od
+    biblioteki langdetect — sprawdzamy ścieżkę przypisania, nie samą
+    bibliotekę.
+    """
+    jez_de = _jezyk("de", "TEST-niemiecki-fd389", "tde389")
+    session = _session(importer_user)
+    result = FetchedPublication(
+        raw_data={},
+        title="Der Einfluss von Umweltfaktoren auf die Gesundheit",
+        language=None,
+    )
+
+    with patch("importer_publikacji.views.helpers._detect_language", return_value="de"):
+        _auto_match_type_and_language(session, result)
+
+    assert session.jezyk == jez_de
+
+
+@pytest.mark.django_db
+def test_jezyk_z_enum_nadal_dziala(importer_user):
+    """Regression guard: kod z enuma ({en}) nadal dopasowuje się przez
+    Komparator gdy istnieje pasujący Jezyk.
+    """
+    jez_en = _jezyk("en", "TEST-angielski-fd389", "ten389")
+    session = _session(importer_user)
+    result = FetchedPublication(
+        raw_data={},
+        title="The influence of environmental factors on health",
+        language="en",
+    )
+
+    _auto_match_type_and_language(session, result)
+
+    assert session.jezyk == jez_en


### PR DESCRIPTION
## Zgłoszenie

Fixes Freshdesk **FD#389** — https://iplweb.freshdesk.com/a/tickets/389
(_Importer publikacji — autodetekcja języka pracy_)

## Problem

Importer publikacji **już** wykrywa język pracy (`_detect_language` —
heurystyka polskich znaków diakrytycznych + `langdetect`). Wykryty (lub
podany przez źródło: CrossRef `language`, PBN `mainLanguage`, BibTeX
`language`) kod był jednak mapowany na obiekt `Jezyk` **wyłącznie** przez
`Komparator.porownaj_language`, które twardo odrzuca każdy kod spoza
statycznego enuma `Jezyk.SKROT_CROSSREF` = `{en, es, pl}`
(`crossref_bpp/core.py:586`).

Skutek: publikacja niemiecka / francuska / rosyjska / ukraińska (częste w
polskich bibliografiach) była **wykrywana**, ale jej język **nie był
przypisywany** — pole zostawało puste, mimo że instalacja miała pasujący
rekord `Jezyk`. Co ciekawe, ścieżka języka **streszczeń** już używała
łagodnego dopasowania (`_resolve_jezyk`), więc zachowanie było niespójne.

## Rozwiązanie

W `_auto_match_type_and_language` (`importer_publikacji/tasks.py`): gdy
`Komparator.porownaj_language` nie zwróci dopasowania, dokładamy fallback
do `_resolve_jezyk(language_code)` — dopasowanie po `skrot_crossref`, ta
sama logika, której importer używa już dla języka streszczeń.

- Bez migracji, bez zmiany enuma `SKROT_CROSSREF` (zmiana `TextChoices`
  wygenerowałaby migrację).
- Zachowuje dotychczasowe zachowanie dla `{en, es, pl}` (komparator nadal
  pierwszy).
- Język podany przez źródło ma pierwszeństwo nad heurystyką (bez zmian).

## Testy (TDD)

Nowy `src/importer_publikacji/tests/test_repro_fd389.py` — najpierw
czerwony, potem zielony:

1. język `de` podany przez źródło + istnieje `Jezyk(skrot_crossref="de")`
   → `session.jezyk` przypisany,
2. język `de` wykryty (patch `_detect_language`) → przypisany,
3. _regression guard_: kod z enuma (`en`) nadal dopasowuje się przez
   `Komparator`.

Cała aplikacja: `416 passed, 1 skipped` (bez regresji).

🤖 Generated with [Claude Code](https://claude.com/claude-code)