### PR TITLE
fix(pbn): traktuj syntetyczny ISSN xpbn-<uuid> z PBN jako brak ISSN

### DIFF
--- a/src/bpp/newsfragments/pbn-xpbn-issn.bugfix.rst
+++ b/src/bpp/newsfragments/pbn-xpbn-issn.bugfix.rst
@@ -1,0 +1,1 @@
+Import z PBN: czasopisma bez ISSN (PBN podsyła wtedy syntetyczny placeholder ``xpbn-<uuid>``) nie wywalają już importu błędem ``value too long`` — placeholder jest traktowany jako brak ISSN. Dotyczy zarówno masowego importu źródeł MNiSW, jak i importu pojedynczej publikacji z PBN.

--- a/src/importer_publikacji/providers/pbn.py
+++ b/src/importer_publikacji/providers/pbn.py
@@ -158,6 +158,20 @@ def _extract_isbn(obj: dict) -> str | None:
     return None
 
 
+def _extract_issn(value: str | None) -> str | None:
+    """Odfiltruj syntetyczny placeholder ISSN z PBN.
+
+    PBN dla czasopism bez ISSN podsyła wewnętrzny identyfikator ``xpbn-<uuid>``
+    (41 znaków) — nie jest to ISSN, a do tego przekracza ``max_length=32`` pól
+    ISSN w BPP (dosłowny zapis wywalał ``DataError: value too long``).
+    Traktujemy go jako *brak* ISSN.
+    """
+    value = (value or "").strip()
+    if not value or value.startswith("xpbn-"):
+        return None
+    return value
+
+
 def _get_current_version_object(data: dict) -> dict | None:
     """Wyciągnij obiekt z bieżącej wersji publikacji PBN."""
     versions = data.get("versions", [])
@@ -253,8 +267,8 @@ class PBNProvider(DataProvider):
             year=_extract_year(obj),
             authors=_extract_authors(obj),
             source_title=journal.get("title"),
-            issn=journal.get("issn"),
-            e_issn=journal.get("eissn"),
+            issn=_extract_issn(journal.get("issn")),
+            e_issn=_extract_issn(journal.get("eissn")),
             isbn=_extract_isbn(obj),
             publisher=journal.get("publisher"),
             publication_type=PBN_TYPE_MAP.get(obj.get("type", "")),

