### PR TITLE
fix(api): serializuj Patent.rodzaj_prawa — koniec 500 na /api/v1/patent/{id}/

### DIFF
--- a/src/api_v1/serializers/patent.py
+++ b/src/api_v1/serializers/patent.py
@@ -40,9 +40,11 @@ class PatentSerializer(
 ):
     slowa_kluczowe = TagListSerializerField()
 
-    rodzaj_prawa = serializers.RelatedField(read_only=True)
-    # "bpp.Rodzaj_Prawa_Patentowego", CASCADE, null=True, blank=True
-    # )
+    # FK -> bpp.Rodzaj_Prawa_Patentowego (ModelZNazwa; __str__ zwraca nazwa).
+    # Goły ``RelatedField`` jest abstrakcyjny (brak to_representation) i wywala
+    # serializację patentu z ustawionym rodzaj_prawa. StringRelatedField daje
+    # ``nazwa`` i jest spójny z resztą API (zasieg, licencja, status_korekty...).
+    rodzaj_prawa = serializers.StringRelatedField(read_only=True)
 
     # Faza B (#438) II-2: ``Patent.wydzial`` to teraz FK->Jednostka (korzeń
     # drzewa, mirror dawnego Wydzial) — link musi wskazywać jednostka-detail.

--- a/src/api_v1/tests/test_patent.py
+++ b/src/api_v1/tests/test_patent.py
@@ -6,12 +6,27 @@ from django.utils.timezone import localtime
 from model_bakery import baker
 
 from bpp.models import Patent
+from bpp.models.system import Rodzaj_Prawa_Patentowego
 
 
 @pytest.mark.django_db
 def test_rest_api_patent_detail(client, patent):
     res = client.get(reverse("api_v1:patent-detail", args=(patent.pk,)))
     assert res.status_code == 200
+
+
+@pytest.mark.django_db
+def test_rest_api_patent_detail_z_rodzajem_prawa(client, patent):
+    # Regresja: goły serializers.RelatedField wywalał 500 (NotImplementedError:
+    # to_representation must be implemented) na patencie z ustawionym
+    # rodzaj_prawa. Powinno zwrócić 200 i nazwę rodzaju prawa.
+    rodzaj = baker.make(Rodzaj_Prawa_Patentowego, nazwa="Patent na wynalazek")
+    patent.rodzaj_prawa = rodzaj
+    patent.save()
+
+    res = client.get(reverse("api_v1:patent-detail", args=(patent.pk,)))
+    assert res.status_code == 200
+    assert res.json()["rodzaj_prawa"] == "Patent na wynalazek"
 
 
 @pytest.mark.django_db

--- a/src/bpp/newsfragments/api-patent-rodzaj-prawa.bugfix.rst
+++ b/src/bpp/newsfragments/api-patent-rodzaj-prawa.bugfix.rst
@@ -1,0 +1,3 @@
+API ``/api/v1/patent/{id}/`` zwracało błąd 500 dla patentów z ustawionym
+rodzajem prawa patentowego (goły ``RelatedField`` nie miał reprezentacji).
+Pole ``rodzaj_prawa`` jest teraz serializowane jako jego nazwa.


### PR DESCRIPTION
## Problem (Rollbar #423, 12×, produkcja: umlub, up.lublin)

`GET /api/v1/patent/{id}/` zwracał **500 na każdym patencie** z ustawionym rodzajem prawa:

```
NotImplementedError: RelatedField.to_representation() must be implemented for field rodzaj_prawa.
```

## Przyczyna

`src/api_v1/serializers/patent.py` deklarował `rodzaj_prawa = serializers.RelatedField(read_only=True)`. Goły DRF `RelatedField` jest abstrakcyjny — nie ma `to_representation`, więc serializacja się wywala.

## Poprawka

`rodzaj_prawa = serializers.StringRelatedField(read_only=True)` — spójne z całą resztą serializera (`zasieg`, `status_korekty`, `dyscyplina`, `organ_przyznajacy`, … używają `StringRelatedField`). Output = nazwa rodzaju prawa (model `Rodzaj_Prawa_Patentowego` dziedziczy `ModelZNazwa`, `__str__` → `nazwa`).

## Test

`src/api_v1/tests/test_patent.py::test_rest_api_patent_detail_z_rodzajem_prawa` — patent z `rodzaj_prawa`, `GET` detalu, asercja 200 + poprawna wartość. TDD potwierdzone (fail-before = 500, pass-after). Pełny plik: 8 passed na testcontainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
