### PR TITLE
fix(raport_slotow): PDF raportu slotów-autora bez chrome strony (FD#405)

### DIFF
--- a/src/bpp/newsfragments/+fd405.bugfix.md
+++ b/src/bpp/newsfragments/+fd405.bugfix.md
@@ -1,0 +1,6 @@
+Eksport raportu slotów - autor do PDF zawiera teraz wyłącznie sam raport.
+Wcześniej do pliku PDF potrafiło wyciec menu serwisu, surowy szablon
+powiadomień (`{{#clickURL}}`) i stopka strony — działo się tak, gdy serwer
+nie zdążył dociągnąć stylów do wydruku. PDF jest teraz generowany z
+dedykowanego, samowystarczalnego szablonu, więc wygląda poprawnie niezależnie
+od stanu plików statycznych (FD#405).

--- a/src/django_bpp/templates/base.html
+++ b/src/django_bpp/templates/base.html
@@ -67,7 +67,10 @@
         });
     </script>
     {% load notifications %}
-    <div id="messageTemplate">
+    {# inline display:none (a nie tylko reguła w SCSS) jest celowy: gdy CSS #}
+    {# serwisu się nie wczyta (np. wydruk / WeasyPrint), surowy szablon #}
+    {# mustache nie może wyciec do treści — patrz FD#405. #}
+    <div id="messageTemplate" style="display: none">
     {% verbatim messageTemplate %}
     <div data-closable
          data-url="{{ closeURL }}"

--- a/src/raport_slotow/templates/raport_slotow/raport_slotow_autor_pdf.html
+++ b/src/raport_slotow/templates/raport_slotow/raport_slotow_autor_pdf.html
@@ -1,0 +1,77 @@
+{% load render_table from django_tables2 %}<!DOCTYPE html>
+{# Goły szablon raportu slotów-autora przeznaczony WYŁĄCZNIE do PDF-a #}
+{# (WeasyPrint). Świadomie NIE rozszerza base.html — nie ma tu menu, #}
+{# stopki serwisu, szablonu powiadomień #messageTemplate ani JS-a, więc #}
+{# nic z "chrome" strony nie może wyciec do PDF-a (FD#405). #}
+{# CSS jest wpisany poniżej w całości: WeasyPrint nie musi dociągać #}
+{# zbundlowanego CSS-a serwisu (co na produkcji bywa zawodne — hashowane #}
+{# statyki + self-fetch po HTTP), więc wydruk jest deterministyczny. #}
+<html lang="pl">
+<head>
+    <meta charset="utf-8">
+    <title>Raport slotów - {{ autor }} za {{ od_roku }} - {{ do_roku }}</title>
+    <style>
+        @page {
+            size: A4 landscape;
+            margin: 1.2cm 1cm;
+        }
+        body {
+            font-family: "DejaVu Sans", Arial, sans-serif;
+            font-size: 8pt;
+            color: #000;
+        }
+        h1 { font-size: 14pt; margin: 0 0 .2em; }
+        h2 { font-size: 11pt; margin: 0 0 .4em; font-weight: normal; }
+        h4 { font-size: 9pt; margin: .4em 0; font-weight: normal; }
+        .meta { margin-bottom: .4em; }
+        .meta strong { margin-right: .2em; }
+        .meta-sep { padding-left: 2em; }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: .5em;
+            table-layout: fixed;
+        }
+        /* powtarzaj nagłówek tabeli na każdej stronie wydruku */
+        thead { display: table-header-group; }
+        tr { page-break-inside: avoid; }
+        th, td {
+            border: .5pt solid #999;
+            padding: 2pt 3pt;
+            text-align: left;
+            vertical-align: top;
+            word-wrap: break-word;
+            overflow-wrap: break-word;
+        }
+        th { background: #e8e8e8; font-weight: bold; }
+        a { color: #000; text-decoration: none; }
+        .pdf-footer {
+            margin-top: .8em;
+            font-size: 7pt;
+            color: #555;
+            border-top: .5pt solid #ccc;
+            padding-top: .3em;
+        }
+    </style>
+</head>
+<body>
+    <h1>Raport slotów</h1>
+    <h2>{{ autor }} za {{ od_roku }} - {{ do_roku }}</h2>
+
+    <div class="meta">
+        {% if autor.orcid %}<strong>ORCID:</strong> {{ autor.orcid }}<span class="meta-sep"></span>{% endif %}
+        {% if autor.pbn_id %}<strong>PBN ID:</strong> {{ autor.pbn_id }}<span class="meta-sep"></span>{% endif %}
+        {% if autor.pbn_uuid %}<strong>PBN UUID:</strong> {{ autor.pbn_uuid }}<span class="meta-sep"></span>{% endif %}
+        <strong>BPP ID:</strong> {{ autor.pk }}
+    </div>
+    <h4>{{ opis_dzialania }}</h4>
+
+    {% for table in tables %}
+        {% render_table table %}
+    {% endfor %}
+
+    <div class="pdf-footer">
+        Wygenerowano dnia {{ wygenerowano }}, BPP wersja {{ wersja }}.
+    </div>
+</body>
+</html>

--- a/src/raport_slotow/tests/test_views/test_repro_fd405.py
+++ b/src/raport_slotow/tests/test_views/test_repro_fd405.py
@@ -1,0 +1,64 @@
+"""Repro dla FD#405 — eksport PDF raportu slotów-autora.
+
+Objaw zgłoszony przez klienta (publikacje.up.lublin.pl): wygenerowany PDF
+zawiera „chrome" strony WWW — górne menu, surowy szablon mustache
+``{{#clickURL}}``, link „Przejdź do głównej zawartości" i stopkę serwisu —
+zamiast samego raportu. Przyczyna: gałąź PDF renderowała pełny szablon
+``base.html`` i podawała go WeasyPrintowi, licząc na ukrycie chrome przez
+reguły ``@media print`` ze skompilowanego CSS, który na produkcji się nie
+wczytuje.
+
+Test przechwytuje HTML przekazywany do WeasyPrint (bez realnego renderowania
+PDF) i sprawdza, że chrome NIE wycieka, a treść raportu jest obecna.
+"""
+
+from unittest import mock
+
+from django.urls import reverse
+
+
+def _otworz_raport(admin_app, autor):
+    url = reverse("raport_slotow:index")
+    form_page = admin_app.get(url)
+
+    autor_form = None
+    for form in form_page.forms.values():
+        if "obiekt" in form.fields:
+            autor_form = form
+            break
+    assert autor_form is not None, "Form with 'obiekt' field not found"
+    autor_form["obiekt"].force_value(autor.pk)
+    return autor_form.submit().maybe_follow()
+
+
+def test_repro_fd405_pdf_bez_chrome(admin_app, autor_jan_kowalski):
+    raport_page = _otworz_raport(admin_app, autor_jan_kowalski)
+
+    captured = {}
+
+    class FakeHTML:
+        def __init__(self, *args, string=None, **kwargs):
+            captured["string"] = string
+
+        def write_pdf(self, *args, **kwargs):
+            return b"%PDF-1.7\nfake"
+
+    with mock.patch("weasyprint.HTML", FakeHTML):
+        pdf_page = raport_page.click("pobierz PDF")
+
+    assert pdf_page.status_code == 200
+
+    html = captured.get("string")
+    assert html is not None, "WeasyPrint nie został wywołany z HTML-em"
+    if isinstance(html, bytes):
+        html = html.decode("utf-8")
+
+    # chrome strony WWW NIE może trafiać do PDF:
+    assert "{{#clickURL}}" not in html, "szablon mustache powiadomień wyciekł"
+    assert "messageTemplate" not in html, "div #messageTemplate wyciekł"
+    assert "Przejdź do głównej zawartości" not in html, "skip-link wyciekł do PDF"
+    assert "iplweb" not in html, "stopka serwisu wyciekła do PDF"
+
+    # treść raportu MUSI pozostać:
+    assert "Raport slotów" in html
+    assert str(autor_jan_kowalski) in html

--- a/src/raport_slotow/views/autor.py
+++ b/src/raport_slotow/views/autor.py
@@ -3,16 +3,17 @@ from copy import copy
 
 from django.http import HttpResponse, HttpResponseRedirect
 from django.template.defaultfilters import pluralize
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.views.generic import FormView, TemplateView
 from django_tables2 import MultiTableMixin, RequestConfig
 from django_weasyprint.utils import DjangoURLFetcher
+from formdefaults.helpers import FormDefaultsMixin
 
 from bpp.models import Cache_Punktacja_Autora_Query_View, Dyscyplina_Naukowa
 from django_bpp.version import VERSION
-from formdefaults.helpers import FormDefaultsMixin
 from nowe_raporty.views import BaseRaportAuthMixin
 from raport_slotow.forms.autor import AutorRaportSlotowForm
 from raport_slotow.tables import RaportSlotowAutorTable
@@ -188,26 +189,36 @@ class RaportSlotow(BaseRaportAuthMixin, MyExportMixin, MultiTableMixin, Template
                 new_get = copy(self.request.GET)
                 new_get["_export"] = "html"
                 self.request.GET = new_get
-                context = self.get_context_data(**kwargs)
-                ret = self.render_to_response(context)
+                template_context = self.get_context_data(**kwargs)
+                template_context["wersja"] = VERSION
+                template_context["wygenerowano"] = timezone.make_naive(timezone.now())
 
-                # UWAGA: jeżeli w wygenerowanej stronie WWW cokolwiek będzie dostępne
-                # za hasłem, to może się ona nie wygenerować prawidłowo. Żeby wyrenderować
-                # PDFa, serwer wstecznie odpytuje sam siebie - o CSSy, obrazki, fonty itp.
-                # Jeżeli nagle będziemy mieli jakis zahasłowany statyczny asset, to będzie
-                # trzeba go tutaj udostępnić, żeby WeasyPrint miał ułatwione zadanie.
-                # (mpasternak, 17.03.2021)
+                # PDF renderujemy z osobnego, "gołego" szablonu (bez menu,
+                # stopki serwisu, szablonu powiadomień #messageTemplate ani
+                # JS-a), a CSS jest wpisany w ten szablon w całości. Dzięki
+                # temu WeasyPrint nie musi dociągać zbundlowanego CSS-a
+                # serwisu — co na produkcji bywa zawodne (hashowane statyki +
+                # self-fetch po HTTP) i powodowało wyciek całego "chrome"
+                # strony do PDF-a (FD#405). url_fetcher zostaje jako zabez
+                # pieczenie, ale goły szablon nie odwołuje się do zasobów
+                # zewnętrznych, więc nie jest już krytyczny.
+                html_string = render_to_string(
+                    "raport_slotow/raport_slotow_autor_pdf.html",
+                    template_context,
+                    request=self.request,
+                )
+
                 from weasyprint import HTML
 
                 # disable host and certificate check
-                context = ssl.create_default_context()
-                context.check_hostname = False
-                context.verify_mode = ssl.CERT_NONE
-                url_fetcher = DjangoURLFetcher(ssl_context=context)
+                ssl_context = ssl.create_default_context()
+                ssl_context.check_hostname = False
+                ssl_context.verify_mode = ssl.CERT_NONE
+                url_fetcher = DjangoURLFetcher(ssl_context=ssl_context)
 
                 response = HttpResponse(
                     content=HTML(
-                        string=ret.render().content,
+                        string=html_string,
                         base_url=self.request.build_absolute_uri(),
                         url_fetcher=url_fetcher,
                     ).write_pdf(),


### PR DESCRIPTION
## Problem (FD#405)

Klient **publikacje.up.lublin.pl** (zgł. Iwona Zakrzewska) — eksport
**raportu slotów - autor** do PDF zawiera „chrome" strony WWW zamiast samego
raportu: górne menu (jako goła lista punktowana), surowy szablon mustache
`{{#clickURL}}`, link „Przejdź do głównej zawartości" oraz stopkę serwisu
(„Oprogramowanie BPP © … iplweb", „Dokument wygenerowano…"). Realny PDF z
ticketu miał 14 stron, z czego pierwsze 3 to czysty chrome — tabela raportu
zaczynała się dopiero na stronie 4.

## Root cause

Gałąź PDF w `RaportSlotow.get()` renderowała **pełny** szablon
`raport_slotow_autor.html` (→ `base.html` → `bare.html`, z menu, stopką i
`#messageTemplate`) i podawała go WeasyPrintowi, licząc na ukrycie chrome
regułami `@media print` / `display:none` ze **skompilowanego CSS-a**.

Na produkcji ten CSS się nie wczytywał:
`DjangoURLFetcher` (django-weasyprint) dla statyków pod `STATIC_URL` przy
`DEBUG=False` robi odwrotny lookup w manifeście `ManifestStaticFilesStorage`
(`TolerantManifestStaticFilesStorage`), a potem `staticfiles.finders.find()`
— który szuka w **źródłowych** katalogach `static/`, nie w `STATIC_ROOT`.
Gdy plik nie zostanie znaleziony, fetcher spada do realnego **self-fetch po
HTTP** do samego serwera (stąd już wyłączone sprawdzanie SSL w kodzie). Na UP
ta ścieżka pada → **0 CSS → nic się nie chowa → cały chrome wchodzi do PDF**.
To regresja od przejścia na hashowane statyki.

Dodatkowo `#messageTemplate` (mustache powiadomień) miał `display:none`
przeniesiony z inline-style do SCSS — więc jego ukrycie też zależało od
wczytania CSS-a i wyciekał niezależnie od reszty.

## Rozwiązanie (A + B + D)

- **A.** PDF renderowany z nowego, gołego szablonu
  `raport_slotow_autor_pdf.html` — **bez** `base.html`, menu, stopki,
  `#messageTemplate` i JS-a. Chrome'u fizycznie nie ma w HTML-u.
- **B.** CSS wpisany w ten szablon w całości (landscape A4, stylowanie tabeli,
  powtarzanie nagłówka na stronach). WeasyPrint **niczego nie dociąga** →
  wydruk deterministyczny niezależnie od stanu plików statycznych. Odpowiada
  to też na „co gdy użyjemy WeasyPrint w przyszłości" — wzorzec: nie polegać
  na zbundlowanym CSS serwisu, tylko inline'ować to, czego PDF potrzebuje.
- **D.** `#messageTemplate` w `base.html` znów ma inline `style="display:none"`
  (obok reguły w SCSS) — surowy mustache nie wyciecze przy braku CSS, również
  przy wydruku z przeglądarki i przyszłym użyciu WeasyPrint.

Stopka PDF: zostawiona **minimalna** linijka „Wygenerowano dnia …, BPP wersja
…" (przydatna na raporcie do nagród/ewaluacji); usunięto marketing iplweb,
„Baza danych ©" i linijkę o JavaScript. Łatwo wyciąć całkiem, jeśli klient woli.

## Testy

- Nowy `test_repro_fd405` — mockuje `weasyprint.HTML`, przechwytuje HTML
  podawany do WeasyPrint i sprawdza brak `{{#clickURL}}`, `messageTemplate`,
  skip-linka i stopki `iplweb`, przy zachowanej treści raportu. Najpierw
  czerwony (repro), po fixie zielony.
- Istniejący `test_RaportSlotow_get_pdf` (realny render PDF przez WeasyPrint)
  nadal zielony → goły szablon produkuje poprawny `%PDF-1.7`.
- Cały `test_views/` + `test_raport_slotow_autor/`: 35 passed.

## Uwaga na przyszłość

`ssl_context` w gałęzi PDF nadal wyłącza weryfikację TLS (kod przeniesiony,
nie nowy). Po tym fixie goły szablon nie dociąga zasobów zewnętrznych, więc
ten `url_fetcher` jest już w praktyce zbędny — można go usunąć w osobnym PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)