### PR TITLE
feat(zrodlo-admin): kolumny mniswID + liczba publikacji i filtry

### DIFF
--- a/docs/superpowers/specs/2026-07-04-zrodlo-admin-mnisw-publikacje-design.md
+++ b/docs/superpowers/specs/2026-07-04-zrodlo-admin-mnisw-publikacje-design.md
@@ -1,0 +1,86 @@
+# Kolumny i filtry w adminie Źródeł: mniswID + liczba publikacji
+
+Data: 2026-07-04
+Gałąź: `feature/zrodlo-admin-mnisw-publikacje`
+
+## Cel
+
+Ułatwić redaktorowi w adminie Django (`Zrodlo`) porządkowanie źródeł:
+odnalezienie i hurtowe usunięcie źródeł, które **nie mają publikacji**
+oraz **nie mają mniswID** (ministerialnego identyfikatora z PBN).
+
+## Kontekst kodu
+
+- Model: `src/bpp/models/zrodlo.py:133` — `Zrodlo`. Relacja do PBN przez
+  `pbn_uid` FK → `pbn_api.Journal` (nullable, `SET_NULL`).
+- `mniswId`: `src/pbn_api/models/journal.py:21` — `IntegerField(null=True,
+  db_index=True)` na `Journal`. Dostęp: `zrodlo.pbn_uid.mniswId`.
+- Publikacje → źródło: **tylko** `Wydawnictwo_Ciagle.zrodlo`
+  (`src/bpp/models/wydawnictwo_ciagle.py:139`, nullable `SET_NULL`, brak
+  `related_name` → reverse `wydawnictwo_ciagle`). To jedyny realny model z FK
+  do `Zrodlo`, więc autorytatywne źródło odpowiedzi „czy ma publikacje".
+- Admin: `src/bpp/admin/zrodlo.py:111` — `ZrodloAdmin`. `list_display`
+  pokazuje już `pbn_uid_id`. `BaseBppAdminMixin` **nie** nadpisuje
+  `ModelAdmin.get_queryset(self, request)`.
+- Filtry: `src/bpp/admin/filters.py` — bazy `SimpleNotNullFilter` (brak/jest)
+  i `SimpleListFilter`. Istnieje `PBN_UID_IDObecnyFilter` (obecność `pbn_uid`).
+
+## Rozróżnienie mniswID vs pbn_uid
+
+Istniejący `PBN_UID_IDObecnyFilter` sprawdza obecność **`pbn_uid`**
+(powiązanie z `Journal`). To NIE to samo co obecność `mniswId`: źródło może
+mieć `pbn_uid`, ale powiązany `Journal` może mieć `mniswId = NULL`. Dlatego
+potrzebny osobny filtr i osobna kolumna po `pbn_uid__mniswId`.
+
+## Zmiany
+
+Zero migracji, zero zmian w modelach. Dwa pliki:
+
+### `src/bpp/admin/filters.py`
+
+1. `MniswIdObecnyFilter(SimpleNotNullFilter)` — `db_field_name =
+   "pbn_uid__mniswId"`, `parameter_name = "mnisw_id"`, tytuł „mniswID",
+   etykiety „nie ma mniswID" / „ma mniswID".
+2. `MaPublikacjeFilter(SimpleListFilter)` — `parameter_name =
+   "ma_publikacje"`, tytuł „ma publikacje". Filtruje po annotacji
+   `_liczba_prac` (dostarczanej przez `ZrodloAdmin.get_queryset`):
+   - `"nie"` → `.filter(_liczba_prac=0)`
+   - `"tak"` → `.filter(_liczba_prac__gt=0)`
+
+### `src/bpp/admin/zrodlo.py`
+
+1. `get_queryset(self, request)` — `super().get_queryset(request).annotate(
+   _liczba_prac=Count("wydawnictwo_ciagle"))`.
+2. Metoda `mnisw_id_display` — `@admin.display(description="mniswID",
+   ordering="pbn_uid__mniswId")`, zwraca `obj.pbn_uid.mniswId if
+   obj.pbn_uid_id else None`.
+3. Metoda `liczba_prac_display` — `@admin.display(description="Publikacje",
+   ordering="_liczba_prac")`, zwraca `obj._liczba_prac`.
+4. `list_display` += `"mnisw_id_display"`, `"liczba_prac_display"`.
+5. `list_filter` += `MniswIdObecnyFilter`, `MaPublikacjeFilter`.
+6. `list_select_related` += `"pbn_uid"` (uniknięcie N+1 przy kolumnie
+   mniswID).
+
+## Workflow usuwania
+
+Filtr „ma publikacje = nie ma" + „mniswID = nie ma mniswID" → zaznacz
+wszystko → akcja „Usuń wybrane źródła".
+
+## Testy (`src/bpp/tests/`)
+
+TDD, pytest + `model_bakery.baker`, `@pytest.mark.django_db`:
+
+- annotacja/kolumna liczby prac: źródło z N wydawnictwami ciągłymi → N;
+  źródło bez prac → 0.
+- kolumna mniswID: źródło z `pbn_uid`→`Journal(mniswId=123)` → 123; źródło
+  bez `pbn_uid` → None; źródło z `pbn_uid`, ale `mniswId=None` → None.
+- `MaPublikacjeFilter`: „nie" zwraca tylko źródła bez prac; „tak" tylko z
+  pracami.
+- `MniswIdObecnyFilter`: „brak" zwraca źródła bez mniswID (w tym te z
+  `pbn_uid` ale `mniswId=None`); „jest" tylko z mniswID.
+
+## Poza zakresem (YAGNI)
+
+- Liczenie z cache `Rekord` (wszystkie typy rekordów) — źródła referuje tylko
+  `Wydawnictwo_Ciagle`, więc niepotrzebne.
+- Nowa akcja adminowa do usuwania — wbudowana akcja „Usuń wybrane" wystarcza.

