### PR TITLE
fix(raport-slotow): raport zerowy — temp table ginęła przy leniwym renderze pod ASGI

### DIFF
--- a/src/bpp/newsfragments/+raport-zerowy-temp-table-asgi.bugfix.rst
+++ b/src/bpp/newsfragments/+raport-zerowy-temp-table-asgi.bugfix.rst
@@ -1,0 +1,13 @@
+Naprawiono losowe błędy „relacja raport_slotow_raportzerowyentry
+nie istnieje" przy oglądaniu raportu slotów — autorzy zerowi.
+Wyniki raportu odczytywane są z tymczasowej (sesyjnej) tabeli
+PostgreSQL, a odpowiedź renderowana była leniwie — pod serwerem
+ASGI równoległy request (np. websocket powiadomień otwierany przez
+przeglądarkę) mógł w międzyczasie zamknąć połączenie z bazą, przez
+co tabela tymczasowa znikała przed odczytem. Strona raportu
+renderuje się teraz w całości w obrębie tego samego połączenia.
+
+Dodatkowo przezroczysty reconnect do bazy danych (silnik
+``django_bpp.db_connclosed_fix``) loguje ostrzeżenie zamiast
+działać po cichu — utrata stanu sesji PostgreSQL (tabele
+tymczasowe, advisory locks) jest teraz widoczna w logach.

--- a/src/django_bpp/db_connclosed_fix/base.py
+++ b/src/django_bpp/db_connclosed_fix/base.py
@@ -1,8 +1,12 @@
+import logging
+
 import django.db
 from django.db.backends.postgresql.base import (
     DatabaseWrapper as BuiltinPostgresDatabaseWrapper,
 )
 from psycopg2 import InterfaceError
+
+logger = logging.getLogger(__name__)
 
 
 class DatabaseWrapper(BuiltinPostgresDatabaseWrapper):
@@ -10,6 +14,17 @@ class DatabaseWrapper(BuiltinPostgresDatabaseWrapper):
         try:
             return super().create_cursor(name=name)
         except InterfaceError:
+            # Reconnect tworzy NOWĄ sesję PostgreSQL — cały stan sesyjny
+            # (tabele tymczasowe, advisory locks, SET) przepada. Logujemy
+            # z traceback-iem, bo cicha podmiana sesji maskuje błędy typu
+            # "relacja ... nie istnieje" na tabelach tymczasowych.
+            logger.warning(
+                "Polaczenie DB (alias=%s) bylo zamkniete przy tworzeniu "
+                "kursora; przezroczysty reconnect — stan sesji PostgreSQL "
+                "(temp tables, advisory locks) zostal utracony.",
+                self.alias,
+                exc_info=True,
+            )
             django.db.close_old_connections()
             django.db.connection.connect()
             return super().create_cursor(name=name)

--- a/src/raport_slotow/tests/test_views/test_raport_slotow_zerowy.py
+++ b/src/raport_slotow/tests/test_views/test_raport_slotow_zerowy.py
@@ -4,15 +4,14 @@ import django
 import pytest
 from django.urls import reverse
 
-from raport_slotow.forms.zerowy import RaportSlotowZerowyParametryFormularz
-from raport_slotow.views.zerowy import RaportSlotowZerowyWyniki
-
 from bpp.models import OpcjaWyswietlaniaField, Uczelnia
 from bpp.models.dyscyplina_naukowa import Autor_Dyscyplina
 from bpp.models.sloty.core import IPunktacjaCacher
 from bpp.models.system import Charakter_Formalny
 from bpp.models.wydawca import Wydawca
 from bpp.models.wydawnictwo_zwarte import Wydawnictwo_Zwarte
+from raport_slotow.forms.zerowy import RaportSlotowZerowyParametryFormularz
+from raport_slotow.views.zerowy import RaportSlotowZerowyWyniki
 
 
 @pytest.fixture
