### PR TITLE
fix(pbn): import pomija prace usuniete w PBN (status=DELETED)

### DIFF
--- a/src/bpp/newsfragments/pbn-import-pomijaj-deleted.bugfix.rst
+++ b/src/bpp/newsfragments/pbn-import-pomijaj-deleted.bugfix.rst
@@ -1,0 +1,3 @@
+Import z PBN pomija prace usunięte po stronie PBN (``status == "DELETED"``) —
+wcześniej taka praca była materializowana jako nowy rekord ``Wydawnictwo_Ciagle``
+/ ``Wydawnictwo_Zwarte`` w BPP.

--- a/src/bpp/newsfragments/pbn-import-pomijaj-deleted.bugfix.rst
+++ b/src/bpp/newsfragments/pbn-import-pomijaj-deleted.bugfix.rst
@@ -1,3 +1,5 @@
-Import z PBN pomija prace usunięte po stronie PBN (``status == "DELETED"``) —
-wcześniej taka praca była materializowana jako nowy rekord ``Wydawnictwo_Ciagle``
-/ ``Wydawnictwo_Zwarte`` w BPP.
+Import z PBN pomija obiekty usunięte po stronie PBN (``status == "DELETED"``),
+gdy nie mają jeszcze odpowiednika w BPP — wcześniej taka praca, wydawca lub
+naukowiec (import autorów z uczelni) był tworzony jako nowy rekord w BPP
+(``Wydawnictwo_Ciagle``/``Wydawnictwo_Zwarte``, ``Wydawca``, ``Autor``).
+Dopasowywanie istniejących rekordów BPP pozostaje bez zmian.

--- a/src/pbn_integrator/importer/__init__.py
+++ b/src/pbn_integrator/importer/__init__.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 
 from bpp.models import Dyscyplina_Naukowa, Jednostka, Rekord, Rodzaj_Zrodla
 from pbn_api.client import PBNClient
+from pbn_api.const import DELETED
 from pbn_api.models import Publication
 
 # Re-export publication import functions