--- a/docs/superpowers/specs/2026-07-04-zrodlo-admin-mnisw-publikacje-design.md
+++ b/docs/superpowers/specs/2026-07-04-zrodlo-admin-mnisw-publikacje-design.md
@@ -43,32 +43,42 @@ Zero migracji, zero zmian w modelach. Dwa pliki:
    etykiety „nie ma mniswID" / „ma mniswID".
 2. `MaPublikacjeFilter(SimpleListFilter)` — `parameter_name =
    "ma_publikacje"`, tytuł „ma publikacje". Filtruje po annotacji
-   `_liczba_prac` (dostarczanej przez `ZrodloAdmin.get_queryset`):
+   `_liczba_prac`. `ZrodloAdmin.get_queryset` zwykle ją dostarcza; filtr
+   dodatkowo sam annotuje ją, gdy jej brak (moduł filtrów jest współdzielony
+   — inaczej `FieldError` przy reużyciu):
    - `"nie"` → `.filter(_liczba_prac=0)`
    - `"tak"` → `.filter(_liczba_prac__gt=0)`
 
 ### `src/bpp/admin/zrodlo.py`
 
 1. `get_queryset(self, request)` — `super().get_queryset(request).annotate(
-   _liczba_prac=Count("wydawnictwo_ciagle"))`.
+   _liczba_prac=Count("wydawnictwo_ciagle", distinct=True),
+   _mnisw_id=F("pbn_uid__mniswId"))`. `distinct=True` chroni licznik przed
+   zawyżeniem, gdyby wyszukiwarka DjangoQL dorzuciła drugi multi-valued JOIN.
 2. Metoda `mnisw_id_display` — `@admin.display(description="mniswID",
-   ordering="pbn_uid__mniswId")`, zwraca `obj.pbn_uid.mniswId if
-   obj.pbn_uid_id else None`.
+   ordering="_mnisw_id")`, zwraca `obj._mnisw_id`.
 3. Metoda `liczba_prac_display` — `@admin.display(description="Publikacje",
    ordering="_liczba_prac")`, zwraca `obj._liczba_prac`.
 4. `list_display` += `"mnisw_id_display"`, `"liczba_prac_display"`.
 5. `list_filter` += `MniswIdObecnyFilter`, `MaPublikacjeFilter`.