@@ -138,3 +137,41 @@ def test_raport_slotow_zerowy_formularz_zamowienia(
     uczelnia.save()
     res = admin_client.get(reverse("raport_slotow:raport-slotow-zerowy-parametry"))
     assert res.status_code == 200
+
+
+def test_raport_slotow_zerowy_response_wyrenderowany_w_widoku(
+    fikstura_raportu_slotow, admin_user, uczelnia, rf
+):
+    """Widok MUSI zwrócić już wyrenderowaną odpowiedź.
+
+    Wynik raportu czyta z tabeli TYMCZASOWEJ PostgreSQL, która żyje w sesji
+    (połączeniu) DB. Pod ASGI (daphne) leniwy render TemplateResponse
+    wykonuje się w OSOBNYM sync_to_async-chunku niż widok; pomiędzy nimi
+    inny równoległy request współdzielący wątek executora może zamknąć
+    połączenie (close_old_connections przy CONN_MAX_AGE=0) — wtedy render
+    dostaje świeżą sesję bez temp table i wali się ProgrammingError
+    "relacja raport_slotow_raportzerowyentry nie istnieje". Render w ciele
+    widoku (ten sam chunk co CREATE TEMPORARY TABLE) zamyka tę szczelinę.
+    """
+    uczelnia.pokazuj_raport_slotow_zerowy = OpcjaWyswietlaniaField.POKAZUJ_ZAWSZE
+    uczelnia.save()
+
+    from django.contrib.messages.storage.fallback import FallbackStorage
+    from django.contrib.sessions.backends.db import SessionStore
+
+    request = rf.get(
+        reverse("raport_slotow:raport-slotow-zerowy-wyniki")
+        + "?od_roku=2020&do_roku=2020&min_pk=0&rodzaj_raportu=SL&_export=html"
+    )
+    request.user = admin_user
+    request.session = SessionStore()
+    request._messages = FallbackStorage(request)
+
+    response = RaportSlotowZerowyWyniki.as_view()(request)
+
+    assert getattr(response, "is_rendered", True), (
+        "TemplateResponse opuścił widok niewyrenderowany — SELECT z tabeli "
+        "tymczasowej odbędzie się poza widokiem i pod ASGI może trafić "
+        "w inne połączenie DB (bez temp table)."
+    )
+    assert b"Kowalski" in response.content

--- a/src/raport_slotow/views/zerowy.py
+++ b/src/raport_slotow/views/zerowy.py
@@ -71,7 +71,15 @@ class RaportSlotowZerowyWyniki(
         if self.request.GET.get("submit") == "Pobierz XLS":
             return self.create_export("xlsx")
 
-        return super().render_to_response(context, **kwargs)
+        response = super().render_to_response(context, **kwargs)
+        if hasattr(response, "render"):
+            # Wynik czyta z tabeli TYMCZASOWEJ (sesyjnej) PostgreSQL. Render
+            # musi się odbyć jeszcze w ciele widoku — pod ASGI leniwy render
+            # TemplateResponse leci osobnym sync_to_async-chunkiem i inny
+            # request współdzielący wątek może w międzyczasie zamknąć
+            # połączenie (temp table znika → "relacja nie istnieje").
+            response.render()
+        return response
 
     def get_queryset(self):
         od_roku = self.form.cleaned_data["od_roku"]


### PR DESCRIPTION
## Problem

Raport slotów — autorzy zerowi wywalał się losowo (~50% wejść z przeglądarki) z błędem:

```
django.db.utils.ProgrammingError: BŁĄD: relacja "raport_slotow_raportzerowyentry" nie istnieje
```

Nigdy w testach ani przy pojedynczych requestach curlem — wyłącznie z przeglądarki.

## Root cause

Wyniki raportu czytane są z tabeli **TYMCZASOWEJ** (sesyjnej) PostgreSQL tworzonej w `get_queryset()`. Pod daphne/ASGI render `TemplateResponse` wykonuje się w **osobnym** `sync_to_async`-chunku niż widok (`BaseHandler._get_response_async`). W szczelinie między chunkami równoległy request (websocket `/asgi/notifications/`, statiki) współdzielący wątek executora może przez `close_old_connections()` (`CONN_MAX_AGE=0`) zamknąć połączenie widoku. `ensure_connection()` po cichu otwiera nową sesję — bez temp table — i SELECT pada.

Zdiagnozowane instrumentacją `pg_backend_pid()` + tożsamości wątku/wrappera: daphne trzyma pulę ~4 współdzielonych wątków, `DatabaseWrapper` jest per-wątek. Reprodukcja: raport + równoległy request w pętli → 10–20% HTTP 500.

## Fix

Jawny `response.render()` w ciele widoku (`render_to_response`) — utworzenie tabeli i cały jej odczyt dzieją się w jednym nieprzerywalnym sync-chunku, na jednym połączeniu. Szczelina wyścigu znika strukturalnie.

Dodatkowo `django_bpp.db_connclosed_fix` loguje warning z traceback-iem przy przezroczystym reconnec­cie — nie był winowajcą, ale po cichu maskował utratę stanu sesji PG (temp tables, advisory locks).

## Testy

- Nowy test regresyjny `test_raport_slotow_zerowy_response_wyrenderowany_w_widoku` — niezmiennik `response.is_rendered` przy wyjściu z widoku (czerwony przed fixem, zielony po).
- Weryfikacja na żywym serwerze: pętla 20× raport + równoległy request — **0 błędów** (przed fixem 500-tki w 10–20% iteracji).
- `src/raport_slotow/`: 87/87 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
