### PR TITLE
SEO: metadane cytowań do <head>, canonical/description/OG, sitemap w robots.txt

### DIFF
--- a/src/bpp/newsfragments/+seo-head-metadata.feature
+++ b/src/bpp/newsfragments/+seo-head-metadata.feature
@@ -1,0 +1,6 @@
+SEO: metadane cytowań (Google Scholar, Dublin Core, PRISM, JSON-LD) na
+stronie opisu publikacji przeniesione do sekcji `<head>` (wcześniej trafiały
+do `<body>`, gdzie parsery Google Scholar je ignorowały). Dodano link
+kanoniczny, opis (`meta description`) i tagi Open Graph dla strony publikacji
+oraz domyślne dla całego serwisu, a `robots.txt` ogłasza teraz host-zależny
+adres sitemapy.

--- a/src/bpp/templates/browse/bibliography_metadata.html
+++ b/src/bpp/templates/browse/bibliography_metadata.html
@@ -39,27 +39,11 @@ like Zotero, Mendeley, EndNote, etc.
     <meta name="DC.relation" content="{{ praca.public_www|default:praca.www }}" />
 {% endif %}
 
-{% comment %} Enhanced Highwire/Google Scholar Tags {% endcomment %}
-{% if praca.doi %}
-    <meta name="citation_doi" content="{{ praca.doi }}" />
-{% endif %}
-{% if praca.isbn %}
-    <meta name="citation_isbn" content="{{ praca.isbn }}" />
-{% endif %}
-{% if praca.issn %}
-    <meta name="citation_issn" content="{{ praca.issn }}" />
-{% endif %}
-{% if praca.wydawca %}
-    <meta name="citation_publisher" content="{{ praca.wydawca }}" />
-{% endif %}
-{% if praca.streszczenia.exists %}
-    {% for streszczenie in praca.streszczenia.all %}
-        {% if forloop.first %}
-            <meta name="citation_abstract" content="{{ streszczenie.streszczenie|striptags|truncatewords:150 }}" />
-        {% endif %}
-    {% endfor %}
-{% endif %}
-<meta name="citation_language" content="{{ praca.jezyk.skrot|default:'pl' }}" />
+{% comment %}
+Pozostałe tagi citation_* (doi, isbn, issn, publisher, abstract, language)
+emituje browse/google_scholar.html, dołączany do <head> obok tego pliku —
+tu zostaje tylko citation_pmid, którego tamten szablon nie ma.
+{% endcomment %}
 {% if praca.pubmed_id %}
     <meta name="citation_pmid" content="{{ praca.pubmed_id }}" />
 {% endif %}

--- a/src/bpp/templates/browse/bibliography_metadata.html
+++ b/src/bpp/templates/browse/bibliography_metadata.html
@@ -91,13 +91,13 @@ tu zostaje tylko citation_pmid, którego tamten szablon nie ma.
     {% for autor in autorzy %}
     {
       "@type": "Person",
-      "name": "{{ autor.autor.imiona }} {{ autor.autor.nazwisko }}",
-      "givenName": "{{ autor.autor.imiona }}",
-      "familyName": "{{ autor.autor.nazwisko }}"
+      "name": {{ autor.autor.imiona|add:" "|add:autor.autor.nazwisko|jsonify }},
+      "givenName": {{ autor.autor.imiona|jsonify }},
+      "familyName": {{ autor.autor.nazwisko|jsonify }}
       {% if autor.autor.orcid %},"identifier": {
         "@type": "PropertyValue",
         "propertyID": "ORCID",
-        "value": "{{ autor.autor.orcid }}"
+        "value": {{ autor.autor.orcid|jsonify }}
       }{% endif %}
     }{% if not forloop.last %},{% endif %}
     {% endfor %}

--- a/src/bpp/templates/browse/google_scholar.html
+++ b/src/bpp/templates/browse/google_scholar.html
@@ -33,9 +33,7 @@ These tags are recognized by Google Scholar and most reference managers
 {% if praca.wydawca %}
     <meta name="citation_publisher" content="{{ praca.wydawca }}">
 {% endif %}
-{% if praca.jezyk %}
-    <meta name="citation_language" content="{% if praca.jezyk.skrot %}{{ praca.jezyk.skrot }}{% else %}pl{% endif %}">
-{% endif %}
+<meta name="citation_language" content="{% if praca.jezyk.skrot %}{{ praca.jezyk.skrot }}{% else %}pl{% endif %}">
 {% if praca.public_www %}
     <meta name="citation_pdf_url" content="{{ praca.public_www }}">
 {% elif praca.www %}

