### PR TITLE
fix(ci): run bumpver via uvx in release-candidate (avoid full-project native build)

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -76,15 +76,25 @@ jobs:
             # Nowy cykl: policz BASE RAZ (bumpver test daje następny final),
             # gałąź z dev, ustaw rc1 JAWNIE przez --set-version (BUILD nie
             # może auto-dryfować przy kolejnych RC, stąd nie --tag-num).
+            #
+            # UWAGA: uzywamy `uvx bumpver` (izolowany tool env, ~5 pakietow),
+            # a NIE `uv run bumpver`. `uv run` na goRym hoscie runnera synchro-
+            # nizowalby CALY projekt bpp (300+ pakietow) tylko po to, by odpalic
+            # utility do wersjonowania — a to buduje natywne rozszerzenia ze
+            # zrodel (pycairo przez xhtml2pdf→svglib→rlpycairo) i wywala sie na
+            # runnerze bez naglowkow cairo/kompilatora. bumpver czyta tylko
+            # ./pyproject.toml i edytuje pliki — nie potrzebuje env projektu.
+            # NIE dopisuj `2>/dev/null` — ukrylo by realny blad (patrz historia:
+            # cichy exit 1 gdy sync sie sypal, bo stderr szedl do /dev/null).
             CUR="v$(./bin/bpp-version.py)"
-            BASE=$(uv run bumpver test "$CUR" 'vYYYY0M.BUILD[-TAGNUM]' 2>/dev/null \
+            BASE=$(uvx bumpver test "$CUR" 'vYYYY0M.BUILD[-TAGNUM]' \
                    | awk '/PEP440/{print $NF}')
             # Guard: pusty BASE (np. bumpver test padł) dałby malformed
             # "v-rc1" + gałąź "release/v" — przerwij zanim coś powstanie.
             [ -n "$BASE" ] || { echo "::error::Nie udało się policzyć BASE (bumpver test)."; exit 1; }
             RELEASE_REF="release/v${BASE}"
             git switch -C _rc origin/dev
-            uv run bumpver update --no-fetch --commit --no-push \
+            uvx bumpver update --no-fetch --commit --no-push \
               --set-version "v${BASE}-rc1"
           else
             # Kontynuacja: checkout gałęzi, podbierz fixy z dev, rc(N+1).
@@ -96,7 +106,7 @@ jobs:
             BASE=$(echo "$CUR_PEP" | sed -E 's/rc[0-9]+$//')
             RCN=$(echo "$CUR_PEP" | sed -E 's/.*rc([0-9]+)$/\1/')
             NEXT_RC=$((RCN + 1))
-            uv run bumpver update --no-fetch --commit --no-push \
+            uvx bumpver update --no-fetch --commit --no-push \
               --set-version "v${BASE}-rc${NEXT_RC}"
           fi
 


### PR DESCRIPTION
Follow-up to #445. That PR was squash-merged with only its first commit (the `pull-requests: read` permissions fix) **before** this second fix was pushed, so this change was stranded on the branch. The new `release-candidate.yml` on `dev` is therefore still broken at the "Bump RC" step (confirmed by run 28739954086 — silent exit 1).

## Problem

`uv run bumpver` on the bare `ubuntu-latest` host force-syncs the **entire bpp project** (300+ packages) just to run a version utility. That sync builds native extensions from source — `pycairo` (via `xhtml2pdf → svglib → rlpycairo → pycairo`) — which fails on the runner (no cairo dev headers). The error was **invisible**: `2>/dev/null` on `BASE=$(…)` sent stderr to `/dev/null`, and `set -euo pipefail` killed the step before the `[ -n "$BASE" ]` guard could print `::error::` → ~10s, bare exit 1, empty log.

Reproduced on Linux — `uv run` fails building pycairo; `uvx bumpver` installs 5 packages and succeeds.

## Fix

- `uv run bumpver` → `uvx bumpver` (isolated tool env, no project sync) in all three call sites. `bumpver` only reads `./pyproject.toml` and edits files — it needs none of bpp's runtime deps. Verified `uvx bumpver test` and `uvx bumpver update --dry` produce identical results.
- Removed `2>/dev/null` so any future `bumpver` failure is visible (per the repo's no-swallowing-errors rule).

`uv lock` (separate step) is untouched — it only resolves lockfile metadata, no builds, safe on the bare host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)