### PR TITLE
fix(admin): licznik filtrów tylko gdy admin wystawia endpoint _filter_count

### DIFF
--- a/src/bpp/newsfragments/admin-filter-count-bppuser.bugfix.rst
+++ b/src/bpp/newsfragments/admin-filter-count-bppuser.bugfix.rst
@@ -1,0 +1,4 @@
+Liczniki filtrów w adminie: naprawiono ``NoReverseMatch`` (połykany wyjątek,
+szum w logach/Rollbarze) przy filtrowaniu changelistów adminów bez endpointu
+``_filter_count`` (np. użytkownicy). Licznik jest teraz liczony wyłącznie tam,
+gdzie admin faktycznie wystawia ten endpoint.

--- a/src/bpp/tests/test_admin/test_bppuser_filter_count.py
+++ b/src/bpp/tests/test_admin/test_bppuser_filter_count.py
@@ -1,0 +1,49 @@
+"""Regresja: liczniki filtrów HTMX na adminach BEZ endpointu `_filter_count`.
+
+`BppUserAdmin` dziedziczy po django-owym `UserAdmin`, a NIE po
+`DynamicAdminFilterMixin`/`BaseBppAdminMixin`, więc nie rejestruje URL-a
+`admin:bpp_bppuser_filter_count`. Wcześniej szablon `admin/change_list.html`
+wywoływał `get_selected_filter_count_url` bezwarunkowo (poza `{% if show_counts %}`),
+przez co dla każdego filtrowanego changelistu bez tego endpointu leciał
+`NoReverseMatch` połykany przez `zaloguj_polkniety_wyjatek` (szum w Rollbarze).
+"""
+
+import pytest
+from django.urls import NoReverseMatch, reverse
+
+
+@pytest.mark.django_db
+def test_bppuser_admin_nie_ma_endpointu_filter_count():
+    """BppUserAdmin nie wystawia endpointu licznika filtrów."""
+    with pytest.raises(NoReverseMatch):
+        reverse("admin:bpp_bppuser_filter_count")
+
+
+@pytest.mark.django_db
+def test_admin_z_mixinem_ma_endpoint_filter_count():
+    """Admin dziedziczący DynamicAdminFilterMixin (Autor) MA endpoint."""
+    # Nie powinno rzucić NoReverseMatch:
+    assert reverse("admin:bpp_autor_filter_count")
+
+
+@pytest.mark.django_db
+def test_bppuser_changelist_z_filtrem_nie_loguje_polknietego_wyjatku(
+    admin_client, mocker
+):
+    """Filtrowany changelist BppUser nie próbuje reverse nieistniejącego URL-a.
+
+    Zastosowanie filtru `is_staff` zaznacza wybór inny niż "Wszyscy", co
+    wcześniej wyzwalało `get_selected_filter_count_url` -> `reverse(...)` ->
+    `NoReverseMatch` -> `zaloguj_polkniety_wyjatek`. Po naprawie licznik jest
+    liczony wyłącznie gdy admin wystawia endpoint (`show_counts`), więc żaden
+    połknięty wyjątek nie powinien zostać zalogowany.
+    """
+    spy = mocker.patch(
+        "bpp.templatetags.admin_filter_helpers.zaloguj_polkniety_wyjatek"
+    )
+
+    url = reverse("admin:bpp_bppuser_changelist")
+    response = admin_client.get(url, {"is_staff__exact": "1"})
+
+    assert response.status_code == 200
+    spy.assert_not_called()

--- a/src/django_bpp/templates/admin/change_list.html
+++ b/src/django_bpp/templates/admin/change_list.html
@@ -1097,7 +1097,13 @@
                 {% should_show_filter_counts cl as show_counts %}
                 {% for spec in cl.filter_specs %}
                     {% get_selected_filter_value spec cl as selected_value %}
-                    {% get_selected_filter_count_url spec cl as selected_count_url %}
+                    {# Licznik liczymy TYLKO gdy admin wystawia endpoint #}
+                    {# `_filter_count` (show_counts). Inaczej reverse() dla #}
+                    {# nieistniejącego URL-a rzucałby NoReverseMatch przy #}
+                    {# każdym filtrowanym changeliście (np. BppUser). #}
+                    {% if show_counts %}
+                        {% get_selected_filter_count_url spec cl as selected_count_url %}
+                    {% endif %}
                     <div class="filter-group">
                         <h3 class="filter-title filter-collapsible collapsed{% if selected_value %} has-selection{% endif %}"
                             data-filter-id="filter-{{ forloop.counter }}">


### PR DESCRIPTION
## Problem (Rollbar #431, 4×, produkcja: vizja — z RC 202607.1397rc1)

`NoReverseMatch: Reverse for 'bpp_bppuser_filter_count' not found` przy filtrowaniu changelistu adminów, które nie wystawiają endpointu liczników filtrów (np. `BppUser`, `Group`, `Site`, adminy third-party). Wyjątek był połykany przez `zaloguj_polkniety_wyjatek` — **szum w logach/Rollbarze przy każdym filtrowanym renderze**.

## Przyczyna

Endpoint `_filter_count` rejestruje `DynamicAdminFilterMixin.get_urls()` (razem z atrybutem `dynamic_filter_counts_enable`). Adminy spoza bazy BPP go nie dziedziczą. Ale wspólny szablon `change_list.html` wołał tag `get_selected_filter_count_url` **bezwarunkowo** — poza guardem `{% if show_counts %}` — więc próbował `reverse()` nieistniejącego URL-a.

## Poprawka

Przeniesienie wywołania tagu **do wnętrza istniejącego guardu `{% if show_counts %}`** w `src/django_bpp/templates/admin/change_list.html`. Rozwiązanie systemowe (jeden wspólny szablon → naprawia BppUser i każdy inny admin bez opt-inu), bez sterowania połykanym wyjątkiem: `reverse` licznika wołany wyłącznie tam, gdzie endpoint na pewno istnieje.

## Test

`src/bpp/tests/test_admin/test_bppuser_filter_count.py` — 3 testy, w tym regresyjny na spy `zaloguj_polkniety_wyjatek` (filtrowany changelist BppUser nie loguje połkniętego wyjątku). TDD potwierdzone (fail bez fixa). `3 passed` na testcontainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