--- a/src/bpp/templates/browse/praca.html
+++ b/src/bpp/templates/browse/praca.html
@@ -5,6 +5,43 @@
     {{ rekord.tytul_oryginalny|striptags }}
 {% endblock %}
 
+{# Kanoniczny URL rekordu = adres po slugu (widok i tak tam przekierowuje). #}
+{# Bez tego warianty z parametrami zapytania rozpraszałyby ranking. #}
+{% block canonical %}
+    {% if request %}
+        <link rel="canonical"
+              href="{{ request.scheme }}://{{ request.get_host }}{% if rekord.slug %}{% url 'bpp:browse_praca_by_slug' rekord.slug %}{% else %}{{ rekord.get_absolute_url }}{% endif %}"/>
+    {% endif %}
+{% endblock %}
+
+{# Opis (snippet w Google) z opisu bibliograficznego rekordu. #}
+{% block meta_description %}
+    <meta name="description"
+          content="{{ rekord.opis_bibliograficzny_cache|striptags|truncatewords:40 }}"/>
+{% endblock %}
+
+{# Open Graph — podgląd publikacji przy udostępnianiu w sieci. #}
+{% block opengraph %}
+    <meta property="og:type" content="article"/>
+    <meta property="og:site_name" content="Bibliografia Publikacji {{ uczelnia.skrot }}"/>
+    <meta property="og:title" content="{{ rekord.tytul_oryginalny|striptags }}"/>
+    <meta property="og:description"
+          content="{{ rekord.opis_bibliograficzny_cache|striptags|truncatewords:40 }}"/>
+    {% if request %}
+        <meta property="og:url"
+              content="{{ request.scheme }}://{{ request.get_host }}{% if rekord.slug %}{% url 'bpp:browse_praca_by_slug' rekord.slug %}{% else %}{{ rekord.get_absolute_url }}{% endif %}"/>
+    {% endif %}
+{% endblock %}
+
+{# Metadane cytowań (Highwire/Google Scholar, Dublin Core, PRISM, JSON-LD) #}
+{# MUSZĄ być w <head> — parsery Scholara i menedżery bibliografii ignorują #}
+{# <meta> w body. Dlatego wstrzykujemy je przez extrahead, nie w content. #}
+{% block extrahead %}
+    {{ block.super }}
+    {% include "browse/bibliography_metadata.html" with praca=rekord.original autorzy=rekord.original.autorzy_dla_opisu %}
+    {% include "browse/google_scholar.html" with praca=rekord.original autorzy=rekord.original.autorzy_dla_opisu rekord=rekord %}
+{% endblock %}
+
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -15,5 +52,4 @@
 
 {% block content %}
     {% include "browse/praca_tabela_mono.html" with praca=rekord.original autorzy=rekord.original.autorzy_dla_opisu rekord=rekord links="normal"%}
-    {% include "browse/google_scholar.html" with praca=rekord.original autorzy=rekord.original.autorzy_dla_opisu rekord=rekord %}
 {% endblock %}

--- a/src/bpp/templates/browse/praca_tabela_mono.html
+++ b/src/bpp/templates/browse/praca_tabela_mono.html
@@ -1,9 +1,8 @@
 {% load prace user_in_group dspace_links %}
 
-{% comment %} Include bibliography metadata in head section {% endcomment %}
-{% if not request.is_ajax %}
-    {% include "browse/bibliography_metadata.html" with praca=praca autorzy=autorzy %}
-{% endif %}
+{# Metadane bibliograficzne (citation_*, DC, PRISM, JSON-LD) są teraz #}
+{# wstrzykiwane do <head> przez browse/praca.html (blok extrahead) — #}
+{# parsery Google Scholar czytają wyłącznie head, nie body. #}
 
 <!-- Main publication container with modern card layout -->
 <div class="praca-mono">

--- a/src/bpp/templatetags/prace.py
+++ b/src/bpp/templatetags/prace.py
@@ -119,13 +119,33 @@ def safe_streszczenie(value):
 
 @register.filter(name="jsonify")
 def jsonify(value):
-    """Convert a value to JSON string for use in JSON-LD structured data."""
+    """Convert a value to a JSON literal for use inside a <script> JSON-LD block.
+
+    Zwraca `mark_safe`, więc autoescaping Django NIE zamieni cudzysłowów
+    JSON-a na `&quot;` — to było realnym bugiem: HTML5 nie dekoduje encji
+    w treści `<script>`, więc `"headline": &quot;...&quot;` dawało
+    niepoprawny JSON-LD (Google go odrzucał).
+
+    Skoro pomijamy autoescaping, sami escapujemy znaki groźne wewnątrz
+    `<script>` (`<`, `>`, `&` oraz separatory linii U+2028/U+2029) na
+    sekwencje `\\uXXXX` — to wciąż poprawny JSON, a zarazem uniemożliwia
+    wyłamanie się z taga przez `</script>` (ochrona przed XSS). Ta sama
+    technika co `django.utils.html.json_script`.
+    """
     if value is None:
-        return "null"
+        return mark_safe("null")
     # Handle Django model instances by converting them to string
     if hasattr(value, "_meta"):
         value = str(value)
-    return json.dumps(value, ensure_ascii=False)
+    result = json.dumps(value, ensure_ascii=False)
+    result = (
+        result.replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace(" ", "\\u2028")
+        .replace(" ", "\\u2029")
+    )
+    return mark_safe(result)
 
 
 @register.simple_tag

--- a/src/bpp/tests/test_views/test_seo_metadata.py
+++ b/src/bpp/tests/test_views/test_seo_metadata.py
@@ -79,6 +79,49 @@ def test_json_ld_obecny(client, rekord_publikacji):
 
 
 @pytest.mark.django_db(transaction=True)
+def test_json_ld_poprawny_json_przy_groznych_znakach(client, db, transactional_db):
+    """JSON-LD musi być poprawnym JSON-em nawet gdy dane mają " < & </script>.
+
+    Regresja: autoescaping zamieniał cudzysłowy z `jsonify` na `&quot;`, a
+    HTML5 nie dekoduje encji w <script> — JSON-LD był niepoprawny i Google
+    go odrzucał. Filtr `jsonify` zwraca teraz mark_safe + escapuje <, >, &.
+    """
+    import json
+    import re
+
+    rebuild_contenttypes()
+    aut, _ = Typ_Odpowiedzialnosci.objects.get_or_create(
+        skrot="aut.", defaults={"nazwa": "autor"}
+    )
+    ch, _ = Charakter_Formalny.objects.get_or_create(
+        skrot="AC",
+        defaults={"nazwa": "Artykuł", "nazwa_w_primo": "Artykuł"},
+    )
+    c = any_ciagle(
+        tytul_oryginalny='Tytuł z " cudzysłowem & <b>znacznikiem</b>',
+        charakter_formalny=ch,
+        rok=2024,
+    )
+    a = baker.make(Autor, nazwisko='O"Brien & <Co>', imiona="Jan")
+    j = baker.make(Jednostka)
+    Wydawnictwo_Ciagle_Autor.objects.create(
+        rekord=c, autor=a, jednostka=j, typ_odpowiedzialnosci=aut
+    )
+    Rekord.objects.full_refresh()
+    rekord = Rekord.objects.first()
+
+    html = client.get(rekord.get_absolute_url(), follow=True).content.decode("utf-8")
+    payload = re.search(
+        r'<script type="application/ld\+json">(.*?)</script>', html, re.S
+    ).group(1)
+
+    parsed = json.loads(payload)  # rzuci, jeśli JSON-LD jest niepoprawny
+    assert parsed["author"][0]["name"] == 'Jan O"Brien & <Co>'
+    # Brak dosłownego "<" w payloadzie => nie da się wyłamać przez </script>.
+    assert "<" not in payload
+
+
+@pytest.mark.django_db(transaction=True)
 def test_link_kanoniczny(client, rekord_publikacji):
     res = client.get(rekord_publikacji.get_absolute_url(), follow=True)
     head = _head(res)
@@ -110,3 +153,20 @@ def test_robots_txt_wskazuje_sitemap(client):
     assert "/sitemap.xml" in body
     # Lista Disallow ze statycznego pliku nadal obecna.
     assert "Disallow:" in body
+
+
+@pytest.mark.django_db
+def test_robots_txt_sitemap_zalezna_od_hosta(client, settings):
+    """Sitemap musi wskazywać host requestu, a odpowiedź mieć Vary: Host.
+
+    Bez Vary: Host owijający cache_page zaserwowałby pierwszemu hostowi
+    cache współdzielony z innymi domenami multi-hosted.
+    """
+    settings.ALLOWED_HOSTS = ["bpp.uczelnia-a.pl", "bpp.uczelnia-b.pl"]
+
+    res_a = client.get(reverse("robots_txt"), HTTP_HOST="bpp.uczelnia-a.pl")
+    res_b = client.get(reverse("robots_txt"), HTTP_HOST="bpp.uczelnia-b.pl")
+
+    assert "Sitemap: http://bpp.uczelnia-a.pl/sitemap.xml" in res_a.content.decode()
+    assert "Sitemap: http://bpp.uczelnia-b.pl/sitemap.xml" in res_b.content.decode()
+    assert "Host" in res_a.get("Vary", "")

--- a/src/bpp/tests/test_views/test_seo_metadata.py
+++ b/src/bpp/tests/test_views/test_seo_metadata.py
@@ -1,0 +1,112 @@
+"""Testy metadanych SEO na stronie opisu publikacji.
+
+Tagi cytowań (Highwire/Google Scholar, Dublin Core, PRISM) MUSZĄ trafić do
+sekcji <head> dokumentu — parsery Google Scholar i menedżery bibliografii
+czytają wyłącznie head, ignorując <meta> w body. Dodatkowo strona opisu
+powinna mieć link kanoniczny, opis (meta description) i tagi Open Graph.
+"""
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.models import Autor, Jednostka
+from bpp.models.cache import Rekord
+from bpp.models.system import Charakter_Formalny, Typ_Odpowiedzialnosci
+from bpp.models.wydawnictwo_ciagle import Wydawnictwo_Ciagle_Autor
+from bpp.tests.util import any_ciagle
+from bpp.util import rebuild_contenttypes
+
+
+@pytest.fixture
+def rekord_publikacji(db, transactional_db):
+    rebuild_contenttypes()
+
+    aut, _ = Typ_Odpowiedzialnosci.objects.get_or_create(
+        skrot="aut.", defaults={"nazwa": "autor"}
+    )
+    ch, _ = Charakter_Formalny.objects.get_or_create(
+        skrot="AC",
+        defaults={"nazwa": "Artykuł w czasopiśmie", "nazwa_w_primo": "Artykuł"},
+    )
+
+    c = any_ciagle(
+        tytul_oryginalny="Badanie wpływu czegoś na coś",
+        charakter_formalny=ch,
+        doi="10.1234/przykladowy.doi",
+        rok=2024,
+    )
+    a = baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
+    j = baker.make(Jednostka)
+    Wydawnictwo_Ciagle_Autor.objects.create(
+        rekord=c, autor=a, jednostka=j, typ_odpowiedzialnosci=aut
+    )
+
+    Rekord.objects.full_refresh()
+    return Rekord.objects.get(tytul_oryginalny="Badanie wpływu czegoś na coś")
+
+
+def _head(response):
+    """Zwróć fragment <head> odpowiedzi (wszystko przed <body)."""
+    html = response.content.decode("utf-8")
+    return html.split("<body", 1)[0]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_citation_tags_w_head(client, rekord_publikacji):
+    """Tagi citation_* Google Scholar muszą być w <head>, nie w <body>."""
+    res = client.get(rekord_publikacji.get_absolute_url(), follow=True)
+    assert res.status_code == 200
+    head = _head(res)
+    assert 'name="citation_title"' in head
+    assert 'name="citation_author"' in head
+    assert 'name="citation_doi"' in head
+
+
+@pytest.mark.django_db(transaction=True)
+def test_dublin_core_w_head(client, rekord_publikacji):
+    res = client.get(rekord_publikacji.get_absolute_url(), follow=True)
+    head = _head(res)
+    assert 'name="DC.title"' in head
+
+
+@pytest.mark.django_db(transaction=True)
+def test_json_ld_obecny(client, rekord_publikacji):
+    res = client.get(rekord_publikacji.get_absolute_url(), follow=True)
+    html = res.content.decode("utf-8")
+    assert 'application/ld+json' in html
+    assert '"@type": "ScholarlyArticle"' in html
+
+
+@pytest.mark.django_db(transaction=True)
+def test_link_kanoniczny(client, rekord_publikacji):
+    res = client.get(rekord_publikacji.get_absolute_url(), follow=True)
+    head = _head(res)
+    assert 'rel="canonical"' in head
+
+
+@pytest.mark.django_db(transaction=True)
+def test_meta_description(client, rekord_publikacji):
+    res = client.get(rekord_publikacji.get_absolute_url(), follow=True)
+    head = _head(res)
+    assert 'name="description"' in head
+
+
+@pytest.mark.django_db(transaction=True)
+def test_open_graph(client, rekord_publikacji):
+    res = client.get(rekord_publikacji.get_absolute_url(), follow=True)
+    head = _head(res)
+    assert 'property="og:title"' in head
+    assert 'property="og:type"' in head
+
+
+@pytest.mark.django_db
+def test_robots_txt_wskazuje_sitemap(client):
+    """robots.txt musi ogłaszać host-zależny adres sitemapy."""
+    res = client.get(reverse("robots_txt"))
+    assert res.status_code == 200
+    body = res.content.decode("utf-8")
+    assert "Sitemap:" in body
+    assert "/sitemap.xml" in body
+    # Lista Disallow ze statycznego pliku nadal obecna.
+    assert "Disallow:" in body

--- a/src/bpp/views/__init__.py
+++ b/src/bpp/views/__init__.py
@@ -13,6 +13,7 @@ except ImportError:
 from django.http import JsonResponse
 from django.http.response import HttpResponse, HttpResponseServerError
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.vary import vary_on_headers
 from django.views.defaults import page_not_found, permission_denied
 from django_sendfile import sendfile
 
@@ -165,6 +166,7 @@ def _read_static_robots(settings):
         return f.read()
 
 
+@vary_on_headers("Host")
 def robots_txt(request):
     """Serwuj robots.txt z host-zależną dyrektywą Sitemap.
 
@@ -172,6 +174,13 @@ def robots_txt(request):
     sitemapy. W produkcji do listy Disallow dopisujemy bezwzględny URL
     sitemapy zbudowany z hosta requestu — poprawny dla każdego z domen
     multi-hosted (hardcode jednej domeny byłby błędny dla pozostałych).
+
+    `vary_on_headers("Host")` jest KONIECZNE: widok jest owinięty w
+    `cache_page` (urls.py), a odpowiedź zależy teraz od hosta. Bez
+    `Vary: Host` pierwszy request po wygaśnięciu cache (np. wewnętrzny
+    `appserver:8000` albo probe po IP) zabetonowałby swój host w
+    sitemapie serwowanej WSZYSTKIM domenom na 24h. Vary keyuje cache
+    per-host.
     """
     from django.conf import settings
 

--- a/src/bpp/views/__init__.py
+++ b/src/bpp/views/__init__.py
@@ -141,15 +141,44 @@ def handler500(request):
     return HttpResponseServerError(body, content_type="text/html; charset=utf-8")
 
 
+def _read_static_robots(settings):
+    """Zwróć treść statycznego robots.txt (lista Disallow).
+
+    Najpierw STATIC_ROOT (produkcja po collectstatic), w razie braku —
+    przez staticfiles finders (dev/test, gdzie collectstatic nie biegł).
+    """
+    import os
+
+    candidate = os.path.join(settings.STATIC_ROOT or "", "robots.txt")
+    if os.path.exists(candidate):
+        path = candidate
+    else:
+        from django.contrib.staticfiles import finders
+
+        path = finders.find("robots.txt")
+
+    if not path:
+        # Nie powinno się zdarzyć — robots.txt jest w src/bpp/static/.
+        return "User-agent: *\n"
+
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
 def robots_txt(request):
-    """Serve robots.txt - restricted version for test environments."""
+    """Serwuj robots.txt z host-zależną dyrektywą Sitemap.
+
+    W konfiguracji testowej blokujemy całość (Disallow: /) i nie ogłaszamy
+    sitemapy. W produkcji do listy Disallow dopisujemy bezwzględny URL
+    sitemapy zbudowany z hosta requestu — poprawny dla każdego z domen
+    multi-hosted (hardcode jednej domeny byłby błędny dla pozostałych).
+    """
     from django.conf import settings
 
     if getattr(settings, "DJANGO_BPP_ENABLE_TEST_CONFIGURATION", False):
-        content = "User-agent: *\nDisallow: /\n"
-    else:
-        from django.views.static import serve as static_serve
+        return HttpResponse("User-agent: *\nDisallow: /\n", content_type="text/plain")
 
-        return static_serve(request, "robots.txt", document_root=settings.STATIC_ROOT)
-
-    return HttpResponse(content, content_type="text/plain")
+    body = _read_static_robots(settings).rstrip("\n")
+    sitemap_url = request.build_absolute_uri("/sitemap.xml")
+    body = f"{body}\n\nSitemap: {sitemap_url}\n"
+    return HttpResponse(body, content_type="text/plain")

--- a/src/django_bpp/templates/bare.html
+++ b/src/django_bpp/templates/bare.html
@@ -11,8 +11,26 @@
         - Bibliografia Publikacji {{ uczelnia.skrot }}
     {% endblock %}</title>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="theme-color" content="#e6e6e6">
+
+    {# SEO: opis strony (snippet w Google). Strony treściowe (opis #}
+    {# publikacji, autor) nadpisują blok własnym, konkretnym opisem. #}
+    {% block meta_description %}
+        <meta name="description"
+              content="Bibliografia Publikacji Pracowników {{ uczelnia.nazwa|default:uczelnia.skrot }} — baza publikacji naukowych."/>
+    {% endblock %}
+
+    {# SEO: link kanoniczny. Domyślnie pusty — strony, które mają #}
+    {# jednoznaczny URL (opis publikacji), wypełniają go same. #}
+    {% block canonical %}{% endblock %}
+
+    {# SEO: Open Graph — podgląd przy udostępnianiu (FB/LinkedIn/Slack). #}
+    {% block opengraph %}
+        <meta property="og:site_name" content="Bibliografia Publikacji {{ uczelnia.skrot }}"/>
+        <meta property="og:type" content="website"/>
+        {% if request %}<meta property="og:url" content="{{ request.build_absolute_uri }}"/>{% endif %}
+    {% endblock %}
 
     {% if uczelnia.pokazuj_deklaracje_dostepnosci == 1 %}
         <meta name="deklaracja-dostępności" content="{{ uczelnia.deklaracja_dostepnosci_url }}"/>


### PR DESCRIPTION
## Kontekst

Pytanie wyjściowe: *czy możemy ułatwić Google szybsze/lepsze indeksowanie, w tym strony opisu publikacji?*

Audyt `bare.html`/`base.html` + ścieżki strony publikacji ujawnił, że BPP ma już sporo (sitemap przez `static_sitemaps`, robots.txt, bogate metadane cytowań, JSON-LD), ale z **kluczowym defektem**: tagi `citation_*`/Dublin Core/PRISM były emitowane w `<body>`, gdzie Google Scholar i menedżery bibliografii ich **nie czytają**.

## Zmiany

**🔴 Krytyczne**
- **Metadane cytowań → `<head>`.** `praca.html` wstrzykuje `bibliography_metadata.html` + `google_scholar.html` przez blok `extrahead` zamiast przez `content`. Usunięte z body (`praca_tabela_mono.html`).
- **`robots.txt` ogłasza sitemapę.** Widok `robots_txt` dokleja host-zależny `Sitemap: https://<host>/sitemap.xml` — poprawny dla każdej z domen multi-hosted (bez hardcode'u jednej domeny).

**🟠 Rdzeń SEO**
- **`<meta name="description">`** — per-page (z opisu bibliograficznego) + domyślny site-wide.
- **`<link rel="canonical">`** — na stronie publikacji wskazuje URL po slugu (eliminuje rozproszenie rankingu przez warianty z query string).

**🟡 Dopełnienie**
- **Open Graph** (`og:type/title/description/url/site_name`) — podgląd przy udostępnianiu; per-page na publikacji + domyślny site-wide.
- **viewport** z `initial-scale=1` (mobile-friendliness).
- **De-dup**: usunięto duplikujące się `citation_*` z `bibliography_metadata.html` (emituje je `google_scholar.html`); zostaje unikalne `citation_pmid`.

## Testy

Nowy `test_seo_metadata.py` (TDD — najpierw RED): weryfikuje, że metadane lądują w `<head>` (split na `<body`), oraz obecność canonical/description/OG i `Sitemap:` w robots.txt. Renderowanie potwierdza: `citation_doi` ×1 w head, 0 tagów citation w body.

- `test_seo_metadata.py`: 7 passed
- `test_views_browse.py`: 22 passed (bez regresji)
- pre-commit: czysto

## Uwagi do review

- JSON-LD (`ScholarlyArticle`/`Book`) działa w body i head — nie wymagał przenoszenia, ale przy okazji jest teraz w head razem z resztą.
- Domyślny site-wide `meta description` jest generyczny — strony treściowe (publikacja) nadpisują własnym; warto z czasem dodać override też dla strony autora/źródła.

🤖 Generated with [Claude Code](https://claude.com/claude-code)