### PR TITLE
feat(admin): filtr "źródło usunięte w PBN" (wyd. ciągłe) + status PBN dla źródeł

### DIFF
--- a/src/bpp/admin/filters.py
+++ b/src/bpp/admin/filters.py
@@ -177,15 +177,22 @@ class PBN_UID_IDObecnyFilter(SimpleNotNullFilter):
 
 
 class PBNStatusFilter(SimpleListFilter):
-    """Filtruje po statusie powiązanej pracy PBN (``pbn_uid.status``).
+    """Filtruje po statusie powiązanego lustra PBN (``pbn_uid.status``).
 
-    Wyłapuje rekordy powiązane z pracą skasowaną w PBN (``DELETED``), aktywną
-    (``ACTIVE``) albo bez powiązania (``pbn_uid`` puste). Statusy DELETED/ACTIVE
-    żyją na lustrze ``pbn_api.Publication`` — traversujemy przez ``pbn_uid``.
+    Wyłapuje rekordy powiązane z obiektem skasowanym w PBN (``DELETED``),
+    aktywnym (``ACTIVE``) albo bez powiązania (``pbn_uid`` puste). Statusy
+    DELETED/ACTIVE żyją na lustrze PBN (``pbn_api.Publication`` dla wydawnictw,
+    ``pbn_api.Journal`` dla źródeł) — traversujemy przez ``pbn_uid``.
+
+    Podklasy mogą traversować dalej (np. przez źródło pracy), ustawiając
+    ``pbn_relation`` na inną ścieżkę FK do lustra PBN.
     """
 
     title = "PBN: status"
     parameter_name = "pbn_status"
+    # Ścieżka ORM do FK wskazującego na lustro PBN. Domyślnie ``pbn_uid`` na
+    # samym rekordzie; podklasa może wskazać relację przez inny model.
+    pbn_relation = "pbn_uid"
 
     def lookups(self, request, model_admin):
         return [
@@ -197,12 +204,26 @@ class PBNStatusFilter(SimpleListFilter):
     def queryset(self, request, queryset):
         v = self.value()
         if v == "deleted":
-            return queryset.filter(pbn_uid__status=DELETED)
+            return queryset.filter(**{f"{self.pbn_relation}__status": DELETED})
         elif v == "active":
-            return queryset.filter(pbn_uid__status=ACTIVE)
+            return queryset.filter(**{f"{self.pbn_relation}__status": ACTIVE})
         elif v == "brak":
-            return queryset.filter(pbn_uid_id__isnull=True)
+            return queryset.filter(**{f"{self.pbn_relation}_id__isnull": True})
         return queryset
+
+
+class ZrodloUsunieteWPBNFilter(PBNStatusFilter):
+    """Status ŹRÓDŁA pracy w PBN (``zrodlo.pbn_uid.status``).
+
+    W adminie ``Wydawnictwo_Ciagle`` wyłapuje prace, których źródło (czasopismo)
+    jest skasowane w PBN — niezależnie od statusu samego rekordu (ten drugi
+    pilnuje ``PBNStatusFilter``). ``brak`` = praca bez źródła albo ze źródłem
+    bez powiązania PBN.
+    """
+
+    title = "Źródło: status w PBN"
+    parameter_name = "zrodlo_pbn_status"
+    pbn_relation = "zrodlo__pbn_uid"
 
 
 class MniswIdObecnyFilter(SimpleNotNullFilter):

--- a/src/bpp/admin/wydawnictwo_ciagle.py
+++ b/src/bpp/admin/wydawnictwo_ciagle.py
@@ -16,6 +16,7 @@ from bpp.admin.filters import (
     PBN_UID_IDObecnyFilter,
     PBNStatusFilter,
     UtworzonePrzezFilter,
+    ZrodloUsunieteWPBNFilter,
 )
 from bpp.admin.helpers.djangoql import BppDjangoQLSearchMixin
 from bpp.admin.helpers.fieldsets import (
@@ -383,6 +384,7 @@ class Wydawnictwo_CiagleAdmin(
         UtworzonePrzezFilter,
         PBN_UID_IDObecnyFilter,
         PBNStatusFilter,
+        ZrodloUsunieteWPBNFilter,
         BezJakichkolwiekDyscyplinFilter,
     ]
 

--- a/src/bpp/admin/zrodlo.py
+++ b/src/bpp/admin/zrodlo.py
@@ -19,6 +19,7 @@ from .filters import (
     MaPublikacjeFilter,
     MniswIdObecnyFilter,
     PBN_UID_IDObecnyFilter,
+    PBNStatusFilter,
 )
 from .helpers.fieldsets import ADNOTACJE_FIELDSET, MODEL_PUNKTOWANY_Z_KWARTYLAMI_BAZA
 from .helpers.mixins import ZapiszZAdnotacjaMixin
@@ -164,6 +165,7 @@ class ZrodloAdmin(
         "openaccess_tryb_dostepu",
         "openaccess_licencja",
         PBN_UID_IDObecnyFilter,
+        PBNStatusFilter,
         MniswIdObecnyFilter,
         MaPublikacjeFilter,
     ]

--- a/src/bpp/newsfragments/pbn-status-zrodlo-ciagle.feature.rst
+++ b/src/bpp/newsfragments/pbn-status-zrodlo-ciagle.feature.rst
@@ -1,0 +1,4 @@
+W adminie wydawnictw ciągłych dodano filtr „Źródło: status w PBN"
+(skasowany/aktywny/brak) — pozwala wyłapać prace, których źródło jest
+skasowane w PBN. W adminie źródeł dodano filtr „PBN: status"
+(skasowany/aktywny/brak) po statusie odpowiednika źródła w PBN.

--- a/src/bpp/tests/test_admin/test_zrodlo_pbn_status_filter.py
+++ b/src/bpp/tests/test_admin/test_zrodlo_pbn_status_filter.py
@@ -1,0 +1,121 @@
+"""Filtry admina po statusie ŹRÓDŁA w PBN.
+
+Dwa uzupełnienia do ``PBNStatusFilter`` (który patrzy tylko na własny
+``pbn_uid`` rekordu):
+
+1. ``ZrodloUsunieteWPBNFilter`` — w adminie ``Wydawnictwo_Ciagle`` wyłapuje
+   prace, których ŹRÓDŁO (czasopismo) jest skasowane w PBN
+   (``zrodlo.pbn_uid.status == "DELETED"``), niezależnie od statusu samego
+   rekordu.
+2. ``PBNStatusFilter`` podpięty do adminu ``Zrodlo`` — źródło samo w sobie ma
+   ``pbn_uid`` (Journal) ze statusem, więc ten sam filtr działa 1:1.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.admin.filters import PBNStatusFilter, ZrodloUsunieteWPBNFilter
+from bpp.models import Wydawnictwo_Ciagle, Zrodlo
+from pbn_api.models import Journal
+
+
+def _journal(mongo_id, status):
+    return baker.make(
+        Journal,
+        mongoId=mongo_id,
+        versions=[{"current": True, "object": {"title": mongo_id}}],
+        status=status,
+    )
+
+
+def _apply(filter_cls, value, model, queryset=None):
+    f = filter_cls(None, {}, model, None)
+    f.value = lambda *a, **k: value
+    return f.queryset(None, queryset if queryset is not None else model.objects.all())
+
+
+# --- Wydawnictwo_Ciagle po statusie ŹRÓDŁA -------------------------------
+
+
+@pytest.fixture
+def trzy_ciagle_wg_zrodla():
+    """(deleted, active, brak) — Wydawnictwo_Ciagle wg statusu PBN źródła."""
+    z_del = baker.make(Zrodlo, pbn_uid=_journal("z_del", "DELETED"))
+    z_act = baker.make(Zrodlo, pbn_uid=_journal("z_act", "ACTIVE"))
+    wc_del = baker.make(Wydawnictwo_Ciagle, zrodlo=z_del)
+    wc_act = baker.make(Wydawnictwo_Ciagle, zrodlo=z_act)
+    wc_brak = baker.make(Wydawnictwo_Ciagle, zrodlo=None)
+    return wc_del, wc_act, wc_brak
+
+
+@pytest.mark.django_db
+def test_zrodlo_deleted(trzy_ciagle_wg_zrodla):
+    wc_del, wc_act, wc_brak = trzy_ciagle_wg_zrodla
+    qs = _apply(ZrodloUsunieteWPBNFilter, "deleted", Wydawnictwo_Ciagle)
+    assert wc_del in qs
+    assert wc_act not in qs
+    assert wc_brak not in qs
+
+
+@pytest.mark.django_db
+def test_zrodlo_active(trzy_ciagle_wg_zrodla):
+    wc_del, wc_act, wc_brak = trzy_ciagle_wg_zrodla
+    qs = _apply(ZrodloUsunieteWPBNFilter, "active", Wydawnictwo_Ciagle)
+    assert wc_act in qs
+    assert wc_del not in qs
+    assert wc_brak not in qs
+
+
+@pytest.mark.django_db
+def test_zrodlo_brak(trzy_ciagle_wg_zrodla):
+    """'brak' — źródło bez powiązania PBN (albo w ogóle bez źródła)."""
+    wc_del, wc_act, wc_brak = trzy_ciagle_wg_zrodla
+    z_bez_pbn = baker.make(Zrodlo, pbn_uid=None)
+    wc_zrodlo_bez_pbn = baker.make(Wydawnictwo_Ciagle, zrodlo=z_bez_pbn)
+    qs = _apply(ZrodloUsunieteWPBNFilter, "brak", Wydawnictwo_Ciagle)
+    assert wc_brak in qs
+    assert wc_zrodlo_bez_pbn in qs
+    assert wc_del not in qs
+    assert wc_act not in qs
+
+
+@pytest.mark.django_db
+def test_zrodlo_brak_wartosci_nie_zaweza(trzy_ciagle_wg_zrodla):
+    qs = _apply(ZrodloUsunieteWPBNFilter, None, Wydawnictwo_Ciagle)
+    assert qs.count() == 3
+
+
+def test_zrodlo_lookups_ma_trzy_opcje():
+    f = ZrodloUsunieteWPBNFilter(None, {}, Wydawnictwo_Ciagle, None)
+    keys = [k for k, _label in f.lookups(None, None)]
+    assert keys == ["deleted", "active", "brak"]
+
+
+# --- Zrodlo po własnym statusie PBN --------------------------------------
+
+
+@pytest.mark.django_db
+def test_pbnstatusfilter_dziala_dla_zrodla():
+    z_del = baker.make(Zrodlo, pbn_uid=_journal("zz_del", "DELETED"))
+    z_act = baker.make(Zrodlo, pbn_uid=_journal("zz_act", "ACTIVE"))
+    z_brak = baker.make(Zrodlo, pbn_uid=None)
+
+    qs_del = _apply(PBNStatusFilter, "deleted", Zrodlo)
+    assert z_del in qs_del
+    assert z_act not in qs_del
+    assert z_brak not in qs_del
+
+    qs_brak = _apply(PBNStatusFilter, "brak", Zrodlo)
+    assert z_brak in qs_brak
+    assert z_del not in qs_brak
+
+
+# --- Podpięcie do adminów (regresja) -------------------------------------
+
+
+def test_filtry_podpiete_do_adminow():
+    from bpp.admin.wydawnictwo_ciagle import Wydawnictwo_CiagleAdmin
+    from bpp.admin.zrodlo import ZrodloAdmin
+
+    assert ZrodloUsunieteWPBNFilter in Wydawnictwo_CiagleAdmin.list_filter
+    assert PBNStatusFilter in ZrodloAdmin.list_filter


