### PR TITLE
fix(api): polski przecinek dziesiętny w uploadzie punktacji źródła

### DIFF
--- a/src/bpp/newsfragments/punktacja-przecinek-dziesietny.bugfix.rst
+++ b/src/bpp/newsfragments/punktacja-przecinek-dziesietny.bugfix.rst
@@ -1,0 +1,5 @@
+Upload punktacji źródła: wartości dziesiętne wpisane z przecinkiem (np.
+``impact_factor`` = ``3,2``) nie wywalają już zapisu błędem 500 — przecinek
+jest normalizowany do kropki. Dotyczy zarówno tworzenia, jak i nadpisywania
+punktacji; wartość niepoprawna po normalizacji zwraca teraz czytelny błąd 400
+zamiast 500.

--- a/src/bpp/tests/test_views/test_api.py
+++ b/src/bpp/tests/test_views/test_api.py
@@ -328,6 +328,60 @@ def test_upload_punktacja_zrodla_overwrite():
 
 
 # =============================================================================
+# Regresja: bibliotekarze wpisują liczby z polskim przecinkiem dziesiętnym
+# ("3,2"). Bez normalizacji przecinek -> kropka DecimalField wywala
+# ValidationError / decimal.InvalidOperation w transakcji i zapis znika,
+# a frontend dostaje 500. Patrz Rollbar: UploadPunktacjaZrodlaView.post.
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_upload_punktacja_zrodla_przecinek_create():
+    """Ścieżka create: brak wpisu Punktacja_Zrodla, wartości z przecinkiem."""
+    from decimal import Decimal
+
+    z = any_zrodlo()
+    fr = FakeRequest(dict(impact_factor="3,2", punkty_kbn="12,5"))
+    res = UploadPunktacjaZrodlaView().post(fr, z.pk, CURRENT_YEAR)
+
+    assert res.status_code == 200
+    assert Punktacja_Zrodla.objects.count() == 1
+    pz = Punktacja_Zrodla.objects.get()
+    assert pz.impact_factor == Decimal("3.2")
+    assert pz.punkty_kbn == Decimal("12.5")
+
+
+@pytest.mark.django_db
+def test_upload_punktacja_zrodla_przecinek_overwrite():
+    """Ścieżka update/overwrite: istniejący wpis, wartości z przecinkiem."""
+    from decimal import Decimal
+
+    z = any_zrodlo()
+    Punktacja_Zrodla.objects.create(rok=CURRENT_YEAR, zrodlo=z, impact_factor=1)
+
+    fr = FakeRequest(dict(impact_factor="3,2", punktacja_snip="0,125", overwrite="1"))
+    res = UploadPunktacjaZrodlaView().post(fr, z.pk, CURRENT_YEAR)
+
+    assert res.status_code == 200
+    assert Punktacja_Zrodla.objects.count() == 1
+    pz = Punktacja_Zrodla.objects.get()
+    assert pz.impact_factor == Decimal("3.2")
+    assert pz.punktacja_snip == Decimal("0.125")
+
+
+@pytest.mark.django_db
+def test_upload_punktacja_zrodla_niepoprawna_liczba():
+    """Po normalizacji nadal śmieć -> 400 z kontekstem, nie goły 500."""
+    z = any_zrodlo()
+    fr = FakeRequest(dict(impact_factor="abc"))
+    res = UploadPunktacjaZrodlaView().post(fr, z.pk, CURRENT_YEAR)
+
+    assert res.status_code == 400
+    assert "impact_factor" in res.content.decode()
+    assert Punktacja_Zrodla.objects.count() == 0
+
+
+# =============================================================================
 # Regresja bezpieczeństwa: te endpointy MUSZĄ wymagać logowania.
 # Bez auth dało się anonimowo zapisywać do Punktacja_Zrodla i wyciągać
 # metadane autorów. Patrz: ANALYSIS.md #1 (2026-05-02).

--- a/src/bpp/views/api/__init__.py
+++ b/src/bpp/views/api/__init__.py
@@ -1,5 +1,7 @@
+from decimal import Decimal, InvalidOperation
+
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.db import transaction
+from django.db import models, transaction
 from django.http import JsonResponse
 from django.http.response import HttpResponseNotFound
 from django.views.generic import View
@@ -8,6 +10,17 @@ from bpp.models import Autor, Autor_Dyscyplina, Uczelnia, Zrodlo
 from bpp.models.abstract import POLA_PUNKTACJI
 from bpp.models.praca_habilitacyjna import Praca_Habilitacyjna
 from bpp.models.zrodlo import Punktacja_Zrodla
