### PR TITLE
fix(admin): podświetlaj składnię DjangoQL warunkowo wg przełącznika trybu

### DIFF
--- a/src/bpp/newsfragments/+admin-djangoql-highlight-warunkowy.bugfix.md
+++ b/src/bpp/newsfragments/+admin-djangoql-highlight-warunkowy.bugfix.md
@@ -1,0 +1,4 @@
+Podświetlanie składni w polu wyszukiwania admina włącza się teraz warunkowo —
+tylko gdy zaznaczono przełącznik „używaj DjangoQL". Przy zwykłym wyszukiwaniu
+podłańcuchowym pole wygląda jak normalny input (wcześniej kolorowanie składni
+było aktywne niezależnie od stanu przełącznika).

--- a/src/bpp/static/bpp/js/djangoql-admin.js
+++ b/src/bpp/static/bpp/js/djangoql-admin.js
@@ -37,14 +37,24 @@
     return { line: line, column: column };
   }
 
-  // Czyste helpery lokalizacji błędu (string→offset, offset→line/column)
-  // wystawiamy na namespace, żeby były jednostkowo testowalne bez DOM ani
-  // DjangoQL. To jedyna funkcja tego eksportu — `wire()`/DOMReady poniżej
-  // wymagają DjangoQL i odpalają się wyłącznie w przeglądarce.
+  // Czy podświetlanie ma być aktywne? Idzie za przełącznikiem trybu
+  // wyszukiwania: gdy admin ma checkbox `.djangoql-toggle` (rysowany przez
+  // completion_admin.js, gdy nadpisano `search_fields`), to jego stan decyduje
+  // — zaznaczony = tryb DjangoQL = koloruj składnię; odznaczony = zwykłe
+  // wyszukiwanie podłańcuchowe = pole ma wyglądać jak normalny input. Bez
+  // przełącznika DjangoQL jest wymuszony, więc podświetlamy zawsze.
+  function highlightEnabled(toggle) {
+    return toggle ? Boolean(toggle.checked) : true;
+  }
+
+  // Czyste helpery (lokalizacja błędu + decyzja o podświetlaniu) wystawiamy na
+  // namespace, żeby były jednostkowo testowalne bez DOM ani DjangoQL. `wire()`
+  // /DOMReady poniżej wymagają DjangoQL i odpalają się wyłącznie w przeglądarce.
   window.bppDjangoQLAdmin = {
     escapeRe: escapeRe,
     locateValue: locateValue,
     lineColFromOffset: lineColFromOffset,
+    highlightEnabled: highlightEnabled,
   };
 
   var H = window.DjangoQLHighlight;
@@ -60,6 +70,40 @@
     // Jedyne miejsce, które dołącza nakładkę w adminie — mamy uchwyt.
     var overlay = H.attachOverlay(textarea);
     if (!overlay) {
+      return;
+    }
+
+    // Nakładka ma iść za przełącznikiem trybu: przy odznaczonym „używaj
+    // DjangoQL" chowamy backdrop i zdejmujemy transparentność tekstu, żeby
+    // pole wyglądało jak zwykły input; przy zaznaczonym — kolorujemy.
+    var toggle = document.querySelector("input.djangoql-toggle");
+
+    function setHighlightEnabled(on) {
+      if (on) {
+        textarea.classList.add("dql-highlight-input");
+        overlay.backdrop.style.display = "";
+        overlay.repaint(); // wartość mogła się zmienić, gdy nakładka spała
+      } else {
+        // Widać wpisywane znaki wprost (bez transparentnego tekstu), a
+        // kolorowany backdrop jest schowany.
+        textarea.classList.remove("dql-highlight-input");
+        overlay.backdrop.style.display = "none";
+      }
+    }
+
+    var enabled = highlightEnabled(toggle);
+    setHighlightEnabled(enabled);
+    if (toggle) {
+      // completion_admin.js trzyma swój handler na `.onchange`; my dokładamy
+      // słuchacza przez addEventListener, więc oba odpalają się niezależnie.
+      toggle.addEventListener("change", function (e) {
+        setHighlightEnabled(highlightEnabled(e.target));
+      });
+    }
+
+    // Falkę błędu rysujemy tylko w trybie DjangoQL — w zwykłym wyszukiwaniu
+    // nie ma błędnego zapytania DjangoQL do oznaczenia.
+    if (!enabled) {
       return;
     }
     var loc = document.querySelector(".bpp-dql-error-loc");