-6. `list_select_related` += `"pbn_uid"` (uniknięcie N+1 przy kolumnie
-   mniswID).
+
+Kolumnę mniswID dostarcza annotacja `_mnisw_id=F("pbn_uid__mniswId")`, a nie
+`list_select_related("pbn_uid")` — `select_related` ciągnąłby ciężki blob
+JSON `Journal.versions` dla każdego wiersza listy, a potrzebna jest tylko
+jedna liczba. Annotacja przez JOIN jest równie wolna od N+1, ale pobiera samą
+kolumnę mniswId.
 
 ## Workflow usuwania
 
 Filtr „ma publikacje = nie ma" + „mniswID = nie ma mniswID" → zaznacz
 wszystko → akcja „Usuń wybrane źródła".
 
-## Testy (`src/bpp/tests/`)
+## Testy (`src/bpp/tests/test_admin/test_zrodlo.py`)
 
-TDD, pytest + `model_bakery.baker`, `@pytest.mark.django_db`:
+TDD, pytest + `model_bakery.baker`, `@pytest.mark.django_db`. Poza testami
+jednostkowymi kolumn i filtrów: smoke-test changelistu (`admin_client`,
+HTTP 200 przy sortowaniu po obu annotowanych kolumnach i przy obu filtrach
+naraz) oraz towncrier newsfragment (`feature`).
 
 - annotacja/kolumna liczby prac: źródło z N wydawnictwami ciągłymi → N;
   źródło bez prac → 0.

--- a/src/bpp/admin/filters.py
+++ b/src/bpp/admin/filters.py
@@ -185,10 +185,12 @@ class MniswIdObecnyFilter(SimpleNotNullFilter):
 
 
 class MaPublikacjeFilter(SimpleListFilter):
-    # Działa na annotacji _liczba_prac dostarczanej przez
-    # ZrodloAdmin.get_queryset (Count("wydawnictwo_ciagle")). Filtrowanie po
-    # annotacji, a nie po wydawnictwo_ciagle__isnull, unika duplikatów wierszy
-    # z JOIN-a (Count + GROUP BY zwija je do jednego wiersza na źródło).
+    # Filtruje po liczbie powiązanych Wydawnictw Ciągłych. Filtrowanie po
+    # annotacji Count (a nie po wydawnictwo_ciagle__isnull) unika duplikatów
+    # wierszy z JOIN-a — Count + GROUP BY zwija je do jednego wiersza na
+    # źródło. ZrodloAdmin.get_queryset zwykle dostarcza już _liczba_prac;
+    # dla bezpieczeństwa (moduł filtrów jest współdzielony) annotujemy ją tu
+    # sami, gdy jej brak — inaczej filtr rzucałby FieldError.
     title = "ma publikacje"
     parameter_name = "ma_publikacje"
 
@@ -197,11 +199,15 @@ class MaPublikacjeFilter(SimpleListFilter):
 
     def queryset(self, request, queryset):
         v = self.value()
+        if v not in ("tak", "nie"):
+            return queryset
+        if "_liczba_prac" not in queryset.query.annotations:
+            queryset = queryset.annotate(
+                _liczba_prac=Count("wydawnictwo_ciagle", distinct=True)
+            )
         if v == "tak":
             return queryset.filter(_liczba_prac__gt=0)
-        elif v == "nie":
-            return queryset.filter(_liczba_prac=0)
-        return queryset
+        return queryset.filter(_liczba_prac=0)
 
 
 class CalkowitaLiczbaAutorowFilter(SimpleIntegerFilter):

--- a/src/bpp/admin/filters.py
+++ b/src/bpp/admin/filters.py
@@ -173,6 +173,37 @@ class PBN_UID_IDObecnyFilter(SimpleNotNullFilter):
     parameter_name = "pbn_uid_id"
 
 