--- a/src/importer_publikacji/tests/test_pbn_provider.py
+++ b/src/importer_publikacji/tests/test_pbn_provider.py
@@ -12,6 +12,7 @@ from importer_publikacji.providers.pbn import (
     _extract_abstract,
     _extract_authors,
     _extract_isbn,
+    _extract_issn,
     _extract_keywords,
     _extract_license_url,
     _extract_year,
@@ -459,6 +460,46 @@ def test_extract_isbn_from_book():
 
 def test_extract_isbn_none():
     assert _extract_isbn({}) is None
+
+
+def test_extract_issn_real():
+    assert _extract_issn("1234-5678") == "1234-5678"
+
+
+def test_extract_issn_none():
+    assert _extract_issn(None) is None
+    assert _extract_issn("") is None
+
+
+def test_extract_issn_pomija_syntetyczny_xpbn():
+    """PBN dla czasopism bez ISSN podsyła placeholder ``xpbn-<uuid>`` (41
+    znaków). Nie jest to ISSN i nie mieści się w polach ISSN (max_length=32),
+    więc traktujemy go jako brak ISSN."""
+    xpbn = "xpbn-1585798a-33ca-44a8-8daf-6f1c15b25127"
+    assert len(xpbn) > 32
+    assert _extract_issn(xpbn) is None
+
+
+@patch("importer_publikacji.providers.pbn._save_to_pbn_publication")
+@patch("importer_publikacji.providers.pbn._get_pbn_client")
+def test_fetch_pomija_syntetyczny_xpbn_issn(mock_get_client, mock_save):
+    """Fetch publikacji, której czasopismo ma placeholder ``xpbn-`` w ISSN,
+    nie może przenieść 41-znakowego śmiecia do pól ISSN rekordu."""
+    import copy
+
+    data = copy.deepcopy(SAMPLE_PBN_ARTICLE)
+    journal = data["versions"][0]["object"]["journal"]
+    journal["issn"] = "xpbn-1585798a-33ca-44a8-8daf-6f1c15b25127"
+    journal["eissn"] = "xpbn-8f1c1585-44a8-33ca-8daf-6b25127c1579"
+
+    mock_client = MagicMock()
+    mock_client.get_publication_by_id.return_value = data
+    mock_get_client.return_value = mock_client
+
+    pub = PBNProvider().fetch(SAMPLE_PBN_UID)
+
+    assert pub.issn is None
+    assert pub.e_issn is None
 
 
 def test_extract_license_url():

--- a/src/pbn_integrator/importer/sources.py
+++ b/src/pbn_integrator/importer/sources.py
@@ -27,6 +27,18 @@ logger = logging.getLogger(__name__)
 MAX_SLUG_RETRIES = 10
 
 
+def _real_issn(value):
+    """Odfiltruj syntetyczny placeholder PBN z pola ISSN.
+
+    PBN dla czasopism bez ISSN podsyła wewnętrzny identyfikator w formie
+    ``xpbn-<uuid>`` (41 znaków), który nie jest ISSN-em, a do tego nie mieści
+    się w ``Zrodlo.issn`` (max_length=32) — dosłowny zapis wywalał
+    ``DataError: value too long``. Traktujemy go z powrotem jako *brak* ISSN.
+    """
+    value = (value or "").strip()
+    return "" if value.startswith("xpbn-") else value
+
+
 def dopisz_jedno_zrodlo(pbn_journal, rodzaj_periodyk, dyscypliny_cache):
     """Process single journal - re-entrant, can be interrupted.
 
@@ -44,8 +56,8 @@ def dopisz_jedno_zrodlo(pbn_journal, rodzaj_periodyk, dyscypliny_cache):
                 zrodlo = Zrodlo.objects.create(
                     nazwa=cv.get("title") or "",
                     skrot=cv.get("title") or "",
-                    issn=cv.get("issn") or "",
-                    e_issn=cv.get("eissn") or "",
+                    issn=_real_issn(cv.get("issn")),
+                    e_issn=_real_issn(cv.get("eissn")),
                     pbn_uid=pbn_journal,
                     rodzaj=rodzaj_periodyk,
                 )

--- a/src/pbn_integrator/tests/test_integrator_import.py
+++ b/src/pbn_integrator/tests/test_integrator_import.py
@@ -12,7 +12,42 @@ from unittest.mock import Mock, patch
 import pytest
 from model_bakery import baker
 
+from bpp.models import Rodzaj_Zrodla, Zrodlo
 from pbn_api.models import Journal, Publisher
+
+
+@pytest.mark.django_db
+def test_dopisz_jedno_zrodlo_pomija_syntetyczny_xpbn_issn():
+    """PBN podsyła placeholder ``xpbn-<uuid>`` (41 znaków) dla czasopism bez
+    ISSN. Pole ``Zrodlo.issn`` to CharField(max_length=32), więc dosłowny
+    zapis wywalał ``DataError: value too long``. Placeholder oznacza *brak*
+    ISSN, więc ma trafić do bazy jako pusty string."""
+    from pbn_integrator.importer import dopisz_jedno_zrodlo
+
+    xpbn = "xpbn-1585798a-33ca-44a8-8daf-6f1c15b25127"
+    assert len(xpbn) > 32  # gwarantuje, że bez fixa INSERT by pękł
+
+    pbn_journal = baker.make(
+        Journal,
+        status="ACTIVE",
+        versions=[
+            {
+                "current": True,
+                "object": {
+                    "title": "Andrologia i Seksualna Medycyna",
+                    "issn": xpbn,
+                    "eissn": xpbn,
+                },
+            }
+        ],
+    )
+    rodzaj_periodyk, _ = Rodzaj_Zrodla.objects.get_or_create(nazwa="periodyk")
+
+    dopisz_jedno_zrodlo(pbn_journal, rodzaj_periodyk, {})
+
+    zrodlo = Zrodlo.objects.get(pbn_uid=pbn_journal)
+    assert zrodlo.issn == ""
+    assert zrodlo.e_issn == ""
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

PBN dla czasopism **bez ISSN** podsyła w polu `issn`/`eissn` wewnętrzny placeholder w formie `xpbn-<uuid>` (41 znaków). Pola ISSN w BPP to `CharField(max_length=32)`, więc dosłowny zapis wywalał:

```
DataError: value too long for type character varying(32)
```

- **Masowy import źródeł MNiSW** (`dopisz_jedno_zrodlo`) — każde takie czasopismo było po cichu pomijane. **47× dziś w produkcji**, [Rollbar #435](https://app.rollbar.com/a/michal.dtz/fix/item/bpp/435) (host `bpp.apoz.edu.pl`, `202607.1397rc1`).
- **Import pojedynczej publikacji z PBN** (`providers/pbn.py`) — ten sam uśpiony wariant; `issn`/`eissn` trafiały wprost do rekordu publikacji (ten sam mixin `max_length=32`).

## Fix

Placeholder `xpbn-...` oznacza *brak* ISSN, więc oba wejścia tłumaczą go z powrotem na pusty/`None` ISSN — stan od zawsze obsługiwany (pole `blank=True`, integracja po ISSN pomija puste wartości).

| Plik | Zmiana |
|---|---|
| `pbn_integrator/importer/sources.py` | helper `_real_issn()` w `dopisz_jedno_zrodlo` |
| `importer_publikacji/providers/pbn.py` | helper `_extract_issn()` w `fetch()` |

Helper nie jest współdzielony między apkami świadomie: jedyny wspólny „dom" (`pbn_api.const`/`utils`) to shim-y do zewnętrznego `pbn_client`, a import międzyaplikacyjny byłby gorszym couplingiem niż 5-znakowy literał w dwóch miejscach.

## Testy (TDD)

RED padał na produkcyjnym `DataError`, GREEN przechodzi. **52 passed** (`test_integrator_import` + `test_pbn_provider`), ruff czysty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)