### PR DESCRIPTION
## Kontekst

Uzupełnienie do zmergowanych już PR-ów #450 (filtr `PBN: status` dla wydawnictw) i #443 (mniswID + filtry dla źródeł). Oryginalne zlecenie miało 4 kryteria filtrowania po statusie PBN — dwa nie powstały:

| # | Wymaganie | Status przed | Ten PR |
|---|-----------|--------------|--------|
| 1 | Wyd. (zwarte+ciągłe): odpowiednik usunięty w PBN | ✅ #450 | — |
| 2 | **Wyd. ciągłe: źródło usunięte w PBN** | ❌ brak | ✅ |
| 3 | **Źródła: status usunięty w PBN** | ❌ brak | ✅ |
| 4 | Źródła: po mniswID | ✅ #443 | — |

## Zmiany

- **`ZrodloUsunieteWPBNFilter`** — nowy filtr „Źródło: status w PBN" (skasowany/aktywny/brak) na adminie wydawnictwa ciągłego; traversuje `zrodlo.pbn_uid.status`. Wyłapuje prace, których czasopismo jest skasowane w PBN, niezależnie od statusu samego rekordu.
- **`PBNStatusFilter` podpięty do `ZrodloAdmin`** — źródło ma własny `pbn_uid` (Journal ze statusem), więc ten sam filtr działa 1:1.
- `PBNStatusFilter` uogólniony na atrybut `pbn_relation` (domyślnie `"pbn_uid"`) — DRY, w pełni wstecznie kompatybilny (istniejące testy #450 przechodzą bez zmian).

## Testy

`test_zrodlo_pbn_status_filter.py` — deleted/active/brak dla obu filtrów + regresja podpięcia do adminów. 15/15 przechodzi lokalnie (8 nowych + 7 regresyjnych z #450). Brak zmian w modelach → brak migracji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)