+class MniswIdObecnyFilter(SimpleNotNullFilter):
+    # Uwaga: to NIE jest to samo, co PBN_UID_IDObecnyFilter. Źródło może mieć
+    # pbn_uid (powiązany Journal), ale ten Journal może mieć mniswId = NULL.
+    title = "mniswID"
+    parameter_name = "mnisw_id"
+    db_field_name = "pbn_uid__mniswId"
+
+    def lookups(self, request, model_admin):
+        return [("brak", "nie ma mniswID"), ("jest", "ma mniswID")]
+
+
+class MaPublikacjeFilter(SimpleListFilter):
+    # Działa na annotacji _liczba_prac dostarczanej przez
+    # ZrodloAdmin.get_queryset (Count("wydawnictwo_ciagle")). Filtrowanie po
+    # annotacji, a nie po wydawnictwo_ciagle__isnull, unika duplikatów wierszy
+    # z JOIN-a (Count + GROUP BY zwija je do jednego wiersza na źródło).
+    title = "ma publikacje"
+    parameter_name = "ma_publikacje"
+
+    def lookups(self, request, model_admin):
+        return [("tak", "ma publikacje"), ("nie", "nie ma publikacji")]
+
+    def queryset(self, request, queryset):
+        v = self.value()
+        if v == "tak":
+            return queryset.filter(_liczba_prac__gt=0)
+        elif v == "nie":
+            return queryset.filter(_liczba_prac=0)
+        return queryset
+
+
 class CalkowitaLiczbaAutorowFilter(SimpleIntegerFilter):
     title = "całkowita liczba autorów"
     parameter_name = "calkowita_liczba_autorow"

--- a/src/bpp/admin/zrodlo.py
+++ b/src/bpp/admin/zrodlo.py
@@ -2,7 +2,7 @@
 from dal import autocomplete
 from django import forms
 from django.contrib import admin
-from django.db.models import Count
+from django.db.models import Count, F
 
 from bpp.admin.helpers.djangoql import BppDjangoQLSearchMixin
 from bpp.models.zrodlo import Redakcja_Zrodla
@@ -158,22 +158,27 @@ class ZrodloAdmin(
         MniswIdObecnyFilter,
         MaPublikacjeFilter,
     ]
-    list_select_related = ["openaccess_licencja", "rodzaj", "pbn_uid"]
+    list_select_related = ["openaccess_licencja", "rodzaj"]
 
     def get_queryset(self, request):
-        # Annotacja liczby publikacji (tylko Wydawnictwo_Ciagle ma FK do
-        # Zrodlo). Zasila kolumnę liczby prac oraz MaPublikacjeFilter.
+        # _liczba_prac: liczba publikacji (tylko Wydawnictwo_Ciagle ma FK do
+        # Zrodlo). distinct=True chroni licznik przed zawyżeniem, gdyby
+        # wyszukiwarka DjangoQL dorzuciła drugi multi-valued JOIN.
+        # _mnisw_id: annotacja pojedynczej kolumny mniswId przez JOIN do
+        # Journal — tańsze niż select_related("pbn_uid"), które ciągnęłoby
+        # ciężki blob JSON Journal.versions dla każdego wiersza listy.
         return (
             super()
             .get_queryset(request)
-            .annotate(_liczba_prac=Count("wydawnictwo_ciagle"))
+            .annotate(
+                _liczba_prac=Count("wydawnictwo_ciagle", distinct=True),
+                _mnisw_id=F("pbn_uid__mniswId"),
+            )
         )
 
-    @admin.display(description="mniswID", ordering="pbn_uid__mniswId")
+    @admin.display(description="mniswID", ordering="_mnisw_id")
     def mnisw_id_display(self, obj):
-        if obj.pbn_uid_id is None:
-            return None
-        return obj.pbn_uid.mniswId
+        return obj._mnisw_id
 
     @admin.display(description="Publikacje", ordering="_liczba_prac")
     def liczba_prac_display(self, obj):