--- a/src/integration_tests/test_admin_djangoql_highlight.py
+++ b/src/integration_tests/test_admin_djangoql_highlight.py
@@ -1,0 +1,55 @@
+"""Podświetlanie składni DjangoQL w pasku wyszukiwania admina ma iść za
+przełącznikiem trybu — aktywne tylko, gdy zaznaczono „używaj DjangoQL"."""
+
+from playwright.sync_api import Page
+
+from django_bpp.playwright_util import wait_for_page_load
+
+
+def _highlight_active(page: Page) -> bool:
+    """Nakładka jest AKTYWNA, gdy tekst pola jest transparentny
+    (``.dql-highlight-input``) i kolorowany backdrop jest widoczny."""
+    return page.evaluate(
+        "() => {"
+        "  const ta = document.querySelector('textarea[name=q]');"
+        "  const bd = document.querySelector('.dql-highlight-backdrop');"
+        "  return !!ta && ta.classList.contains('dql-highlight-input')"
+        "    && !!bd && getComputedStyle(bd).display !== 'none';"
+        "}"
+    )
+
+
+def test_admin_djangoql_highlight_follows_toggle(
+    channels_live_server, admin_page: Page, transactional_db
+):
+    # Admin Źródła używa BppDjangoQLSearchMixin i nadpisuje search_fields,
+    # więc completion_admin.js rysuje przełącznik trybu (.djangoql-toggle).
+    admin_page.goto(channels_live_server.url + "/admin/bpp/zrodlo/")
+    wait_for_page_load(admin_page)
+
+    # textarę i przełącznik tworzy completion_admin.js na DOMReady; nasza
+    # nakładka doczepia się klatkę później i znaczy pole atrybutem
+    # dataset.dqlHighlight='on' — poczekaj aż wszystko wstanie.
+    admin_page.wait_for_selector("input.djangoql-toggle", timeout=10000)
+    admin_page.wait_for_function(
+        "() => document.querySelector('textarea[name=q]')"
+        "  && document.querySelector('textarea[name=q]')"
+        "       .dataset.dqlHighlight === 'on'",
+        timeout=10000,
+    )
+
+    toggle = admin_page.locator("input.djangoql-toggle")
+
+    # Zaznaczony przełącznik → tryb DjangoQL → podświetlanie AKTYWNE.
+    if not toggle.is_checked():
+        toggle.check()
+    assert _highlight_active(admin_page) is True
+
+    # Odznaczony → zwykłe wyszukiwanie podłańcuchowe → podświetlanie ZNIKA
+    # (pole ma wyglądać jak normalny input).
+    toggle.uncheck()
+    assert _highlight_active(admin_page) is False
+
+    # Ponowne zaznaczenie → podświetlanie wraca.
+    toggle.check()
+    assert _highlight_active(admin_page) is True

--- a/tests/js/djangoql-locate.test.js
+++ b/tests/js/djangoql-locate.test.js
@@ -8,10 +8,12 @@ import { describe, test, expect, beforeAll } from "vitest";
 
 let locateValue;
 let lineColFromOffset;
+let highlightEnabled;
 
 beforeAll(async () => {
     await import("../../src/bpp/static/bpp/js/djangoql-admin.js");
-    ({ locateValue, lineColFromOffset } = window.bppDjangoQLAdmin);
+    ({ locateValue, lineColFromOffset, highlightEnabled } =
+        window.bppDjangoQLAdmin);
 });
 
 describe("lineColFromOffset (0-based offset → 1-based line/column)", () => {
@@ -50,5 +52,19 @@ describe("locateValue (offset tokenu z granicami słownymi)", () => {
 
     test("brak wartości → -1", () => {
         expect(locateValue("rok = 1", "niema")).toBe(-1);
+    });
+});
+
+describe("highlightEnabled (podświetlanie idzie za przełącznikiem trybu)", () => {
+    test("brak przełącznika → DjangoQL wymuszony → zawsze podświetlaj", () => {
+        expect(highlightEnabled(null)).toBe(true);
+    });
+
+    test("przełącznik zaznaczony → tryb DjangoQL → podświetlaj", () => {
+        expect(highlightEnabled({ checked: true })).toBe(true);
+    });
+
+    test("przełącznik odznaczony → zwykłe wyszukiwanie → nie podświetlaj", () => {
+        expect(highlightEnabled({ checked: false })).toBe(false);
     });
 });


### PR DESCRIPTION
## Problem

Podświetlanie składni w polu „wyszukiwanie" w adminie było aktywne
**niezależnie** od stanu przełącznika „używaj DjangoQL". Nakładka
(`bpp/js/djangoql-admin.js`) doczepiała się bezwarunkowo na `DOMReady`,
więc kolorowanie tokenów DjangoQL pokazywało się także w trybie zwykłego
wyszukiwania podłańcuchowego, gdzie nie ma ono sensu.

## Rozwiązanie

Nakładka idzie teraz za przełącznikiem trybu (`.djangoql-toggle`, rysowanym
przez `completion_admin.js`, gdy admin nadpisuje `search_fields`):

- **zaznaczony** → tryb DjangoQL → koloruj składnię,
- **odznaczony** → zwykłe wyszukiwanie → zdejmij transparentność tekstu
  i schowaj backdrop, pole wygląda jak normalny input,
- **bez przełącznika** → DjangoQL jest wymuszony → podświetlaj zawsze
  (zgodnie z serwerowym `search_mode_toggle_enabled()`).

Reagujemy na zmianę przełącznika przez `addEventListener('change')`,
niezależnie od handlera `completion_admin.js`. Falkę błędu rysujemy tylko
w trybie DjangoQL.

## Testy

- **vitest** (`tests/js/djangoql-locate.test.js`) — nowy czysty helper
  `highlightEnabled(toggle)` + 3 przypadki (brak przełącznika/zaznaczony/
  odznaczony). Cała suita: 46 passed.
- **Playwright** (`src/integration_tests/test_admin_djangoql_highlight.py`) —
  `test_admin_djangoql_highlight_follows_toggle` steruje realnym
  przełącznikiem na `/admin/bpp/zrodlo/`: aktywne przy zaznaczonym →
  znika po odznaczeniu → wraca po ponownym zaznaczeniu. Przechodzi lokalnie
  (na starym kodzie asercja „odznaczony ⇒ nieaktywne" pada — realny gejt
  regresji).
- **ruff + pre-commit**: wszystkie hooki zielone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)