### PR TITLE
Preload fontu Foundation Icons + font-display:block w top_bar (fix tofu w Firefoksie)

### DIFF
--- a/src/bpp/newsfragments/top-bar-ikony-font-preload.bugfix.rst
+++ b/src/bpp/newsfragments/top-bar-ikony-font-preload.bugfix.rst
@@ -1,0 +1,5 @@
+Ikony Foundation w górnym menu (``top_bar.html``) nie pokazywały się przez
+chwilę jako "kwadraciki z kodem" (tofu) w Firefoksie, zanim font ikonowy się
+doczytał. Font ``foundation-icons.woff`` jest teraz preloadowany w ``<head>``,
+a ``@font-face`` ma wymuszone ``font-display: block`` — zamiast pudełek z kodem
+widać pustkę, a po doczytaniu fontu ikona doskakuje.

--- a/src/django_bpp/templates/bare.html
+++ b/src/django_bpp/templates/bare.html
@@ -14,6 +14,16 @@
     <meta name="viewport" content="width=device-width"/>
     <meta name="theme-color" content="#e6e6e6">
 
+    {# Preload fontu ikonowego Foundation: bez tego przeglądarka odkrywa #}
+    {# foundation-icons.woff dopiero po sparsowaniu CSS-u i napotkaniu #}
+    {# elementu .fi-* — co w oknie ładowania pokazuje tofu (kwadraciki #}
+    {# z kodem) zamiast ikon. Preload pobiera font od razu, równolegle. #}
+    {# crossorigin jest wymagane: fonty zawsze fetchowane w trybie CORS, #}
+    {# bez tego atrybutu preload nie zmatchuje i font pobrałby się dwa razy. #}
+    <link rel="preload" as="font" type="font/woff"
+          href="{% static "foundation-datepicker/foundation/fonts/foundation-icons.woff" %}"
+          crossorigin>
+
     {% if uczelnia.pokazuj_deklaracje_dostepnosci == 1 %}
         <meta name="deklaracja-dostępności" content="{{ uczelnia.deklaracja_dostepnosci_url }}"/>
     {% endif %}
@@ -56,6 +66,24 @@
         <link rel="stylesheet" href="{% static "cookielaw/css/cookielaw.css" %}"/>
         <link rel="stylesheet" href="{% static "datatables.net-zf/css/dataTables.foundation.css" %}"/>
     {% endcompress %}
+
+    {# Nadpisanie @font-face Foundation Icons: vendorowy foundation-icons.css #}
+    {# (z node_modules, nie wolno go edytować — nadpisze go make assets) nie #}
+    {# ustawia font-display, więc domyślne 'auto' po block-period pokazuje #}
+    {# fallback → tofu. Redeklaracja tej samej rodziny PO vendorze wygrywa #}
+    {# w kaskadzie i wymusza font-display: block: zamiast kwadracików widać #}
+    {# pustkę, a po doczytaniu fontu ikona doskakuje. URL woff = ten z #}
+    {# preloadu wyżej, więc przeglądarka deduplikuje pobranie. #}
+    <style>
+        @font-face {
+            font-family: "foundation-icons";
+            src: url("{% static "foundation-datepicker/foundation/fonts/foundation-icons.woff" %}") format("woff"),
+                 url("{% static "foundation-datepicker/foundation/fonts/foundation-icons.ttf" %}") format("truetype");
+            font-weight: normal;
+            font-style: normal;
+            font-display: block;
+        }
+    </style>
 
     {# JavaScript bundle - built with esbuild, includes jQuery and all JS deps. #}
     {# Owinięte w {% compress js %}, żeby django-compressor wyemitował plik z #}


### PR DESCRIPTION
## Problem

Ikony Foundation w górnym menu (`top_bar.html`) migały w Firefoksie jako **tofu** — „kwadraciki z kodem" — zanim font ikonowy się doczytał.

Dwie przyczyny:
1. Vendorowy `foundation-icons.css` (z `node_modules/foundation-datepicker`, zbierany do gitignored `staticroot` — **niemodyfikowalny**, `make assets` by nadpisał) **nie ustawia `font-display`**. Domyślne `auto` po ~3 s block-period pokazuje fallback, który nie ma glifów z Private Use Area → tofu.
2. Font był **odkrywany późno** — przeglądarka fetchuje `foundation-icons.woff` dopiero po sparsowaniu CSS-u i napotkaniu elementu `.fi-*`.

## Rozwiązanie

Dwie zmiany w `src/django_bpp/templates/bare.html`:

- **`<link rel="preload" as="font" ... crossorigin>`** wysoko w `<head>` — font pobierany od razu, równolegle z CSS-em. `crossorigin` wymagane (fonty zawsze fetchowane w trybie CORS), inaczej preload nie zmatchuje i font pobrałby się dwa razy.
- **Nadpisanie `@font-face` z `font-display: block`** po vendorowym CSS — wygrywa w kaskadzie; zamiast tofu widać pustkę, a po doczytaniu fontu ikona doskakuje.

URL woff z preloadu i z `@font-face` rozwiązują się (pod `ManifestStaticFilesStorage`) do tej samej zahashowanej nazwy co wewnętrzne `url()` vendorowego CSS → przeglądarka deduplikuje pobranie.

## Weryfikacja

- ✅ Pliki fontów (`foundation-icons.woff` + `.ttf`) istnieją w źródle → brak 404.
- ✅ Fragment renderuje się przez silnik Django bez błędu składni; `{% static %}` rozwiązuje poprawnie.
- ⚠️ Render na żywo w Firefoksie nie potwierdzony (run-site padł w trakcie sesji) — warto zerknąć po deployu/lokalnie.

Bez zmian w SCSS → bez `grunt build`. Sam szablon, łapie się od ręki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)