--- a/src/bpp/admin/zrodlo.py
+++ b/src/bpp/admin/zrodlo.py
@@ -2,6 +2,7 @@
 from dal import autocomplete
 from django import forms
 from django.contrib import admin
+from django.db.models import Count
 
 from bpp.admin.helpers.djangoql import BppDjangoQLSearchMixin
 from bpp.models.zrodlo import Redakcja_Zrodla
@@ -14,7 +15,11 @@ from ..models import (  # Publikacja_Habilitacyjna
     Zrodlo,
 )
 from .core import BaseBppAdminMixin
-from .filters import PBN_UID_IDObecnyFilter
+from .filters import (
+    MaPublikacjeFilter,
+    MniswIdObecnyFilter,
+    PBN_UID_IDObecnyFilter,
+)
 from .helpers.fieldsets import ADNOTACJE_FIELDSET, MODEL_PUNKTOWANY_Z_KWARTYLAMI_BAZA
 from .helpers.mixins import ZapiszZAdnotacjaMixin
 from .helpers.widgets import CHARMAP_SINGLE_LINE, COMMA_DECIMAL_FIELD_OVERRIDE
@@ -132,7 +137,17 @@ class ZrodloAdmin(
     ]
 
     autocomplete_fields = ["pbn_uid"]
-    list_display = ["nazwa", "skrot", "rodzaj", "www", "issn", "e_issn", "pbn_uid_id"]
+    list_display = [
+        "nazwa",
+        "skrot",
+        "rodzaj",
+        "www",
+        "issn",
+        "e_issn",
+        "pbn_uid_id",
+        "mnisw_id_display",
+        "liczba_prac_display",
+    ]
     list_filter = [
         "rodzaj",
         "zasieg",
@@ -140,8 +155,30 @@ class ZrodloAdmin(
         "openaccess_tryb_dostepu",
         "openaccess_licencja",
         PBN_UID_IDObecnyFilter,
+        MniswIdObecnyFilter,
+        MaPublikacjeFilter,
     ]
-    list_select_related = ["openaccess_licencja", "rodzaj"]
+    list_select_related = ["openaccess_licencja", "rodzaj", "pbn_uid"]
+
+    def get_queryset(self, request):
+        # Annotacja liczby publikacji (tylko Wydawnictwo_Ciagle ma FK do
+        # Zrodlo). Zasila kolumnę liczby prac oraz MaPublikacjeFilter.
+        return (
+            super()
+            .get_queryset(request)
+            .annotate(_liczba_prac=Count("wydawnictwo_ciagle"))
+        )
+
+    @admin.display(description="mniswID", ordering="pbn_uid__mniswId")
+    def mnisw_id_display(self, obj):
+        if obj.pbn_uid_id is None:
+            return None
+        return obj.pbn_uid.mniswId
+
+    @admin.display(description="Publikacje", ordering="_liczba_prac")
+    def liczba_prac_display(self, obj):
+        return obj._liczba_prac
+
     fieldsets = (
         (
             None,

--- a/src/bpp/newsfragments/+zrodlo-admin-mnisw-publikacje.feature
+++ b/src/bpp/newsfragments/+zrodlo-admin-mnisw-publikacje.feature
@@ -1,0 +1,3 @@
+Admin źródeł: nowe kolumny „mniswID" i „Publikacje" (liczba prac,
+sortowalna) oraz filtry „ma mniswID" i „ma publikacje" — ułatwiają
+znalezienie i hurtowe usunięcie źródeł bez publikacji i bez mniswID.

--- a/src/bpp/tests/test_admin/test_zrodlo.py
+++ b/src/bpp/tests/test_admin/test_zrodlo.py
@@ -41,7 +41,7 @@ def test_liczba_prac_annotation(admin_user, zrodlo):
 
 
 @pytest.mark.django_db
-def test_mnisw_id_display(zrodlo):
+def test_mnisw_id_display(admin_user, zrodlo):
     admin = _admin()
 
     # źródło z pbn_uid i mniswId
@@ -61,9 +61,12 @@ def test_mnisw_id_display(zrodlo):
     # źródło bez pbn_uid w ogóle
     z_bez_pbn = zrodlo
 
-    assert admin.mnisw_id_display(z_z_mnisw) == 12345
-    assert admin.mnisw_id_display(z_bez_mnisw) is None
-    assert admin.mnisw_id_display(z_bez_pbn) is None
+    # kolumna czyta annotację _mnisw_id z get_queryset, więc pobieramy
+    # instancje przez queryset adminu
+    qs = admin.get_queryset(_request(admin_user))
+    assert admin.mnisw_id_display(qs.get(pk=z_z_mnisw.pk)) == 12345
+    assert admin.mnisw_id_display(qs.get(pk=z_bez_mnisw.pk)) is None
+    assert admin.mnisw_id_display(qs.get(pk=z_bez_pbn.pk)) is None
 
 
 @pytest.mark.django_db
@@ -83,6 +86,26 @@ def test_MaPublikacjeFilter(admin_user, zrodlo):
 
     f.value = lambda *a, **kw: "nie"
     z_nie = f.queryset(None, base_qs)
+    assert puste in z_nie
+    assert zrodlo not in z_nie
+
+
+@pytest.mark.django_db
+def test_MaPublikacjeFilter_bez_annotacji(zrodlo):
+    # Filtr musi sam annotować _liczba_prac, gdy queryset jej nie ma
+    # (moduł filtrów jest współdzielony) — inaczej FieldError.
+    baker.make(Wydawnictwo_Ciagle, zrodlo=zrodlo)
+    puste = baker.make(Zrodlo, nazwa="Puste", skrot="Pu.")
+
+    f = MaPublikacjeFilter(None, {}, Zrodlo, None)
+
+    f.value = lambda *a, **kw: "tak"
+    z_tak = f.queryset(None, Zrodlo.objects.all())
+    assert zrodlo in z_tak
+    assert puste not in z_tak
+
+    f.value = lambda *a, **kw: "nie"
+    z_nie = f.queryset(None, Zrodlo.objects.all())
     assert puste in z_nie
     assert zrodlo not in z_nie
 
@@ -120,8 +143,8 @@ def test_MniswIdObecnyFilter(zrodlo):
 
 @pytest.mark.django_db
 def test_changelist_renderuje_sie_z_filtrami(admin_client, zrodlo):
-    # Smoke: annotacja + ordering po polu z JOIN-a (pbn_uid__mniswId) oraz
-    # nowe filtry nie mogą wywalić changelistu.
+    # Smoke: annotacje (Count + mniswId przez JOIN) i nowe filtry nie mogą
+    # wywalić changelistu, także przy sortowaniu po kolumnach z annotacji.
     baker.make(Wydawnictwo_Ciagle, zrodlo=zrodlo)
     baker.make(
         Zrodlo,
@@ -132,7 +155,9 @@ def test_changelist_renderuje_sie_z_filtrami(admin_client, zrodlo):
     url = reverse("admin:bpp_zrodlo_changelist")
 
     assert admin_client.get(url).status_code == 200
-    # sortowanie po kolumnie liczby prac (index 8 w list_display)
+    # sortowanie po mniswID (index 7) — annotacja _mnisw_id po JOIN-ie do Journal
+    assert admin_client.get(url, {"o": "7"}).status_code == 200
+    # sortowanie po liczbie prac (index 8) — annotacja Count z GROUP BY
     assert admin_client.get(url, {"o": "8"}).status_code == 200
     # oba nowe filtry naraz
     assert (

--- a/src/bpp/tests/test_admin/test_zrodlo.py
+++ b/src/bpp/tests/test_admin/test_zrodlo.py
@@ -1,0 +1,141 @@
+"""Testy kolumn i filtrów adminu Zrodlo: mniswID + liczba publikacji."""
+
+import pytest
+from django.contrib import admin as django_admin
+from django.test import RequestFactory
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.admin.filters import MaPublikacjeFilter, MniswIdObecnyFilter
+from bpp.admin.zrodlo import ZrodloAdmin
+from bpp.models import Wydawnictwo_Ciagle, Zrodlo
+from pbn_api.models import Journal
+
+
+def _admin():
+    return ZrodloAdmin(Zrodlo, django_admin.site)
+
+
+def _request(admin_user):
+    req = RequestFactory().get("/")
+    req.user = admin_user
+    return req
+
+
+@pytest.mark.django_db
+def test_liczba_prac_annotation(admin_user, zrodlo):
+    baker.make(Wydawnictwo_Ciagle, zrodlo=zrodlo)
+    baker.make(Wydawnictwo_Ciagle, zrodlo=zrodlo)
+    puste = baker.make(Zrodlo, nazwa="Puste", skrot="Pu.")
+
+    admin = _admin()
+    qs = admin.get_queryset(_request(admin_user))
+
+    z_full = qs.get(pk=zrodlo.pk)
+    z_empty = qs.get(pk=puste.pk)
+
+    assert z_full._liczba_prac == 2
+    assert admin.liczba_prac_display(z_full) == 2
+    assert z_empty._liczba_prac == 0
+    assert admin.liczba_prac_display(z_empty) == 0
+
+
+@pytest.mark.django_db
+def test_mnisw_id_display(zrodlo):
+    admin = _admin()
+
+    # źródło z pbn_uid i mniswId
+    z_z_mnisw = baker.make(
+        Zrodlo,
+        nazwa="Z mniswID",
+        skrot="Z m.",
+        pbn_uid=baker.make(Journal, mniswId=12345),
+    )
+    # źródło z pbn_uid, ale bez mniswId
+    z_bez_mnisw = baker.make(
+        Zrodlo,
+        nazwa="Bez mniswID",
+        skrot="B m.",
+        pbn_uid=baker.make(Journal, mniswId=None),
+    )
+    # źródło bez pbn_uid w ogóle
+    z_bez_pbn = zrodlo
+
+    assert admin.mnisw_id_display(z_z_mnisw) == 12345
+    assert admin.mnisw_id_display(z_bez_mnisw) is None
+    assert admin.mnisw_id_display(z_bez_pbn) is None
+
+
+@pytest.mark.django_db
+def test_MaPublikacjeFilter(admin_user, zrodlo):
+    baker.make(Wydawnictwo_Ciagle, zrodlo=zrodlo)
+    puste = baker.make(Zrodlo, nazwa="Puste", skrot="Pu.")
+
+    admin = _admin()
+    base_qs = admin.get_queryset(_request(admin_user))
+
+    f = MaPublikacjeFilter(None, {}, Zrodlo, admin)
+
+    f.value = lambda *a, **kw: "tak"
+    z_tak = f.queryset(None, base_qs)
+    assert zrodlo in z_tak
+    assert puste not in z_tak
+
+    f.value = lambda *a, **kw: "nie"
+    z_nie = f.queryset(None, base_qs)
+    assert puste in z_nie
+    assert zrodlo not in z_nie
+
+
+@pytest.mark.django_db
+def test_MniswIdObecnyFilter(zrodlo):
+    z_z_mnisw = baker.make(
+        Zrodlo,
+        nazwa="Z mniswID",
+        skrot="Z m.",
+        pbn_uid=baker.make(Journal, mniswId=999),
+    )
+    z_bez_mnisw = baker.make(
+        Zrodlo,
+        nazwa="Bez mniswID",
+        skrot="B m.",
+        pbn_uid=baker.make(Journal, mniswId=None),
+    )
+    z_bez_pbn = zrodlo
+
+    f = MniswIdObecnyFilter(None, {}, Zrodlo, None)
+
+    f.value = lambda *a, **kw: "jest"
+    z_jest = f.queryset(None, Zrodlo.objects.all())
+    assert z_z_mnisw in z_jest
+    assert z_bez_mnisw not in z_jest
+    assert z_bez_pbn not in z_jest
+
+    f.value = lambda *a, **kw: "brak"
+    z_brak = f.queryset(None, Zrodlo.objects.all())
+    assert z_bez_mnisw in z_brak
+    assert z_bez_pbn in z_brak
+    assert z_z_mnisw not in z_brak
+
+
+@pytest.mark.django_db
+def test_changelist_renderuje_sie_z_filtrami(admin_client, zrodlo):
+    # Smoke: annotacja + ordering po polu z JOIN-a (pbn_uid__mniswId) oraz
+    # nowe filtry nie mogą wywalić changelistu.
+    baker.make(Wydawnictwo_Ciagle, zrodlo=zrodlo)
+    baker.make(
+        Zrodlo,
+        nazwa="Z mniswID",
+        skrot="Z m.",
+        pbn_uid=baker.make(Journal, mniswId=42),
+    )
+    url = reverse("admin:bpp_zrodlo_changelist")
+
+    assert admin_client.get(url).status_code == 200
+    # sortowanie po kolumnie liczby prac (index 8 w list_display)
+    assert admin_client.get(url, {"o": "8"}).status_code == 200
+    # oba nowe filtry naraz
+    assert (
+        admin_client.get(url, {"ma_publikacje": "nie", "mnisw_id": "brak"}).status_code
+        == 200
+    )


### PR DESCRIPTION
## Cel

Ułatwić redaktorowi porządkowanie źródeł w adminie Django: odnalezienie i **hurtowe usunięcie źródeł bez publikacji oraz bez mniswID**.

## Zmiany w adminie `Zrodlo`

| Element | Szczegóły |
|---|---|
| Kolumna **mniswID** | `pbn_uid.mniswId` przez annotację `F(...)`, sortowalna. Pusto = brak odpowiednika PBN *lub* `Journal` bez `mniswId`. |
| Kolumna **Publikacje** | liczba powiązanych `Wydawnictwo_Ciagle` (`Count(distinct=True)`), sortowalna — `0` = kandydat do usunięcia. |
| Filtr **ma mniswID** (tak/nie) | `MniswIdObecnyFilter` po `pbn_uid__mniswId`. Osobny od istniejącego „PBN UID", bo źródło może mieć `pbn_uid`, a `Journal.mniswId=NULL`. |
| Filtr **ma publikacje** (tak/nie) | `MaPublikacjeFilter` po annotacji liczby prac (bez duplikatów wierszy z JOIN-a). |

**Workflow usuwania:** filtr „ma publikacje = nie ma publikacji" + „mniswID = nie ma mniswID" → zaznacz wszystkie → akcja „Usuń wybrane źródła".

## Uwagi implementacyjne

- **Zero migracji, zero zmian w modelach.** Tylko warstwa admina.
- mniswID dostarcza annotacja `F("pbn_uid__mniswId")`, a nie `select_related("pbn_uid")` — `select_related` ciągnąłby ciężki blob JSON `Journal.versions` dla każdego wiersza listy; annotacja jest równie wolna od N+1, ale pobiera samą jedną kolumnę.
- `Count(distinct=True)` chroni licznik przed zawyżeniem, gdyby wyszukiwarka DjangoQL dorzuciła drugi multi-valued JOIN.
- `MaPublikacjeFilter` sam annotuje `_liczba_prac`, gdy queryset jej nie ma (moduł filtrów jest współdzielony) — nie rzuci `FieldError` przy ewentualnym reużyciu.

## Testy

`src/bpp/tests/test_admin/test_zrodlo.py` — 6 testów (TDD): obie kolumny, oba filtry, filtr bez annotacji, oraz smoke-test changelistu (`admin_client`, HTTP 200 przy sortowaniu po obu annotowanych kolumnach i przy obu filtrach naraz). Lokalnie: **6 passed**. ruff + pre-commit czysto. Newsfragment (towncrier, `feature`) dołączony.

Spec (design): `docs/superpowers/specs/2026-07-04-zrodlo-admin-mnisw-publikacje-design.md`

Kod przeszedł self-review czystym subagentem Fable; naniesione poprawki (annotacja zamiast blobu, `distinct=True`, hardening filtra) są w drugim commicie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)