### PR TITLE
fix(api): namespace api_v1: dla pola wydawca w API prac dr/hab

### DIFF
--- a/src/api_v1/serializers/praca_doktorska.py
+++ b/src/api_v1/serializers/praca_doktorska.py
@@ -5,7 +5,6 @@ from api_v1.serializers.util import (
     AbsoluteUrlSerializerMixin,
     WydawnictwoSerializerMixin,
 )
-
 from bpp.models import Praca_Doktorska
 
 
@@ -24,6 +23,10 @@ class Praca_DoktorskaSerializer(
 
     jednostka = serializers.HyperlinkedRelatedField(
         view_name="api_v1:jednostka-detail", read_only=True
+    )
+
+    wydawca = serializers.HyperlinkedRelatedField(
+        view_name="api_v1:wydawca-detail", read_only=True
     )
 
     slowa_kluczowe = TagListSerializerField()

--- a/src/api_v1/serializers/praca_habilitacyjna.py
+++ b/src/api_v1/serializers/praca_habilitacyjna.py
@@ -5,7 +5,6 @@ from api_v1.serializers.util import (
     AbsoluteUrlSerializerMixin,
     WydawnictwoSerializerMixin,
 )
-
 from bpp.models import Praca_Habilitacyjna
 
 
@@ -22,6 +21,10 @@ class Praca_HabilitacyjnaSerializer(
 
     jednostka = serializers.HyperlinkedRelatedField(
         view_name="api_v1:jednostka-detail", read_only=True
+    )
+
+    wydawca = serializers.HyperlinkedRelatedField(
+        view_name="api_v1:wydawca-detail", read_only=True
     )
 
     publikacja_habilitacyjna = serializers.RelatedField(read_only=True)

--- a/src/api_v1/tests/test_praca_doktorska.py
+++ b/src/api_v1/tests/test_praca_doktorska.py
@@ -78,6 +78,35 @@ def test_rest_api_praca_doktorska_ukryj_status(
     assert res.json()["count"] == 0
 
 
+@pytest.mark.django_db
+def test_rest_api_praca_doktorska_detail_z_wydawca(client, praca_doktorska, wydawca):
+    # Regresja: HyperlinkedModelSerializer bez jawnej deklaracji pola `wydawca`
+    # auto-generował HyperlinkedRelatedField z view_name="wydawca-detail" (bez
+    # namespace api_v1:), przez co reverse rzucał NoReverseMatch → 500.
+    praca_doktorska.wydawca = wydawca
+    praca_doktorska.save()
+
+    res = client.get(
+        reverse("api_v1:praca_doktorska-detail", args=(praca_doktorska.pk,))
+    )
+    assert res.status_code == 200
+
+    wydawca_url = reverse("api_v1:wydawca-detail", args=(wydawca.pk,))
+    assert res.json()["wydawca"].endswith(wydawca_url)
+
+
+@pytest.mark.django_db
+def test_rest_api_praca_doktorska_list_z_wydawca(client, praca_doktorska, wydawca):
+    praca_doktorska.wydawca = wydawca
+    praca_doktorska.save()
+
+    res = client.get(reverse("api_v1:praca_doktorska-list"))
+    assert res.status_code == 200
+
+    wydawca_url = reverse("api_v1:wydawca-detail", args=(wydawca.pk,))
+    assert res.json()["results"][0]["wydawca"].endswith(wydawca_url)
+
+
 @pytest.fixture
 def wiele_prac_doktorskich(db, typy_odpowiedzialnosci):
     # Create one template object using baker.make to get all required fields with defaults

--- a/src/api_v1/tests/test_praca_habilitacyjna.py
+++ b/src/api_v1/tests/test_praca_habilitacyjna.py
@@ -72,6 +72,39 @@ def test_rest_api_praca_habilitacyjna_ukryj_status(
     assert res.json()["count"] == 0
 
 
+@pytest.mark.django_db
+def test_rest_api_praca_habilitacyjna_detail_z_wydawca(
+    client, praca_habilitacyjna, wydawca
+):
+    # Regresja: HyperlinkedModelSerializer bez jawnej deklaracji pola `wydawca`
+    # auto-generował HyperlinkedRelatedField z view_name="wydawca-detail" (bez
+    # namespace api_v1:), przez co reverse rzucał NoReverseMatch → 500.
+    praca_habilitacyjna.wydawca = wydawca
+    praca_habilitacyjna.save()
+
+    res = client.get(
+        reverse("api_v1:praca_habilitacyjna-detail", args=(praca_habilitacyjna.pk,))
+    )
+    assert res.status_code == 200
+
+    wydawca_url = reverse("api_v1:wydawca-detail", args=(wydawca.pk,))
+    assert res.json()["wydawca"].endswith(wydawca_url)
+
+
+@pytest.mark.django_db
+def test_rest_api_praca_habilitacyjna_list_z_wydawca(
+    client, praca_habilitacyjna, wydawca
+):
+    praca_habilitacyjna.wydawca = wydawca
+    praca_habilitacyjna.save()
+
+    res = client.get(reverse("api_v1:praca_habilitacyjna-list"))
+    assert res.status_code == 200
+
+    wydawca_url = reverse("api_v1:wydawca-detail", args=(wydawca.pk,))
+    assert res.json()["results"][0]["wydawca"].endswith(wydawca_url)
+
+
 @pytest.fixture
 def wiele_prac_habilitacyjnych(db, typy_odpowiedzialnosci):
     # Create one template object using baker.make to get all required fields with defaults

--- a/src/bpp/newsfragments/api-praca-doktorska-habilitacyjna-wydawca.bugfix.rst
+++ b/src/bpp/newsfragments/api-praca-doktorska-habilitacyjna-wydawca.bugfix.rst
@@ -1,0 +1,3 @@
+Naprawiono błąd 500 (NoReverseMatch) w API REST dla ``/api/v1/praca_doktorska/``
+oraz ``/api/v1/praca_habilitacyjna/``, gdy rekord miał ustawionego wydawcę —
+pole ``wydawca`` generowało hiperłącze bez przestrzeni nazw ``api_v1:``.


### PR DESCRIPTION
## Problem (Rollbar #425, produkcja: umlub)

`GET /api/v1/praca_doktorska/` (oraz `/api/v1/praca_habilitacyjna/`) zwracał **500**, gdy rekord miał ustawionego wydawcę:

```
ImproperlyConfigured: Could not resolve URL for hyperlinked relationship using view name "wydawca-detail"
→ NoReverseMatch: Reverse for 'wydawca-detail' not found
```

## Przyczyna

Oba serializery wymieniały `"wydawca"` w `Meta.fields`, ale **nie deklarowały pola jawnie**. `HyperlinkedModelSerializer` auto-generował wtedy `HyperlinkedRelatedField` z `view_name="wydawca-detail"` — **bez** przestrzeni nazw `api_v1:`, więc reverse nie znajdował URL-a (router jest pod namespace `api_v1`).

## Poprawka

Jawna deklaracja pola w obu serializerach, spójna z istniejącym wzorcem (`wydawca.py`, `wydawnictwo_zwarte.py`):

```python
wydawca = serializers.HyperlinkedRelatedField(
    view_name="api_v1:wydawca-detail", read_only=True
)
```

Zweryfikowano, że pozostałe pola relacyjne obu serializerów są już poprawnie zadeklarowane (brak innych wystąpień tego buga).

## Test

`test_praca_doktorska.py` / `test_praca_habilitacyjna.py` — praca z wydawcą, `GET` listy i detalu, asercja 200 + poprawny hiperłącze. TDD potwierdzone (fail-before = 500). `20 passed` na testcontainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