+
+# Pola punktacji będące liczbami dziesiętnymi (DecimalField). Bibliotekarze
+# w Polsce naturalnie wpisują je z przecinkiem dziesiętnym ("3,2"), a
+# DecimalField wymaga kropki — bez normalizacji zapis wywala się na
+# ValidationError / decimal.InvalidOperation. Pola całkowite (kwartyle)
+# celowo pomijamy, żeby nie ruszać wartości nie-dziesiętnych.
+POLA_DZIESIETNE = frozenset(
+    pole
+    for pole in POLA_PUNKTACJI
+    if isinstance(Punktacja_Zrodla._meta.get_field(pole), models.DecimalField)
+)
 
 
 class RokHabilitacjiView(LoginRequiredMixin, View):
@@ -46,6 +59,34 @@ class UploadPunktacjaZrodlaView(LoginRequiredMixin, View):
     def ok(self):
         return JsonResponse({"result": "ok"})
 
+    @staticmethod
+    def zbierz_punktacje(post):
+        """Wyciąga z POST pola punktacji, normalizując polski przecinek
+        dziesiętny (``"3,2"``) na kropkę dla pól ``DecimalField``.
+
+        Zwraca ``(kw_punktacji, bledne_pola)`` — słownik wartości gotowych
+        do zapisu oraz listę pól, których po normalizacji nie dało się
+        sparsować jako liczby (zamiast wywalać się gołym 500).
+        """
+        kw_punktacji = {}
+        bledne_pola = []
+        for element in list(post.keys()):
+            if element not in POLA_PUNKTACJI:
+                continue
+            value = post.get(element)
+            if value == "":
+                continue
+            value = value or "0.0"
+            if element in POLA_DZIESIETNE:
+                value = value.replace(",", ".")
+                try:
+                    value = Decimal(value)
+                except InvalidOperation:
+                    bledne_pola.append(element)
+                    continue
+            kw_punktacji[element] = value
+        return kw_punktacji, bledne_pola
+
     @transaction.atomic
     def post(self, request, zrodlo_id, rok, *args, **kw):
         try:
@@ -53,11 +94,16 @@ class UploadPunktacjaZrodlaView(LoginRequiredMixin, View):
         except Zrodlo.DoesNotExist:
             return HttpResponseNotFound("Zrodlo")
 
-        kw_punktacji = {}
-        for element in list(request.POST.keys()):
-            if element in POLA_PUNKTACJI:
-                if request.POST.get(element) != "":
-                    kw_punktacji[element] = request.POST.get(element) or "0.0"
+        kw_punktacji, bledne_pola = self.zbierz_punktacje(request.POST)
+        if bledne_pola:
+            return JsonResponse(
+                {
+                    "result": "error",
+                    "reason": "Nieprawidłowa wartość liczbowa w polach: "
+                    + ", ".join(sorted(bledne_pola)),
+                },
+                status=400,
+            )
 
         try:
             pz = Punktacja_Zrodla.objects.get(zrodlo=z, rok=rok)


### PR DESCRIPTION
## Problem (Rollbar #402, 3×, produkcja: ihit i in.)

Upload punktacji źródła (`POST /bpp/api/upload-punktacja-zrodla/<zrodlo>/<rok>/`) zwracał **500**, gdy bibliotekarz wpisał liczbę z przecinkiem dziesiętnym:

```
ValidationError: ['Wartością „3,2” musi być liczba dziesiętna.']  (decimal.InvalidOperation)
```

Zapis bibliotekarza cicho przepadał — polscy użytkownicy naturalnie wpisują przecinek.

## Poprawka

`src/bpp/views/api/__init__.py`:

- `POLA_DZIESIETNE` — wyliczane jako przecięcie `POLA_PUNKTACJI` z polami `DecimalField` modelu (`impact_factor`, `punkty_kbn`, `index_copernicus`, `punktacja_wewnetrzna`, `punktacja_snip`). Pola całkowite (`kwartyl_w_scopus/wos`) **celowo nietknięte**.
- Wydzielony helper `zbierz_punktacje(post)` normalizuje `,`→`.` i parsuje na `Decimal`; wołany **raz, przed rozgałęzieniem** create/update — obejmuje obie ścieżki.
- Wartość niepoprawna po normalizacji → **czytelny 400** z listą błędnych pól, zamiast gołego 500.

## Test

`src/bpp/tests/test_views/test_api.py` — 3 testy: przecinek na ścieżce create, na overwrite, oraz wartość niepoprawna (400). Asercje na `Decimal("3.2")` / `Decimal("0.125")`. TDD potwierdzone (fail-before). `8 passed` na testcontainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
