### PR TITLE
fix(ci): make release-candidate workflow actually run (permissions + bumpver via uvx)

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -175,6 +175,15 @@ jobs:
     uses: ./.github/workflows/build-docker-images.yml
     permissions:
       contents: read
+      # Reusable build-docker-images.yml ma job `check-flag`, ktory deklaruje
+      # `pull-requests: read` (uzywa `gh pr list`/`gh pr view` na sciezce
+      # pull_request/workflow_dispatch — dedup i hint). GitHub waliduje
+      # uprawnienia reusable workflow STATYCZNIE: caller musi nadac >= tego,
+      # co deklaruje dowolny nested job, niezaleznie od tego ze na sciezce
+      # workflow_call (VERSION_TAG ustawiony) check-flag konczy sie wczesnie
+      # i tego scope'u nie tyka. Bez tej linii: "requesting 'pull-requests:
+      # read', but is only allowed 'pull-requests: none'".
+      pull-requests: read
     with:
       ref: ${{ needs.prepare.outputs.release_ref }}
       version_tag: ${{ needs.prepare.outputs.version_tag }}


### PR DESCRIPTION
Two fixes to get `make release-candidate` (new workflow from #422) working. Each was blocking the next.

## Fix 1 — reusable-workflow permissions (parse error)

`make release-candidate` failed to even start:

> The nested job `check-flag` is requesting `pull-requests: read`, but is only allowed `pull-requests: none`.

`build-docker-images.yml`'s `check-flag` job statically declares `pull-requests: read`. GitHub validates reusable-workflow permissions **statically** — the caller must grant ≥ what any nested job declares, regardless of runtime path. The `build:` caller granted only `contents: read`, so `pull-requests` degraded to `none`.

→ Added `pull-requests: read` to the `build:` caller job.

## Fix 2 — `bumpver` via `uvx`, not `uv run` (silent exit 1)

After Fix 1, the `prepare` job died in "Bump RC" with **zero output** and exit 1 (~10s).

Root cause (reproduced on Linux): `uv run bumpver` force-syncs the **entire bpp project** (300+ packages) on the bare runner host just to run a version utility. That sync builds native extensions from source — `pycairo` (via `xhtml2pdf → svglib → rlpycairo → pycairo`) — which fails on the runner (no cairo dev headers / compiler for that path). The error was **invisible** because `2>/dev/null` on the `BASE=$(…)` pipe sent stderr to `/dev/null`, and `set -euo pipefail` killed the step before the `[ -n "$BASE" ]` guard could print its `::error::`.

→ `uv run bumpver` → `uvx bumpver` (isolated tool env, ~5 packages, no project sync). `bumpver` only reads `./pyproject.toml` and edits files — it needs none of bpp's runtime deps. Verified `uvx bumpver test` and `uvx bumpver update --dry` produce identical results.
→ Removed `2>/dev/null` so any future `bumpver` failure is visible (per the repo's no-swallowing-errors rule).

`uv lock` (separate step) stays as-is — it only resolves lockfile metadata, no package builds, safe on the bare host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)