### PR TITLE
refactor: uproszczenie 9 funkcji oznaczonych # noqa: C901 (bez zmiany zachowania)

### DIFF
--- a/src/bpp/export/bibtex.py
+++ b/src/bpp/export/bibtex.py
@@ -113,7 +113,91 @@ def generate_bibtex_key(wydawnictwo) -> str:
     return "_".join(key_parts)
 
 
-def wydawnictwo_ciagle_to_bibtex(wydawnictwo_ciagle) -> str:  # noqa: C901
+def _emit_field(name: str, raw_value, sanitize: bool = True) -> str:
+    """
+    Emit a single ``  name = {value},\n`` BibTeX line, or "" when empty.
+
+    The truthiness of ``raw_value`` decides whether the field appears at all
+    (mirroring the original per-field ``if value:`` guards). String values are
+    escaped through :func:`sanitize_bibtex_string` unless ``sanitize`` is False
+    (used for already-safe values such as the numeric ``year`` and literal
+    ``type``/``note`` markers).
+    """
+    if not raw_value:
+        return ""
+    value = sanitize_bibtex_string(raw_value) if sanitize else raw_value
+    return f"  {name} = {{{value}}},\n"
+
+
+def _build_bibtex_entry(entry_type: str, key: str, fields) -> str:
+    """
+    Assemble a complete BibTeX entry from an ordered field spec.
+
+    Args:
+        entry_type: BibTeX entry type without the ``@`` (e.g. ``"article"``).
+        key: Citation key.
+        fields: Iterable of ``(name, raw_value, sanitize)`` tuples emitted in
+            order; empty values are skipped by :func:`_emit_field`.
+
+    Returns:
+        BibTeX formatted string (trailing comma stripped, closing brace added).
+    """
+    bibtex_entry = f"@{entry_type}{{{key},\n"
+    for name, raw_value, sanitize in fields:
+        bibtex_entry += _emit_field(name, raw_value, sanitize)
+    return bibtex_entry.rstrip(",\n") + "\n}\n"
+
+
+def _address_from_miejsce_i_rok(miejsce_i_rok) -> str | None:
+    """
+    Extract the address portion from a ``miejsce_i_rok`` ("place year") field.
+
+    A trailing 4-digit year token is dropped; the remainder is the address.
+    When no trailing year is present the whole (stripped) field is the address.
+    Returns ``None`` when nothing usable remains.
+    """
+    if not miejsce_i_rok:
+        return None
+    miejsce_i_rok = miejsce_i_rok.strip()
+    parts = miejsce_i_rok.split()
+    if not parts:
+        return None
+    if len(parts) > 1 and re.match(r"\d{4}", parts[-1]):
+        address = " ".join(parts[:-1])
+        return address or None
+    return miejsce_i_rok
+
+
+def _school_from_jednostka(publikacja) -> str | None:
+    """Return the faculty (wydzial) name for a thesis' unit, if available."""
+    jednostka = getattr(publikacja, "jednostka", None)
+    if not jednostka:
+        return None
+    wydzial = getattr(jednostka, "wydzial", None)
+    if not wydzial:
+        return None
+    return wydzial.nazwa
+
+
+def _method_value(publikacja, method_name: str):
+    """
+    Call a no-arg helper method (e.g. ``numer_tomu``) and return ``str`` of a
+    truthy result, else ``None`` — preserving the original ``str(method())``
+    coercion guarded by a truthiness check.
+    """
+    method = getattr(publikacja, method_name, None)
+    if method is None:
+        return None
+    result = method()
+    return str(result) if result else None
+
+
+def _attr(publikacja, name: str):
+    """Return a (possibly nested) attribute or ``None`` if absent/falsy."""
+    return getattr(publikacja, name, None) or None
+
+
+def wydawnictwo_ciagle_to_bibtex(wydawnictwo_ciagle) -> str:
     """
     Convert Wydawnictwo_Ciagle instance to BibTeX format.
 
@@ -123,72 +207,38 @@ def wydawnictwo_ciagle_to_bibtex(wydawnictwo_ciagle) -> str:  # noqa: C901
     Returns:
         BibTeX formatted string
     """
-    key = generate_bibtex_key(wydawnictwo_ciagle)
-    authors = format_authors_bibtex(wydawnictwo_ciagle)
-
-    bibtex_entry = f"@article{{{key},\n"
-
-    # Title
-    if wydawnictwo_ciagle.tytul_oryginalny:
-        title = sanitize_bibtex_string(wydawnictwo_ciagle.tytul_oryginalny)
-        bibtex_entry += f"  title = {{{title}}},\n"
-
-    # Authors
-    if authors:
-        bibtex_entry += f"  author = {{{sanitize_bibtex_string(authors)}}},\n"
-
-    # Journal
-    if hasattr(wydawnictwo_ciagle, "zrodlo") and wydawnictwo_ciagle.zrodlo:
-        journal = sanitize_bibtex_string(wydawnictwo_ciagle.zrodlo.nazwa)
-        bibtex_entry += f"  journal = {{{journal}}},\n"
-
-    # Year
-    if wydawnictwo_ciagle.rok:
-        bibtex_entry += f"  year = {{{wydawnictwo_ciagle.rok}}},\n"
-
-    # Volume (tom)
-    if hasattr(wydawnictwo_ciagle, "numer_tomu") and wydawnictwo_ciagle.numer_tomu():
-        volume = sanitize_bibtex_string(str(wydawnictwo_ciagle.numer_tomu()))
-        bibtex_entry += f"  volume = {{{volume}}},\n"
-
-    # Number (numer wydania/zeszytu)
-    if (
-        hasattr(wydawnictwo_ciagle, "numer_wydania")
-        and wydawnictwo_ciagle.numer_wydania()
-    ):
-        number = sanitize_bibtex_string(str(wydawnictwo_ciagle.numer_wydania()))
-        bibtex_entry += f"  number = {{{number}}},\n"
-
-    # Pages
-    if (
-        hasattr(wydawnictwo_ciagle, "zakres_stron")
-        and wydawnictwo_ciagle.zakres_stron()
-    ):
-        pages = sanitize_bibtex_string(str(wydawnictwo_ciagle.zakres_stron()))
-        bibtex_entry += f"  pages = {{{pages}}},\n"
-
-    # DOI
-    if hasattr(wydawnictwo_ciagle, "doi") and wydawnictwo_ciagle.doi:
-        doi = sanitize_bibtex_string(wydawnictwo_ciagle.doi)
-        bibtex_entry += f"  doi = {{{doi}}},\n"
-
-    # ISSN
-    if hasattr(wydawnictwo_ciagle, "issn") and wydawnictwo_ciagle.issn:
-        issn = sanitize_bibtex_string(wydawnictwo_ciagle.issn)
-        bibtex_entry += f"  issn = {{{issn}}},\n"
-
-    # URL
-    if hasattr(wydawnictwo_ciagle, "www") and wydawnictwo_ciagle.www:
-        url = sanitize_bibtex_string(wydawnictwo_ciagle.www)
-        bibtex_entry += f"  url = {{{url}}},\n"
-
-    # Remove trailing comma and newline, add closing brace
-    bibtex_entry = bibtex_entry.rstrip(",\n") + "\n}\n"
-
-    return bibtex_entry
+    w = wydawnictwo_ciagle
+    zrodlo = _attr(w, "zrodlo")
+    fields = [
+        ("title", w.tytul_oryginalny, True),
+        ("author", format_authors_bibtex(w), True),
+        ("journal", zrodlo.nazwa if zrodlo else None, True),
+        ("year", w.rok, False),
+        ("volume", _method_value(w, "numer_tomu"), True),
+        ("number", _method_value(w, "numer_wydania"), True),
+        ("pages", _method_value(w, "zakres_stron"), True),
+        ("doi", _attr(w, "doi"), True),
+        ("issn", _attr(w, "issn"), True),
+        ("url", _attr(w, "www"), True),
+    ]
+    return _build_bibtex_entry("article", generate_bibtex_key(w), fields)
 
 
-def wydawnictwo_zwarte_to_bibtex(wydawnictwo_zwarte) -> str:  # noqa: C901
+def _zwarte_entry_type(wydawnictwo_zwarte) -> str:
+    """Pick the BibTeX entry type for a Wydawnictwo_Zwarte by its traits."""
+    if _attr(wydawnictwo_zwarte, "wydawnictwo_nadrzedne"):
+        return "incollection"  # Chapter in book
+    charakter_formalny = _attr(wydawnictwo_zwarte, "charakter_formalny")
+    if charakter_formalny:
+        charakter = charakter_formalny.nazwa.lower()
+        if "rozdział" in charakter or "chapter" in charakter:
+            return "incollection"
+        if "konferencja" in charakter or "conference" in charakter:
+            return "inproceedings"
+    return "book"
+
+
+def wydawnictwo_zwarte_to_bibtex(wydawnictwo_zwarte) -> str:
     """
     Convert Wydawnictwo_Zwarte instance to BibTeX format.
 
@@ -198,124 +248,47 @@ def wydawnictwo_zwarte_to_bibtex(wydawnictwo_zwarte) -> str:  # noqa: C901
     Returns:
         BibTeX formatted string
     """
-    key = generate_bibtex_key(wydawnictwo_zwarte)
-    authors = format_authors_bibtex(wydawnictwo_zwarte)
+    w = wydawnictwo_zwarte
+    entry_type = _zwarte_entry_type(w)
+    get_wydawnictwo = getattr(w, "get_wydawnictwo", None)
+    publisher = get_wydawnictwo() if get_wydawnictwo else None
+    nadrzedne = _attr(w, "wydawnictwo_nadrzedne")
+    booktitle = (
+        nadrzedne.tytul_oryginalny
+        if entry_type == "incollection" and nadrzedne
+        else None
+    )
+    seria = _attr(w, "seria_wydawnicza")
+    fields = [
+        ("title", w.tytul_oryginalny, True),
+        ("author", format_authors_bibtex(w), True),
+        ("publisher", publisher, True),
+        ("address", _address_from_miejsce_i_rok(_attr(w, "miejsce_i_rok")), True),
+        ("year", w.rok, False),
+        ("pages", _attr(w, "strony"), True),
+        ("booktitle", booktitle, True),
+        ("doi", _attr(w, "doi"), True),
+        ("isbn", _attr(w, "isbn"), True),
+        ("url", _attr(w, "www"), True),
+        ("edition", _attr(w, "oznaczenie_wydania"), True),
+        ("series", seria.nazwa if seria else None, True),
+    ]
+    return _build_bibtex_entry(entry_type, generate_bibtex_key(w), fields)
 
