### PR TITLE
feat(admin): filtr "PBN: status" (skasowany/aktywny/brak) dla wydawnictw

### DIFF
--- a/src/bpp/admin/filters.py
+++ b/src/bpp/admin/filters.py
@@ -6,6 +6,7 @@ from django.db.models.functions import Cast
 
 from bpp.models import BppUser, Wydawnictwo_Zwarte
 from bpp.models.struktura import Jednostka
+from pbn_api.const import ACTIVE, DELETED
 
 
 class SimpleIntegerFilter(SimpleListFilter):
@@ -171,6 +172,35 @@ class PBN_UID_IDAutoraObecnyFilter(SimpleNotNullFilter):
 class PBN_UID_IDObecnyFilter(SimpleNotNullFilter):
     title = "PBN UID"
     parameter_name = "pbn_uid_id"
+
+
+class PBNStatusFilter(SimpleListFilter):
+    """Filtruje po statusie powiązanej pracy PBN (``pbn_uid.status``).
+
+    Wyłapuje rekordy powiązane z pracą skasowaną w PBN (``DELETED``), aktywną
+    (``ACTIVE``) albo bez powiązania (``pbn_uid`` puste). Statusy DELETED/ACTIVE
+    żyją na lustrze ``pbn_api.Publication`` — traversujemy przez ``pbn_uid``.
+    """
+
+    title = "PBN: status"
+    parameter_name = "pbn_status"
+
+    def lookups(self, request, model_admin):
+        return [
+            ("deleted", "skasowany w PBN"),
+            ("active", "aktywny w PBN"),
+            ("brak", "brak powiązania"),
+        ]
+
+    def queryset(self, request, queryset):
+        v = self.value()
+        if v == "deleted":
+            return queryset.filter(pbn_uid__status=DELETED)
+        elif v == "active":
+            return queryset.filter(pbn_uid__status=ACTIVE)
+        elif v == "brak":
+            return queryset.filter(pbn_uid_id__isnull=True)
+        return queryset
 
 
 class MniswIdObecnyFilter(SimpleNotNullFilter):

--- a/src/bpp/admin/wydawnictwo_ciagle.py
+++ b/src/bpp/admin/wydawnictwo_ciagle.py
@@ -14,6 +14,7 @@ from bpp.admin.filters import (
     MaKonferencjeFilter,
     OstatnioZmienionePrzezFilter,
     PBN_UID_IDObecnyFilter,
+    PBNStatusFilter,
     UtworzonePrzezFilter,
 )
 from bpp.admin.helpers.djangoql import BppDjangoQLSearchMixin
@@ -381,6 +382,7 @@ class Wydawnictwo_CiagleAdmin(
         OstatnioZmienionePrzezFilter,
         UtworzonePrzezFilter,
         PBN_UID_IDObecnyFilter,
+        PBNStatusFilter,
         BezJakichkolwiekDyscyplinFilter,
     ]
 

--- a/src/bpp/admin/wydawnictwo_zwarte.py
+++ b/src/bpp/admin/wydawnictwo_zwarte.py
@@ -17,6 +17,7 @@ from bpp.admin.filters import (
     MaWydawnictwoNadrzedneFilter,
     OstatnioZmienionePrzezFilter,
     PBN_UID_IDObecnyFilter,
+    PBNStatusFilter,
     UtworzonePrzezFilter,
 )
 from bpp.admin.helpers import fieldsets
@@ -154,6 +155,7 @@ class Wydawnictwo_ZwarteAdmin_Baza(BaseBppAdminMixin, admin.ModelAdmin):
         OstatnioZmienionePrzezFilter,
         UtworzonePrzezFilter,
         PBN_UID_IDObecnyFilter,
+        PBNStatusFilter,
         BezJakichkolwiekDyscyplinFilter,
     ]
 

--- a/src/bpp/newsfragments/admin-filtr-pbn-status.feature.rst
+++ b/src/bpp/newsfragments/admin-filtr-pbn-status.feature.rst
@@ -1,0 +1,4 @@
+Admin ``Wydawnictwo ciągłe`` i ``Wydawnictwo zwarte`` ma nowy filtr „PBN:
+status" — pozwala wyłapać rekordy powiązane z pracą skasowaną w PBN
+(``DELETED``), aktywną (``ACTIVE``) albo bez powiązania. To samo zawężenie
+działa też w wyszukiwaniu DjangoQL: ``pbn_uid.status = "DELETED"``.

