### PR TITLE
fix(browse): COinS nie wycieka reprów bound-method do tytułu rekordu (FD#420)

### DIFF
--- a/src/bpp/newsfragments/+fd420.bugfix.md
+++ b/src/bpp/newsfragments/+fd420.bugfix.md
@@ -1,0 +1,3 @@
+Tytuł publikacji na stronie rekordu nie jest już zniekształcany przez
+metadane dla menedżerów bibliografii (COinS) — numery stron są poprawnie
+osadzane, zamiast wyciekać jako wewnętrzny tekst diagnostyczny (FD#420).

--- a/src/bpp/templatetags/prace.py
+++ b/src/bpp/templatetags/prace.py
@@ -195,11 +195,16 @@ def generate_coins(praca, autorzy):  # noqa
     if hasattr(praca, "numer_zeszytu") and praca.numer_zeszytu:
         coins_data.append(f"rft.issue={quote(str(praca.numer_zeszytu))}")
 
-    # Pages
-    if hasattr(praca, "pierwsza_strona") and praca.pierwsza_strona:
-        coins_data.append(f"rft.spage={praca.pierwsza_strona}")
-    if hasattr(praca, "ostatnia_strona") and praca.ostatnia_strona:
-        coins_data.append(f"rft.epage={praca.ostatnia_strona}")
+    # Pages — pierwsza_strona/ostatnia_strona to metody, więc trzeba je
+    # wywołać; bez () do title= wyciekał repr bound-methody (FD#420).
+    if hasattr(praca, "pierwsza_strona"):
+        spage = praca.pierwsza_strona()
+        if spage:
+            coins_data.append(f"rft.spage={quote(str(spage))}")
+    if hasattr(praca, "ostatnia_strona"):
+        epage = praca.ostatnia_strona()
+        if epage:
+            coins_data.append(f"rft.epage={quote(str(epage))}")
 
     # Identifiers
     if hasattr(praca, "doi") and praca.doi:

--- a/src/bpp/tests/test_templatetags/test_repro_fd420.py
+++ b/src/bpp/tests/test_templatetags/test_repro_fd420.py
@@ -1,0 +1,43 @@
+"""Repro dla FD#420 — metadane COinS (Z3988) na stronie rekordu.
+
+`pierwsza_strona`/`ostatnia_strona` to metody, a `generate_coins` odwoływał
+się do nich bez `()`, przez co do atrybutu `title` wyciekał repr bound-methody
+(`<bound method ... of <Wydawnictwo_Ciagle: ...>>`). Repr zawiera znaki `"` i
+`<`/`>`, które rozbijały atrybut HTML i psuły wygląd strony.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Wydawnictwo_Ciagle
+from bpp.templatetags.prace import generate_coins
+
+
+@pytest.mark.django_db
+def test_generate_coins_strony_nie_wyciekaja_jako_bound_method():
+    praca = baker.make(
+        Wydawnictwo_Ciagle,
+        tytul_oryginalny="Tytuł testowy",
+        strony="4880-4881",
+    )
+
+    coins = generate_coins(praca, [])
+
+    assert "bound method" not in coins
+    assert "rft.spage=4880" in coins
+    assert "rft.epage=4881" in coins
+
+
+@pytest.mark.django_db
+def test_generate_coins_pusta_strona_pomijana():
+    praca = baker.make(
+        Wydawnictwo_Ciagle,
+        tytul_oryginalny="Tytuł testowy",
+        strony="",
+    )
+
+    coins = generate_coins(praca, [])
+
+    assert "bound method" not in coins
+    assert "rft.spage=" not in coins
+    assert "rft.epage=" not in coins


### PR DESCRIPTION
## Problem

Na stronie rekordu tytuł publikacji wyświetlał się zniekształcony — do
widocznej części strony wyciekał tekst typu
`<bound method ModelZeSzczegolami.pierwsza_strona of <Wydawnictwo_Ciagle: ...>>`.

Zgłoszone z `bpp.ihit.waw.pl` dla rekordu z DOI
`10.1182/blood.v130.suppl_1.4880.4880`, ale dotyczyło **każdego** rekordu.

## Przyczyna

`generate_coins` (template tag budujący metadane COinS/Z3988 dla Zotero,
Mendeley itp.) odwoływał się do `praca.pierwsza_strona` /
`praca.ostatnia_strona` **bez nawiasów** — a to są metody, nie property.
W efekcie:

- bound method jest zawsze truthy → warunek zawsze przechodził (więc bug
  trafiał w każdy rekord, nie tylko ten ze stronami),
- f-string robił `str()` na obiekcie metody → repr `<bound method ...>`,
- repr zawiera `"`, `<`, `>`, a wartość (w odróżnieniu od pozostałych pól)
  nie była przepuszczana przez `quote()`, więc `"` przedwcześnie zamykał
  atrybut `title="..."` w `mark_safe`-owanym spanie i reszta wyciekała do DOM.

W szablonach Django (`{{ praca.pierwsza_strona }}`) to działało, bo szablony
auto-wołają metody — popsuta była tylko ścieżka pythonowa z f-stringiem.

## Poprawka

- wywołujemy metody `pierwsza_strona()` / `ostatnia_strona()`,
- wynik przepuszczamy przez `quote()` jak pozostałe pola COinS,
- guard sprawdza zwróconą wartość, więc puste strony są pomijane.

## Test

Repro `src/bpp/tests/test_templatetags/test_repro_fd420.py` — sprawdza, że
COinS dla rekordu ze `strony="4880-4881"` zawiera `rft.spage=4880` /
`rft.epage=4881` i **nie** zawiera `bound method`, oraz że pusta strona jest
pomijana. Czerwony przed, zielony po. Cały `test_templatetags/`: 27 passed.

Fixes Freshdesk FD#420 — https://iplweb.freshdesk.com/a/tickets/420

🤖 Generated with [Claude Code](https://claude.com/claude-code)