### PR TITLE
refactor: tura 2 upraszczania złożoności (# noqa: C901) — 22 funkcje

### DIFF
--- a/src/bpp/finders.py
+++ b/src/bpp/finders.py
@@ -40,13 +40,7 @@ def may_contain_match(directory, patterns):
     return any(pattern.startswith(directory) for pattern in patterns)
 
 
-def get_files(storage, match_patterns="*", ignore_patterns=None, location=""):  # noqa: C901
-    if ignore_patterns is None:
-        ignore_patterns = []
-    if match_patterns is None:
-        match_patterns = []
-
-    directories, files = storage.listdir(location)
+def _iter_matching_files(files, match_patterns, ignore_patterns, location):
     for fn in files:
         if django_utils.matches_patterns(fn, ignore_patterns):
             continue
@@ -55,6 +49,11 @@ def get_files(storage, match_patterns="*", ignore_patterns=None, location=""):  
         if not django_utils.matches_patterns(fn, match_patterns):
             continue
         yield fn
+
+
+def _iter_matching_subdirs(
+    storage, directories, match_patterns, ignore_patterns, location
+):
     for dir in directories:
         if django_utils.matches_patterns(dir, ignore_patterns):
             continue
@@ -63,8 +62,20 @@ def get_files(storage, match_patterns="*", ignore_patterns=None, location=""):  
         if may_contain_match(dir, match_patterns) or django_utils.matches_patterns(
             dir, match_patterns
         ):
-            for fn in get_files(storage, match_patterns, ignore_patterns, dir):
-                yield fn
+            yield from get_files(storage, match_patterns, ignore_patterns, dir)
+
+
+def get_files(storage, match_patterns="*", ignore_patterns=None, location=""):
+    if ignore_patterns is None:
+        ignore_patterns = []
+    if match_patterns is None:
+        match_patterns = []
+
+    directories, files = storage.listdir(location)
+    yield from _iter_matching_files(files, match_patterns, ignore_patterns, location)
+    yield from _iter_matching_subdirs(
+        storage, directories, match_patterns, ignore_patterns, location
+    )
 
 
 class YarnFinder(FileSystemFinder):

--- a/src/bpp/management/commands/compare_dbtemplates.py
+++ b/src/bpp/management/commands/compare_dbtemplates.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
             help="Only display names of changed templates (no diff output)",
         )
 
-    def handle(self, *args, **options):  # noqa: C901
+    def handle(self, *args, **options):
         if Template is None:
             raise CommandError(
                 "dbtemplates is not installed or not properly configured. "
@@ -96,24 +96,43 @@ class Command(BaseCommand):
             self.list_templates()
             return
 
-        # Get templates to compare
-        if options["template_names"]:
-            templates = []
-            for name in options["template_names"]:
-                try:
-                    template = Template.objects.get(name=name)
-                    templates.append(template)
-                except Template.DoesNotExist:
-                    self.stderr.write(
-                        self.style.WARNING(f"Template '{name}' not found in database")
-                    )
-        else:
-            templates = Template.objects.all()
-
+        templates = self._get_templates_to_compare(options)
         if not templates:
             raise CommandError("No templates to compare")
 
-        # Prepare output
+        output_lines, changed_templates, compared_count, differences_found = (
+            self._collect_differences(templates, options)
+        )
+
+        self._emit_output(output_lines, changed_templates, options)
+        self._emit_summary(compared_count, differences_found)
+
+    def _get_templates_to_compare(self, options):
+        """Resolve the set of templates to compare.
+
+        Without explicit ``template_names`` this is every database template;
+        otherwise each named template is looked up individually and a warning
+        is written to stderr for any that do not exist.
+        """
+        if not options["template_names"]:
+            return Template.objects.all()
+
+        templates = []
+        for name in options["template_names"]:
+            try:
+                templates.append(Template.objects.get(name=name))
+            except Template.DoesNotExist:
+                self.stderr.write(
+                    self.style.WARNING(f"Template '{name}' not found in database")
+                )
+        return templates
+
+    def _collect_differences(self, templates, options):
+        """Walk the templates and gather diff output / changed names.
+
+        Returns ``(output_lines, changed_templates, compared_count,
+        differences_found)``.
+        """
         output_lines = []
         changed_templates = []
         compared_count = 0
@@ -121,55 +140,56 @@ class Command(BaseCommand):
 
         for template in templates:
             if options["only_display_changed"]:
-                # Only check if template has differences, don't generate full diff
-                has_changes = self.template_has_changes(template, options)
-                if has_changes:
+                # Only check if template has differences, skip full diff.
+                if self.template_has_changes(template, options):
                     changed_templates.append(template.name)
                     differences_found += 1
             else:
-                # Generate full diff output
+                # Generate full diff output.
                 diff_output = self.compare_template(template, options)
                 if diff_output:
                     output_lines.extend(diff_output)
                     differences_found += 1
             compared_count += 1
 
-        # Write output
+        return output_lines, changed_templates, compared_count, differences_found
+
+    def _emit_output(self, output_lines, changed_templates, options):
+        """Write the collected output to a file or stdout."""
         if options["only_display_changed"]:
             if changed_templates:
-                output_content = "\n".join(changed_templates)
-
-                if options["output"]:
-                    try:
-                        with open(options["output"], "w", encoding="utf-8") as f:
-                            f.write(output_content + "\n")
-                        self.stdout.write(
-                            self.style.SUCCESS(
-                                f"Changed template names written to {options['output']}"
-                            )
-                        )
-                    except OSError as e:
-                        raise CommandError(f"Error writing to file: {e}") from e
-                else:
-                    self.stdout.write(output_content)
+                self._write_or_print(
+                    "\n".join(changed_templates),
+                    options["output"],
+                    "Changed template names written to",
+                )
         elif output_lines:
-            output_content = "\n".join(output_lines)
+            self._write_or_print(
+                "\n".join(output_lines),
+                options["output"],
+                "Differences written to",
+            )
 
-            if options["output"]:
-                try:
-                    with open(options["output"], "w", encoding="utf-8") as f:
-                        f.write(output_content + "\n")
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f"Differences written to {options['output']}"
-                        )
-                    )
-                except OSError as e:
-                    raise CommandError(f"Error writing to file: {e}") from e
-            else:
-                self.stdout.write(output_content)
+    def _write_or_print(self, content, output_path, success_prefix):
+        """Print ``content`` to stdout, or write it to ``output_path``.
 
-        # Summary
+        On a successful file write, emit ``"{success_prefix} {output_path}"``
+        as a SUCCESS message — mirroring the original per-branch wording.
+        """
+        if not output_path:
+            self.stdout.write(content)
+            return
+
+        try:
+            with open(output_path, "w", encoding="utf-8") as f:
+                f.write(content + "\n")
+        except OSError as e:
+            raise CommandError(f"Error writing to file: {e}") from e
+
+        self.stdout.write(self.style.SUCCESS(f"{success_prefix} {output_path}"))
+
+    def _emit_summary(self, compared_count, differences_found):
+        """Print the final match/difference summary line."""
         if differences_found == 0:
             self.stdout.write(
                 self.style.SUCCESS(
@@ -203,6 +223,13 @@ class Command(BaseCommand):
 
             self.stdout.write(f"  {fs_exists} {template.name}")
 
+    @staticmethod
+    def _normalize_lines(content, options):
+        """Split ``content`` into lines, optionally stripping whitespace."""
+        if options["ignore_whitespace"]:
+            return [line.strip() for line in content.splitlines()]
+        return content.splitlines()
+
     def template_has_changes(self, db_template, options):
         """Check if a template has changes without generating full diff output"""
         fs_content = self.get_filesystem_template_content(db_template.name)
@@ -211,20 +238,13 @@ class Command(BaseCommand):
             # Filesystem template not found - consider this as a change
             return True
 
-        db_content = db_template.content
-
-        # Normalize content if ignoring whitespace
-        if options["ignore_whitespace"]:
-            db_lines = [line.strip() for line in db_content.splitlines()]
-            fs_lines = [line.strip() for line in fs_content.splitlines()]
-        else:
-            db_lines = db_content.splitlines()
-            fs_lines = fs_content.splitlines()
+        db_lines = self._normalize_lines(db_template.content, options)
+        fs_lines = self._normalize_lines(fs_content, options)
 
         # Check if templates are identical
         return db_lines != fs_lines
 
-    def compare_template(self, db_template, options):  # noqa: C901
+    def compare_template(self, db_template, options):
         """Compare a single template and return diff output"""
         fs_content = self.get_filesystem_template_content(db_template.name)
 
@@ -235,44 +255,25 @@ class Command(BaseCommand):
                 "",
             ]
 
-        db_content = db_template.content
-
-        # Normalize content if ignoring whitespace
-        if options["ignore_whitespace"]:
-            db_lines = [line.strip() for line in db_content.splitlines()]
-            fs_lines = [line.strip() for line in fs_content.splitlines()]
-        else:
-            db_lines = db_content.splitlines()
-            fs_lines = fs_content.splitlines()
+        db_lines = self._normalize_lines(db_template.content, options)
+        fs_lines = self._normalize_lines(fs_content, options)
 
         # Check if templates are identical
         if db_lines == fs_lines:
             return None
 
-        # Generate diff
-        if options["side_by_side"]:
-            diff_lines = list(
-                difflib.unified_diff(
-                    fs_lines,
-                    db_lines,
-                    fromfile=f"filesystem/{db_template.name}",
-                    tofile=f"database/{db_template.name}",
-                    lineterm="",
-                    n=options["context_lines"],
-                )
+        # Generate diff. The ``side_by_side`` flag historically produced the
+        # same unified diff as the default, so a single call covers both.
+        diff_lines = list(
+            difflib.unified_diff(
+                fs_lines,
+                db_lines,
+                fromfile=f"filesystem/{db_template.name}",
+                tofile=f"database/{db_template.name}",
+                lineterm="",
+                n=options["context_lines"],
             )
-        else:
-            # Unified diff (default)
-            diff_lines = list(
-                difflib.unified_diff(
-                    fs_lines,
-                    db_lines,
-                    fromfile=f"filesystem/{db_template.name}",
-                    tofile=f"database/{db_template.name}",
-                    lineterm="",
-                    n=options["context_lines"],
-                )
-            )
+        )
 
         if not diff_lines:
             return None
@@ -286,26 +287,37 @@ class Command(BaseCommand):
 
         # Apply coloring if not disabled
         if not options["no_color"] and sys.stdout.isatty():
-            colored_lines = []
-            for line in diff_lines:
-                if line.startswith("+++"):
-                    colored_lines.append(self.style.SUCCESS(line))
-                elif line.startswith("---"):
-                    colored_lines.append(self.style.ERROR(line))
-                elif line.startswith("@@"):
-                    colored_lines.append(self.style.WARNING(line))
-                elif line.startswith("+"):
-                    colored_lines.append(self.style.SUCCESS(line))
-                elif line.startswith("-"):
-                    colored_lines.append(self.style.ERROR(line))
-                else:
-                    colored_lines.append(line)
-            result.extend(colored_lines)
+            result.extend(self._colorize_diff(diff_lines))
         else:
             result.extend(diff_lines)
 
         result.append("")  # Empty line separator
         return result
+
+    def _colorize_diff(self, diff_lines):
+        """Apply diff styling to ``diff_lines``.
+
+        Prefixes are checked longest-first so the multi-character markers
+        (``+++``/``---``/``@@``) win over the single-character ``+``/``-``,
+        matching the original if/elif chain exactly.
+        """
+        prefix_styles = (
+            ("+++", self.style.SUCCESS),
+            ("---", self.style.ERROR),
+            ("@@", self.style.WARNING),
+            ("+", self.style.SUCCESS),
+            ("-", self.style.ERROR),
+        )
+
+        colored_lines = []
+        for line in diff_lines:
+            for prefix, style in prefix_styles:
+                if line.startswith(prefix):
+                    colored_lines.append(style(line))
+                    break
+            else:
+                colored_lines.append(line)
+        return colored_lines
 
     def get_filesystem_template_content(self, template_name):
         """Get template content from filesystem"""

--- a/src/bpp/middleware.py
+++ b/src/bpp/middleware.py
@@ -144,56 +144,97 @@ class MaliciousRequestBlockingMiddleware(MiddlewareMixin):
     # Blocked path suffixes (for vim backups like file.py~)
     BLOCKED_SUFFIXES = ("~",)
 
-    def process_request(self, request):  # noqa: C901
-        path = request.path
-        path_lower = path.lower()
+    def process_request(self, request):
+        # Each checker inspects ``request`` and returns a
+        # ``(block_reason, identifier)`` tuple when it wants to block, or
+        # ``None`` to let the request fall through to the next check. The
+        # checkers run in declaration order — the same order in which the
+        # original inline checks were written — so the first matching rule
+        # wins and the reported ``block_reason`` is unchanged.
+        checks = (
+            self._check_path_length,
+            self._check_full_url_length,
+            self._check_nested_next,
+            self._check_pagination,
+            self._check_blocked_extension,
+            self._check_blocked_path,
+            self._check_backup_suffix,
+        )
+        for check in checks:
+            result = check(request)
+            if result is not None:
+                return self._block_request(request, *result)
 
+        return None
+
+    def _check_path_length(self, request):
         # Block excessively long paths (potential buffer overflow attempts)
+        path = request.path
         if len(path) > 1024:
-            return self._block_request(request, "path_too_long", path[:100])
+            return ("path_too_long", path[:100])
+        return None
 
+    def _check_full_url_length(self, request):
         # Block excessively long full URLs (path + query string). Catches
         # scanner bots that follow login redirects without cookies and end up
         # accumulating exponentially growing percent-encoded ``?next=`` chains.
         # Skip the check for whitelisted paths (e.g. ``/api/`` endpoints which
         # legitimately carry verbose DataTables query params).
-        if not any(s in path for s in self.URL_LENGTH_WHITELIST_SUBSTRINGS):
-            full_path = request.get_full_path()
-            if len(full_path) > self.MAX_FULL_PATH_LENGTH:
-                return self._block_request(request, "url_too_long", full_path[:100])
+        path = request.path
+        if any(s in path for s in self.URL_LENGTH_WHITELIST_SUBSTRINGS):
+            return None
+        full_path = request.get_full_path()
+        if len(full_path) > self.MAX_FULL_PATH_LENGTH:
+            return ("url_too_long", full_path[:100])
+        return None
 
+    def _check_nested_next(self, request):
         # Block nested ``?next=`` redirect chains. Django decodes one level of
         # percent-encoding when parsing query string, so a legitimate single
         # redirect target (e.g. ``next=/foo/``) never contains ``?next=`` —
         # but a re-redirected scanner trail does (``next=/login/?next=/foo``).
         next_param = request.GET.get("next", "")
         if next_param and "?next=" in next_param.lower():
-            return self._block_request(request, "nested_next", next_param[:100])
+            return ("nested_next", next_param[:100])
+        return None
 
+    def _check_pagination(self, request):
         # Check pagination parameter for SQL injection
         page_param = request.GET.get("page", "")
-        if page_param:
-            # Allow "last" keyword (Django pagination feature)
-            if page_param.lower() != "last":
-                # Block if > 5 chars AND contains non-numeric characters
-                if len(page_param) > 5 and not page_param.isdigit():
-                    return self._block_request(request, "pagination", page_param[:100])
+        if not page_param:
+            return None
+        # Allow "last" keyword (Django pagination feature)
+        if page_param.lower() == "last":
+            return None
+        # Block if > 5 chars AND contains non-numeric characters
+        if len(page_param) > 5 and not page_param.isdigit():
+            return ("pagination", page_param[:100])
+        return None
 
+    def _check_blocked_extension(self, request):
         # Check for blocked file extensions
+        path = request.path
+        path_lower = path.lower()
         for ext in self.BLOCKED_EXTENSIONS:
             if path_lower.endswith(ext):
-                return self._block_request(request, "blocked_extension", path[:100])
+                return ("blocked_extension", path[:100])
+        return None
 
+    def _check_blocked_path(self, request):
         # Check for blocked path patterns
+        path = request.path
+        path_lower = path.lower()
         for blocked_path in self.BLOCKED_PATHS:
             if blocked_path.lower() in path_lower:
-                return self._block_request(request, "blocked_path", path[:100])
+                return ("blocked_path", path[:100])
+        return None
 
+    def _check_backup_suffix(self, request):
         # Check for vim backup files (ending with ~)
+        path = request.path
         for suffix in self.BLOCKED_SUFFIXES:
             if path.endswith(suffix):
-                return self._block_request(request, "backup_file", path[:100])
-
+                return ("backup_file", path[:100])
         return None
 
     def _block_request(self, request, block_reason, identifier):

--- a/src/bpp/newsfragments/uproszczenie-zlozonosci-c901-tura2.feature.rst
+++ b/src/bpp/newsfragments/uproszczenie-zlozonosci-c901-tura2.feature.rst
@@ -1,0 +1,12 @@
+Uproszczono kolejne 22 złożone funkcje oznaczone dotąd ``# noqa: C901``
+(scoring i przemapowywanie podobnych źródeł PBN, scalanie i wyszukiwanie
+duplikatów autorów oraz źródeł, dopasowywanie autorów po stronie PBN, import
+słowników/dyscyplin/czasopism PBN, budowa menu, eksport XLSX raportu slotów,
+parsowanie historii komunikatów PBN, finder plików statycznych, middleware
+blokujące złośliwe żądania, polecenie porównywania szablonów oraz aktualizacja
+liczby cytowań z WoS). Powtarzalne łańcuchy ``if``/``elif`` i zduplikowane
+bloki zastąpiono tabelami danych (reguły scoringu, deskryptory pól, listy
+strategii dopasowania) oraz wydzielonymi funkcjami pomocniczymi; każda funkcja
+ma teraz złożoność cyklomatyczną poniżej 10. Zachowanie jest niezmienione —
+zabezpieczone nowymi testami charakteryzującymi pinującymi bieżące zachowanie
+przed refaktorem — a kod jest znacznie czytelniejszy i łatwiejszy w utrzymaniu.

--- a/src/bpp/tasks.py
+++ b/src/bpp/tasks.py
@@ -57,7 +57,31 @@ def usun_stare_logi_logowania_easyaudit(
     return deleted
 
 
-def _zaktualizuj_liczbe_cytowan(klasy=None):  # noqa: C901
+# Mapowanie kluczy z odpowiedzi WoS API na atrybuty modelu publikacji.
+# Każdy wpis: (klucz_w_odpowiedzi, atrybut_modelu).
+_POLA_CYTOWAN = (
+    ("timesCited", "liczba_cytowan"),
+    ("pmid", "pubmed_id"),
+    ("doi", "doi"),
+)
+
+
+def _zaktualizuj_pola_z_wos(obj, item):
+    """Nadpisz pola `obj` wartościami z `item` (odpowiedź WoS).
+
+    Pole jest aktualizowane tylko gdy nowa wartość nie jest None ORAZ różni
+    się od bieżącej. Zwraca True, jeśli cokolwiek się zmieniło.
+    """
+    changed = False
+    for klucz, atrybut in _POLA_CYTOWAN:
+        wartosc = item.get(klucz)
+        if wartosc is not None and getattr(obj, atrybut) != wartosc:
+            setattr(obj, atrybut, wartosc)
+            changed = True
+    return changed
+
+
+def _zaktualizuj_liczbe_cytowan(klasy=None):
     if klasy is None:
         klasy = (
             Wydawnictwo_Ciagle,
@@ -85,30 +109,8 @@ def _zaktualizuj_liczbe_cytowan(klasy=None):  # noqa: C901
 
             for grp in client.query_multiple(filtered):
                 for k, item in grp.items():
-                    changed = False
-
-                    timesCited = item.get("timesCited")
-                    doi = item.get("doi")
-                    pubmed_id = item.get("pmid")
-
                     obj = klass.objects.get(pk=k)
-
-                    if timesCited is not None:
-                        if obj.liczba_cytowan != timesCited:
-                            obj.liczba_cytowan = timesCited
-                            changed = True
-
-                    if pubmed_id is not None:
-                        if obj.pubmed_id != pubmed_id:
-                            obj.pubmed_id = pubmed_id
-                            changed = True
-
-                    if doi is not None:
-                        if obj.doi != doi:
-                            obj.doi = doi
-                            changed = True
-
-                    if changed:
+                    if _zaktualizuj_pola_z_wos(obj, item):
                         obj.save()
 
 

--- a/src/bpp/tests/test_finders.py
+++ b/src/bpp/tests/test_finders.py
@@ -1,0 +1,102 @@
+"""Charakteryzacyjne testy dla bpp.finders.get_files.
+
+Pinują OBECNE zachowanie przeszukiwania storage (filesystem walk),
+aby umożliwić bezpieczny refactor (zdjęcie # noqa: C901).
+"""
+
+from django.core.files.storage import FileSystemStorage
+
+from bpp.finders import get_files, may_contain_match
+
+
+def _make_tree(tmp_path):
+    (tmp_path / "a.css").write_text("a")
+    (tmp_path / "b.js").write_text("b")
+    (tmp_path / "skip.css").write_text("s")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "c.css").write_text("c")
+    (sub / "d.txt").write_text("d")
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "e.css").write_text("e")
+    return FileSystemStorage(location=str(tmp_path))
+
+
+def test_match_wszystkie_pliki_rekurencyjnie(tmp_path):
+    storage = _make_tree(tmp_path)
+    # match_patterns="*" jako string przekazany do matches_patterns;
+    # rekursja wchodzi do podkatalogów bo may_contain_match("*"...).
+    result = sorted(get_files(storage, match_patterns="*"))
+    assert result == [
+        "a.css",
+        "b.js",
+        "other/e.css",
+        "skip.css",
+        "sub/c.css",
+        "sub/d.txt",
+    ]
+
+
+def test_ignore_patterns_pomijaja_pliki(tmp_path):
+    storage = _make_tree(tmp_path)
+    result = sorted(
+        get_files(storage, match_patterns="*", ignore_patterns=["*.js", "skip.css"])
+    )
+    assert result == [
+        "a.css",
+        "other/e.css",
+        "sub/c.css",
+        "sub/d.txt",
+    ]
+
+
+def test_ignore_patterns_pomija_caly_katalog(tmp_path):
+    storage = _make_tree(tmp_path)
+    result = sorted(
+        get_files(
+            storage,
+            match_patterns=["*.css", "sub/*", "other/*"],
+            ignore_patterns=["other"],
+        )
+    )
+    # katalog "other" jest ignorowany w całości
+    assert "other/e.css" not in result
+    assert "a.css" in result
+    assert "sub/c.css" in result
+
+
+def test_match_pattern_konkretny_glob(tmp_path):
+    storage = _make_tree(tmp_path)
+    # Tylko pliki .css na poziomie root pasują wzorcem "*.css";
+    # do podkatalogów "sub"/"other" wchodzi rekursja gdy
+    # may_contain_match (pattern.startswith(directory)) — tu nie pasuje,
+    # więc podkatalogi NIE są przeszukiwane.
+    result = sorted(get_files(storage, match_patterns=["*.css"]))
+    assert result == ["a.css", "skip.css"]
+
+
+def test_match_pattern_z_prefiksem_podkatalogu(tmp_path):
+    storage = _make_tree(tmp_path)
+    # "sub/*.css" → may_contain_match("sub") True, więc wchodzi do "sub",
+    # ale nie do "other".
+    result = sorted(get_files(storage, match_patterns=["sub/*.css"]))
+    assert result == ["sub/c.css"]
+
+
+def test_match_patterns_none_daje_pusta_liste(tmp_path):
+    storage = _make_tree(tmp_path)
+    # match_patterns=None → [] → matches_patterns zawsze False → nic.
+    assert list(get_files(storage, match_patterns=None)) == []
+
+
+def test_location_zaweza_przeszukiwanie(tmp_path):
+    storage = _make_tree(tmp_path)
+    result = sorted(get_files(storage, match_patterns="*", location="sub"))
+    assert result == ["sub/c.css", "sub/d.txt"]
+
+
+def test_may_contain_match_helper():
+    assert may_contain_match("sub", ["sub/foo.css"]) is True
+    assert may_contain_match("other", ["sub/foo.css"]) is False
+    assert may_contain_match("sub", []) is False

--- a/src/bpp/tests/test_finders.py
+++ b/src/bpp/tests/test_finders.py
@@ -1,7 +1,7 @@
 """Charakteryzacyjne testy dla bpp.finders.get_files.
 
 Pinują OBECNE zachowanie przeszukiwania storage (filesystem walk),
-aby umożliwić bezpieczny refactor (zdjęcie # noqa: C901).
+aby umożliwić bezpieczny refactor (zdjęcie C901).
 """
 
 from django.core.files.storage import FileSystemStorage

--- a/src/bpp/tests/test_management_commands_compare_dbtemplates.py
+++ b/src/bpp/tests/test_management_commands_compare_dbtemplates.py
@@ -1,0 +1,221 @@
+"""Characterization tests for the ``compare_dbtemplates`` management command.
+
+These tests pin the *current* observable behaviour of ``Command.handle`` and
+``Command.compare_template`` before the C901 refactor. The filesystem side of
+the comparison is stubbed via ``get_filesystem_template_content`` so the tests
+are deterministic and do not depend on real template files on disk.
+
+The baseline database already ships dbtemplates rows (loaded via a
+data-migration) which cannot be deleted (protected FKs), so each test scopes
+the comparison to explicit ``template_names`` instead of relying on an empty
+table.
+"""
+
+import io
+from unittest import mock
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from model_bakery import baker
+
+from bpp.management.commands.compare_dbtemplates import Command
+
+
+@pytest.fixture
+def template(db):
+    from dbtemplates.models import Template
+
+    return baker.make(Template, name="foo/bar.html", content="line1\nline2\n")
+
+
+def _run(*args, fs_content, **kwargs):
+    """Call the command with the filesystem side stubbed.
+
+    ``fs_content`` may be a string/None (same for every template) or a
+    callable taking the template name and returning the content.
+
+    ``mock.patch.object`` replaces the method with a plain Mock, so the stub
+    is called as ``get_filesystem_template_content(name)`` — no bound
+    ``self`` is passed.
+    """
+    out = io.StringIO()
+    err = io.StringIO()
+
+    if callable(fs_content):
+        side_effect = lambda name: fs_content(name)  # noqa: E731
+    else:
+        side_effect = lambda name: fs_content  # noqa: E731
+
+    with mock.patch.object(
+        Command, "get_filesystem_template_content", side_effect=side_effect
+    ):
+        call_command("compare_dbtemplates", *args, stdout=out, stderr=err, **kwargs)
+    return out.getvalue(), err.getvalue()
+
+
+@pytest.mark.django_db
+def test_list_templates(template):
+    from dbtemplates.models import Template
+
+    baker.make(Template, name="missing/onfs.html", content="x")
+
+    def fs(name):
+        return "content" if name == "foo/bar.html" else None
+
+    out, err = _run("--list", fs_content=fs)
+
+    assert "templates in database:" in out
+    assert "✓ foo/bar.html" in out
+    assert "✗ missing/onfs.html" in out
+
+
+@pytest.mark.django_db
+def test_no_templates_raises(template):
+    # Only a non-existent name is requested → nothing to compare → CommandError.
+    with pytest.raises(CommandError, match="No templates to compare"):
+        _run("does-not-exist.html", fs_content="whatever")
+
+
+@pytest.mark.django_db
+def test_all_match(template):
+    out, err = _run("foo/bar.html", fs_content="line1\nline2\n")
+
+    assert "All 1 templates match their filesystem counterparts" in out
+
+
+@pytest.mark.django_db
+def test_diff_reported(template):
+    out, err = _run("foo/bar.html", fs_content="line1\nDIFFERENT\n")
+
+    assert "Template: foo/bar.html" in out
+    assert "=" * 60 in out
+    assert "-DIFFERENT" in out
+    assert "+line2" in out
+    assert "Found differences in 1 out of 1 templates" in out
+
+
+@pytest.mark.django_db
+def test_filesystem_not_found(template):
+    out, err = _run("foo/bar.html", fs_content=None)
+
+    assert "--- Template: foo/bar.html" in out
+    assert "!!! Filesystem template not found" in out
+    assert "Found differences in 1 out of 1 templates" in out
+
+
+@pytest.mark.django_db
+def test_only_display_changed_lists_names(template):
+    from dbtemplates.models import Template
+
+    baker.make(Template, name="same/same.html", content="aaa")
+
+    def fs(name):
+        # foo/bar.html differs; same/same.html matches
+        return "aaa" if name == "same/same.html" else "totally other"
+
+    out, err = _run(
+        "foo/bar.html", "same/same.html", "--only-display-changed", fs_content=fs
+    )
+
+    assert "foo/bar.html" in out
+    assert "same/same.html" not in out
+    assert "Found differences in 1 out of 2 templates" in out
+
+
+@pytest.mark.django_db
+def test_only_display_changed_to_file(template, tmp_path):
+    target = tmp_path / "changed.txt"
+    out, err = _run(
+        "foo/bar.html",
+        "--only-display-changed",
+        f"--output={target}",
+        fs_content="nope different",
+    )
+
+    assert target.read_text(encoding="utf-8").strip() == "foo/bar.html"
+    assert f"Changed template names written to {target}" in out
+
+
+@pytest.mark.django_db
+def test_diff_to_file(template, tmp_path):
+    target = tmp_path / "diff.txt"
+    out, err = _run(
+        "foo/bar.html", f"--output={target}", fs_content="line1\nDIFFERENT\n"
+    )
+
+    written = target.read_text(encoding="utf-8")
+    assert "Template: foo/bar.html" in written
+    assert f"Differences written to {target}" in out
+
+
+@pytest.mark.django_db
+def test_specific_template_missing_in_db_warns(template):
+    out, err = _run("foo/bar.html", "nonexistent.html", fs_content="line1\nline2\n")
+
+    assert "Template 'nonexistent.html' not found in database" in err
+    # foo/bar.html matches, so overall "All N match"
+    assert "All 1 templates match their filesystem counterparts" in out
+
+
+@pytest.mark.django_db
+def test_ignore_whitespace_makes_equal(template):
+    # Same logical lines, differing only by leading/trailing whitespace.
+    out, err = _run(
+        "foo/bar.html", "--ignore-whitespace", fs_content="  line1  \n\tline2\t\n"
+    )
+
+    assert "All 1 templates match their filesystem counterparts" in out
+
+
+@pytest.mark.django_db
+def test_without_ignore_whitespace_differs(template):
+    out, err = _run("foo/bar.html", fs_content="  line1  \n\tline2\t\n")
+
+    assert "Found differences in 1 out of 1 templates" in out
+
+
+@pytest.mark.django_db
+def test_color_branch_when_tty(template):
+    # Force the coloring branch (sys.stdout.isatty() True) and ensure the
+    # diff body still renders. Django styling is a no-op on a non-tty
+    # underlying stream, so we only assert on content, not ANSI codes.
+    with mock.patch("sys.stdout.isatty", return_value=True):
+        out, err = _run("foo/bar.html", fs_content="line1\nDIFFERENT\n")
+
+    assert "Template: foo/bar.html" in out
+    assert "DIFFERENT" in out
+
+
+@pytest.mark.django_db
+def test_compare_template_returns_none_on_match(template):
+    cmd = Command()
+    options = {
+        "ignore_whitespace": False,
+        "side_by_side": False,
+        "context_lines": 3,
+        "no_color": True,
+    }
+    with mock.patch.object(
+        Command, "get_filesystem_template_content", return_value="line1\nline2\n"
+    ):
+        assert cmd.compare_template(template, options) is None
+
+
+@pytest.mark.django_db
+def test_compare_template_side_by_side(template):
+    cmd = Command()
+    options = {
+        "ignore_whitespace": False,
+        "side_by_side": True,
+        "context_lines": 3,
+        "no_color": True,
+    }
+    with mock.patch.object(
+        Command, "get_filesystem_template_content", return_value="line1\nX\n"
+    ):
+        result = cmd.compare_template(template, options)
+
+    assert result is not None
+    assert any("Template: foo/bar.html" in line for line in result)
+    assert any(line.startswith("-X") for line in result)

--- a/src/bpp/tests/test_zaktualizuj_liczbe_cytowan.py
+++ b/src/bpp/tests/test_zaktualizuj_liczbe_cytowan.py
@@ -1,0 +1,173 @@
+"""Testy charakteryzujące dla `_zaktualizuj_liczbe_cytowan`.
+
+Pinują BIEŻĄCE zachowanie funkcji aktualizującej liczbę cytowań / DOI /
+PubMed ID z danych klienta WoS — bazą pod behavior-preserving refactor
+(zdjęcie # noqa: C901). Mapowanie kluczy (zachowane):
+
+    item["timesCited"] -> obj.liczba_cytowan
+    item["pmid"]       -> obj.pubmed_id
+    item["doi"]        -> obj.doi
+
+Guard każdego pola: wartość `is not None` ORAZ różna od bieżącej.
+`obj.save()` wołane tylko gdy cokolwiek się zmieniło. Funkcja nic nie
+zwraca (None).
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Zwarte
+from bpp.tasks import _zaktualizuj_liczbe_cytowan
+
+
+def _patch_wosclient(mocker, payload):
+    """Podstaw klienta WoS, którego query_multiple zwraca `payload`."""
+    client = Mock()
+    client.query_multiple = Mock(return_value=payload)
+    mocker.patch("bpp.models.struktura.Uczelnia.wosclient", return_value=client)
+    return client
+
+
+@pytest.mark.django_db
+def test_aktualizuje_wszystkie_pola_gdy_inne(uczelnia, wydawnictwo_ciagle, mocker):
+    wydawnictwo_ciagle.liczba_cytowan = None
+    wydawnictwo_ciagle.pubmed_id = None
+    wydawnictwo_ciagle.doi = None
+    wydawnictwo_ciagle.save()
+
+    _patch_wosclient(
+        mocker,
+        [
+            {
+                wydawnictwo_ciagle.pk: {
+                    "timesCited": 42,
+                    "pmid": 123456,
+                    "doi": "10.1234/abc",
+                }
+            }
+        ],
+    )
+
+    _zaktualizuj_liczbe_cytowan([Wydawnictwo_Ciagle])
+
+    wydawnictwo_ciagle.refresh_from_db()
+    assert wydawnictwo_ciagle.liczba_cytowan == 42
+    assert wydawnictwo_ciagle.pubmed_id == 123456
+    assert wydawnictwo_ciagle.doi == "10.1234/abc"
+
+
+@pytest.mark.django_db
+def test_nie_aktualizuje_pol_gdy_wartosc_none(uczelnia, wydawnictwo_ciagle, mocker):
+    wydawnictwo_ciagle.liczba_cytowan = 7
+    wydawnictwo_ciagle.pubmed_id = 999
+    wydawnictwo_ciagle.doi = "10.9999/keep"
+    wydawnictwo_ciagle.save()
+
+    # Pusty słownik -> wszystkie .get(...) zwracają None -> nic nie ruszamy.
+    _patch_wosclient(mocker, [{wydawnictwo_ciagle.pk: {}}])
+
+    spy = mocker.spy(Wydawnictwo_Ciagle, "save")
+
+    _zaktualizuj_liczbe_cytowan([Wydawnictwo_Ciagle])
+
+    spy.assert_not_called()
+    wydawnictwo_ciagle.refresh_from_db()
+    assert wydawnictwo_ciagle.liczba_cytowan == 7
+    assert wydawnictwo_ciagle.pubmed_id == 999
+    assert wydawnictwo_ciagle.doi == "10.9999/keep"
+
+
+@pytest.mark.django_db
+def test_nie_zapisuje_gdy_wartosci_rowne(uczelnia, wydawnictwo_ciagle, mocker):
+    wydawnictwo_ciagle.liczba_cytowan = 5
+    wydawnictwo_ciagle.pubmed_id = 111
+    wydawnictwo_ciagle.doi = "10.1/same"
+    wydawnictwo_ciagle.save()
+
+    _patch_wosclient(
+        mocker,
+        [
+            {
+                wydawnictwo_ciagle.pk: {
+                    "timesCited": 5,
+                    "pmid": 111,
+                    "doi": "10.1/same",
+                }
+            }
+        ],
+    )
+
+    spy = mocker.spy(Wydawnictwo_Ciagle, "save")
+
+    _zaktualizuj_liczbe_cytowan([Wydawnictwo_Ciagle])
+
+    # Identyczne wartości -> changed pozostaje False -> brak save().
+    spy.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_aktualizuje_tylko_rozne_pole(uczelnia, wydawnictwo_ciagle, mocker):
+    wydawnictwo_ciagle.liczba_cytowan = 5
+    wydawnictwo_ciagle.pubmed_id = 111
+    wydawnictwo_ciagle.doi = "10.1/orig"
+    wydawnictwo_ciagle.save()
+
+    # Tylko liczba_cytowan się różni; pmid/doi takie same.
+    _patch_wosclient(
+        mocker,
+        [
+            {
+                wydawnictwo_ciagle.pk: {
+                    "timesCited": 99,
+                    "pmid": 111,
+                    "doi": "10.1/orig",
+                }
+            }
+        ],
+    )
+
+    spy = mocker.spy(Wydawnictwo_Ciagle, "save")
+
+    _zaktualizuj_liczbe_cytowan([Wydawnictwo_Ciagle])
+
+    spy.assert_called_once()
+    wydawnictwo_ciagle.refresh_from_db()
+    assert wydawnictwo_ciagle.liczba_cytowan == 99
+    assert wydawnictwo_ciagle.pubmed_id == 111
+    assert wydawnictwo_ciagle.doi == "10.1/orig"
+
+
+@pytest.mark.django_db
+def test_obsluguje_wiele_typow_modeli(
+    uczelnia, wydawnictwo_ciagle, wydawnictwo_zwarte, mocker
+):
+    wydawnictwo_ciagle.liczba_cytowan = None
+    wydawnictwo_ciagle.save()
+    wydawnictwo_zwarte.liczba_cytowan = None
+    wydawnictwo_zwarte.save()
+
+    client = Mock()
+    client.query_multiple = Mock(
+        side_effect=[
+            [{wydawnictwo_ciagle.pk: {"timesCited": 11}}],
+            [{wydawnictwo_zwarte.pk: {"timesCited": 22}}],
+        ]
+    )
+    mocker.patch("bpp.models.struktura.Uczelnia.wosclient", return_value=client)
+
+    _zaktualizuj_liczbe_cytowan([Wydawnictwo_Ciagle, Wydawnictwo_Zwarte])
+
+    wydawnictwo_ciagle.refresh_from_db()
+    wydawnictwo_zwarte.refresh_from_db()
+    assert wydawnictwo_ciagle.liczba_cytowan == 11
+    assert wydawnictwo_zwarte.liczba_cytowan == 22
+
+
+@pytest.mark.django_db
+def test_zwraca_none(uczelnia, wydawnictwo_ciagle, mocker):
+    _patch_wosclient(mocker, [{wydawnictwo_ciagle.pk: {"timesCited": 1}}])
+
+    result = _zaktualizuj_liczbe_cytowan([Wydawnictwo_Ciagle])
+
+    assert result is None

--- a/src/bpp/tests/test_zaktualizuj_liczbe_cytowan.py
+++ b/src/bpp/tests/test_zaktualizuj_liczbe_cytowan.py
@@ -2,7 +2,7 @@
 
 Pinują BIEŻĄCE zachowanie funkcji aktualizującej liczbę cytowań / DOI /
 PubMed ID z danych klienta WoS — bazą pod behavior-preserving refactor
-(zdjęcie # noqa: C901). Mapowanie kluczy (zachowane):
+(zdjęcie C901). Mapowanie kluczy (zachowane):
 
     item["timesCited"] -> obj.liczba_cytowan
     item["pmid"]       -> obj.pubmed_id

--- a/src/deduplikator_autorow/tests/test_characterization_duplicate_view.py
+++ b/src/deduplikator_autorow/tests/test_characterization_duplicate_view.py
@@ -1,6 +1,6 @@
 """Testy charakteryzujące ``duplicate_authors_view``.
 
-Pinują bieżące zachowanie PRZED refaktorem (zdjęcie ``# noqa: C901``).
+Pinują bieżące zachowanie PRZED refaktorem (zdjęcie ``C901``).
 Pokrywają: brak skanu (running / brak), pusty pending, ścieżkę nawigacji,
 wyszukiwanie po nazwisku (z wynikami / bez / skip_count poza zakresem),
 filtr confidence_band (high/low) oraz allow_merge_all / low_confidence_names.

--- a/src/deduplikator_autorow/tests/test_characterization_duplicate_view.py
+++ b/src/deduplikator_autorow/tests/test_characterization_duplicate_view.py
@@ -1,0 +1,215 @@
+"""Testy charakteryzujące ``duplicate_authors_view``.
+
+Pinują bieżące zachowanie PRZED refaktorem (zdjęcie ``# noqa: C901``).
+Pokrywają: brak skanu (running / brak), pusty pending, ścieżkę nawigacji,
+wyszukiwanie po nazwisku (z wynikami / bez / skip_count poza zakresem),
+filtr confidence_band (high/low) oraz allow_merge_all / low_confidence_names.
+"""
+
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from django.utils import timezone
+from model_bakery import baker
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+from deduplikator_autorow.models import DuplicateCandidate, DuplicateScanRun
+
+
+@pytest.fixture
+def auth_client(client, db):
+    user = baker.make("bpp.BppUser", is_active=True)
+    grp, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    user.groups.add(grp)
+    client.force_login(user)
+    return client
+
+
+URL = "deduplikator_autorow:duplicate_authors"
+
+
+def _candidate(scan, main, dup, *, percent, mode="pbn", name="X Y"):
+    return DuplicateCandidate.objects.create(
+        scan_run=scan,
+        main_autor=main,
+        duplicate_autor=dup,
+        confidence_score=int(percent * 100),
+        confidence_percent=percent,
+        main_autor_name=name,
+        duplicate_autor_name=name,
+        scan_mode=mode,
+    )
+
+
+@pytest.mark.django_db
+def test_no_completed_scan_no_running(auth_client):
+    response = auth_client.get(reverse(URL))
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["completed_scan"] is None
+    assert ctx["no_scan_available"] is True
+    assert ctx["glowny_autor"] is None
+    assert ctx["pending_candidates_count"] == 0
+
+
+@pytest.mark.django_db
+def test_no_completed_scan_with_running_shows_info(auth_client):
+    DuplicateScanRun.objects.create(
+        status=DuplicateScanRun.Status.RUNNING,
+        total_authors_to_scan=10,
+        authors_scanned=3,
+    )
+    response = auth_client.get(reverse(URL))
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["running_scan"] is not None
+    assert ctx["no_scan_available"] is False
+    msgs = [m.message for m in ctx["messages"]]
+    assert any("Skanowanie w toku" in m for m in msgs)
+
+
+@pytest.fixture
+def completed_scan(db):
+    return DuplicateScanRun.objects.create(
+        status=DuplicateScanRun.Status.COMPLETED,
+        finished_at=timezone.now(),
+    )
+
+
+@pytest.mark.django_db
+def test_completed_scan_no_pending_shows_brak(auth_client, completed_scan):
+    response = auth_client.get(reverse(URL))
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["glowny_autor"] is None
+    assert ctx["pending_candidates_count"] == 0
+    msgs = [m.message for m in ctx["messages"]]
+    assert any("Brak duplikatów do sprawdzenia" in m for m in msgs)
+
+
+@pytest.fixture
+def scan_one_main(completed_scan):
+    """Jeden główny autor z dwoma kandydatami: high (0.8) i low (0.3)."""
+    main = baker.make("bpp.Autor", nazwisko="Mainowski", imiona="Adam")
+    dup_hi = baker.make("bpp.Autor", nazwisko="Mainowski", imiona="Adam")
+    dup_lo = baker.make("bpp.Autor", nazwisko="Mainowski", imiona="Adam")
+    _candidate(completed_scan, main, dup_hi, percent=0.8, name="Mainowski Adam")
+    _candidate(completed_scan, main, dup_lo, percent=0.3, name="Mainowski Adam")
+    return completed_scan, main
+
+
+@pytest.mark.django_db
+def test_navigation_default_shows_main_author(auth_client, scan_one_main):
+    _scan, main = scan_one_main
+    response = auth_client.get(reverse(URL))
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["glowny_autor"] == main
+    assert ctx["pending_candidates_count"] == 2
+    # Per-main band counters: total 2, high (>=0.5) 1, low 1
+    assert ctx["candidates_total_for_main"] == 2
+    assert ctx["candidates_high_for_main"] == 1
+    assert ctx["candidates_low_for_main"] == 1
+    # Domyślnie confidence_band == "all" → oba kandydaci widoczni
+    assert len(ctx["duplikaty_z_publikacjami"]) == 2
+    # allow_merge_all False bo jest low-confidence (0.3 → 30% < 50)
+    assert ctx["allow_merge_all"] is False
+    assert ctx["low_confidence_names"]
+
+
+@pytest.mark.django_db
+def test_confidence_band_high(auth_client, scan_one_main):
+    response = auth_client.get(reverse(URL) + "?confidence=high")
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["confidence_band"] == "high"
+    # Tylko high (0.8) kandydat
+    assert len(ctx["duplikaty_z_publikacjami"]) == 1
+    # Wszyscy widoczni mają wysoką pewność → allow_merge_all True
+    assert ctx["allow_merge_all"] is True
+    assert ctx["low_confidence_names"] == []
+
+
+@pytest.mark.django_db
+def test_confidence_band_low(auth_client, scan_one_main):
+    response = auth_client.get(reverse(URL) + "?confidence=low")
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["confidence_band"] == "low"
+    assert len(ctx["duplikaty_z_publikacjami"]) == 1
+    # Widoczny kandydat ma niską pewność → merge zablokowany
+    assert ctx["allow_merge_all"] is False
+    assert ctx["low_confidence_names"]
+
+
+@pytest.mark.django_db
+def test_invalid_confidence_band_falls_back_to_all(auth_client, scan_one_main):
+    response = auth_client.get(reverse(URL) + "?confidence=zzz")
+    assert response.context["confidence_band"] == "all"
+    assert len(response.context["duplikaty_z_publikacjami"]) == 2
+
+
+@pytest.mark.django_db
+def test_search_lastname_with_results(auth_client, scan_one_main):
+    _scan, main = scan_one_main
+    response = auth_client.get(reverse(URL) + "?search_lastname=Mainowski")
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["search_lastname"] == "Mainowski"
+    assert ctx["search_results_count"] == 1
+    assert ctx["glowny_autor"] == main
+    assert ctx["search_total_authors"] == 1
+    assert ctx["search_has_prev"] is False
+    assert ctx["search_has_next"] is False
+
+
+@pytest.mark.django_db
+def test_search_lastname_no_results(auth_client, scan_one_main):
+    response = auth_client.get(reverse(URL) + "?search_lastname=Nieistnieje")
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["search_lastname"] == "Nieistnieje"
+    assert ctx["search_results_count"] == 0
+    assert ctx["glowny_autor"] is None
+
+
+@pytest.mark.django_db
+def test_search_skip_count_out_of_range_resets(auth_client, scan_one_main):
+    _scan, main = scan_one_main
+    response = auth_client.get(
+        reverse(URL) + "?search_lastname=Mainowski&skip_count=99"
+    )
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["skip_count"] == 0
+    assert ctx["glowny_autor"] == main
+
+
+@pytest.mark.django_db
+def test_search_invalid_skip_count_defaults_zero(auth_client, scan_one_main):
+    response = auth_client.get(
+        reverse(URL) + "?search_lastname=Mainowski&skip_count=abc"
+    )
+    assert response.status_code == 200
+    assert response.context["skip_count"] == 0
+
+
+@pytest.mark.django_db
+def test_navigation_invalid_skip_count_defaults_zero(auth_client, scan_one_main):
+    response = auth_client.get(reverse(URL) + "?skip_count=notanumber")
+    assert response.status_code == 200
+    assert response.context["skip_count"] == 0
+    assert response.context["glowny_autor"] is not None
+
+
+@pytest.mark.django_db
+def test_scientist_set_when_pbn_uid(auth_client, completed_scan):
+    from pbn_api.models import Scientist
+
+    sci = baker.make(Scientist)
+    main = baker.make("bpp.Autor", nazwisko="Pbnowy", imiona="Jan", pbn_uid=sci)
+    dup = baker.make("bpp.Autor", nazwisko="Pbnowy", imiona="Jan")
+    _candidate(completed_scan, main, dup, percent=0.8, name="Pbnowy Jan")
+    response = auth_client.get(reverse(URL))
+    assert response.status_code == 200
+    assert response.context["scientist"] == sci

--- a/src/deduplikator_autorow/tests/test_finders_characterization.py
+++ b/src/deduplikator_autorow/tests/test_finders_characterization.py
@@ -2,7 +2,7 @@
 
 Pinują AKTUALNE zachowanie search_author_by_lastname oraz
 znajdz_pierwszego_autora_z_duplikatami przed refaktoryzacją (zdjęcie
-# noqa: C901). Skupiają się na obserwowalnym kontrakcie zwracanych wartości
+C901). Skupiają się na obserwowalnym kontrakcie zwracanych wartości
 (Scientist albo None) oraz na gałęziach wykluczania i wczesnych zwrotów.
 """
 

--- a/src/deduplikator_autorow/tests/test_finders_characterization.py
+++ b/src/deduplikator_autorow/tests/test_finders_characterization.py
@@ -1,0 +1,129 @@
+"""Charakteryzacyjne testy dla finderów z utils/finders.py.
+
+Pinują AKTUALNE zachowanie search_author_by_lastname oraz
+znajdz_pierwszego_autora_z_duplikatami przed refaktoryzacją (zdjęcie
+# noqa: C901). Skupiają się na obserwowalnym kontrakcie zwracanych wartości
+(Scientist albo None) oraz na gałęziach wykluczania i wczesnych zwrotów.
+"""
+
+import pytest
+from model_bakery import baker
+
+from deduplikator_autorow.utils.finders import (
+    search_author_by_lastname,
+    znajdz_pierwszego_autora_z_duplikatami,
+)
+from pbn_api.models import OsobaZInstytucji, Scientist
+
+
+@pytest.fixture
+def glowny_z_duplikatem(autor_maker, tytuly):
+    """Główny autor z OsobaZInstytucji + duplikat bez własnej OsobaZInstytucji."""
+    glowny = autor_maker(imiona="Janusz", nazwisko="Wyszukiwalski")
+    scientist = baker.make(Scientist)
+    glowny.pbn_uid = scientist
+    glowny.save()
+    osoba = baker.make(OsobaZInstytucji, personId=scientist)
+    duplikat = baker.make("bpp.Autor", imiona="Janusz", nazwisko="Wyszukiwalski")
+    return glowny, scientist, osoba, duplikat
+
+
+# ============================================================================
+# search_author_by_lastname
+# ============================================================================
+
+
+def test_search_author_by_lastname_empty_returns_none(db):
+    """Pusty / None search_term -> wczesny zwrot None."""
+    assert search_author_by_lastname("") is None
+    assert search_author_by_lastname(None) is None
+
+
+def test_search_author_by_lastname_returns_scientist_with_duplicates(
+    glowny_z_duplikatem,
+):
+    """Zwraca Scientist (pbn_uid) autora, który ma duplikaty."""
+    glowny, scientist, osoba, duplikat = glowny_z_duplikatem
+
+    result = search_author_by_lastname("Wyszukiwalski")
+
+    assert result == scientist
+
+
+def test_search_author_by_lastname_excludes_by_pbn_uid(glowny_z_duplikatem):
+    """Autor wykluczony (po pbn_uid) nie jest zwracany -> None."""
+    glowny, scientist, osoba, duplikat = glowny_z_duplikatem
+
+    result = search_author_by_lastname("Wyszukiwalski", excluded_authors=[scientist])
+
+    assert result is None
+
+
+def test_search_author_by_lastname_no_match_returns_none(db, autor_maker, tytuly):
+    """Brak autorów pasujących do nazwiska -> None."""
+    autor_maker(imiona="Jan", nazwisko="Inny")
+
+    result = search_author_by_lastname("NieIstnieje")
+
+    assert result is None
+
+
+def test_search_author_by_lastname_author_without_osoba_z_instytucji(
+    db, autor_maker, tytuly
+):
+    """Autor z pbn_uid, ale bez OsobaZInstytucji jest pomijany -> None."""
+    glowny = autor_maker(imiona="Jan", nazwisko="Bezosobowy")
+    scientist = baker.make(Scientist)
+    glowny.pbn_uid = scientist
+    glowny.save()
+    # brak OsobaZInstytucji -> RelatedObjectDoesNotExist -> continue
+
+    result = search_author_by_lastname("Bezosobowy")
+
+    assert result is None
+
+
+# ============================================================================
+# znajdz_pierwszego_autora_z_duplikatami
+# ============================================================================
+
+
+def test_znajdz_pierwszego_returns_scientist_with_duplicates(glowny_z_duplikatem):
+    """Zwraca Scientist głównego autora, który ma duplikaty."""
+    glowny, scientist, osoba, duplikat = glowny_z_duplikatem
+
+    result = znajdz_pierwszego_autora_z_duplikatami()
+
+    assert result == scientist
+
+
+def test_znajdz_pierwszego_no_duplicates_returns_none(db, autor_maker, tytuly):
+    """Główny autor bez żadnych duplikatów -> None."""
+    glowny = autor_maker(imiona="Jan", nazwisko="Samotny")
+    scientist = baker.make(Scientist)
+    glowny.pbn_uid = scientist
+    glowny.save()
+    baker.make(OsobaZInstytucji, personId=scientist)
+
+    result = znajdz_pierwszego_autora_z_duplikatami()
+
+    assert result is None
+
+
+def test_znajdz_pierwszego_excluded_author_returns_none(glowny_z_duplikatem):
+    """Wykluczenie głównego autora (Scientist) -> None."""
+    glowny, scientist, osoba, duplikat = glowny_z_duplikatem
+
+    result = znajdz_pierwszego_autora_z_duplikatami(excluded_authors=[scientist])
+
+    assert result is None
+
+
+def test_znajdz_pierwszego_skips_scientist_without_bpp_author(db):
+    """Scientist bez rekordu w BPP (brak Autora) jest pomijany -> None."""
+    scientist = baker.make(Scientist)
+    baker.make(OsobaZInstytucji, personId=scientist)
+
+    result = znajdz_pierwszego_autora_z_duplikatami()
+
+    assert result is None

--- a/src/deduplikator_autorow/tests/test_scal_autora_characterization.py
+++ b/src/deduplikator_autorow/tests/test_scal_autora_characterization.py
@@ -1,7 +1,7 @@
 """Charakteryzacyjne testy dla scal_autora.
 
 Pinują AKTUALNE zachowanie funkcji scalania duplikatu autora na głównego
-autora przed refaktoryzacją (zdjęcie # noqa: C901). Pokrywają gałęzie
+autora przed refaktoryzacją (zdjęcie C901). Pokrywają gałęzie
 napędzające złożoność: przenoszenie poszczególnych typów relacji (ciągłe,
 zwarte, patenty, prace dokt./hab.), transfer dyscyplin, kolizję istniejącej
 publikacji, usuwanie dyscypliny przy braku u głównego, kolejkę PBN i

--- a/src/deduplikator_autorow/tests/test_scal_autora_characterization.py
+++ b/src/deduplikator_autorow/tests/test_scal_autora_characterization.py
@@ -1,0 +1,272 @@
+"""Charakteryzacyjne testy dla scal_autora.
+
+Pinują AKTUALNE zachowanie funkcji scalania duplikatu autora na głównego
+autora przed refaktoryzacją (zdjęcie # noqa: C901). Pokrywają gałęzie
+napędzające złożoność: przenoszenie poszczególnych typów relacji (ciągłe,
+zwarte, patenty, prace dokt./hab.), transfer dyscyplin, kolizję istniejącej
+publikacji, usuwanie dyscypliny przy braku u głównego, kolejkę PBN i
+końcowe usunięcie duplikatu.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import (
+    Autor_Dyscyplina,
+    Patent_Autor,
+    Wydawnictwo_Ciagle_Autor,
+    Wydawnictwo_Zwarte_Autor,
+)
+from deduplikator_autorow.utils.merge import scal_autora
+from pbn_export_queue.models import PBN_Export_Queue
+
+
+@pytest.fixture
+def user(db):
+    return baker.make("bpp.BppUser")
+
+
+@pytest.fixture
+def main_dup(autor_maker, tytuly):
+    glowny = autor_maker(imiona="Jan", nazwisko="Kowalski")
+    duplikat = autor_maker(imiona="Jan", nazwisko="Kowalski-Duplikat")
+    return glowny, duplikat
+
+
+def test_scal_autora_reassigns_wydawnictwo_ciagle(
+    main_dup, user, wydawnictwo_ciagle, jednostka
+):
+    """Wydawnictwo_Ciagle_Autor duplikatu przechodzi na głównego autora."""
+    glowny, duplikat = main_dup
+    dup_pk = duplikat.pk
+    wydawnictwo_ciagle.dodaj_autora(duplikat, jednostka)
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    assert result["total_updated"] == 1
+    assert Wydawnictwo_Ciagle_Autor.objects.filter(
+        rekord=wydawnictwo_ciagle, autor=glowny
+    ).exists()
+    assert not Wydawnictwo_Ciagle_Autor.objects.filter(autor_id=dup_pk).exists()
+    # Duplikat usunięty na końcu operacji
+    assert not type(glowny).objects.filter(pk=dup_pk).exists()
+    assert any("Wydawnictwo_Ciagle_Autor" in r for r in result["updated_records"])
+
+
+def test_scal_autora_reassigns_wydawnictwo_zwarte(
+    main_dup, user, wydawnictwo_zwarte, jednostka
+):
+    """Wydawnictwo_Zwarte_Autor duplikatu przechodzi na głównego autora."""
+    glowny, duplikat = main_dup
+    wydawnictwo_zwarte.dodaj_autora(duplikat, jednostka)
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    assert result["total_updated"] == 1
+    assert Wydawnictwo_Zwarte_Autor.objects.filter(
+        rekord=wydawnictwo_zwarte, autor=glowny
+    ).exists()
+    assert any("Wydawnictwo_Zwarte_Autor" in r for r in result["updated_records"])
+
+
+def test_scal_autora_reassigns_patent(main_dup, user, patent, jednostka):
+    """Patent_Autor duplikatu przechodzi na głównego autora."""
+    glowny, duplikat = main_dup
+    patent.dodaj_autora(duplikat, jednostka)
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    assert result["total_updated"] == 1
+    assert Patent_Autor.objects.filter(rekord=patent, autor=glowny).exists()
+    assert any("Patent_Autor" in r for r in result["updated_records"])
+
+
+def test_scal_autora_reassigns_praca_habilitacyjna(main_dup, user, habilitacja):
+    """Praca_Habilitacyjna duplikatu przechodzi na głównego autora."""
+    glowny, duplikat = main_dup
+    habilitacja.autor = duplikat
+    habilitacja.save()
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    assert result["total_updated"] == 1
+    habilitacja.refresh_from_db()
+    assert habilitacja.autor == glowny
+    assert any("Praca_Habilitacyjna" in r for r in result["updated_records"])
+
+
+def test_scal_autora_reassigns_praca_doktorska(main_dup, user, doktorat):
+    """Praca_Doktorska duplikatu przechodzi na głównego autora."""
+    glowny, duplikat = main_dup
+    doktorat.autor = duplikat
+    doktorat.save()
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    assert result["total_updated"] == 1
+    doktorat.refresh_from_db()
+    assert doktorat.autor == glowny
+    assert any("Praca_Doktorska" in r for r in result["updated_records"])
+
+
+def test_scal_autora_transfers_disciplines(
+    main_dup, user, dyscyplina1, rok, rodzaj_autora_n
+):
+    """Autor_Dyscyplina duplikatu jest kopiowana do głównego autora."""
+    glowny, duplikat = main_dup
+    Autor_Dyscyplina.objects.create(
+        autor=duplikat,
+        rok=rok,
+        dyscyplina_naukowa=dyscyplina1,
+        rodzaj_autora=rodzaj_autora_n,
+    )
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    assert len(result["disciplines_transferred"]) == 1
+    assert Autor_Dyscyplina.objects.filter(
+        autor=glowny, rok=rok, dyscyplina_naukowa=dyscyplina1
+    ).exists()
+
+
+def test_scal_autora_does_not_duplicate_existing_discipline(
+    main_dup, user, dyscyplina1, rok, rodzaj_autora_n
+):
+    """Gdy główny autor ma już dyscyplinę na dany rok, nie jest kopiowana."""
+    glowny, duplikat = main_dup
+    Autor_Dyscyplina.objects.create(
+        autor=glowny,
+        rok=rok,
+        dyscyplina_naukowa=dyscyplina1,
+        rodzaj_autora=rodzaj_autora_n,
+    )
+    Autor_Dyscyplina.objects.create(
+        autor=duplikat,
+        rok=rok,
+        dyscyplina_naukowa=dyscyplina1,
+        rodzaj_autora=rodzaj_autora_n,
+    )
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    assert result["disciplines_transferred"] == []
+    assert (
+        Autor_Dyscyplina.objects.filter(
+            autor=glowny, rok=rok, dyscyplina_naukowa=dyscyplina1
+        ).count()
+        == 1
+    )
+
+
+def test_scal_autora_existing_publication_conflict_deletes_duplicate_record(
+    main_dup, user, wydawnictwo_ciagle, jednostka
+):
+    """Gdy główny ma już tę publikację z tym typem odpowiedzialności,
+    rekord duplikatu jest usuwany (nie przemapowany) i dodawane ostrzeżenie."""
+    glowny, duplikat = main_dup
+    wydawnictwo_ciagle.dodaj_autora(glowny, jednostka)
+    wydawnictwo_ciagle.dodaj_autora(duplikat, jednostka)
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    # Rekord duplikatu usunięty, nie przemapowany -> total_updated == 0
+    assert result["total_updated"] == 0
+    assert any("już ma publikację" in w for w in result["warnings"])
+    # Główny autor wciąż ma dokładnie jeden rekord dla tej publikacji
+    assert (
+        Wydawnictwo_Ciagle_Autor.objects.filter(
+            rekord=wydawnictwo_ciagle, autor=glowny
+        ).count()
+        == 1
+    )
+
+
+def test_scal_autora_removes_discipline_when_main_lacks_it(
+    main_dup, user, wydawnictwo_ciagle, jednostka, dyscyplina1
+):
+    """Gdy rekord duplikatu ma dyscyplinę, której główny nie posiada
+    (brak Autor_Dyscyplina), dyscyplina jest usuwana z rekordu + ostrzeżenie."""
+    glowny, duplikat = main_dup
+    # Ustaw dyscyplinę bezpośrednio (omijając full_clean), bo duplikat nie ma
+    # przypisania Autor_Dyscyplina — to właśnie wymusza ścieżkę usunięcia
+    # dyscypliny przy braku jej u głównego autora.
+    wca = wydawnictwo_ciagle.dodaj_autora(duplikat, jednostka)
+    Wydawnictwo_Ciagle_Autor.objects.filter(pk=wca.pk).update(
+        dyscyplina_naukowa=dyscyplina1
+    )
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    assert result["total_updated"] == 1
+    wca = Wydawnictwo_Ciagle_Autor.objects.get(rekord=wydawnictwo_ciagle, autor=glowny)
+    assert wca.dyscyplina_naukowa is None
+    assert any("nie ma dyscypliny" in w for w in result["warnings"])
+
+
+def test_scal_autora_queues_pbn_when_not_skipped(
+    main_dup, user, wydawnictwo_ciagle, jednostka
+):
+    """skip_pbn=False dodaje publikację do kolejki eksportu PBN."""
+    glowny, duplikat = main_dup
+    wydawnictwo_ciagle.dodaj_autora(duplikat, jednostka)
+    before = PBN_Export_Queue.objects.count()
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=False)
+
+    assert result["success"] is True
+    assert len(result["publications_queued_for_pbn"]) == 1
+    assert PBN_Export_Queue.objects.count() == before + 1
+
+
+def test_scal_autora_skip_pbn_does_not_queue(
+    main_dup, user, wydawnictwo_ciagle, jednostka
+):
+    """skip_pbn=True nie dodaje nic do kolejki PBN."""
+    glowny, duplikat = main_dup
+    wydawnictwo_ciagle.dodaj_autora(duplikat, jednostka)
+    before = PBN_Export_Queue.objects.count()
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    assert result["publications_queued_for_pbn"] == []
+    assert PBN_Export_Queue.objects.count() == before
+
+
+def test_scal_autora_no_relations_just_deletes_duplicate(main_dup, user):
+    """Bez żadnych relacji: sukces, total_updated 0, duplikat usunięty."""
+    glowny, duplikat = main_dup
+    dup_pk = duplikat.pk
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    assert result["success"] is True
+    assert result["total_updated"] == 0
+    assert result["updated_records"] == []
+    assert not type(glowny).objects.filter(pk=dup_pk).exists()
+
+
+def test_scal_autora_result_dict_shape(main_dup, user):
+    """Kształt zwracanego słownika jest stabilny."""
+    glowny, duplikat = main_dup
+
+    result = scal_autora(glowny, duplikat, user, skip_pbn=True)
+
+    for key in (
+        "success",
+        "warnings",
+        "updated_records",
+        "total_updated",
+        "publications_queued_for_pbn",
+        "disciplines_transferred",
+    ):
+        assert key in result

--- a/src/deduplikator_autorow/utils/finders.py
+++ b/src/deduplikator_autorow/utils/finders.py
@@ -10,7 +10,41 @@ from .analysis import autor_ma_publikacje_z_lat
 from .search import szukaj_kopii
 
 
-def znajdz_pierwszego_autora_z_duplikatami(  # noqa: C901
+def _ma_nowe_publikacje(rekord_w_bpp, duplikaty, limit: int) -> bool:
+    """
+    Czy główny autor (rekord_w_bpp) lub którykolwiek z pierwszych ``limit``
+    duplikatów ma publikacje z lat 2022-2025.
+    """
+    if autor_ma_publikacje_z_lat(rekord_w_bpp):
+        return True
+    for duplikat in duplikaty[:limit]:
+        if autor_ma_publikacje_z_lat(duplikat):
+            return True
+    return False
+
+
+def _osoby_z_instytucji_query(excluded_authors: list[Scientist]):
+    """
+    Buduje queryset OsobaZInstytucji (posortowany po nazwisku) z wykluczeniem
+    autorów jawnie wskazanych oraz ignorowanych (IgnoredScientist).
+    """
+    excluded_scientist_ids = [author.pk for author in excluded_authors]
+    ignored_scientist_ids = list(
+        IgnoredScientist.objects.values_list("scientist_id", flat=True)
+    )
+
+    osoby_query = (
+        OsobaZInstytucji.objects.select_related("personId").all().order_by("lastName")
+    )
+
+    all_excluded_ids = excluded_scientist_ids + ignored_scientist_ids
+    if all_excluded_ids:
+        osoby_query = osoby_query.exclude(personId__pk__in=all_excluded_ids)
+
+    return osoby_query
+
+
+def znajdz_pierwszego_autora_z_duplikatami(
     excluded_authors: list[Scientist] | None = None,
 ) -> Scientist | None:
     """
@@ -31,23 +65,9 @@ def znajdz_pierwszego_autora_z_duplikatami(  # noqa: C901
     if excluded_authors is None:
         excluded_authors = []
 
-    # Pobierz IDs wykluczonych autorów
-    excluded_scientist_ids = [author.pk for author in excluded_authors]
-
-    # Pobierz IDs ignorowanych autorów
-    ignored_scientist_ids = list(
-        IgnoredScientist.objects.values_list("scientist_id", flat=True)
-    )
-
-    # Przeszukaj wszystkie rekordy OsobaZInstytucji, wykluczając określonych autorów
-    osoby_query = (
-        OsobaZInstytucji.objects.select_related("personId").all().order_by("lastName")
-    )
-
-    # Exclude both explicitly excluded and ignored authors
-    all_excluded_ids = excluded_scientist_ids + ignored_scientist_ids
-    if all_excluded_ids:
-        osoby_query = osoby_query.exclude(personId__pk__in=all_excluded_ids)
+    # Przeszukaj wszystkie rekordy OsobaZInstytucji, wykluczając określonych
+    # i ignorowanych autorów
+    osoby_query = _osoby_z_instytucji_query(excluded_authors)
 
     # Zbierz autorów z duplikatami, podzielonych na dwie grupy
     autorzy_z_nowymi_publikacjami = []
@@ -67,30 +87,20 @@ def znajdz_pierwszego_autora_z_duplikatami(  # noqa: C901
         # Wyszukaj duplikaty dla tego autora
         duplikaty = szukaj_kopii(osoba_z_instytucji)
 
-        # Jeśli znaleziono duplikaty
-        if duplikaty.exists():
-            # Sprawdź czy główny autor lub któryś z duplikatów ma publikacje z lat 2022-2025
-            ma_nowe_publikacje = autor_ma_publikacje_z_lat(scientist.rekord_w_bpp)
+        if not duplikaty.exists():
+            continue
 
-            # Sprawdź również duplikaty
-            if not ma_nowe_publikacje:
-                for duplikat in duplikaty[
-                    :10
-                ]:  # Sprawdź pierwsze 10 duplikatów dla wydajności
-                    if autor_ma_publikacje_z_lat(duplikat):
-                        ma_nowe_publikacje = True
-                        break
+        # Sprawdź czy główny autor lub któryś z pierwszych 10 duplikatów ma
+        # publikacje z lat 2022-2025 i dodaj do odpowiedniej grupy
+        if _ma_nowe_publikacje(scientist.rekord_w_bpp, duplikaty, 10):
+            autorzy_z_nowymi_publikacjami.append(scientist)
+        else:
+            autorzy_bez_nowych_publikacji.append(scientist)
 
-            # Dodaj do odpowiedniej listy
-            if ma_nowe_publikacje:
-                autorzy_z_nowymi_publikacjami.append(scientist)
-            else:
-                autorzy_bez_nowych_publikacji.append(scientist)
-
-            # Jeśli mamy już 50 autorów z nowymi publikacjami, możemy zwrócić pierwszego
-            # (optymalizacja dla dużych baz danych)
-            if len(autorzy_z_nowymi_publikacjami) >= 50:
-                return autorzy_z_nowymi_publikacjami[0]
+        # Jeśli mamy już 50 autorów z nowymi publikacjami, możemy zwrócić pierwszego
+        # (optymalizacja dla dużych baz danych)
+        if len(autorzy_z_nowymi_publikacjami) >= 50:
+            return autorzy_z_nowymi_publikacjami[0]
 
     # Zwróć pierwszego autora z nowymi publikacjami, jeśli taki istnieje
     if autorzy_z_nowymi_publikacjami:
@@ -104,7 +114,20 @@ def znajdz_pierwszego_autora_z_duplikatami(  # noqa: C901
     return None
 
 
-def search_author_by_lastname(search_term, excluded_authors=None):  # noqa: C901
+def _osoba_z_instytucji_autora(autor) -> OsobaZInstytucji | None:
+    """
+    Zwraca OsobaZInstytucji powiązaną z autorem przez pbn_uid (Scientist),
+    albo None jeśli autor nie ma pbn_uid lub powiązanej OsobaZInstytucji.
+    """
+    if not autor.pbn_uid_id:
+        return None
+    try:
+        return autor.pbn_uid.osobazinstytucji
+    except Scientist.osobazinstytucji.RelatedObjectDoesNotExist:
+        return None
+
+
+def search_author_by_lastname(search_term, excluded_authors=None):
     """
     Wyszukuje pierwszego autora z duplikatami według części nazwiska.
     Priorytetyzuje autorów z publikacjami z lat 2022-2025.
@@ -137,36 +160,23 @@ def search_author_by_lastname(search_term, excluded_authors=None):  # noqa: C901
 
     # Znajdź autorów z duplikatami i podziel ich na grupy
     for autor in matching_authors[:200]:  # Sprawdź więcej autorów niż poprzednio
-        # Sprawdź czy autor ma odpowiednik w Scientist
-        if autor.pbn_uid_id:
-            try:
-                if autor.pbn_uid.osobazinstytucji:
-                    duplikaty = szukaj_kopii(autor.pbn_uid.osobazinstytucji)
-                    if duplikaty.exists():
-                        # Sprawdź czy autor lub jego duplikaty mają publikacje z lat 2022-2025
-                        ma_nowe_publikacje = autor_ma_publikacje_z_lat(autor)
+        osoba_z_instytucji = _osoba_z_instytucji_autora(autor)
+        if not osoba_z_instytucji:
+            continue
 
-                        # Sprawdź również duplikaty
-                        if not ma_nowe_publikacje:
-                            for duplikat in duplikaty[
-                                :5
-                            ]:  # Sprawdź pierwsze 5 duplikatów
-                                if autor_ma_publikacje_z_lat(duplikat):
-                                    ma_nowe_publikacje = True
-                                    break
+        duplikaty = szukaj_kopii(osoba_z_instytucji)
+        if not duplikaty.exists():
+            continue
 
-                        # Dodaj do odpowiedniej listy
-                        if ma_nowe_publikacje:
-                            autorzy_z_nowymi_publikacjami.append(autor.pbn_uid)
-                        else:
-                            autorzy_bez_nowych_publikacji.append(autor.pbn_uid)
+        # Sprawdź czy autor lub pierwszych 5 duplikatów ma publikacje 2022-2025
+        if _ma_nowe_publikacje(autor, duplikaty, 5):
+            autorzy_z_nowymi_publikacjami.append(autor.pbn_uid)
+        else:
+            autorzy_bez_nowych_publikacji.append(autor.pbn_uid)
 
-                        # Jeśli mamy już 20 autorów z nowymi publikacjami, możemy zwrócić pierwszego
-                        if len(autorzy_z_nowymi_publikacjami) >= 20:
-                            return autorzy_z_nowymi_publikacjami[0]
-
-            except Scientist.osobazinstytucji.RelatedObjectDoesNotExist:
-                continue
+        # Jeśli mamy już 20 autorów z nowymi publikacjami, możemy zwrócić pierwszego
+        if len(autorzy_z_nowymi_publikacjami) >= 20:
+            return autorzy_z_nowymi_publikacjami[0]
 
     # Zwróć pierwszego autora z nowymi publikacjami, jeśli taki istnieje
     if autorzy_z_nowymi_publikacjami:

--- a/src/deduplikator_autorow/utils/merge.py
+++ b/src/deduplikator_autorow/utils/merge.py
@@ -63,7 +63,199 @@ def _assign_discipline_if_missing(
     return False
 
 
-def scal_autora(  # noqa: C901
+def _transfer_disciplines(glowny_autor, autor_duplikat, user, log_ctx, results):
+    """
+    Kopiuje przypisania dyscyplin (Autor_Dyscyplina) z duplikatu na głównego
+    autora — tylko te, których główny autor jeszcze nie posiada dla danego roku
+    i dyscypliny. Każdy transfer jest logowany w LogScalania.
+    """
+    from bpp.models import Autor_Dyscyplina
+    from deduplikator_autorow.models import LogScalania
+
+    for dup_disc in Autor_Dyscyplina.objects.filter(autor=autor_duplikat):
+        # Check if main author already has this discipline for this year
+        existing = Autor_Dyscyplina.objects.filter(
+            autor=glowny_autor,
+            rok=dup_disc.rok,
+            dyscyplina_naukowa=dup_disc.dyscyplina_naukowa,
+        ).exists()
+
+        if existing:
+            continue
+
+        # Create new discipline record for main author
+        new_disc = Autor_Dyscyplina.objects.create(
+            autor=glowny_autor,
+            rok=dup_disc.rok,
+            rodzaj_autora=dup_disc.rodzaj_autora,
+            wymiar_etatu=dup_disc.wymiar_etatu,
+            dyscyplina_naukowa=dup_disc.dyscyplina_naukowa,
+            procent_dyscypliny=dup_disc.procent_dyscypliny,
+            subdyscyplina_naukowa=dup_disc.subdyscyplina_naukowa,
+            procent_subdyscypliny=dup_disc.procent_subdyscypliny,
+        )
+        results["disciplines_transferred"].append(
+            f"{dup_disc.dyscyplina_naukowa} ({dup_disc.rok})"
+        )
+
+        # Log discipline transfer
+        LogScalania.objects.create(
+            main_autor=glowny_autor,
+            content_type=ContentType.objects.get_for_model(Autor_Dyscyplina),
+            object_id=new_disc.pk,
+            modified_record=new_disc,
+            dyscyplina_after=dup_disc.dyscyplina_naukowa,
+            operation_type="DISCIPLINE_TRANSFER",
+            operation_details=f"Przeniesiono dyscyplinę {dup_disc.dyscyplina_naukowa} "
+            f"za rok {dup_disc.rok}",
+            created_by=user,
+            disciplines_transferred=1,
+            **log_ctx,
+        )
+
+
+def _transfer_authorship_record(
+    record,
+    glowny_autor,
+    user,
+    skip_pbn,
+    auto_assign_discipline,
+    use_subdiscipline,
+    model_label,
+    log_publication,
+    log_ctx,
+    results,
+):
+    """
+    Przenosi pojedynczy rekord autorstwa (Wydawnictwo_*_Autor / Patent_Autor)
+    z duplikatu na głównego autora.
+
+    Zwraca True jeśli rekord został przemapowany, False jeśli był kolizją z
+    istniejącą publikacją głównego autora i został usunięty.
+    """
+    from bpp.models import Autor_Dyscyplina
+    from deduplikator_autorow.models import LogScalania
+    from pbn_export_queue.models import PBN_Export_Queue
+
+    model = type(record)
+
+    # Store old discipline before any changes
+    old_discipline = record.dyscyplina_naukowa
+
+    # CHECK IF MAIN AUTHOR ALREADY HAS THIS PUBLICATION
+    existing = model.objects.filter(
+        rekord=record.rekord,
+        autor=glowny_autor,
+        typ_odpowiedzialnosci=record.typ_odpowiedzialnosci,
+    ).exists()
+
+    if existing:
+        # Main author already has this publication - delete duplicate's record
+        results["warnings"].append(
+            f"Autor główny już ma publikację {record.rekord} "
+            f"z typem odpowiedzialności {record.typ_odpowiedzialnosci}. "
+            f"Usunięto duplikat."
+        )
+        record.delete()
+        return False
+
+    # Sprawdź dyscypliny
+    rok = record.rekord.rok if record.rekord else None
+    if record.dyscyplina_naukowa:
+        if (
+            rok
+            and not Autor_Dyscyplina.objects.filter(
+                autor=glowny_autor,
+                rok=rok,
+                dyscyplina_naukowa=record.dyscyplina_naukowa,
+            ).exists()
+        ):
+            results["warnings"].append(
+                f"Autor główny nie ma dyscypliny {record.dyscyplina_naukowa} "
+                f"za rok {rok}. Dyscyplina została usunięta z publikacji: "
+                f"{record.rekord}"
+            )
+            record.dyscyplina_naukowa = None
+
+    # Przypisz dyscyplinę jeśli brak i włączona opcja
+    _assign_discipline_if_missing(
+        record,
+        glowny_autor,
+        rok,
+        auto_assign_discipline,
+        use_subdiscipline,
+        results["warnings"],
+    )
+
+    # Przemapuj autora
+    record.autor = glowny_autor
+    record.save()
+
+    # Log publication transfer (tylko dla Wydawnictwo_Ciagle_Autor)
+    if log_publication:
+        LogScalania.objects.create(
+            main_autor=glowny_autor,
+            content_type=ContentType.objects.get_for_model(record.rekord),
+            object_id=record.rekord.pk,
+            modified_record=record.rekord,
+            dyscyplina_before=old_discipline,
+            dyscyplina_after=record.dyscyplina_naukowa,
+            operation_type="PUBLICATION_TRANSFER",
+            operation_details=f"Przeniesiono publikację: {record.rekord}",
+            created_by=user,
+            publications_transferred=1,
+            warnings=(
+                results["warnings"][-1]
+                if old_discipline and not record.dyscyplina_naukowa
+                else ""
+            ),
+            **log_ctx,
+        )
+
+    # Dodaj do kolejki PBN
+    if not skip_pbn and record.rekord:
+        content_type = ContentType.objects.get_for_model(record.rekord)
+        PBN_Export_Queue.objects.create(
+            content_type=content_type,
+            object_id=record.rekord.pk,
+            zamowil=user,
+        )
+        results["publications_queued_for_pbn"].append(str(record.rekord))
+
+    results["updated_records"].append(f"{model_label}: {record.rekord}")
+    results["total_updated"] += 1
+    return True
+
+
+def _transfer_simple_authorship(
+    model, model_label, glowny_autor, autor_duplikat, user, skip_pbn, results
+):
+    """
+    Przenosi proste rekordy autorstwa (Praca_Habilitacyjna / Praca_Doktorska),
+    gdzie sam obiekt jest publikacją — przemapowuje autora i kolejkuje do PBN.
+    """
+    from pbn_export_queue.models import PBN_Export_Queue
+
+    for praca in model.objects.filter(autor=autor_duplikat):
+        # Przemapuj autora
+        praca.autor = glowny_autor
+        praca.save()
+
+        # Dodaj do kolejki PBN
+        if not skip_pbn:
+            content_type = ContentType.objects.get_for_model(praca)
+            PBN_Export_Queue.objects.create(
+                content_type=content_type,
+                object_id=praca.pk,
+                zamowil=user,
+            )
+            results["publications_queued_for_pbn"].append(str(praca))
+
+        results["updated_records"].append(f"{model_label}: {praca}")
+        results["total_updated"] += 1
+
+
+def scal_autora(
     glowny_autor,
     autor_duplikat,
     user,
@@ -88,14 +280,12 @@ def scal_autora(  # noqa: C901
         dict: Wynik operacji scalania zawierający szczegóły przemapowań
     """
     from bpp.models import (
-        Autor_Dyscyplina,
         Patent_Autor,
         Praca_Doktorska,
         Praca_Habilitacyjna,
         Wydawnictwo_Ciagle_Autor,
         Wydawnictwo_Zwarte_Autor,
     )
-    from pbn_export_queue.models import PBN_Export_Queue
 
     results = {
         "success": True,
@@ -106,11 +296,22 @@ def scal_autora(  # noqa: C901
         "disciplines_transferred": [],
     }
 
+    # Modele rekordów autorstwa: (model, etykieta, czy logować transfer publikacji).
+    # Tylko Wydawnictwo_Ciagle_Autor loguje PUBLICATION_TRANSFER w LogScalania —
+    # zachowane jako historyczny quirk oryginalnego kodu.
+    authorship_models = [
+        ("Wydawnictwo_Ciagle_Autor", Wydawnictwo_Ciagle_Autor, True),
+        ("Wydawnictwo_Zwarte_Autor", Wydawnictwo_Zwarte_Autor, False),
+        ("Patent_Autor", Patent_Autor, False),
+    ]
+    # Proste publikacje (sam obiekt jest publikacją).
+    simple_models = [
+        ("Praca_Habilitacyjna", Praca_Habilitacyjna),
+        ("Praca_Doktorska", Praca_Doktorska),
+    ]
+
     try:
         with transaction.atomic():
-            # Import logging model
-            from deduplikator_autorow.models import LogScalania
-
             # Store duplicate info before deletion
             duplicate_autor_str = str(autor_duplikat)
             duplicate_autor_id = autor_duplikat.pk
@@ -123,332 +324,44 @@ def scal_autora(  # noqa: C901
                 autor_duplikat.pbn_uid if hasattr(autor_duplikat, "pbn_uid") else None
             )
 
+            # Wspólny kontekst dla wpisów LogScalania.
+            log_ctx = {
+                "duplicate_autor_str": duplicate_autor_str,
+                "duplicate_autor_id": duplicate_autor_id,
+                "main_scientist": main_scientist,
+                "duplicate_scientist": duplicate_scientist,
+            }
+
             # 0. Transfer disciplines from duplicate to main author
-            duplicate_disciplines = Autor_Dyscyplina.objects.filter(
-                autor=autor_duplikat
-            )
+            _transfer_disciplines(glowny_autor, autor_duplikat, user, log_ctx, results)
 
-            for dup_disc in duplicate_disciplines:
-                # Check if main author already has this discipline for this year
-                existing = Autor_Dyscyplina.objects.filter(
-                    autor=glowny_autor,
-                    rok=dup_disc.rok,
-                    dyscyplina_naukowa=dup_disc.dyscyplina_naukowa,
-                ).exists()
-
-                if not existing:
-                    # Create new discipline record for main author
-                    new_disc = Autor_Dyscyplina.objects.create(
-                        autor=glowny_autor,
-                        rok=dup_disc.rok,
-                        rodzaj_autora=dup_disc.rodzaj_autora,
-                        wymiar_etatu=dup_disc.wymiar_etatu,
-                        dyscyplina_naukowa=dup_disc.dyscyplina_naukowa,
-                        procent_dyscypliny=dup_disc.procent_dyscypliny,
-                        subdyscyplina_naukowa=dup_disc.subdyscyplina_naukowa,
-                        procent_subdyscypliny=dup_disc.procent_subdyscypliny,
-                    )
-                    results["disciplines_transferred"].append(
-                        f"{dup_disc.dyscyplina_naukowa} ({dup_disc.rok})"
+            # 1-3. Rekordy autorstwa (ciągłe, zwarte, patenty)
+            for model_label, model, log_publication in authorship_models:
+                for record in model.objects.filter(autor=autor_duplikat):
+                    _transfer_authorship_record(
+                        record,
+                        glowny_autor,
+                        user,
+                        skip_pbn,
+                        auto_assign_discipline,
+                        use_subdiscipline,
+                        model_label,
+                        log_publication,
+                        log_ctx,
+                        results,
                     )
 
-                    # Log discipline transfer
-                    LogScalania.objects.create(
-                        main_autor=glowny_autor,
-                        duplicate_autor_str=duplicate_autor_str,
-                        duplicate_autor_id=duplicate_autor_id,
-                        main_scientist=main_scientist,
-                        duplicate_scientist=duplicate_scientist,
-                        content_type=ContentType.objects.get_for_model(
-                            Autor_Dyscyplina
-                        ),
-                        object_id=new_disc.pk,
-                        modified_record=new_disc,
-                        dyscyplina_after=dup_disc.dyscyplina_naukowa,
-                        operation_type="DISCIPLINE_TRANSFER",
-                        operation_details=f"Przeniesiono dyscyplinę {dup_disc.dyscyplina_naukowa} "
-                        f"za rok {dup_disc.rok}",
-                        created_by=user,
-                        disciplines_transferred=1,
-                    )
-
-            # 1. Wydawnictwo_Ciagle_Autor
-            wc_autorzy = Wydawnictwo_Ciagle_Autor.objects.filter(autor=autor_duplikat)
-            for wc_autor in wc_autorzy:
-                # Store old discipline before any changes
-                old_discipline = wc_autor.dyscyplina_naukowa
-
-                # CHECK IF MAIN AUTHOR ALREADY HAS THIS PUBLICATION
-                existing = Wydawnictwo_Ciagle_Autor.objects.filter(
-                    rekord=wc_autor.rekord,
-                    autor=glowny_autor,
-                    typ_odpowiedzialnosci=wc_autor.typ_odpowiedzialnosci,
-                ).exists()
-
-                if existing:
-                    # Main author already has this publication - delete duplicate's record
-                    results["warnings"].append(
-                        f"Autor główny już ma publikację {wc_autor.rekord} "
-                        f"z typem odpowiedzialności {wc_autor.typ_odpowiedzialnosci}. "
-                        f"Usunięto duplikat."
-                    )
-                    wc_autor.delete()
-                    continue
-
-                # Sprawdź dyscypliny
-                rok = wc_autor.rekord.rok if wc_autor.rekord else None
-                if wc_autor.dyscyplina_naukowa:
-                    if (
-                        rok
-                        and not Autor_Dyscyplina.objects.filter(
-                            autor=glowny_autor,
-                            rok=rok,
-                            dyscyplina_naukowa=wc_autor.dyscyplina_naukowa,
-                        ).exists()
-                    ):
-                        results["warnings"].append(
-                            f"Autor główny nie ma dyscypliny {wc_autor.dyscyplina_naukowa} "
-                            f"za rok {rok}. Dyscyplina została usunięta z publikacji: "
-                            f"{wc_autor.rekord}"
-                        )
-                        wc_autor.dyscyplina_naukowa = None
-
-                # Przypisz dyscyplinę jeśli brak i włączona opcja
-                _assign_discipline_if_missing(
-                    wc_autor,
+            # 4-5. Prace doktorskie / habilitacyjne
+            for model_label, model in simple_models:
+                _transfer_simple_authorship(
+                    model,
+                    model_label,
                     glowny_autor,
-                    rok,
-                    auto_assign_discipline,
-                    use_subdiscipline,
-                    results["warnings"],
+                    autor_duplikat,
+                    user,
+                    skip_pbn,
+                    results,
                 )
-
-                # Przemapuj autora
-                wc_autor.autor = glowny_autor
-                wc_autor.save()
-
-                # Log publication transfer
-                LogScalania.objects.create(
-                    main_autor=glowny_autor,
-                    duplicate_autor_str=duplicate_autor_str,
-                    duplicate_autor_id=duplicate_autor_id,
-                    main_scientist=main_scientist,
-                    duplicate_scientist=duplicate_scientist,
-                    content_type=ContentType.objects.get_for_model(wc_autor.rekord),
-                    object_id=wc_autor.rekord.pk,
-                    modified_record=wc_autor.rekord,
-                    dyscyplina_before=old_discipline,
-                    dyscyplina_after=wc_autor.dyscyplina_naukowa,
-                    operation_type="PUBLICATION_TRANSFER",
-                    operation_details=f"Przeniesiono publikację: {wc_autor.rekord}",
-                    created_by=user,
-                    publications_transferred=1,
-                    warnings=(
-                        results["warnings"][-1]
-                        if old_discipline and not wc_autor.dyscyplina_naukowa
-                        else ""
-                    ),
-                )
-
-                # Dodaj do kolejki PBN
-                if not skip_pbn and wc_autor.rekord:
-                    content_type = ContentType.objects.get_for_model(wc_autor.rekord)
-                    PBN_Export_Queue.objects.create(
-                        content_type=content_type,
-                        object_id=wc_autor.rekord.pk,
-                        zamowil=user,
-                    )
-                    results["publications_queued_for_pbn"].append(str(wc_autor.rekord))
-
-                results["updated_records"].append(
-                    f"Wydawnictwo_Ciagle_Autor: {wc_autor.rekord}"
-                )
-                results["total_updated"] += 1
-
-            # 2. Wydawnictwo_Zwarte_Autor
-            wz_autorzy = Wydawnictwo_Zwarte_Autor.objects.filter(autor=autor_duplikat)
-            for wz_autor in wz_autorzy:
-                # Store old discipline before any changes
-                old_discipline = wz_autor.dyscyplina_naukowa
-
-                # CHECK IF MAIN AUTHOR ALREADY HAS THIS PUBLICATION
-                existing = Wydawnictwo_Zwarte_Autor.objects.filter(
-                    rekord=wz_autor.rekord,
-                    autor=glowny_autor,
-                    typ_odpowiedzialnosci=wz_autor.typ_odpowiedzialnosci,
-                ).exists()
-
-                if existing:
-                    # Main author already has this publication - delete duplicate's record
-                    results["warnings"].append(
-                        f"Autor główny już ma publikację {wz_autor.rekord} "
-                        f"z typem odpowiedzialności {wz_autor.typ_odpowiedzialnosci}. "
-                        f"Usunięto duplikat."
-                    )
-                    wz_autor.delete()
-                    continue
-
-                # Sprawdź dyscypliny
-                rok = wz_autor.rekord.rok if wz_autor.rekord else None
-                if wz_autor.dyscyplina_naukowa:
-                    if (
-                        rok
-                        and not Autor_Dyscyplina.objects.filter(
-                            autor=glowny_autor,
-                            rok=rok,
-                            dyscyplina_naukowa=wz_autor.dyscyplina_naukowa,
-                        ).exists()
-                    ):
-                        results["warnings"].append(
-                            f"Autor główny nie ma dyscypliny {wz_autor.dyscyplina_naukowa} "
-                            f"za rok {rok}. Dyscyplina została usunięta z publikacji: "
-                            f"{wz_autor.rekord}"
-                        )
-                        wz_autor.dyscyplina_naukowa = None
-
-                # Przypisz dyscyplinę jeśli brak i włączona opcja
-                _assign_discipline_if_missing(
-                    wz_autor,
-                    glowny_autor,
-                    rok,
-                    auto_assign_discipline,
-                    use_subdiscipline,
-                    results["warnings"],
-                )
-
-                # Przemapuj autora
-                wz_autor.autor = glowny_autor
-                wz_autor.save()
-
-                # Dodaj do kolejki PBN
-                if not skip_pbn and wz_autor.rekord:
-                    content_type = ContentType.objects.get_for_model(wz_autor.rekord)
-                    PBN_Export_Queue.objects.create(
-                        content_type=content_type,
-                        object_id=wz_autor.rekord.pk,
-                        zamowil=user,
-                    )
-                    results["publications_queued_for_pbn"].append(str(wz_autor.rekord))
-
-                results["updated_records"].append(
-                    f"Wydawnictwo_Zwarte_Autor: {wz_autor.rekord}"
-                )
-                results["total_updated"] += 1
-
-            # 3. Patent_Autor
-            patent_autorzy = Patent_Autor.objects.filter(autor=autor_duplikat)
-            for patent_autor in patent_autorzy:
-                # Store old discipline before any changes
-                old_discipline = patent_autor.dyscyplina_naukowa
-
-                # CHECK IF MAIN AUTHOR ALREADY HAS THIS PUBLICATION
-                existing = Patent_Autor.objects.filter(
-                    rekord=patent_autor.rekord,
-                    autor=glowny_autor,
-                    typ_odpowiedzialnosci=patent_autor.typ_odpowiedzialnosci,
-                ).exists()
-
-                if existing:
-                    # Main author already has this publication - delete duplicate's record
-                    results["warnings"].append(
-                        f"Autor główny już ma publikację {patent_autor.rekord} "
-                        f"z typem odpowiedzialności {patent_autor.typ_odpowiedzialnosci}. "
-                        f"Usunięto duplikat."
-                    )
-                    patent_autor.delete()
-                    continue
-
-                # Sprawdź dyscypliny
-                rok = patent_autor.rekord.rok if patent_autor.rekord else None
-                if patent_autor.dyscyplina_naukowa:
-                    if (
-                        rok
-                        and not Autor_Dyscyplina.objects.filter(
-                            autor=glowny_autor,
-                            rok=rok,
-                            dyscyplina_naukowa=patent_autor.dyscyplina_naukowa,
-                        ).exists()
-                    ):
-                        results["warnings"].append(
-                            f"Autor główny nie ma dyscypliny "
-                            f"{patent_autor.dyscyplina_naukowa} "
-                            f"za rok {rok}. Dyscyplina została usunięta z publikacji: "
-                            f"{patent_autor.rekord}"
-                        )
-                        patent_autor.dyscyplina_naukowa = None
-
-                # Przypisz dyscyplinę jeśli brak i włączona opcja
-                _assign_discipline_if_missing(
-                    patent_autor,
-                    glowny_autor,
-                    rok,
-                    auto_assign_discipline,
-                    use_subdiscipline,
-                    results["warnings"],
-                )
-
-                # Przemapuj autora
-                patent_autor.autor = glowny_autor
-                patent_autor.save()
-
-                # Dodaj do kolejki PBN
-                if not skip_pbn and patent_autor.rekord:
-                    content_type = ContentType.objects.get_for_model(
-                        patent_autor.rekord
-                    )
-                    PBN_Export_Queue.objects.create(
-                        content_type=content_type,
-                        object_id=patent_autor.rekord.pk,
-                        zamowil=user,
-                    )
-                    results["publications_queued_for_pbn"].append(
-                        str(patent_autor.rekord)
-                    )
-
-                results["updated_records"].append(
-                    f"Patent_Autor: {patent_autor.rekord}"
-                )
-                results["total_updated"] += 1
-
-            # 4. Praca_Habilitacyjna
-            prace_hab = Praca_Habilitacyjna.objects.filter(autor=autor_duplikat)
-            for praca_hab in prace_hab:
-                # Przemapuj autora
-                praca_hab.autor = glowny_autor
-                praca_hab.save()
-
-                # Dodaj do kolejki PBN
-                if not skip_pbn:
-                    content_type = ContentType.objects.get_for_model(praca_hab)
-                    PBN_Export_Queue.objects.create(
-                        content_type=content_type,
-                        object_id=praca_hab.pk,
-                        zamowil=user,
-                    )
-                    results["publications_queued_for_pbn"].append(str(praca_hab))
-
-                results["updated_records"].append(f"Praca_Habilitacyjna: {praca_hab}")
-                results["total_updated"] += 1
-
-            # 5. Praca_Doktorska
-            prace_dokt = Praca_Doktorska.objects.filter(autor=autor_duplikat)
-            for praca_dokt in prace_dokt:
-                # Przemapuj autora
-                praca_dokt.autor = glowny_autor
-                praca_dokt.save()
-
-                # Dodaj do kolejki PBN
-                if not skip_pbn:
-                    content_type = ContentType.objects.get_for_model(praca_dokt)
-                    PBN_Export_Queue.objects.create(
-                        content_type=content_type,
-                        object_id=praca_dokt.pk,
-                        zamowil=user,
-                    )
-                    results["publications_queued_for_pbn"].append(str(praca_dokt))
-
-                results["updated_records"].append(f"Praca_Doktorska: {praca_dokt}")
-                results["total_updated"] += 1
 
             autor_duplikat.delete()
 

--- a/src/deduplikator_autorow/utils/search.py
+++ b/src/deduplikator_autorow/utils/search.py
@@ -52,7 +52,104 @@ def initial_match_filter(field: str, initial: str) -> Q:
     )
 
 
-def szukaj_kopii(osoba_z_instytucji: OsobaZInstytucji) -> QuerySet[Autor]:  # noqa: C901
+def _nazwisko_query(nazwisko: str) -> Q:
+    """
+    Buduje warunek Q dopasowujący kandydatów po samym nazwisku:
+    pełne nazwisko, odwrócone dwuczłonowe, części złożonego oraz nazwisko
+    jako pełny człon w nazwisku złożonym.
+    """
+    # 1. Pełne nazwisko - dokładne dopasowanie (case insensitive)
+    q = Q(nazwisko__iexact=nazwisko)
+
+    if "-" in nazwisko:
+        czesci_nazwiska = nazwisko.split("-")
+
+        # 2. Nazwisko odwrócone (np. "Gal-Cisoń" -> "Cisoń-Gal")
+        if len(czesci_nazwiska) == 2:
+            odwrocone_nazwisko = f"{czesci_nazwiska[1]}-{czesci_nazwiska[0]}"
+            q |= Q(nazwisko__iexact=odwrocone_nazwisko)
+
+        # 3. Części nazwiska złożonego (np. "Gal-Cisoń" -> "Gal" lub "Cisoń")
+        for czesc in czesci_nazwiska:
+            czesc = czesc.strip()
+            if len(czesc) > 2:  # Tylko części dłuższe niż 2 znaki
+                q |= Q(nazwisko__iexact=czesc)
+
+    # 4. Nazwisko jako pełny człon w nazwisku złożonym
+    # np. "Woźniak" dopasuje "Kowalska-Woźniak" lub "Woźniak-Kowalska"
+    # ale NIE "Przewoźniak" (bo Woźniak to tylko część słowa)
+    # Warunek: nazwisko musi być na początku (przed myślnikiem) lub na końcu (po myślniku)
+    if len(nazwisko) > 3:
+        # Dopasuj: "Nazwisko-..." lub "...-Nazwisko"
+        q |= Q(nazwisko__istartswith=nazwisko + "-")
+        q |= Q(nazwisko__iendswith="-" + nazwisko)
+
+    return q
+
+
+def _swap_query(nazwisko: str, imiona: str) -> Q:
+    """
+    Buduje warunek Q dla zamiany imienia z nazwiskiem (swap detection):
+    nazwisko duplikatu == imię głównego ORAZ imię duplikatu == nazwisko głównego.
+    Wymaga minimum 3 znaków aby uniknąć fałszywych dopasowań.
+    """
+    q = Q()
+    if imiona and len(nazwisko) >= 3:
+        for imie_glownego in imiona.split():
+            if len(imie_glownego) >= 3:
+                # Obie strony zamiany muszą się zgadzać (AND, nie OR)
+                q |= Q(nazwisko__iexact=imie_glownego) & word_match_filter(
+                    "imiona", nazwisko
+                )
+    return q
+
+
+def _imiona_filter(imiona: str, nazwisko: str) -> Q:
+    """
+    Buduje dodatkowy filtr Q po imionach: dokładne/podobne dopasowanie pełnych
+    imion, dopasowanie inicjałów oraz swap (imię duplikatu == nazwisko głównego).
+    """
+    filtr_imion = Q()
+
+    for imie in imiona.split():
+        if not imie:
+            continue
+
+        # Sprawdź czy to inicjał (1-2 znaki, ewentualnie z kropką)
+        is_initial = len(imie) <= 2 or (len(imie) == 2 and imie[1] == ".")
+
+        if is_initial:
+            # Dla inicjałów - szukaj inicjału lub imion zaczynających się od tej litery
+            inicjal = imie[0].upper()
+            filtr_imion |= initial_match_filter("imiona", inicjal)
+            filtr_imion |= Q(imiona__istartswith=inicjal)
+            continue
+
+        # Dla pełnych imion - bardziej restrykcyjne dopasowanie
+        # Dokładne dopasowanie imienia (jako pełne słowo)
+        filtr_imion |= word_match_filter("imiona", imie)
+
+        # Podobne imiona (pierwsze 3+ znaki) - dla imion >= 3 znaków
+        # np. "Jan" dopasuje "Janek", "Janusz"
+        if len(imie) >= 3:
+            prefix = imie[:3]
+            filtr_imion |= Q(imiona__istartswith=prefix)
+
+        # Dopasuj pełne imię do inicjału duplikatu
+        # "Jan" powinien pasować do "J."
+        inicjal = imie[0].upper()
+        filtr_imion |= initial_match_filter("imiona", inicjal)
+
+    # Dla swap detection - imię duplikatu może być równe nazwisku głównego
+    # np. główny: "Kowalski Janusz" -> duplikat: "Janusz Kowalski"
+    # Imię duplikatu ("Kowalski") = nazwisko głównego ("Kowalski")
+    if len(nazwisko) >= 5:
+        filtr_imion |= word_match_filter("imiona", nazwisko)
+
+    return filtr_imion
+
+
+def szukaj_kopii(osoba_z_instytucji: OsobaZInstytucji) -> QuerySet[Autor]:
     """
     Funkcja wyszukuje potencjalnie zdublowanych autorów w systemie BPP
     na podstawie głównego autora z OsobaZInstytucji.
@@ -92,97 +189,19 @@ def szukaj_kopii(osoba_z_instytucji: OsobaZInstytucji) -> QuerySet[Autor]:  # no
     if not nazwisko:
         return Autor.objects.none()
 
-    # Rozpocznij budowanie zapytania
-    q = Q()
-
-    # 1. Pełne nazwisko - dokładne dopasowanie (case insensitive)
-    q |= Q(nazwisko__iexact=nazwisko)
-
-    # 2. Nazwisko odwrócone (np. "Gal-Cisoń" -> "Cisoń-Gal")
-    if "-" in nazwisko:
-        czesci_nazwiska = nazwisko.split("-")
-        if len(czesci_nazwiska) == 2:
-            odwrocone_nazwisko = f"{czesci_nazwiska[1]}-{czesci_nazwiska[0]}"
-            q |= Q(nazwisko__iexact=odwrocone_nazwisko)
-
-    # 3. Części nazwiska złożonego (np. "Gal-Cisoń" -> "Gal" lub "Cisoń")
-    if "-" in nazwisko:
-        czesci_nazwiska = nazwisko.split("-")
-        for czesc in czesci_nazwiska:
-            czesc = czesc.strip()
-            if len(czesc) > 2:  # Tylko części dłuższe niż 2 znaki
-                q |= Q(nazwisko__iexact=czesc)
-
-    # 4. Nazwisko jako pełny człon w nazwisku złożonym
-    # np. "Woźniak" dopasuje "Kowalska-Woźniak" lub "Woźniak-Kowalska"
-    # ale NIE "Przewoźniak" (bo Woźniak to tylko część słowa)
-    # Warunek: nazwisko musi być na początku (przed myślnikiem) lub na końcu (po myślniku)
-    if len(nazwisko) > 3:
-        # Dopasuj: "Nazwisko-..." lub "...-Nazwisko"
-        q |= Q(nazwisko__istartswith=nazwisko + "-")
-        q |= Q(nazwisko__iendswith="-" + nazwisko)
-
-    # 6. Zamiana imienia z nazwiskiem (swap detection) - OBA warunki muszą być spełnione
-    # Sprawdzamy czy:
-    # - nazwisko duplikatu == imię głównego autora ORAZ
-    # - imię duplikatu == nazwisko głównego autora
-    # Wymaga minimum 3 znaków aby uniknąć fałszywych dopasowań
-    if imiona and len(nazwisko) >= 3:
-        for imie_glownego in imiona.split():
-            if len(imie_glownego) >= 3:
-                # Obie strony zamiany muszą się zgadzać (AND, nie OR)
-                swap_condition = Q(nazwisko__iexact=imie_glownego) & word_match_filter(
-                    "imiona", nazwisko
-                )
-                q |= swap_condition
+    # Zbuduj zapytanie na podstawie nazwiska + ewentualnej zamiany imię/nazwisko
+    q = _nazwisko_query(nazwisko) | _swap_query(nazwisko, imiona)
 
     # Wyszukaj kandydatów na duplikaty
     kandydaci = Autor.objects.filter(q).exclude(pk=glowny_autor.pk)
 
     # Dodatkowe filtrowanie po imieniu jeśli jest dostępne
-    if imiona:
-        # Pobierz wszystkie imiona
-        lista_imion = imiona.split()
-
-        if lista_imion:
-            filtr_imion = Q()
-
-            for imie in lista_imion:
-                if len(imie) > 0:
-                    # Sprawdź czy to inicjał (1-2 znaki, ewentualnie z kropką)
-                    is_initial = len(imie) <= 2 or (len(imie) == 2 and imie[1] == ".")
-
-                    if is_initial:
-                        # Dla inicjałów - szukaj inicjału lub imion zaczynających się od tej litery
-                        inicjal = imie[0].upper()
-                        filtr_imion |= initial_match_filter("imiona", inicjal)
-                        filtr_imion |= Q(imiona__istartswith=inicjal)
-                    else:
-                        # Dla pełnych imion - bardziej restrykcyjne dopasowanie
-                        # Dokładne dopasowanie imienia (jako pełne słowo)
-                        filtr_imion |= word_match_filter("imiona", imie)
-
-                        # Podobne imiona (pierwsze 3+ znaki) - dla imion >= 3 znaków
-                        # np. "Jan" dopasuje "Janek", "Janusz"
-                        if len(imie) >= 3:
-                            prefix = imie[:3]
-                            filtr_imion |= Q(imiona__istartswith=prefix)
-
-                        # Dopasuj pełne imię do inicjału duplikatu
-                        # "Jan" powinien pasować do "J."
-                        inicjal = imie[0].upper()
-                        filtr_imion |= initial_match_filter("imiona", inicjal)
-
-            # Dla swap detection - imię duplikatu może być równe nazwisku głównego
-            # np. główny: "Kowalski Janusz" -> duplikat: "Janusz Kowalski"
-            # Imię duplikatu ("Kowalski") = nazwisko głównego ("Kowalski")
-            if len(nazwisko) >= 5:
-                filtr_imion |= word_match_filter("imiona", nazwisko)
-
-            # Zastosuj filtr imion jako dodatkowy warunek OR z pustymi imionami
-            kandydaci = kandydaci.filter(
-                filtr_imion | Q(imiona__isnull=True) | Q(imiona__exact="")
-            )
+    if imiona and imiona.split():
+        filtr_imion = _imiona_filter(imiona, nazwisko)
+        # Zastosuj filtr imion jako dodatkowy warunek OR z pustymi imionami
+        kandydaci = kandydaci.filter(
+            filtr_imion | Q(imiona__isnull=True) | Q(imiona__exact="")
+        )
 
     kandydaci = kandydaci.exclude(
         pk__in=NotADuplicate.objects.values_list("autor_id", flat=True)

--- a/src/deduplikator_autorow/views/duplicates.py
+++ b/src/deduplikator_autorow/views/duplicates.py
@@ -37,60 +37,41 @@ from .helpers import (
     group_required,
 )
 
+TEMPLATE_DUPLICATE_AUTHORS = "deduplikator_autorow/duplicate_authors.html"
 
-@group_required(GR_WPROWADZANIE_DANYCH)
-def duplicate_authors_view(request):  # noqa: C901
-    """
-    Widok pokazujący główny rekord autora wraz z możliwymi duplikatami
-    i ich publikacjami (do 500 na duplikat).
 
-    Uses pre-computed duplicates from DuplicateCandidate table.
-    """
-    from bpp.models import Autor_Dyscyplina
+def _normalize_choice(value, allowed, default):
+    """Zwróć ``value`` jeśli jest w ``allowed``, inaczej ``default``."""
+    return value if value in allowed else default
 
-    # Get scan status
-    running_scan = get_running_scan()
-    completed_scan = get_latest_usable_scan()
 
-    # Filter mode: pbn|general|both (default both)
-    mode = request.GET.get("mode", "both")
-    if mode not in ("pbn", "general", "both"):
-        mode = "both"
+def _parse_skip_count(request):
+    """Wczytaj skip_count z GET jako int, z fallbackiem 0."""
+    try:
+        return int(request.GET.get("skip_count", 0))
+    except (ValueError, TypeError):
+        return 0
 
-    # Filter confidence band: all|high|low (default all). high=>=50%, low=<50%.
-    # Próg porównujemy do confidence_percent jako ułamka, bo display % jest
-    # liczone z confidence_percent * 100 z klampem.
-    confidence_band = request.GET.get("confidence", "all")
-    if confidence_band not in ("all", "high", "low"):
-        confidence_band = "all"
-    confidence_threshold_frac = MIN_PEWNOSC_DO_WYSWIETLENIA / 100.0
 
-    # Common context
-    not_duplicate_count = NotADuplicate.objects.count()
-    ignored_authors_count = IgnoredScientist.objects.count()
-    latest_pbn_download = PbnDownloadTask.get_latest_task()
-
-    # Check PBN people data freshness
+def _build_base_context(request, running_scan, completed_scan, mode):
+    """Zbuduj wspólny kontekst używany we wszystkich scenariuszach widoku."""
     pbn_data_fresh, pbn_stale_message, pbn_last_download = is_pbn_people_data_fresh()
-
     recent_merges = (
         LogScalania.objects.filter(created_by=request.user)
         .select_related("main_autor", "dyscyplina_before", "dyscyplina_after")
         .order_by("-created_on")[:10]
     )
-
-    # Base context for all scenarios
-    context = {
+    return {
         "scientist": None,
         "glowny_autor": None,
-        "latest_pbn_download": latest_pbn_download,
+        "latest_pbn_download": PbnDownloadTask.get_latest_task(),
         "duplikaty_z_publikacjami": [],
         "analiza": None,
         "has_skipped_authors": False,
         "has_previous_authors": False,
         "total_authors_with_duplicates": 0,
-        "not_duplicate_count": not_duplicate_count,
-        "ignored_authors_count": ignored_authors_count,
+        "not_duplicate_count": NotADuplicate.objects.count(),
+        "ignored_authors_count": IgnoredScientist.objects.count(),
         "search_lastname": "",
         "search_results_count": None,
         "recent_merges": recent_merges,
@@ -111,17 +92,9 @@ def duplicate_authors_view(request):  # noqa: C901
         "pbn_last_download": pbn_last_download,
     }
 
-    # If no completed scan, show "run scan first" message
-    if not completed_scan:
-        if running_scan:
-            messages.info(
-                request,
-                f"Skanowanie w toku: {running_scan.progress_percent}% "
-                f"({running_scan.authors_scanned}/{running_scan.total_authors_to_scan} autorów)",
-            )
-        return render(request, "deduplikator_autorow/duplicate_authors.html", context)
 
-    # Count pending candidates
+def _add_pending_counts(context, completed_scan, confidence_band):
+    """Policz PENDING-ujące kandydaty i wstaw liczniki do kontekstu."""
     base_pending_qs = DuplicateCandidate.objects.filter(
         scan_run=completed_scan,
         status=DuplicateCandidate.Status.PENDING,
@@ -135,115 +108,101 @@ def duplicate_authors_view(request):  # noqa: C901
     ).count()
     context["confidence_band"] = confidence_band
 
-    # Handle search by lastname
-    search_lastname = request.GET.get("search_lastname", "").strip()
-    context["search_lastname"] = search_lastname
 
-    if search_lastname:
-        # Search within stored candidates - confidence_band celowo NIE filtruje
-        # wyboru głównego autora (filtr per-autor stosujemy niżej, na liście
-        # candidates_for_author).
-        candidates = (
-            DuplicateCandidate.objects.filter(
-                scan_run=completed_scan,
-                status=DuplicateCandidate.Status.PENDING,
-                main_autor__nazwisko__icontains=search_lastname,
-            )
-            .select_related("main_autor", "duplicate_autor")
-            .order_by("-priority", "-confidence_score")
+def _resolve_by_search(request, completed_scan, mode, search_lastname, context):
+    """Wybierz głównego autora i jego kandydatów na podstawie nazwiska.
+
+    confidence_band celowo NIE filtruje wyboru głównego autora (filtr per-autor
+    stosujemy później, na liście candidates_for_author).
+    """
+    candidates = (
+        DuplicateCandidate.objects.filter(
+            scan_run=completed_scan,
+            status=DuplicateCandidate.Status.PENDING,
+            main_autor__nazwisko__icontains=search_lastname,
         )
-        if mode != "both":
-            candidates = candidates.filter(scan_mode=mode)
+        .select_related("main_autor", "duplicate_autor")
+        .order_by("-priority", "-confidence_score")
+    )
+    if mode != "both":
+        candidates = candidates.filter(scan_mode=mode)
 
-        context["search_results_count"] = (
-            candidates.values("main_autor").distinct().count()
-        )
+    context["search_results_count"] = candidates.values("main_autor").distinct().count()
 
-        if candidates.exists():
-            search_author_ids = list(
-                candidates.values_list("main_autor", flat=True)
-                .distinct()
-                .order_by("main_autor")
-            )
-            try:
-                skip_count = int(request.GET.get("skip_count", 0))
-            except (ValueError, TypeError):
-                skip_count = 0
-            if skip_count >= len(search_author_ids):
-                skip_count = 0
-            glowny_autor_id = search_author_ids[skip_count]
-            glowny_autor = Autor.objects.get(pk=glowny_autor_id)
-            candidates_for_author = candidates.filter(main_autor=glowny_autor)
-            context["skip_count"] = skip_count
-            context["search_total_authors"] = len(search_author_ids)
-            context["search_has_prev"] = skip_count > 0
-            context["search_has_next"] = skip_count < len(search_author_ids) - 1
-        else:
-            glowny_autor = None
-            candidates_for_author = DuplicateCandidate.objects.none()
-    else:
-        # Handle navigation - use skip_count as offset
-        try:
-            skip_count = int(request.GET.get("skip_count", 0))
-        except (ValueError, TypeError):
-            skip_count = 0
+    if not candidates.exists():
+        return None, DuplicateCandidate.objects.none()
 
-        # Get next author with pending duplicates using offset.
-        # confidence_band NIE jest tu przekazywane — chcemy iterować po
-        # WSZYSTKICH głównych autorach niezależnie od pewności ich kandydatów,
-        # filtr stosujemy niżej tylko na widocznym podzbiorze.
-        glowny_autor, candidates_for_author, skip_count = _get_next_candidate_group(
-            completed_scan,
-            skip_count=skip_count,
-            mode=mode,
-        )
-        context["skip_count"] = skip_count
+    search_author_ids = list(
+        candidates.values_list("main_autor", flat=True)
+        .distinct()
+        .order_by("main_autor")
+    )
+    skip_count = _parse_skip_count(request)
+    if skip_count >= len(search_author_ids):
+        skip_count = 0
+    glowny_autor = Autor.objects.get(pk=search_author_ids[skip_count])
+    candidates_for_author = candidates.filter(main_autor=glowny_autor)
+    context["skip_count"] = skip_count
+    context["search_total_authors"] = len(search_author_ids)
+    context["search_has_prev"] = skip_count > 0
+    context["search_has_next"] = skip_count < len(search_author_ids) - 1
+    return glowny_autor, candidates_for_author
 
-    # Filter per-author by confidence band (NOT main author selection).
-    # Liczniki "X / Y" oraz per-band wyliczamy zanim podstawimy filtr.
+
+def _resolve_by_navigation(request, completed_scan, mode, context):
+    """Wybierz kolejnego głównego autora poprzez offset skip_count.
+
+    confidence_band NIE jest tu przekazywane — chcemy iterować po WSZYSTKICH
+    głównych autorach niezależnie od pewności ich kandydatów, filtr stosujemy
+    później tylko na widocznym podzbiorze.
+    """
+    glowny_autor, candidates_for_author, skip_count = _get_next_candidate_group(
+        completed_scan,
+        skip_count=_parse_skip_count(request),
+        mode=mode,
+    )
+    context["skip_count"] = skip_count
+    return glowny_autor, candidates_for_author
+
+
+def _apply_confidence_band(
+    candidates_for_author, glowny_autor, confidence_band, threshold, context
+):
+    """Policz liczniki per-band i przefiltruj listę widocznych kandydatów."""
     if glowny_autor:
-        candidates_total_for_main = candidates_for_author.count()
-        candidates_high_for_main = candidates_for_author.filter(
-            confidence_percent__gte=confidence_threshold_frac
-        ).count()
-        candidates_low_for_main = candidates_total_for_main - candidates_high_for_main
+        total = candidates_for_author.count()
+        high = candidates_for_author.filter(confidence_percent__gte=threshold).count()
+        low = total - high
     else:
-        candidates_total_for_main = 0
-        candidates_high_for_main = 0
-        candidates_low_for_main = 0
+        total = high = low = 0
     if confidence_band == "high":
         candidates_for_author = candidates_for_author.filter(
-            confidence_percent__gte=confidence_threshold_frac
+            confidence_percent__gte=threshold
         )
     elif confidence_band == "low":
         candidates_for_author = candidates_for_author.filter(
-            confidence_percent__lt=confidence_threshold_frac
+            confidence_percent__lt=threshold
         )
-    context["candidates_total_for_main"] = candidates_total_for_main
-    context["candidates_high_for_main"] = candidates_high_for_main
-    context["candidates_low_for_main"] = candidates_low_for_main
+    context["candidates_total_for_main"] = total
+    context["candidates_high_for_main"] = high
+    context["candidates_low_for_main"] = low
+    return candidates_for_author
 
-    if not glowny_autor:
-        if pending_count == 0:
-            messages.info(
-                request,
-                "Brak duplikatów do sprawdzenia. Wszystkie zostały już przetworzone.",
-            )
-        return render(request, "deduplikator_autorow/duplicate_authors.html", context)
 
-    # Build context for the main author
+def _build_main_author_context(context, glowny_autor, candidates_for_author):
+    """Uzupełnij kontekst danymi głównego autora i jego duplikatów."""
+    from bpp.models import Autor_Dyscyplina
+
     context["glowny_autor"] = glowny_autor
 
     # Try to get scientist for main author (for backward compatibility)
     if glowny_autor.pbn_uid:
         context["scientist"] = glowny_autor.pbn_uid
 
-    # Build duplicate list from stored candidates
-    duplikaty_z_publikacjami = []
-    for candidate in candidates_for_author:
-        pub_data = _build_context_from_candidate(candidate, glowny_autor)
-        duplikaty_z_publikacjami.append(pub_data)
-
+    duplikaty_z_publikacjami = [
+        _build_context_from_candidate(candidate, glowny_autor)
+        for candidate in candidates_for_author
+    ]
     context["duplikaty_z_publikacjami"] = duplikaty_z_publikacjami
     context["first_candidate"] = (
         candidates_for_author.first() if candidates_for_author else None
@@ -280,7 +239,75 @@ def duplicate_authors_view(request):  # noqa: C901
     context["glowne_publikacje_count"] = glowny_autor_qs.count()
     context["glowne_publikacje_year_range"] = _calculate_year_range(glowny_autor_qs)
 
-    return render(request, "deduplikator_autorow/duplicate_authors.html", context)
+
+@group_required(GR_WPROWADZANIE_DANYCH)
+def duplicate_authors_view(request):
+    """
+    Widok pokazujący główny rekord autora wraz z możliwymi duplikatami
+    i ich publikacjami (do 500 na duplikat).
+
+    Uses pre-computed duplicates from DuplicateCandidate table.
+    """
+    running_scan = get_running_scan()
+    completed_scan = get_latest_usable_scan()
+
+    # Filter mode: pbn|general|both (default both)
+    mode = _normalize_choice(
+        request.GET.get("mode", "both"), ("pbn", "general", "both"), "both"
+    )
+    # Filter confidence band: all|high|low (default all). high=>=50%, low=<50%.
+    # Próg porównujemy do confidence_percent jako ułamka, bo display % jest
+    # liczone z confidence_percent * 100 z klampem.
+    confidence_band = _normalize_choice(
+        request.GET.get("confidence", "all"), ("all", "high", "low"), "all"
+    )
+    confidence_threshold_frac = MIN_PEWNOSC_DO_WYSWIETLENIA / 100.0
+
+    context = _build_base_context(request, running_scan, completed_scan, mode)
+
+    # If no completed scan, show "run scan first" message
+    if not completed_scan:
+        if running_scan:
+            messages.info(
+                request,
+                f"Skanowanie w toku: {running_scan.progress_percent}% "
+                f"({running_scan.authors_scanned}/{running_scan.total_authors_to_scan} autorów)",
+            )
+        return render(request, TEMPLATE_DUPLICATE_AUTHORS, context)
+
+    _add_pending_counts(context, completed_scan, confidence_band)
+
+    # Handle search by lastname
+    search_lastname = request.GET.get("search_lastname", "").strip()
+    context["search_lastname"] = search_lastname
+
+    if search_lastname:
+        glowny_autor, candidates_for_author = _resolve_by_search(
+            request, completed_scan, mode, search_lastname, context
+        )
+    else:
+        glowny_autor, candidates_for_author = _resolve_by_navigation(
+            request, completed_scan, mode, context
+        )
+
+    candidates_for_author = _apply_confidence_band(
+        candidates_for_author,
+        glowny_autor,
+        confidence_band,
+        confidence_threshold_frac,
+        context,
+    )
+
+    if not glowny_autor:
+        if context["pending_candidates_count"] == 0:
+            messages.info(
+                request,
+                "Brak duplikatów do sprawdzenia. Wszystkie zostały już przetworzone.",
+            )
+        return render(request, TEMPLATE_DUPLICATE_AUTHORS, context)
+
+    _build_main_author_context(context, glowny_autor, candidates_for_author)
+    return render(request, TEMPLATE_DUPLICATE_AUTHORS, context)
 
 
 @group_required(GR_WPROWADZANIE_DANYCH)

--- a/src/deduplikator_zrodel/tests/test_scoring.py
+++ b/src/deduplikator_zrodel/tests/test_scoring.py
@@ -27,6 +27,7 @@ from model_bakery import baker
 
 from bpp.models.zrodlo import Rodzaj_Zrodla, Zasieg_Zrodla, Zrodlo
 from deduplikator_zrodel.utils import ocen_podobienstwo
+from pbn_api.models import Journal
 
 
 @pytest.fixture
@@ -136,3 +137,63 @@ def test_score_jest_addytywny(rodzaj, zasieg):
     # 100 + 60 = 160 gwarantowane; identyczny skrót dorzuci +10
     assert score >= 160
     assert score <= 170
+
+
+@pytest.mark.django_db
+def test_to_samo_pbn_uid_daje_80(rodzaj, zasieg):
+    """Oba źródła wskazujące na ten sam pbn_api.Journal — +80."""
+    journal = baker.make(Journal)
+    a = _make_zrodlo(rodzaj, zasieg, nazwa="A", skrot="A", pbn_uid=journal)
+    b = _make_zrodlo(rodzaj, zasieg, nazwa="B", skrot="B", pbn_uid=journal)
+    assert ocen_podobienstwo(a, b) == 80
+
+
+@pytest.mark.django_db
+def test_rozne_pbn_uid_nie_daje_punktow(rodzaj, zasieg):
+    """Różne obiekty Journal — żadnych punktów za PBN UID."""
+    a = _make_zrodlo(rodzaj, zasieg, nazwa="A", skrot="A", pbn_uid=baker.make(Journal))
+    b = _make_zrodlo(rodzaj, zasieg, nazwa="B", skrot="B", pbn_uid=baker.make(Journal))
+    assert ocen_podobienstwo(a, b) == 0
+
+
+@pytest.mark.django_db
+def test_jeden_pbn_uid_brak_drugiego_nie_daje_punktow(rodzaj, zasieg):
+    """Gdy tylko jedno źródło ma pbn_uid — brak dopasowania PBN."""
+    a = _make_zrodlo(rodzaj, zasieg, nazwa="A", skrot="A", pbn_uid=baker.make(Journal))
+    b = _make_zrodlo(rodzaj, zasieg, nazwa="B", skrot="B")
+    assert ocen_podobienstwo(a, b) == 0
+
+
+@pytest.mark.django_db
+def test_pbn_plus_issn_addytywne(rodzaj, zasieg):
+    """ISSN (100) + PBN UID (80) = 180."""
+    journal = baker.make(Journal)
+    a = _make_zrodlo(
+        rodzaj, zasieg, nazwa="A", skrot="A", issn="1234-5678", pbn_uid=journal
+    )
+    b = _make_zrodlo(
+        rodzaj, zasieg, nazwa="B", skrot="B", issn="1234-5678", pbn_uid=journal
+    )
+    assert ocen_podobienstwo(a, b) == 180
+
+
+@pytest.mark.django_db
+def test_bardzo_podobna_nazwa_trigram_daje_punkty(rodzaj, zasieg):
+    """Nazwy różniące się jednym znakiem (różne po normalizacji, ale wysoki
+    trigram) trafiają do gałęzi trigramowej i dają dodatnie punkty (>0.7 → +20
+    lub >0.9 → +40)."""
+    a = _make_zrodlo(rodzaj, zasieg, nazwa="Acta Biochimica Polonica", skrot="zzz1")
+    b = _make_zrodlo(rodzaj, zasieg, nazwa="Acta Biochimica Polonicx", skrot="qqq2")
+    score = ocen_podobienstwo(a, b)
+    # Różne skróty (zzz1/qqq2) nie dorzucą nic; cały wynik pochodzi z trigramu
+    # nazwy. Pin: gałąź trigramowa daje 20 lub 40 (zależnie od progu).
+    assert score in (20, 40)
+
+
+@pytest.mark.django_db
+def test_niepodobna_nazwa_trigram_nie_daje_punktow(rodzaj, zasieg):
+    """Nazwy o niskim podobieństwie trigramowym (poniżej 0.7) nie dają
+    punktów za nazwę."""
+    a = _make_zrodlo(rodzaj, zasieg, nazwa="Acta Biochimica", skrot="zzz1")
+    b = _make_zrodlo(rodzaj, zasieg, nazwa="Zoologica Universalis", skrot="qqq2")
+    assert ocen_podobienstwo(a, b) == 0

--- a/src/deduplikator_zrodel/tests/test_znajdz_podobne.py
+++ b/src/deduplikator_zrodel/tests/test_znajdz_podobne.py
@@ -1,0 +1,181 @@
+"""Charakterystyczne testy dla `znajdz_podobne_zrodla`.
+
+Funkcja buduje QuerySet kandydatów na duplikaty danego źródła. Testy pinują
+obecne zachowanie filtrów (przed refaktorem zdejmującym # noqa: C901):
+
+- kandydat MUSI mieć powiązane wydawnictwo ciągłe (pub_count > 0),
+- własne źródło jest zawsze wykluczone,
+- pary oznaczone jako NotADuplicate są wykluczane (w obie strony),
+- źródła z IgnoredSource są wykluczane,
+- źródła z RÓŻNYM mniswId (gdy główne ma mniswId) są wykluczane,
+- dopasowanie po: identycznym ISSN / e-ISSN, tym samym pbn_uid,
+  podobnej nazwie (trigram >= 0.5), podobnym skrócie (trigram >= 0.6),
+- brak jakiegokolwiek kryterium → pusty QuerySet (Zrodlo.objects.none()).
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Wydawnictwo_Ciagle
+from bpp.models.zrodlo import Rodzaj_Zrodla, Zasieg_Zrodla, Zrodlo
+from deduplikator_zrodel.models import IgnoredSource, NotADuplicate
+from deduplikator_zrodel.utils import znajdz_podobne_zrodla
+from pbn_api.models import Journal
+
+
+@pytest.fixture
+def rodzaj():
+    return Rodzaj_Zrodla.objects.create(nazwa="Czasopismo")
+
+
+@pytest.fixture
+def zasieg():
+    return Zasieg_Zrodla.objects.create(nazwa="Krajowy")
+
+
+def _zrodlo(rodzaj, zasieg, *, z_publikacja=True, **kw):
+    """Tworzy źródło; domyślnie z powiązanym wydawnictwem ciągłym, żeby
+    przeszło filtr pub_count > 0 (kandydaci bez publikacji są pomijani)."""
+    kw.setdefault("rodzaj", rodzaj)
+    kw.setdefault("zasieg", zasieg)
+    z = baker.make(Zrodlo, **kw)
+    if z_publikacja:
+        baker.make(Wydawnictwo_Ciagle, zrodlo=z)
+    return z
+
+
+@pytest.mark.django_db
+def test_dopasowanie_po_identycznym_issn(rodzaj, zasieg):
+    glowne = _zrodlo(rodzaj, zasieg, nazwa="Glowne", skrot="G", issn="1234-5678")
+    kandydat = _zrodlo(rodzaj, zasieg, nazwa="Kandydat", skrot="K", issn="1234-5678")
+    wyniki = list(znajdz_podobne_zrodla(glowne))
+    assert kandydat in wyniki
+
+
+@pytest.mark.django_db
+def test_dopasowanie_po_e_issn(rodzaj, zasieg):
+    glowne = _zrodlo(rodzaj, zasieg, nazwa="Glowne", skrot="G", e_issn="2222-3333")
+    kandydat = _zrodlo(rodzaj, zasieg, nazwa="Kandydat", skrot="K", e_issn="2222-3333")
+    assert kandydat in list(znajdz_podobne_zrodla(glowne))
+
+
+@pytest.mark.django_db
+def test_dopasowanie_po_tym_samym_pbn_uid(rodzaj, zasieg):
+    journal = baker.make(Journal)
+    glowne = _zrodlo(rodzaj, zasieg, nazwa="Glowne", skrot="G", pbn_uid=journal)
+    kandydat = _zrodlo(rodzaj, zasieg, nazwa="Inna", skrot="K", pbn_uid=journal)
+    assert kandydat in list(znajdz_podobne_zrodla(glowne))
+
+
+@pytest.mark.django_db
+def test_dopasowanie_po_podobnej_nazwie(rodzaj, zasieg):
+    glowne = _zrodlo(rodzaj, zasieg, nazwa="Acta Biochimica Polonica", skrot="G")
+    kandydat = _zrodlo(rodzaj, zasieg, nazwa="Acta Biochimica Polonica", skrot="K")
+    assert kandydat in list(znajdz_podobne_zrodla(glowne))
+
+
+@pytest.mark.django_db
+def test_kandydat_bez_publikacji_jest_pomijany(rodzaj, zasieg):
+    glowne = _zrodlo(rodzaj, zasieg, nazwa="Glowne", skrot="G", issn="1234-5678")
+    bez_pub = _zrodlo(
+        rodzaj,
+        zasieg,
+        z_publikacja=False,
+        nazwa="Kandydat",
+        skrot="K",
+        issn="1234-5678",
+    )
+    assert bez_pub not in list(znajdz_podobne_zrodla(glowne))
+
+
+@pytest.mark.django_db
+def test_wlasne_zrodlo_nie_jest_swoim_duplikatem(rodzaj, zasieg):
+    glowne = _zrodlo(rodzaj, zasieg, nazwa="Glowne", skrot="G", issn="1234-5678")
+    assert glowne not in list(znajdz_podobne_zrodla(glowne))
+
+
+@pytest.mark.django_db
+def test_notaduplicate_wyklucza_kandydata(rodzaj, zasieg):
+    glowne = _zrodlo(rodzaj, zasieg, nazwa="Glowne", skrot="G", issn="1234-5678")
+    kandydat = _zrodlo(rodzaj, zasieg, nazwa="Kandydat", skrot="K", issn="1234-5678")
+    NotADuplicate.objects.create(zrodlo=glowne, duplikat=kandydat)
+    assert kandydat not in list(znajdz_podobne_zrodla(glowne))
+
+
+@pytest.mark.django_db
+def test_notaduplicate_dziala_w_obie_strony(rodzaj, zasieg):
+    glowne = _zrodlo(rodzaj, zasieg, nazwa="Glowne", skrot="G", issn="1234-5678")
+    kandydat = _zrodlo(rodzaj, zasieg, nazwa="Kandydat", skrot="K", issn="1234-5678")
+    # Zapis w odwrotnej kolejności (duplikat=glowne) — i tak wyklucza.
+    NotADuplicate.objects.create(zrodlo=kandydat, duplikat=glowne)
+    assert kandydat not in list(znajdz_podobne_zrodla(glowne))
+
+
+@pytest.mark.django_db
+def test_ignoredsource_wyklucza_kandydata(rodzaj, zasieg):
+    glowne = _zrodlo(rodzaj, zasieg, nazwa="Glowne", skrot="G", issn="1234-5678")
+    kandydat = _zrodlo(rodzaj, zasieg, nazwa="Kandydat", skrot="K", issn="1234-5678")
+    IgnoredSource.objects.create(zrodlo=kandydat)
+    assert kandydat not in list(znajdz_podobne_zrodla(glowne))
+
+
+@pytest.mark.django_db
+def test_rozny_mniswid_wyklucza_kandydata(rodzaj, zasieg):
+    """Gdy główne źródło ma pbn_uid z mniswId, kandydaci z RÓŻNYM mniswId są
+    wykluczani (różne czasopisma ministerialne ≠ duplikaty)."""
+    glowne = _zrodlo(
+        rodzaj,
+        zasieg,
+        nazwa="Glowne",
+        skrot="G",
+        issn="1234-5678",
+        pbn_uid=baker.make(Journal, mniswId=111),
+    )
+    kandydat = _zrodlo(
+        rodzaj,
+        zasieg,
+        nazwa="Kandydat",
+        skrot="K",
+        issn="1234-5678",
+        pbn_uid=baker.make(Journal, mniswId=222),
+    )
+    assert kandydat not in list(znajdz_podobne_zrodla(glowne))
+
+
+@pytest.mark.django_db
+def test_ten_sam_mniswid_nie_wyklucza(rodzaj, zasieg):
+    glowne = _zrodlo(
+        rodzaj,
+        zasieg,
+        nazwa="Glowne",
+        skrot="G",
+        issn="1234-5678",
+        pbn_uid=baker.make(Journal, mniswId=111),
+    )
+    kandydat = _zrodlo(
+        rodzaj,
+        zasieg,
+        nazwa="Kandydat",
+        skrot="K",
+        issn="1234-5678",
+        pbn_uid=baker.make(Journal, mniswId=111),
+    )
+    assert kandydat in list(znajdz_podobne_zrodla(glowne))
+
+
+@pytest.mark.django_db
+def test_brak_kryteriow_zwraca_pusty_queryset(rodzaj, zasieg):
+    """Źródło bez nazwy/skrotu/issn/pbn_uid nie ma żadnego kryterium → none()."""
+    glowne = baker.make(
+        Zrodlo, rodzaj=rodzaj, zasieg=zasieg, nazwa="", skrot="", issn="", e_issn=""
+    )
+    _zrodlo(rodzaj, zasieg, nazwa="Cokolwiek", skrot="C", issn="1234-5678")
+    assert list(znajdz_podobne_zrodla(glowne)) == []
+
+
+@pytest.mark.django_db
+def test_brak_dopasowania_pomimo_kandydatow(rodzaj, zasieg):
+    """Kandydat istnieje (ma publikację), ale nic go nie łączy z głównym."""
+    glowne = _zrodlo(rodzaj, zasieg, nazwa="Foo Journal", skrot="fj", issn="1111-1111")
+    inny = _zrodlo(rodzaj, zasieg, nazwa="Zupelnie Inne", skrot="zi", issn="9999-9999")
+    assert inny not in list(znajdz_podobne_zrodla(glowne))

--- a/src/deduplikator_zrodel/tests/test_znajdz_podobne.py
+++ b/src/deduplikator_zrodel/tests/test_znajdz_podobne.py
@@ -1,7 +1,7 @@
 """Charakterystyczne testy dla `znajdz_podobne_zrodla`.
 
 Funkcja buduje QuerySet kandydatów na duplikaty danego źródła. Testy pinują
-obecne zachowanie filtrów (przed refaktorem zdejmującym # noqa: C901):
+obecne zachowanie filtrów (przed refaktorem zdejmującym C901):
 
 - kandydat MUSI mieć powiązane wydawnictwo ciągłe (pub_count > 0),
 - własne źródło jest zawsze wykluczone,

--- a/src/deduplikator_zrodel/utils.py
+++ b/src/deduplikator_zrodel/utils.py
@@ -17,14 +17,60 @@ from .models import IgnoredSource, NotADuplicate
 logger = logging.getLogger(__name__)
 
 
-def znajdz_podobne_zrodla(zrodlo):  # noqa: C901
-    """
-    Znajduje potencjalne duplikaty dla danego źródła.
+def _norm(value, normalizer):
+    """Znormalizowana wartość albo None, gdy `value` jest puste/None.
 
-    Returns:
-        QuerySet of Zrodlo objects that might be duplicates
+    Odwzorowuje wzorzec `normalizer(x) if x else None` rozsiany po module.
     """
-    # Wyklucz źródła bez publikacji - sprawdzamy czy mają powiązane wydawnictwa ciągłe
+    return normalizer(value) if value else None
+
+
+def _both_equal(a, b):
+    """True, gdy oba argumenty są prawdziwe (truthy) i równe."""
+    return bool(a) and a == b
+
+
+def _both_set_and_different(a, b):
+    """True, gdy oba argumenty są ustawione (truthy) i różne."""
+    return bool(a) and bool(b) and a != b
+
+
+def _trigram_sim(field, value, pk):
+    """Trigram similarity pola `field` względem `value` dla źródła `pk`.
+
+    Zwraca None, gdy nie da się policzyć (brak rekordu / wynik None) —
+    zachowuje stare `except (AttributeError, TypeError): pass`.
+    """
+    try:
+        return (
+            Zrodlo.objects.filter(pk=pk)
+            .annotate(sim=TrigramSimilarity(field, value))
+            .first()
+            .sim
+        )
+    except (AttributeError, TypeError):
+        return None
+
+
+def _excluded_pair_ids(zrodlo):
+    """ID źródeł oznaczonych z `zrodlo` jako NIE-duplikat (w obie strony),
+    z pominięciem samego `zrodlo`."""
+    pairs = NotADuplicate.objects.filter(
+        Q(zrodlo=zrodlo) | Q(duplikat=zrodlo)
+    ).values_list("duplikat_id", "zrodlo_id")
+
+    excluded_ids = set()
+    for dup_id, zr_id in pairs:
+        excluded_ids.add(dup_id)
+        excluded_ids.add(zr_id)
+    excluded_ids.discard(zrodlo.pk)
+    return excluded_ids
+
+
+def _candidates_queryset(zrodlo):
+    """QuerySet kandydatów na duplikaty: źródła z publikacjami, bez samego
+    `zrodlo`, bez par NotADuplicate, bez IgnoredSource, bez innego MNiSW ID."""
+    # Wyklucz źródła bez publikacji - sprawdzamy powiązane wydawnictwa ciągłe
     candidates = (
         Zrodlo.objects.exclude(pk=zrodlo.pk)
         .annotate(pub_count=Count("wydawnictwo_ciagle"))
@@ -32,16 +78,7 @@ def znajdz_podobne_zrodla(zrodlo):  # noqa: C901
     )
 
     # Wyklucz źródła już oznaczone jako "to nie duplikat"
-    excluded_pks = NotADuplicate.objects.filter(
-        Q(zrodlo=zrodlo) | Q(duplikat=zrodlo)
-    ).values_list("duplikat_id", "zrodlo_id")
-
-    excluded_ids = set()
-    for dup_id, zr_id in excluded_pks:
-        excluded_ids.add(dup_id)
-        excluded_ids.add(zr_id)
-    excluded_ids.discard(zrodlo.pk)
-
+    excluded_ids = _excluded_pair_ids(zrodlo)
     if excluded_ids:
         candidates = candidates.exclude(pk__in=excluded_ids)
 
@@ -53,19 +90,22 @@ def znajdz_podobne_zrodla(zrodlo):  # noqa: C901
     # Wyklucz źródła z INNYM MNiSW ID (jeśli główne źródło ma MNiSW ID)
     # Różne MNiSW ID = różne czasopisma ministerialne = NIE duplikaty
     if zrodlo.pbn_uid_id and zrodlo.pbn_uid.mniswId:
-        # Wyklucz źródła które mają mniswId RÓŻNY od głównego źródła
         candidates = candidates.exclude(
             Q(pbn_uid__mniswId__isnull=False)
             & ~Q(pbn_uid__mniswId=zrodlo.pbn_uid.mniswId)
         )
 
-    # Kryteria wyszukiwania
+    return candidates
+
+
+def _base_filters(zrodlo):
+    """Q łączące kryteria: identyczny ISSN/E-ISSN, to samo pbn_uid, podobna
+    nazwa (trigram >= 0.5)."""
     filters = Q()
 
     # 1. Identyczny ISSN lub E-ISSN (po normalizacji)
-    norm_issn = normalize_issn(zrodlo.issn) if zrodlo.issn else None
-    norm_e_issn = normalize_issn(zrodlo.e_issn) if zrodlo.e_issn else None
-
+    norm_issn = _norm(zrodlo.issn, normalize_issn)
+    norm_e_issn = _norm(zrodlo.e_issn, normalize_issn)
     if norm_issn:
         filters |= Q(issn__iregex=r"[\s\.\-]*".join(norm_issn))
     if norm_e_issn:
@@ -78,23 +118,35 @@ def znajdz_podobne_zrodla(zrodlo):  # noqa: C901
     # 3. Podobna nazwa (trigram similarity >= 0.5)
     if zrodlo.nazwa:
         norm_nazwa = normalize_tytul_zrodla(zrodlo.nazwa)
-        similar_by_name = (
+        similar_ids = (
             Zrodlo.objects.annotate(similarity=TrigramSimilarity("nazwa", norm_nazwa))
             .filter(similarity__gte=0.5)
             .exclude(pk=zrodlo.pk)
+            .values_list("pk", flat=True)
         )
-        similar_ids = similar_by_name.values_list("pk", flat=True)
         if similar_ids:
             filters |= Q(pk__in=similar_ids)
 
-    # 4. Podobny skrót
+    return filters
+
+
+def znajdz_podobne_zrodla(zrodlo):
+    """
+    Znajduje potencjalne duplikaty dla danego źródła.
+
+    Returns:
+        QuerySet of Zrodlo objects that might be duplicates
+    """
+    candidates = _candidates_queryset(zrodlo)
+    filters = _base_filters(zrodlo)
+
+    # 4. Podobny skrót — rozszerza filtry o już-pasujących kandydatów ze
+    # zbliżonym skrótem (trigram >= 0.6, niższy próg).
     if zrodlo.skrot:
         norm_skrot = normalize_skrot(zrodlo.skrot)
-        # Użyj trigram dla skrótów, ale z niższym progiem
         candidates_with_filters = candidates.filter(filters).annotate(
             skrot_similarity=TrigramSimilarity("skrot", norm_skrot)
         )
-        # Dodaj te ze skrótem podobnym >= 0.6
         similar_skrot_ids = candidates_with_filters.filter(
             skrot_similarity__gte=0.6
         ).values_list("pk", flat=True)
@@ -107,111 +159,74 @@ def znajdz_podobne_zrodla(zrodlo):  # noqa: C901
     return candidates.filter(filters).distinct()
 
 
-def ocen_podobienstwo(zrodlo_glowne, zrodlo_kandydat):  # noqa: C901
+def _score_nazwa(nazwa_glowna, norm_g, norm_k, kandydat_pk):
+    """Punkty za nazwę: +60 za identyczną (case-insensitive po normalizacji),
+    w przeciwnym razie +40 (trigram > 0.9) / +20 (trigram > 0.7) / 0."""
+    if not (norm_g and norm_k):
+        return 0
+    if norm_g.lower() == norm_k.lower():
+        return 60
+    similarity = _trigram_sim("nazwa", nazwa_glowna, kandydat_pk)
+    if similarity and similarity > 0.9:
+        return 40
+    if similarity and similarity > 0.7:
+        return 20
+    return 0
+
+
+def _score_skrot(skrot_glowny, norm_g, norm_k, kandydat_pk):
+    """Punkty za skrót (niska waga): +10 gdy trigram skrótu > 0.7, inaczej 0."""
+    if not (norm_g and norm_k):
+        return 0
+    similarity = _trigram_sim("skrot", skrot_glowny, kandydat_pk)
+    if similarity and similarity > 0.7:
+        return 10
+    return 0
+
+
+def ocen_podobienstwo(zrodlo_glowne, zrodlo_kandydat):
     """
     Oblicza wskaźnik pewności, że dwa źródła to duplikaty.
 
     Returns:
         int: Punkty pewności (wyższe = większe prawdopodobieństwo duplikatu)
     """
-    score = 0
+    g, k = zrodlo_glowne, zrodlo_kandydat
 
-    # Normalizacja danych
-    norm_issn_g = normalize_issn(zrodlo_glowne.issn) if zrodlo_glowne.issn else None
-    norm_issn_k = normalize_issn(zrodlo_kandydat.issn) if zrodlo_kandydat.issn else None
-
-    norm_e_issn_g = (
-        normalize_issn(zrodlo_glowne.e_issn) if zrodlo_glowne.e_issn else None
+    # 1. ISSN / E-ISSN: po +100 za zgodny numer, +20 bonus gdy oba zgodne.
+    issn_match = _both_equal(
+        _norm(g.issn, normalize_issn), _norm(k.issn, normalize_issn)
     )
-    norm_e_issn_k = (
-        normalize_issn(zrodlo_kandydat.e_issn) if zrodlo_kandydat.e_issn else None
+    e_issn_match = _both_equal(
+        _norm(g.e_issn, normalize_issn), _norm(k.e_issn, normalize_issn)
     )
 
-    norm_nazwa_g = (
-        normalize_tytul_zrodla(zrodlo_glowne.nazwa) if zrodlo_glowne.nazwa else ""
-    )
-    norm_nazwa_k = (
-        normalize_tytul_zrodla(zrodlo_kandydat.nazwa) if zrodlo_kandydat.nazwa else ""
-    )
-
-    norm_skrot_g = normalize_skrot(zrodlo_glowne.skrot) if zrodlo_glowne.skrot else ""
-    norm_skrot_k = (
-        normalize_skrot(zrodlo_kandydat.skrot) if zrodlo_kandydat.skrot else ""
-    )
-
-    # 1. ISSN matching
-    issn_match = False
-    e_issn_match = False
-
-    if norm_issn_g and norm_issn_k and norm_issn_g == norm_issn_k:
-        score += 100
-        issn_match = True
-
-    if norm_e_issn_g and norm_e_issn_k and norm_e_issn_g == norm_e_issn_k:
-        score += 100
-        e_issn_match = True
-
-    # Bonus jeśli oba numery się zgadzają
+    score = 100 * issn_match + 100 * e_issn_match
     if issn_match and e_issn_match:
         score += 20
 
-    # 2. PBN UID matching
-    if (
-        zrodlo_glowne.pbn_uid_id
-        and zrodlo_kandydat.pbn_uid_id
-        and zrodlo_glowne.pbn_uid_id == zrodlo_kandydat.pbn_uid_id
-    ):
+    # 2. PBN UID matching: +80 za to samo pbn_uid.
+    if _both_equal(g.pbn_uid_id, k.pbn_uid_id):
         score += 80
 
-    # 3. Nazwa matching
-    if norm_nazwa_g and norm_nazwa_k:
-        if norm_nazwa_g.lower() == norm_nazwa_k.lower():
-            score += 60
-        else:
-            # Oblicz trigram similarity dla nazwy
-            try:
-                similarity = (
-                    Zrodlo.objects.filter(pk=zrodlo_kandydat.pk)
-                    .annotate(sim=TrigramSimilarity("nazwa", zrodlo_glowne.nazwa))
-                    .first()
-                    .sim
-                )
-                if similarity and similarity > 0.9:
-                    score += 40
-                elif similarity and similarity > 0.7:
-                    score += 20
-            except (AttributeError, TypeError):
-                pass
+    # 3. Nazwa i 4. Skrót.
+    score += _score_nazwa(
+        g.nazwa,
+        _norm(g.nazwa, normalize_tytul_zrodla),
+        _norm(k.nazwa, normalize_tytul_zrodla),
+        k.pk,
+    )
+    score += _score_skrot(
+        g.skrot,
+        _norm(g.skrot, normalize_skrot),
+        _norm(k.skrot, normalize_skrot),
+        k.pk,
+    )
 
-    # 4. Skrót matching (niska waga jak chciał użytkownik)
-    if norm_skrot_g and norm_skrot_k:
-        try:
-            skrot_similarity = (
-                Zrodlo.objects.filter(pk=zrodlo_kandydat.pk)
-                .annotate(sim=TrigramSimilarity("skrot", zrodlo_glowne.skrot))
-                .first()
-                .sim
-            )
-            if skrot_similarity and skrot_similarity > 0.7:
-                score += 10
-        except (AttributeError, TypeError):
-            pass
-
-    # 5. Kary za różnice
-    # Różny rodzaj źródła
-    if (
-        zrodlo_glowne.rodzaj_id
-        and zrodlo_kandydat.rodzaj_id
-        and zrodlo_glowne.rodzaj_id != zrodlo_kandydat.rodzaj_id
-    ):
+    # 5. Kary za różnice: różny rodzaj -15, różny zasięg -10.
+    if _both_set_and_different(g.rodzaj_id, k.rodzaj_id):
         score -= 15
-
-    # Różny zasięg
-    if (
-        zrodlo_glowne.zasieg_id
-        and zrodlo_kandydat.zasieg_id
-        and zrodlo_glowne.zasieg_id != zrodlo_kandydat.zasieg_id
-    ):
+    if _both_set_and_different(g.zasieg_id, k.zasieg_id):
         score -= 10
 
     return score

--- a/src/django_bpp/menu.py
+++ b/src/django_bpp/menu.py
@@ -184,6 +184,164 @@ def submenu_multicolumn(label, column1_tuples, column2_tuples, icon_class=None):
     return parent
 
 
+# First 5 theme options for column 1
+THEME_ITEMS_COL1 = [
+    ("Domyślny (ciemny)", "default", "theme-selector-default"),
+    ("Klasyczny jasny", "classic-light", "theme-selector-classic-light"),
+    ("Granatowy akademicki", "navy-academic", "theme-selector-navy-academic"),
+    ("Szary profesjonalny", "gray-professional", "theme-selector-gray-professional"),
+    ("Kremowo-zielony", "cream-green", "theme-selector-cream-green"),
+]
+
+# Remaining theme options for column 2
+THEME_ITEMS_COL2 = [
+    ("Minimalistyczny jasny", "minimal-light", "theme-selector-minimal-light"),
+    ("Złoty", "golden", "theme-selector-golden"),
+    ("Srebrny", "srebrny", "theme-selector-srebrny"),
+    ("Brat Ludwika", "mario-bros", "theme-selector-mario-bros"),
+    ("Brat Mariana", "luigi", "theme-selector-luigi"),
+]
+
+# Font options for column 2
+FONT_ITEMS = [
+    ("Domyślna czcionka", "default", "font-selector-default"),
+    ("Inter", "inter-small", "font-selector-inter-small"),
+    ("Open Sans", "opensans-small", "font-selector-opensans-small"),
+    ("Roboto", "roboto-small", "font-selector-roboto-small"),
+    ("Lato", "lato-small", "font-selector-lato-small"),
+    ("Source Sans Pro", "sourcesans-small", "font-selector-sourcesans-small"),
+    ("Segoe UI", "segoeui-small", "font-selector-segoeui-small"),
+    ("Arial", "arial-small", "font-selector-arial-small"),
+    ("Verdana", "verdana-small", "font-selector-verdana-small"),
+    ("Calibri", "calibri-small", "font-selector-calibri-small"),
+]
+
+
+def _styled_item(label, url, css_classes):
+    item = items.MenuItem(label, url=url)
+    item.css_classes = css_classes
+    return item
+
+
+def _should_hide_wydzial():
+    """Czy ukryć pozycję „wydział" w menu Struktura (na podst. ustawień/uczelni)."""
+    from django.conf import settings
+
+    from bpp.models import Uczelnia
+
+    uczelnia = Uczelnia.objects.get_default()
+    uzywaj_wydzialow = True
+    if uczelnia is not None:
+        uzywaj_wydzialow = uczelnia.uzywaj_wydzialow
+
+    return (
+        (not getattr(settings, "DJANGO_BPP_UCZELNIA_UZYWA_WYDZIALOW", True))
+        or (not uzywaj_wydzialow)
+    ) and STRUKTURA_MENU[1][1].find("wydzial") >= 0
+
+
+def _add_group_submenus(menu, user, groups):
+    """Dodaj poddrzewa menu zależne od grup/uprawnień użytkownika."""
+
+    def flt(n1, n2, v, icon_class=None):
+        if user.is_superuser or n1 in groups:
+            menu.children += [
+                submenu(n2, v, icon_class),
+            ]
+
+    flt("web", "WWW", WEB_MENU, "menu-icon-web")
+    flt("dane systemowe", "PBN API", PBN_MENU, "menu-icon-api")
+
+    # Combine "Dane" and "systemowe" into single 2-column menu
+    if user.is_superuser or "dane systemowe" in groups:
+        menu.children += [
+            submenu_multicolumn(
+                "Dane systemowe", SYSTEM_MENU, SYSTEM_MENU_2, "menu-icon-settings"
+            ),
+        ]
+
+    if _should_hide_wydzial():
+        STRUKTURA_MENU.pop(1)
+
+    flt("struktura", "Struktura", STRUKTURA_MENU, "menu-icon-structure")
+    flt(GR_WPROWADZANIE_DANYCH, "Wprowadzanie danych", REDAKTOR_MENU, "menu-icon-edit")
+    if GR_ZGLOSZENIA_PUBLIKACJI not in groups and not user.is_superuser:
+        # Wyrzuć "zgłoszenia publikacji" z REDAKTOR_MENU
+        del menu.children[-1].children[-1]
+
+    flt("raporty", "Raporty", RAPORTY_MENU, "menu-icon-reports")
+    flt("administracja", "Administracja", ADMIN_MENU, "menu-icon-admin")
+
+    # Add Docker services to Administracja menu (superusers only)
+    if user.is_superuser:
+        for label, url in DOCKER_SERVICES_MENU:
+            menu.children[-1].children.append(items.MenuItem(label, url))
+
+
+def _build_user_menu(user):
+    """Zbuduj menu „Mój profil" (akcje użytkownika + motywy + czcionki)."""
+    username = (
+        user.first_name or user.username or user.get_short_name() or user.get_username()
+    )
+
+    # Column 1: user actions and first themes
+    column1_children = [_styled_item(username, "#", ["column-1"])]
+
+    if user.has_usable_password():
+        column1_children.append(
+            _styled_item(
+                str(_("Change password")),
+                reverse("admin:password_change"),
+                ["column-1"],
+            )
+        )
+
+    column1_children.append(
+        _styled_item(str(_("Log out")), reverse("admin:logout"), ["column-1"])
+    )
+    column1_children.append(_styled_item("---", "#", ["theme-separator", "column-1"]))
+    for theme_name, theme_key, css_class in THEME_ITEMS_COL1:
+        column1_children.append(
+            _styled_item(
+                theme_name,
+                f"#theme-{theme_key}",
+                ["theme-selector-item", css_class, "column-1"],
+            )
+        )
+
+    # Column 2: remaining themes, spacers, then fonts
+    column2_children = []
+    for theme_name, theme_key, css_class in THEME_ITEMS_COL2:
+        column2_children.append(
+            _styled_item(
+                theme_name,
+                f"#theme-{theme_key}",
+                ["theme-selector-item", css_class, "column-2"],
+            )
+        )
+
+    # Add 4 empty spacer entries above fonts in column 2
+    for _i in range(4):
+        column2_children.append(_styled_item("", "#", ["menu-spacer", "column-2"]))
+
+    column2_children.append(_styled_item("---", "#", ["font-separator", "column-2"]))
+    for font_name, font_key, css_class in FONT_ITEMS:
+        column2_children.append(
+            _styled_item(
+                font_name,
+                f"#font-{font_key}",
+                ["font-selector-item", css_class, "column-2"],
+            )
+        )
+
+    # Combine all children in order (column1 first, then column2)
+    user_menu = items.MenuItem(
+        "Mój profil", children=column1_children + column2_children
+    )
+    user_menu.css_classes = ["menu-icon-user", "has-columns"]
+    return user_menu
+
+
 class CustomMenu(Menu):
     def __init__(self, **kwargs):
         Menu.__init__(self, **kwargs)
@@ -198,175 +356,17 @@ class CustomMenu(Menu):
             # items.Bookmarks(),  # Hidden - user requested to hide bookmarks menu
         ]
 
-    def init_with_context(self, context):  # noqa: C901
+    def init_with_context(self, context):
         user = context["request"].user
         if not hasattr(user, "__admin_menu_groups"):
             user.__admin_menu_groups = [x.name for x in user.cached_groups]
         groups = user.__admin_menu_groups
 
-        def flt(n1, n2, v, icon_class=None):
-            if user.is_superuser or n1 in groups:
-                self.children += [
-                    submenu(n2, v, icon_class),
-                ]
-
         # Dashboard is now second item (index 1), add icon
         if len(self.children) >= 2:
             self.children[1].css_classes = ["menu-icon-dashboard"]  # Dashboard (Panel)
 
-        flt("web", "WWW", WEB_MENU, "menu-icon-web")
-
-        flt("dane systemowe", "PBN API", PBN_MENU, "menu-icon-api")
-
-        # Combine "Dane" and "systemowe" into single 2-column menu
-        if user.is_superuser or "dane systemowe" in groups:
-            self.children += [
-                submenu_multicolumn(
-                    "Dane systemowe", SYSTEM_MENU, SYSTEM_MENU_2, "menu-icon-settings"
-                ),
-            ]
-
-        from django.conf import settings
-
-        from bpp.models import Uczelnia
-
-        uczelnia = Uczelnia.objects.get_default()
-        uzywaj_wydzialow = True
-        if uczelnia is not None:
-            uzywaj_wydzialow = uczelnia.uzywaj_wydzialow
-
-        if (
-            (not getattr(settings, "DJANGO_BPP_UCZELNIA_UZYWA_WYDZIALOW", True))
-            or (not uzywaj_wydzialow)
-        ) and STRUKTURA_MENU[1][1].find("wydzial") >= 0:
-            STRUKTURA_MENU.pop(1)
-
-        flt("struktura", "Struktura", STRUKTURA_MENU, "menu-icon-structure")
-        flt(
-            GR_WPROWADZANIE_DANYCH,
-            "Wprowadzanie danych",
-            REDAKTOR_MENU,
-            "menu-icon-edit",
-        )
-        if GR_ZGLOSZENIA_PUBLIKACJI not in groups and not user.is_superuser:
-            # Wyrzuć "zgłoszenia publikacji" z REDAKTOR_MENU
-            del self.children[-1].children[-1]
-
-        flt("raporty", "Raporty", RAPORTY_MENU, "menu-icon-reports")
-        flt("administracja", "Administracja", ADMIN_MENU, "menu-icon-admin")
-
-        # Add Docker services to Administracja menu (superusers only)
-        if user.is_superuser:
-            for label, url in DOCKER_SERVICES_MENU:
-                self.children[-1].children.append(items.MenuItem(label, url))
-
-        # Create user menu with "Mój profil" label and dropdown - add at the end
-        username = (
-            user.first_name
-            or user.username
-            or user.get_short_name()
-            or user.get_username()
-        )
-
-        # Prepare column 1 items (user actions and themes)
-        column1_children = []
-
-        # Add username as first item (not clickable - no URL)
-        username_item = items.MenuItem(username, url="#")
-        username_item.css_classes = ["column-1"]
-        column1_children.append(username_item)
-
-        # Add "Change password" if user has usable password
-        if user.has_usable_password():
-            change_pwd_item = items.MenuItem(
-                str(_("Change password")), reverse("admin:password_change")
-            )
-            change_pwd_item.css_classes = ["column-1"]
-            column1_children.append(change_pwd_item)
-
-        # Add "Log out"
-        logout_item = items.MenuItem(str(_("Log out")), reverse("admin:logout"))
-        logout_item.css_classes = ["column-1"]
-        column1_children.append(logout_item)
-
-        # Add separator for theme options
-        separator = items.MenuItem("---", url="#")
-        separator.css_classes = ["theme-separator", "column-1"]
-        column1_children.append(separator)
-
-        # First 5 theme options for column 1
-        theme_items_col1 = [
-            ("Domyślny (ciemny)", "default", "theme-selector-default"),
-            ("Klasyczny jasny", "classic-light", "theme-selector-classic-light"),
-            ("Granatowy akademicki", "navy-academic", "theme-selector-navy-academic"),
-            (
-                "Szary profesjonalny",
-                "gray-professional",
-                "theme-selector-gray-professional",
-            ),
-            ("Kremowo-zielony", "cream-green", "theme-selector-cream-green"),
-        ]
-
-        for theme_name, theme_key, css_class in theme_items_col1:
-            theme_item = items.MenuItem(theme_name, url=f"#theme-{theme_key}")
-            theme_item.css_classes = ["theme-selector-item", css_class, "column-1"]
-            column1_children.append(theme_item)
-
-        # Prepare column 2 items (remaining themes and fonts)
-        column2_children = []
-
-        # Remaining theme options for column 2
-        theme_items_col2 = [
-            ("Minimalistyczny jasny", "minimal-light", "theme-selector-minimal-light"),
-            ("Złoty", "golden", "theme-selector-golden"),
-            ("Srebrny", "srebrny", "theme-selector-srebrny"),
-            ("Brat Ludwika", "mario-bros", "theme-selector-mario-bros"),
-            ("Brat Mariana", "luigi", "theme-selector-luigi"),
-        ]
-
-        for theme_name, theme_key, css_class in theme_items_col2:
-            theme_item = items.MenuItem(theme_name, url=f"#theme-{theme_key}")
-            theme_item.css_classes = ["theme-selector-item", css_class, "column-2"]
-            column2_children.append(theme_item)
-
-        # Add 4 empty spacer entries above fonts in column 2
-        for _i in range(4):
-            spacer_item = items.MenuItem("", url="#")
-            spacer_item.css_classes = ["menu-spacer", "column-2"]
-            column2_children.append(spacer_item)
-
-        # Add separator for font options
-        font_separator = items.MenuItem("---", url="#")
-        font_separator.css_classes = ["font-separator", "column-2"]
-        column2_children.append(font_separator)
-
-        # Font options for column 2
-        font_items = [
-            ("Domyślna czcionka", "default", "font-selector-default"),
-            ("Inter", "inter-small", "font-selector-inter-small"),
-            ("Open Sans", "opensans-small", "font-selector-opensans-small"),
-            ("Roboto", "roboto-small", "font-selector-roboto-small"),
-            ("Lato", "lato-small", "font-selector-lato-small"),
-            ("Source Sans Pro", "sourcesans-small", "font-selector-sourcesans-small"),
-            ("Segoe UI", "segoeui-small", "font-selector-segoeui-small"),
-            ("Arial", "arial-small", "font-selector-arial-small"),
-            ("Verdana", "verdana-small", "font-selector-verdana-small"),
-            ("Calibri", "calibri-small", "font-selector-calibri-small"),
-        ]
-
-        for font_name, font_key, css_class in font_items:
-            font_item = items.MenuItem(font_name, url=f"#font-{font_key}")
-            font_item.css_classes = ["font-selector-item", css_class, "column-2"]
-            column2_children.append(font_item)
-
-        # Combine all children in order (column1 first, then column2)
-        user_children = column1_children + column2_children
-
-        # Create user menu item with icon class and columns support - label is "Mój profil"
-        user_menu = items.MenuItem("Mój profil", children=user_children)
-        user_menu.css_classes = ["menu-icon-user", "has-columns"]
-
-        # Add user menu to children
-        self.children.append(user_menu)
+        _add_group_submenus(self, user, groups)
+        self.children.append(_build_user_menu(user))
 
         return super().init_with_context(context)

--- a/src/django_bpp/tests/test_menu.py
+++ b/src/django_bpp/tests/test_menu.py
@@ -1,7 +1,7 @@
 """Charakteryzacyjne testy dla django_bpp.menu.CustomMenu.init_with_context.
 
 Pinują OBECNE zachowanie budowania menu admina zależnie od grup/uprawnień
-użytkownika, aby umożliwić bezpieczny refactor (zdjęcie # noqa: C901).
+użytkownika, aby umożliwić bezpieczny refactor (zdjęcie C901).
 
 Zachowane quirki (NIE są naprawiane w refaktorze):
 - użytkownik bez grup i nie-superuser → IndexError (usuwanie z pustego

--- a/src/django_bpp/tests/test_menu.py
+++ b/src/django_bpp/tests/test_menu.py
@@ -1,0 +1,170 @@
+"""Charakteryzacyjne testy dla django_bpp.menu.CustomMenu.init_with_context.
+
+Pinują OBECNE zachowanie budowania menu admina zależnie od grup/uprawnień
+użytkownika, aby umożliwić bezpieczny refactor (zdjęcie # noqa: C901).
+
+Zachowane quirki (NIE są naprawiane w refaktorze):
+- użytkownik bez grup i nie-superuser → IndexError (usuwanie z pustego
+  poddrzewa "Dashboard"),
+- usuwanie "zgłoszeń" faktycznie kasuje OSTATNI element REDAKTOR_MENU
+  ("Importer publikacji"), nie "Zgłoszenia publikacji",
+- STRUKTURA_MENU.pop(1) mutuje modułową listę (chronione fixturą snapshotu).
+"""
+
+import pytest
+from django.contrib.auth.models import Group
+from django.test import RequestFactory, override_settings
+from model_bakery import baker
+
+from django_bpp import menu as menu_module
+from django_bpp.menu import CustomMenu
+
+
+@pytest.fixture(autouse=True)
+def _snapshot_struktura_menu():
+    """STRUKTURA_MENU jest mutowane przez pop(1) — przywróć po teście."""
+    saved = list(menu_module.STRUKTURA_MENU)
+    yield
+    menu_module.STRUKTURA_MENU[:] = saved
+
+
+def _menu_for(user):
+    rf = RequestFactory()
+    req = rf.get("/admin/")
+    req.user = user
+    m = CustomMenu()
+    m.init_with_context({"request": req})
+    return m
+
+
+def _labels(menu):
+    return [str(c.title) for c in menu.children]
+
+
+def _child(menu, label):
+    return next(c for c in menu.children if str(c.title) == label)
+
+
+@pytest.mark.django_db
+def test_superuser_widzi_pelne_menu():
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=True, first_name="Jan")
+    m = _menu_for(u)
+    assert _labels(m) == [
+        "BPP",
+        "Dashboard",
+        "WWW",
+        "PBN API",
+        "Dane systemowe",
+        "Struktura",
+        "Wprowadzanie danych",
+        "Raporty",
+        "Administracja",
+        "Mój profil",
+    ]
+
+
+@pytest.mark.django_db
+def test_superuser_redaktor_zachowuje_importer_publikacji():
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=True)
+    m = _menu_for(u)
+    redaktor = _child(m, "Wprowadzanie danych")
+    assert len(redaktor.children) == 16
+    assert str(redaktor.children[-1].title) == "Importer publikacji"
+
+
+@pytest.mark.django_db
+def test_superuser_administracja_ma_uslugi_docker():
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=True)
+    m = _menu_for(u)
+    admin = _child(m, "Administracja")
+    labels = [str(c.title) for c in admin.children]
+    assert "Grafana" in labels
+    assert "Dozzle (logi)" in labels
+    assert "Flower (Celery)" in labels
+
+
+@pytest.mark.django_db
+def test_uzytkownik_bez_grup_powoduje_indexerror():
+    # Quirk: del self.children[-1].children[-1] na pustym "Dashboard".
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=True)
+    with pytest.raises(IndexError):
+        _menu_for(u)
+
+
+@pytest.mark.django_db
+def test_grupa_wprowadzanie_danych_kasuje_ostatni_element_redaktora():
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=True, first_name="Ala")
+    u.groups.add(Group.objects.get_or_create(name="wprowadzanie danych")[0])
+    m = _menu_for(u)
+    assert _labels(m) == ["BPP", "Dashboard", "Wprowadzanie danych", "Mój profil"]
+    redaktor = _child(m, "Wprowadzanie danych")
+    # OSTATNI element ("Importer publikacji") jest usuwany; zostaje 15.
+    assert len(redaktor.children) == 15
+    assert str(redaktor.children[-1].title) == "Zgłoszenia publikacji"
+
+
+@pytest.mark.django_db
+def test_grupa_zgloszenia_publikacji_nie_kasuje_elementu():
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=True, first_name="Bob")
+    u.groups.add(Group.objects.get_or_create(name="wprowadzanie danych")[0])
+    u.groups.add(Group.objects.get_or_create(name="zgłoszenia publikacji")[0])
+    m = _menu_for(u)
+    redaktor = _child(m, "Wprowadzanie danych")
+    assert len(redaktor.children) == 16
+    assert str(redaktor.children[-1].title) == "Importer publikacji"
+
+
+@pytest.mark.django_db
+def test_grupa_web_dodaje_tylko_www():
+    u = baker.make("bpp.BppUser", is_superuser=False, is_staff=True, first_name="Cyd")
+    u.groups.add(Group.objects.get_or_create(name="web")[0])
+    m = _menu_for(u)
+    assert _labels(m) == ["BPP", "Dashboard", "WWW", "Mój profil"]
+
+
+def _struktura_links(menu):
+    struktura = _child(menu, "Struktura")
+    return [c.url for c in struktura.children]
+
+
+@pytest.mark.django_db
+def test_struktura_pokazuje_wydzial_domyslnie():
+    # Superuser → admin_tools nie przycina pozycji wg uprawnień.
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=True, first_name="Dan")
+    links = _struktura_links(_menu_for(u))
+    # Domyślnie (używaj wydziałów) wydział JEST obecny — pełne 4 pozycje.
+    assert "/admin/bpp/wydzial/" in links
+    assert len(links) == 4
+
+
+@pytest.mark.django_db
+@override_settings(DJANGO_BPP_UCZELNIA_UZYWA_WYDZIALOW=False)
+def test_struktura_bez_wydzialow_usuwa_pozycje():
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=True, first_name="Ela")
+    links = _struktura_links(_menu_for(u))
+    # STRUKTURA_MENU.pop(1) usuwa pozycję "wydział".
+    assert "/admin/bpp/wydzial/" not in links
+    assert len(links) == 3
+
+
+@pytest.mark.django_db
+def test_uzytkownik_z_haslem_ma_zmiane_hasla_w_profilu():
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=True, first_name="Fil")
+    u.set_password("x")
+    u.save()
+    m = _menu_for(u)
+    profil = _child(m, "Mój profil")
+    labels = [str(c.title) for c in profil.children]
+    assert "Change password" in labels
+    assert "Fil" in labels  # first_name jako etykieta użytkownika
+
+
+@pytest.mark.django_db
+def test_profil_bez_uzywalnego_hasla_nie_ma_zmiany_hasla():
+    u = baker.make("bpp.BppUser", is_superuser=True, is_staff=True, first_name="Gob")
+    u.set_unusable_password()
+    u.save()
+    m = _menu_for(u)
+    profil = _child(m, "Mój profil")
+    labels = [str(c.title) for c in profil.children]
+    assert "Change password" not in labels

--- a/src/pbn_api/templatetags/pbn_extras.py
+++ b/src/pbn_api/templatetags/pbn_extras.py
@@ -11,8 +11,73 @@ register = template.Library()
 logger = logging.getLogger(__name__)
 
 
+# Format: 2025-09-04 19:40:42.324808+00:00
+_TIMESTAMP_PATTERN = r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2})"
+_SEPARATOR_PATTERN = r"={3,}"
+
+# Reguły klasyfikacji typu wiadomości — pierwsza pasująca (kolejność jak
+# w pierwotnym łańcuchu if/elif). Zachowane semantyki: w obrębie linii
+# wygrywa pierwsza reguła, a kolejne linie nadpisują typ wiadomości.
+_TYPE_RULES = (
+    (("błąd", "error", "traceback"), "error"),
+    (("pomyślnie", "success"), "success"),
+    (("autoryzacji", "auth"), "warning"),
+    (("ponownie wysłano",), "resend"),
+)
+
+
+def _classify_line(line):
+    """Zwróć typ wiadomości dla danej linii albo None, gdy nic nie pasuje."""
+    low = line.lower()
+    for keywords, msg_type in _TYPE_RULES:
+        if any(keyword in low for keyword in keywords):
+            return msg_type
+    return None
+
+
+def _new_message(timestamp_str):
+    return {
+        "timestamp": timestamp_str,
+        "datetime": parse_timestamp(timestamp_str),
+        "content": [],
+        "type": "info",  # Default type
+    }
+
+
+def _split_into_messages(text):
+    """Podziel surowy tekst na listę bloków-wiadomości (z surową treścią)."""
+    messages = []
+    current_message = None
+    lines = text.split("\n")
+
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        timestamp_match = re.match(_TIMESTAMP_PATTERN, line)
+
+        if timestamp_match:
+            if current_message and current_message["content"]:
+                messages.append(current_message)
+            current_message = _new_message(timestamp_match.group(1))
+            # Skip the separator line if present
+            next_line = lines[i + 1].strip() if i + 1 < len(lines) else ""
+            if re.match(_SEPARATOR_PATTERN, next_line):
+                i += 1
+        elif current_message is not None and line:
+            current_message["content"].append(line)
+            msg_type = _classify_line(line)
+            if msg_type:
+                current_message["type"] = msg_type
+
+        i += 1
+
+    if current_message and current_message["content"]:
+        messages.append(current_message)
+    return messages
+
+
 @register.filter
-def parse_historia_komunikatow(text):  # noqa: C901
+def parse_historia_komunikatow(text):
     """
     Parse historia komunikatów field into a structured format.
     Returns a list of message blocks with date and content.
@@ -20,63 +85,7 @@ def parse_historia_komunikatow(text):  # noqa: C901
     if not text:
         return []
 
-    # Pattern to match timestamp lines with separator
-    # Format: 2025-09-04 19:40:42.324808+00:00
-    timestamp_pattern = r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2})"
-    separator_pattern = r"={3,}"
-
-    messages = []
-    current_message = None
-
-    lines = text.split("\n")
-    i = 0
-
-    while i < len(lines):
-        line = lines[i].strip()
-
-        # Check if this line contains a timestamp
-        timestamp_match = re.match(timestamp_pattern, line)
-        if timestamp_match:
-            # Save the previous message if exists
-            if current_message and current_message["content"]:
-                messages.append(current_message)
-
-            # Start a new message
-            timestamp_str = timestamp_match.group(1)
-            current_message = {
-                "timestamp": timestamp_str,
-                "datetime": parse_timestamp(timestamp_str),
-                "content": [],
-                "type": "info",  # Default type
-            }
-
-            # Skip the separator line if present
-            if i + 1 < len(lines) and re.match(separator_pattern, lines[i + 1].strip()):
-                i += 1
-
-        elif current_message is not None and line:
-            # Add content to current message
-            current_message["content"].append(line)
-
-            # Determine message type based on content
-            if (
-                "błąd" in line.lower()
-                or "error" in line.lower()
-                or "traceback" in line.lower()
-            ):
-                current_message["type"] = "error"
-            elif "pomyślnie" in line.lower() or "success" in line.lower():
-                current_message["type"] = "success"
-            elif "autoryzacji" in line.lower() or "auth" in line.lower():
-                current_message["type"] = "warning"
-            elif "ponownie wysłano" in line.lower():
-                current_message["type"] = "resend"
-
-        i += 1
-
-    # Don't forget the last message
-    if current_message and current_message["content"]:
-        messages.append(current_message)
+    messages = _split_into_messages(text)
 
     # Process content for each message
     for msg in messages:

--- a/src/pbn_api/tests/test_pbn_extras.py
+++ b/src/pbn_api/tests/test_pbn_extras.py
@@ -1,0 +1,118 @@
+"""Charakteryzacyjne testy dla pbn_extras.parse_historia_komunikatow.
+
+Pinują OBECNE zachowanie parsera tekstu historii komunikatów PBN, aby
+umożliwić bezpieczny refactor (zdjęcie # noqa: C901).
+"""
+
+from datetime import datetime
+
+from pbn_api.templatetags.pbn_extras import (
+    parse_historia_komunikatow,
+    parse_timestamp,
+)
+
+TS1 = "2025-09-04 19:40:42.324808+00:00"
+TS2 = "2025-09-05 10:00:00.000001+00:00"
+
+
+def test_pusty_tekst_zwraca_pusta_liste():
+    assert parse_historia_komunikatow("") == []
+    assert parse_historia_komunikatow(None) == []
+
+
+def test_pojedyncza_wiadomosc_info():
+    text = f"{TS1}\nJakas tresc komunikatu"
+    result = parse_historia_komunikatow(text)
+    assert len(result) == 1
+    msg = result[0]
+    assert msg["timestamp"] == TS1
+    assert msg["datetime"] == datetime(2025, 9, 4, 19, 40, 42)
+    assert msg["content"] == "Jakas tresc komunikatu"
+    assert msg["type"] == "info"
+    assert msg["is_traceback"] is False
+
+
+def test_linia_separatora_jest_pomijana():
+    text = f"{TS1}\n===========\nTresc po separatorze"
+    result = parse_historia_komunikatow(text)
+    assert len(result) == 1
+    assert result[0]["content"] == "Tresc po separatorze"
+
+
+def test_typ_error_z_bledu():
+    text = f"{TS1}\nWystapil błąd podczas wysylki"
+    assert parse_historia_komunikatow(text)[0]["type"] == "error"
+
+
+def test_typ_error_z_error_i_traceback():
+    assert parse_historia_komunikatow(f"{TS1}\nAn error happened")[0]["type"] == "error"
+    assert (
+        parse_historia_komunikatow(f"{TS1}\nlowercase traceback here")[0]["type"]
+        == "error"
+    )
+
+
+def test_typ_success():
+    text = f"{TS1}\nWyslano pomyślnie do PBN"
+    assert parse_historia_komunikatow(text)[0]["type"] == "success"
+
+
+def test_typ_warning_autoryzacja():
+    text = f"{TS1}\nBlad autoryzacji uzytkownika"
+    assert parse_historia_komunikatow(text)[0]["type"] == "warning"
+
+
+def test_typ_resend():
+    text = f"{TS1}\nponownie wysłano dane"
+    assert parse_historia_komunikatow(text)[0]["type"] == "resend"
+
+
+def test_typ_ostatnia_linia_wygrywa():
+    # Type jest ustawiany per-linia w łańcuchu if/elif, więc OSTATNIA
+    # pasująca linia nadpisuje poprzednie.
+    text = f"{TS1}\nWystapil błąd\nale ostatecznie pomyślnie zakonczono"
+    assert parse_historia_komunikatow(text)[0]["type"] == "success"
+
+
+def test_wiele_wiadomosci_sortowanych_najnowsze_pierwsze():
+    text = f"{TS1}\nStarsza wiadomosc\n{TS2}\nNowsza wiadomosc"
+    result = parse_historia_komunikatow(text)
+    assert len(result) == 2
+    assert result[0]["timestamp"] == TS2
+    assert result[0]["content"] == "Nowsza wiadomosc"
+    assert result[1]["timestamp"] == TS1
+    assert result[1]["content"] == "Starsza wiadomosc"
+
+
+def test_is_traceback_wykrywa_duze_T():
+    text = f"{TS1}\nTraceback (most recent call last):\n  File foo"
+    msg = parse_historia_komunikatow(text)[0]
+    assert msg["is_traceback"] is True
+    assert msg["type"] == "error"
+    # Każda linia jest .strip()owana, więc wcięcie "  File foo" znika.
+    assert msg["content"] == "Traceback (most recent call last):\nFile foo"
+
+
+def test_tresc_przed_pierwszym_timestampem_ignorowana():
+    text = "Tresc bez timestampu\nwiecej tresci"
+    assert parse_historia_komunikatow(text) == []
+
+
+def test_timestamp_bez_tresci_pomijany():
+    text = f"{TS1}\n{TS2}\nTylko druga ma tresc"
+    result = parse_historia_komunikatow(text)
+    assert len(result) == 1
+    assert result[0]["timestamp"] == TS2
+
+
+def test_wielolinijkowa_tresc_laczona():
+    text = f"{TS1}\nLinia 1\nLinia 2\nLinia 3"
+    assert parse_historia_komunikatow(text)[0]["content"] == "Linia 1\nLinia 2\nLinia 3"
+
+
+def test_parse_timestamp_poprawny():
+    assert parse_timestamp(TS1) == datetime(2025, 9, 4, 19, 40, 42)
+
+
+def test_parse_timestamp_niepoprawny_zwraca_none():
+    assert parse_timestamp("to nie jest data") is None

--- a/src/pbn_api/tests/test_pbn_extras.py
+++ b/src/pbn_api/tests/test_pbn_extras.py
@@ -1,7 +1,7 @@
 """Charakteryzacyjne testy dla pbn_extras.parse_historia_komunikatow.
 
 Pinują OBECNE zachowanie parsera tekstu historii komunikatów PBN, aby
-umożliwić bezpieczny refactor (zdjęcie # noqa: C901).
+umożliwić bezpieczny refactor (zdjęcie C901).
 """
 
 from datetime import datetime

--- a/src/pbn_integrator/tests/test_c901_dict_transforms.py
+++ b/src/pbn_integrator/tests/test_c901_dict_transforms.py
@@ -1,0 +1,518 @@
+"""Characterization tests pinning current behavior of the C901 dictionary
+transforms before refactoring:
+
+* ``integruj_jezyki``     (pbn_integrator/utils/dictionaries.py)
+* ``integruj_dyscypliny`` (pbn_integrator/utils/dictionaries.py)
+* ``integruj_zrodla``     (pbn_integrator/utils/journals.py)
+
+These lock the OBSERVABLE behavior of every branch so the subsequent
+complexity-reducing refactor can be proven behavior-preserving.
+"""
+
+from datetime import date
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Jezyk, Zrodlo
+from pbn_api.models import Discipline, DisciplineGroup, Journal, Language
+
+# ---------------------------------------------------------------------------
+# integruj_jezyki
+# ---------------------------------------------------------------------------
+
+
+def _lang_payload(code, **lang):
+    return {"code": code, "language": dict(lang)}
+
+
+@pytest.mark.django_db
+def test_jezyki_creates_then_updates_remote_language():
+    """Loop 1: Language is created when absent and updated when payload
+    differs from the stored ``language`` dict."""
+    from pbn_integrator.utils import integruj_jezyki
+
+    client = Mock()
+    client.get_languages.return_value = [
+        _lang_payload("zzz", **{"639-2": "zzz", "pl": None, "en": "Zzz"}),
+    ]
+    integruj_jezyki(client, create_if_not_exists=False)
+    created = Language.objects.get(code="zzz")
+    assert created.language == {"639-2": "zzz", "pl": None, "en": "Zzz"}
+
+    # Second pass with a changed language dict -> updated in place.
+    client.get_languages.return_value = [
+        _lang_payload("zzz", **{"639-2": "zzz", "pl": None, "en": "Changed"}),
+    ]
+    integruj_jezyki(client, create_if_not_exists=False)
+    created.refresh_from_db()
+    assert created.language["en"] == "Changed"
+
+
+@pytest.mark.django_db
+def test_jezyki_maps_existing_jezyk_by_skrot_and_does_not_overwrite():
+    """Loop 2: an existing BPP ``Jezyk`` matched by ``skrot`` gets its
+    ``pbn_uid`` set when empty, and is left untouched when already set."""
+    from pbn_integrator.utils import integruj_jezyki
+
+    lang = baker.make(Language, code="zzz", language={"639-2": "zzz", "pl": "Zetka"})
+    jezyk = baker.make(Jezyk, nazwa="Zetka jezyk", skrot="zzz", pbn_uid=None)
+
+    client = Mock()
+    client.get_languages.return_value = []
+    integruj_jezyki(client, create_if_not_exists=False)
+
+    jezyk.refresh_from_db()
+    assert jezyk.pbn_uid_id == lang.pk
+
+    # Re-running must not overwrite an already-mapped pbn_uid.
+    other = baker.make(Language, code="zzz2", language={"639-2": "zzz"})
+    jezyk.pbn_uid = other
+    jezyk.save()
+    integruj_jezyki(client, create_if_not_exists=False)
+    jezyk.refresh_from_db()
+    assert jezyk.pbn_uid_id == other.pk
+
+
+@pytest.mark.django_db
+def test_jezyki_found_by_nazwa_fallback_maps_pbn_uid():
+    """Loop 2: not matched by skrot, but matched by ``nazwa__iexact`` of the
+    Polish name -> falls through to the bottom mapping."""
+    from pbn_integrator.utils import integruj_jezyki
+
+    lang = baker.make(Language, code="qqq", language={"639-2": "qqq", "pl": "Kwakwa"})
+    # skrot deliberately does NOT match 'qqq'; nazwa matches the 'pl' value.
+    jezyk = baker.make(Jezyk, nazwa="Kwakwa", skrot="nomatch9", pbn_uid=None)
+
+    client = Mock()
+    client.get_languages.return_value = []
+    integruj_jezyki(client, create_if_not_exists=False)
+
+    jezyk.refresh_from_db()
+    assert jezyk.pbn_uid_id == lang.pk
+
+
+@pytest.mark.django_db
+def test_jezyki_creates_jezyk_from_pl_when_missing_and_flag_set():
+    """Loop 2: unmatched, ``pl`` present, create flag set -> new Jezyk with
+    nazwa=pl, skrot=639-2, pbn_uid set."""
+    from pbn_integrator.utils import integruj_jezyki
+
+    lang = baker.make(
+        Language,
+        code="ppp",
+        language={"639-2": "ppp", "pl": "Brakujacy", "en": "Missing"},
+    )
+
+    client = Mock()
+    client.get_languages.return_value = []
+    integruj_jezyki(client, create_if_not_exists=True)
+
+    created = Jezyk.objects.get(nazwa="Brakujacy")
+    assert created.skrot == "ppp"
+    assert created.pbn_uid_id == lang.pk
+
+
+@pytest.mark.django_db
+def test_jezyki_creates_jezyk_from_en_when_no_pl():
+    """Loop 2: unmatched, ``pl`` is None, create flag set -> new Jezyk uses
+    the English name."""
+    from pbn_integrator.utils import integruj_jezyki
+
+    lang = baker.make(
+        Language,
+        code="eee",
+        language={"639-2": "eee", "pl": None, "en": "OnlyEnglish"},
+    )
+
+    client = Mock()
+    client.get_languages.return_value = []
+    integruj_jezyki(client, create_if_not_exists=True)
+
+    created = Jezyk.objects.get(nazwa="OnlyEnglish")
+    assert created.skrot == "eee"
+    assert created.pbn_uid_id == lang.pk
+
+
+@pytest.mark.django_db
+def test_jezyki_warns_when_missing_and_no_create_flag_with_pl():
+    """Loop 2: unmatched, pl present, create flag unset -> warn, no Jezyk."""
+    from pbn_integrator.utils import integruj_jezyki
+
+    baker.make(Language, code="www", language={"639-2": "www", "pl": "Niematego"})
+
+    client = Mock()
+    client.get_languages.return_value = []
+    with pytest.warns(UserWarning, match="Brak jezyka po stronie BPP"):
+        integruj_jezyki(client, create_if_not_exists=False)
+
+    assert not Jezyk.objects.filter(nazwa="Niematego").exists()
+
+
+@pytest.mark.django_db
+def test_jezyki_warns_when_missing_and_no_create_flag_without_pl():
+    """Loop 2: unmatched, pl None, create flag unset -> warn (en branch)."""
+    from pbn_integrator.utils import integruj_jezyki
+
+    baker.make(
+        Language,
+        code="vvv",
+        language={"639-2": "vvv", "pl": None, "en": "NoPl"},
+    )
+
+    client = Mock()
+    client.get_languages.return_value = []
+    with pytest.warns(UserWarning, match="Brak jezyka po stronie BPP"):
+        integruj_jezyki(client, create_if_not_exists=False)
+
+    assert not Jezyk.objects.filter(nazwa="NoPl").exists()
+
+
+@pytest.mark.django_db
+def test_jezyki_639_1_participates_in_query():
+    """Loop 2: a Jezyk whose skrot equals the 639-1 code is matched via the
+    extra OR term added only when 639-1 is present."""
+    from pbn_integrator.utils import integruj_jezyki
+
+    lang = baker.make(
+        Language,
+        code="aaa",
+        language={"639-2": "nomatchX", "639-1": "qx", "pl": "Cos"},
+    )
+    jezyk = baker.make(Jezyk, nazwa="Cos jezyk", skrot="qx", pbn_uid=None)
+
+    client = Mock()
+    client.get_languages.return_value = []
+    integruj_jezyki(client, create_if_not_exists=False)
+
+    jezyk.refresh_from_db()
+    assert jezyk.pbn_uid_id == lang.pk
+
+
+# ---------------------------------------------------------------------------
+# integruj_dyscypliny
+# ---------------------------------------------------------------------------
+
+
+def _make_group():
+    return baker.make(
+        DisciplineGroup,
+        uuid=uuid4(),
+        validityDateFrom=date(2022, 1, 1),
+        validityDateTo=None,
+    )
+
+
+@pytest.mark.django_db
+def test_dyscypliny_creates_group_from_dict():
+    """Group as dict, not present -> created with given pk."""
+    from pbn_integrator.utils import integruj_dyscypliny
+
+    gid = 987654
+    client = Mock()
+    client.get_discipline_groups.return_value = [
+        {
+            "id": gid,
+            "uuid": str(uuid4()),
+            "validityDateFrom": "2022-01-01",
+            "validityDateTo": None,
+        }
+    ]
+    client.get_disciplines.return_value = []
+    integruj_dyscypliny(client)
+
+    assert DisciplineGroup.objects.filter(pk=gid).exists()
+
+
+@pytest.mark.django_db
+def test_dyscypliny_skips_existing_group_dict():
+    """Group as dict, already present -> left untouched (no error)."""
+    from pbn_integrator.utils import integruj_dyscypliny
+
+    grp = _make_group()
+    client = Mock()
+    client.get_discipline_groups.return_value = [
+        {
+            "id": grp.pk,
+            "uuid": str(uuid4()),
+            "validityDateFrom": "2099-01-01",
+            "validityDateTo": None,
+        }
+    ]
+    client.get_disciplines.return_value = []
+    integruj_dyscypliny(client)
+
+    grp.refresh_from_db()
+    # untouched: still original validity date
+    assert grp.validityDateFrom == date(2022, 1, 1)
+
+
+@pytest.mark.django_db
+def test_dyscypliny_model_group_not_in_db_is_skipped():
+    """Group as (unsaved) model object missing from DB -> NOT created."""
+    from pbn_integrator.utils import integruj_dyscypliny
+
+    unsaved = DisciplineGroup(uuid=uuid4(), validityDateFrom=date(2022, 1, 1))
+    before = DisciplineGroup.objects.count()
+
+    client = Mock()
+    client.get_discipline_groups.return_value = [unsaved]
+    client.get_disciplines.return_value = []
+    integruj_dyscypliny(client)
+
+    assert DisciplineGroup.objects.count() == before
+
+
+@pytest.mark.django_db
+def test_dyscypliny_creates_discipline_dict_parent_group_dict():
+    """Discipline dict whose parent_group is a dict -> parent_group_id taken
+    from the nested id; created with explicit pk when 'id' present."""
+    from pbn_integrator.utils import integruj_dyscypliny
+
+    grp = _make_group()
+    client = Mock()
+    client.get_discipline_groups.return_value = []
+    client.get_disciplines.return_value = [
+        {
+            "id": 555001,
+            "uuid": str(uuid4()),
+            "code": "33.1",
+            "name": "Nauka A",
+            "parent_group": {"id": grp.pk},
+        }
+    ]
+    integruj_dyscypliny(client)
+
+    d = Discipline.objects.get(code="33.1")
+    assert d.pk == 555001
+    assert d.parent_group_id == grp.pk
+    assert d.name == "Nauka A"
+
+
+@pytest.mark.django_db
+def test_dyscypliny_creates_discipline_dict_parent_group_model():
+    """Discipline dict whose parent_group is a model object -> uses its pk."""
+    from pbn_integrator.utils import integruj_dyscypliny
+
+    grp = _make_group()
+    client = Mock()
+    client.get_discipline_groups.return_value = []
+    client.get_disciplines.return_value = [
+        {
+            "uuid": str(uuid4()),
+            "code": "33.2",
+            "name": "Nauka B",
+            "parent_group": grp,
+        }
+    ]
+    integruj_dyscypliny(client)
+
+    d = Discipline.objects.get(code="33.2")
+    assert d.parent_group_id == grp.pk
+
+
+@pytest.mark.django_db
+def test_dyscypliny_creates_discipline_dict_parent_group_id_key():
+    """Discipline dict with no parent_group, but a parent_group_id key."""
+    from pbn_integrator.utils import integruj_dyscypliny
+
+    grp = _make_group()
+    client = Mock()
+    client.get_discipline_groups.return_value = []
+    client.get_disciplines.return_value = [
+        {
+            "uuid": str(uuid4()),
+            "code": "33.3",
+            "name": "Nauka C",
+            "parent_group": None,
+            "parent_group_id": grp.pk,
+        }
+    ]
+    integruj_dyscypliny(client)
+
+    d = Discipline.objects.get(code="33.3")
+    assert d.parent_group_id == grp.pk
+
+
+@pytest.mark.django_db
+def test_dyscypliny_updates_name_and_skips_when_same():
+    """Existing discipline: name differs -> updated; name same -> untouched."""
+    from pbn_integrator.utils import integruj_dyscypliny
+
+    grp = _make_group()
+    disc = baker.make(
+        Discipline, code="33.4", name="Stara", parent_group=grp, uuid=uuid4()
+    )
+
+    client = Mock()
+    client.get_discipline_groups.return_value = []
+    client.get_disciplines.return_value = [
+        {
+            "uuid": str(uuid4()),
+            "code": "33.4",
+            "name": "Nowa",
+            "parent_group": grp,
+        }
+    ]
+    integruj_dyscypliny(client)
+    disc.refresh_from_db()
+    assert disc.name == "Nowa"
+
+    # Same name -> no-op; uuid/parent unchanged.
+    client.get_disciplines.return_value = [
+        {
+            "uuid": str(uuid4()),
+            "code": "33.4",
+            "name": "Nowa",
+            "parent_group": grp,
+        }
+    ]
+    integruj_dyscypliny(client)
+    disc.refresh_from_db()
+    assert disc.name == "Nowa"
+
+
+@pytest.mark.django_db
+def test_dyscypliny_discipline_model_object_create_and_update():
+    """Discipline supplied as a model object: create path (new code) then
+    update path (existing code, differing name)."""
+    from pbn_integrator.utils import integruj_dyscypliny
+
+    grp = _make_group()
+    remote = Discipline(code="33.5", name="Mname", parent_group=grp, uuid=uuid4())
+
+    client = Mock()
+    client.get_discipline_groups.return_value = []
+    client.get_disciplines.return_value = [remote]
+    integruj_dyscypliny(client)
+
+    d = Discipline.objects.get(code="33.5")
+    assert d.name == "Mname"
+    assert d.parent_group_id == grp.pk
+
+    # Now an existing discipline returned as model object with new name.
+    remote2 = Discipline(code="33.5", name="Mname2", parent_group=grp, uuid=uuid4())
+    client.get_disciplines.return_value = [remote2]
+    integruj_dyscypliny(client)
+    d.refresh_from_db()
+    assert d.name == "Mname2"
+
+
+# ---------------------------------------------------------------------------
+# integruj_zrodla
+# ---------------------------------------------------------------------------
+
+
+def _journal(**kw):
+    kw.setdefault("status", "ACTIVE")
+    return baker.make(Journal, **kw)
+
+
+@pytest.mark.django_db
+def test_zrodla_matches_by_issn():
+    from pbn_integrator.utils import integruj_zrodla
+
+    j = _journal(issn="1111-1111", eissn="", title="Cokolwiek", mniswId=1)
+    z = baker.make(
+        Zrodlo, nazwa="Inny tytul", issn="1111-1111", e_issn="", pbn_uid=None
+    )
+
+    integruj_zrodla(disable_progress_bar=True)
+    z.refresh_from_db()
+    assert z.pbn_uid_id == j.pk
+
+
+@pytest.mark.django_db
+def test_zrodla_matches_by_eissn():
+    from pbn_integrator.utils import integruj_zrodla
+
+    j = _journal(issn="", eissn="2222-2222", title="Brak", mniswId=2)
+    z = baker.make(
+        Zrodlo, nazwa="Bez tytulu", issn="", e_issn="2222-2222", pbn_uid=None
+    )
+
+    integruj_zrodla(disable_progress_bar=True)
+    z.refresh_from_db()
+    assert z.pbn_uid_id == j.pk
+
+
+@pytest.mark.django_db
+def test_zrodla_matches_by_title():
+    from pbn_integrator.utils import integruj_zrodla
+
+    j = _journal(issn="", eissn="", title="Dokladny Tytul", mniswId=3)
+    z = baker.make(Zrodlo, nazwa="Dokladny Tytul", issn="", e_issn="", pbn_uid=None)
+
+    integruj_zrodla(disable_progress_bar=True)
+    z.refresh_from_db()
+    assert z.pbn_uid_id == j.pk
+
+
+@pytest.mark.django_db
+def test_zrodla_no_match_leaves_pbn_uid_none():
+    from pbn_integrator.utils import integruj_zrodla
+
+    _journal(issn="9999-9999", eissn="", title="Zupelnie inne", mniswId=4)
+    z = baker.make(
+        Zrodlo,
+        nazwa="Nieistniejace zrodlo",
+        issn="0000-0001",
+        e_issn="",
+        pbn_uid=None,
+    )
+
+    integruj_zrodla(disable_progress_bar=True)
+    z.refresh_from_db()
+    assert z.pbn_uid_id is None
+
+
+@pytest.mark.django_db
+def test_zrodla_multiple_matches_prefers_one_with_mniswid():
+    """Multiple PBN journals match -> the one with a mniswId wins."""
+    from pbn_integrator.utils import integruj_zrodla
+
+    _journal(issn="3333-3333", eissn="", title="Wielo A", mniswId=None)
+    with_mnisw = _journal(issn="3333-3333", eissn="", title="Wielo B", mniswId=77)
+    z = baker.make(
+        Zrodlo, nazwa="Wieloznaczne", issn="3333-3333", e_issn="", pbn_uid=None
+    )
+
+    integruj_zrodla(disable_progress_bar=True)
+    z.refresh_from_db()
+    assert z.pbn_uid_id == with_mnisw.pk
+
+
+@pytest.mark.django_db
+def test_zrodla_multiple_matches_no_mniswid_picks_longest_versions():
+    """Multiple matches, none with mniswId -> picks the journal whose
+    ``versions`` blob is the largest (longest pg_column_size)."""
+    from pbn_integrator.utils import integruj_zrodla
+
+    _journal(
+        issn="4444-4444",
+        eissn="",
+        title="Krotki",
+        mniswId=None,
+        versions=[{"current": True, "object": {"title": "Krotki"}}],
+    )
+    big = _journal(
+        issn="4444-4444",
+        eissn="",
+        title="Dlugi",
+        mniswId=None,
+        versions=[
+            {
+                "current": True,
+                "object": {"title": "Dlugi", "blob": "y" * 5000},
+            }
+        ],
+    )
+    z = baker.make(
+        Zrodlo, nazwa="Dwa bez mnisw", issn="4444-4444", e_issn="", pbn_uid=None
+    )
+
+    integruj_zrodla(disable_progress_bar=True)
+    z.refresh_from_db()
+    assert z.pbn_uid_id == big.pk

--- a/src/pbn_integrator/tests/test_matchuj_autora_po_stronie_pbn.py
+++ b/src/pbn_integrator/tests/test_matchuj_autora_po_stronie_pbn.py
@@ -1,0 +1,232 @@
+"""Charakteryzacyjne testy dla matchuj_autora_po_stronie_pbn.
+
+Pinują OBECNE zachowanie funkcji dopasowującej autora BPP do rekordu
+naukowca po stronie PBN (kolejność strategii, wczesne returny, ścieżki
+braku dopasowania oraz logika ratingu przy wielu dopasowaniach po nazwisku
+spoza API instytucji). Mają przejść na NIEZMIENIONYM kodzie.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Uczelnia
+from pbn_api.models import Scientist
+from pbn_api.models.institution import Institution
+from pbn_integrator.utils.scientists import matchuj_autora_po_stronie_pbn
+
+
+def _make_scientist(
+    *,
+    from_institution_api,
+    name="Jan",
+    lastName="Kowalski",
+    orcid=None,
+    extra_object=None,
+):
+    """Utwórz Scientist z bieżącą wersją zawierającą podane pola obiektu."""
+    obj = {"name": name, "lastName": lastName}
+    if orcid is not None:
+        obj["orcid"] = orcid
+    if extra_object:
+        obj.update(extra_object)
+    return baker.make(
+        Scientist,
+        name=name,
+        lastName=lastName,
+        orcid=orcid or "",
+        from_institution_api=from_institution_api,
+        versions=[{"current": True, "object": obj}],
+    )
+
+
+@pytest.mark.django_db
+def test_orcid_match_w_rekordach_z_api_instytucji():
+    """ORCID w rekordzie from_institution_api=True → zwraca ten rekord."""
+    s = _make_scientist(from_institution_api=True, orcid="0000-0001-1111-1111")
+    res = matchuj_autora_po_stronie_pbn("Jan", "Kowalski", "0000-0001-1111-1111")
+    assert res == s
+
+
+@pytest.mark.django_db
+def test_orcid_match_tylko_spoza_api_instytucji():
+    """ORCID tylko w rekordzie spoza API instytucji → strategia A pudłuje,
+    strategia B trafia."""
+    s = _make_scientist(from_institution_api=False, orcid="0000-0002-2222-2222")
+    res = matchuj_autora_po_stronie_pbn("Jan", "Kowalski", "0000-0002-2222-2222")
+    assert res == s
+
+
+@pytest.mark.django_db
+def test_orcid_z_api_instytucji_ma_priorytet_nad_nazwiskiem():
+    """Rekord ORCID z API instytucji wygrywa, zanim w ogóle padnie match po
+    nazwisku."""
+    orcid_inst = _make_scientist(
+        from_institution_api=True,
+        name="Jan",
+        lastName="Kowalski",
+        orcid="0000-0003-3333-3333",
+    )
+    # Inny rekord pasujący po nazwisku - nie powinien zostać wybrany.
+    _make_scientist(
+        from_institution_api=True, name="Jan", lastName="Kowalski", orcid=None
+    )
+    res = matchuj_autora_po_stronie_pbn("Jan", "Kowalski", "0000-0003-3333-3333")
+    assert res == orcid_inst
+
+
+@pytest.mark.django_db
+def test_orcid_spoza_api_ma_priorytet_nad_nazwiskiem():
+    """Strategia B (ORCID spoza API) ma priorytet nad matchowaniem po
+    nazwisku."""
+    orcid_rec = _make_scientist(
+        from_institution_api=False,
+        name="Anna",
+        lastName="Nowak",
+        orcid="0000-0004-4444-4444",
+    )
+    # Rekord z API instytucji pasujący po nazwisku, ale BEZ tego ORCID.
+    _make_scientist(
+        from_institution_api=True, name="Anna", lastName="Nowak", orcid=None
+    )
+    res = matchuj_autora_po_stronie_pbn("Anna", "Nowak", "0000-0004-4444-4444")
+    assert res == orcid_rec
+
+
+@pytest.mark.django_db
+def test_orcid_multiple_w_api_instytucji_kontynuuje_do_nazwiska():
+    """Wiele rekordów ORCID w API instytucji → strategia A loguje i pudłuje,
+    ale match po nazwisku w API instytucji złapie."""
+    _make_scientist(from_institution_api=True, orcid="0000-0005-5555-5555")
+    _make_scientist(from_institution_api=True, orcid="0000-0005-5555-5555")
+    # Z dwóch powyższych match po nazwisku też zwróci Multiple (strategia C),
+    # więc oczekujemy None.
+    res = matchuj_autora_po_stronie_pbn("Jan", "Kowalski", "0000-0005-5555-5555")
+    assert res is None
+
+
+@pytest.mark.django_db
+def test_brak_orcid_pomija_strategie_orcid_i_idzie_po_nazwisku():
+    """orcid=None → pomijamy strategie ORCID, dopasowanie po nazwisku."""
+    s = _make_scientist(from_institution_api=True, name="Ewa", lastName="Wiśniewska")
+    res = matchuj_autora_po_stronie_pbn("Ewa", "Wiśniewska", None)
+    assert res == s
+
+
+@pytest.mark.django_db
+def test_nazwisko_match_z_api_instytucji():
+    """Dopasowanie po imieniu+nazwisku w rekordach z API instytucji."""
+    s = _make_scientist(from_institution_api=True, name="Piotr", lastName="Zieliński")
+    res = matchuj_autora_po_stronie_pbn("Piotr", "Zieliński", None)
+    assert res == s
+
+
+@pytest.mark.django_db
+def test_nazwisko_match_z_api_instytucji_ma_priorytet_nad_spoza():
+    """Rekord z API instytucji wygrywa z rekordem spoza API instytucji
+    przy dopasowaniu po nazwisku."""
+    inst = _make_scientist(
+        from_institution_api=True, name="Piotr", lastName="Zieliński"
+    )
+    _make_scientist(from_institution_api=False, name="Piotr", lastName="Zieliński")
+    res = matchuj_autora_po_stronie_pbn("Piotr", "Zieliński", None)
+    assert res == inst
+
+
+@pytest.mark.django_db
+def test_nazwisko_match_tylko_spoza_api_instytucji():
+    """Dopasowanie po nazwisku tylko w rekordach spoza API instytucji."""
+    s = _make_scientist(
+        from_institution_api=False, name="Marek", lastName="Lewandowski"
+    )
+    res = matchuj_autora_po_stronie_pbn("Marek", "Lewandowski", None)
+    assert res == s
+
+
+@pytest.mark.django_db
+def test_brak_dopasowania_zwraca_none():
+    """Nikt nie pasuje → None."""
+    res = matchuj_autora_po_stronie_pbn("Nikt", "Nieznany", None)
+    assert res is None
+
+
+@pytest.mark.django_db
+def test_imiona_i_nazwisko_sa_strippowane():
+    """Białe znaki w imionach/nazwisku są obcinane przed dopasowaniem."""
+    s = _make_scientist(from_institution_api=True, name="Jan", lastName="Kowalski")
+    res = matchuj_autora_po_stronie_pbn("  Jan  ", "  Kowalski  ", None)
+    assert res == s
+
+
+@pytest.mark.django_db
+def test_nazwisko_multiple_z_api_instytucji_zwraca_none():
+    """Wiele rekordów po nazwisku w API instytucji → strategia C loguje
+    i pudłuje; brak rekordów spoza API → None."""
+    _make_scientist(from_institution_api=True, name="Jan", lastName="Kowalski")
+    _make_scientist(from_institution_api=True, name="Jan", lastName="Kowalski")
+    res = matchuj_autora_po_stronie_pbn("Jan", "Kowalski", None)
+    assert res is None
+
+
+@pytest.mark.django_db
+def test_nazwisko_multiple_spoza_api_wybiera_najlepszy_gdy_w_jednostce(uczelnia):
+    """Wiele rekordów spoza API instytucji + jeden pracuje w jednostce →
+    rating wybiera rekord z największą liczbą punktów."""
+    inst = baker.make(Institution, mongoId="INST-PBN-UID")
+    uczelnia.pbn_uid = inst
+    uczelnia.save()
+    Uczelnia.objects.__dict__.pop("default", None)
+
+    najlepszy = _make_scientist(
+        from_institution_api=False,
+        name="Jan",
+        lastName="Kowalski",
+        extra_object={
+            "currentEmployments": [{"institutionId": "INST-PBN-UID"}],
+            "externalIdentifiers": ["x"],
+            "legacyIdentifiers": ["y"],
+            "qualifications": "prof.",
+        },
+    )
+    # Drugi rekord - 0 punktów, nie pracuje w jednostce.
+    _make_scientist(from_institution_api=False, name="Jan", lastName="Kowalski")
+
+    res = matchuj_autora_po_stronie_pbn("Jan", "Kowalski", None)
+    assert res == najlepszy
+
+    Uczelnia.objects.__dict__.pop("default", None)
+
+
+@pytest.mark.django_db
+def test_nazwisko_multiple_spoza_api_nie_wybiera_gdy_nie_w_jednostce(uczelnia):
+    """Wiele rekordów spoza API instytucji, żaden nie pracuje w jednostce →
+    NIE WYBIERA NIC (None)."""
+    inst = baker.make(Institution, mongoId="INST-PBN-UID")
+    uczelnia.pbn_uid = inst
+    uczelnia.save()
+    Uczelnia.objects.__dict__.pop("default", None)
+
+    _make_scientist(
+        from_institution_api=False,
+        name="Jan",
+        lastName="Kowalski",
+        extra_object={
+            "currentEmployments": [{"institutionId": "INNA-INSTYTUCJA"}],
+        },
+    )
+    _make_scientist(from_institution_api=False, name="Jan", lastName="Kowalski")
+
+    res = matchuj_autora_po_stronie_pbn("Jan", "Kowalski", None)
+    assert res is None
+
+    Uczelnia.objects.__dict__.pop("default", None)
+
+
+@pytest.mark.django_db
+def test_orcid_brak_dopasowania_spada_do_nazwiska(uczelnia):
+    """ORCID podany, ale nie pasuje nigdzie → spadamy do dopasowania po
+    nazwisku, które trafia."""
+    s = _make_scientist(
+        from_institution_api=True, name="Jan", lastName="Kowalski", orcid=None
+    )
+    res = matchuj_autora_po_stronie_pbn("Jan", "Kowalski", "0000-0009-9999-9999")
+    assert res == s

--- a/src/pbn_integrator/utils/dictionaries.py
+++ b/src/pbn_integrator/utils/dictionaries.py
@@ -10,65 +10,76 @@ from bpp.models import Jezyk
 from pbn_api.models import Country, Discipline, DisciplineGroup, Language
 
 
-def integruj_jezyki(client, create_if_not_exists=False):  # noqa: C901
+def _sync_remote_languages(client):
+    """Create/update local ``Language`` records from the PBN payload."""
+    for remote_lang in client.get_languages():
+        lang, created = Language.objects.get_or_create(
+            code=remote_lang["code"],
+            defaults={"language": remote_lang["language"]},
+        )
+        if not created and remote_lang["language"] != lang.language:
+            lang.language = remote_lang["language"]
+            lang.save()
+
+
+def _jezyk_query(elem):
+    """Build the ``Q`` lookup matching a BPP ``Jezyk`` to a PBN language."""
+    qry = Q(skrot__istartswith=elem.language.get("639-2")) | Q(skrot__iexact=elem.code)
+    if elem.language.get("639-1"):
+        qry |= Q(skrot__iexact=elem.language["639-1"])
+    return qry
+
+
+def _resolve_missing_jezyk(elem, create_if_not_exists):
+    """Handle a PBN language with no skrot/code match.
+
+    Returns a ``Jezyk`` still needing ``pbn_uid`` mapping (matched by name),
+    or ``None`` when the element was fully handled (created or warned).
+    """
+    pl = elem.language.get("pl")
+    if pl is not None:
+        try:
+            return Jezyk.objects.get(nazwa__iexact=pl)
+        except Jezyk.DoesNotExist:
+            nazwa = pl
+    else:
+        nazwa = elem.language.get("en")
+
+    if create_if_not_exists:
+        Jezyk.objects.create(
+            nazwa=nazwa, skrot=elem.language.get("639-2"), pbn_uid=elem
+        )
+    else:
+        warnings.warn(f"Brak jezyka po stronie BPP: {elem}", stacklevel=2)
+    return None
+
+
+def _map_language_to_jezyk(elem, create_if_not_exists):
+    """Establish the ``Jezyk.pbn_uid`` mapping for a single PBN language."""
+    try:
+        jezyk = Jezyk.objects.get(_jezyk_query(elem))
+    except Jezyk.DoesNotExist:
+        jezyk = _resolve_missing_jezyk(elem, create_if_not_exists)
+        if jezyk is None:
+            return
+
+    if jezyk.pbn_uid_id is None:
+        jezyk.pbn_uid = elem
+        jezyk.save()
+
+
+def integruj_jezyki(client, create_if_not_exists=False):
     """Integrate languages from PBN.
 
     Args:
         client: PBN client.
         create_if_not_exists: Whether to create missing languages in BPP.
     """
-    for remote_lang in client.get_languages():
-        try:
-            lang = Language.objects.get(code=remote_lang["code"])
-        except Language.DoesNotExist:
-            lang = Language.objects.create(
-                code=remote_lang["code"], language=remote_lang["language"]
-            )
-
-        if remote_lang["language"] != lang.language:
-            lang.language = remote_lang["language"]
-            lang.save()
+    _sync_remote_languages(client)
 
     # Ustaw odpowiedniki w PBN dla jęyzków z bazy danych:
     for elem in Language.objects.all():
-        try:
-            qry = Q(skrot__istartswith=elem.language.get("639-2")) | Q(
-                skrot__iexact=elem.code
-            )
-            if elem.language.get("639-1"):
-                qry |= Q(skrot__iexact=elem.language["639-1"])
-
-            jezyk = Jezyk.objects.get(qry)
-        except Jezyk.DoesNotExist:
-            if elem.language.get("pl") is not None:
-                try:
-                    jezyk = Jezyk.objects.get(nazwa__iexact=elem.language.get("pl"))
-                except Jezyk.DoesNotExist:
-                    if create_if_not_exists:
-                        Jezyk.objects.create(
-                            nazwa=elem.language.get("pl"),
-                            skrot=elem.language.get("639-2"),
-                            pbn_uid=elem,
-                        )
-                    else:
-                        warnings.warn(
-                            f"Brak jezyka po stronie BPP: {elem}", stacklevel=2
-                        )
-                    continue
-            else:
-                if create_if_not_exists:
-                    Jezyk.objects.create(
-                        nazwa=elem.language.get("en"),
-                        skrot=elem.language.get("639-2"),
-                        pbn_uid=elem,
-                    )
-                else:
-                    warnings.warn(f"Brak jezyka po stronie BPP: {elem}", stacklevel=2)
-                continue
-
-        if jezyk.pbn_uid_id is None:
-            jezyk.pbn_uid = elem
-            jezyk.save()
+        _map_language_to_jezyk(elem, create_if_not_exists)
 
 
 def integruj_kraje(client):
@@ -91,74 +102,80 @@ def integruj_kraje(client):
             c.save()
 
 
-def integruj_dyscypliny(client):  # noqa: C901
+def _ensure_discipline_groups(client):
+    """Create any missing discipline groups (dict payloads only)."""
+    for remote_group in client.get_discipline_groups():
+        is_dict = isinstance(remote_group, dict)
+        group_id = remote_group.get("id") if is_dict else remote_group.pk
+        if DisciplineGroup.objects.filter(pk=group_id).exists():
+            continue
+        if is_dict:
+            DisciplineGroup.objects.create(
+                pk=group_id,
+                **{k: v for k, v in remote_group.items() if k != "id"},
+            )
+        # else: remote_group is a DisciplineGroup model object missing from
+        # the DB -- skip, as the original code did.
+
+
+def _parent_group_id_from_dict(remote_discipline):
+    """Resolve ``parent_group_id`` for a dict discipline payload."""
+    parent_group = remote_discipline.get("parent_group")
+    if isinstance(parent_group, dict):
+        return parent_group.get("id")
+    if hasattr(parent_group, "pk"):
+        return parent_group.pk
+    return remote_discipline.get("parent_group_id")
+
+
+def _discipline_fields(remote_discipline):
+    """Normalize a dict-or-model discipline payload into a field mapping."""
+    if isinstance(remote_discipline, dict):
+        return {
+            "code": remote_discipline.get("code"),
+            "disc_id": remote_discipline.get("id"),
+            "name": remote_discipline.get("name"),
+            "uuid": remote_discipline.get("uuid"),
+            "parent_group_id": _parent_group_id_from_dict(remote_discipline),
+        }
+
+    parent_group = getattr(remote_discipline, "parent_group", None)
+    return {
+        "code": remote_discipline.code,
+        "disc_id": remote_discipline.pk,
+        "name": remote_discipline.name,
+        "uuid": getattr(remote_discipline, "uuid", None),
+        "parent_group_id": parent_group.pk if parent_group else None,
+    }
+
+
+def _upsert_discipline(fields):
+    """Create a missing discipline or update its name in place."""
+    try:
+        d = Discipline.objects.get(code=fields["code"])
+    except Discipline.DoesNotExist:
+        create_kwargs = {
+            "code": fields["code"],
+            "name": fields["name"],
+            "parent_group_id": fields["parent_group_id"],
+            "uuid": fields["uuid"],
+        }
+        if fields["disc_id"]:
+            create_kwargs["pk"] = fields["disc_id"]
+        Discipline.objects.create(**create_kwargs)
+        return
+
+    if fields["name"] != d.name:
+        d.name = fields["name"]
+        d.save()
+
+
+def integruj_dyscypliny(client):
     """Import discipline groups and disciplines from PBN.
 
     Args:
         client: PBN client.
     """
-    # First, ensure all discipline groups exist
-    for remote_group in client.get_discipline_groups():
-        # Handle both dict and DisciplineGroup model object
-        group_id = (
-            remote_group.get("id")
-            if isinstance(remote_group, dict)
-            else remote_group.pk
-        )
-        try:
-            DisciplineGroup.objects.get(pk=group_id)
-        except DisciplineGroup.DoesNotExist:
-            if isinstance(remote_group, dict):
-                DisciplineGroup.objects.create(
-                    pk=group_id, **{k: v for k, v in remote_group.items() if k != "id"}
-                )
-            # else: remote_group is already a DisciplineGroup model object, skip
-
-    # Now create/update disciplines
+    _ensure_discipline_groups(client)
     for remote_discipline in client.get_disciplines():
-        # Handle both dict and Discipline model object
-        if isinstance(remote_discipline, dict):
-            code = remote_discipline.get("code")
-            disc_id = remote_discipline.get("id")
-            name = remote_discipline.get("name")
-            uuid = remote_discipline.get("uuid")
-            # Handle parent_group which could be dict or model object
-            parent_group = remote_discipline.get("parent_group")
-            if isinstance(parent_group, dict):
-                parent_group_id = parent_group.get("id")
-            elif hasattr(parent_group, "pk"):
-                parent_group_id = parent_group.pk
-            else:
-                parent_group_id = remote_discipline.get("parent_group_id")
-        else:
-            code = remote_discipline.code
-            disc_id = remote_discipline.pk
-            name = remote_discipline.name
-            uuid = (
-                remote_discipline.uuid if hasattr(remote_discipline, "uuid") else None
-            )
-            parent_group_id = (
-                remote_discipline.parent_group.pk
-                if hasattr(remote_discipline, "parent_group")
-                and remote_discipline.parent_group
-                else None
-            )
-
-        try:
-            d = Discipline.objects.get(code=code)
-        except Discipline.DoesNotExist:
-            create_kwargs = {
-                "code": code,
-                "name": name,
-                "parent_group_id": parent_group_id,
-                "uuid": uuid,
-            }
-            if disc_id:
-                create_kwargs["pk"] = disc_id
-            Discipline.objects.create(**create_kwargs)
-            continue
-
-        # Update existing discipline if needed
-        if name != d.name:
-            d.name = name
-            d.save()
+        _upsert_discipline(_discipline_fields(remote_discipline))

--- a/src/pbn_integrator/utils/journals.py
+++ b/src/pbn_integrator/utils/journals.py
@@ -63,67 +63,73 @@ def pobierz_zrodla_mnisw(client: PBNClient, callback=None):
     )
 
 
-def integruj_zrodla(disable_progress_bar=False):  # noqa: C901
+def _zrodlo_query(zrodlo):
+    """Build the combined ``Q`` lookup matching a ``Zrodlo`` to PBN journals."""
+    queries = []
+
+    if zrodlo.issn:
+        queries.append(Q(issn=zrodlo.issn) | Q(eissn=zrodlo.issn))
+
+    if zrodlo.e_issn:
+        queries.append(Q(eissn=zrodlo.e_issn) | Q(issn=zrodlo.e_issn))
+
+    queries.append(Q(title__iexact=zrodlo.nazwa))
+
+    return reduce(operator.or_, queries)
+
+
+def _najlepszy_journal(zrodlo, qry):
+    """Return the best-matching PBN ``Journal`` for ``qry`` or ``None``.
+
+    On multiple matches, prefer one carrying a ``mniswId``; otherwise pick
+    the journal with the largest ``versions`` blob (longest description).
+    """
+    try:
+        return Journal.objects.get(qry)
+    except Journal.DoesNotExist:
+        return None
+    except Journal.MultipleObjectsReturned:
+        # warnings.warn(
+        #     f"Znaleziono liczne dopasowania w PBN dla {zrodlo}, szukam czy jakies ma mniswId"
+        # )
+        for u in Journal.objects.filter(qry):
+            if u.mniswId is not None:
+                return u
+
+        print(
+            f"Znaleziono liczne dopasowania w PBN dla {zrodlo}, żadnie nie ma mniswId, wybieram to z "
+            f"najdłuższym opisem"
+        )
+        return (
+            Journal.objects.filter(qry)
+            .annotate(
+                json_len=Func(
+                    F("versions"),
+                    function="pg_column_size",
+                    output_field=IntegerField(),
+                )
+            )
+            .order_by("-json_len")
+            .first()
+        )
+
+
+def integruj_zrodla(disable_progress_bar=False):
     """Integrate BPP sources with PBN journals.
 
     Args:
         disable_progress_bar: Whether to disable progress bar.
     """
-
-    def fun(qry):
-        found = False
-        try:
-            u = Journal.objects.get(qry)
-            found = True
-        except Journal.DoesNotExist:
-            return False
-        except Journal.MultipleObjectsReturned:
-            # warnings.warn(
-            #     f"Znaleziono liczne dopasowania w PBN dla {zrodlo}, szukam czy jakies ma mniswId"
-            # )
-            for u in Journal.objects.filter(qry):
-                if u.mniswId is not None:
-                    found = True
-                    break
-
-            if not found:
-                print(
-                    f"Znaleziono liczne dopasowania w PBN dla {zrodlo}, żadnie nie ma mniswId, wybieram to z "
-                    f"najdłuższym opisem"
-                )
-                u = (
-                    Journal.objects.filter(qry)
-                    .annotate(
-                        json_len=Func(
-                            F("versions"),
-                            function="pg_column_size",
-                            output_field=IntegerField(),
-                        )
-                    )
-                    .order_by("-json_len")
-                    .first()
-                )
-
-        zrodlo.pbn_uid = u
-        zrodlo.save()
-        return True
-
     for zrodlo in pbar(
         Zrodlo.objects.filter(pbn_uid_id=None),
         label="Integracja zrodel",
         disable_progress_bar=disable_progress_bar,
     ):
-        queries = []
+        u = _najlepszy_journal(zrodlo, _zrodlo_query(zrodlo))
 
-        if zrodlo.issn:
-            queries.append(Q(issn=zrodlo.issn) | Q(eissn=zrodlo.issn))
-
-        if zrodlo.e_issn:
-            queries.append(Q(eissn=zrodlo.e_issn) | Q(issn=zrodlo.e_issn))
-
-        queries.append(Q(title__iexact=zrodlo.nazwa))
-
-        if fun(reduce(operator.or_, queries)):
+        if u is not None:
+            zrodlo.pbn_uid = u
+            zrodlo.save()
             print(f"\nZNALEZIONO dopasowania w PBN dla {zrodlo} -> {zrodlo.pbn_uid}")
             continue
 

--- a/src/pbn_integrator/utils/scientists.py
+++ b/src/pbn_integrator/utils/scientists.py
@@ -321,8 +321,144 @@ def weryfikuj_orcidy(client: PBNClient, instutition_id):
         )
 
 
-def matchuj_autora_po_stronie_pbn(imiona, nazwisko, orcid):  # noqa: C901
+def _qry_po_orcid(orcid):
+    """Zbuduj zapytanie szukające bieżącej wersji rekordu po ORCID."""
+    return Q(versions__contains=[{"current": True, "object": {"orcid": orcid}}])
+
+
+def _qry_po_nazwisku(imiona, nazwisko):
+    """Zbuduj zapytanie szukające bieżącej wersji rekordu po imieniu+nazwisku."""
+    return Q(
+        versions__contains=[
+            {
+                "current": True,
+                "object": {"lastName": nazwisko.strip(), "name": imiona.strip()},
+            }
+        ]
+    )
+
+
+def _loguj_duplikaty(qry):
+    """Wypisz rekordy pasujące do zapytania (gdy jest ich wiele)."""
+    for elem in Scientist.objects.filter(qry):
+        logger.info(f"\t *  {elem.pk} {elem.name} {elem.lastName}")
+
+
+def _match_orcid_z_api_instytucji(imiona, nazwisko, orcid):
+    """ORCID w rekordach zaimportowanych przez API instytucji."""
+    qry = _qry_po_orcid(orcid) & Q(from_institution_api=True)
+    try:
+        return Scientist.objects.get(qry)
+    except Scientist.DoesNotExist:
+        return None
+    except Scientist.MultipleObjectsReturned:
+        logger.info(
+            f"XXX ORCID istnieje wiele razy w bazie PBN w rekordach importowanych przez API instytucji {orcid}"
+        )
+        _loguj_duplikaty(qry)
+        return None
+
+
+def _match_orcid_spoza_api_instytucji(imiona, nazwisko, orcid):
+    """ORCID w rekordach spoza API instytucji."""
+    qry = _qry_po_orcid(orcid)
+    try:
+        return Scientist.objects.exclude(from_institution_api=True).get(qry)
+    except Scientist.DoesNotExist:
+        logger.info(
+            f"*** ORCID nie istnieje w rekordach ani z API instytucji, ani we wszystkich {orcid}"
+        )
+        return None
+    except Scientist.MultipleObjectsReturned:
+        logger.info(
+            f"XXX ORCID istnieje wiele razy w bazie PBN w rekordach importowanych nie-przez API instytucji {orcid}"
+        )
+        _loguj_duplikaty(qry)
+        return None
+
+
+def _match_nazwisko_z_api_instytucji(imiona, nazwisko, orcid):
+    """Imię+nazwisko w rekordach z API instytucji."""
+    qry = _qry_po_nazwisku(imiona, nazwisko)
+    try:
+        return Scientist.objects.filter(from_institution_api=True).get(qry)
+    except Scientist.DoesNotExist:
+        logger.info(
+            f"*** BRAK AUTORA w PBN z API instytucji, istnieje w BPP (im/naz): {nazwisko} {imiona}"
+        )
+        return None
+    except Scientist.MultipleObjectsReturned:
+        logger.info(
+            f"XXX AUTOR istnieje wiele razy w bazie PBN z API INSTYTUCJI (im/naz) {nazwisko} {imiona}"
+        )
+        return None
+
+
+def _wybierz_najlepszego_spoza_api(qry, imiona, nazwisko):
+    """Wybierz najlepiej oceniony rekord spoza API instytucji.
+
+    Punktuje rekordy po obecności wybranych pól; jeżeli żaden z kandydatów
+    nie pracuje w domyślnej jednostce — nie wybiera niczego.
+    """
+    logger.info(
+        f"XXX AUTOR istnieje wiele razy w bazie PBN z danych "
+        f"spoza API INSTYTUCJI {nazwisko} {imiona}, "
+        f"próba dobrania najlepszego"
+    )
+
+    can_be_set = False
+    rated_elems = []
+    for elem in Scientist.objects.exclude(from_institution_api=True).filter(qry):
+        cur_elem_points = 0
+        for attr in [
+            "currentEmployments",
+            "externalIdentifiers",
+            "legacyIdentifiers",
+            "qualifications",
+        ]:
+            if elem.value_or_none("object", attr):
+                cur_elem_points += 1
+
+        currentEmployments = elem.value_or_none("object", "currentEmployments")
+        if currentEmployments is not None:
+            for pos in currentEmployments:
+                if pos.get("institutionId") == Uczelnia.objects.default.pbn_uid_id:
+                    can_be_set = True
+
+        rated_elems.append((cur_elem_points, elem.pk))
+
+    rated_elems.sort(reverse=True)
+    if can_be_set:
+        logger.info(f"--> Sposrod elementow {rated_elems} wybieram pierwszy")
+        return Scientist.objects.get(pk=rated_elems[0][1])
+
+    logger.info(
+        f"XXX Sposrod elementow {rated_elems} NIE WYBIERAM NIC, bo autor nie pracuje w jednostce"
+    )
+    return None
+
+
+def _match_nazwisko_spoza_api_instytucji(imiona, nazwisko, orcid):
+    """Imię+nazwisko w rekordach spoza API instytucji."""
+    qry = _qry_po_nazwisku(imiona, nazwisko)
+    try:
+        return Scientist.objects.exclude(from_institution_api=True).get(qry)
+    except Scientist.DoesNotExist:
+        logger.info(
+            f"*** BRAK AUTORA w PBN z danych spoza API instytucji, istnieje w BPP: {nazwisko} {imiona}"
+        )
+        return None
+    except Scientist.MultipleObjectsReturned:
+        return _wybierz_najlepszego_spoza_api(qry, imiona, nazwisko)
+
+
+def matchuj_autora_po_stronie_pbn(imiona, nazwisko, orcid):
     """Match an author on the PBN side.
+
+    Próbuje kolejnych strategii dopasowania w ustalonej kolejności
+    i zwraca pierwszy trafiony rekord. Gdy podany jest ORCID, najpierw
+    szuka po ORCID (rekordy z API instytucji, potem spoza), a następnie
+    po imieniu+nazwisku (rekordy z API instytucji, potem spoza).
 
     Args:
         imiona: First names.
@@ -332,106 +468,19 @@ def matchuj_autora_po_stronie_pbn(imiona, nazwisko, orcid):  # noqa: C901
     Returns:
         Scientist object or None.
     """
+    strategie = []
     if orcid is not None:
-        # Szukamy w rekordach zaimportowanych przez API instytucji
+        strategie.append(_match_orcid_z_api_instytucji)
+        strategie.append(_match_orcid_spoza_api_instytucji)
+    strategie.append(_match_nazwisko_z_api_instytucji)
+    strategie.append(_match_nazwisko_spoza_api_instytucji)
 
-        qry = Q(versions__contains=[{"current": True, "object": {"orcid": orcid}}]) & Q(
-            from_institution_api=True
-        )
-        try:
-            res = Scientist.objects.get(qry)
+    for strategia in strategie:
+        res = strategia(imiona, nazwisko, orcid)
+        if res is not None:
             return res
-        except Scientist.DoesNotExist:
-            pass
-        except Scientist.MultipleObjectsReturned:
-            logger.info(
-                f"XXX ORCID istnieje wiele razy w bazie PBN w rekordach importowanych przez API instytucji {orcid}"
-            )
-            for elem in Scientist.objects.filter(qry):
-                logger.info(f"\t *  {elem.pk} {elem.name} {elem.lastName}")
 
-        # Szukamy w rekordach wszystkich przez API instytucji
-
-        qry = Q(versions__contains=[{"current": True, "object": {"orcid": orcid}}])
-        try:
-            res = Scientist.objects.exclude(from_institution_api=True).get(qry)
-            return res
-        except Scientist.DoesNotExist:
-            logger.info(
-                f"*** ORCID nie istnieje w rekordach ani z API instytucji, ani we wszystkich {orcid}"
-            )
-        except Scientist.MultipleObjectsReturned:
-            logger.info(
-                f"XXX ORCID istnieje wiele razy w bazie PBN w rekordach importowanych nie-przez API instytucji {orcid}"
-            )
-            for elem in Scientist.objects.filter(qry):
-                logger.info(f"\t *  {elem.pk} {elem.name} {elem.lastName}")
-
-    qry = Q(
-        versions__contains=[
-            {
-                "current": True,
-                "object": {"lastName": nazwisko.strip(), "name": imiona.strip()},
-            }
-        ]
-    )
-    try:
-        res = Scientist.objects.filter(from_institution_api=True).get(qry)
-        return res
-    except Scientist.DoesNotExist:
-        logger.info(
-            f"*** BRAK AUTORA w PBN z API instytucji, istnieje w BPP (im/naz): {nazwisko} {imiona}"
-        )
-    except Scientist.MultipleObjectsReturned:
-        logger.info(
-            f"XXX AUTOR istnieje wiele razy w bazie PBN z API INSTYTUCJI (im/naz) {nazwisko} {imiona}"
-        )
-
-    # Autorzy nie-z-API instytucji
-
-    try:
-        res = Scientist.objects.exclude(from_institution_api=True).get(qry)
-        return res
-    except Scientist.DoesNotExist:
-        logger.info(
-            f"*** BRAK AUTORA w PBN z danych spoza API instytucji, istnieje w BPP: {nazwisko} {imiona}"
-        )
-    except Scientist.MultipleObjectsReturned:
-        logger.info(
-            f"XXX AUTOR istnieje wiele razy w bazie PBN z danych "
-            f"spoza API INSTYTUCJI {nazwisko} {imiona}, "
-            f"próba dobrania najlepszego"
-        )
-
-        can_be_set = False
-        rated_elems = []
-        for elem in Scientist.objects.exclude(from_institution_api=True).filter(qry):
-            cur_elem_points = 0
-            for attr in [
-                "currentEmployments",
-                "externalIdentifiers",
-                "legacyIdentifiers",
-                "qualifications",
-            ]:
-                if elem.value_or_none("object", attr):
-                    cur_elem_points += 1
-
-            currentEmployments = elem.value_or_none("object", "currentEmployments")
-            if currentEmployments is not None:
-                for pos in currentEmployments:
-                    if pos.get("institutionId") == Uczelnia.objects.default.pbn_uid_id:
-                        can_be_set = True
-
-            rated_elems.append((cur_elem_points, elem.pk))
-
-        rated_elems.sort(reverse=True)
-        if can_be_set:
-            logger.info(f"--> Sposrod elementow {rated_elems} wybieram pierwszy")
-            return Scientist.objects.get(pk=rated_elems[0][1])
-        else:
-            logger.info(
-                f"XXX Sposrod elementow {rated_elems} NIE WYBIERAM NIC, bo autor nie pracuje w jednostce"
-            )
+    return None
 
 
 def integruj_wszystkich_niezintegrowanych_autorow():

--- a/src/przemapuj_prace_autora/test_characterization_view.py
+++ b/src/przemapuj_prace_autora/test_characterization_view.py
@@ -1,0 +1,228 @@
+"""Testy charakteryzujące widok ``przemapuj_prace``.
+
+Pinują bieżące zachowanie PRZED refaktorem (zdjęcie ``# noqa: C901``).
+Pokrywają wszystkie gałęzie: GET, POST/preview, POST/confirm (valid +
+invalid + wyjątek w transakcji) oraz POST bez znanego przycisku.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.models import (
+    Autor,
+    Jednostka,
+    Uczelnia,
+    Wydawnictwo_Ciagle,
+    Wydawnictwo_Ciagle_Autor,
+    Wydawnictwo_Zwarte,
+    Wydawnictwo_Zwarte_Autor,
+    Zrodlo,
+)
+
+from .models import PrzemapoaniePracAutora
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_user(db):
+    return User.objects.create_user(
+        username="charadmin", password="testpass", is_staff=True, is_superuser=True
+    )
+
+
+@pytest.fixture
+def kl(admin_user):
+    client = Client()
+    client.login(username="charadmin", password="testpass")
+    return client
+
+
+@pytest.fixture
+def uczelnia(db):
+    return baker.make(Uczelnia, nazwa="Char Univ")
+
+
+@pytest.fixture
+def jed_a(uczelnia):
+    return baker.make(Jednostka, nazwa="AAA Jed", skrot="AAA", uczelnia=uczelnia)
+
+
+@pytest.fixture
+def jed_b(uczelnia):
+    return baker.make(Jednostka, nazwa="BBB Jed", skrot="BBB", uczelnia=uczelnia)
+
+
+@pytest.fixture
+def jed_c(uczelnia):
+    return baker.make(Jednostka, nazwa="CCC Jed", skrot="CCC", uczelnia=uczelnia)
+
+
+@pytest.fixture
+def autor(jed_b):
+    return baker.make(Autor, imiona="Jan", nazwisko="Char", aktualna_jednostka=jed_b)
+
+
+@pytest.fixture
+def zrodlo(db):
+    return baker.make(Zrodlo, nazwa="Char Journal", skrot="CJ")
+
+
+def _url(autor):
+    return reverse(
+        "przemapuj_prace_autora:przemapuj_prace", kwargs={"autor_id": autor.pk}
+    )
+
+
+@pytest.fixture
+def autor_with_mixed_works(autor, jed_a, jed_b, jed_c, zrodlo):
+    """Autor z pracami ciągłymi (2 w A, 1 w B) i zwartymi (1 w A, 1 w C)."""
+    for tytul in ("C1", "C2"):
+        wc = baker.make(Wydawnictwo_Ciagle, tytul_oryginalny=tytul, zrodlo=zrodlo)
+        baker.make(Wydawnictwo_Ciagle_Autor, rekord=wc, autor=autor, jednostka=jed_a)
+    wc3 = baker.make(Wydawnictwo_Ciagle, tytul_oryginalny="C3", zrodlo=zrodlo)
+    baker.make(Wydawnictwo_Ciagle_Autor, rekord=wc3, autor=autor, jednostka=jed_b)
+
+    wz1 = baker.make(Wydawnictwo_Zwarte, tytul_oryginalny="Z1")
+    baker.make(Wydawnictwo_Zwarte_Autor, rekord=wz1, autor=autor, jednostka=jed_a)
+    wz2 = baker.make(Wydawnictwo_Zwarte, tytul_oryginalny="Z2")
+    baker.make(Wydawnictwo_Zwarte_Autor, rekord=wz2, autor=autor, jednostka=jed_c)
+    return autor
+
+
+@pytest.mark.django_db
+def test_get_renders_unbound_form_and_stats(
+    kl, autor_with_mixed_works, jed_a, jed_b, jed_c
+):
+    response = kl.get(_url(autor_with_mixed_works))
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["preview"] is False
+    assert ctx["autor"] == autor_with_mixed_works
+    assert ctx["form"].is_bound is False
+    assert "historia" in ctx
+
+    stats = {s["id"]: s for s in ctx["jednostki_stats"]}
+    assert stats[jed_a.id]["prace_ciagle"] == 2
+    assert stats[jed_a.id]["prace_zwarte"] == 1
+    assert stats[jed_a.id]["razem"] == 3
+    assert stats[jed_b.id]["prace_ciagle"] == 1
+    assert stats[jed_b.id]["prace_zwarte"] == 0
+    assert stats[jed_b.id]["razem"] == 1
+    assert stats[jed_c.id]["prace_ciagle"] == 0
+    assert stats[jed_c.id]["prace_zwarte"] == 1
+    # Posortowane po nazwie
+    nazwy = [s["nazwa"] for s in ctx["jednostki_stats"]]
+    assert nazwy == sorted(nazwy)
+
+
+@pytest.mark.django_db
+def test_post_preview_valid(kl, autor_with_mixed_works, jed_a, jed_b):
+    response = kl.post(
+        _url(autor_with_mixed_works),
+        {"jednostka_z": jed_a.pk, "jednostka_do": jed_b.pk, "preview": "1"},
+    )
+    assert response.status_code == 200
+    ctx = response.context
+    assert ctx["preview"] is True
+    assert ctx["jednostka_z"] == jed_a
+    assert ctx["jednostka_do"] == jed_b
+    assert ctx["liczba_prac_ciaglych"] == 2
+    assert ctx["liczba_prac_zwartych"] == 1
+    assert ctx["total_count"] == 3
+    assert len(list(ctx["prace_ciagle"])) == 2
+    assert len(list(ctx["prace_zwarte"])) == 1
+
+
+@pytest.mark.django_db
+def test_post_confirm_valid_redirects_and_logs(
+    kl, autor_with_mixed_works, jed_a, jed_b
+):
+    response = kl.post(
+        _url(autor_with_mixed_works),
+        {"jednostka_z": jed_a.pk, "jednostka_do": jed_b.pk, "confirm": "1"},
+    )
+    assert response.status_code == 302
+    assert response.url == _url(autor_with_mixed_works)
+
+    log = PrzemapoaniePracAutora.objects.get(autor=autor_with_mixed_works)
+    assert log.liczba_prac_ciaglych == 2
+    assert log.liczba_prac_zwartych == 1
+    assert log.jednostka_z == jed_a
+    assert log.jednostka_do == jed_b
+    # Prace zostały faktycznie przeniesione
+    assert (
+        Wydawnictwo_Ciagle_Autor.objects.filter(
+            autor=autor_with_mixed_works, jednostka=jed_b
+        ).count()
+        == 3
+    )
+
+
+@pytest.mark.django_db
+def test_post_confirm_invalid_form_same_unit(kl, autor_with_mixed_works, jed_a):
+    """jednostka_z == jednostka_do → form invalid, brak logu, render 200."""
+    response = kl.post(
+        _url(autor_with_mixed_works),
+        {"jednostka_z": jed_a.pk, "jednostka_do": jed_a.pk, "confirm": "1"},
+    )
+    assert response.status_code == 200
+    assert response.context["preview"] is False
+    assert not PrzemapoaniePracAutora.objects.filter(
+        autor=autor_with_mixed_works
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_post_preview_invalid_form(kl, autor_with_mixed_works, jed_a):
+    response = kl.post(
+        _url(autor_with_mixed_works),
+        {"jednostka_z": jed_a.pk, "jednostka_do": jed_a.pk, "preview": "1"},
+    )
+    assert response.status_code == 200
+    assert response.context["preview"] is False
+
+
+@pytest.mark.django_db
+def test_post_without_known_button(kl, autor_with_mixed_works, jed_a, jed_b):
+    """POST bez 'confirm' ani 'preview' → spada do dolnego renderu (200)."""
+    response = kl.post(
+        _url(autor_with_mixed_works),
+        {"jednostka_z": jed_a.pk, "jednostka_do": jed_b.pk},
+    )
+    assert response.status_code == 200
+    assert response.context["preview"] is False
+    assert not PrzemapoaniePracAutora.objects.filter(
+        autor=autor_with_mixed_works
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_post_confirm_exception_shows_error(
+    kl, autor_with_mixed_works, jed_a, jed_b, monkeypatch
+):
+    """Wyjątek w transakcji → messages.error + render 200 (bez redirectu)."""
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("wybuch")
+
+    monkeypatch.setattr(
+        "przemapuj_prace_autora.views.PrzemapoaniePracAutora.objects.create",
+        boom,
+    )
+    response = kl.post(
+        _url(autor_with_mixed_works),
+        {"jednostka_z": jed_a.pk, "jednostka_do": jed_b.pk, "confirm": "1"},
+        follow=False,
+    )
+    assert response.status_code == 200
+    assert response.context["preview"] is False
+    msgs = [m.message for m in response.context["messages"]]
+    assert any("Wystąpił błąd podczas przemapowania prac" in m for m in msgs)
+    # Transakcja wycofana — log nie powstał
+    assert not PrzemapoaniePracAutora.objects.filter(
+        autor=autor_with_mixed_works
+    ).exists()

--- a/src/przemapuj_prace_autora/test_characterization_view.py
+++ b/src/przemapuj_prace_autora/test_characterization_view.py
@@ -1,6 +1,6 @@
 """Testy charakteryzujące widok ``przemapuj_prace``.
 
-Pinują bieżące zachowanie PRZED refaktorem (zdjęcie ``# noqa: C901``).
+Pinują bieżące zachowanie PRZED refaktorem (zdjęcie ``C901``).
 Pokrywają wszystkie gałęzie: GET, POST/preview, POST/confirm (valid +
 invalid + wyjątek w transakcji) oraz POST bez znanego przycisku.
 """

--- a/src/przemapuj_prace_autora/views.py
+++ b/src/przemapuj_prace_autora/views.py
@@ -32,19 +32,28 @@ def wybierz_autora(request):
     return render(request, "przemapuj_prace_autora/wybierz_autora.html", context)
 
 
-@login_required
-def przemapuj_prace(request, autor_id):  # noqa: C901
-    """Główny widok do przemapowania prac autora między jednostkami"""
-    autor = get_object_or_404(Autor, pk=autor_id)
+def _accumulate_jednostka_stats(stats_dict, stat, field):
+    """Wrzuć licznik prac danego typu (``field``) do agregatu per-jednostka."""
+    entry = stats_dict.setdefault(
+        stat["jednostka__id"],
+        {
+            "jednostka_nazwa": stat["jednostka__nazwa"],
+            "jednostka_skrot": stat["jednostka__skrot"],
+            "prace_ciagle": 0,
+            "prace_zwarte": 0,
+        },
+    )
+    entry[field] = stat["liczba"]
 
-    # Zbierz statystyki o pracach autora w różnych jednostkach
+
+def _build_jednostki_stats(autor):
+    """Zbuduj posortowaną listę statystyk prac autora per jednostka."""
     prace_ciagle_stats = (
         Wydawnictwo_Ciagle_Autor.objects.filter(autor=autor)
         .values("jednostka__id", "jednostka__nazwa", "jednostka__skrot")
         .annotate(liczba=Count("id"))
         .order_by("jednostka__nazwa")
     )
-
     prace_zwarte_stats = (
         Wydawnictwo_Zwarte_Autor.objects.filter(autor=autor)
         .values("jednostka__id", "jednostka__nazwa", "jednostka__skrot")
@@ -52,31 +61,12 @@ def przemapuj_prace(request, autor_id):  # noqa: C901
         .order_by("jednostka__nazwa")
     )
 
-    # Połącz statystyki
     stats_dict = {}
     for stat in prace_ciagle_stats:
-        jednostka_id = stat["jednostka__id"]
-        if jednostka_id not in stats_dict:
-            stats_dict[jednostka_id] = {
-                "jednostka_nazwa": stat["jednostka__nazwa"],
-                "jednostka_skrot": stat["jednostka__skrot"],
-                "prace_ciagle": 0,
-                "prace_zwarte": 0,
-            }
-        stats_dict[jednostka_id]["prace_ciagle"] = stat["liczba"]
-
+        _accumulate_jednostka_stats(stats_dict, stat, "prace_ciagle")
     for stat in prace_zwarte_stats:
-        jednostka_id = stat["jednostka__id"]
-        if jednostka_id not in stats_dict:
-            stats_dict[jednostka_id] = {
-                "jednostka_nazwa": stat["jednostka__nazwa"],
-                "jednostka_skrot": stat["jednostka__skrot"],
-                "prace_ciagle": 0,
-                "prace_zwarte": 0,
-            }
-        stats_dict[jednostka_id]["prace_zwarte"] = stat["liczba"]
+        _accumulate_jednostka_stats(stats_dict, stat, "prace_zwarte")
 
-    # Konwertuj na listę dla łatwiejszego użycia w template
     jednostki_stats = [
         {
             "id": jed_id,
@@ -89,139 +79,151 @@ def przemapuj_prace(request, autor_id):  # noqa: C901
         for jed_id, data in stats_dict.items()
     ]
     jednostki_stats.sort(key=lambda x: x["nazwa"])
+    return jednostki_stats
+
+
+def _historia_prac_ciaglych(prace_ciagle):
+    """Zbuduj historię prac ciągłych przed przemapowaniem."""
+    historia = []
+    for praca_autor in prace_ciagle:
+        rekord = praca_autor.rekord
+        historia.append(
+            {
+                "id": rekord.id,
+                "tytul": rekord.tytul_oryginalny,
+                "rok": rekord.rok,
+                "zrodlo": (
+                    str(rekord.zrodlo)
+                    if hasattr(rekord, "zrodlo") and rekord.zrodlo
+                    else None
+                ),
+            }
+        )
+    return historia
+
+
+def _historia_prac_zwartych(prace_zwarte):
+    """Zbuduj historię prac zwartych przed przemapowaniem."""
+    historia = []
+    for praca_autor in prace_zwarte:
+        rekord = praca_autor.rekord
+        historia.append(
+            {
+                "id": rekord.id,
+                "tytul": rekord.tytul_oryginalny,
+                "rok": rekord.rok,
+                "isbn": (rekord.isbn if hasattr(rekord, "isbn") else None),
+                "wydawnictwo": (
+                    rekord.wydawnictwo if hasattr(rekord, "wydawnictwo") else None
+                ),
+            }
+        )
+    return historia
+
+
+def _wykonaj_przemapowanie(request, autor, form):
+    """Wykonaj potwierdzone przemapowanie. Zwraca redirect lub ``None``.
+
+    ``None`` oznacza, że wystąpił błąd (komunikat już ustawiony) i widok ma
+    spaść do dolnego renderu.
+    """
+    jednostka_z = form.cleaned_data["jednostka_z"]
+    jednostka_do = form.cleaned_data["jednostka_do"]
+
+    try:
+        with transaction.atomic():
+            prace_ciagle = Wydawnictwo_Ciagle_Autor.objects.filter(
+                autor=autor, jednostka=jednostka_z
+            ).select_related("rekord")
+            prace_ciagle_historia = _historia_prac_ciaglych(prace_ciagle)
+            liczba_prac_ciaglych = len(prace_ciagle_historia)
+            prace_ciagle.update(jednostka=jednostka_do)
+
+            prace_zwarte = Wydawnictwo_Zwarte_Autor.objects.filter(
+                autor=autor, jednostka=jednostka_z
+            ).select_related("rekord")
+            prace_zwarte_historia = _historia_prac_zwartych(prace_zwarte)
+            liczba_prac_zwartych = len(prace_zwarte_historia)
+            prace_zwarte.update(jednostka=jednostka_do)
+
+            PrzemapoaniePracAutora.objects.create(
+                autor=autor,
+                jednostka_z=jednostka_z,
+                jednostka_do=jednostka_do,
+                liczba_prac_ciaglych=liczba_prac_ciaglych,
+                liczba_prac_zwartych=liczba_prac_zwartych,
+                utworzono_przez=request.user,
+                prace_ciagle_historia=prace_ciagle_historia,
+                prace_zwarte_historia=prace_zwarte_historia,
+            )
+
+            messages.success(
+                request,
+                f"Pomyślnie przemapowano {liczba_prac_ciaglych} prac ciągłych "
+                f"i {liczba_prac_zwartych} prac zwartych "
+                f'z jednostki "{jednostka_z}" do jednostki "{jednostka_do}".',
+            )
+
+            return redirect("przemapuj_prace_autora:przemapuj_prace", autor_id=autor.pk)
+
+    except Exception as e:
+        rollbar.report_exc_info(sys.exc_info())
+        messages.error(request, f"Wystąpił błąd podczas przemapowania prac: {str(e)}")
+    return None
+
+
+def _render_preview(request, autor, form, jednostki_stats):
+    """Wyrenderuj podgląd przemapowania dla poprawnego formularza."""
+    jednostka_z = form.cleaned_data["jednostka_z"]
+    jednostka_do = form.cleaned_data["jednostka_do"]
+
+    prace_ciagle = Wydawnictwo_Ciagle_Autor.objects.filter(
+        autor=autor, jednostka=jednostka_z
+    ).select_related("rekord")[:10]  # Pokaż pierwsze 10 jako przykład
+
+    prace_zwarte = Wydawnictwo_Zwarte_Autor.objects.filter(
+        autor=autor, jednostka=jednostka_z
+    ).select_related("rekord")[:10]  # Pokaż pierwsze 10 jako przykład
+
+    liczba_prac_ciaglych = Wydawnictwo_Ciagle_Autor.objects.filter(
+        autor=autor, jednostka=jednostka_z
+    ).count()
+
+    liczba_prac_zwartych = Wydawnictwo_Zwarte_Autor.objects.filter(
+        autor=autor, jednostka=jednostka_z
+    ).count()
+
+    context = {
+        "autor": autor,
+        "form": form,
+        "jednostki_stats": jednostki_stats,
+        "preview": True,
+        "jednostka_z": jednostka_z,
+        "jednostka_do": jednostka_do,
+        "prace_ciagle": prace_ciagle,
+        "prace_zwarte": prace_zwarte,
+        "liczba_prac_ciaglych": liczba_prac_ciaglych,
+        "liczba_prac_zwartych": liczba_prac_zwartych,
+        "total_count": liczba_prac_ciaglych + liczba_prac_zwartych,
+    }
+    return render(request, "przemapuj_prace_autora/przemapuj_prace.html", context)
+
+
+@login_required
+def przemapuj_prace(request, autor_id):
+    """Główny widok do przemapowania prac autora między jednostkami"""
+    autor = get_object_or_404(Autor, pk=autor_id)
+    jednostki_stats = _build_jednostki_stats(autor)
 
     if request.method == "POST":
         form = PrzemapoaniePracAutoraForm(request.POST, autor=autor)
 
-        if "confirm" in request.POST:
-            # Użytkownik potwierdził przemapowanie
-            if form.is_valid():
-                jednostka_z = form.cleaned_data["jednostka_z"]
-                jednostka_do = form.cleaned_data["jednostka_do"]
-
-                try:
-                    with transaction.atomic():
-                        # Zbierz informacje o pracach ciągłych przed przemapowaniem
-                        prace_ciagle = Wydawnictwo_Ciagle_Autor.objects.filter(
-                            autor=autor, jednostka=jednostka_z
-                        ).select_related("rekord")
-
-                        prace_ciagle_historia = []
-                        for praca_autor in prace_ciagle:
-                            prace_ciagle_historia.append(
-                                {
-                                    "id": praca_autor.rekord.id,
-                                    "tytul": praca_autor.rekord.tytul_oryginalny,
-                                    "rok": praca_autor.rekord.rok,
-                                    "zrodlo": (
-                                        str(praca_autor.rekord.zrodlo)
-                                        if hasattr(praca_autor.rekord, "zrodlo")
-                                        and praca_autor.rekord.zrodlo
-                                        else None
-                                    ),
-                                }
-                            )
-
-                        liczba_prac_ciaglych = len(prace_ciagle_historia)
-                        prace_ciagle.update(jednostka=jednostka_do)
-
-                        # Zbierz informacje o pracach zwartych przed przemapowaniem
-                        prace_zwarte = Wydawnictwo_Zwarte_Autor.objects.filter(
-                            autor=autor, jednostka=jednostka_z
-                        ).select_related("rekord")
-
-                        prace_zwarte_historia = []
-                        for praca_autor in prace_zwarte:
-                            prace_zwarte_historia.append(
-                                {
-                                    "id": praca_autor.rekord.id,
-                                    "tytul": praca_autor.rekord.tytul_oryginalny,
-                                    "rok": praca_autor.rekord.rok,
-                                    "isbn": (
-                                        praca_autor.rekord.isbn
-                                        if hasattr(praca_autor.rekord, "isbn")
-                                        else None
-                                    ),
-                                    "wydawnictwo": (
-                                        praca_autor.rekord.wydawnictwo
-                                        if hasattr(praca_autor.rekord, "wydawnictwo")
-                                        else None
-                                    ),
-                                }
-                            )
-
-                        liczba_prac_zwartych = len(prace_zwarte_historia)
-                        prace_zwarte.update(jednostka=jednostka_do)
-
-                        # Zapisz log operacji z historią
-                        PrzemapoaniePracAutora.objects.create(
-                            autor=autor,
-                            jednostka_z=jednostka_z,
-                            jednostka_do=jednostka_do,
-                            liczba_prac_ciaglych=liczba_prac_ciaglych,
-                            liczba_prac_zwartych=liczba_prac_zwartych,
-                            utworzono_przez=request.user,
-                            prace_ciagle_historia=prace_ciagle_historia,
-                            prace_zwarte_historia=prace_zwarte_historia,
-                        )
-
-                        messages.success(
-                            request,
-                            f"Pomyślnie przemapowano {liczba_prac_ciaglych} prac ciągłych "
-                            f"i {liczba_prac_zwartych} prac zwartych "
-                            f'z jednostki "{jednostka_z}" do jednostki "{jednostka_do}".',
-                        )
-
-                        return redirect(
-                            "przemapuj_prace_autora:przemapuj_prace", autor_id=autor.pk
-                        )
-
-                except Exception as e:
-                    rollbar.report_exc_info(sys.exc_info())
-                    messages.error(
-                        request, f"Wystąpił błąd podczas przemapowania prac: {str(e)}"
-                    )
-
-        elif "preview" in request.POST:
-            # Użytkownik chce zobaczyć podgląd
-            if form.is_valid():
-                jednostka_z = form.cleaned_data["jednostka_z"]
-                jednostka_do = form.cleaned_data["jednostka_do"]
-
-                # Pobierz prace do przemapowania
-                prace_ciagle = Wydawnictwo_Ciagle_Autor.objects.filter(
-                    autor=autor, jednostka=jednostka_z
-                ).select_related("rekord")[:10]  # Pokaż pierwsze 10 jako przykład
-
-                prace_zwarte = Wydawnictwo_Zwarte_Autor.objects.filter(
-                    autor=autor, jednostka=jednostka_z
-                ).select_related("rekord")[:10]  # Pokaż pierwsze 10 jako przykład
-
-                liczba_prac_ciaglych = Wydawnictwo_Ciagle_Autor.objects.filter(
-                    autor=autor, jednostka=jednostka_z
-                ).count()
-
-                liczba_prac_zwartych = Wydawnictwo_Zwarte_Autor.objects.filter(
-                    autor=autor, jednostka=jednostka_z
-                ).count()
-
-                context = {
-                    "autor": autor,
-                    "form": form,
-                    "jednostki_stats": jednostki_stats,
-                    "preview": True,
-                    "jednostka_z": jednostka_z,
-                    "jednostka_do": jednostka_do,
-                    "prace_ciagle": prace_ciagle,
-                    "prace_zwarte": prace_zwarte,
-                    "liczba_prac_ciaglych": liczba_prac_ciaglych,
-                    "liczba_prac_zwartych": liczba_prac_zwartych,
-                    "total_count": liczba_prac_ciaglych + liczba_prac_zwartych,
-                }
-                return render(
-                    request, "przemapuj_prace_autora/przemapuj_prace.html", context
-                )
-
+        if "confirm" in request.POST and form.is_valid():
+            response = _wykonaj_przemapowanie(request, autor, form)
+            if response is not None:
+                return response
+        elif "preview" in request.POST and form.is_valid():
+            return _render_preview(request, autor, form, jednostki_stats)
     else:
         form = PrzemapoaniePracAutoraForm(autor=autor)
 

--- a/src/przemapuj_zrodla_pbn/tests/test_przemapuj_zrodlo_characterization.py
+++ b/src/przemapuj_zrodla_pbn/tests/test_przemapuj_zrodlo_characterization.py
@@ -2,7 +2,7 @@
 Testy charakteryzujące (pinning) zachowanie widoku przemapuj_zrodlo.
 
 Utrwalają zachowanie ścieżek confirm/preview/typ_wyboru oraz walidacji przed
-refaktoryzacją zdejmującą # noqa: C901. Testy MUSZĄ przechodzić przeciw kodowi
+refaktoryzacją zdejmującą C901. Testy MUSZĄ przechodzić przeciw kodowi
 PRZED refaktoryzacją.
 """
 

--- a/src/przemapuj_zrodla_pbn/tests/test_przemapuj_zrodlo_characterization.py
+++ b/src/przemapuj_zrodla_pbn/tests/test_przemapuj_zrodlo_characterization.py
@@ -1,0 +1,242 @@
+"""
+Testy charakteryzujące (pinning) zachowanie widoku przemapuj_zrodlo.
+
+Utrwalają zachowanie ścieżek confirm/preview/typ_wyboru oraz walidacji przed
+refaktoryzacją zdejmującą # noqa: C901. Testy MUSZĄ przechodzić przeciw kodowi
+PRZED refaktoryzacją.
+"""
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.models import Wydawnictwo_Ciagle, Zrodlo
+from przemapuj_zrodla_pbn.models import PrzeMapowanieZrodla
+
+
+def _make_journal(**kwargs):
+    defaults = {
+        "title": "",
+        "issn": "",
+        "eissn": "",
+        "websiteLink": "",
+        "mniswId": None,
+    }
+    defaults.update(kwargs)
+    return baker.make("pbn_api.Journal", **defaults)
+
+
+@pytest.mark.django_db
+def test_view_odrzuca_zrodlo_ktore_nie_jest_deleted(client, django_user_model):
+    user = baker.make(django_user_model)
+    client.force_login(user)
+
+    journal_active = _make_journal(status="ACTIVE", title="Aktywne")
+    zrodlo = baker.make("bpp.Zrodlo", nazwa="Aktywne", pbn_uid=journal_active)
+
+    url = reverse(
+        "przemapuj_zrodla_pbn:przemapuj_zrodlo", kwargs={"zrodlo_id": zrodlo.pk}
+    )
+    response = client.get(url)
+
+    assert response.status_code == 302
+    assert response.url == reverse("przemapuj_zrodla_pbn:lista_skasowanych_zrodel")
+
+
+@pytest.mark.django_db
+def test_confirm_przemapowanie_na_istniejace_zrodlo(client, django_user_model):
+    user = baker.make(django_user_model)
+    client.force_login(user)
+
+    journal_deleted = _make_journal(status="DELETED", title="Stara", issn="1234-5678")
+    zrodlo_stare = baker.make(
+        "bpp.Zrodlo", nazwa="Stara", pbn_uid=journal_deleted, issn="1234-5678"
+    )
+
+    journal_active = _make_journal(
+        status="ACTIVE", title="Stara Nowa", issn="1234-5678", mniswId=999
+    )
+    zrodlo_nowe = baker.make(
+        "bpp.Zrodlo", nazwa="Stara Nowa", pbn_uid=journal_active, issn="1234-5678"
+    )
+
+    # Rekord powiązany ze starym źródłem
+    wc = baker.make("bpp.Wydawnictwo_Ciagle", zrodlo=zrodlo_stare)
+
+    url = reverse(
+        "przemapuj_zrodla_pbn:przemapuj_zrodlo",
+        kwargs={"zrodlo_id": zrodlo_stare.pk},
+    )
+    response = client.post(
+        url,
+        {
+            "typ_wyboru": "zrodlo",
+            "zrodlo_docelowe": zrodlo_nowe.pk,
+            "confirm": "1",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse("przemapuj_zrodla_pbn:lista_skasowanych_zrodel")
+
+    # Rekord przeniesiony na nowe źródło
+    wc.refresh_from_db()
+    assert wc.zrodlo_id == zrodlo_nowe.pk
+
+    # Log operacji utworzony
+    log = PrzeMapowanieZrodla.objects.filter(
+        zrodlo_stare=zrodlo_stare, zrodlo_nowe=zrodlo_nowe
+    ).first()
+    assert log is not None
+    assert log.liczba_rekordow == 1
+    assert log.utworzono_przez == user
+
+
+@pytest.mark.django_db
+def test_confirm_przemapowanie_na_journal_tworzy_nowe_zrodlo(client, django_user_model):
+    user = baker.make(django_user_model)
+    client.force_login(user)
+
+    # Rodzaj "czasopismo" jest wymagany przez ścieżkę journal.
+    from bpp.models import Rodzaj_Zrodla
+
+    Rodzaj_Zrodla.objects.get_or_create(nazwa="czasopismo")
+
+    journal_deleted = _make_journal(
+        status="DELETED", title="Stara JD", issn="2222-3333"
+    )
+    zrodlo_stare = baker.make(
+        "bpp.Zrodlo", nazwa="Stara JD", pbn_uid=journal_deleted, issn="2222-3333"
+    )
+
+    # Journal z PBN który NIE ma jeszcze odpowiednika w BPP
+    journal_target = _make_journal(
+        status="ACTIVE", title="Nowy Z PBN", issn="2222-3333", mniswId=7
+    )
+
+    baker.make("bpp.Wydawnictwo_Ciagle", zrodlo=zrodlo_stare)
+
+    url = reverse(
+        "przemapuj_zrodla_pbn:przemapuj_zrodlo",
+        kwargs={"zrodlo_id": zrodlo_stare.pk},
+    )
+    response = client.post(
+        url,
+        {
+            "typ_wyboru": "journal",
+            "journal_docelowy": str(journal_target.pk),
+            "confirm": "1",
+        },
+    )
+
+    assert response.status_code == 302
+    # Nowe źródło utworzone na podstawie journala
+    zrodlo_nowe = Zrodlo.objects.get(pbn_uid=journal_target)
+    assert zrodlo_nowe.nazwa == "Nowy Z PBN"
+    assert zrodlo_nowe.issn == "2222-3333"
+
+    # Rekordy przeniesione
+    assert Wydawnictwo_Ciagle.objects.filter(zrodlo=zrodlo_nowe).count() == 1
+
+
+@pytest.mark.django_db
+def test_confirm_cel_skasowany_jest_poza_sugestiami_wiec_formularz_niewalidny(
+    client, django_user_model
+):
+    # Cel skasowany w PBN NIE pojawia się w sugerowanym querysecie (zawiera
+    # tylko źródła z aktywnym PBN), więc wybór jest niewalidny dla formularza
+    # i widok renderuje stronę (200) bez przemapowania. Strażnik DELETED w
+    # widoku jest wewnętrznym zabezpieczeniem nieosiągalnym tą ścieżką.
+    user = baker.make(django_user_model)
+    client.force_login(user)
+
+    journal_deleted = _make_journal(status="DELETED", title="Stara", issn="9999-0000")
+    zrodlo_stare = baker.make(
+        "bpp.Zrodlo", nazwa="Stara", pbn_uid=journal_deleted, issn="9999-0000"
+    )
+
+    # Cel również skasowany w PBN
+    journal_deleted2 = _make_journal(
+        status="DELETED", title="Stara Cel", issn="9999-0000"
+    )
+    zrodlo_cel = baker.make(
+        "bpp.Zrodlo",
+        nazwa="Stara Cel",
+        pbn_uid=journal_deleted2,
+        issn="9999-0000",
+    )
+    wc = baker.make("bpp.Wydawnictwo_Ciagle", zrodlo=zrodlo_stare)
+
+    url = reverse(
+        "przemapuj_zrodla_pbn:przemapuj_zrodlo",
+        kwargs={"zrodlo_id": zrodlo_stare.pk},
+    )
+    response = client.post(
+        url,
+        {
+            "typ_wyboru": "zrodlo",
+            "zrodlo_docelowe": zrodlo_cel.pk,
+            "confirm": "1",
+        },
+    )
+
+    # Formularz niewalidny -> render strony (200), brak przemapowania
+    assert response.status_code == 200
+
+    # Rekord NIE przeniesiony
+    wc.refresh_from_db()
+    assert wc.zrodlo_id == zrodlo_stare.pk
+    assert not PrzeMapowanieZrodla.objects.filter(zrodlo_stare=zrodlo_stare).exists()
+
+
+@pytest.mark.django_db
+def test_confirm_z_niewalidnym_formularzem_renderuje_strone(client, django_user_model):
+    user = baker.make(django_user_model)
+    client.force_login(user)
+
+    journal_deleted = _make_journal(status="DELETED", title="Stara", issn="")
+    zrodlo_stare = baker.make("bpp.Zrodlo", nazwa="Stara", pbn_uid=journal_deleted)
+
+    url = reverse(
+        "przemapuj_zrodla_pbn:przemapuj_zrodlo",
+        kwargs={"zrodlo_id": zrodlo_stare.pk},
+    )
+    # confirm bez wybranego źródła -> formularz niewalidny -> render strony (200)
+    response = client.post(url, {"typ_wyboru": "zrodlo", "confirm": "1"})
+
+    assert response.status_code == 200
+    assert not PrzeMapowanieZrodla.objects.filter(zrodlo_stare=zrodlo_stare).exists()
+
+
+@pytest.mark.django_db
+def test_preview_journal_renderuje_podglad(client, django_user_model):
+    user = baker.make(django_user_model)
+    client.force_login(user)
+
+    journal_deleted = _make_journal(status="DELETED", title="Stara P", issn="1111-2222")
+    zrodlo_stare = baker.make(
+        "bpp.Zrodlo", nazwa="Stara P", pbn_uid=journal_deleted, issn="1111-2222"
+    )
+
+    journal_target = _make_journal(
+        status="ACTIVE", title="Stara P Nowa", issn="1111-2222", mniswId=7
+    )
+
+    url = reverse(
+        "przemapuj_zrodla_pbn:przemapuj_zrodlo",
+        kwargs={"zrodlo_id": zrodlo_stare.pk},
+    )
+    response = client.post(
+        url,
+        {
+            "typ_wyboru": "journal",
+            "journal_docelowy": str(journal_target.pk),
+            "preview": "1",
+        },
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Podgląd zmian" in content
+    # Tytuł docelowego journala pojawia się w podglądzie.
+    assert "Stara P Nowa" in content

--- a/src/przemapuj_zrodla_pbn/tests/test_znajdz_podobne_zrodla_characterization.py
+++ b/src/przemapuj_zrodla_pbn/tests/test_znajdz_podobne_zrodla_characterization.py
@@ -2,7 +2,7 @@
 Testy charakteryzujące (pinning) zachowanie funkcji znajdz_podobne_zrodla.
 
 Celem tych testów jest UTRWALENIE obecnego zachowania scoringu źródeł przed
-refaktoryzacją zdejmującą # noqa: C901. Pinujemy dla reprezentatywnych wejść:
+refaktoryzacją zdejmującą C901. Pinujemy dla reprezentatywnych wejść:
 - do której kategorii (najlepsze/dobre/akceptowalne) trafia dopasowanie,
 - jaki ma typ dopasowania (reason) oraz dokładny score,
 - kolejność i obcinanie wyników do max_results.

--- a/src/przemapuj_zrodla_pbn/tests/test_znajdz_podobne_zrodla_characterization.py
+++ b/src/przemapuj_zrodla_pbn/tests/test_znajdz_podobne_zrodla_characterization.py
@@ -1,0 +1,340 @@
+"""
+Testy charakteryzujące (pinning) zachowanie funkcji znajdz_podobne_zrodla.
+
+Celem tych testów jest UTRWALENIE obecnego zachowania scoringu źródeł przed
+refaktoryzacją zdejmującą # noqa: C901. Pinujemy dla reprezentatywnych wejść:
+- do której kategorii (najlepsze/dobre/akceptowalne) trafia dopasowanie,
+- jaki ma typ dopasowania (reason) oraz dokładny score,
+- kolejność i obcinanie wyników do max_results.
+
+To NIE jest TDD red-green: testy MUSZĄ przechodzić przeciw kodowi PRZED
+refaktoryzacją. Jeśli któryś opisuje zachowanie błędnie — poprawiamy TEST,
+nie kod (zachowujemy zachowanie 1:1).
+"""
+
+import pytest
+from model_bakery import baker
+
+from przemapuj_zrodla_pbn.views import znajdz_podobne_zrodla
+
+
+def _make_journal(**kwargs):
+    defaults = {
+        "title": "",
+        "issn": "",
+        "eissn": "",
+        "websiteLink": "",
+        "mniswId": None,
+    }
+    defaults.update(kwargs)
+    return baker.make("pbn_api.Journal", **defaults)
+
+
+def _znajdz_item(lista, obj):
+    """Zwróć krotkę (obj, reason, score) dla danego obiektu z listy wyników."""
+    for item in lista:
+        if item[0].pk == obj.pk:
+            return item
+    return None
+
+
+# --- CZĘŚĆ 1: TABELA ZRODLO (zrodla_bpp) ---------------------------------
+
+
+@pytest.mark.django_db
+def test_zrodlo_issn_nazwa_z_mniswid_trafia_do_najlepsze():
+    skasowane = _make_journal(status="DELETED", title="Foo", issn="1111-1111")
+
+    aktywne = _make_journal(status="ACTIVE", title="X", issn="1111-1111", mniswId=999)
+    zrodlo = baker.make(
+        "bpp.Zrodlo", nazwa="Foo Bar", issn="1111-1111", pbn_uid=aktywne
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["zrodla_bpp"]["najlepsze"], zrodlo)
+    assert item is not None
+    assert item[1] == "ISSN+NAZWA"
+    assert item[2] == 1.0
+    # Nie powinien wpaść do innych kategorii
+    assert _znajdz_item(results["zrodla_bpp"]["dobre"], zrodlo) is None
+    assert _znajdz_item(results["zrodla_bpp"]["akceptowalne"], zrodlo) is None
+
+
+@pytest.mark.django_db
+def test_zrodlo_issn_nazwa_bez_mniswid_trafia_do_dobre():
+    skasowane = _make_journal(status="DELETED", title="Foo", issn="1111-1111")
+
+    aktywne = _make_journal(status="ACTIVE", title="X", issn="1111-1111", mniswId=None)
+    zrodlo = baker.make(
+        "bpp.Zrodlo", nazwa="Foo Bar", issn="1111-1111", pbn_uid=aktywne
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["zrodla_bpp"]["dobre"], zrodlo)
+    assert item is not None
+    assert item[1] == "ISSN+NAZWA"
+    assert item[2] == 1.0
+    assert _znajdz_item(results["zrodla_bpp"]["najlepsze"], zrodlo) is None
+
+
+@pytest.mark.django_db
+def test_zrodlo_sam_issn_bez_pasujacej_nazwy_trafia_do_dobre():
+    skasowane = _make_journal(status="DELETED", title="Foo", issn="2222-2222")
+
+    aktywne = _make_journal(status="ACTIVE", title="X", issn="2222-2222", mniswId=999)
+    zrodlo = baker.make(
+        "bpp.Zrodlo",
+        nazwa="Zupelnie Inna Nazwa",
+        issn="2222-2222",
+        pbn_uid=aktywne,
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["zrodla_bpp"]["dobre"], zrodlo)
+    assert item is not None
+    assert item[1] == "ISSN"
+    assert item[2] == 0.9
+    assert _znajdz_item(results["zrodla_bpp"]["najlepsze"], zrodlo) is None
+
+
+@pytest.mark.django_db
+def test_zrodlo_prefix_bez_issn_match_trafia_do_dobre():
+    skasowane = _make_journal(status="DELETED", title="Unikat", issn="", eissn="")
+
+    aktywne = _make_journal(status="ACTIVE", title="X", mniswId=999)
+    zrodlo = baker.make(
+        "bpp.Zrodlo", nazwa="Unikat Czasopismo", issn="", pbn_uid=aktywne
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["zrodla_bpp"]["dobre"], zrodlo)
+    assert item is not None
+    assert item[1] == "PREFIX"
+    assert item[2] == 0.8
+    assert _znajdz_item(results["zrodla_bpp"]["najlepsze"], zrodlo) is None
+
+
+@pytest.mark.django_db
+def test_zrodlo_similarity_bez_mniswid_trafia_do_akceptowalne():
+    skasowane = _make_journal(
+        status="DELETED", title="Aaaa Bbbb Cccc Dddd Eeee", issn=""
+    )
+
+    aktywne = _make_journal(status="ACTIVE", title="X", mniswId=None)
+    # Nazwa podobna ale NIE zaczynająca się od szukanego (różnica na końcu),
+    # więc trafi do scoringu SIMILARITY, nie PREFIX.
+    zrodlo = baker.make(
+        "bpp.Zrodlo", nazwa="Aaaa Bbbb Cccc Dddd EeeX", issn="", pbn_uid=aktywne
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["zrodla_bpp"]["akceptowalne"], zrodlo)
+    assert item is not None
+    assert item[1] == "SIMILARITY"
+    assert item[2] >= 0.5
+    assert _znajdz_item(results["zrodla_bpp"]["dobre"], zrodlo) is None
+
+
+@pytest.mark.django_db
+def test_zrodlo_similarity_z_mniswid_powyzej_07_trafia_do_dobre():
+    skasowane = _make_journal(
+        status="DELETED",
+        title="Czasopismo Naukowe Uniwersytetu Warszawskiego",
+        issn="",
+    )
+
+    aktywne = _make_journal(status="ACTIVE", title="X", mniswId=999)
+    # Jeden znak różnicy w ~45 znakach -> podobieństwo >> 0.7, ale nie prefix.
+    zrodlo = baker.make(
+        "bpp.Zrodlo",
+        nazwa="Czasopismo Naukowe Uniwersytetu WarszawskiegX",
+        issn="",
+        pbn_uid=aktywne,
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["zrodla_bpp"]["dobre"], zrodlo)
+    assert item is not None
+    assert item[1] == "SIMILARITY"
+    assert item[2] > 0.7
+    assert _znajdz_item(results["zrodla_bpp"]["akceptowalne"], zrodlo) is None
+
+
+@pytest.mark.django_db
+def test_nazwa_do_wyszukania_pochodzi_z_zrodla_skasowanego_gdy_istnieje():
+    skasowane = _make_journal(status="DELETED", title="Tytul Z PBN", issn="", eissn="")
+    # Źródło BPP wskazujące na skasowany journal -> nazwa BPP nadpisuje tytuł PBN.
+    baker.make("bpp.Zrodlo", nazwa="Nazwa Z Bpp", pbn_uid=skasowane)
+
+    aktywne = _make_journal(status="ACTIVE", title="X", mniswId=999)
+    # Pasuje prefixem do nazwy BPP ("Nazwa Z Bpp"), a NIE do tytułu PBN.
+    zrodlo = baker.make(
+        "bpp.Zrodlo", nazwa="Nazwa Z Bpp Extra", issn="", pbn_uid=aktywne
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["zrodla_bpp"]["dobre"], zrodlo)
+    assert item is not None
+    assert item[1] == "PREFIX"
+
+
+# --- CZĘŚĆ 2: TABELA JOURNAL (journale_pbn) ------------------------------
+
+
+@pytest.mark.django_db
+def test_journal_issn_nazwa_z_mniswid_trafia_do_najlepsze():
+    skasowane = _make_journal(status="DELETED", title="Jrnl", issn="3333-3333")
+
+    kandydat = _make_journal(
+        status="ACTIVE", title="Jrnl Plus", issn="3333-3333", mniswId=5
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["journale_pbn"]["najlepsze"], kandydat)
+    assert item is not None
+    assert item[1] == "ISSN+NAZWA"
+    assert item[2] == 1.0
+    assert _znajdz_item(results["journale_pbn"]["dobre"], kandydat) is None
+
+
+@pytest.mark.django_db
+def test_journal_issn_nazwa_bez_mniswid_trafia_do_dobre():
+    skasowane = _make_journal(status="DELETED", title="Jrnl", issn="3333-3334")
+
+    kandydat = _make_journal(
+        status="ACTIVE", title="Jrnl Plus", issn="3333-3334", mniswId=None
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["journale_pbn"]["dobre"], kandydat)
+    assert item is not None
+    assert item[1] == "ISSN+NAZWA"
+    assert item[2] == 1.0
+    assert _znajdz_item(results["journale_pbn"]["najlepsze"], kandydat) is None
+
+
+@pytest.mark.django_db
+def test_journal_sam_issn_trafia_do_dobre():
+    skasowane = _make_journal(status="DELETED", title="Jrnl", issn="4444-4444")
+
+    kandydat = _make_journal(
+        status="ACTIVE", title="Inna Nazwa Calkiem", issn="4444-4444", mniswId=5
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["journale_pbn"]["dobre"], kandydat)
+    assert item is not None
+    assert item[1] == "ISSN"
+    assert item[2] == 0.9
+    assert _znajdz_item(results["journale_pbn"]["najlepsze"], kandydat) is None
+
+
+@pytest.mark.django_db
+def test_journal_prefix_bez_issn_trafia_do_dobre():
+    skasowane = _make_journal(status="DELETED", title="Pref", issn="", eissn="")
+
+    kandydat = _make_journal(status="ACTIVE", title="Pref Journal", issn="", mniswId=5)
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["journale_pbn"]["dobre"], kandydat)
+    assert item is not None
+    assert item[1] == "PREFIX"
+    assert item[2] == 0.8
+    assert _znajdz_item(results["journale_pbn"]["najlepsze"], kandydat) is None
+
+
+@pytest.mark.django_db
+def test_journal_similarity_bez_mniswid_trafia_do_akceptowalne():
+    skasowane = _make_journal(
+        status="DELETED", title="Zzzz Yyyy Xxxx Wwww Vvvv", issn=""
+    )
+
+    kandydat = _make_journal(
+        status="ACTIVE", title="Zzzz Yyyy Xxxx Wwww VvvX", issn="", mniswId=None
+    )
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    item = _znajdz_item(results["journale_pbn"]["akceptowalne"], kandydat)
+    assert item is not None
+    assert item[1] == "SIMILARITY"
+    assert item[2] >= 0.5
+    assert _znajdz_item(results["journale_pbn"]["dobre"], kandydat) is None
+
+
+@pytest.mark.django_db
+def test_journal_juz_w_bpp_jest_pomijany():
+    skasowane = _make_journal(status="DELETED", title="Jrnl", issn="5555-5555")
+
+    kandydat = _make_journal(
+        status="ACTIVE", title="Jrnl Plus", issn="5555-5555", mniswId=5
+    )
+    # Journal który ma już odpowiednik w BPP -> NIE pojawia się w journale_pbn.
+    baker.make("bpp.Zrodlo", nazwa="Jrnl Plus", issn="5555-5555", pbn_uid=kandydat)
+
+    results = znajdz_podobne_zrodla(skasowane)
+
+    for subcat in ("najlepsze", "dobre", "akceptowalne"):
+        assert _znajdz_item(results["journale_pbn"][subcat], kandydat) is None
+
+
+# --- SORTOWANIE I OBCINANIE ---------------------------------------------
+
+
+@pytest.mark.django_db
+def test_kategorie_sa_sortowane_malejaco_po_score():
+    skasowane = _make_journal(status="DELETED", title="Foo", issn="6666-6666")
+
+    a = _make_journal(status="ACTIVE", title="X", issn="6666-6666", mniswId=None)
+    # ISSN+NAZWA -> 1.0
+    z_wysoki = baker.make(
+        "bpp.Zrodlo", nazwa="Foo Najlepszy", issn="6666-6666", pbn_uid=a
+    )
+    b = _make_journal(status="ACTIVE", title="Y", issn="6666-6666", mniswId=None)
+    # sam ISSN -> 0.9
+    z_nizszy = baker.make("bpp.Zrodlo", nazwa="Inny Tytul", issn="6666-6666", pbn_uid=b)
+
+    results = znajdz_podobne_zrodla(skasowane)
+    dobre = results["zrodla_bpp"]["dobre"]
+    scores = [item[2] for item in dobre]
+    assert scores == sorted(scores, reverse=True)
+    # Wyższy score przed niższym
+    idx_wysoki = next(i for i, it in enumerate(dobre) if it[0].pk == z_wysoki.pk)
+    idx_nizszy = next(i for i, it in enumerate(dobre) if it[0].pk == z_nizszy.pk)
+    assert idx_wysoki < idx_nizszy
+
+
+@pytest.mark.django_db
+def test_max_results_obcina_kategorie():
+    skasowane = _make_journal(status="DELETED", title="Foo", issn="7777-7777")
+
+    for i in range(4):
+        a = _make_journal(
+            status="ACTIVE", title=f"X{i}", issn="7777-7777", mniswId=None
+        )
+        baker.make("bpp.Zrodlo", nazwa=f"Rozne {i}", issn="7777-7777", pbn_uid=a)
+
+    results = znajdz_podobne_zrodla(skasowane, max_results=2)
+    assert len(results["zrodla_bpp"]["dobre"]) == 2
+
+
+@pytest.mark.django_db
+def test_struktura_wynikow_zawiera_obie_kategorie_glowne():
+    skasowane = _make_journal(status="DELETED", title="Cos", issn="")
+    results = znajdz_podobne_zrodla(skasowane)
+    assert set(results.keys()) == {"zrodla_bpp", "journale_pbn"}
+    for glowna in results.values():
+        assert set(glowna.keys()) == {"najlepsze", "dobre", "akceptowalne"}
+        for lista in glowna.values():
+            assert isinstance(lista, list)

--- a/src/przemapuj_zrodla_pbn/views.py
+++ b/src/przemapuj_zrodla_pbn/views.py
@@ -206,7 +206,109 @@ def find_journals_by_trigram(title, exclude_existing=True, min_similarity=0.5):
     )
 
 
-def znajdz_podobne_zrodla(journal_skasowane, max_results=10):  # noqa: C901
+def _dodaj_issn_dopasowania(
+    matches, nazwa_do_wyszukania, name_attr, has_mnisw, bucket, max_results, seen_ids
+):
+    """Krok ISSN/e-ISSN: rozdziel na (ISSN+NAZWA) i (sam ISSN) i wrzuć do koszyka.
+
+    - ISSN+NAZWA (score 1.0): "najlepsze" gdy ma mniswId, inaczej "dobre".
+    - sam ISSN (score 0.9): zawsze "dobre".
+    """
+    issn_nazwa = []
+    issn_only = []
+    for obj in matches:
+        if obj.pk in seen_ids:
+            continue
+        nazwa_obj = getattr(obj, name_attr)
+        if nazwa_do_wyszukania and nazwa_obj.lower().startswith(
+            nazwa_do_wyszukania.lower()
+        ):
+            issn_nazwa.append(obj)
+        else:
+            issn_only.append(obj)
+
+    for obj in issn_nazwa[:max_results]:
+        seen_ids.add(obj.pk)
+        item = (obj, "ISSN+NAZWA", 1.0)
+        if has_mnisw(obj):
+            bucket["najlepsze"].append(item)
+        else:
+            bucket["dobre"].append(item)
+
+    for obj in issn_only[:max_results]:
+        seen_ids.add(obj.pk)
+        bucket["dobre"].append((obj, "ISSN", 0.9))
+
+
+def _dodaj_prefix_dopasowania(matches, has_mnisw, issn_match, bucket, seen_ids):
+    """Krok PREFIX (score 0.8): "najlepsze" tylko gdy ISSN się zgadza i jest
+    mniswId, w przeciwnym razie "dobre"."""
+    for obj in matches:
+        if obj.pk in seen_ids:
+            continue
+        seen_ids.add(obj.pk)
+        item = (obj, "PREFIX", 0.8)
+        if issn_match(obj) and has_mnisw(obj):
+            bucket["najlepsze"].append(item)
+        else:
+            bucket["dobre"].append(item)
+
+
+def _dodaj_similarity_dopasowania(matches, has_mnisw, bucket, seen_ids):
+    """Krok SIMILARITY: "dobre" gdy ma mniswId i podobieństwo > 0.7, inaczej
+    "akceptowalne"."""
+    for obj in matches:
+        if obj.pk in seen_ids:
+            continue
+        seen_ids.add(obj.pk)
+        podobienstwo = getattr(obj, "similarity", 0.5)
+        item = (obj, "SIMILARITY", podobienstwo)
+        if has_mnisw(obj) and podobienstwo > 0.7:
+            bucket["dobre"].append(item)
+        else:
+            bucket["akceptowalne"].append(item)
+
+
+def _przetworz_strone(
+    *,
+    bucket,
+    nazwa_do_wyszukania,
+    name_attr,
+    has_mnisw,
+    issn_match,
+    issn_matches,
+    finder_prefix,
+    finder_trigram,
+    max_results,
+):
+    """Wykonaj trzy kroki scoringu (ISSN, PREFIX, SIMILARITY) dla jednej tabeli."""
+    seen_ids = set()
+    _dodaj_issn_dopasowania(
+        issn_matches,
+        nazwa_do_wyszukania,
+        name_attr,
+        has_mnisw,
+        bucket,
+        max_results,
+        seen_ids,
+    )
+    if nazwa_do_wyszukania:
+        _dodaj_prefix_dopasowania(
+            finder_prefix(nazwa_do_wyszukania)[:max_results],
+            has_mnisw,
+            issn_match,
+            bucket,
+            seen_ids,
+        )
+        _dodaj_similarity_dopasowania(
+            finder_trigram(nazwa_do_wyszukania)[:max_results],
+            has_mnisw,
+            bucket,
+            seen_ids,
+        )
+
+
+def znajdz_podobne_zrodla(journal_skasowane, max_results=10):
     """
     Znajduje podobne źródła dla skasowanego czasopisma w PBN.
     Szuka w DWÓCH tabelach: Zrodlo (źródła w BPP) i Journal (źródła PBN które NIE są w BPP).
@@ -236,168 +338,58 @@ def znajdz_podobne_zrodla(journal_skasowane, max_results=10):  # noqa: C901
         pass
 
     # CZĘŚĆ 1: SZUKANIE W TABELI ZRODLO (źródła już w BPP)
-    znalezione_zrodla_ids = set()
+    def zrodlo_has_mnisw(zrodlo):
+        return bool(zrodlo.pbn_uid and zrodlo.pbn_uid.mniswId)
 
-    # 1.1. Szukaj po ISSN/e-ISSN w Zrodlo
-    # Pobierz wszystkie aby znaleźć te które mają pasującą nazwę
-    issn_matches = find_by_issn(journal_skasowane, exclude_id=zrodlo_skasowane_id)
+    def zrodlo_issn_match(zrodlo):
+        # PREFIX może być "najlepsze" TYLKO gdy ISSN się zgadza i mamy
+        # skasowane źródło w BPP do porównania.
+        if not (zrodlo_skasowane and journal_skasowane):
+            return False
+        return bool(
+            (journal_skasowane.issn and zrodlo.issn == journal_skasowane.issn)
+            or (journal_skasowane.eissn and zrodlo.e_issn == journal_skasowane.eissn)
+        )
 
-    # Najpierw zbierz te które mają pasującą nazwę + ISSN
-    issn_nazwa_matches_zrodla = []
-    issn_only_matches_zrodla = []
-
-    for zrodlo in issn_matches:
-        if zrodlo.pk not in znalezione_zrodla_ids:
-            # Sprawdź czy nazwa też się zgadza
-            if nazwa_do_wyszukania and zrodlo.nazwa.lower().startswith(
-                nazwa_do_wyszukania.lower()
-            ):
-                issn_nazwa_matches_zrodla.append(zrodlo)
-            else:
-                issn_only_matches_zrodla.append(zrodlo)
-
-    # Dodaj najpierw te z pasującą nazwą (najlepsze dopasowania)
-    for zrodlo in issn_nazwa_matches_zrodla[:max_results]:
-        znalezione_zrodla_ids.add(zrodlo.pk)
-        item = (zrodlo, "ISSN+NAZWA", 1.0)
-        if zrodlo.pbn_uid and zrodlo.pbn_uid.mniswId:
-            results["zrodla_bpp"]["najlepsze"].append(item)
-        else:
-            results["zrodla_bpp"]["dobre"].append(item)
-
-    # Potem dodaj te z samym ISSN (dobre dopasowania)
-    for zrodlo in issn_only_matches_zrodla[:max_results]:
-        znalezione_zrodla_ids.add(zrodlo.pk)
-        item = (zrodlo, "ISSN", 0.9)
-        results["zrodla_bpp"]["dobre"].append(item)
-
-    # 1.2. Szukaj po prefiksie nazwy w Zrodlo
-    if nazwa_do_wyszukania:
-        prefix_matches = find_by_name_prefix(
-            nazwa_do_wyszukania, exclude_id=zrodlo_skasowane_id
-        )[:max_results]
-
-        for zrodlo in prefix_matches:
-            if zrodlo.pk not in znalezione_zrodla_ids:
-                znalezione_zrodla_ids.add(zrodlo.pk)
-                item = (zrodlo, "PREFIX", 0.8)
-
-                # PREFIX może być najlepsze TYLKO jeśli ISSN się zgadza
-                issn_match = False
-                if zrodlo_skasowane and journal_skasowane:
-                    if (
-                        journal_skasowane.issn and zrodlo.issn == journal_skasowane.issn
-                    ) or (
-                        journal_skasowane.eissn
-                        and zrodlo.e_issn == journal_skasowane.eissn
-                    ):
-                        issn_match = True
-
-                if issn_match and zrodlo.pbn_uid and zrodlo.pbn_uid.mniswId:
-                    results["zrodla_bpp"]["najlepsze"].append(item)
-                else:
-                    results["zrodla_bpp"]["dobre"].append(item)
-
-    # 1.3. Szukaj po podobieństwie w Zrodlo
-    if nazwa_do_wyszukania:
-        similarity_matches = find_by_trigram(
-            nazwa_do_wyszukania, exclude_id=zrodlo_skasowane_id, min_similarity=0.5
-        )[:max_results]
-
-        for zrodlo in similarity_matches:
-            if zrodlo.pk not in znalezione_zrodla_ids:
-                znalezione_zrodla_ids.add(zrodlo.pk)
-                podobienstwo = getattr(zrodlo, "similarity", 0.5)
-                item = (zrodlo, "SIMILARITY", podobienstwo)
-
-                if zrodlo.pbn_uid and zrodlo.pbn_uid.mniswId and podobienstwo > 0.7:
-                    results["zrodla_bpp"]["dobre"].append(item)
-                else:
-                    results["zrodla_bpp"]["akceptowalne"].append(item)
+    _przetworz_strone(
+        bucket=results["zrodla_bpp"],
+        nazwa_do_wyszukania=nazwa_do_wyszukania,
+        name_attr="nazwa",
+        has_mnisw=zrodlo_has_mnisw,
+        issn_match=zrodlo_issn_match,
+        issn_matches=find_by_issn(journal_skasowane, exclude_id=zrodlo_skasowane_id),
+        finder_prefix=lambda nazwa: find_by_name_prefix(
+            nazwa, exclude_id=zrodlo_skasowane_id
+        ),
+        finder_trigram=lambda nazwa: find_by_trigram(
+            nazwa, exclude_id=zrodlo_skasowane_id, min_similarity=0.5
+        ),
+        max_results=max_results,
+    )
 
     # CZĘŚĆ 2: SZUKANIE W TABELI JOURNAL (źródła PBN które NIE są w BPP)
-    znalezione_journal_ids = set()
+    def journal_has_mnisw(journal):
+        return bool(journal.mniswId)
 
-    # 2.1. Szukaj po ISSN/e-ISSN w Journal
-    # Pobierz wszystkie aby znaleźć te które mają pasującą nazwę
-    journal_issn_matches = find_journals_by_issn(journal_skasowane)
+    def journal_issn_match(journal):
+        if not journal_skasowane:
+            return False
+        return bool(
+            (journal_skasowane.issn and journal.issn == journal_skasowane.issn)
+            or (journal_skasowane.eissn and journal.eissn == journal_skasowane.eissn)
+        )
 
-    # Najpierw zbierz te które mają pasującą nazwę + ISSN
-    issn_nazwa_matches = []
-    issn_only_matches = []
-
-    for journal in journal_issn_matches:
-        if journal.pk not in znalezione_journal_ids:
-            # Sprawdź czy nazwa też się zgadza
-            if nazwa_do_wyszukania and journal.title.lower().startswith(
-                nazwa_do_wyszukania.lower()
-            ):
-                issn_nazwa_matches.append(journal)
-            else:
-                issn_only_matches.append(journal)
-
-    # Dodaj najpierw te z pasującą nazwą (najlepsze dopasowania)
-    for journal in issn_nazwa_matches[:max_results]:
-        znalezione_journal_ids.add(journal.pk)
-        item = (journal, "ISSN+NAZWA", 1.0)
-        if journal.mniswId:
-            results["journale_pbn"]["najlepsze"].append(item)
-        else:
-            results["journale_pbn"]["dobre"].append(item)
-
-    # Potem dodaj te z samym ISSN (dobre dopasowania)
-    for journal in issn_only_matches[:max_results]:
-        znalezione_journal_ids.add(journal.pk)
-        item = (journal, "ISSN", 0.9)
-        results["journale_pbn"]["dobre"].append(item)
-
-    # 2.2. Szukaj po prefiksie tytułu w Journal
-    if nazwa_do_wyszukania:
-        journal_prefix_matches = find_journals_by_prefix(nazwa_do_wyszukania)[
-            :max_results
-        ]
-
-        for journal in journal_prefix_matches:
-            if journal.pk not in znalezione_journal_ids:
-                znalezione_journal_ids.add(journal.pk)
-                item = (journal, "PREFIX", 0.8)
-
-                # PREFIX może być najlepsze TYLKO jeśli ISSN się zgadza
-                issn_match = False
-                if journal_skasowane:
-                    if (
-                        journal_skasowane.issn
-                        and journal.issn == journal_skasowane.issn
-                    ) or (
-                        journal_skasowane.eissn
-                        and journal.eissn == journal_skasowane.eissn
-                    ):
-                        issn_match = True
-
-                if issn_match and journal.mniswId:
-                    results["journale_pbn"]["najlepsze"].append(item)
-                elif journal.mniswId:
-                    # Jeśli ma mniswId ale ISSN się nie zgadza - to "dobre" nie "najlepsze"
-                    results["journale_pbn"]["dobre"].append(item)
-                else:
-                    results["journale_pbn"]["dobre"].append(item)
-
-    # 2.3. Szukaj po podobieństwie w Journal
-    if nazwa_do_wyszukania:
-        journal_similarity_matches = find_journals_by_trigram(nazwa_do_wyszukania)[
-            :max_results
-        ]
-
-        for journal in journal_similarity_matches:
-            if journal.pk not in znalezione_journal_ids:
-                znalezione_journal_ids.add(journal.pk)
-                podobienstwo = getattr(journal, "similarity", 0.5)
-                item = (journal, "SIMILARITY", podobienstwo)
-
-                if journal.mniswId and podobienstwo > 0.7:
-                    results["journale_pbn"]["dobre"].append(item)
-                else:
-                    results["journale_pbn"]["akceptowalne"].append(item)
+    _przetworz_strone(
+        bucket=results["journale_pbn"],
+        nazwa_do_wyszukania=nazwa_do_wyszukania,
+        name_attr="title",
+        has_mnisw=journal_has_mnisw,
+        issn_match=journal_issn_match,
+        issn_matches=find_journals_by_issn(journal_skasowane),
+        finder_prefix=find_journals_by_prefix,
+        finder_trigram=find_journals_by_trigram,
+        max_results=max_results,
+    )
 
     # Ogranicz każdą kategorię do max_results i posortuj po podobieństwie
     for main_category in results.values():
@@ -434,8 +426,195 @@ def lista_skasowanych_zrodel(request):
     )
 
 
+def _zbuduj_sugerowane_queryset(sugerowane, zrodlo):
+    """Zbuduj queryset źródeł BPP do formularza na podstawie sugestii.
+
+    Gdy są sugestie - ogranicz do nich; w przeciwnym razie pokaż do 20
+    aktywnych źródeł (najpierw z mniswId, potem alfabetycznie)."""
+    wszystkie_zrodla = []
+    for kategoria in ["najlepsze", "dobre", "akceptowalne"]:
+        wszystkie_zrodla.extend(sugerowane["zrodla_bpp"][kategoria])
+
+    if wszystkie_zrodla:
+        # Struktura krotki: (zrodlo, typ_dopasowania, podobienstwo)
+        sugerowane_ids = [item[0].pk for item in wszystkie_zrodla]
+        return Zrodlo.objects.filter(pk__in=sugerowane_ids)
+
+    # Brak sugestii - pokaż wszystkie aktywne źródła
+    return (
+        Zrodlo.objects.filter(pbn_uid__status=ACTIVE)
+        .select_related("pbn_uid")
+        .order_by(
+            models.Case(
+                models.When(pbn_uid__mniswId__isnull=False, then=0),
+                default=1,
+            ),
+            "nazwa",
+        )[:20]
+    )
+
+
+def _zbierz_wszystkie_journale(sugerowane):
+    """Spłaszcz wszystkie sugerowane journale PBN do jednej listy."""
+    wszystkie_journale = []
+    for kategoria in ["najlepsze", "dobre", "akceptowalne"]:
+        wszystkie_journale.extend(sugerowane["journale_pbn"][kategoria])
+    return wszystkie_journale
+
+
+def _utworz_zrodlo_z_journala(request, journal_docelowy):
+    """Utwórz nowe Zrodlo na podstawie wybranego Journal z PBN."""
+    rodzaj_czasopismo = Rodzaj_Zrodla.objects.get(nazwa="czasopismo")
+    zrodlo_nowe = Zrodlo.objects.create(
+        nazwa=journal_docelowy.title or "",
+        issn=journal_docelowy.issn or "",
+        e_issn=journal_docelowy.eissn or "",
+        pbn_uid=journal_docelowy,
+        rodzaj=rodzaj_czasopismo,
+    )
+    messages.info(
+        request,
+        f'Utworzono nowe źródło "{zrodlo_nowe.nazwa}" na podstawie danych z PBN.',
+    )
+    return zrodlo_nowe
+
+
+def _zbierz_rekordy_do_przemapowania(zrodlo):
+    """Zbierz historię i oryginalne rekordy przed przemapowaniem źródła."""
+    rekordy_historia = []
+    rekordy_do_wyslania = []
+    for rekord in Rekord.objects.filter(zrodlo=zrodlo):
+        rekordy_historia.append(
+            {
+                "id": list(rekord.pk),
+                "tytul": rekord.tytul_oryginalny,
+                "rok": rekord.rok,
+                "opis_bibliograficzny": rekord.opis_bibliograficzny_cache or "",
+            }
+        )
+        rekordy_do_wyslania.append(rekord.original)
+    return rekordy_historia, rekordy_do_wyslania
+
+
+def _dodaj_rekordy_do_kolejki_pbn(request, rekordy_do_wyslania):
+    """Dodaj rekordy do kolejki eksportu PBN, zwracając (sukces, lista_bledow)."""
+    sukces_pbn = 0
+    bledy_pbn = []
+    for original_rekord in rekordy_do_wyslania:
+        try:
+            PBN_Export_Queue.objects.sprobuj_utowrzyc_wpis(
+                user=request.user, rekord=original_rekord
+            )
+            sukces_pbn += 1
+        except Exception as e:
+            zaloguj_polkniety_wyjatek(
+                f"Dodawanie rekordu do kolejki eksportu PBN "
+                f"przy przemapowaniu źródła PBN "
+                f"(rekord pk={original_rekord.pk})",
+                logger=logger,
+            )
+            bledy_pbn.append(f"Rekord {original_rekord.pk}: {str(e)}")
+    return sukces_pbn, bledy_pbn
+
+
+def _obsluz_confirm(request, zrodlo, form):
+    """Obsłuż potwierdzone przemapowanie. Zwróć HttpResponse (redirect) lub
+    None gdy należy wyrenderować stronę (np. po błędzie)."""
+    typ_wyboru = form.cleaned_data.get("typ_wyboru")
+
+    # Określ źródło docelowe
+    if typ_wyboru == PrzeMapowanieZrodlaForm.TYP_JOURNAL:
+        journal_docelowy = Journal.objects.get(pk=form.cleaned_data["journal_docelowy"])
+        zrodlo_nowe = _utworz_zrodlo_z_journala(request, journal_docelowy)
+    else:
+        zrodlo_nowe = form.cleaned_data["zrodlo_docelowe"]
+
+    # Walidacja: nie można przemapować na źródło również skasowane
+    if zrodlo_nowe.pbn_uid and zrodlo_nowe.pbn_uid.status == DELETED:
+        messages.error(
+            request,
+            "Nie można przemapować na źródło, które również jest skasowane w PBN!",
+        )
+        return redirect("przemapuj_zrodla_pbn:przemapuj_zrodlo", zrodlo_id=zrodlo.pk)
+
+    try:
+        with transaction.atomic():
+            rekordy_historia, rekordy_do_wyslania = _zbierz_rekordy_do_przemapowania(
+                zrodlo
+            )
+
+            liczba_rekordow_updated = Wydawnictwo_Ciagle.objects.filter(
+                zrodlo=zrodlo
+            ).update(zrodlo=zrodlo_nowe)
+
+            # Zapisz log operacji
+            PrzeMapowanieZrodla.objects.create(
+                zrodlo_skasowane_pbn_uid=zrodlo.pbn_uid,
+                zrodlo_stare=zrodlo,
+                zrodlo_nowe=zrodlo_nowe,
+                liczba_rekordow=liczba_rekordow_updated,
+                utworzono_przez=request.user,
+                rekordy_historia=rekordy_historia,
+            )
+
+            sukces_pbn, bledy_pbn = _dodaj_rekordy_do_kolejki_pbn(
+                request, rekordy_do_wyslania
+            )
+
+            messages.success(
+                request,
+                f"Pomyślnie przemapowano {liczba_rekordow_updated} rekordów "
+                f'ze źródła "{zrodlo}" do źródła "{zrodlo_nowe}". '
+                f"Dodano {sukces_pbn} rekordów do kolejki eksportu PBN.",
+            )
+
+            if bledy_pbn:
+                messages.warning(
+                    request,
+                    f"Wystąpiły błędy przy dodawaniu {len(bledy_pbn)} rekordów do kolejki PBN. "
+                    f"Szczegóły: {'; '.join(bledy_pbn[:5])}",
+                )
+
+            return redirect("przemapuj_zrodla_pbn:lista_skasowanych_zrodel")
+
+    except Exception as e:
+        rollbar.report_exc_info(sys.exc_info())
+        messages.error(request, f"Wystąpił błąd podczas przemapowania: {str(e)}")
+
+    return None
+
+
+def _obsluz_preview(request, zrodlo, form, liczba_rekordow, sugerowane):
+    """Wyrenderuj podgląd zmian przed przemapowaniem."""
+    typ_wyboru = form.cleaned_data.get("typ_wyboru")
+
+    journal_docelowy = None
+    if typ_wyboru == PrzeMapowanieZrodlaForm.TYP_JOURNAL:
+        journal_docelowy = Journal.objects.get(pk=form.cleaned_data["journal_docelowy"])
+        zrodlo_nowe_nazwa = f"{journal_docelowy.title} (NOWE ze źródła PBN)"
+        zrodlo_nowe = None  # Będzie utworzone dopiero po zatwierdzeniu
+    else:
+        zrodlo_nowe = form.cleaned_data["zrodlo_docelowe"]
+        zrodlo_nowe_nazwa = str(zrodlo_nowe)
+
+    rekordy_przyklad = Rekord.objects.filter(zrodlo=zrodlo)[:10]
+
+    context = {
+        "zrodlo": zrodlo,
+        "zrodlo_nowe": zrodlo_nowe,
+        "zrodlo_nowe_nazwa": zrodlo_nowe_nazwa,
+        "journal_docelowy": journal_docelowy,
+        "liczba_rekordow": liczba_rekordow,
+        "rekordy_przyklad": rekordy_przyklad,
+        "form": form,
+        "preview": True,
+        "sugerowane": sugerowane,
+    }
+    return render(request, "przemapuj_zrodla_pbn/przemapuj_zrodlo.html", context)
+
+
 @login_required
-def przemapuj_zrodlo(request, zrodlo_id):  # noqa: C901
+def przemapuj_zrodlo(request, zrodlo_id):
     """Główny widok do przemapowania źródła."""
     zrodlo = get_object_or_404(Zrodlo, pk=zrodlo_id)
 
@@ -451,34 +630,8 @@ def przemapuj_zrodlo(request, zrodlo_id):  # noqa: C901
 
     # Znajdź podobne źródła (w obu tabelach)
     sugerowane = znajdz_podobne_zrodla(zrodlo.pbn_uid)
-
-    # Przygotuj dane dla formularza - tylko źródła z BPP
-    wszystkie_zrodla = []
-    for kategoria in ["najlepsze", "dobre", "akceptowalne"]:
-        wszystkie_zrodla.extend(sugerowane["zrodla_bpp"][kategoria])
-
-    if wszystkie_zrodla:
-        # Struktura krotki: (zrodlo, typ_dopasowania, podobienstwo)
-        sugerowane_ids = [item[0].pk for item in wszystkie_zrodla]
-        sugerowane_queryset = Zrodlo.objects.filter(pk__in=sugerowane_ids)
-    else:
-        # Brak sugestii - pokaż wszystkie aktywne źródła
-        sugerowane_queryset = (
-            Zrodlo.objects.filter(pbn_uid__status=ACTIVE)
-            .select_related("pbn_uid")
-            .order_by(
-                models.Case(
-                    models.When(pbn_uid__mniswId__isnull=False, then=0),
-                    default=1,
-                ),
-                "nazwa",
-            )[:20]
-        )
-
-    # Zbierz wszystkie journale z PBN
-    wszystkie_journale = []
-    for kategoria in ["najlepsze", "dobre", "akceptowalne"]:
-        wszystkie_journale.extend(sugerowane["journale_pbn"][kategoria])
+    sugerowane_queryset = _zbuduj_sugerowane_queryset(sugerowane, zrodlo)
+    wszystkie_journale = _zbierz_wszystkie_journale(sugerowane)
 
     if request.method == "POST":
         form = PrzeMapowanieZrodlaForm(
@@ -488,156 +641,12 @@ def przemapuj_zrodlo(request, zrodlo_id):  # noqa: C901
             sugerowane_journale=wszystkie_journale,
         )
 
-        if "confirm" in request.POST:
-            # Użytkownik potwierdził przemapowanie
-            if form.is_valid():
-                typ_wyboru = form.cleaned_data.get("typ_wyboru")
-
-                # Określ źródło docelowe
-                if typ_wyboru == PrzeMapowanieZrodlaForm.TYP_JOURNAL:
-                    # Użytkownik wybrał Journal z PBN - utwórz nowe Zrodlo
-                    journal_id = form.cleaned_data["journal_docelowy"]
-                    journal_docelowy = Journal.objects.get(pk=journal_id)
-
-                    # Pobierz domyślny rodzaj "czasopismo"
-                    rodzaj_czasopismo = Rodzaj_Zrodla.objects.get(nazwa="czasopismo")
-
-                    # Utwórz nowe Zrodlo na podstawie Journal
-                    zrodlo_nowe = Zrodlo.objects.create(
-                        nazwa=journal_docelowy.title or "",
-                        issn=journal_docelowy.issn or "",
-                        e_issn=journal_docelowy.eissn or "",
-                        pbn_uid=journal_docelowy,
-                        rodzaj=rodzaj_czasopismo,
-                    )
-                    messages.info(
-                        request,
-                        f'Utworzono nowe źródło "{zrodlo_nowe.nazwa}" na podstawie danych z PBN.',
-                    )
-                else:
-                    # Użytkownik wybrał istniejące Zrodlo
-                    zrodlo_nowe = form.cleaned_data["zrodlo_docelowe"]
-
-                # Walidacja: nie można przemapować na źródło również skasowane
-                if zrodlo_nowe.pbn_uid and zrodlo_nowe.pbn_uid.status == DELETED:
-                    messages.error(
-                        request,
-                        "Nie można przemapować na źródło, które również jest skasowane w PBN!",
-                    )
-                    return redirect(
-                        "przemapuj_zrodla_pbn:przemapuj_zrodlo", zrodlo_id=zrodlo.pk
-                    )
-
-                try:
-                    with transaction.atomic():
-                        # Zbierz informacje o rekordach przed przemapowaniem
-                        rekordy = Rekord.objects.filter(zrodlo=zrodlo)
-                        rekordy_historia = []
-                        rekordy_do_wyslania = []
-
-                        for rekord in rekordy:
-                            rekordy_historia.append(
-                                {
-                                    "id": list(rekord.pk),
-                                    "tytul": rekord.tytul_oryginalny,
-                                    "rok": rekord.rok,
-                                    "opis_bibliograficzny": rekord.opis_bibliograficzny_cache
-                                    or "",
-                                }
-                            )
-                            # Zbierz oryginalne rekordy do wysłania do PBN
-                            rekordy_do_wyslania.append(rekord.original)
-
-                        liczba_rekordow_updated = Wydawnictwo_Ciagle.objects.filter(
-                            zrodlo=zrodlo
-                        ).update(zrodlo=zrodlo_nowe)
-
-                        # Zapisz log operacji
-                        PrzeMapowanieZrodla.objects.create(
-                            zrodlo_skasowane_pbn_uid=zrodlo.pbn_uid,
-                            zrodlo_stare=zrodlo,
-                            zrodlo_nowe=zrodlo_nowe,
-                            liczba_rekordow=liczba_rekordow_updated,
-                            utworzono_przez=request.user,
-                            rekordy_historia=rekordy_historia,
-                        )
-
-                        # Dodaj do kolejki PBN
-                        sukces_pbn = 0
-                        bledy_pbn = []
-                        for original_rekord in rekordy_do_wyslania:
-                            try:
-                                PBN_Export_Queue.objects.sprobuj_utowrzyc_wpis(
-                                    user=request.user, rekord=original_rekord
-                                )
-                                sukces_pbn += 1
-                            except Exception as e:
-                                zaloguj_polkniety_wyjatek(
-                                    f"Dodawanie rekordu do kolejki eksportu PBN "
-                                    f"przy przemapowaniu źródła PBN "
-                                    f"(rekord pk={original_rekord.pk})",
-                                    logger=logger,
-                                )
-                                bledy_pbn.append(
-                                    f"Rekord {original_rekord.pk}: {str(e)}"
-                                )
-
-                        messages.success(
-                            request,
-                            f"Pomyślnie przemapowano {liczba_rekordow_updated} rekordów "
-                            f'ze źródła "{zrodlo}" do źródła "{zrodlo_nowe}". '
-                            f"Dodano {sukces_pbn} rekordów do kolejki eksportu PBN.",
-                        )
-
-                        if bledy_pbn:
-                            messages.warning(
-                                request,
-                                f"Wystąpiły błędy przy dodawaniu {len(bledy_pbn)} rekordów do kolejki PBN. "
-                                f"Szczegóły: {'; '.join(bledy_pbn[:5])}",
-                            )
-
-                        return redirect("przemapuj_zrodla_pbn:lista_skasowanych_zrodel")
-
-                except Exception as e:
-                    rollbar.report_exc_info(sys.exc_info())
-                    messages.error(
-                        request, f"Wystąpił błąd podczas przemapowania: {str(e)}"
-                    )
-
-        elif "preview" in request.POST:
-            # Użytkownik chce zobaczyć podgląd
-            if form.is_valid():
-                typ_wyboru = form.cleaned_data.get("typ_wyboru")
-
-                # Określ źródło docelowe dla podglądu
-                journal_docelowy = None
-                if typ_wyboru == PrzeMapowanieZrodlaForm.TYP_JOURNAL:
-                    journal_id = form.cleaned_data["journal_docelowy"]
-                    journal_docelowy = Journal.objects.get(pk=journal_id)
-                    zrodlo_nowe_nazwa = f"{journal_docelowy.title} (NOWE ze źródła PBN)"
-                    zrodlo_nowe = None  # Będzie utworzone dopiero po zatwierdzeniu
-                else:
-                    zrodlo_nowe = form.cleaned_data["zrodlo_docelowe"]
-                    zrodlo_nowe_nazwa = str(zrodlo_nowe)
-
-                # Pobierz przykładowe rekordy
-                rekordy_przyklad = Rekord.objects.filter(zrodlo=zrodlo)[:10]
-
-                context = {
-                    "zrodlo": zrodlo,
-                    "zrodlo_nowe": zrodlo_nowe,
-                    "zrodlo_nowe_nazwa": zrodlo_nowe_nazwa,
-                    "journal_docelowy": journal_docelowy,
-                    "liczba_rekordow": liczba_rekordow,
-                    "rekordy_przyklad": rekordy_przyklad,
-                    "form": form,
-                    "preview": True,
-                    "sugerowane": sugerowane,
-                }
-                return render(
-                    request, "przemapuj_zrodla_pbn/przemapuj_zrodlo.html", context
-                )
-
+        if "confirm" in request.POST and form.is_valid():
+            odpowiedz = _obsluz_confirm(request, zrodlo, form)
+            if odpowiedz is not None:
+                return odpowiedz
+        elif "preview" in request.POST and form.is_valid():
+            return _obsluz_preview(request, zrodlo, form, liczba_rekordow, sugerowane)
     else:
         form = PrzeMapowanieZrodlaForm(
             zrodlo_skasowane=zrodlo,

--- a/src/raport_slotow/tests/test_export_xlsx.py
+++ b/src/raport_slotow/tests/test_export_xlsx.py
@@ -1,0 +1,152 @@
+"""Charakteryzacyjne testy dla raport_slotow.util.MyTableExport.export_xlsx.
+
+Pinują OBECNE zachowanie generatora XLSX (openpyxl): wiersze opisu,
+nagłówek, wiersze danych, wiersz sumy (footer), zdefiniowana tabela
+i autofiltr. Umożliwiają bezpieczny refactor (zdjęcie # noqa: C901).
+
+Nie wymagają bazy danych — django_tables2.Table budowany jest z listy
+słowników.
+"""
+
+from io import BytesIO
+
+import django_tables2 as tables
+import openpyxl
+import pytest
+
+
+class _DemoTable(tables.Table):
+    name = tables.Column()
+    value = tables.Column(footer=lambda table: sum(int(r["value"]) for r in table.data))
+
+
+DATA = [{"name": "Alpha", "value": 10}, {"name": "Beta", "value": 20}]
+
+
+def _load(bytes_):
+    return openpyxl.load_workbook(BytesIO(bytes_)).active
+
+
+def _rows(ws):
+    return list(ws.iter_rows(values_only=True))
+
+
+def test_export_bez_opisu_naglowek_dane_i_suma():
+    from raport_slotow.util import MyTableExport
+
+    ws = _load(MyTableExport("xlsx", _DemoTable(DATA)).export_xlsx())
+    assert ws.title == "Sheet 1"
+    assert _rows(ws) == [
+        ("Name", "Value"),
+        ("Alpha", 10),
+        ("Beta", 20),
+        ("Suma", "=SUBTOTAL(109,Table1[Value])"),
+    ]
+
+
+def test_export_naglowek_jest_pogrubiony():
+    from raport_slotow.util import MyTableExport
+
+    ws = _load(MyTableExport("xlsx", _DemoTable(DATA)).export_xlsx())
+    assert ws["A1"].font.bold is True
+    assert ws["B1"].font.bold is True
+    # Wiersze danych nie są pogrubione
+    assert ws["A2"].font.bold is False
+
+
+def test_export_definiuje_tabele_z_autofiltrem():
+    from raport_slotow.util import MyTableExport
+
+    ws = _load(MyTableExport("xlsx", _DemoTable(DATA)).export_xlsx())
+    assert "Table1" in ws.tables
+    tab = ws.tables["Table1"]
+    # Nagłówek (A1) .. footer (A4) — autofiltr pomija footer (do A3).
+    assert tab.ref == "A1:B4"
+    assert tab.autoFilter.ref == "A1:B3"
+    assert tab.totalsRowShown is True
+    assert tab.totalsRowCount == 1
+    cols = {c.name: c for c in tab.tableColumns}
+    assert cols["Name"].totalsRowLabel == "Suma"
+    assert cols["Name"].totalsRowFunction is None
+    assert cols["Value"].totalsRowFunction == "sum"
+    assert cols["Value"].totalsRowLabel is None
+
+
+def test_export_z_opisem_dwuelementowe_krotki_pogrubione_i_wyrownane():
+    from raport_slotow.util import MyTableExport
+
+    description = [("Nazwa:", "raport"), ("Rok:", 2025)]
+    ws = _load(
+        MyTableExport(
+            "xlsx", _DemoTable(DATA), export_description=description
+        ).export_xlsx()
+    )
+    rows = _rows(ws)
+    assert rows[0] == ("Nazwa:", "raport")
+    assert rows[1] == ("Rok:", 2025)
+    # Pusty wiersz separujący opis od tabeli
+    assert rows[2] == (None, None)
+    assert rows[3] == ("Name", "Value")
+    # Pierwsza kolumna opisu: pogrubiona, wyrównana do prawej; druga do lewej
+    assert ws["A1"].font.bold is True
+    assert ws["A1"].alignment.horizontal == "right"
+    assert ws["B1"].alignment.horizontal == "left"
+
+
+def test_export_opis_krotka_inna_niz_dwuelementowa_bez_pogrubienia():
+    from raport_slotow.util import MyTableExport
+
+    # Krotka o długości != 2 trafia do ws.append, ale bez pogrubienia/align.
+    description = [(1, 2, 3)]
+    ws = _load(
+        MyTableExport(
+            "xlsx", _DemoTable(DATA), export_description=description
+        ).export_xlsx()
+    )
+    rows = _rows(ws)
+    assert rows[0] == (1, 2, 3)
+    assert ws["A1"].font.bold is False
+
+
+def test_export_opis_element_nieiterowalny_jest_owijany_w_liste():
+    from raport_slotow.util import MyTableExport
+
+    # Element nie-Iterable (int) idzie gałęzią else: ws.append([elem]).
+    ws = _load(
+        MyTableExport("xlsx", _DemoTable(DATA), export_description=[99]).export_xlsx()
+    )
+    assert _rows(ws)[0] == (99, None)
+
+
+def test_export_pusty_dataset_nie_tworzy_tabeli():
+    from raport_slotow.util import MyTableExport
+
+    ws = _load(MyTableExport("xlsx", _DemoTable([])).export_xlsx())
+    # Brak danych → blok "if tablib_dataset" pomijany → brak zdefiniowanej tabeli
+    assert len(ws.tables) == 0
+    # Nadal jest nagłówek i wiersz sumy
+    rows = _rows(ws)
+    assert rows[0] == ("Name", "Value")
+    assert rows[-1][0] == "Suma"
+
+
+def test_export_zwraca_bajty():
+    from raport_slotow.util import MyTableExport
+
+    out = MyTableExport("xlsx", _DemoTable(DATA)).export_xlsx()
+    assert isinstance(out, bytes)
+    assert out[:2] == b"PK"  # ZIP/xlsx magic
+
+
+def test_string_w_opisie_jest_zgloszany_jako_typeerror():
+    """Quirk zachowany: zwykły string w opisie wywala TypeError.
+
+    String jest Iterable, więc trafia do ws.append(str), które openpyxl
+    odrzuca. To istniejące zachowanie — NIE naprawiamy go w refaktorze.
+    """
+    from raport_slotow.util import MyTableExport
+
+    with pytest.raises(TypeError):
+        MyTableExport(
+            "xlsx", _DemoTable(DATA), export_description=["samtekst"]
+        ).export_xlsx()

--- a/src/raport_slotow/tests/test_export_xlsx.py
+++ b/src/raport_slotow/tests/test_export_xlsx.py
@@ -2,7 +2,7 @@
 
 Pinują OBECNE zachowanie generatora XLSX (openpyxl): wiersze opisu,
 nagłówek, wiersze danych, wiersz sumy (footer), zdefiniowana tabela
-i autofiltr. Umożliwiają bezpieczny refactor (zdjęcie # noqa: C901).
+i autofiltr. Umożliwiają bezpieczny refactor (zdjęcie C901).
 
 Nie wymagają bazy danych — django_tables2.Table budowany jest z listy
 słowników.

--- a/src/raport_slotow/util.py
+++ b/src/raport_slotow/util.py
@@ -59,6 +59,93 @@ def clone_temporary_table(source_table, target_table, using=DEFAULT_DB_ALIAS):
         cursor.execute(sql)
 
 
+def _write_export_description(ws, export_description):
+    """Wypisz wiersze opisu nad tabelą. Dwuelementowe krotki dostają
+    pogrubioną, wyrównaną do prawej etykietę i wyrównaną do lewej wartość."""
+    for elem in export_description:
+        if isinstance(elem, Iterable):
+            ws.append(elem)
+            if len(elem) == 2:
+                ws[ws.max_row][0].font = openpyxl.styles.Font(bold=True)
+                ws[ws.max_row][0].alignment = openpyxl.styles.Alignment(
+                    horizontal="right"
+                )
+                ws[ws.max_row][1].alignment = openpyxl.styles.Alignment(
+                    horizontal="left"
+                )
+        else:
+            ws.append([elem])
+
+    ws.append([])
+
+
+def _build_footer_row(columns, table_columns, table_name):
+    """Zbuduj wiersz sumy i ustaw funkcje sumujące na kolumnach tabeli.
+
+    Sumowana kolumna po stronie XLSX tworzona jest w taki sposób, że jeżeli
+    jakakolwiek kolumna tabeli ma footer, to jest tam wstawiana suma za pomocą
+    funkcji =SUBTOTAL(109, ...). Pierwsza kolumna (o indeksie zerowym) używana
+    jest dla napisu "Suma".
+    """
+    footer_row = []
+    for no, elem in enumerate(columns):
+        if no == 0:
+            footer_row.append("Suma")
+            table_columns[0].totalsRowLabel = footer_row[0]
+            continue
+
+        if elem.has_footer():
+            table_columns[no].totalsRowFunction = "sum"
+            footer_row.append(f"=SUBTOTAL(109,{table_name}[{elem.header}])")
+            continue
+
+        footer_row.append("")
+    return footer_row
+
+
+def _add_table(ws, table_name, first_table_row, table_columns):
+    max_column_letter = get_column_letter(ws.max_column)
+    max_row = ws.max_row
+
+    style = TableStyleInfo(
+        name="TableStyleMedium9",
+        showFirstColumn=False,
+        showLastColumn=False,
+        showRowStripes=True,
+        showColumnStripes=True,
+    )
+    tab = Table(
+        displayName=table_name,
+        ref=f"A{first_table_row}:{max_column_letter}{max_row}",
+        autoFilter=AutoFilter(
+            ref=f"A{first_table_row}:{max_column_letter}{max_row - 1}"
+        ),
+        totalsRowShown=True,
+        totalsRowCount=1,
+        tableStyleInfo=style,
+        tableColumns=table_columns,
+    )
+    ws.add_table(tab)
+
+
+def _autofit_columns(ws, max_width=75):
+    for col in ws.columns:
+        max_length = 0
+        column = col[0].column_letter  # Get the column name
+        # Since Openpyxl 2.6, the column name is ".column_letter" as .column
+        # became the column number (1-based)
+        for cell in col:
+            try:  # Necessary to avoid error on empty cells
+                if len(str(cell.value)) > max_length:
+                    max_length = len(cell.value)
+            except (ValueError, TypeError):
+                pass
+        adjusted_width = (max_length + 2) * 1.1
+        if adjusted_width > max_width:
+            adjusted_width = max_width
+        ws.column_dimensions[column].width = adjusted_width
+
+
 class MyTableExport(TableExport):
     """
     Fix https://github.com/jazzband/tablib/issues/252
@@ -86,33 +173,19 @@ class MyTableExport(TableExport):
     def export(self):
         return getattr(self, f"export_{self.format}")()
 
-    def export_xlsx(self):  # noqa: C901
+    def export_xlsx(self):
         wb = openpyxl.Workbook()
         ws = wb.active
         ws.title = "Sheet 1"
 
         table_name = "Table1"
 
-        # Write the header row and make cells bold
         tablib_dataset = self.dataset
 
         if self.export_description:
-            for elem in self.export_description:
-                if isinstance(elem, Iterable):
-                    ws.append(elem)
-                    if len(elem) == 2:
-                        ws[ws.max_row][0].font = openpyxl.styles.Font(bold=True)
-                        ws[ws.max_row][0].alignment = openpyxl.styles.Alignment(
-                            horizontal="right"
-                        )
-                        ws[ws.max_row][1].alignment = openpyxl.styles.Alignment(
-                            horizontal="left"
-                        )
-                else:
-                    ws.append([elem])
+            _write_export_description(ws, self.export_description)
 
-            ws.append([])
-
+        # Write the header row and make cells bold
         ws.append(tablib_dataset.headers)
 
         table_columns = tuple(
@@ -120,29 +193,7 @@ class MyTableExport(TableExport):
             for h, header in enumerate(tablib_dataset.headers, start=1)
         )
 
-        # Sumowana kolumna po stronie XLSX tworzona jest w taki sposób, że jeżeli jakakolwiek
-        # kolumna tabeli ma footer, to jest tam wstawiana suma za pomocą funkcji =SUBTOTAL(9, ...)
-        #
-        # W przypadku gdyby to nie wystarczało w przyszłości, to do django_tables2.TableColumn
-        # należałoby dopisać kod funkcji XLSa.
-        #
-        # Do tego, pierwsza kolumna (o indeksie zerowym) uzywana jest dla napisu "Suma"
-
-        footer_row = []
-        for no, elem in enumerate(self.table.columns):
-            if no == 0:
-                footer_row.append("Suma")
-                total_column = table_columns[0]
-                total_column.totalsRowLabel = footer_row[0]
-                continue
-
-            if elem.has_footer():
-                count_column = table_columns[no]
-                count_column.totalsRowFunction = "sum"
-                footer_row.append(f"=SUBTOTAL(109,{table_name}[{elem.header}])")
-                continue
-
-            footer_row.append("")
+        footer_row = _build_footer_row(self.table.columns, table_columns, table_name)
 
         for cell in ws[ws.max_row : ws.max_row]:
             cell.font = openpyxl.styles.Font(bold=True)
@@ -153,46 +204,9 @@ class MyTableExport(TableExport):
         ws.append(footer_row)
 
         if tablib_dataset:
-            max_column = ws.max_column
-            max_column_letter = get_column_letter(max_column)
-            max_row = ws.max_row
+            _add_table(ws, table_name, first_table_row, table_columns)
 
-            style = TableStyleInfo(
-                name="TableStyleMedium9",
-                showFirstColumn=False,
-                showLastColumn=False,
-                showRowStripes=True,
-                showColumnStripes=True,
-            )
-            tab = Table(
-                displayName=table_name,
-                ref=f"A{first_table_row}:{max_column_letter}{max_row}",
-                autoFilter=AutoFilter(
-                    ref=f"A{first_table_row}:{max_column_letter}{max_row - 1}"
-                ),
-                totalsRowShown=True,
-                totalsRowCount=1,
-                tableStyleInfo=style,
-                tableColumns=table_columns,
-            )
-
-            ws.add_table(tab)
-
-        max_width = 75
-        for _ncol, col in enumerate(ws.columns):
-            max_length = 0
-            column = col[0].column_letter  # Get the column name
-            # Since Openpyxl 2.6, the column name is  ".column_letter" as .column became the column number (1-based)
-            for cell in col:
-                try:  # Necessary to avoid error on empty cells
-                    if len(str(cell.value)) > max_length:
-                        max_length = len(cell.value)
-                except (ValueError, TypeError):
-                    pass
-            adjusted_width = (max_length + 2) * 1.1
-            if adjusted_width > max_width:
-                adjusted_width = max_width
-            ws.column_dimensions[column].width = adjusted_width
+        _autofit_columns(ws)
 
         with NamedTemporaryFile() as tmp:
             wb.save(tmp.name)


### PR DESCRIPTION
## Tura 2 upraszczania funkcji `# noqa: C901`

Druga fala behavior-preserving refaktoru funkcji o złożoności cyklomatycznej
> 10 (kontynuacja PR #433, który zdjął pierwsze 9). **22 funkcje** sprowadzone
do CC < 10 i pozbawione `# noqa: C901`, każda pod siatką nowych testów
charakteryzujących (najpierw test pinujący bieżące zachowanie, potem refaktor).

Pliki rozłączne → dyspozycjonowane jako równoległe agenty w osobnych worktree,
scalone octopus-mergem bez konfliktów.

### Zdjęte suppression (22 funkcje, pogrupowane)

| Obszar | Funkcje | CC przed |
|---|---|---|
| `przemapuj_zrodla_pbn/views.py` | `znajdz_podobne_zrodla`, `przemapuj_zrodlo` | 37, 18 |
| `deduplikator_autorow/utils/*` | `scal_autora`, `szukaj_kopii`, `search_author_by_lastname`, `znajdz_pierwszego_autora_z_duplikatami` | 23, 21, 15, 14 |
| `deduplikator_autorow/views/duplicates.py` | `duplicate_authors_view` | 18 |
| `deduplikator_zrodel/utils.py` | `ocen_podobienstwo`, `znajdz_podobne_zrodla` | 15, 13 |
| `pbn_integrator/utils/scientists.py` | `matchuj_autora_po_stronie_pbn` | 19 |
| `pbn_integrator/utils/dictionaries.py` | `integruj_jezyki`, `integruj_dyscypliny` | 12, 11 |
| `pbn_integrator/utils/journals.py` | `integruj_zrodla` | 11 |
| `przemapuj_prace_autora/views.py` | `przemapuj_prace` | 13 |
| `bpp/middleware.py` | `process_request` | 14 |
| `bpp/management/commands/compare_dbtemplates.py` | `handle`, `compare_template` | 19, 13 |
| `bpp/tasks.py` | `_zaktualizuj_liczbe_cytowan` | 14 |
| `bpp/finders.py` | `get_files` | 12 |
| `django_bpp/menu.py` | `init_with_context` | 16 |
| `raport_slotow/util.py` | `export_xlsx` | 16 |
| `pbn_api/templatetags/pbn_extras.py` | `parse_historia_komunikatow` | 13 |

### Metoda

- **Charakteryzacja najpierw**: testy pinujące bieżące zachowanie, przechodzące
  na NIEzmienionym kodzie. Zero "naprawiania przy okazji" — quirki zachowane
  byte-for-byte (np. mylący komentarz w `menu.py`, literówka „żadnie" w
  komunikacie PBN, `LogScalania` tylko dla ciągłych, latentny edge-case
  confidence-band w widoku duplikatów).
- **Refaktor = złożoność → dane**: łańcuchy `if`/`elif` scoringu → tabele reguł;
  powtórzone bloki → deskryptory + pętla; łańcuchy dopasowań → lista strategii;
  reuse helperów; early-return do spłaszczenia.

### Świadomie pominięte

`sprobuj_wyslac_do_pbn` (CC 35, `bpp/admin/helpers/pbn_api/common.py`) oraz
~15 funkcji orkiestracyjnych (Celery, solver ewaluacji, threaded integrator)
NIE są ruszone — analiza wykazała, że ich złożoność jest nieodłączna
(sekwencjonowanie kroków, nie duplikacja), a split tylko rozproszyłby ją do
helperów bez realnego zysku.

### Weryfikacja

- Każda funkcja: `ruff check --select C901 --isolated` → czysto.
- Testy aplikacji zielone per-agent (m.in. 230 `deduplikator_autorow`,
  250 `deduplikator_autorow`+`przemapuj_prace_autora`, 118 `pbn_integrator`,
  86 `bpp` middleware+command).
- `ruff check` + `ruff format --check` na całym diffie (produkcja + testy) → czysto.
- Globalna liczba realnych `# noqa: C901` w `src/`: 55 → 33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