-    # Determine entry type based on characteristics
-    entry_type = "book"
-    if (
-        hasattr(wydawnictwo_zwarte, "wydawnictwo_nadrzedne")
-        and wydawnictwo_zwarte.wydawnictwo_nadrzedne
+
+def _patent_note(patent) -> str | None:
+    """Build the patent ``note`` field from its identifier/date attributes."""
+    note_parts = []
+    for attr_name, label in (
+        ("numer_zgloszenia", "Numer zgłoszenia"),
+        ("numer_prawa_wylacznego", "Numer prawa wyłącznego"),
+        ("data_zgloszenia", "Data zgłoszenia"),
+        ("data_decyzji", "Data decyzji"),
     ):
-        entry_type = "incollection"  # Chapter in book
-    elif (
-        hasattr(wydawnictwo_zwarte, "charakter_formalny")
-        and wydawnictwo_zwarte.charakter_formalny
-    ):
-        charakter = wydawnictwo_zwarte.charakter_formalny.nazwa.lower()
-        if "rozdział" in charakter or "chapter" in charakter:
-            entry_type = "incollection"
-        elif "konferencja" in charakter or "conference" in charakter:
-            entry_type = "inproceedings"
-
-    bibtex_entry = f"@{entry_type}{{{key},\n"
-
-    # Title
-    if wydawnictwo_zwarte.tytul_oryginalny:
-        title = sanitize_bibtex_string(wydawnictwo_zwarte.tytul_oryginalny)
-        bibtex_entry += f"  title = {{{title}}},\n"
-
-    # Authors
-    if authors:
-        bibtex_entry += f"  author = {{{sanitize_bibtex_string(authors)}}},\n"
-
-    # Publisher
-    if (
-        hasattr(wydawnictwo_zwarte, "get_wydawnictwo")
-        and wydawnictwo_zwarte.get_wydawnictwo()
-    ):
-        publisher = sanitize_bibtex_string(wydawnictwo_zwarte.get_wydawnictwo())
-        bibtex_entry += f"  publisher = {{{publisher}}},\n"
-
-    # Year and address from miejsce_i_rok
-    if (
-        hasattr(wydawnictwo_zwarte, "miejsce_i_rok")
-        and wydawnictwo_zwarte.miejsce_i_rok
-    ):
-        miejsce_i_rok = wydawnictwo_zwarte.miejsce_i_rok.strip()
-        # Try to extract address and year
-        parts = miejsce_i_rok.split()
-        if parts:
-            # Last part might be year if it's 4 digits
-            if len(parts) > 1 and re.match(r"\d{4}", parts[-1]):
-                # year_from_field = parts[-1]
-                address = " ".join(parts[:-1])
-                if address:
-                    bibtex_entry += (
-                        f"  address = {{{sanitize_bibtex_string(address)}}},\n"
-                    )
-            else:
-                # Whole field as address
-                bibtex_entry += (
-                    f"  address = {{{sanitize_bibtex_string(miejsce_i_rok)}}},\n"
-                )
-
-    # Year
-    if wydawnictwo_zwarte.rok:
-        bibtex_entry += f"  year = {{{wydawnictwo_zwarte.rok}}},\n"
-
-    # Pages
-    if hasattr(wydawnictwo_zwarte, "strony") and wydawnictwo_zwarte.strony:
-        pages = sanitize_bibtex_string(wydawnictwo_zwarte.strony)
-        bibtex_entry += f"  pages = {{{pages}}},\n"
-
-    # For chapters, add booktitle (parent publication)
-    if (
-        entry_type == "incollection"
-        and hasattr(wydawnictwo_zwarte, "wydawnictwo_nadrzedne")
-        and wydawnictwo_zwarte.wydawnictwo_nadrzedne
-    ):
-        if wydawnictwo_zwarte.wydawnictwo_nadrzedne.tytul_oryginalny:
-            booktitle = sanitize_bibtex_string(
-                wydawnictwo_zwarte.wydawnictwo_nadrzedne.tytul_oryginalny
-            )
-            bibtex_entry += f"  booktitle = {{{booktitle}}},\n"
-
-    # DOI
-    if hasattr(wydawnictwo_zwarte, "doi") and wydawnictwo_zwarte.doi:
-        doi = sanitize_bibtex_string(wydawnictwo_zwarte.doi)
-        bibtex_entry += f"  doi = {{{doi}}},\n"
-
-    # ISBN
-    if hasattr(wydawnictwo_zwarte, "isbn") and wydawnictwo_zwarte.isbn:
-        isbn = sanitize_bibtex_string(wydawnictwo_zwarte.isbn)
-        bibtex_entry += f"  isbn = {{{isbn}}},\n"
-
-    # URL
-    if hasattr(wydawnictwo_zwarte, "www") and wydawnictwo_zwarte.www:
-        url = sanitize_bibtex_string(wydawnictwo_zwarte.www)
-        bibtex_entry += f"  url = {{{url}}},\n"
-
-    # Edition
-    if (
-        hasattr(wydawnictwo_zwarte, "oznaczenie_wydania")
-        and wydawnictwo_zwarte.oznaczenie_wydania
-    ):
-        edition = sanitize_bibtex_string(wydawnictwo_zwarte.oznaczenie_wydania)
-        bibtex_entry += f"  edition = {{{edition}}},\n"
-
-    # Series
-    if (
-        hasattr(wydawnictwo_zwarte, "seria_wydawnicza")
-        and wydawnictwo_zwarte.seria_wydawnicza
-    ):
-        series = sanitize_bibtex_string(wydawnictwo_zwarte.seria_wydawnicza.nazwa)
-        bibtex_entry += f"  series = {{{series}}},\n"
-
-    # Remove trailing comma and newline, add closing brace
-    bibtex_entry = bibtex_entry.rstrip(",\n") + "\n}\n"
-
-    return bibtex_entry
+        value = _attr(patent, attr_name)
+        if value:
+            note_parts.append(f"{label}: {value}")
+    return ". ".join(note_parts) if note_parts else None
 
 
 def patent_to_bibtex(patent) -> str:
@@ -328,54 +301,17 @@ def patent_to_bibtex(patent) -> str:
     Returns:
         BibTeX formatted string
     """
-    key = generate_bibtex_key(patent)
-    authors = format_authors_bibtex(patent)
-
-    bibtex_entry = f"@misc{{{key},\n"
-
-    # Title
-    if patent.tytul_oryginalny:
-        title = sanitize_bibtex_string(patent.tytul_oryginalny)
-        bibtex_entry += f"  title = {{{title}}},\n"
-
-    # Authors
-    if authors:
-        bibtex_entry += f"  author = {{{sanitize_bibtex_string(authors)}}},\n"
-
-    # Year
-    if patent.rok:
-        bibtex_entry += f"  year = {{{patent.rok}}},\n"
-
-    # Note with patent-specific information
-    note_parts = []
-    if hasattr(patent, "numer_zgloszenia") and patent.numer_zgloszenia:
-        note_parts.append(f"Numer zgłoszenia: {patent.numer_zgloszenia}")
-
-    if hasattr(patent, "numer_prawa_wylacznego") and patent.numer_prawa_wylacznego:
-        note_parts.append(f"Numer prawa wyłącznego: {patent.numer_prawa_wylacznego}")
-
-    if hasattr(patent, "data_zgloszenia") and patent.data_zgloszenia:
-        note_parts.append(f"Data zgłoszenia: {patent.data_zgloszenia}")
-
-    if hasattr(patent, "data_decyzji") and patent.data_decyzji:
-        note_parts.append(f"Data decyzji: {patent.data_decyzji}")
-
-    if note_parts:
-        note = sanitize_bibtex_string(". ".join(note_parts))
-        bibtex_entry += f"  note = {{{note}}},\n"
-
-    # URL
-    if hasattr(patent, "www") and patent.www:
-        url = sanitize_bibtex_string(patent.www)
-        bibtex_entry += f"  url = {{{url}}},\n"
-
-    # Remove trailing comma and newline, add closing brace
-    bibtex_entry = bibtex_entry.rstrip(",\n") + "\n}\n"
-
-    return bibtex_entry
+    fields = [
+        ("title", patent.tytul_oryginalny, True),
+        ("author", format_authors_bibtex(patent), True),
+        ("year", patent.rok, False),
+        ("note", _patent_note(patent), True),
+        ("url", _attr(patent, "www"), True),
+    ]
+    return _build_bibtex_entry("misc", generate_bibtex_key(patent), fields)
 
 
-def praca_doktorska_to_bibtex(praca_doktorska) -> str:  # noqa: C901
+def praca_doktorska_to_bibtex(praca_doktorska) -> str:
     """
     Convert Praca_Doktorska instance to BibTeX format.
 
@@ -385,67 +321,20 @@ def praca_doktorska_to_bibtex(praca_doktorska) -> str:  # noqa: C901
     Returns:
         BibTeX formatted string
     """
-    key = generate_bibtex_key(praca_doktorska)
-    authors = format_authors_bibtex(praca_doktorska)
-
-    bibtex_entry = f"@phdthesis{{{key},\n"
-
-    # Title
-    if praca_doktorska.tytul_oryginalny:
-        title = sanitize_bibtex_string(praca_doktorska.tytul_oryginalny)
-        bibtex_entry += f"  title = {{{title}}},\n"
-
-    # Author
-    if authors:
-        bibtex_entry += f"  author = {{{sanitize_bibtex_string(authors)}}},\n"
-
-    # School (University)
-    if hasattr(praca_doktorska, "jednostka") and praca_doktorska.jednostka:
-        if (
-            hasattr(praca_doktorska.jednostka, "wydzial")
-            and praca_doktorska.jednostka.wydzial
-        ):
-            school = sanitize_bibtex_string(praca_doktorska.jednostka.wydzial.nazwa)
-            bibtex_entry += f"  school = {{{school}}},\n"
-
-    # Year
-    if praca_doktorska.rok:
-        bibtex_entry += f"  year = {{{praca_doktorska.rok}}},\n"
-
-    # Type
-    bibtex_entry += "  type = {Rozprawa doktorska},\n"
-
-    # Publisher/address from miejsce_i_rok
-    if hasattr(praca_doktorska, "miejsce_i_rok") and praca_doktorska.miejsce_i_rok:
-        miejsce_i_rok = praca_doktorska.miejsce_i_rok.strip()
-        # Try to extract address and year
-        parts = miejsce_i_rok.split()
-        if parts:
-            # Last part might be year if it's 4 digits
-            if len(parts) > 1 and re.match(r"\d{4}", parts[-1]):
-                address = " ".join(parts[:-1])
-                if address:
-                    bibtex_entry += (
-                        f"  address = {{{sanitize_bibtex_string(address)}}},\n"
-                    )
-            else:
-                # Whole field as address
-                bibtex_entry += (
-                    f"  address = {{{sanitize_bibtex_string(miejsce_i_rok)}}},\n"
-                )
-
-    # URL
-    if hasattr(praca_doktorska, "www") and praca_doktorska.www:
-        url = sanitize_bibtex_string(praca_doktorska.www)
-        bibtex_entry += f"  url = {{{url}}},\n"
-
-    # Remove trailing comma and newline, add closing brace
-    bibtex_entry = bibtex_entry.rstrip(",\n") + "\n}\n"
-
-    return bibtex_entry
+    p = praca_doktorska
+    fields = [
+        ("title", p.tytul_oryginalny, True),
+        ("author", format_authors_bibtex(p), True),
+        ("school", _school_from_jednostka(p), True),
+        ("year", p.rok, False),
+        ("type", "Rozprawa doktorska", False),
+        ("address", _address_from_miejsce_i_rok(_attr(p, "miejsce_i_rok")), True),
+        ("url", _attr(p, "www"), True),
+    ]
+    return _build_bibtex_entry("phdthesis", generate_bibtex_key(p), fields)
 
 
-def praca_habilitacyjna_to_bibtex(praca_habilitacyjna) -> str:  # noqa: C901
+def praca_habilitacyjna_to_bibtex(praca_habilitacyjna) -> str:
     """
     Convert Praca_Habilitacyjna instance to BibTeX format.
 
@@ -455,67 +344,17 @@ def praca_habilitacyjna_to_bibtex(praca_habilitacyjna) -> str:  # noqa: C901
     Returns:
         BibTeX formatted string
     """
-    key = generate_bibtex_key(praca_habilitacyjna)
-    authors = format_authors_bibtex(praca_habilitacyjna)
-
-    bibtex_entry = f"@misc{{{key},\n"
-
-    # Title
-    if praca_habilitacyjna.tytul_oryginalny:
-        title = sanitize_bibtex_string(praca_habilitacyjna.tytul_oryginalny)
-        bibtex_entry += f"  title = {{{title}}},\n"
-
-    # Author
-    if authors:
-        bibtex_entry += f"  author = {{{sanitize_bibtex_string(authors)}}},\n"
-
-    # Year
-    if praca_habilitacyjna.rok:
-        bibtex_entry += f"  year = {{{praca_habilitacyjna.rok}}},\n"
-
-    # Note indicating this is a habilitation thesis
-    bibtex_entry += "  note = {Rozprawa habilitacyjna},\n"
-
-    # School (University)
-    if hasattr(praca_habilitacyjna, "jednostka") and praca_habilitacyjna.jednostka:
-        if (
-            hasattr(praca_habilitacyjna.jednostka, "wydzial")
-            and praca_habilitacyjna.jednostka.wydzial
-        ):
-            school = sanitize_bibtex_string(praca_habilitacyjna.jednostka.wydzial.nazwa)
-            bibtex_entry += f"  school = {{{school}}},\n"
-
-    # Publisher/address from miejsce_i_rok
-    if (
-        hasattr(praca_habilitacyjna, "miejsce_i_rok")
-        and praca_habilitacyjna.miejsce_i_rok
-    ):
-        miejsce_i_rok = praca_habilitacyjna.miejsce_i_rok.strip()
-        # Try to extract address and year
-        parts = miejsce_i_rok.split()
-        if parts:
-            # Last part might be year if it's 4 digits
-            if len(parts) > 1 and re.match(r"\d{4}", parts[-1]):
-                address = " ".join(parts[:-1])
-                if address:
-                    bibtex_entry += (
-                        f"  address = {{{sanitize_bibtex_string(address)}}},\n"
-                    )
-            else:
-                # Whole field as address
-                bibtex_entry += (
-                    f"  address = {{{sanitize_bibtex_string(miejsce_i_rok)}}},\n"
-                )
-
-    # URL
-    if hasattr(praca_habilitacyjna, "www") and praca_habilitacyjna.www:
-        url = sanitize_bibtex_string(praca_habilitacyjna.www)
-        bibtex_entry += f"  url = {{{url}}},\n"
-
-    # Remove trailing comma and newline, add closing brace
-    bibtex_entry = bibtex_entry.rstrip(",\n") + "\n}\n"
-
-    return bibtex_entry
+    p = praca_habilitacyjna
+    fields = [
+        ("title", p.tytul_oryginalny, True),
+        ("author", format_authors_bibtex(p), True),
+        ("year", p.rok, False),
+        ("note", "Rozprawa habilitacyjna", False),
+        ("school", _school_from_jednostka(p), True),
+        ("address", _address_from_miejsce_i_rok(_attr(p, "miejsce_i_rok")), True),
+        ("url", _attr(p, "www"), True),
+    ]
+    return _build_bibtex_entry("misc", generate_bibtex_key(p), fields)
 
 
 def export_to_bibtex(publications) -> str:

--- a/src/bpp/newsfragments/uproszczenie-zlozonosci-c901.feature.rst
+++ b/src/bpp/newsfragments/uproszczenie-zlozonosci-c901.feature.rst
@@ -1,0 +1,8 @@
+Uproszczono dziewięć złożonych funkcji oznaczonych dotąd ``# noqa: C901``
+(eksport XLSX możliwości odpinania, analiza duplikatów autorów, scalanie
+danych CrossRef/PBN, porównywanie metryk autorów oraz cztery eksportery
+BibTeX). Powtarzalne łańcuchy ``if``/``elif`` i zduplikowane bloki zastąpiono
+tabelami danych (deskryptory kolumn, reguły scoringu, specyfikacje pól) oraz
+wydzielonymi funkcjami pomocniczymi. Zachowanie jest niezmienione —
+zabezpieczone nowymi testami charakteryzującymi — a kod jest znacznie
+czytelniejszy i łatwiejszy w utrzymaniu.

--- a/src/bpp/tests/test_export/test_bibtex_characterization.py
+++ b/src/bpp/tests/test_export/test_bibtex_characterization.py
@@ -1,0 +1,262 @@
+"""
+Characterization tests pinning the EXACT BibTeX byte output for a
+representative populated instance of each publication type.
+
+These exist to guarantee that the behavior-preserving refactor of
+``bpp.export.bibtex`` keeps output byte-identical.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.export.bibtex import (
+    generate_bibtex_key,
+    praca_doktorska_to_bibtex,
+    praca_habilitacyjna_to_bibtex,
+    wydawnictwo_ciagle_to_bibtex,
+    wydawnictwo_zwarte_to_bibtex,
+)
+from bpp.models import (
+    Autor,
+    Praca_Doktorska,
+    Praca_Habilitacyjna,
+    Wydawnictwo_Ciagle,
+    Wydawnictwo_Zwarte,
+    Zrodlo,
+)
+
+
+@pytest.mark.django_db
+def test_char_wydawnictwo_ciagle_full():
+    autor = baker.make(Autor, nazwisko="Smith", imiona="John")
+    zrodlo = baker.make(Zrodlo, nazwa="Test Journal")
+    wyd = baker.make(
+        Wydawnictwo_Ciagle,
+        tytul_oryginalny="Test Article Title",
+        rok=2023,
+        zrodlo=zrodlo,
+        tom="12",
+        nr_zeszytu="4",
+        strony="10-20",
+        doi="10.1000/test",
+        issn="1234-5678",
+        www="https://example.com",
+    )
+    baker.make(
+        "bpp.Wydawnictwo_Ciagle_Autor",
+        rekord=wyd,
+        autor=autor,
+        zapisany_jako="Smith, John",
+        kolejnosc=1,
+    )
+
+    key = generate_bibtex_key(wyd)
+    expected = (
+        f"@article{{{key},\n"
+        "  title = {Test Article Title},\n"
+        "  author = {Smith, John},\n"
+        "  journal = {Test Journal},\n"
+        "  year = {2023},\n"
+        "  volume = {12},\n"
+        "  number = {4},\n"
+        "  pages = {10-20},\n"
+        "  doi = {10.1000/test},\n"
+        "  issn = {1234-5678},\n"
+        "  url = {https://example.com}\n"
+        "}\n"
+    )
+    assert wydawnictwo_ciagle_to_bibtex(wyd) == expected
+    assert key == f"Smith_2023_id{wyd.pk}"
+
+
+@pytest.mark.django_db
+def test_char_wydawnictwo_ciagle_minimal_omits_missing():
+    """Missing fields must be omitted, key/year still emitted."""
+    autor = baker.make(Autor, nazwisko="Brown", imiona="Bob")
+    wyd = baker.make(
+        Wydawnictwo_Ciagle,
+        tytul_oryginalny="Bare Article",
+        rok=2020,
+        zrodlo=None,
+        tom="",
+        nr_zeszytu="",
+        strony="",
+        doi="",
+        issn="",
+        www="",
+        informacje="",
+        szczegoly="",
+    )
+    baker.make(
+        "bpp.Wydawnictwo_Ciagle_Autor",
+        rekord=wyd,
+        autor=autor,
+        zapisany_jako="Brown, Bob",
+        kolejnosc=1,
+    )
+
+    key = generate_bibtex_key(wyd)
+    expected = (
+        f"@article{{{key},\n"
+        "  title = {Bare Article},\n"
+        "  author = {Brown, Bob},\n"
+        "  year = {2020}\n"
+        "}\n"
+    )
+    assert wydawnictwo_ciagle_to_bibtex(wyd) == expected
+
+
+@pytest.mark.django_db
+def test_char_wydawnictwo_zwarte_book_full():
+    autor = baker.make(Autor, nazwisko="Johnson", imiona="Jane")
+    wydawca = baker.make("bpp.Wydawca", nazwa="Test Publisher")
+    seria = baker.make("bpp.Seria_Wydawnicza", nazwa="My Series")
+    wyd = baker.make(
+        Wydawnictwo_Zwarte,
+        tytul_oryginalny="Test Book Title",
+        rok=2022,
+        wydawca=wydawca,
+        wydawca_opis="",
+        miejsce_i_rok="New York 2022",
+        strony="1-300",
+        doi="10.2000/book",
+        isbn="978-0-123456-78-9",
+        www="https://book.example.com",
+        oznaczenie_wydania="2nd ed.",
+        seria_wydawnicza=seria,
+    )
+    baker.make(
+        "bpp.Wydawnictwo_Zwarte_Autor",
+        rekord=wyd,
+        autor=autor,
+        zapisany_jako="Johnson, Jane",
+        kolejnosc=1,
+    )
+
+    key = generate_bibtex_key(wyd)
+    expected = (
+        f"@book{{{key},\n"
+        "  title = {Test Book Title},\n"
+        "  author = {Johnson, Jane},\n"
+        "  publisher = {Test Publisher},\n"
+        "  address = {New York},\n"
+        "  year = {2022},\n"
+        "  pages = {1-300},\n"
+        "  doi = {10.2000/book},\n"
+        "  isbn = {978-0-123456-78-9},\n"
+        "  url = {https://book.example.com},\n"
+        "  edition = {2nd ed.},\n"
+        "  series = {My Series}\n"
+        "}\n"
+    )
+    assert wydawnictwo_zwarte_to_bibtex(wyd) == expected
+
+
+@pytest.mark.django_db
+def test_char_wydawnictwo_zwarte_chapter_incollection():
+    parent = baker.make(
+        Wydawnictwo_Zwarte, tytul_oryginalny="Parent Book Title", rok=2023
+    )
+    autor = baker.make(Autor, nazwisko="Brown", imiona="Bob")
+    wydawca = baker.make("bpp.Wydawca", nazwa="Chapter Publisher")
+    chapter = baker.make(
+        Wydawnictwo_Zwarte,
+        tytul_oryginalny="Chapter Title",
+        rok=2023,
+        wydawca=wydawca,
+        wydawca_opis="",
+        wydawnictwo_nadrzedne=parent,
+        miejsce_i_rok="",
+        strony="45-60",
+        doi="",
+        isbn="",
+        www="",
+        oznaczenie_wydania="",
+        seria_wydawnicza=None,
+    )
+    baker.make(
+        "bpp.Wydawnictwo_Zwarte_Autor",
+        rekord=chapter,
+        autor=autor,
+        zapisany_jako="Brown, Bob",
+        kolejnosc=1,
+    )
+
+    key = generate_bibtex_key(chapter)
+    expected = (
+        f"@incollection{{{key},\n"
+        "  title = {Chapter Title},\n"
+        "  author = {Brown, Bob},\n"
+        "  publisher = {Chapter Publisher},\n"
+        "  year = {2023},\n"
+        "  pages = {45-60},\n"
+        "  booktitle = {Parent Book Title}\n"
+        "}\n"
+    )
+    assert wydawnictwo_zwarte_to_bibtex(chapter) == expected
+
+
+@pytest.mark.django_db
+def test_char_praca_doktorska_full():
+    autor = baker.make(Autor, nazwisko="Smith", imiona="John")
+    uczelnia = baker.make("bpp.Uczelnia", nazwa="University")
+    wydzial = baker.make("bpp.Wydzial", nazwa="Faculty of Science", uczelnia=uczelnia)
+    jednostka = baker.make(
+        "bpp.Jednostka", nazwa="Department", wydzial=wydzial, uczelnia=uczelnia
+    )
+    praca = baker.make(
+        Praca_Doktorska,
+        tytul_oryginalny="Doctoral Dissertation Title",
+        rok=2023,
+        autor=autor,
+        jednostka=jednostka,
+        miejsce_i_rok="Warsaw 2023",
+        www="https://thesis.example.com",
+    )
+
+    key = generate_bibtex_key(praca)
+    expected = (
+        f"@phdthesis{{{key},\n"
+        "  title = {Doctoral Dissertation Title},\n"
+        "  author = {Smith John},\n"
+        "  school = {Faculty of Science},\n"
+        "  year = {2023},\n"
+        "  type = {Rozprawa doktorska},\n"
+        "  address = {Warsaw},\n"
+        "  url = {https://thesis.example.com}\n"
+        "}\n"
+    )
+    assert praca_doktorska_to_bibtex(praca) == expected
+
+
+@pytest.mark.django_db
+def test_char_praca_habilitacyjna_full():
+    autor = baker.make(Autor, nazwisko="Johnson", imiona="Jane")
+    uczelnia = baker.make("bpp.Uczelnia", nazwa="University")
+    wydzial = baker.make("bpp.Wydzial", nazwa="Faculty of Medicine", uczelnia=uczelnia)
+    jednostka = baker.make(
+        "bpp.Jednostka", nazwa="Department", wydzial=wydzial, uczelnia=uczelnia
+    )
+    praca = baker.make(
+        Praca_Habilitacyjna,
+        tytul_oryginalny="Habilitation Thesis Title",
+        rok=2022,
+        autor=autor,
+        jednostka=jednostka,
+        miejsce_i_rok="Cracow 2022",
+        www="https://habil.example.com",
+    )
+
+    key = generate_bibtex_key(praca)
+    expected = (
+        f"@misc{{{key},\n"
+        "  title = {Habilitation Thesis Title},\n"
+        "  author = {Johnson Jane},\n"
+        "  year = {2022},\n"
+        "  note = {Rozprawa habilitacyjna},\n"
+        "  school = {Faculty of Medicine},\n"
+        "  address = {Cracow},\n"
+        "  url = {https://habil.example.com}\n"
+        "}\n"
+    )
+    assert praca_habilitacyjna_to_bibtex(praca) == expected

--- a/src/crossref_bpp/admin/helpers.py
+++ b/src/crossref_bpp/admin/helpers.py
@@ -4,7 +4,94 @@ from crossref_bpp.core import Komparator
 from import_common.normalization import normalize_title
 
 
-def convert_crossref_to_changeform_initial_data(z: dict) -> dict:  # noqa: C901
+def _komparator_pk(metoda, wartosc):
+    """Zwróć ``pk`` rekordu BPP dopasowanego przez dany komparator albo None."""
+    rekord = metoda(wartosc).rekord_po_stronie_bpp
+    return rekord.pk if rekord is not None else None
+
+
+def _extract_title(z: dict):
+    """Tytuł: lista łączona ". ", a następnie normalizacja."""
+    title = z.get("title")
+    if isinstance(title, list):
+        title = ". ".join(title)
+    return normalize_title(title)
+
+
+def _extract_zrodlo(z: dict):
+    """PK źródła dopasowanego po container-title (albo None)."""
+    try:
+        tytul_kontenera = z.get("container-title")[0]
+    except (IndexError, TypeError):
+        # IndexError: pusta lista; TypeError: brak klucza (z.get(...) → None)
+        return None
+
+    if not tytul_kontenera:
+        return None
+
+    zrodlo = Komparator.porownaj_container_title(tytul_kontenera).rekord_po_stronie_bpp
+    return zrodlo.pk if zrodlo is not None else None
+
+
+def _extract_wydawca(z: dict):
+    """(pk_wydawcy, opis_tekstowy). Opis ustawiany tylko gdy brak dopasowania."""
+    wydawca_idx = Komparator.porownaj_publisher(
+        z.get("publisher")
+    ).rekord_po_stronie_bpp
+    if wydawca_idx is None:
+        return None, z.get("publisher")
+    return wydawca_idx, ""
+
+
+def _extract_issn_isbn_typed(z: dict, key: str):
+    """Z listy ``issn-type`` / ``isbn-type`` wyciągnij (electronic, pozostały)."""
+    e_value = None
+    value = None
+    for wpis in z.get(key, []) or []:
+        if wpis.get("type") == "electronic":
+            e_value = wpis.get("value")
+        else:
+            value = wpis.get("value")
+    return e_value, value
+
+
+def _fallback_identifier(z: dict, key: str, value, e_value):
+    """Uzupełnij ISSN/ISBN z pola skalarnej-listy, jeśli różny od electronic.
+
+    Odwzorowuje oryginalną logikę: jeśli ``value`` już jest ustawione z
+    pętli ``*-type``, nie ruszaj. W przeciwnym razie weź pierwszy element
+    listy ``z[key]``; ale wyzeruj, jeśli równy ``e_value`` (czyli pole
+    zawierało wariant electronic).
+    """
+    if value is not None:
+        return value
+    if not z.get(key, None):
+        return value
+    try:
+        value = z.get(key)[0]
+    except IndexError:
+        return None
+    if value is not None and value == e_value:
+        return None
+    return value
+
+
+def _extract_license(z: dict):
+    """(pk_licencji, ilość_miesięcy) dla pierwszej dopasowanej licencji."""
+    for _licencja in z.get("license", []):
+        licencja = Komparator.porownaj_license(_licencja).rekord_po_stronie_bpp
+        if licencja is None:
+            continue
+        ilosc_miesiecy = None
+        try:
+            ilosc_miesiecy = int(math.ceil(int(_licencja.get("delay-in-days")) / 30))
+        except (TypeError, ValueError):
+            pass
+        return licencja.pk, ilosc_miesiecy
+    return None, None
+
+
+def convert_crossref_to_changeform_initial_data(z: dict) -> dict:
     """
     Funkcja, która przerabia słownik CrossRef API na słownik
     początkowych argumentów dla changeform. Używany wewnętrznie przez
@@ -12,102 +99,14 @@ def convert_crossref_to_changeform_initial_data(z: dict) -> dict:  # noqa: C901
     CrossRef słownik do argumentów początkowych.
     """
 
-    title = z.get("title")
-    if isinstance(title, list):
-        title = ". ".join(title)
-    title = normalize_title(title)
+    wydawca_idx, wydawca_txt = _extract_wydawca(z)
 
-    try:
-        tytul_kontenera = z.get("container-title")[0]
-    except (IndexError, TypeError):
-        # IndexError: pusta lista; TypeError: brak klucza (z.get(...) → None)
-        tytul_kontenera = None
+    e_issn, issn = _extract_issn_isbn_typed(z, "issn-type")
+    e_isbn, isbn = _extract_issn_isbn_typed(z, "isbn-type")
+    issn = _fallback_identifier(z, "ISSN", issn, e_issn)
+    isbn = _fallback_identifier(z, "ISBN", isbn, e_isbn)
 
-    zrodlo = None
-    if tytul_kontenera:
-        zrodlo = Komparator.porownaj_container_title(
-            tytul_kontenera
-        ).rekord_po_stronie_bpp
-
-    if zrodlo is not None:
-        zrodlo = zrodlo.pk
-
-    wydawca_txt = ""
-    wydawca_idx = Komparator.porownaj_publisher(
-        z.get("publisher")
-    ).rekord_po_stronie_bpp
-    if wydawca_idx is None:
-        wydawca_txt = z.get("publisher")
-
-    charakter_formalny_pk = None
-    charakter_formalny = Komparator.porownaj_type(z.get("type")).rekord_po_stronie_bpp
-    if charakter_formalny is not None:
-        charakter_formalny_pk = charakter_formalny.pk
-
-    jezyk_pk = None
-    jezyk = Komparator.porownaj_language(z.get("language")).rekord_po_stronie_bpp
-    if jezyk is not None:
-        jezyk_pk = jezyk.pk
-
-    issn = None
-    e_issn = None
-    if z.get("issn-type", []):
-        for _issn in z.get("issn-type"):
-            if _issn.get("type") == "electronic":
-                e_issn = _issn.get("value")
-            else:
-                issn = _issn.get("value")
-
-    isbn = None
-    e_isbn = None
-    if z.get("isbn-type", []):
-        for _isbn in z.get("isbn-type"):
-            if _isbn.get("type") == "electronic":
-                e_isbn = _isbn.get("value")
-            else:
-                isbn = _isbn.get("value")
-
-    # Jeżeli nie udało się pobrać ISSN w poprzedniej pętli przy analizie listy issn-type,
-    # wobec tego pobierz ISSN z parametru ISSN po stronie crossref-api. ALE ustaw issn
-    # jedynie wtedy gdy jest ono INNE niż e_issn (ustawiony w pętli powyżej):
-    if issn is None:
-        if z.get("ISSN", None):
-            try:
-                issn = z.get("ISSN")[0]
-            except IndexError:
-                issn = None
-
-            if issn is not None:
-                if issn == e_issn:
-                    # Jeżeli ISSN jest RÓWNY e_issn czyli w polu ISSN w CrossRef API
-                    # był podany ISSN typu "electronic", to w takim razie nie używaj tej
-                    # wartości jako ISSN.
-                    issn = None
-
-    if isbn is None:
-        if z.get("ISBN", None):
-            try:
-                isbn = z.get("ISBN")[0]
-            except IndexError:
-                isbn = None
-
-            if isbn is not None:
-                if isbn == e_isbn:
-                    isbn = None
-
-    licencja_pk = None
-    licencja_ilosc_miesiecy = None
-    for _licencja in z.get("license", []):
-        licencja = Komparator.porownaj_license(_licencja).rekord_po_stronie_bpp
-        if licencja is not None:
-            licencja_pk = licencja.pk
-            try:
-                licencja_ilosc_miesiecy = int(
-                    math.ceil(int(_licencja.get("delay-in-days")) / 30)
-                )
-            except (TypeError, ValueError):
-                pass
-            break
+    licencja_pk, licencja_ilosc_miesiecy = _extract_license(z)
 
     rok = z.get("published", {}).get("date-parts", [[""]])[0][0]
 
@@ -115,17 +114,17 @@ def convert_crossref_to_changeform_initial_data(z: dict) -> dict:  # noqa: C901
     if z.get("publisher-location"):
         miejsce_i_rok = z.get("publisher-location") + " " + str(rok)
 
-    ret = {
-        "tytul_oryginalny": title,
-        "zrodlo": zrodlo,
+    return {
+        "tytul_oryginalny": _extract_title(z),
+        "zrodlo": _extract_zrodlo(z),
         "nr_zeszytu": z.get("issue", ""),
         "strony": z.get("page", ""),
         "slowa_kluczowe": ", ".join(f'"{x}"' for x in z.get("subject", [])),
         "wydawca": wydawca_idx,
         "wydawca_opis": wydawca_txt,
         "doi": z.get("DOI"),
-        "charakter_formalny": charakter_formalny_pk,
-        "jezyk": jezyk_pk,
+        "charakter_formalny": _komparator_pk(Komparator.porownaj_type, z.get("type")),
+        "jezyk": _komparator_pk(Komparator.porownaj_language, z.get("language")),
         "adnotacje": "Dodano na podstawie CrossRef API",
         "e_issn": e_issn,
         "e_isbn": e_isbn,
@@ -140,10 +139,63 @@ def convert_crossref_to_changeform_initial_data(z: dict) -> dict:  # noqa: C901
         "rok": rok,
     }
 
-    return ret
+
+def _merge_pbn_title(merged_data, data_sources, pbn_object):
+    """Uzupełnij/poszerz tytuł danymi z PBN."""
+    pbn_title = pbn_object.get("title")
+    if not pbn_title:
+        return
+    if not merged_data.get("tytul_oryginalny"):
+        merged_data["tytul_oryginalny"] = normalize_title(pbn_title)
+        data_sources["tytul_oryginalny"] = "PBN"
+    elif normalize_title(pbn_title) != merged_data.get("tytul_oryginalny"):
+        # Jeśli tytuły się różnią, zachowaj oba z adnotacją
+        merged_data["tytul_alternatywny"] = normalize_title(pbn_title)
+        data_sources["tytul_alternatywny"] = "PBN"
 
 
-def merge_crossref_and_pbn_data(crossref_data: dict, pbn_data: dict) -> dict:  # noqa: C901
+def _merge_pbn_fill_or_conflict(merged_data, data_sources, field, pbn_value):
+    """Uzupełnij puste pole z PBN albo oznacz konflikt CrossRef+PBN.
+
+    Odwzorowuje powtarzający się wzorzec dla tom/nr_zeszytu/strony.
+    """
+    if not pbn_value:
+        return
+    if not merged_data.get(field):
+        merged_data[field] = pbn_value
+        data_sources[field] = "PBN"
+    elif merged_data.get(field) != pbn_value:
+        data_sources[field] = "CrossRef+PBN"
+
+
+def _merge_pbn_uid(merged_data, data_sources, pbn_data):
+    pbn_id = (
+        pbn_data.get("pbnId") or pbn_data.get("objectId") or pbn_data.get("mongoId")
+    )
+    if pbn_id:
+        # To pole będzie obsłużone osobno w widoku, ale zachowujemy informację
+        merged_data["pbn_uid"] = pbn_id
+        data_sources["pbn_uid"] = "PBN"
+
+
+def _merge_pbn_charakter_formalny(merged_data, data_sources, pbn_object):
+    pbn_type = pbn_object.get("type")
+    if pbn_type and not merged_data.get("charakter_formalny"):
+        # Mapowanie typu PBN na charakter formalny będzie przez Komparator
+        cf = Komparator.porownaj_type(pbn_type).rekord_po_stronie_bpp
+        if cf:
+            merged_data["charakter_formalny"] = cf.pk
+            data_sources["charakter_formalny"] = "PBN"
+
+
+def _merge_pbn_simple_field(merged_data, data_sources, field, value):
+    """Skopiuj proste, prawdziwe pole z PBN i oznacz jego źródło."""
+    if value:
+        merged_data[field] = value
+        data_sources[field] = "PBN"
+
+
+def merge_crossref_and_pbn_data(crossref_data: dict, pbn_data: dict) -> dict:
     """
     Funkcja łącząca dane z CrossRef API i PBN API.
     CrossRef jest bazą, PBN wzbogaca dane dodatkowymi polami.
@@ -159,12 +211,7 @@ def merge_crossref_and_pbn_data(crossref_data: dict, pbn_data: dict) -> dict:  #
     merged_data = convert_crossref_to_changeform_initial_data(crossref_data)
 
     # Słownik przechowujący źródła danych dla każdego pola
-    data_sources = {}
-
-    # Oznacz wszystkie pola CrossRef
-    for key in merged_data:
-        if merged_data[key]:
-            data_sources[key] = "CrossRef"
+    data_sources = {key: "CrossRef" for key in merged_data if merged_data[key]}
 
     # Jeśli nie ma danych PBN, zwróć tylko dane CrossRef
     if not pbn_data:
@@ -177,78 +224,45 @@ def merge_crossref_and_pbn_data(crossref_data: dict, pbn_data: dict) -> dict:  #
     # Wyciągnij dane z obiektu PBN
     pbn_object = pbn_data.get("object", {}) if isinstance(pbn_data, dict) else {}
 
-    # Uzupełnij tytuł jeśli brak w CrossRef lub różny
-    pbn_title = pbn_object.get("title")
-    if pbn_title:
-        if not merged_data.get("tytul_oryginalny"):
-            merged_data["tytul_oryginalny"] = normalize_title(pbn_title)
-            data_sources["tytul_oryginalny"] = "PBN"
-        elif normalize_title(pbn_title) != merged_data.get("tytul_oryginalny"):
-            # Jeśli tytuły się różnią, zachowaj oba z adnotacją
-            merged_data["tytul_alternatywny"] = normalize_title(pbn_title)
-            data_sources["tytul_alternatywny"] = "PBN"
+    _merge_pbn_title(merged_data, data_sources, pbn_object)
 
-    # Dodaj punktację ministerialną z PBN
-    mnisw_points = pbn_object.get("mniswPointsForInstitution")
-    if mnisw_points:
-        merged_data["punkty_kbn"] = mnisw_points
-        data_sources["punkty_kbn"] = "PBN"
-
-    # Uzupełnij numer tomu jeśli brak
-    pbn_volume = pbn_object.get("volume")
-    if pbn_volume and not merged_data.get("tom"):
-        merged_data["tom"] = pbn_volume
-        data_sources["tom"] = "PBN"
-    elif pbn_volume and merged_data.get("tom") != pbn_volume:
-        data_sources["tom"] = "CrossRef+PBN"
-
-    # Uzupełnij numer wydania
-    pbn_issue = pbn_object.get("issue")
-    if pbn_issue and not merged_data.get("nr_zeszytu"):
-        merged_data["nr_zeszytu"] = pbn_issue
-        data_sources["nr_zeszytu"] = "PBN"
-    elif pbn_issue and merged_data.get("nr_zeszytu") != pbn_issue:
-        data_sources["nr_zeszytu"] = "CrossRef+PBN"
-
-    # Uzupełnij strony
-    pbn_pages = pbn_object.get("pages")
-    if pbn_pages and not merged_data.get("strony"):
-        merged_data["strony"] = pbn_pages
-        data_sources["strony"] = "PBN"
-    elif pbn_pages and merged_data.get("strony") != pbn_pages:
-        data_sources["strony"] = "CrossRef+PBN"
-
-    # Dodaj PBN UID jeśli dostępny
-    pbn_id = (
-        pbn_data.get("pbnId") or pbn_data.get("objectId") or pbn_data.get("mongoId")
+    _merge_pbn_simple_field(
+        merged_data,
+        data_sources,
+        "punkty_kbn",
+        pbn_object.get("mniswPointsForInstitution"),
     )
-    if pbn_id:
-        # To pole będzie obsłużone osobno w widoku, ale zachowujemy informację
-        merged_data["pbn_uid"] = pbn_id
-        data_sources["pbn_uid"] = "PBN"
 
-    # Uzupełnij typ publikacji jeśli brak w CrossRef
-    pbn_type = pbn_object.get("type")
-    if pbn_type and not merged_data.get("charakter_formalny"):
-        # Mapowanie typu PBN na charakter formalny będzie przez Komparator
-        cf = Komparator.porownaj_type(pbn_type).rekord_po_stronie_bpp
-        if cf:
-            merged_data["charakter_formalny"] = cf.pk
-            data_sources["charakter_formalny"] = "PBN"
+    _merge_pbn_fill_or_conflict(
+        merged_data, data_sources, "tom", pbn_object.get("volume")
+    )
+    _merge_pbn_fill_or_conflict(
+        merged_data, data_sources, "nr_zeszytu", pbn_object.get("issue")
+    )
+    _merge_pbn_fill_or_conflict(
+        merged_data, data_sources, "strony", pbn_object.get("pages")
+    )
+
+    _merge_pbn_uid(merged_data, data_sources, pbn_data)
+    _merge_pbn_charakter_formalny(merged_data, data_sources, pbn_object)
 
     # Liczba arkuszy wydawniczych (specyficzne dla PBN)
-    sheets = pbn_object.get("sheets")
-    if sheets:
-        merged_data["liczba_arkuszy_wydawniczych"] = sheets
-        data_sources["liczba_arkuszy_wydawniczych"] = "PBN"
+    _merge_pbn_simple_field(
+        merged_data,
+        data_sources,
+        "liczba_arkuszy_wydawniczych",
+        pbn_object.get("sheets"),
+    )
 
     # Konferencja (jeśli jest w PBN)
     conference = pbn_object.get("conference")
     if conference:
-        conference_name = conference.get("name")
-        if conference_name:
-            merged_data["konferencja_nazwa"] = conference_name
-            data_sources["konferencja_nazwa"] = "PBN"
+        _merge_pbn_simple_field(
+            merged_data,
+            data_sources,
+            "konferencja_nazwa",
+            conference.get("name"),
+        )
 
     # Dodaj informacje o autorach z PBN jeśli brakuje w CrossRef
     pbn_authors = pbn_object.get("authors", [])

--- a/src/crossref_bpp/tests/test_helpers_characterization.py
+++ b/src/crossref_bpp/tests/test_helpers_characterization.py
@@ -1,0 +1,418 @@
+"""Charakteryzacyjne testy dla helpers.py — pinują OBECNE zachowanie przed
+refaktorem redukującym złożoność cyklomatyczną (C901).
+
+Komparatory wykonują zapytania do bazy; na pustej bazie zwracają
+``WynikPorownania`` z ``rekord_po_stronie_bpp == None`` (porównaj FD#323).
+Dlatego pola mapowane przez Komparator (zrodlo, wydawca, charakter_formalny,
+jezyk, openaccess_licencja) wychodzą None / tekst, co jest tu pinowane.
+"""
+
+import pytest
+
+from crossref_bpp.admin.helpers import (
+    convert_crossref_to_changeform_initial_data,
+    merge_crossref_and_pbn_data,
+)
+
+
+# --------------------------------------------------------------------------
+# convert_crossref_to_changeform_initial_data
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_convert_empty_dict():
+    ret = convert_crossref_to_changeform_initial_data({})
+    assert ret["tytul_oryginalny"] is None
+    assert ret["zrodlo"] is None
+    assert ret["nr_zeszytu"] == ""
+    assert ret["strony"] == ""
+    assert ret["slowa_kluczowe"] == ""
+    assert ret["wydawca"] is None
+    assert ret["wydawca_opis"] is None
+    assert ret["doi"] is None
+    assert ret["charakter_formalny"] is None
+    assert ret["jezyk"] is None
+    assert ret["adnotacje"] == "Dodano na podstawie CrossRef API"
+    assert ret["e_issn"] is None
+    assert ret["e_isbn"] is None
+    assert ret["isbn"] is None
+    assert ret["oznaczenie_wydania"] is None
+    assert ret["miejsce_i_rok"] == ""
+    assert ret["openaccess_licencja"] is None
+    assert ret["openaccess_ilosc_miesiecy"] is None
+    assert ret["issn"] is None
+    assert ret["www"] == ""
+    assert ret["tom"] == ""
+    assert ret["rok"] == ""
+
+
+@pytest.mark.django_db
+def test_convert_title_as_list_joined_with_dot_space():
+    ret = convert_crossref_to_changeform_initial_data(
+        {"title": ["Pierwszy", "Drugi"]}
+    )
+    assert ret["tytul_oryginalny"] == "Pierwszy. Drugi"
+
+
+@pytest.mark.django_db
+def test_convert_title_as_scalar():
+    ret = convert_crossref_to_changeform_initial_data({"title": "Sam tytul"})
+    assert ret["tytul_oryginalny"] == "Sam tytul"
+
+
+@pytest.mark.django_db
+def test_convert_keywords_quoted_and_joined():
+    ret = convert_crossref_to_changeform_initial_data(
+        {"subject": ["alfa", "beta"]}
+    )
+    assert ret["slowa_kluczowe"] == '"alfa", "beta"'
+
+
+@pytest.mark.django_db
+def test_convert_wydawca_opis_filled_when_no_match():
+    ret = convert_crossref_to_changeform_initial_data({"publisher": "Wiley"})
+    assert ret["wydawca"] is None
+    assert ret["wydawca_opis"] == "Wiley"
+
+
+@pytest.mark.django_db
+def test_convert_basic_scalar_fields_passthrough():
+    z = {
+        "issue": "3",
+        "page": "10-20",
+        "DOI": "10.1/x",
+        "edition-number": "2nd",
+        "volume": "42",
+    }
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["nr_zeszytu"] == "3"
+    assert ret["strony"] == "10-20"
+    assert ret["doi"] == "10.1/x"
+    assert ret["oznaczenie_wydania"] == "2nd"
+    assert ret["tom"] == "42"
+
+
+@pytest.mark.django_db
+def test_convert_www_from_resource_primary_url():
+    z = {"resource": {"primary": {"URL": "http://example.com/a"}}}
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["www"] == "http://example.com/a"
+
+
+@pytest.mark.django_db
+def test_convert_www_missing_resource_is_empty_string():
+    ret = convert_crossref_to_changeform_initial_data({"resource": {}})
+    assert ret["www"] == ""
+
+
+@pytest.mark.django_db
+def test_convert_issn_type_electronic_and_print():
+    z = {
+        "issn-type": [
+            {"type": "electronic", "value": "1111-1111"},
+            {"type": "print", "value": "2222-2222"},
+        ]
+    }
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["e_issn"] == "1111-1111"
+    assert ret["issn"] == "2222-2222"
+
+
+@pytest.mark.django_db
+def test_convert_isbn_type_electronic_and_print():
+    z = {
+        "isbn-type": [
+            {"type": "electronic", "value": "978-e"},
+            {"type": "print", "value": "978-p"},
+        ]
+    }
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["e_isbn"] == "978-e"
+    assert ret["isbn"] == "978-p"
+
+
+@pytest.mark.django_db
+def test_convert_issn_fallback_from_ISSN_when_no_issn_type():
+    z = {"ISSN": ["3333-3333"]}
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["issn"] == "3333-3333"
+
+
+@pytest.mark.django_db
+def test_convert_issn_fallback_skipped_when_equals_e_issn():
+    # ISSN equal to e_issn (electronic) => issn must stay None
+    z = {
+        "issn-type": [{"type": "electronic", "value": "4444-4444"}],
+        "ISSN": ["4444-4444"],
+    }
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["e_issn"] == "4444-4444"
+    assert ret["issn"] is None
+
+
+@pytest.mark.django_db
+def test_convert_issn_fallback_kept_when_differs_from_e_issn():
+    z = {
+        "issn-type": [{"type": "electronic", "value": "4444-4444"}],
+        "ISSN": ["5555-5555"],
+    }
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["e_issn"] == "4444-4444"
+    assert ret["issn"] == "5555-5555"
+
+
+@pytest.mark.django_db
+def test_convert_isbn_fallback_from_ISBN_when_no_isbn_type():
+    z = {"ISBN": ["978-fallback"]}
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["isbn"] == "978-fallback"
+
+
+@pytest.mark.django_db
+def test_convert_isbn_fallback_skipped_when_equals_e_isbn():
+    z = {
+        "isbn-type": [{"type": "electronic", "value": "978-e"}],
+        "ISBN": ["978-e"],
+    }
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["e_isbn"] == "978-e"
+    assert ret["isbn"] is None
+
+
+@pytest.mark.django_db
+def test_convert_issn_empty_ISSN_list_index_error_yields_none():
+    z = {"ISSN": []}
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["issn"] is None
+
+
+@pytest.mark.django_db
+def test_convert_rok_from_published_date_parts():
+    z = {"published": {"date-parts": [[2021, 5, 1]]}}
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["rok"] == 2021
+
+
+@pytest.mark.django_db
+def test_convert_rok_default_empty_when_no_published():
+    ret = convert_crossref_to_changeform_initial_data({})
+    assert ret["rok"] == ""
+
+
+@pytest.mark.django_db
+def test_convert_miejsce_i_rok_combines_location_and_year():
+    z = {
+        "publisher-location": "Warszawa",
+        "published": {"date-parts": [[1999]]},
+    }
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["miejsce_i_rok"] == "Warszawa 1999"
+
+
+@pytest.mark.django_db
+def test_convert_miejsce_i_rok_empty_without_location():
+    z = {"published": {"date-parts": [[1999]]}}
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["miejsce_i_rok"] == ""
+
+
+@pytest.mark.django_db
+def test_convert_container_title_empty_list_yields_no_zrodlo():
+    ret = convert_crossref_to_changeform_initial_data({"container-title": []})
+    assert ret["zrodlo"] is None
+
+
+@pytest.mark.django_db
+def test_convert_license_unmatched_yields_none_pk_and_no_months():
+    # License URL spoza creativecommons => brak dopasowania => pk None
+    z = {
+        "license": [
+            {
+                "URL": "http://onlinelibrary.wiley.com/x",
+                "delay-in-days": 60,
+            }
+        ]
+    }
+    ret = convert_crossref_to_changeform_initial_data(z)
+    assert ret["openaccess_licencja"] is None
+    assert ret["openaccess_ilosc_miesiecy"] is None
+
+
+# --------------------------------------------------------------------------
+# merge_crossref_and_pbn_data
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_merge_no_pbn_data_returns_crossref_only():
+    crossref = {"title": ["Tytul"], "DOI": "10.1/x"}
+    ret = merge_crossref_and_pbn_data(crossref, {})
+    assert ret["has_pbn_data"] is False
+    assert ret["tytul_oryginalny"] == "Tytul"
+    assert "data_sources" in ret
+    assert ret["data_sources"]["tytul_oryginalny"] == "CrossRef"
+    assert ret["data_sources"]["doi"] == "CrossRef"
+
+
+@pytest.mark.django_db
+def test_merge_data_sources_only_for_truthy_fields():
+    crossref = {"DOI": "10.1/x"}
+    ret = merge_crossref_and_pbn_data(crossref, {})
+    # nr_zeszytu == "" (falsy) => not in data_sources
+    assert "nr_zeszytu" not in ret["data_sources"]
+    assert ret["data_sources"]["doi"] == "CrossRef"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_fills_missing_title():
+    crossref = {}
+    pbn = {"object": {"title": "PBN Tytul"}}
+    ret = merge_crossref_and_pbn_data(crossref, pbn)
+    assert ret["has_pbn_data"] is True
+    assert ret["tytul_oryginalny"] == "PBN Tytul"
+    assert ret["data_sources"]["tytul_oryginalny"] == "PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_different_title_becomes_alternatywny():
+    crossref = {"title": ["CrossRef Tytul"]}
+    pbn = {"object": {"title": "PBN Tytul"}}
+    ret = merge_crossref_and_pbn_data(crossref, pbn)
+    assert ret["tytul_oryginalny"] == "CrossRef Tytul"
+    assert ret["tytul_alternatywny"] == "PBN Tytul"
+    assert ret["data_sources"]["tytul_alternatywny"] == "PBN"
+    assert "Tytuł w PBN: PBN Tytul" in ret["adnotacje"]
+
+
+@pytest.mark.django_db
+def test_merge_pbn_same_title_no_alternatywny():
+    crossref = {"title": ["Ten Sam"]}
+    pbn = {"object": {"title": "Ten Sam"}}
+    ret = merge_crossref_and_pbn_data(crossref, pbn)
+    assert "tytul_alternatywny" not in ret
+
+
+@pytest.mark.django_db
+def test_merge_pbn_mnisw_points():
+    ret = merge_crossref_and_pbn_data(
+        {}, {"object": {"mniswPointsForInstitution": 140}}
+    )
+    assert ret["punkty_kbn"] == 140
+    assert ret["data_sources"]["punkty_kbn"] == "PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_volume_fills_when_missing():
+    ret = merge_crossref_and_pbn_data({}, {"object": {"volume": "7"}})
+    assert ret["tom"] == "7"
+    assert ret["data_sources"]["tom"] == "PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_volume_conflict_marks_crossref_plus_pbn():
+    crossref = {"volume": "5"}
+    pbn = {"object": {"volume": "7"}}
+    ret = merge_crossref_and_pbn_data(crossref, pbn)
+    assert ret["tom"] == "5"
+    assert ret["data_sources"]["tom"] == "CrossRef+PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_volume_equal_keeps_crossref_source():
+    crossref = {"volume": "7"}
+    pbn = {"object": {"volume": "7"}}
+    ret = merge_crossref_and_pbn_data(crossref, pbn)
+    assert ret["tom"] == "7"
+    assert ret["data_sources"]["tom"] == "CrossRef"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_issue_and_pages_fill_and_conflict():
+    crossref = {"issue": "1", "page": "1-2"}
+    pbn = {"object": {"issue": "9", "pages": "3-4"}}
+    ret = merge_crossref_and_pbn_data(crossref, pbn)
+    assert ret["nr_zeszytu"] == "1"
+    assert ret["data_sources"]["nr_zeszytu"] == "CrossRef+PBN"
+    assert ret["strony"] == "1-2"
+    assert ret["data_sources"]["strony"] == "CrossRef+PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_issue_pages_fill_when_missing():
+    pbn = {"object": {"issue": "9", "pages": "3-4"}}
+    ret = merge_crossref_and_pbn_data({}, pbn)
+    assert ret["nr_zeszytu"] == "9"
+    assert ret["data_sources"]["nr_zeszytu"] == "PBN"
+    assert ret["strony"] == "3-4"
+    assert ret["data_sources"]["strony"] == "PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_uid_precedence_pbnId_first():
+    pbn = {"object": {}, "pbnId": "A", "objectId": "B", "mongoId": "C"}
+    ret = merge_crossref_and_pbn_data({}, pbn)
+    assert ret["pbn_uid"] == "A"
+    assert ret["data_sources"]["pbn_uid"] == "PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_uid_falls_back_to_objectId_then_mongoId():
+    ret = merge_crossref_and_pbn_data({}, {"object": {}, "objectId": "B"})
+    assert ret["pbn_uid"] == "B"
+    ret2 = merge_crossref_and_pbn_data({}, {"object": {}, "mongoId": "C"})
+    assert ret2["pbn_uid"] == "C"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_sheets():
+    ret = merge_crossref_and_pbn_data({}, {"object": {"sheets": "2.5"}})
+    assert ret["liczba_arkuszy_wydawniczych"] == "2.5"
+    assert ret["data_sources"]["liczba_arkuszy_wydawniczych"] == "PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_conference_name():
+    pbn = {"object": {"conference": {"name": "Konferencja X"}}}
+    ret = merge_crossref_and_pbn_data({}, pbn)
+    assert ret["konferencja_nazwa"] == "Konferencja X"
+    assert ret["data_sources"]["konferencja_nazwa"] == "PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_conference_without_name_ignored():
+    pbn = {"object": {"conference": {"city": "Lublin"}}}
+    ret = merge_crossref_and_pbn_data({}, pbn)
+    assert "konferencja_nazwa" not in ret
+
+
+@pytest.mark.django_db
+def test_merge_pbn_authors_added_when_crossref_has_no_author():
+    pbn = {"object": {"authors": [{"name": "Jan"}]}}
+    ret = merge_crossref_and_pbn_data({}, pbn)
+    assert ret["pbn_authors"] == [{"name": "Jan"}]
+    assert ret["data_sources"]["pbn_authors"] == "PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_authors_skipped_when_crossref_has_author():
+    crossref = {"author": [{"given": "A", "family": "B"}]}
+    pbn = {"object": {"authors": [{"name": "Jan"}]}}
+    ret = merge_crossref_and_pbn_data(crossref, pbn)
+    assert "pbn_authors" not in ret
+
+
+@pytest.mark.django_db
+def test_merge_adnotacje_updated_with_pbn():
+    ret = merge_crossref_and_pbn_data({}, {"object": {"title": "T"}})
+    assert ret["adnotacje"] == "Dodano na podstawie CrossRef API i PBN API"
+    assert ret["data_sources"]["adnotacje"] == "CrossRef+PBN"
+
+
+@pytest.mark.django_db
+def test_merge_pbn_data_not_a_dict_raises_attributeerror():
+    # OBECNE zachowanie: pbn_data truthy ale nie-dict => pbn_object == {}
+    # (isinstance check), ale pbn_id robi pbn_data.get(...) bez ochrony,
+    # więc lista rzuca AttributeError. Pinujemy ten stan.
+    with pytest.raises(AttributeError):
+        merge_crossref_and_pbn_data({"DOI": "10.1/x"}, ["something"])

--- a/src/crossref_bpp/tests/test_helpers_characterization.py
+++ b/src/crossref_bpp/tests/test_helpers_characterization.py
@@ -14,7 +14,6 @@ from crossref_bpp.admin.helpers import (
     merge_crossref_and_pbn_data,
 )
 
-
 # --------------------------------------------------------------------------
 # convert_crossref_to_changeform_initial_data
 # --------------------------------------------------------------------------
@@ -49,9 +48,7 @@ def test_convert_empty_dict():
 
 @pytest.mark.django_db
 def test_convert_title_as_list_joined_with_dot_space():
-    ret = convert_crossref_to_changeform_initial_data(
-        {"title": ["Pierwszy", "Drugi"]}
-    )
+    ret = convert_crossref_to_changeform_initial_data({"title": ["Pierwszy", "Drugi"]})
     assert ret["tytul_oryginalny"] == "Pierwszy. Drugi"
 
 
@@ -63,9 +60,7 @@ def test_convert_title_as_scalar():
 
 @pytest.mark.django_db
 def test_convert_keywords_quoted_and_joined():
-    ret = convert_crossref_to_changeform_initial_data(
-        {"subject": ["alfa", "beta"]}
-    )
+    ret = convert_crossref_to_changeform_initial_data({"subject": ["alfa", "beta"]})
     assert ret["slowa_kluczowe"] == '"alfa", "beta"'
 
 

--- a/src/deduplikator_autorow/tests/test_analiza_duplikatow_characterization.py
+++ b/src/deduplikator_autorow/tests/test_analiza_duplikatow_characterization.py
@@ -15,7 +15,6 @@ import pytest
 from model_bakery import baker
 
 from deduplikator_autorow.utils import analiza_duplikatow
-
 from pbn_api.models import OsobaZInstytucji, Scientist
 
 pytestmark = pytest.mark.django_db

--- a/src/deduplikator_autorow/tests/test_analiza_duplikatow_characterization.py
+++ b/src/deduplikator_autorow/tests/test_analiza_duplikatow_characterization.py
@@ -1,0 +1,111 @@
+"""
+Charakteryzacyjne testy `analiza_duplikatow` przypinające BIEŻĄCE zachowanie
+przed refaktorem obniżającym złożoność cyklomatyczną (C901).
+
+Pokrywają gałęzie nieobjęte pozostałymi plikami testowymi:
+- ścieżka błędu (brak rekordu w BPP dla Scientist),
+- analiza płci (RÓŻNA PŁEĆ → kara -100),
+- dokładny shape zwracanego słownika + dokładna wartość `pewnosc`.
+
+Wartości `pewnosc` są przypięte dokładnie (a nie tylko ">=") aby refaktor
+nie mógł niezauważalnie zmienić scoringu.
+"""
+
+import pytest
+from model_bakery import baker
+
+from deduplikator_autorow.utils import analiza_duplikatow
+
+from pbn_api.models import OsobaZInstytucji, Scientist
+
+pytestmark = pytest.mark.django_db
+
+
+def test_analiza_duplikatow_brak_rekordu_w_bpp():
+    """Scientist bez powiązanego Autora → słownik z błędem."""
+    scientist = baker.make(Scientist)
+    osoba = baker.make(OsobaZInstytucji, personId=scientist)
+
+    wynik = analiza_duplikatow(osoba)
+
+    assert wynik == {"error": "Nie można znaleźć głównego autora"}
+
+
+def test_analiza_duplikatow_dict_shape_i_dokladna_pewnosc(
+    osoba_z_instytucji, glowny_autor, autor_maker, tytuly
+):
+    """Pełne dopasowanie: przypięty kształt słownika + dokładny scoring.
+
+    glowny: 'Jan Marian' / 'Gal-Cisoń' / 'dr hab.', bez ORCID, bez publikacji.
+    duplikat: identyczne imiona/nazwisko, tytuł 'dr' (default), bez ORCID.
+
+    Scoring (bieżący):
+      +10  mało publikacji (0)
+      -15  różny tytuł naukowy ('dr' vs 'dr hab.')
+      +40  identyczne nazwisko
+      +60  wspólne imię (2) -> 30*2
+      +10  pasujące inicjały (2) -> 5*2
+      = 105
+    """
+    duplikat = autor_maker(imiona="Jan Marian", nazwisko="Gal-Cisoń")
+
+    wynik = analiza_duplikatow(osoba_z_instytucji)
+
+    assert set(wynik.keys()) == {
+        "glowny_autor",
+        "duplikaty",
+        "analiza",
+        "ilosc_duplikatow",
+    }
+    assert wynik["glowny_autor"] == glowny_autor
+    assert wynik["ilosc_duplikatow"] == 1
+    assert len(wynik["analiza"]) == 1
+
+    a = wynik["analiza"][0]
+    assert a["autor"] == duplikat
+    assert a["pewnosc"] == 105
+    assert a["powody_podobienstwa"] == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "różny tytuł naukowy - mniej prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "wspólne imię (2)",
+        "pasujące inicjały (2)",
+    ]
+
+
+def test_analiza_duplikatow_rozna_plec_kara(
+    osoba_z_instytucji, glowny_autor, autor_maker, tytuly
+):
+    """Różna płeć (Maria/FEMALE vs Mariusz/MALE) → kara -100, reason RÓŻNA PŁEĆ.
+
+    Nazwiska identyczne, imiona przechodzą hard-rejection przez wspólny
+    3-znakowy prefiks 'mar'. Scoring:
+      -100 RÓŻNA PŁEĆ
+      +10  mało publikacji (0)
+      -15  różny tytuł naukowy
+      +40  identyczne nazwisko
+      +15  podobne imię (1)
+      +5   pasujące inicjały (1)
+      = -45
+    """
+    glowny_autor.imiona = "Maria"
+    glowny_autor.save()
+
+    duplikat = autor_maker(imiona="Mariusz", nazwisko="Gal-Cisoń")
+
+    wynik = analiza_duplikatow(osoba_z_instytucji)
+
+    a = next((x for x in wynik["analiza"] if x["autor"] == duplikat), None)
+    assert a is not None
+    assert any(powod.startswith("RÓŻNA PŁEĆ:") for powod in a["powody_podobienstwa"])
+    assert a["pewnosc"] == -45
+
+
+def test_analiza_duplikatow_brak_duplikatow(osoba_z_instytucji, glowny_autor, tytuly):
+    """Brak kandydatów → puste listy, ilosc_duplikatow == 0."""
+    wynik = analiza_duplikatow(osoba_z_instytucji)
+
+    assert wynik["glowny_autor"] == glowny_autor
+    assert wynik["ilosc_duplikatow"] == 0
+    assert wynik["analiza"] == []
+    assert list(wynik["duplikaty"]) == []

--- a/src/deduplikator_autorow/tests/test_analysis_meta_characterization.py
+++ b/src/deduplikator_autorow/tests/test_analysis_meta_characterization.py
@@ -1,0 +1,367 @@
+"""Charakteryzacyjne testy ``analiza_pary_meta``.
+
+Pinują DOKŁADNE (score, reasons) dla reprezentatywnych wejść, tak aby
+refaktoryzacja na tabelę reguł była gwarantowanie behavior-preserving.
+Każdy assert sprawdza zarówno zwracany int, jak i pełną listę powodów
+(w identycznej kolejności) — to jest właściwa charakteryzacja zachowania.
+"""
+
+from deduplikator_autorow.utils.analysis_meta import analiza_pary_meta
+
+
+def _meta(
+    nazwisko="kowalski",
+    imiona=("jan",),
+    orcid=None,
+    tytul=False,
+    tytul_id=None,
+    pubs=0,
+    lata=None,
+):
+    return {
+        "nazwisko_norm": nazwisko,
+        "nazwisko_parts": nazwisko.split("-"),
+        "imiona_norm": list(imiona),
+        "orcid_value": orcid,
+        "ma_orcid": bool(orcid),
+        "ma_tytul": tytul,
+        "tytul_id": tytul_id if tytul_id is not None else (1 if tytul else None),
+        "publikacje_count": pubs,
+        "lata_publikacji": set(lata or []),
+    }
+
+
+# --- Para identyczna -------------------------------------------------------
+
+
+def test_identyczna_para_domyslna():
+    score, reasons = analiza_pary_meta(_meta(), _meta())
+    assert score == 85
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+# --- Hard rejection: zupełnie różne imiona ---------------------------------
+
+
+def test_hard_rejection_rozne_imiona():
+    a = _meta(nazwisko="kowalski", imiona=("jan",))
+    b = _meta(nazwisko="kowalski", imiona=("agnieszka",))
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == -1000
+    assert reasons == [
+        "odrzucono: zupełnie różne imiona ('jan' vs 'agnieszka') — to różni autorzy"
+    ]
+
+
+# --- Gałęzie liczby publikacji ---------------------------------------------
+
+
+def test_srednio_publikacji_6():
+    score, reasons = analiza_pary_meta(_meta(pubs=6), _meta(pubs=6))
+    assert score == 65
+    assert reasons == [
+        "średnio publikacji (6) - możliwy duplikat",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+def test_wiele_publikacji_11():
+    score, reasons = analiza_pary_meta(_meta(pubs=11), _meta(pubs=11))
+    assert score == 55
+    assert reasons == [
+        "wiele publikacji (11) - mało prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+# --- Gałęzie tytułu naukowego ----------------------------------------------
+
+
+def test_brak_tytulu_u_kandydata():
+    score, reasons = analiza_pary_meta(_meta(tytul=True), _meta(tytul=False))
+    assert score == 100
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "brak tytułu naukowego u kandydata - prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+def test_oba_maja_identyczny_tytul():
+    a = _meta(tytul=True, tytul_id=5)
+    b = _meta(tytul=True, tytul_id=5)
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 95
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczny tytuł naukowy",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+def test_oba_maja_rozny_tytul():
+    a = _meta(tytul=True, tytul_id=5)
+    b = _meta(tytul=True, tytul_id=9)
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 70
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "różny tytuł naukowy",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+# --- Gałęzie ORCID ----------------------------------------------------------
+
+
+def test_brak_orcid_u_kandydata():
+    a = _meta(orcid="0000-0001-1111-1111")
+    b = _meta(orcid=None)
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 100
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "brak ORCID u kandydata - prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+def test_identyczny_orcid():
+    a = _meta(orcid="0000-0001-1111-1111")
+    b = _meta(orcid="0000-0001-1111-1111")
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 135
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczny ORCID - to ten sam autor",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+def test_rozny_orcid():
+    a = _meta(imiona=("jan",), orcid="0000-0001-1111-1111")
+    b = _meta(imiona=("jan",), orcid="0000-0002-2222-2222")
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 35
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "różny ORCID - to różni autorzy",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+# --- Gałęzie nazwiska -------------------------------------------------------
+
+
+def test_nazwisko_zawieranie():
+    a = _meta(nazwisko="kowalski", imiona=("jan",))
+    b = _meta(nazwisko="kowalski-nowak", imiona=("jan",))
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 75
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "podobne nazwisko (zawieranie)",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+def test_nazwisko_permutacja_czlonow():
+    a = _meta(nazwisko="gal-cison", imiona=("jan",))
+    b = _meta(nazwisko="cison-gal", imiona=("jan",))
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 80
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczne człony nazwiska złożonego (permutacja)",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+def test_nazwisko_wspolny_czlon():
+    a = _meta(nazwisko="gal-cison", imiona=("jan",))
+    b = _meta(nazwisko="gal-nowak", imiona=("jan",))
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 65
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "wspólny człon nazwiska złożonego (gal)",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+# --- Swap imię ↔ nazwisko ---------------------------------------------------
+
+
+def test_swap_imie_nazwisko():
+    a = _meta(nazwisko="kowalski", imiona=("jan",))
+    b = _meta(nazwisko="jan", imiona=("kowalski",))
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 60
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "wykryto pełną zamianę imienia z nazwiskiem",
+    ]
+
+
+# --- Podobne imię (3-prefix) ------------------------------------------------
+
+
+def test_podobne_imie_3prefix():
+    a = _meta(nazwisko="kowalski", imiona=("janusz",))
+    b = _meta(nazwisko="kowalski", imiona=("janowski",))
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 70
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "podobne imię (1)",
+        "pasujące inicjały (1)",
+    ]
+
+
+# --- Brak imion u kandydata (b puste, a niepuste) ---------------------------
+
+
+def test_brak_imion_u_kandydata():
+    a = _meta(imiona=("jan",))
+    b = _meta(imiona=())
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 60
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "brak imion u kandydata",
+    ]
+
+
+# --- Gałęzie lat publikacji -------------------------------------------------
+
+
+def test_wspolne_lata():
+    a = _meta(lata=[2020, 2021])
+    b = _meta(lata=[2021, 2022])
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 105
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+        "wspólne lata publikacji: [2021]",
+    ]
+
+
+def test_bliskie_lata():
+    a = _meta(lata=[2020])
+    b = _meta(lata=[2022])
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 100
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+        "bliskie lata publikacji (różnica 2)",
+    ]
+
+
+def test_srednia_odleglosc_lat():
+    a = _meta(lata=[2020])
+    b = _meta(lata=[2025])
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 80
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+        "średnia odległość lat publikacji (5)",
+    ]
+
+
+def test_duza_odleglosc_lat():
+    a = _meta(lata=[2000])
+    b = _meta(lata=[2020])
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 65
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczne nazwisko",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+        "duża odległość lat publikacji (20)",
+    ]
+
+
+# --- Oba bez imion: brak gałęzi imion, brak hard-rejection ------------------
+
+
+def test_oba_bez_imion():
+    a = _meta(imiona=())
+    b = _meta(imiona=())
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 50
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczne nazwisko",
+    ]
+
+
+# --- Brakujące klucze opcjonalne (.get fallbacks) + None tytul_id ----------
+
+
+def test_brakujace_klucze_opcjonalne():
+    """Bez ``nazwisko_parts`` / ``tytul_id`` / ``orcid_value`` w dict-cie.
+
+    Pinuje fallbacki ``.get(...)``: brak ``nazwisko_parts`` → puste człony,
+    a ``tytul_id`` nieobecne po obu stronach (None == None) → tytuł
+    traktowany jako identyczny.
+    """
+    a = {
+        "nazwisko_norm": "abcdef",
+        "imiona_norm": ["jan"],
+        "ma_orcid": False,
+        "ma_tytul": True,
+        "publikacje_count": 0,
+        "lata_publikacji": set(),
+    }
+    b = {
+        "nazwisko_norm": "xyzwvu",
+        "imiona_norm": ["jan"],
+        "ma_orcid": False,
+        "ma_tytul": True,
+        "publikacje_count": 0,
+        "lata_publikacji": set(),
+    }
+    score, reasons = analiza_pary_meta(a, b)
+    assert score == 55
+    assert reasons == [
+        "mało publikacji (0) - prawdopodobny duplikat",
+        "identyczny tytuł naukowy",
+        "wspólne imię (1)",
+        "pasujące inicjały (1)",
+    ]

--- a/src/deduplikator_autorow/utils/analysis.py
+++ b/src/deduplikator_autorow/utils/analysis.py
@@ -15,8 +15,335 @@ from .search import szukaj_kopii
 
 logger = logging.getLogger(__name__)
 
+_BRAK_GLOWNEGO_AUTORA = {"error": "Nie można znaleźć głównego autora"}
 
-def analiza_duplikatow(osoba_z_instytucji: OsobaZInstytucji) -> dict:  # noqa: C901
+
+def _ustal_glownego_autora(osoba_z_instytucji: OsobaZInstytucji):
+    """Zwraca głównego autora BPP dla OsobaZInstytucji albo ``None``.
+
+    ``None`` oznacza, że nie udało się ustalić głównego autora (brak
+    Scientist, brak rekordu w BPP albo wyjątek przy ustalaniu).
+    """
+    try:
+        scientist = osoba_z_instytucji.personId
+        if not scientist:
+            return None
+        glowny_autor = scientist.rekord_w_bpp
+    except Exception:
+        zaloguj_polkniety_wyjatek(
+            "Ustalanie głównego autora z BPP dla OsobaZInstytucji "
+            f"(pk={osoba_z_instytucji.pk}) w analizie duplikatów",
+            logger=logger,
+            do_rollbar=True,
+        )
+        return None
+    return glowny_autor or None
+
+
+def _imiona_calkowicie_rozlaczne(glowny_autor: Autor, duplikat: Autor) -> bool:
+    """HARD REJECTION: imiona zupełnie rozłączne i to NIE swap.
+
+    Zwraca ``True`` gdy obie strony mają imiona, ale nie ma między nimi
+    żadnego punktu wspólnego (pełne imię, 3-prefix, inicjał) ani wykrytej
+    pełnej zamiany imię↔nazwisko. 'Jan' nie może być duplikatem 'Agnieszki'
+    niezależnie od ORCID, nazwiska czy lat publikacji.
+    """
+    if not (duplikat.imiona and glowny_autor.imiona):
+        return False
+
+    imiona_glowny = glowny_autor.imiona.split()
+    imiona_duplikat = duplikat.imiona.split()
+
+    common = sum(
+        1
+        for ig in imiona_glowny
+        for id_ in imiona_duplikat
+        if ig.lower() == id_.lower()
+    )
+    similar = sum(
+        1
+        for ig in imiona_glowny
+        for id_ in imiona_duplikat
+        if len(ig) >= 3
+        and len(id_) >= 3
+        and ig.lower() != id_.lower()
+        and (
+            ig.lower().startswith(id_.lower()[:3])
+            or id_.lower().startswith(ig.lower()[:3])
+        )
+    )
+    initials_g = {ig[0].upper() for ig in imiona_glowny if ig}
+    # 'J.' / 'J' / 'Jan' wszystkie dają inicjał na pierwszym znaku
+    initials_d = {token[0].upper() for token in imiona_duplikat if token}
+    init_count = len(initials_g & initials_d)
+    # Inicjały też liczone do swap-detection: 'Jan Kowalski' ↔ 'Kowalski J.'
+    # (database swap z inicjałem) musi przejść.
+    swap = (
+        bool(duplikat.nazwisko)
+        and bool(glowny_autor.nazwisko)
+        and any(_name_or_initial_match(duplikat.nazwisko, ig) for ig in imiona_glowny)
+        and any(
+            _name_or_initial_match(glowny_autor.nazwisko, id_)
+            for id_ in imiona_duplikat
+        )
+    )
+    return common == 0 and similar == 0 and init_count == 0 and not swap
+
+
+def _ocena_plci(
+    glowny_autor: Autor, plec_glowny: Gender, duplikat: Autor
+) -> tuple[int, list[str]]:
+    """Jeśli płcie są na pewno różne, to NIE mogą być duplikatami."""
+    plec_duplikat = zgadnij_plec_autora(duplikat.imiona, duplikat.plec)
+    if not plcie_sa_rozne(plec_glowny, plec_duplikat):
+        return 0, []
+
+    plec_glowny_str = "mężczyzna" if plec_glowny == Gender.MALE else "kobieta"
+    plec_duplikat_str = "mężczyzna" if plec_duplikat == Gender.MALE else "kobieta"
+    # Bardzo silna kara - praktycznie wyklucza duplikat
+    return -100, [
+        f"RÓŻNA PŁEĆ: główny autor to {plec_glowny_str} "
+        f"({glowny_autor.imiona or '?'}), "
+        f"duplikat to {plec_duplikat_str} ({duplikat.imiona or '?'}) "
+        "- NIE MOGĄ być tą samą osobą"
+    ]
+
+
+def _ocena_liczby_publikacji(
+    glowny_autor: Autor, duplikat: Autor
+) -> tuple[int, list[str]]:
+    """Autorzy z wieloma publikacjami rzadziej są duplikatami."""
+    publikacje_duplikat = Rekord.objects.prace_autora(duplikat).count()
+    publikacje_glowny = Rekord.objects.prace_autora(glowny_autor).count()
+
+    if publikacje_duplikat > publikacje_glowny and publikacje_duplikat > 3:
+        return -30, [
+            f"duplikat ma więcej publikacji ({publikacje_duplikat}) niż główny "
+            f"({publikacje_glowny}) - prawdopodobnie NIE jest duplikatem"
+        ]
+    if publikacje_duplikat > 10:
+        return -20, [
+            f"wiele publikacji ({publikacje_duplikat}) - mało prawdopodobny duplikat"
+        ]
+    if publikacje_duplikat > 5:
+        return -10, [f"średnio publikacji ({publikacje_duplikat}) - możliwy duplikat"]
+    # publikacje_duplikat <= 5
+    return 10, [f"mało publikacji ({publikacje_duplikat}) - prawdopodobny duplikat"]
+
+
+def _ocena_tytulu(glowny_autor: Autor, duplikat: Autor) -> tuple[int, list[str]]:
+    """Analiza tytułu naukowego."""
+    if not duplikat.tytul and glowny_autor.tytul:
+        return 15, ["brak tytułu naukowego - prawdopodobny duplikat"]
+    if duplikat.tytul and glowny_autor.tytul:
+        if duplikat.tytul == glowny_autor.tytul:
+            return 10, ["identyczny tytuł naukowy"]
+        return -15, ["różny tytuł naukowy - mniej prawdopodobny duplikat"]
+    return 0, []
+
+
+def _ocena_orcid(glowny_autor: Autor, duplikat: Autor) -> tuple[int, list[str]]:
+    """Analiza ORCID."""
+    if not duplikat.orcid and glowny_autor.orcid:
+        return 15, ["brak ORCID - prawdopodobny duplikat"]
+    if duplikat.orcid and glowny_autor.orcid:
+        if duplikat.orcid == glowny_autor.orcid:
+            return 50, ["identyczny ORCID - to ten sam autor"]
+        return -50, ["różny ORCID - to różni autorzy"]
+    return 0, []
+
+
+def _ocena_nazwiska(glowny_autor: Autor, duplikat: Autor) -> tuple[int, list[str]]:
+    """Analiza nazwiska."""
+    if not (duplikat.nazwisko and glowny_autor.nazwisko):
+        return 0, []
+    dup = duplikat.nazwisko.lower()
+    glw = glowny_autor.nazwisko.lower()
+    if dup == glw:
+        return 40, ["identyczne nazwisko"]
+    if glw in dup or dup in glw:
+        return 30, ["podobne nazwisko"]
+    return 0, []
+
+
+def _ocena_zamiany_imienia_nazwiska(
+    glowny_autor: Autor, duplikat: Autor
+) -> tuple[int, list[str]]:
+    """Analiza zamiany imienia z nazwiskiem (name-surname swap detection).
+
+    Punktuje tylko pełną zamianę (OBE strony muszą się zgadzać) - dokładnie
+    LUB jako inicjał (np. 'J.' do 'Jan'). Częściowa zamiana nie istnieje.
+    """
+    if not (
+        duplikat.nazwisko
+        and duplikat.imiona
+        and glowny_autor.nazwisko
+        and glowny_autor.imiona
+    ):
+        return 0, []
+
+    imiona_glowny = glowny_autor.imiona.split()
+    imiona_duplikat = duplikat.imiona.split()
+
+    zamiana_nazwisko_duplikat = any(
+        _name_or_initial_match(duplikat.nazwisko, imie_g) for imie_g in imiona_glowny
+    )
+    zamiana_nazwisko_glowny = any(
+        _name_or_initial_match(glowny_autor.nazwisko, imie_d)
+        for imie_d in imiona_duplikat
+    )
+
+    if zamiana_nazwisko_duplikat and zamiana_nazwisko_glowny:
+        return 50, [
+            f"wykryto pełną zamianę imienia z nazwiskiem "
+            f"('{glowny_autor.nazwisko} {glowny_autor.imiona}' ↔ "
+            f"'{duplikat.nazwisko} {duplikat.imiona}')"
+        ]
+    return 0, []
+
+
+def _inicjaly_duplikatu(imiona: str) -> list[str]:
+    """Wyodrębnia inicjały z duplikatu (obsługa 'J.', 'J. M.', 'Jan M.' itp.)."""
+    inicjaly = []
+    for token in imiona.split():
+        if len(token) == 1 or (len(token) == 2 and token.endswith(".")):
+            # To jest inicjał
+            inicjaly.append(token[0].upper())
+        elif len(token) > 1 and not token.endswith("."):
+            # To jest pełne imię
+            inicjaly.append(token[0].upper())
+    return inicjaly
+
+
+def _ocena_imion(glowny_autor: Autor, duplikat: Autor) -> tuple[int, list[str]]:
+    """Analiza imion: dokładne dopasowania, podobne imiona, inicjały."""
+    if not glowny_autor.imiona:
+        return 0, []
+    if not duplikat.imiona:
+        return 10, ["brak imion w duplikacie"]
+
+    imiona_glowny = glowny_autor.imiona.split()
+    imiona_duplikat = duplikat.imiona.split()
+
+    pewnosc = 0
+    powody: list[str] = []
+
+    dokladne_dopasowania = sum(
+        1
+        for imie_g in imiona_glowny
+        for imie_d in imiona_duplikat
+        if imie_g.lower() == imie_d.lower()
+    )
+    if dokladne_dopasowania > 0:
+        powody.append(f"wspólne imię ({dokladne_dopasowania})")
+        pewnosc += 30 * dokladne_dopasowania
+
+    podobne_dopasowania = sum(
+        1
+        for imie_g in imiona_glowny
+        for imie_d in imiona_duplikat
+        if len(imie_g) >= 3
+        and len(imie_d) >= 3
+        and (
+            imie_g.lower().startswith(imie_d.lower()[:3])
+            or imie_d.lower().startswith(imie_g.lower()[:3])
+        )
+        and imie_g.lower() != imie_d.lower()
+    )
+    if podobne_dopasowania > 0:
+        powody.append(f"podobne imię ({podobne_dopasowania})")
+        pewnosc += 15 * podobne_dopasowania
+
+    inicjaly_glowny = [imie[0].upper() for imie in imiona_glowny if len(imie) > 0]
+    inicjaly_duplikat = _inicjaly_duplikatu(duplikat.imiona)
+    dopasowania_inicjalow = sum(
+        1
+        for inicjal_g in inicjaly_glowny
+        for inicjal_d in inicjaly_duplikat
+        if inicjal_g == inicjal_d
+    )
+    if dopasowania_inicjalow > 0:
+        powody.append(f"pasujące inicjały ({dopasowania_inicjalow})")
+        pewnosc += 5 * dopasowania_inicjalow
+
+    return pewnosc, powody
+
+
+def _lata_publikacji(autor: Autor) -> set:
+    return set(
+        Rekord.objects.prace_autora(autor)
+        .filter(rok__isnull=False)
+        .values_list("rok", flat=True)
+    )
+
+
+def _ocena_temporalna(glowny_autor: Autor, duplikat: Autor) -> tuple[int, list[str]]:
+    """Analiza temporalna - porównanie lat publikacji."""
+    lata_glowny = _lata_publikacji(glowny_autor)
+    lata_duplikat = _lata_publikacji(duplikat)
+
+    if not (lata_glowny and lata_duplikat):
+        return 0, []
+
+    wspolne_lata = lata_glowny & lata_duplikat
+    if wspolne_lata:
+        return 20, [f"wspólne lata publikacji: {sorted(wspolne_lata)}"]
+
+    min_odleglosc = min(
+        abs(rok_glowny - rok_duplikat)
+        for rok_glowny in lata_glowny
+        for rok_duplikat in lata_duplikat
+    )
+    if min_odleglosc <= 2:
+        return 15, [
+            f"bliskie lata publikacji (różnica {min_odleglosc} lat) "
+            "- prawdopodobny duplikat"
+        ]
+    if min_odleglosc <= 7:
+        return -5, [
+            f"średnia odległość lat publikacji ({min_odleglosc} lat) - możliwy duplikat"
+        ]
+    return -20, [
+        f"duża odległość lat publikacji ({min_odleglosc} lat) "
+        "- mało prawdopodobny duplikat"
+    ]
+
+
+# Kolejność MA znaczenie - definiuje kolejność wpisów w "powody_podobienstwa".
+_OCENY = (
+    _ocena_liczby_publikacji,
+    _ocena_tytulu,
+    _ocena_orcid,
+    _ocena_nazwiska,
+    _ocena_zamiany_imienia_nazwiska,
+    _ocena_imion,
+    _ocena_temporalna,
+)
+
+
+def _analizuj_duplikat(
+    glowny_autor: Autor, plec_glowny: Gender, duplikat: Autor
+) -> dict | None:
+    """Zwraca słownik analizy pojedynczego duplikatu albo ``None``.
+
+    ``None`` oznacza hard rejection (imiona całkowicie rozłączne).
+    """
+    if _imiona_calkowicie_rozlaczne(glowny_autor, duplikat):
+        return None
+
+    analiza = {"autor": duplikat, "powody_podobienstwa": [], "pewnosc": 0}  # 0-100%
+
+    oceny = [_ocena_plci(glowny_autor, plec_glowny, duplikat)]
+    oceny += [ocena(glowny_autor, duplikat) for ocena in _OCENY]
+
+    for delta, powody in oceny:
+        analiza["pewnosc"] += delta
+        analiza["powody_podobienstwa"].extend(powody)
+
+    return analiza
+
+
+def analiza_duplikatow(osoba_z_instytucji: OsobaZInstytucji) -> dict:
     """
     Przeprowadza szczegółową analizę znalezionych duplikatów.
 
@@ -29,332 +356,21 @@ def analiza_duplikatow(osoba_z_instytucji: OsobaZInstytucji) -> dict:  # noqa: C
             - duplikaty: lista znalezionych duplikatów
             - analiza: szczegółowa analiza każdego duplikatu
     """
-    try:
-        scientist = osoba_z_instytucji.personId
-        if not scientist:
-            return {"error": "Nie można znaleźć głównego autora"}
-        glowny_autor = scientist.rekord_w_bpp
-    except Exception:
-        zaloguj_polkniety_wyjatek(
-            "Ustalanie głównego autora z BPP dla OsobaZInstytucji "
-            f"(pk={osoba_z_instytucji.pk}) w analizie duplikatów",
-            logger=logger,
-            do_rollbar=True,
-        )
-        return {"error": "Nie można znaleźć głównego autora"}
-
-    if not glowny_autor:
-        return {"error": "Nie można znaleźć głównego autora"}
+    glowny_autor = _ustal_glownego_autora(osoba_z_instytucji)
+    if glowny_autor is None:
+        return dict(_BRAK_GLOWNEGO_AUTORA)
 
     duplikaty = szukaj_kopii(osoba_z_instytucji)
-
-    analiza_duplikatow_lista = []
 
     # Zgadnij płeć głównego autora (raz, przed pętlą)
     plec_glowny = zgadnij_plec_autora(glowny_autor.imiona, glowny_autor.plec)
 
-    for duplikat in duplikaty:
-        # HARD REJECTION: imiona zupełnie rozłączne (brak common, similar,
-        # initial overlap) i to NIE swap → nie jest tym samym autorem.
-        # 'Jan' nie może być duplikatem 'Agnieszki' niezależnie od ORCID,
-        # nazwiska czy lat publikacji. Pomijamy całkowicie.
-        if duplikat.imiona and glowny_autor.imiona:
-            imiona_glowny_pre = glowny_autor.imiona.split()
-            imiona_duplikat_pre = duplikat.imiona.split()
-            common_pre = sum(
-                1
-                for ig in imiona_glowny_pre
-                for id_ in imiona_duplikat_pre
-                if ig.lower() == id_.lower()
-            )
-            similar_pre = sum(
-                1
-                for ig in imiona_glowny_pre
-                for id_ in imiona_duplikat_pre
-                if len(ig) >= 3
-                and len(id_) >= 3
-                and ig.lower() != id_.lower()
-                and (
-                    ig.lower().startswith(id_.lower()[:3])
-                    or id_.lower().startswith(ig.lower()[:3])
-                )
-            )
-            initials_g_pre = {ig[0].upper() for ig in imiona_glowny_pre if ig}
-            initials_d_pre = set()
-            for token in imiona_duplikat_pre:
-                if not token:
-                    continue
-                # 'J.' / 'J' / 'Jan' wszystkie dają inicjał na pierwszym znaku
-                initials_d_pre.add(token[0].upper())
-            init_count_pre = len(initials_g_pre & initials_d_pre)
-            # Inicjały też liczone do swap-detection: 'Jan Kowalski' ↔
-            # 'Kowalski J.' (database swap z inicjałem) musi przejść.
-            swap_pre = (
-                bool(duplikat.nazwisko)
-                and bool(glowny_autor.nazwisko)
-                and any(
-                    _name_or_initial_match(duplikat.nazwisko, ig)
-                    for ig in imiona_glowny_pre
-                )
-                and any(
-                    _name_or_initial_match(glowny_autor.nazwisko, id_)
-                    for id_ in imiona_duplikat_pre
-                )
-            )
-            if (
-                common_pre == 0
-                and similar_pre == 0
-                and init_count_pre == 0
-                and not swap_pre
-            ):
-                continue
-
-        analiza = {"autor": duplikat, "powody_podobienstwa": [], "pewnosc": 0}  # 0-100%
-
-        # Analiza płci - jeśli płcie są na pewno różne, to NIE mogą być duplikatami
-        plec_duplikat = zgadnij_plec_autora(duplikat.imiona, duplikat.plec)
-
-        if plcie_sa_rozne(plec_glowny, plec_duplikat):
-            plec_glowny_str = "mężczyzna" if plec_glowny == Gender.MALE else "kobieta"
-            plec_duplikat_str = (
-                "mężczyzna" if plec_duplikat == Gender.MALE else "kobieta"
-            )
-            analiza["powody_podobienstwa"].append(
-                f"RÓŻNA PŁEĆ: główny autor to {plec_glowny_str} "
-                f"({glowny_autor.imiona or '?'}), "
-                f"duplikat to {plec_duplikat_str} ({duplikat.imiona or '?'}) "
-                "- NIE MOGĄ być tą samą osobą"
-            )
-            analiza["pewnosc"] -= (
-                100  # Bardzo silna kara - praktycznie wyklucza duplikat
-            )
-
-        # Analiza liczby publikacji - autorzy z wieloma publikacjami rzadziej są duplikatami
-        publikacje_duplikat = Rekord.objects.prace_autora(duplikat).count()
-        publikacje_glowny = Rekord.objects.prace_autora(glowny_autor).count()
-
-        # Sprawdź czy potencjalny duplikat ma więcej publikacji niż główny autor
-        if publikacje_duplikat > publikacje_glowny and publikacje_duplikat > 3:
-            analiza["powody_podobienstwa"].append(
-                f"duplikat ma więcej publikacji ({publikacje_duplikat}) niż główny "
-                f"({publikacje_glowny}) - prawdopodobnie NIE jest duplikatem"
-            )
-            analiza["pewnosc"] -= 30  # znacznie zmniejsz pewność
-        elif publikacje_duplikat > 10:
-            analiza["powody_podobienstwa"].append(
-                f"wiele publikacji ({publikacje_duplikat}) - mało prawdopodobny duplikat"
-            )
-            analiza["pewnosc"] -= 20  # znacznie zmniejsz pewność
-        elif publikacje_duplikat > 5:
-            analiza["powody_podobienstwa"].append(
-                f"średnio publikacji ({publikacje_duplikat}) - możliwy duplikat"
-            )
-            analiza["pewnosc"] -= 10  # zmniejsz pewność
-        elif publikacje_duplikat <= 5:
-            analiza["powody_podobienstwa"].append(
-                f"mało publikacji ({publikacje_duplikat}) - prawdopodobny duplikat"
-            )
-            analiza["pewnosc"] += (
-                10  # zwiększ pewność dla autorów z małą liczbą publikacji
-            )
-
-        # Analiza tytułu naukowego
-        if not duplikat.tytul and glowny_autor.tytul:
-            analiza["powody_podobienstwa"].append(
-                "brak tytułu naukowego - prawdopodobny duplikat"
-            )
-            analiza["pewnosc"] += 15
-        elif duplikat.tytul and glowny_autor.tytul:
-            if duplikat.tytul == glowny_autor.tytul:
-                analiza["powody_podobienstwa"].append("identyczny tytuł naukowy")
-                analiza["pewnosc"] += 10
-            else:
-                analiza["powody_podobienstwa"].append(
-                    "różny tytuł naukowy - mniej prawdopodobny duplikat"
-                )
-                analiza["pewnosc"] -= 15
-
-        # Analiza ORCID
-        if not duplikat.orcid and glowny_autor.orcid:
-            analiza["powody_podobienstwa"].append("brak ORCID - prawdopodobny duplikat")
-            analiza["pewnosc"] += 15
-        elif duplikat.orcid and glowny_autor.orcid:
-            if duplikat.orcid == glowny_autor.orcid:
-                analiza["powody_podobienstwa"].append(
-                    "identyczny ORCID - to ten sam autor"
-                )
-                analiza["pewnosc"] += 50  # bardzo wysoka pewność
-            else:
-                analiza["powody_podobienstwa"].append("różny ORCID - to różni autorzy")
-                analiza["pewnosc"] -= 50  # bardzo zmniejsz pewność
-
-        # Analiza nazwiska
-        if duplikat.nazwisko and glowny_autor.nazwisko:
-            if duplikat.nazwisko.lower() == glowny_autor.nazwisko.lower():
-                analiza["powody_podobienstwa"].append("identyczne nazwisko")
-                analiza["pewnosc"] += 40
-            elif (
-                glowny_autor.nazwisko.lower() in duplikat.nazwisko.lower()
-                or duplikat.nazwisko.lower() in glowny_autor.nazwisko.lower()
-            ):
-                analiza["powody_podobienstwa"].append("podobne nazwisko")
-                analiza["pewnosc"] += 30
-
-        # Analiza zamiany imienia z nazwiskiem (name-surname swap detection)
-        # Wykrywamy tylko dokładne zamiany, bez podobieństwa opartego na pierwszych znakach
-        if (
-            duplikat.nazwisko
-            and duplikat.imiona
-            and glowny_autor.nazwisko
-            and glowny_autor.imiona
-        ):
-            imiona_glowny = glowny_autor.imiona.split()
-            imiona_duplikat = duplikat.imiona.split()
-
-            # Sprawdź czy nazwisko duplikatu pasuje do imienia głównego
-            # (dokładnie LUB jako inicjał, np. 'J.' do 'Jan').
-            dokladna_zamiana_nazwisko_duplikat = any(
-                _name_or_initial_match(duplikat.nazwisko, imie_g)
-                for imie_g in imiona_glowny
-            )
-
-            # Sprawdź czy nazwisko głównego pasuje do imienia duplikatu
-            # (dokładnie LUB jako inicjał).
-            dokladna_zamiana_nazwisko_glowny = any(
-                _name_or_initial_match(glowny_autor.nazwisko, imie_d)
-                for imie_d in imiona_duplikat
-            )
-
-            # Punktacja za zamianę - tylko pełna zamiana (OBE strony muszą się zgadzać)
-            # Częściowa zamiana nie istnieje - swap to albo "Jan Kowalski"→"Kowalski Jan", albo nic
-            if dokladna_zamiana_nazwisko_duplikat and dokladna_zamiana_nazwisko_glowny:
-                analiza["powody_podobienstwa"].append(
-                    f"wykryto pełną zamianę imienia z nazwiskiem "
-                    f"('{glowny_autor.nazwisko} {glowny_autor.imiona}' ↔ "
-                    f"'{duplikat.nazwisko} {duplikat.imiona}')"
-                )
-                analiza["pewnosc"] += 50
-
-        # Analiza imion
-        if duplikat.imiona and glowny_autor.imiona:
-            imiona_glowny = glowny_autor.imiona.split()
-            imiona_duplikat = duplikat.imiona.split()
-
-            # Sprawdź dokładne dopasowania imion
-            dokladne_dopasowania = sum(
-                1
-                for imie_g in imiona_glowny
-                for imie_d in imiona_duplikat
-                if imie_g.lower() == imie_d.lower()
-            )
-
-            if dokladne_dopasowania > 0:
-                analiza["powody_podobienstwa"].append(
-                    f"wspólne imię ({dokladne_dopasowania})"
-                )
-                analiza["pewnosc"] += 30 * dokladne_dopasowania
-
-            # Sprawdź podobne imiona (pierwsze 3 znaki)
-            podobne_dopasowania = sum(
-                1
-                for imie_g in imiona_glowny
-                for imie_d in imiona_duplikat
-                if len(imie_g) >= 3
-                and len(imie_d) >= 3
-                and (
-                    imie_g.lower().startswith(imie_d.lower()[:3])
-                    or imie_d.lower().startswith(imie_g.lower()[:3])
-                )
-                and imie_g.lower() != imie_d.lower()
-            )
-
-            if podobne_dopasowania > 0:
-                analiza["powody_podobienstwa"].append(
-                    f"podobne imię ({podobne_dopasowania})"
-                )
-                analiza["pewnosc"] += 15 * podobne_dopasowania
-
-            # Sprawdź dopasowania inicjałów
-            inicjaly_glowny = [
-                imie[0].upper() for imie in imiona_glowny if len(imie) > 0
-            ]
-
-            # Wyodrębnij inicjały z duplikatu (obsługa "J.", "J. M.", "Jan M." itp.)
-            inicjaly_duplikat = []
-            for token in duplikat.imiona.split():
-                if len(token) == 1 or (len(token) == 2 and token.endswith(".")):
-                    # To jest inicjał
-                    inicjaly_duplikat.append(token[0].upper())
-                elif len(token) > 1 and not token.endswith("."):
-                    # To jest pełne imię
-                    inicjaly_duplikat.append(token[0].upper())
-
-            dopasowania_inicjalow = sum(
-                1
-                for inicjal_g in inicjaly_glowny
-                for inicjal_d in inicjaly_duplikat
-                if inicjal_g == inicjal_d
-            )
-
-            if dopasowania_inicjalow > 0:
-                analiza["powody_podobienstwa"].append(
-                    f"pasujące inicjały ({dopasowania_inicjalow})"
-                )
-                analiza["pewnosc"] += 5 * dopasowania_inicjalow
-
-        elif not duplikat.imiona and glowny_autor.imiona:
-            analiza["powody_podobienstwa"].append("brak imion w duplikacie")
-            analiza["pewnosc"] += 10
-
-        # Analiza temporalna - porównanie lat publikacji
-        lata_glowny = set(
-            Rekord.objects.prace_autora(glowny_autor)
-            .filter(rok__isnull=False)
-            .values_list("rok", flat=True)
-        )
-        lata_duplikat = set(
-            Rekord.objects.prace_autora(duplikat)
-            .filter(rok__isnull=False)
-            .values_list("rok", flat=True)
-        )
-
-        if lata_glowny and lata_duplikat:
-            # Sprawdź czy są wspólne lata lub bliskie lata (+/- 2)
-            wspolne_lata = lata_glowny & lata_duplikat
-
-            if wspolne_lata:
-                analiza["powody_podobienstwa"].append(
-                    f"wspólne lata publikacji: {sorted(wspolne_lata)}"
-                )
-                analiza["pewnosc"] += 20  # wysokie prawdopodobieństwo duplikatu
-            else:
-                # Sprawdź bliskie lata (+/- 2 lata)
-                min_odleglosc = float("inf")
-                for rok_glowny in lata_glowny:
-                    for rok_duplikat in lata_duplikat:
-                        odleglosc = abs(rok_glowny - rok_duplikat)
-                        min_odleglosc = min(min_odleglosc, odleglosc)
-
-                if min_odleglosc <= 2:
-                    analiza["powody_podobienstwa"].append(
-                        f"bliskie lata publikacji (różnica {min_odleglosc} lat) "
-                        "- prawdopodobny duplikat"
-                    )
-                    analiza["pewnosc"] += 15
-                elif min_odleglosc <= 7:
-                    analiza["powody_podobienstwa"].append(
-                        f"średnia odległość lat publikacji ({min_odleglosc} lat) "
-                        "- możliwy duplikat"
-                    )
-                    analiza["pewnosc"] -= 5
-                else:
-                    analiza["powody_podobienstwa"].append(
-                        f"duża odległość lat publikacji ({min_odleglosc} lat) "
-                        "- mało prawdopodobny duplikat"
-                    )
-                    analiza["pewnosc"] -= 20
-
-        analiza_duplikatow_lista.append(analiza)
+    analiza_duplikatow_lista = [
+        analiza
+        for duplikat in duplikaty
+        if (analiza := _analizuj_duplikat(glowny_autor, plec_glowny, duplikat))
+        is not None
+    ]
 
     # Sortuj duplikaty według pewności
     analiza_duplikatow_lista.sort(key=lambda x: x["pewnosc"], reverse=True)

--- a/src/deduplikator_autorow/utils/analysis_meta.py
+++ b/src/deduplikator_autorow/utils/analysis_meta.py
@@ -32,26 +32,14 @@ def _name_or_initial_match(a: str, b: str) -> bool:
     return False
 
 
-def analiza_pary_meta(a: dict, b: dict) -> tuple[int, list[str]]:  # noqa: C901
-    """Zwraca (score, reasons) dla pary (a, b) na bazie meta-cache.
-
-    HARD REJECTION: jeżeli obie strony mają imiona, ale nie ma między nimi
-    żadnego punktu wspólnego (ani pełne imię, ani 3-prefix, ani inicjał),
-    a jednocześnie NIE wykryto pełnej zamiany imię↔nazwisko, kandydat jest
-    natychmiast odrzucany. Zwracamy mocno ujemny score gwarantujący filtr
-    `score >= min_confidence` w `search_general.generate_pairs`. To nie jest
-    duplikat — żaden bonus z innych kryteriów (ORCID, nazwisko, lata) nie
-    może tego nadpisać. 'Jan' i 'Agnieszka' to różne osoby.
-    """
-    # Wczesne policzenie sygnałów dopasowania imion + ewentualnego swap-a.
-    common_imie = set(a["imiona_norm"]) & set(b["imiona_norm"])
+def _signals(a: dict, b: dict) -> dict:
+    """Policz sygnały dopasowania imion + swap-a (raz, używane wielokrotnie)."""
     similar_imie = 0
     for ia in a["imiona_norm"]:
         for ib in b["imiona_norm"]:
             if len(ia) >= 3 and len(ib) >= 3 and ia != ib:
                 if ia.startswith(ib[:3]) or ib.startswith(ia[:3]):
                     similar_imie += 1
-    init_count_imie = _common_initials(a["imiona_norm"], b["imiona_norm"])
     # Swap obejmuje też przypadek z inicjałem: 'Jan Kowalski' ↔ 'Kowalski J.'
     # gdzie database swap (imiona='Kowalski', nazwisko='J.') ma inicjał 'J'
     # pasujący do imienia 'Jan' z drugiej strony.
@@ -69,14 +57,155 @@ def analiza_pary_meta(a: dict, b: dict) -> tuple[int, list[str]]:  # noqa: C901
             for imie in a["imiona_norm"]
         )
     )
+    return {
+        "common_imie": set(a["imiona_norm"]) & set(b["imiona_norm"]),
+        "similar_imie": similar_imie,
+        "init_count_imie": _common_initials(a["imiona_norm"], b["imiona_norm"]),
+        "wykryto_swap": wykryto_swap,
+    }
+
+
+def _rule_publikacje(a: dict, b: dict, sig: dict) -> tuple[int, str]:
+    pubs_b = b["publikacje_count"]
+    if pubs_b <= 5:
+        return 10, f"mało publikacji ({pubs_b}) - prawdopodobny duplikat"
+    if pubs_b <= 10:
+        return -10, f"średnio publikacji ({pubs_b}) - możliwy duplikat"
+    return -20, f"wiele publikacji ({pubs_b}) - mało prawdopodobny duplikat"
+
+
+def _rule_tytul(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
+    if not b["ma_tytul"] and a["ma_tytul"]:
+        return 15, "brak tytułu naukowego u kandydata - prawdopodobny duplikat"
+    if b["ma_tytul"] and a["ma_tytul"]:
+        if a.get("tytul_id") == b.get("tytul_id"):
+            return 10, "identyczny tytuł naukowy"
+        return -15, "różny tytuł naukowy"
+    return None
+
+
+def _rule_orcid(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
+    if not b["ma_orcid"] and a["ma_orcid"]:
+        return 15, "brak ORCID u kandydata - prawdopodobny duplikat"
+    if b["ma_orcid"] and a["ma_orcid"]:
+        if a.get("orcid_value") == b.get("orcid_value"):
+            return 50, "identyczny ORCID - to ten sam autor"
+        return -50, "różny ORCID - to różni autorzy"
+    return None
+
+
+def _rule_nazwisko(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
+    if not (a["nazwisko_norm"] and b["nazwisko_norm"]):
+        return None
+    if a["nazwisko_norm"] == b["nazwisko_norm"]:
+        return 40, "identyczne nazwisko"
+    if (
+        a["nazwisko_norm"] in b["nazwisko_norm"]
+        or b["nazwisko_norm"] in a["nazwisko_norm"]
+    ):
+        return 30, "podobne nazwisko (zawieranie)"
+    parts_a = set(a.get("nazwisko_parts") or [])
+    parts_b = set(b.get("nazwisko_parts") or [])
+    common_parts = parts_a & parts_b
+    if common_parts and (len(parts_a) > 1 or len(parts_b) > 1):
+        if parts_a == parts_b:
+            # Pełny zestaw członów się zgadza (np. permutacja
+            # 'gal-cisoń' ↔ 'cisoń-gal').
+            return 35, "identyczne człony nazwiska złożonego (permutacja)"
+        return 20, (
+            f"wspólny człon nazwiska złożonego ({', '.join(sorted(common_parts))})"
+        )
+    return None
+
+
+def _rule_swap(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
+    if sig["wykryto_swap"]:
+        return 50, "wykryto pełną zamianę imienia z nazwiskiem"
+    return None
+
+
+def _rule_wspolne_imie(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
+    n = len(sig["common_imie"])
+    if n:
+        return 30 * n, f"wspólne imię ({n})"
+    return None
+
+
+def _rule_podobne_imie(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
+    n = sig["similar_imie"]
+    if n:
+        return 15 * n, f"podobne imię ({n})"
+    return None
+
+
+def _rule_inicjaly(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
+    n = sig["init_count_imie"]
+    if n:
+        return 5 * n, f"pasujące inicjały ({n})"
+    return None
+
+
+def _rule_brak_imion(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
+    if not b["imiona_norm"] and a["imiona_norm"]:
+        return 10, "brak imion u kandydata"
+    return None
+
+
+def _rule_lata(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
+    common_lata = a["lata_publikacji"] & b["lata_publikacji"]
+    if common_lata:
+        return 20, f"wspólne lata publikacji: {sorted(common_lata)}"
+    if not (a["lata_publikacji"] and b["lata_publikacji"]):
+        return None
+    min_dist = min(
+        abs(ra - rb) for ra in a["lata_publikacji"] for rb in b["lata_publikacji"]
+    )
+    if min_dist <= 2:
+        return 15, f"bliskie lata publikacji (różnica {min_dist})"
+    if min_dist <= 7:
+        return -5, f"średnia odległość lat publikacji ({min_dist})"
+    return -20, f"duża odległość lat publikacji ({min_dist})"
+
+
+# Kolejność reguł = kolejność powodów w wyniku (musi pozostać identyczna).
+_RULES = (
+    _rule_publikacje,
+    _rule_tytul,
+    _rule_orcid,
+    _rule_nazwisko,
+    _rule_swap,
+    _rule_wspolne_imie,
+    _rule_podobne_imie,
+    _rule_inicjaly,
+    _rule_brak_imion,
+    _rule_lata,
+)
+
+
+def analiza_pary_meta(a: dict, b: dict) -> tuple[int, list[str]]:
+    """Zwraca (score, reasons) dla pary (a, b) na bazie meta-cache.
+
+    HARD REJECTION: jeżeli obie strony mają imiona, ale nie ma między nimi
+    żadnego punktu wspólnego (ani pełne imię, ani 3-prefix, ani inicjał),
+    a jednocześnie NIE wykryto pełnej zamiany imię↔nazwisko, kandydat jest
+    natychmiast odrzucany. Zwracamy mocno ujemny score gwarantujący filtr
+    `score >= min_confidence` w `search_general.generate_pairs`. To nie jest
+    duplikat — żaden bonus z innych kryteriów (ORCID, nazwisko, lata) nie
+    może tego nadpisać. 'Jan' i 'Agnieszka' to różne osoby.
+
+    Scoring jest tabelą reguł ``_RULES`` — każda reguła zwraca
+    ``(waga, powód)`` albo ``None`` (brak wkładu). Pętla akumuluje punkty i
+    powody w kolejności reguł; ta kolejność jest częścią kontraktu.
+    """
+    sig = _signals(a, b)
 
     if (
         a["imiona_norm"]
         and b["imiona_norm"]
-        and not common_imie
-        and similar_imie == 0
-        and init_count_imie == 0
-        and not wykryto_swap
+        and not sig["common_imie"]
+        and sig["similar_imie"] == 0
+        and sig["init_count_imie"] == 0
+        and not sig["wykryto_swap"]
     ):
         return -1000, [
             f"odrzucono: zupełnie różne imiona "
@@ -86,103 +215,11 @@ def analiza_pary_meta(a: dict, b: dict) -> tuple[int, list[str]]:  # noqa: C901
 
     score = 0
     reasons: list[str] = []
-
-    pubs_b = b["publikacje_count"]
-    if pubs_b <= 5:
-        score += 10
-        reasons.append(f"mało publikacji ({pubs_b}) - prawdopodobny duplikat")
-    elif pubs_b <= 10:
-        score -= 10
-        reasons.append(f"średnio publikacji ({pubs_b}) - możliwy duplikat")
-    else:
-        score -= 20
-        reasons.append(f"wiele publikacji ({pubs_b}) - mało prawdopodobny duplikat")
-
-    if not b["ma_tytul"] and a["ma_tytul"]:
-        score += 15
-        reasons.append("brak tytułu naukowego u kandydata - prawdopodobny duplikat")
-    elif b["ma_tytul"] and a["ma_tytul"]:
-        if a.get("tytul_id") == b.get("tytul_id"):
-            score += 10
-            reasons.append("identyczny tytuł naukowy")
-        else:
-            score -= 15
-            reasons.append("różny tytuł naukowy")
-
-    if not b["ma_orcid"] and a["ma_orcid"]:
-        score += 15
-        reasons.append("brak ORCID u kandydata - prawdopodobny duplikat")
-    elif b["ma_orcid"] and a["ma_orcid"]:
-        if a.get("orcid_value") == b.get("orcid_value"):
-            score += 50
-            reasons.append("identyczny ORCID - to ten sam autor")
-        else:
-            score -= 50
-            reasons.append("różny ORCID - to różni autorzy")
-
-    if a["nazwisko_norm"] and b["nazwisko_norm"]:
-        if a["nazwisko_norm"] == b["nazwisko_norm"]:
-            score += 40
-            reasons.append("identyczne nazwisko")
-        elif (
-            a["nazwisko_norm"] in b["nazwisko_norm"]
-            or b["nazwisko_norm"] in a["nazwisko_norm"]
-        ):
-            score += 30
-            reasons.append("podobne nazwisko (zawieranie)")
-        else:
-            parts_a = set(a.get("nazwisko_parts") or [])
-            parts_b = set(b.get("nazwisko_parts") or [])
-            common_parts = parts_a & parts_b
-            if common_parts and (len(parts_a) > 1 or len(parts_b) > 1):
-                if parts_a == parts_b:
-                    # Pełny zestaw członów się zgadza (np. permutacja
-                    # 'gal-cisoń' ↔ 'cisoń-gal').
-                    score += 35
-                    reasons.append("identyczne człony nazwiska złożonego (permutacja)")
-                else:
-                    score += 20
-                    reasons.append(
-                        f"wspólny człon nazwiska złożonego "
-                        f"({', '.join(sorted(common_parts))})"
-                    )
-
-    if wykryto_swap:
-        score += 50
-        reasons.append("wykryto pełną zamianę imienia z nazwiskiem")
-
-    if common_imie:
-        score += 30 * len(common_imie)
-        reasons.append(f"wspólne imię ({len(common_imie)})")
-
-    if similar_imie:
-        score += 15 * similar_imie
-        reasons.append(f"podobne imię ({similar_imie})")
-
-    if init_count_imie:
-        score += 5 * init_count_imie
-        reasons.append(f"pasujące inicjały ({init_count_imie})")
-
-    if not b["imiona_norm"] and a["imiona_norm"]:
-        score += 10
-        reasons.append("brak imion u kandydata")
-
-    common_lata = a["lata_publikacji"] & b["lata_publikacji"]
-    if common_lata:
-        score += 20
-        reasons.append(f"wspólne lata publikacji: {sorted(common_lata)}")
-    elif a["lata_publikacji"] and b["lata_publikacji"]:
-        min_dist = min(
-            abs(ra - rb) for ra in a["lata_publikacji"] for rb in b["lata_publikacji"]
-        )
-        if min_dist <= 2:
-            score += 15
-            reasons.append(f"bliskie lata publikacji (różnica {min_dist})")
-        elif min_dist <= 7:
-            score -= 5
-            reasons.append(f"średnia odległość lat publikacji ({min_dist})")
-        else:
-            score -= 20
-            reasons.append(f"duża odległość lat publikacji ({min_dist})")
+    for rule in _RULES:
+        result = rule(a, b, sig)
+        if result is not None:
+            weight, reason = result
+            score += weight
+            reasons.append(reason)
 
     return score, reasons

--- a/src/ewaluacja_optymalizacja/tests/test_export_unpinning_xlsx.py
+++ b/src/ewaluacja_optymalizacja/tests/test_export_unpinning_xlsx.py
@@ -81,16 +81,22 @@ def _make_opportunity(
     autor_a = baker.make(
         Autor, nazwisko="Kowalski", imiona="Jan", system_kadrowy_id=123
     )
-    autor_b = baker.make(
-        Autor, nazwisko="Nowak", imiona="Anna", system_kadrowy_id=456
-    )
+    autor_b = baker.make(Autor, nazwisko="Nowak", imiona="Anna", system_kadrowy_id=456)
     metryka_a = _make_metryka(
-        autor_a, dyscyplina, jednostka_a,
-        procent="50.00", nazbierany="2.0000", maksymalny="4.0000",
+        autor_a,
+        dyscyplina,
+        jednostka_a,
+        procent="50.00",
+        nazbierany="2.0000",
+        maksymalny="4.0000",
     )
     metryka_b = _make_metryka(
-        autor_b, dyscyplina, jednostka_b,
-        procent="75.00", nazbierany="3.0000", maksymalny="4.0000",
+        autor_b,
+        dyscyplina,
+        jednostka_b,
+        procent="75.00",
+        nazbierany="3.0000",
+        maksymalny="4.0000",
     )
 
     return baker.make(
@@ -169,7 +175,9 @@ def test_export_empty_has_headers_and_no_filters(client, admin_user, uczelnia):
     assert "attachment; filename=" in response["Content-Disposition"]
 
     ws = _load_sheet(response)
-    headers = [ws.cell(row=1, column=c).value for c in range(1, len(EXPECTED_HEADERS) + 1)]
+    headers = [
+        ws.cell(row=1, column=c).value for c in range(1, len(EXPECTED_HEADERS) + 1)
+    ]
     assert headers == EXPECTED_HEADERS
 
     # Stopka: brak danych -> "Brak filtrów" gdzieś w arkuszu
@@ -188,8 +196,11 @@ def test_export_single_row_cell_values(
 ):
     """Pojedynczy pełny wiersz: pinujemy zawartość kluczowych kolumn."""
     _make_opportunity(
-        uczelnia, dyscyplina, wydawnictwo_zwarte,
-        punkty_kbn="140.00", makes_sense=True,
+        uczelnia,
+        dyscyplina,
+        wydawnictwo_zwarte,
+        punkty_kbn="140.00",
+        makes_sense=True,
         rekord_tytul="Tytuł testowej pracy",
     )
 
@@ -208,7 +219,9 @@ def test_export_single_row_cell_values(
     assert cell(3) == 140.0  # Punktacja źródła (float)
     assert cell(4) == "Nauki testowe"  # Dyscyplina
     assert "Kowalski" in cell(5)  # Autor A
-    assert cell(6) == "pracownik naukowy w liczbie N"  # Rodzaj autora A (lookup skrot N)
+    assert (
+        cell(6) == "pracownik naukowy w liczbie N"
+    )  # Rodzaj autora A (lookup skrot N)
     assert cell(7) == 123  # ID systemu kadrowego A
     assert cell(8) == "Jednostka A"  # Jednostka A
     assert cell(9) == pytest.approx(0.5)  # % wykorzystania slotów A (50/100)
@@ -235,9 +248,7 @@ def test_export_only_sensible_filter_in_footer(
     client, admin_user, uczelnia, dyscyplina, rodzaj_autora_n, wydawnictwo_zwarte
 ):
     """only_sensible=1: w stopce pojawia się 'Tylko sensowne: TAK'."""
-    _make_opportunity(
-        uczelnia, dyscyplina, wydawnictwo_zwarte, makes_sense=True
-    )
+    _make_opportunity(uczelnia, dyscyplina, wydawnictwo_zwarte, makes_sense=True)
     client.force_login(admin_user)
     response = client.get(reverse(EXPORT_URL), {"only_sensible": "1"})
     assert response.status_code == 200
@@ -267,9 +278,7 @@ def test_export_punktacja_zrodla_filter_buckets(
     client, admin_user, uczelnia, dyscyplina, rodzaj_autora_n, wydawnictwo_zwarte
 ):
     """punktacja_zrodla=140-200 zostawia pracę o punktach 140 i odnotowuje filtr."""
-    _make_opportunity(
-        uczelnia, dyscyplina, wydawnictwo_zwarte, punkty_kbn="140.00"
-    )
+    _make_opportunity(uczelnia, dyscyplina, wydawnictwo_zwarte, punkty_kbn="140.00")
     client.force_login(admin_user)
     response = client.get(reverse(EXPORT_URL), {"punktacja_zrodla": "140-200"})
     assert response.status_code == 200
@@ -278,6 +287,4 @@ def test_export_punktacja_zrodla_filter_buckets(
     # wiersz danych obecny (Lp. == 1)
     assert ws.cell(row=2, column=1).value == 1
     col1 = [ws.cell(row=r, column=1).value for r in range(1, ws.max_row + 1)]
-    assert any(
-        v == "Punktacja źródła: 140-200 punktów" for v in col1
-    )
+    assert any(v == "Punktacja źródła: 140-200 punktów" for v in col1)

--- a/src/ewaluacja_optymalizacja/tests/test_export_unpinning_xlsx.py
+++ b/src/ewaluacja_optymalizacja/tests/test_export_unpinning_xlsx.py
@@ -1,0 +1,283 @@
+"""Characterization tests dla ``export_unpinning_opportunities_xlsx``.
+
+Te testy pinują OBECNE zachowanie eksportu XLSX (zawartość komórek, filtry,
+stopkę) zanim funkcja zostanie uproszczona/zrefaktoryzowana. Mają przechodzić
+na nie-zmienionym kodzie; po refaktorze muszą pozostać zielone bez modyfikacji.
+"""
+
+import io
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+from openpyxl import load_workbook
+
+from bpp.models import (
+    Autor,
+    Dyscyplina_Naukowa,
+    Jednostka,
+    Rekord,
+    Uczelnia,
+)
+from ewaluacja_common.models import Rodzaj_Autora
+from ewaluacja_metryki.models import MetrykaAutora
+
+from ..models import UnpinningOpportunity
+
+EXPORT_URL = "ewaluacja_optymalizacja:unpinning-export-xlsx"
+
+
+@pytest.fixture
+def uczelnia():
+    return baker.make(Uczelnia, nazwa="Testowa Uczelnia")
+
+
+@pytest.fixture
+def dyscyplina():
+    return baker.make(Dyscyplina_Naukowa, nazwa="Nauki testowe")
+
+
+@pytest.fixture
+def rodzaj_autora_n():
+    obj, _ = Rodzaj_Autora.objects.get_or_create(
+        skrot="N",
+        defaults=dict(nazwa="pracownik naukowy", sort=1),
+    )
+    return obj
+
+
+def _make_metryka(autor, dyscyplina, jednostka, *, procent, nazbierany, maksymalny):
+    return baker.make(
+        MetrykaAutora,
+        autor=autor,
+        dyscyplina_naukowa=dyscyplina,
+        jednostka=jednostka,
+        rodzaj_autora="N",
+        procent_wykorzystania_slotow=Decimal(procent),
+        slot_nazbierany=Decimal(nazbierany),
+        slot_maksymalny=Decimal(maksymalny),
+        punkty_nazbierane=Decimal("100"),
+    )
+
+
+def _make_opportunity(
+    uczelnia,
+    dyscyplina,
+    wydawnictwo_zwarte,
+    *,
+    punkty_kbn="140.00",
+    makes_sense=True,
+    rekord_tytul="Tytuł testowej pracy",
+):
+    """Zbuduj kompletny ``UnpinningOpportunity`` z prawdziwym wpisem Rekord."""
+    wydawnictwo_zwarte.punkty_kbn = Decimal(punkty_kbn)
+    wydawnictwo_zwarte.save()
+    Rekord.objects.full_refresh()
+    rekord = Rekord.objects.get_for_model(wydawnictwo_zwarte)
+
+    jednostka_a = baker.make(Jednostka, nazwa="Jednostka A")
+    jednostka_b = baker.make(Jednostka, nazwa="Jednostka B")
+    autor_a = baker.make(
+        Autor, nazwisko="Kowalski", imiona="Jan", system_kadrowy_id=123
+    )
+    autor_b = baker.make(
+        Autor, nazwisko="Nowak", imiona="Anna", system_kadrowy_id=456
+    )
+    metryka_a = _make_metryka(
+        autor_a, dyscyplina, jednostka_a,
+        procent="50.00", nazbierany="2.0000", maksymalny="4.0000",
+    )
+    metryka_b = _make_metryka(
+        autor_b, dyscyplina, jednostka_b,
+        procent="75.00", nazbierany="3.0000", maksymalny="4.0000",
+    )
+
+    return baker.make(
+        UnpinningOpportunity,
+        uczelnia=uczelnia,
+        dyscyplina_naukowa=dyscyplina,
+        rekord_id=rekord.pk,
+        rekord_tytul=rekord_tytul,
+        autor_could_benefit=autor_a,
+        metryka_could_benefit=metryka_a,
+        autor_currently_using=autor_b,
+        metryka_currently_using=metryka_b,
+        slot_in_work=Decimal("1.0000"),
+        slots_missing=Decimal("0.5000"),
+        makes_sense=makes_sense,
+        punkty_roznica_a=Decimal("10.0000"),
+        sloty_roznica_a=Decimal("0.2500"),
+        punkty_roznica_b=Decimal("20.0000"),
+        sloty_roznica_b=Decimal("0.5000"),
+    )
+
+
+def _load_sheet(response):
+    wb = load_workbook(io.BytesIO(response.content))
+    return wb.active
+
+
+EXPECTED_HEADERS = [
+    "Lp.",
+    "Tytuł pracy",
+    "Punktacja źródła",
+    "Dyscyplina",
+    "Autor A (do odpięcia)",
+    "Rodzaj autora A",
+    "ID systemu kadrowego A",
+    "Jednostka A",
+    "% wykorzystania slotów A",
+    "Sloty nazbierane A",
+    "Sloty maksymalne A",
+    "B może wziąć (slotów)",
+    "Slot w pracy",
+    "Różnica punktów A",
+    "Różnica slotów A",
+    "Różnica punktów B",
+    "Różnica slotów B",
+    "Autor B (skorzysta)",
+    "Rodzaj autora B",
+    "ID systemu kadrowego B",
+    "Jednostka B",
+    "% wykorzystania slotów B",
+    "Sloty nazbierane B",
+    "Sloty maksymalne B",
+    "Sensowne?",
+]
+
+
+@pytest.mark.django_db
+def test_export_no_uczelnia_redirects(client, admin_user):
+    """Bez uczelni w systemie eksport przekierowuje na index."""
+    Uczelnia.objects.all().delete()
+    client.force_login(admin_user)
+    response = client.get(reverse(EXPORT_URL))
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_export_empty_has_headers_and_no_filters(client, admin_user, uczelnia):
+    """Pusta lista: poprawne nagłówki, content-type XLSX, 'Brak filtrów'."""
+    client.force_login(admin_user)
+    response = client.get(reverse(EXPORT_URL))
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    assert "attachment; filename=" in response["Content-Disposition"]
+
+    ws = _load_sheet(response)
+    headers = [ws.cell(row=1, column=c).value for c in range(1, len(EXPECTED_HEADERS) + 1)]
+    assert headers == EXPECTED_HEADERS
+
+    # Stopka: brak danych -> "Brak filtrów" gdzieś w arkuszu
+    all_values = {
+        ws.cell(row=r, column=c).value
+        for r in range(1, ws.max_row + 1)
+        for c in range(1, 3)
+    }
+    assert "Brak filtrów" in all_values
+    assert "Podsumowanie:" in all_values
+
+
+@pytest.mark.django_db
+def test_export_single_row_cell_values(
+    client, admin_user, uczelnia, dyscyplina, rodzaj_autora_n, wydawnictwo_zwarte
+):
+    """Pojedynczy pełny wiersz: pinujemy zawartość kluczowych kolumn."""
+    _make_opportunity(
+        uczelnia, dyscyplina, wydawnictwo_zwarte,
+        punkty_kbn="140.00", makes_sense=True,
+        rekord_tytul="Tytuł testowej pracy",
+    )
+
+    client.force_login(admin_user)
+    response = client.get(reverse(EXPORT_URL))
+    assert response.status_code == 200
+
+    ws = _load_sheet(response)
+    row = 2  # pierwszy wiersz danych
+
+    def cell(col):
+        return ws.cell(row=row, column=col).value
+
+    assert cell(1) == 1  # Lp.
+    assert cell(2) == "Tytuł testowej pracy"  # Tytuł pracy
+    assert cell(3) == 140.0  # Punktacja źródła (float)
+    assert cell(4) == "Nauki testowe"  # Dyscyplina
+    assert "Kowalski" in cell(5)  # Autor A
+    assert cell(6) == "pracownik naukowy w liczbie N"  # Rodzaj autora A (lookup skrot N)
+    assert cell(7) == 123  # ID systemu kadrowego A
+    assert cell(8) == "Jednostka A"  # Jednostka A
+    assert cell(9) == pytest.approx(0.5)  # % wykorzystania slotów A (50/100)
+    assert cell(10) == pytest.approx(2.0)  # Sloty nazbierane A
+    assert cell(11) == pytest.approx(4.0)  # Sloty maksymalne A
+    assert cell(12) == pytest.approx(0.5)  # B może wziąć (slots_missing)
+    assert cell(13) == pytest.approx(1.0)  # Slot w pracy
+    assert cell(14) == pytest.approx(10.0)  # Różnica punktów A
+    assert cell(15) == pytest.approx(0.25)  # Różnica slotów A
+    assert cell(16) == pytest.approx(20.0)  # Różnica punktów B
+    assert cell(17) == pytest.approx(0.5)  # Różnica slotów B
+    assert "Nowak" in cell(18)  # Autor B
+    assert cell(19) == "pracownik naukowy w liczbie N"  # Rodzaj autora B
+    assert cell(20) == 456  # ID systemu kadrowego B
+    assert cell(21) == "Jednostka B"  # Jednostka B
+    assert cell(22) == pytest.approx(0.75)  # % wykorzystania slotów B
+    assert cell(23) == pytest.approx(3.0)  # Sloty nazbierane B
+    assert cell(24) == pytest.approx(4.0)  # Sloty maksymalne B
+    assert cell(25) == "TAK"  # Sensowne?
+
+
+@pytest.mark.django_db
+def test_export_only_sensible_filter_in_footer(
+    client, admin_user, uczelnia, dyscyplina, rodzaj_autora_n, wydawnictwo_zwarte
+):
+    """only_sensible=1: w stopce pojawia się 'Tylko sensowne: TAK'."""
+    _make_opportunity(
+        uczelnia, dyscyplina, wydawnictwo_zwarte, makes_sense=True
+    )
+    client.force_login(admin_user)
+    response = client.get(reverse(EXPORT_URL), {"only_sensible": "1"})
+    assert response.status_code == 200
+
+    ws = _load_sheet(response)
+    col1 = [ws.cell(row=r, column=1).value for r in range(1, ws.max_row + 1)]
+    assert any(v == "Tylko sensowne: TAK" for v in col1)
+
+
+@pytest.mark.django_db
+def test_export_dyscyplina_filter_in_footer(
+    client, admin_user, uczelnia, dyscyplina, rodzaj_autora_n, wydawnictwo_zwarte
+):
+    """Filtr dyscypliny: w stopce 'Dyscyplina: <nazwa>'."""
+    _make_opportunity(uczelnia, dyscyplina, wydawnictwo_zwarte)
+    client.force_login(admin_user)
+    response = client.get(reverse(EXPORT_URL), {"dyscyplina": str(dyscyplina.pk)})
+    assert response.status_code == 200
+
+    ws = _load_sheet(response)
+    col1 = [ws.cell(row=r, column=1).value for r in range(1, ws.max_row + 1)]
+    assert any(v == f"Dyscyplina: {dyscyplina.nazwa}" for v in col1)
+
+
+@pytest.mark.django_db
+def test_export_punktacja_zrodla_filter_buckets(
+    client, admin_user, uczelnia, dyscyplina, rodzaj_autora_n, wydawnictwo_zwarte
+):
+    """punktacja_zrodla=140-200 zostawia pracę o punktach 140 i odnotowuje filtr."""
+    _make_opportunity(
+        uczelnia, dyscyplina, wydawnictwo_zwarte, punkty_kbn="140.00"
+    )
+    client.force_login(admin_user)
+    response = client.get(reverse(EXPORT_URL), {"punktacja_zrodla": "140-200"})
+    assert response.status_code == 200
+
+    ws = _load_sheet(response)
+    # wiersz danych obecny (Lp. == 1)
+    assert ws.cell(row=2, column=1).value == 1
+    col1 = [ws.cell(row=r, column=1).value for r in range(1, ws.max_row + 1)]
+    assert any(
+        v == "Punktacja źródła: 140-200 punktów" for v in col1
+    )

--- a/src/ewaluacja_optymalizacja/views/unpinning_list.py
+++ b/src/ewaluacja_optymalizacja/views/unpinning_list.py
@@ -1,6 +1,7 @@
 """Widoki listy możliwości odpinania."""
 
 import logging
+from collections import namedtuple
 from decimal import Decimal
 
 from celery.result import AsyncResult
@@ -8,6 +9,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 from django.views.decorators.http import require_POST
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 
 from bpp.models import Uczelnia
 
@@ -227,460 +229,207 @@ def unpinning_opportunities_list(request):
     )
 
 
-@login_required
-def export_unpinning_opportunities_xlsx(request):  # noqa: C901
-    """Export unpinning opportunities list to XLSX format with filters applied"""
-    import datetime
-    from decimal import Decimal
-
-    from django.http import HttpResponse
-    from openpyxl import Workbook
-    from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
-    from openpyxl.utils import get_column_letter
-
-    from bpp.models import Dyscyplina_Naukowa, Rekord
+def _format_rodzaj_autora(metryka):
+    """Zwróć czytelną nazwę rodzaju autora na podstawie skrótu w metryce."""
     from ewaluacja_common.models import Rodzaj_Autora
 
-    from ..models import UnpinningOpportunity
+    if metryka.rodzaj_autora == " ":
+        return "Brak danych"
+    try:
+        return Rodzaj_Autora.objects.get(skrot=metryka.rodzaj_autora).nazwa
+    except Rodzaj_Autora.DoesNotExist:
+        return metryka.rodzaj_autora
 
-    # Pobierz pierwszą uczelnię (zakładamy, że jest tylko jedna)
-    uczelnia = Uczelnia.objects.first()
 
-    if not uczelnia:
-        messages.error(request, "Nie znaleziono uczelni w systemie.")
-        return redirect("ewaluacja_optymalizacja:index")
+def _punktacja_zrodla_cell(opp):
+    """Punktacja źródła jako float (komórka XLSX), 0 gdy brak danych."""
+    try:
+        return float(opp.rekord.original.punkty_kbn or 0)
+    except (AttributeError, TypeError, ValueError):
+        return 0
 
-    # Filtrowanie (identyczne jak w unpinning_opportunities_list)
-    opportunities_qs = UnpinningOpportunity.objects.filter(uczelnia=uczelnia)
 
-    # Filtr po dyscyplinie (opcjonalnie)
-    dyscyplina_id = request.GET.get("dyscyplina")
-    if dyscyplina_id:
-        try:
-            dyscyplina_id = int(dyscyplina_id)
-            opportunities_qs = opportunities_qs.filter(
-                dyscyplina_naukowa_id=dyscyplina_id
-            )
-        except (ValueError, TypeError):
-            pass
+def _jednostka_nazwa(metryka):
+    return metryka.jednostka.nazwa if metryka.jednostka else "-"
 
-    # Filtr "tylko sensowne"
-    only_sensible = request.GET.get("only_sensible")
-    if only_sensible == "1":
-        opportunities_qs = opportunities_qs.filter(makes_sense=True)
 
-    # Select related dla optymalizacji
-    opportunities_qs = opportunities_qs.select_related(
-        "autor_could_benefit",
-        "autor_currently_using",
-        "dyscyplina_naukowa",
-        "metryka_could_benefit",
-        "metryka_currently_using",
-        "metryka_could_benefit__autor",
-        "metryka_currently_using__autor",
-        "metryka_could_benefit__jednostka",
-        "metryka_currently_using__jednostka",
-    )
+# Opis kolumn eksportu XLSX. Każdy wpis to (nagłówek, getter, format, align),
+# gdzie getter dostaje (opp, lp) i zwraca wartość komórki. Pętla pisząca wiersz
+# jest jedna — dzięki temu znika 25 powtórzonych bloków ``if row_fill``.
+_ExportColumn = namedtuple("_ExportColumn", "header getter number_format alignment")
 
-    # Preload Rekord objects to avoid N+1 queries
-    all_opportunities = list(opportunities_qs)
-    rekord_ids = [opp.rekord_id for opp in all_opportunities]
-    rekordy = {r.pk: r for r in Rekord.objects.filter(pk__in=rekord_ids)}
+_FMT_DECIMAL = "0.00"
+_FMT_PERCENT = "0.00%"
+_ALIGN_CENTER = Alignment(horizontal="center")
+_ALIGN_RIGHT = Alignment(horizontal="right")
 
-    # Attach rekord objects to opportunities
-    for opp in all_opportunities:
-        opp._cached_rekord = rekordy.get(opp.rekord_id)
 
-    # Filtr po punktacji źródła (identyczne jak w unpinning_opportunities_list)
-    punktacja_zrodla = request.GET.get("punktacja_zrodla")
-    if punktacja_zrodla:
-        filtered_opportunities = []
-        for opp in all_opportunities:
-            try:
-                punkty = opp.rekord.original.punkty_kbn or Decimal("0")
-            except (AttributeError, TypeError):
-                punkty = Decimal("0")
+def _build_export_columns():
+    """Zbuduj listę deskryptorów kolumn (lazy — używa Alignment z openpyxl)."""
 
-            if punktacja_zrodla == "0-100" and punkty < Decimal("100"):
-                filtered_opportunities.append(opp)
-            elif punktacja_zrodla == "100-140" and Decimal("100") <= punkty < Decimal(
-                "140"
-            ):
-                filtered_opportunities.append(opp)
-            elif punktacja_zrodla == "140-200" and Decimal("140") <= punkty < Decimal(
-                "200"
-            ):
-                filtered_opportunities.append(opp)
-            elif punktacja_zrodla == "200+" and punkty >= Decimal("200"):
-                filtered_opportunities.append(opp)
+    def metryka_a(opp):
+        return opp.metryka_could_benefit
 
-        all_opportunities = filtered_opportunities
+    def metryka_b(opp):
+        return opp.metryka_currently_using
 
-    opportunities_qs = all_opportunities
-
-    # Setup workbook
-    wb = Workbook()
-    ws = wb.active
-    ws.title = "Możliwości odpinania"
-
-    # Define styles
-    header_font = Font(bold=True, color="FFFFFF")
-    header_fill = PatternFill(
-        start_color="366092", end_color="366092", fill_type="solid"
-    )
-    header_alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
-
-    thin_border = Border(
-        left=Side(style="thin"),
-        right=Side(style="thin"),
-        top=Side(style="thin"),
-        bottom=Side(style="thin"),
-    )
-
-    even_row_fill = PatternFill(
-        start_color="F2F2F2", end_color="F2F2F2", fill_type="solid"
-    )
-
-    sensible_row_fill = PatternFill(
-        start_color="E7F7E7", end_color="E7F7E7", fill_type="solid"
-    )
-
-    # Define headers
-    headers = [
-        "Lp.",
-        "Tytuł pracy",
-        "Punktacja źródła",
-        "Dyscyplina",
-        "Autor A (do odpięcia)",
-        "Rodzaj autora A",
-        "ID systemu kadrowego A",
-        "Jednostka A",
-        "% wykorzystania slotów A",
-        "Sloty nazbierane A",
-        "Sloty maksymalne A",
-        "B może wziąć (slotów)",
-        "Slot w pracy",
-        "Różnica punktów A",
-        "Różnica slotów A",
-        "Różnica punktów B",
-        "Różnica slotów B",
-        "Autor B (skorzysta)",
-        "Rodzaj autora B",
-        "ID systemu kadrowego B",
-        "Jednostka B",
-        "% wykorzystania slotów B",
-        "Sloty nazbierane B",
-        "Sloty maksymalne B",
-        "Sensowne?",
+    return [
+        _ExportColumn("Lp.", lambda opp, lp: lp, None, None),
+        _ExportColumn("Tytuł pracy", lambda opp, lp: opp.rekord_tytul, None, None),
+        _ExportColumn(
+            "Punktacja źródła",
+            lambda opp, lp: _punktacja_zrodla_cell(opp),
+            None,
+            _ALIGN_CENTER,
+        ),
+        _ExportColumn(
+            "Dyscyplina",
+            lambda opp, lp: opp.dyscyplina_naukowa.nazwa,
+            None,
+            None,
+        ),
+        _ExportColumn(
+            "Autor A (do odpięcia)",
+            lambda opp, lp: str(opp.autor_could_benefit),
+            None,
+            None,
+        ),
+        _ExportColumn(
+            "Rodzaj autora A",
+            lambda opp, lp: _format_rodzaj_autora(metryka_a(opp)),
+            None,
+            None,
+        ),
+        _ExportColumn(
+            "ID systemu kadrowego A",
+            lambda opp, lp: opp.autor_could_benefit.system_kadrowy_id or "",
+            None,
+            None,
+        ),
+        _ExportColumn(
+            "Jednostka A",
+            lambda opp, lp: _jednostka_nazwa(metryka_a(opp)),
+            None,
+            None,
+        ),
+        _ExportColumn(
+            "% wykorzystania slotów A",
+            lambda opp, lp: float(metryka_a(opp).procent_wykorzystania_slotow) / 100,
+            _FMT_PERCENT,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Sloty nazbierane A",
+            lambda opp, lp: float(metryka_a(opp).slot_nazbierany),
+            _FMT_DECIMAL,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Sloty maksymalne A",
+            lambda opp, lp: float(metryka_a(opp).slot_maksymalny),
+            _FMT_DECIMAL,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "B może wziąć (slotów)",
+            lambda opp, lp: float(opp.slots_missing),
+            _FMT_DECIMAL,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Slot w pracy",
+            lambda opp, lp: float(opp.slot_in_work),
+            _FMT_DECIMAL,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Różnica punktów A",
+            lambda opp, lp: float(opp.punkty_roznica_a),
+            _FMT_DECIMAL,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Różnica slotów A",
+            lambda opp, lp: float(opp.sloty_roznica_a),
+            _FMT_DECIMAL,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Różnica punktów B",
+            lambda opp, lp: float(opp.punkty_roznica_b),
+            _FMT_DECIMAL,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Różnica slotów B",
+            lambda opp, lp: float(opp.sloty_roznica_b),
+            _FMT_DECIMAL,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Autor B (skorzysta)",
+            lambda opp, lp: str(opp.autor_currently_using),
+            None,
+            None,
+        ),
+        _ExportColumn(
+            "Rodzaj autora B",
+            lambda opp, lp: _format_rodzaj_autora(metryka_b(opp)),
+            None,
+            None,
+        ),
+        _ExportColumn(
+            "ID systemu kadrowego B",
+            lambda opp, lp: opp.autor_currently_using.system_kadrowy_id or "",
+            None,
+            None,
+        ),
+        _ExportColumn(
+            "Jednostka B",
+            lambda opp, lp: _jednostka_nazwa(metryka_b(opp)),
+            None,
+            None,
+        ),
+        _ExportColumn(
+            "% wykorzystania slotów B",
+            lambda opp, lp: float(metryka_b(opp).procent_wykorzystania_slotow) / 100,
+            _FMT_PERCENT,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Sloty nazbierane B",
+            lambda opp, lp: float(metryka_b(opp).slot_nazbierany),
+            _FMT_DECIMAL,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Sloty maksymalne B",
+            lambda opp, lp: float(metryka_b(opp).slot_maksymalny),
+            _FMT_DECIMAL,
+            _ALIGN_RIGHT,
+        ),
+        _ExportColumn(
+            "Sensowne?",
+            lambda opp, lp: "TAK" if opp.makes_sense else "NIE",
+            None,
+            None,
+        ),
     ]
 
-    # Write headers
-    for col, header in enumerate(headers, 1):
-        cell = ws.cell(row=1, column=col, value=header)
-        cell.font = header_font
-        cell.fill = header_fill
-        cell.alignment = header_alignment
-        cell.border = thin_border
 
-    # Helper function to format rodzaj_autora
-    def format_rodzaj_autora(metryka):
-        if metryka.rodzaj_autora == " ":
-            return "Brak danych"
-        try:
-            rodzaj = Rodzaj_Autora.objects.get(skrot=metryka.rodzaj_autora)
-            return rodzaj.nazwa
-        except Rodzaj_Autora.DoesNotExist:
-            return metryka.rodzaj_autora
+def _row_fill(opp, row_idx, sensible_fill, even_fill):
+    """Kolor wiersza: zielony dla sensownych, naprzemienny dla reszty."""
+    if opp.makes_sense:
+        return sensible_fill
+    return even_fill if row_idx % 2 == 0 else None
 
-    # Write data rows
-    last_data_row = 1
-    for row_idx, opp in enumerate(opportunities_qs, 2):
-        last_data_row = row_idx
 
-        # Determine row fill (sensible = green, otherwise alternating)
-        if opp.makes_sense:
-            row_fill = sensible_row_fill
-        else:
-            row_fill = even_row_fill if row_idx % 2 == 0 else None
+def _build_filter_info(dyscyplina_id, punktacja_zrodla, only_sensible):
+    """Złóż listę opisów zastosowanych filtrów do stopki arkusza."""
+    from bpp.models import Dyscyplina_Naukowa
 
-        col = 1
-
-        # Lp.
-        cell = ws.cell(row=row_idx, column=col, value=row_idx - 1)
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Tytuł pracy
-        cell = ws.cell(row=row_idx, column=col, value=opp.rekord_tytul)
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Punktacja źródła
-        try:
-            punkty_kbn = float(opp.rekord.original.punkty_kbn or 0)
-        except (AttributeError, TypeError, ValueError):
-            punkty_kbn = 0
-        cell = ws.cell(row=row_idx, column=col, value=punkty_kbn)
-        cell.border = thin_border
-        cell.alignment = Alignment(horizontal="center")
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Dyscyplina
-        cell = ws.cell(row=row_idx, column=col, value=opp.dyscyplina_naukowa.nazwa)
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Autor A (do odpięcia)
-        cell = ws.cell(row=row_idx, column=col, value=str(opp.autor_could_benefit))
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Rodzaj autora A
-        cell = ws.cell(
-            row=row_idx,
-            column=col,
-            value=format_rodzaj_autora(opp.metryka_could_benefit),
-        )
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # ID systemu kadrowego A
-        cell = ws.cell(
-            row=row_idx,
-            column=col,
-            value=opp.autor_could_benefit.system_kadrowy_id or "",
-        )
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Jednostka A
-        jednostka_a = (
-            opp.metryka_could_benefit.jednostka.nazwa
-            if opp.metryka_could_benefit.jednostka
-            else "-"
-        )
-        cell = ws.cell(row=row_idx, column=col, value=jednostka_a)
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # % wykorzystania slotów A
-        cell = ws.cell(
-            row=row_idx,
-            column=col,
-            value=float(opp.metryka_could_benefit.procent_wykorzystania_slotow) / 100,
-        )
-        cell.number_format = "0.00%"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Sloty nazbierane A
-        cell = ws.cell(
-            row=row_idx,
-            column=col,
-            value=float(opp.metryka_could_benefit.slot_nazbierany),
-        )
-        cell.number_format = "0.00"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Sloty maksymalne A
-        cell = ws.cell(
-            row=row_idx,
-            column=col,
-            value=float(opp.metryka_could_benefit.slot_maksymalny),
-        )
-        cell.number_format = "0.00"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # B może wziąć (slotów)
-        cell = ws.cell(row=row_idx, column=col, value=float(opp.slots_missing))
-        cell.number_format = "0.00"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Slot w pracy
-        cell = ws.cell(row=row_idx, column=col, value=float(opp.slot_in_work))
-        cell.number_format = "0.00"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Różnica punktów A
-        cell = ws.cell(row=row_idx, column=col, value=float(opp.punkty_roznica_a))
-        cell.number_format = "0.00"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Różnica slotów A
-        cell = ws.cell(row=row_idx, column=col, value=float(opp.sloty_roznica_a))
-        cell.number_format = "0.00"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Różnica punktów B
-        cell = ws.cell(row=row_idx, column=col, value=float(opp.punkty_roznica_b))
-        cell.number_format = "0.00"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Różnica slotów B
-        cell = ws.cell(row=row_idx, column=col, value=float(opp.sloty_roznica_b))
-        cell.number_format = "0.00"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Autor B (skorzysta)
-        cell = ws.cell(row=row_idx, column=col, value=str(opp.autor_currently_using))
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Rodzaj autora B
-        cell = ws.cell(
-            row=row_idx,
-            column=col,
-            value=format_rodzaj_autora(opp.metryka_currently_using),
-        )
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # ID systemu kadrowego B
-        cell = ws.cell(
-            row=row_idx,
-            column=col,
-            value=opp.autor_currently_using.system_kadrowy_id or "",
-        )
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Jednostka B
-        jednostka_b = (
-            opp.metryka_currently_using.jednostka.nazwa
-            if opp.metryka_currently_using.jednostka
-            else "-"
-        )
-        cell = ws.cell(row=row_idx, column=col, value=jednostka_b)
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # % wykorzystania slotów B
-        cell = ws.cell(
-            row=row_idx,
-            column=col,
-            value=float(opp.metryka_currently_using.procent_wykorzystania_slotow) / 100,
-        )
-        cell.number_format = "0.00%"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Sloty nazbierane B
-        cell = ws.cell(
-            row=row_idx,
-            column=col,
-            value=float(opp.metryka_currently_using.slot_nazbierany),
-        )
-        cell.number_format = "0.00"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Sloty maksymalne B
-        cell = ws.cell(
-            row=row_idx,
-            column=col,
-            value=float(opp.metryka_currently_using.slot_maksymalny),
-        )
-        cell.number_format = "0.00"
-        cell.alignment = Alignment(horizontal="right")
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-        # Sensowne?
-        cell = ws.cell(
-            row=row_idx, column=col, value="TAK" if opp.makes_sense else "NIE"
-        )
-        cell.border = thin_border
-        if row_fill:
-            cell.fill = row_fill
-        col += 1
-
-    # Setup auto-filter, freeze panes
-    if last_data_row > 1:
-        last_col_letter = get_column_letter(len(headers))
-        filter_range = f"A1:{last_col_letter}{last_data_row}"
-        ws.auto_filter.ref = filter_range
-
-    ws.freeze_panes = ws["A2"]
-
-    from bpp.util import auto_fit_columns
-
-    auto_fit_columns(ws)
-
-    # Add summary
-    summary_row = last_data_row + 2 if last_data_row > 1 else 3
-    ws.cell(row=summary_row, column=1, value="Podsumowanie:")
-    ws.cell(row=summary_row + 1, column=1, value="Liczba wierszy:")
-    ws.cell(row=summary_row + 1, column=2, value=len(opportunities_qs))
-
-    # Add filter information
     filter_info = []
+
     if dyscyplina_id:
         try:
             dyscyplina = Dyscyplina_Naukowa.objects.get(pk=dyscyplina_id)
@@ -696,25 +445,162 @@ def export_unpinning_opportunities_xlsx(request):  # noqa: C901
             "200+": "200+ punktów",
         }
         filter_info.append(
-            f"Punktacja źródła: {punktacja_labels.get(punktacja_zrodla, punktacja_zrodla)}"
+            "Punktacja źródła: "
+            f"{punktacja_labels.get(punktacja_zrodla, punktacja_zrodla)}"
         )
 
     if only_sensible == "1":
         filter_info.append("Tylko sensowne: TAK")
 
+    return filter_info
+
+
+def _get_export_opportunities(request, uczelnia):
+    """Pobierz i przefiltruj możliwości odpinania zgodnie z parametrami GET."""
+    from ..models import UnpinningOpportunity
+
+    opportunities_qs = UnpinningOpportunity.objects.filter(uczelnia=uczelnia)
+
+    dyscyplina_id = _get_dyscyplina_filter(request)
+    if dyscyplina_id:
+        opportunities_qs = opportunities_qs.filter(dyscyplina_naukowa_id=dyscyplina_id)
+
+    only_sensible = request.GET.get("only_sensible")
+    if only_sensible == "1":
+        opportunities_qs = opportunities_qs.filter(makes_sense=True)
+
+    opportunities_qs = opportunities_qs.select_related(
+        "autor_could_benefit",
+        "autor_currently_using",
+        "dyscyplina_naukowa",
+        "metryka_could_benefit",
+        "metryka_currently_using",
+        "metryka_could_benefit__autor",
+        "metryka_currently_using__autor",
+        "metryka_could_benefit__jednostka",
+        "metryka_currently_using__jednostka",
+    )
+
+    all_opportunities = _cache_rekord_objects(opportunities_qs)
+
+    punktacja_zrodla = request.GET.get("punktacja_zrodla")
+    all_opportunities = _filter_by_punktacja(all_opportunities, punktacja_zrodla)
+
+    return all_opportunities, dyscyplina_id, punktacja_zrodla, only_sensible
+
+
+def _write_export_sheet(ws, opportunities):
+    """Zapisz nagłówki i wiersze danych do arkusza; zwróć numer ostatniego wiersza."""
+    header_font = Font(bold=True, color="FFFFFF")
+    header_fill = PatternFill(
+        start_color="366092", end_color="366092", fill_type="solid"
+    )
+    header_alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+    thin_border = Border(
+        left=Side(style="thin"),
+        right=Side(style="thin"),
+        top=Side(style="thin"),
+        bottom=Side(style="thin"),
+    )
+    even_row_fill = PatternFill(
+        start_color="F2F2F2", end_color="F2F2F2", fill_type="solid"
+    )
+    sensible_row_fill = PatternFill(
+        start_color="E7F7E7", end_color="E7F7E7", fill_type="solid"
+    )
+
+    columns = _build_export_columns()
+
+    for col, column in enumerate(columns, 1):
+        cell = ws.cell(row=1, column=col, value=column.header)
+        cell.font = header_font
+        cell.fill = header_fill
+        cell.alignment = header_alignment
+        cell.border = thin_border
+
+    last_data_row = 1
+    for row_idx, opp in enumerate(opportunities, 2):
+        last_data_row = row_idx
+        row_fill = _row_fill(opp, row_idx, sensible_row_fill, even_row_fill)
+        lp = row_idx - 1
+
+        for col, column in enumerate(columns, 1):
+            cell = ws.cell(row=row_idx, column=col, value=column.getter(opp, lp))
+            cell.border = thin_border
+            if column.number_format:
+                cell.number_format = column.number_format
+            if column.alignment:
+                cell.alignment = column.alignment
+            if row_fill:
+                cell.fill = row_fill
+
+    return last_data_row, len(columns)
+
+
+def _write_export_footer(ws, last_data_row, n_columns, count, filter_info):
+    """Auto-filtr, zamrożenie nagłówka, podsumowanie i opis filtrów."""
+    from openpyxl.utils import get_column_letter
+
+    from bpp.util import auto_fit_columns
+
+    if last_data_row > 1:
+        last_col_letter = get_column_letter(n_columns)
+        ws.auto_filter.ref = f"A1:{last_col_letter}{last_data_row}"
+
+    ws.freeze_panes = ws["A2"]
+    auto_fit_columns(ws)
+
+    summary_row = last_data_row + 2 if last_data_row > 1 else 3
+    ws.cell(row=summary_row, column=1, value="Podsumowanie:")
+    ws.cell(row=summary_row + 1, column=1, value="Liczba wierszy:")
+    ws.cell(row=summary_row + 1, column=2, value=count)
+
     filters_row = summary_row + 3
     ws.cell(row=filters_row, column=1, value="Zastosowane filtry:")
+    ws.cell(
+        row=filters_row + 1,
+        column=1,
+        value="; ".join(filter_info) if filter_info else "Brak filtrów",
+    )
 
-    if filter_info:
-        ws.cell(row=filters_row + 1, column=1, value="; ".join(filter_info))
-    else:
-        ws.cell(row=filters_row + 1, column=1, value="Brak filtrów")
 
-    # Create response
+@login_required
+def export_unpinning_opportunities_xlsx(request):
+    """Export unpinning opportunities list to XLSX format with filters applied"""
+    import datetime
+
+    from django.http import HttpResponse
+    from openpyxl import Workbook
+
+    # Pobierz pierwszą uczelnię (zakładamy, że jest tylko jedna)
+    uczelnia = Uczelnia.objects.first()
+    if not uczelnia:
+        messages.error(request, "Nie znaleziono uczelni w systemie.")
+        return redirect("ewaluacja_optymalizacja:index")
+
+    (
+        opportunities,
+        dyscyplina_id,
+        punktacja_zrodla,
+        only_sensible,
+    ) = _get_export_opportunities(request, uczelnia)
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Możliwości odpinania"
+
+    last_data_row, n_columns = _write_export_sheet(ws, opportunities)
+
+    filter_info = _build_filter_info(dyscyplina_id, punktacja_zrodla, only_sensible)
+    _write_export_footer(ws, last_data_row, n_columns, len(opportunities), filter_info)
+
     response = HttpResponse(
         content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     )
-    filename = f"unpinning_opportunities_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx"
+    filename = (
+        "unpinning_opportunities_"
+        f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx"
+    )
     response["Content-Disposition"] = f'attachment; filename="{filename}"'
 
     wb.save(response)


### PR DESCRIPTION
## Cel

Redukcja złożoności cyklomatycznej (ruff **C901**) dziewięciu funkcji
dotąd uciszonych przez `# noqa: C901`. Refaktor **w pełni zachowujący
zachowanie**, każda zmiana pod siatką nowych **testów charakteryzujących**
pinujących identyczny output na obecnym kodzie *przed* refaktorem.

## Funkcje (CC przed → po)

| Funkcja | Plik | przed | po |
|---------|------|:---:|:---:|
| `export_unpinning_opportunities_xlsx` | `ewaluacja_optymalizacja/views/unpinning_list.py` | 51 | <10 |
| `analiza_duplikatow` | `deduplikator_autorow/utils/analysis.py` | 39 | 2 |
| `convert_crossref_to_changeform_initial_data` | `crossref_bpp/admin/helpers.py` | 28 | <10 |
| `analiza_pary_meta` | `deduplikator_autorow/utils/analysis_meta.py` | 28 | 9 |
| `merge_crossref_and_pbn_data` | `crossref_bpp/admin/helpers.py` | 22 | <10 |
| `wydawnictwo_zwarte_to_bibtex` | `bpp/export/bibtex.py` | 21 | 5 |
| `wydawnictwo_ciagle_to_bibtex` | `bpp/export/bibtex.py` | 11 | 2 |
| `praca_doktorska_to_bibtex` | `bpp/export/bibtex.py` | 11 | 1 |
| `praca_habilitacyjna_to_bibtex` | `bpp/export/bibtex.py` | 11 | 1 |

Wszystkie `# noqa: C901` w tych plikach usunięte (zero pozostało).

## Wzorzec

Za każdym razem ten sam ruch: **powtarzalność/duplikacja → dane**.
- XLSX: 25 powtórzonych bloków zapisu komórek → tabela deskryptorów kolumn + jedna pętla; reuse istniejących helperów zamiast inline-duplikacji.
- BibTeX: ~330 linii zduplikowanej emisji pól w 4 funkcjach → wspólny `_build_bibtex_entry` + `_emit_field` + spec pól (output byte-identyczny).
- `analiza_pary_meta` / `analiza_duplikatow`: łańcuchy `if` scoringu → tabele reguł `(waga, powód)` / `(delta, [powody])` + akumulacja w ustalonej kolejności.
- CrossRef: powtarzane wzorce ekstrakcji/scalania → helpery pól.

## Weryfikacja

- Nowe testy charakteryzujące (render XLSX→BytesIO + asercje na komórki, byte-exact BibTeX, dokładne wartości score+reasons) — zielone *przed i po* refaktorze.
- **339 testów zielonych** w katalogach `deduplikator_autorow/tests`, `crossref_bpp/tests`, `bpp/tests/test_export` + testy `ewaluacja_optymalizacja`.
- `ruff check` + `ruff format` czyste na wszystkich 5 plikach.

## Świadomie pominięte

Ciężkie funkcje będące głównie **orkiestracją** (Celery `handle`, `*_worker_task`,
`sprobuj_wyslac_do_pbn`, `integruj_*`) — tam złożoność jest nieodłączna od
progress-barów i obsługi błędów, a rozbijanie dałoby niski zysk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)