@@ -72,6 +73,11 @@ def importuj_publikacje_po_pbn_uid_id(
 
     assert pbn_publication is not None
 
+    # Praca usunięta po stronie PBN nie może materializować się jako świeży
+    # rekord BPP. To choke point dla WSZYSTKICH wejść (batch i import po UID).
+    if pbn_publication.status == DELETED:
+        return None
+
     cv = pbn_publication.current_version
 
     match cv["object"].pop("type"):
@@ -133,7 +139,9 @@ def importuj_publikacje_instytucji(
     client: PBNClient, default_jednostka: Jednostka, pbn_uid_id=None
 ):
     niechciane = list(Rekord.objects.values_list("pbn_uid_id", flat=True))
-    chciane = Publication.objects.all().exclude(pk__in=niechciane)
+    chciane = (
+        Publication.objects.all().exclude(status=DELETED).exclude(pk__in=niechciane)
+    )
 
     if pbn_uid_id:
         chciane = chciane.filter(pk=pbn_uid_id)

--- a/src/pbn_integrator/importer/publishers.py
+++ b/src/pbn_integrator/importer/publishers.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from bpp import const
 from bpp.models import Wydawca
 from bpp.models.wydawca import Poziom_Wydawcy
+from pbn_api.const import DELETED
 from pbn_api.models import Publisher
 from pbn_integrator.utils import zapisz_mongodb
 
@@ -130,6 +131,10 @@ def importuj_jednego_wydawce(publisher, verbosity=1):
             has_wydawca = True
 
     if not has_wydawca:
+        # Wydawca skasowany w PBN i bez odpowiednika w BPP — nie twórz nowego.
+        # (Match istniejącego zostawiamy nietknięty — to osobna ścieżka.)
+        if publisher.status == DELETED:
+            return False
         # Nie ma takiego wydawcy w bazie, utwórz go:
         _utworz_nowego_wydawce(publisher, points_to_poziom_map, verbosity)
         return True

--- a/src/pbn_integrator/tests/test_importer_pomija_deleted.py
+++ b/src/pbn_integrator/tests/test_importer_pomija_deleted.py
@@ -1,0 +1,75 @@
+"""Import PBN → BPP musi POMIJAĆ prace usunięte w PBN (``status == DELETED``).
+
+Geneza: importer publikacji (w odróżnieniu od integracji konferencji/źródeł,
+które jawnie robią ``.exclude(status="DELETED")``) NIE sprawdzał statusu lustra
+``pbn_api.Publication``. Skutek: praca usunięta po stronie PBN materializowała
+się jako świeży ``Wydawnictwo_Ciagle``/``Wydawnictwo_Zwarte`` po stronie BPP.
+
+Te testy pilnują dwóch ścieżek tworzących rekord:
+- ``importuj_publikacje_po_pbn_uid_id`` — choke point (również import
+  pojedynczej pracy po UID),
+- ``importuj_publikacje_instytucji`` — batch po całym lustrze.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Rekord, Wydawnictwo_Ciagle
+from pbn_api.models import Publication
+from pbn_integrator import importer
+
+ARTICLE_OBJECT = {
+    "type": "ARTICLE",
+    "title": "Praca usunięta w PBN",
+    "year": 2023,
+}
+
+
+def _make_publication(mongo_id, status):
+    return baker.make(
+        Publication,
+        mongoId=mongo_id,
+        versions=[{"current": True, "object": dict(ARTICLE_OBJECT)}],
+        status=status,
+    )
+
+
+@pytest.mark.django_db
+def test_importuj_po_uid_pomija_deleted():
+    """Import pojedynczej pracy DELETED nie tworzy rekordu BPP (zwraca None)."""
+    _make_publication("d1", "DELETED")
+
+    # client=None jest bezpieczne: guard musi odrzucić DELETED zanim
+    # cokolwiek sięgnie do klienta PBN.
+    ret = importer.importuj_publikacje_po_pbn_uid_id(
+        "d1",
+        client=None,
+        default_jednostka=None,
+    )
+
+    assert ret is None
+    assert Wydawnictwo_Ciagle.objects.count() == 0
+    assert Rekord.objects.filter(pbn_uid_id="d1").count() == 0
+
+
+@pytest.mark.django_db
+def test_importuj_publikacje_instytucji_nie_dispatchuje_deleted(monkeypatch):
+    """Batch po lustrze pomija prace DELETED — dispatch dostaje tylko ACTIVE."""
+    from bpp.models import Dyscyplina_Naukowa, Rodzaj_Zrodla  # noqa: F401
+
+    Rodzaj_Zrodla.objects.get_or_create(nazwa="periodyk")
+
+    _make_publication("a1", "ACTIVE")
+    _make_publication("d1", "DELETED")
+
+    dispatched = []
+    monkeypatch.setattr(
+        importer,
+        "importuj_publikacje_po_pbn_uid_id",
+        lambda mongoId, **kwargs: dispatched.append(mongoId),
+    )
+
+    importer.importuj_publikacje_instytucji(client=None, default_jednostka=None)
+
+    assert "a1" in dispatched
+    assert "d1" not in dispatched

--- a/src/pbn_integrator/tests/test_importer_pomija_deleted.py
+++ b/src/pbn_integrator/tests/test_importer_pomija_deleted.py
@@ -131,9 +131,7 @@ def test_integruj_autorow_pomija_deleted_bez_odpowiednika():
     """DELETED naukowiec bez dopasowania w BPP nie tworzy nowego Autora."""
     _make_scientist("s_del", "DELETED")
 
-    integruj_autorow_z_uczelni(
-        client=None, instutition_id=None, import_unexistent=True
-    )
+    integruj_autorow_z_uczelni(client=None, instutition_id=None, import_unexistent=True)
 
     assert Autor.objects.filter(pbn_uid_id="s_del").count() == 0
 
@@ -143,8 +141,6 @@ def test_integruj_autorow_tworzy_active():
     """Kontrola: ACTIVE naukowiec bez dopasowania nadal jest tworzony."""
     _make_scientist("s_act", "ACTIVE")
 
-    integruj_autorow_z_uczelni(
-        client=None, instutition_id=None, import_unexistent=True
-    )
+    integruj_autorow_z_uczelni(client=None, instutition_id=None, import_unexistent=True)
 
     assert Autor.objects.filter(pbn_uid_id="s_act").count() == 1

--- a/src/pbn_integrator/tests/test_importer_pomija_deleted.py
+++ b/src/pbn_integrator/tests/test_importer_pomija_deleted.py
@@ -14,9 +14,10 @@ Te testy pilnują dwóch ścieżek tworzących rekord:
 import pytest
 from model_bakery import baker
 
-from bpp.models import Rekord, Wydawnictwo_Ciagle
-from pbn_api.models import Publication
+from bpp.models import Autor, Rekord, Wydawca, Wydawnictwo_Ciagle
+from pbn_api.models import Publication, Publisher, Scientist
 from pbn_integrator import importer
+from pbn_integrator.utils.scientists import integruj_autorow_z_uczelni
 
 ARTICLE_OBJECT = {
     "type": "ARTICLE",
@@ -73,3 +74,77 @@ def test_importuj_publikacje_instytucji_nie_dispatchuje_deleted(monkeypatch):
 
     assert "a1" in dispatched
     assert "d1" not in dispatched
+
+
+# --- Wydawcy: hurtowy import nie tworzy Wydawca dla DELETED bez odpowiednika ---
+
+
+def _make_publisher(mongo_id, status):
+    return baker.make(
+        Publisher,
+        mongoId=mongo_id,
+        publisherName=f"Wydawnictwo {mongo_id}",
+        mniswId=123,
+        versions=[{"current": True, "object": {"points": {}}}],
+        status=status,
+    )
+
+
+@pytest.mark.django_db
+def test_importuj_wydawce_pomija_deleted_bez_odpowiednika():
+    """DELETED wydawca bez odpowiednika w BPP nie tworzy nowego Wydawca."""
+    publisher = _make_publisher("p_del", "DELETED")
+
+    ret = importer.importuj_jednego_wydawce(publisher)
+
+    assert not ret
+    assert Wydawca.objects.filter(pbn_uid=publisher).count() == 0
+
+
+@pytest.mark.django_db
+def test_importuj_wydawce_tworzy_active():
+    """Kontrola: ACTIVE wydawca nadal jest tworzony (guard jest status-specific)."""
+    publisher = _make_publisher("p_act", "ACTIVE")
+
+    importer.importuj_jednego_wydawce(publisher)
+
+    assert Wydawca.objects.filter(pbn_uid=publisher).count() == 1
+
+
+# --- Autorzy z uczelni: import_unexistent nie tworzy Autor dla DELETED ---
+
+
+def _make_scientist(mongo_id, status):
+    return baker.make(
+        Scientist,
+        mongoId=mongo_id,
+        versions=[
+            {"current": True, "object": {"name": "Jan", "lastName": f"Nowak{mongo_id}"}}
+        ],
+        status=status,
+        from_institution_api=True,
+    )
+
+
+@pytest.mark.django_db
+def test_integruj_autorow_pomija_deleted_bez_odpowiednika():
+    """DELETED naukowiec bez dopasowania w BPP nie tworzy nowego Autora."""
+    _make_scientist("s_del", "DELETED")
+
+    integruj_autorow_z_uczelni(
+        client=None, instutition_id=None, import_unexistent=True
+    )
+
+    assert Autor.objects.filter(pbn_uid_id="s_del").count() == 0
+
+
+@pytest.mark.django_db
+def test_integruj_autorow_tworzy_active():
+    """Kontrola: ACTIVE naukowiec bez dopasowania nadal jest tworzony."""
+    _make_scientist("s_act", "ACTIVE")
+
+    integruj_autorow_z_uczelni(
+        client=None, instutition_id=None, import_unexistent=True
+    )
+
+    assert Autor.objects.filter(pbn_uid_id="s_act").count() == 1

--- a/src/pbn_integrator/utils/scientists.py
+++ b/src/pbn_integrator/utils/scientists.py
@@ -14,6 +14,7 @@ from django.db.models import Q
 
 from bpp.models import Autor, Autor_Dyscyplina, Tytul, Uczelnia
 from bpp.util import pbar
+from pbn_api.const import DELETED
 from pbn_api.models import Scientist
 from pbn_integrator.utils.constants import CPU_COUNT
 from pbn_integrator.utils.django_imports import _ensure_django_imports
@@ -308,6 +309,12 @@ def integruj_autorow_z_uczelni(
             if not import_unexistent:
                 # Brak autora po stronie BPP, nie chcemy tworzyć nowych rekordów
                 logger.info(f"Brak dopasowania w jednostce dla autora {person}")
+                continue
+
+            if person.status == DELETED:
+                # Naukowiec skasowany w PBN i bez odpowiednika w BPP — nie
+                # twórz nowego autora. (Match istniejącego to osobna ścieżka.)
+                logger.info(f"Pomijam skasowanego w PBN autora {person}")
                 continue
 
             utworz_wpis_dla_jednego_autora(person)


### PR DESCRIPTION
## Problem

Import PBN → BPP tworzył lokalny rekord (`Wydawnictwo_Ciagle`/`Wydawnictwo_Zwarte`) **także dla prac usuniętych po stronie PBN** (`status == "DELETED"`). Importer publikacji — w odróżnieniu od integracji konferencji (`conferences.py:65`) i źródeł — nie sprawdzał statusu lustra `pbn_api.Publication`.

Prace DELETED trafiają do lustra celowo (`pobierz_skasowane_prace`, `offline_data` iterują `[ACTIVE, DELETED]`), ale **nie powinny** materializować się jako świeże rekordy bibliograficzne BPP. Istnienie downstream-owego detektora `komparator_pbn` (`.filter(pbn_uid__status="DELETED")`) potwierdza, że taka niespójność realnie występowała.

## Zmiana

Dwa strażniki w `src/pbn_integrator/importer/__init__.py`:

1. **Choke point** — `importuj_publikacje_po_pbn_uid_id`: po pobraniu lustra, `if status == DELETED: return None` (zanim cokolwiek sięgnie do klienta PBN). Pokrywa **obie** ścieżki: import pojedynczej pracy po UID *i* batch.
2. **Queryset** — `importuj_publikacje_instytucji`: `.exclude(status=DELETED)`, żeby batch nawet nie dispatch-ował znanych DELETED.

## Testy (TDD)

`src/pbn_integrator/tests/test_importer_pomija_deleted.py` — najpierw RED (bez guarda praca DELETED tworzyła `Wydawnictwo_Ciagle`), potem GREEN:
- `test_importuj_po_uid_pomija_deleted` — import po UID zwraca `None`, zero rekordów;
- `test_importuj_publikacje_instytucji_nie_dispatchuje_deleted` — batch dispatchuje tylko ACTIVE.

Lokalnie: 14 passed (nowy plik + sąsiednie `test_integruj_*`/`test_integrator_import`), ruff czysty. Brak migracji → baseline bez zmian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)