--- a/src/bpp/tests/test_admin/test_pbn_status_filter.py
+++ b/src/bpp/tests/test_admin/test_pbn_status_filter.py
@@ -1,0 +1,120 @@
+"""Filtr admina po statusie powiązanej pracy PBN (``pbn_uid.status``).
+
+Pozwala w adminie ``Wydawnictwo_Ciagle``/``Wydawnictwo_Zwarte`` wyłapać rekordy
+powiązane z pracą skasowaną w PBN (``status == "DELETED"``), aktywną
+(``ACTIVE``) albo bez powiązania (``pbn_uid`` puste).
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.admin.filters import PBNStatusFilter
+from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Zwarte
+from pbn_api.models import Publication
+
+
+def _pub(mongo_id, status):
+    return baker.make(
+        Publication,
+        mongoId=mongo_id,
+        versions=[{"current": True, "object": {"title": mongo_id}}],
+        status=status,
+    )
+
+
+@pytest.fixture
+def trzy_wydawnictwa_ciagle():
+    """(deleted, active, brak) — po jednym Wydawnictwo_Ciagle każdego rodzaju."""
+    wc_del = baker.make(Wydawnictwo_Ciagle, pbn_uid=_pub("wc_del", "DELETED"))
+    wc_act = baker.make(Wydawnictwo_Ciagle, pbn_uid=_pub("wc_act", "ACTIVE"))
+    wc_brak = baker.make(Wydawnictwo_Ciagle, pbn_uid=None)
+    return wc_del, wc_act, wc_brak
+
+
+def _apply(value, model):
+    f = PBNStatusFilter(None, {}, model, None)
+    f.value = lambda *a, **k: value
+    return f.queryset(None, model.objects.all())
+
+
+@pytest.mark.django_db
+def test_filtr_deleted(trzy_wydawnictwa_ciagle):
+    wc_del, wc_act, wc_brak = trzy_wydawnictwa_ciagle
+    qs = _apply("deleted", Wydawnictwo_Ciagle)
+    assert wc_del in qs
+    assert wc_act not in qs
+    assert wc_brak not in qs
+
+
+@pytest.mark.django_db
+def test_filtr_active(trzy_wydawnictwa_ciagle):
+    wc_del, wc_act, wc_brak = trzy_wydawnictwa_ciagle
+    qs = _apply("active", Wydawnictwo_Ciagle)
+    assert wc_act in qs
+    assert wc_del not in qs
+    assert wc_brak not in qs
+
+
+@pytest.mark.django_db
+def test_filtr_brak(trzy_wydawnictwa_ciagle):
+    wc_del, wc_act, wc_brak = trzy_wydawnictwa_ciagle
+    qs = _apply("brak", Wydawnictwo_Ciagle)
+    assert wc_brak in qs
+    assert wc_del not in qs
+    assert wc_act not in qs
+
+
+@pytest.mark.django_db
+def test_filtr_brak_wartosci_nie_zaweza(trzy_wydawnictwa_ciagle):
+    """Brak wybranej wartości filtra → queryset niezmieniony."""
+    qs = _apply(None, Wydawnictwo_Ciagle)
+    assert qs.count() == 3
+
+
+def test_lookups_ma_trzy_opcje():
+    f = PBNStatusFilter(None, {}, Wydawnictwo_Ciagle, None)
+    keys = [k for k, _label in f.lookups(None, None)]
+    assert keys == ["deleted", "active", "brak"]
+
+
+@pytest.mark.django_db
+def test_filtr_dziala_tez_dla_zwarte():
+    wz_del = baker.make(Wydawnictwo_Zwarte, pbn_uid=_pub("wz_del", "DELETED"))
+    wz_act = baker.make(Wydawnictwo_Zwarte, pbn_uid=_pub("wz_act", "ACTIVE"))
+    qs = _apply("deleted", Wydawnictwo_Zwarte)
+    assert wz_del in qs
+    assert wz_act not in qs
+
+
+def test_filtr_podpiety_do_obu_adminow():
+    """Regresja: filtr jest w list_filter obu adminów."""
+    from bpp.admin.wydawnictwo_ciagle import Wydawnictwo_CiagleAdmin
+    from bpp.admin.wydawnictwo_zwarte import Wydawnictwo_ZwarteAdmin
+
+    assert PBNStatusFilter in Wydawnictwo_CiagleAdmin.list_filter
+    assert PBNStatusFilter in Wydawnictwo_ZwarteAdmin.list_filter
+
+
+@pytest.mark.django_db
+def test_djangoql_pbn_uid_status_dziala(trzy_wydawnictwa_ciagle):
+    """Regresja: DjangoQL admina waliduje i filtruje ``pbn_uid.status``.
+
+    ``pbn_api`` nie jest wykluczone z ``BppQLSchema``, więc traversal
+    ``pbn_uid.status`` musi się walidować i faktycznie zawężać wyniki. To pilnuje,
+    że przyszłe uszczelnianie schematu nie odetnie tej (użytecznej) ścieżki.
+    """
+    from djangoql.queryset import apply_search
+
+    from bpp.djangoql_schema import BppQLSchema
+
+    wc_del, wc_act, wc_brak = trzy_wydawnictwa_ciagle
+
+    qs = apply_search(
+        Wydawnictwo_Ciagle.objects.all(),
+        'pbn_uid.status = "DELETED"',
+        schema=BppQLSchema,
+    )
+
+    assert wc_del in qs
+    assert wc_act not in qs
+    assert wc_brak not in qs


### PR DESCRIPTION
## Po co

Po zmergowaniu #449 (import nie tworzy już rekordów BPP dla prac DELETED w PBN) pojawiła się potrzeba **znalezienia** rekordów, które powstały wcześniej — powiązanych z pracą skasowaną po stronie PBN. W adminie `Wydawnictwo_Ciagle`/`Zwarte` był tylko filtr „PBN UID obecny/brak", bez statusu.

## Co

Nowy `PBNStatusFilter` (`bpp/admin/filters.py`) traversujący `pbn_uid__status`, dodany do `list_filter` obu adminów. Trzy opcje:
- **skasowany w PBN** (`DELETED`)
- **aktywny w PBN** (`ACTIVE`)
- **brak powiązania** (`pbn_uid` puste)

## DjangoQL — działa już bez zmian

Przy okazji zweryfikowałem (test regresyjny): `pbn_uid.status = "DELETED"` w polu DjangoQL admina **waliduje się i filtruje poprawnie**. `pbn_api` nie jest wykluczone z `BppQLSchema`, więc traversal po `pbn_uid` jest dostępny. Test pilnuje, że przyszłe uszczelnianie schematu tej ścieżki nie odetnie.

## Testy (TDD)

`src/bpp/tests/test_admin/test_pbn_status_filter.py` — RED (ImportError) → GREEN. 8 testów: deleted/active/brak dla `Wydawnictwo_Ciagle`, kontrola pustej wartości, `Wydawnictwo_Zwarte`, obecność w `list_filter` obu adminów, oraz regresja DjangoQL. Lokalnie 8/8, ruff czysty. Bez migracji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)