### PR TITLE
feat(admin): bezpieczne kasowanie tylko pustych jednostek

### DIFF
--- a/docs/superpowers/specs/2026-07-07-kasowanie-pustych-jednostek-design.md
+++ b/docs/superpowers/specs/2026-07-07-kasowanie-pustych-jednostek-design.md
@@ -1,0 +1,135 @@
+# Bezpieczne kasowanie pustych jednostek (admin)
+
+Data: 2026-07-07
+Status: zaakceptowany (design), do implementacji
+
+## Problem
+
+`JednostkaAdmin` bramkuje kasowanie wyłącznie po grupie
+(`RestrictDeletionToAdministracjaGroupMixin`) — każdy członek grupy
+`administracja` może usunąć jednostkę. Nie ma żadnego zabezpieczenia przed
+tym, CO zniknie w kaskadzie.
+
+Większość FK wskazujących na `Jednostka` ma `on_delete=CASCADE`
+(`Autor_Jednostka`, `Jednostka_Rodzic`, cache `Autorzy`/`Rekord`, MPTT
+`children` przez self-FK `parent`, …). Skutek: dzisiejsze skasowanie
+jednostki **po cichu kaskaduje** — kasuje powiązania autor-jednostka,
+historię przypisań, wpisy cache, całe poddrzewo podjednostek. To utrata
+danych bez ostrzeżenia.
+
+## Cel
+
+Pozwolić skasować jednostkę **tylko wtedy, gdy jest w pełni pusta**:
+ściśle zero referencji przez FK/M2M i zero podjednostek. W przeciwnym razie
+odrzucić operację z czytelnym komunikatem, który wymienia CO blokuje.
+
+## Decyzje projektowe
+
+1. **Definicja „pustej" — ściśle zero referencji.** Jakikolwiek wiersz
+   wskazujący na jednostkę przez FK/M2M blokuje kasowanie: podjednostki,
+   `Autor_Jednostka` (nawet puste), własna historia `Jednostka_Rodzic`,
+   cache, PBN itd. Nie rozróżniamy „własnych artefaktów" od „realnych
+   powiązań" — wszystko liczy się jako blokada.
+
+2. **Mechanizm/UX — bramkuj standardowy delete + komunikat.** Zostaje zwykły
+   przycisk „Usuń" Django. Gdy jednostka ma referencje, strona potwierdzenia
+   wyświetla listę blokad i **nie pozwala potwierdzić**. Gdy pusta — kasuje
+   normalnie. Działa też dla akcji masowej „Usuń wybrane".
+
+3. **Bramka grupy `administracja` zostaje bez zmian.** Nowy warunek „pusta"
+   jest DODATKOWY — nie zastępuje istniejącego `has_delete_permission`
+   opartego o grupę. Aby skasować: trzeba być w grupie `administracja`
+   ORAZ jednostka musi być pusta.
+
+## Architektura (trzy warstwy)
+
+### 1. Warstwa logiki — model `Jednostka`
+
+Jedno źródło prawdy, testowalne bez admina. W `src/bpp/models/jednostka.py`:
+
+```python
+def przeszkody_w_kasowaniu(self) -> list[tuple[str, int]]:
+    """Lista (etykieta, liczba) niepustych odwrotnych relacji FK/M2M
+    wskazujących na tę jednostkę. Pusta lista ⇔ jednostkę można skasować."""
+```
+
+- Iteruje po `self._meta.related_objects` (odwrotne FK/O2O) oraz relacjach
+  M2M `auto_created`. Dla każdej relacji z `count() > 0` zwraca krotkę
+  `(etykieta, liczba)`, gdzie `etykieta` bierze się z `verbose_name_plural`
+  powiązanego modelu (np. „powiązania jednostka-rodzic", „jednostki
+  podrzędne").
+- Podjednostki (`children`, self-FK `parent`) pojawiają się tu naturalnie
+  jako jedna z relacji — NIE ma osobnej gałęzi kodu „czy ma dzieci".
+- Zwraca pustą listę wtedy i tylko wtedy, gdy jednostka jest w pełni pusta.
+
+Helper:
+
+```python
+def czy_mozna_skasowac(self) -> bool:
+    return not self.przeszkody_w_kasowaniu()
+```
+
+Uwagi implementacyjne:
+- Odwrotny denorm self-FK `wydzial` (`related_name="+"`, `SET_NULL`) też
+  istnieje w `_meta.related_objects`; dla pustej jednostki-liścia jest
+  pusty, więc nie przeszkadza. Zgodnie ze „ściśle zero" jego niepustość
+  (gdyby jakaś jednostka wskazywała `wydzial` na tę) też blokuje — co jest
+  poprawne (to root z poddrzewem, i tak zablokowany przez `children`).
+- Etykieta dla relacji bez czytelnego `verbose_name_plural` (np. `+`)
+  degraduje do sensownego fallbacku (np. `related_model._meta.verbose_name_plural`).
+
+### 2. Warstwa admina — `JednostkaAdmin`
+
+Override `get_deleted_objects(self, objs, request)`:
+
+- Woła `super().get_deleted_objects(objs, request)` →
+  `(deletable_objects, model_count, perms_needed, protected)`.
+- Dla każdej `obj` w `objs`, jeśli `obj.przeszkody_w_kasowaniu()` nie jest
+  puste, dokłada do `protected` czytelny wpis, np.:
+  *„Jednostka «X» — nie można usunąć: 3× powiązania autor-jednostka,
+  2× jednostki podrzędne"*.
+- Zwraca zmodyfikowaną krotkę. Django renderuje `protected` na stronie
+  potwierdzenia i chowa przycisk potwierdzenia. Ten sam kod obsługuje delete
+  pojedynczy i akcję masową (obie ścieżki wołają `get_deleted_objects`).
+
+Defense-in-depth — guard w `delete_model` i `delete_queryset`:
+- Jeśli jakąś inną drogą (skrypt, przyszły kod) trafi tam niepusta
+  jednostka, odmów (pomiń/`messages.error`) zamiast po cichu kaskadować.
+  Filtruje niepuste z que/pojedynczego usuwania.
+
+`has_delete_permission` — **bez zmian** (istniejąca bramka grupy).
+
+### 3. Testy (TDD, pytest + `model_bakery.baker`)
+
+Model (`przeszkody_w_kasowaniu` / `czy_mozna_skasowac`):
+- Pusta jednostka → `[]`, `czy_mozna_skasowac() is True`.
+- Z jednym `Autor_Jednostka` → dokładnie jeden wpis, `czy_mozna_skasowac()`
+  `is False`.
+- Z podjednostką (`parent=jednostka`) → wpis „jednostki podrzędne".
+- Z wpisem `Jednostka_Rodzic` (własna historia) → wpis blokujący
+  (potwierdza semantykę „ściśle zero").
+
+Admin (przez `client` zalogowany jako user w grupie `administracja`):
+- POST delete na PUSTEJ jednostce → znika z bazy (`DoesNotExist`).
+- GET/POST delete na NIEPUSTEJ → strona potwierdzenia zawiera wpis
+  `protected`; obiekt NADAL istnieje po próbie.
+- Akcja masowa „Usuń wybrane" na mieszance pusta+niepusta → pusta skasowana,
+  niepusta zostaje.
+
+## Świadomie poza zakresem (YAGNI)
+
+- Brak zmian w API i management-commands — feature dotyczy wyłącznie admin UI.
+- Brak „trybu wymuszonego kaskadowego kasowania" — jeśli coś wisi, użytkownik
+  musi to najpierw ręcznie odpiąć/przenieść.
+- Brak luzowania bramki grupy `administracja`.
+
+## Pliki
+
+- `src/bpp/models/jednostka.py` — metody `przeszkody_w_kasowaniu`,
+  `czy_mozna_skasowac`.
+- `src/bpp/admin/jednostka.py` — override `get_deleted_objects`,
+  guardy `delete_model` / `delete_queryset` (możliwe wydzielenie do mixinu
+  w `src/bpp/admin/core.py`, jeśli okaże się reużywalne).
+- Testy: `src/bpp/tests/` (model) + test admina obok istniejących testów
+  `JednostkaAdmin`.
+- Newsfragment towncriera (feature).

--- a/docs/superpowers/specs/2026-07-07-kasowanie-pustych-jednostek-design.md
+++ b/docs/superpowers/specs/2026-07-07-kasowanie-pustych-jednostek-design.md
@@ -1,7 +1,7 @@
 # Bezpieczne kasowanie pustych jednostek (admin)
 
 Data: 2026-07-07
-Status: zaakceptowany (design), do implementacji
+Status: zaakceptowany (design, po adwersaryjnym self-review), do implementacji
 
 ## Problem
 
@@ -11,30 +11,54 @@ Status: zaakceptowany (design), do implementacji
 tym, CO zniknie w kaskadzie.
 
 Większość FK wskazujących na `Jednostka` ma `on_delete=CASCADE`
-(`Autor_Jednostka`, `Jednostka_Rodzic`, cache `Autorzy`/`Rekord`, MPTT
-`children` przez self-FK `parent`, …). Skutek: dzisiejsze skasowanie
-jednostki **po cichu kaskaduje** — kasuje powiązania autor-jednostka,
-historię przypisań, wpisy cache, całe poddrzewo podjednostek. To utrata
-danych bez ostrzeżenia.
+(`Autor_Jednostka`, `Jednostka_Rodzic`, cache `Autorzy`, MPTT `children`
+przez self-FK `parent`, …). Skutek: dzisiejsze skasowanie jednostki **po
+cichu kaskaduje** — kasuje powiązania autor-jednostka, historię przypisań,
+wpisy cache, całe poddrzewo podjednostek. To utrata danych bez ostrzeżenia.
 
 ## Cel
 
 Pozwolić skasować jednostkę **tylko wtedy, gdy jest w pełni pusta**:
-ściśle zero referencji przez FK/M2M i zero podjednostek. W przeciwnym razie
-odrzucić operację z czytelnym komunikatem, który wymienia CO blokuje.
+ściśle zero referencji przez odwrotne, KONKRETNE i ZARZĄDZANE FK/M2M
+i zero podjednostek. W przeciwnym razie odrzucić operację z czytelnym
+komunikatem, który wymienia CO blokuje.
 
 ## Decyzje projektowe
 
-1. **Definicja „pustej" — ściśle zero referencji.** Jakikolwiek wiersz
-   wskazujący na jednostkę przez FK/M2M blokuje kasowanie: podjednostki,
-   `Autor_Jednostka` (nawet puste), własna historia `Jednostka_Rodzic`,
-   cache, PBN itd. Nie rozróżniamy „własnych artefaktów" od „realnych
-   powiązań" — wszystko liczy się jako blokada.
+1. **Definicja „pustej" — ściśle zero referencji z realnych tabel.**
+   Blokuje jakikolwiek wiersz wskazujący na jednostkę przez odwrotny,
+   konkretny FK/O2O lub przez model łączący M2M, o ile powiązany model jest
+   ZARZĄDZANY (`_meta.managed is True`): podjednostki, `Autor_Jednostka`
+   (nawet puste), własna historia `Jednostka_Rodzic`, cache `Autorzy`
+   (realna tabela), PBN itd. **Nie rozróżniamy** „własnych artefaktów" od
+   „realnych powiązań" wśród tabel — wszystko liczy się jako blokada.
+
+   **NIE blokują** (świadomie, doprecyzowane po review):
+   - **Niezarządzane widoki SQL** (`_meta.managed is False`, `DO_NOTHING`):
+     `AutorzyView`, `Cache_Punktacja_Autora_*`, `Nowe_Sumy_View` itp. Widok
+     nie przechowuje danych — jest wyliczany z tabel bazowych i sam się
+     przelicza; fizycznie nie może „blokować" kasowania. Jednostka bez
+     publikacji i tak nie ma wierszy w tych widokach.
+   - **Relacje generyczne** (reversion `Version`, easyaudit, cacheops).
+     Model `Jednostka` NIE ma żadnego `GenericRelation`, więc te obiekty nie
+     pojawiają się w `_meta.related_objects` i nie są liczone. To jest
+     pożądane — log audytu / rewizja historii nie powinny blokować kasowania
+     świeżej, pustej jednostki.
+
+   Innymi słowy: „ściśle zero" dotyczy konkretnych odwrotnych FK/M2M do
+   **realnych, zarządzanych tabel** — nie widoków ani relacji generycznych.
 
 2. **Mechanizm/UX — bramkuj standardowy delete + komunikat.** Zostaje zwykły
    przycisk „Usuń" Django. Gdy jednostka ma referencje, strona potwierdzenia
-   wyświetla listę blokad i **nie pozwala potwierdzić**. Gdy pusta — kasuje
-   normalnie. Działa też dla akcji masowej „Usuń wybrane".
+   wyświetla listę blokad (mechanizm `protected` z `get_deleted_objects`)
+   i **nie pozwala potwierdzić**. Gdy pusta — kasuje normalnie.
+
+   **Akcja masowa „Usuń wybrane" — blokada całej partii (natywne Django).**
+   `delete_selected` liczy blokady dla CAŁEGO zaznaczenia; jeśli choć jedna
+   zaznaczona jednostka jest niepusta, `protected` jest niepuste i Django
+   **nie kasuje NICZEGO** (nawet pustych z zaznaczenia), pokazując listę
+   blokad. To spójne z tym, jak Django traktuje `PROTECT` w akcji masowej —
+   zero dodatkowego kodu. Użytkownik odznacza niepuste i ponawia.
 
 3. **Bramka grupy `administracja` zostaje bez zmian.** Nowy warunek „pusta"
    jest DODATKOWY — nie zastępuje istniejącego `has_delete_permission`
@@ -50,17 +74,36 @@ Jedno źródło prawdy, testowalne bez admina. W `src/bpp/models/jednostka.py`:
 ```python
 def przeszkody_w_kasowaniu(self) -> list[tuple[str, int]]:
     """Lista (etykieta, liczba) niepustych odwrotnych relacji FK/M2M
-    wskazujących na tę jednostkę. Pusta lista ⇔ jednostkę można skasować."""
+    do REALNYCH, zarządzanych tabel wskazujących na tę jednostkę.
+    Pusta lista ⇔ jednostkę można skasować."""
 ```
 
-- Iteruje po `self._meta.related_objects` (odwrotne FK/O2O) oraz relacjach
-  M2M `auto_created`. Dla każdej relacji z `count() > 0` zwraca krotkę
-  `(etykieta, liczba)`, gdzie `etykieta` bierze się z `verbose_name_plural`
-  powiązanego modelu (np. „powiązania jednostka-rodzic", „jednostki
-  podrzędne").
+Zasady iteracji (wynik adwersaryjnego review):
+
+- Iteruj po `self._meta.related_objects` (odwrotne FK/O2O oraz odwrotne M2M).
+- **Liczenie jednolicie przez POLE, nie akcesor** — kluczowe, bo:
+  - odwrotny **O2O** (`Nowe_Sumy_View`, accessor `nowe_sumy_view`) NIE ma
+    `.count()`, a samo dotknięcie akcesora rzuca `RelatedObjectDoesNotExist`;
+  - dlatego licz: `rel.related_model._base_manager.filter(**{rel.field.name:
+    self}).count()` — działa jednakowo dla FK, O2O i M2M-through.
+- **Pomiń modele niezarządzane** (`rel.related_model._meta.managed is False`)
+  — to widoki SQL (patrz decyzja 1), tanio je wyklucza i skraca listę
+  z ~35 relacji do garstki realnych.
+- **Pomiń zduplikowany odwrotny M2M**: `related_objects` zawiera i odwrotny
+  M2M `autor` (accessor `autor_set`, `auto_created` przez `Autor.jednostki`),
+  i FK modelu-łączącego `Autor_Jednostka`. Ta sama więź trafiłaby na listę
+  dwa razy. Pomiń `rel.many_to_many and rel.field.auto_created` — model
+  łączący (`Autor_Jednostka`) i tak pokrywa tę relację.
 - Podjednostki (`children`, self-FK `parent`) pojawiają się tu naturalnie
   jako jedna z relacji — NIE ma osobnej gałęzi kodu „czy ma dzieci".
-- Zwraca pustą listę wtedy i tylko wtedy, gdy jednostka jest w pełni pusta.
+- Denorm self-FK `wydzial` (`related_name="+"`) jest HIDDEN i `related_objects`
+  go POMIJA (nie ma go tam — wbrew pierwotnej, błędnej uwadze w tym specu).
+  To nieszkodliwe dla „ściśle zero": węzeł, na który wskazuje cudzy `wydzial`,
+  jest korzeniem z poddrzewem, więc blokuje go bezpośrednie `children`.
+  NIE używać `get_fields(include_hidden=True)` — trafiłoby na akcesor `+`
+  bez managera i crashowało.
+- Etykieta krotki = `rel.related_model._meta.verbose_name_plural`
+  (już zlokalizowane), zwracana dla każdej relacji z `count() > 0`.
 
 Helper:
 
@@ -69,35 +112,41 @@ def czy_mozna_skasowac(self) -> bool:
     return not self.przeszkody_w_kasowaniu()
 ```
 
-Uwagi implementacyjne:
-- Odwrotny denorm self-FK `wydzial` (`related_name="+"`, `SET_NULL`) też
-  istnieje w `_meta.related_objects`; dla pustej jednostki-liścia jest
-  pusty, więc nie przeszkadza. Zgodnie ze „ściśle zero" jego niepustość
-  (gdyby jakaś jednostka wskazywała `wydzial` na tę) też blokuje — co jest
-  poprawne (to root z poddrzewem, i tak zablokowany przez `children`).
-- Etykieta dla relacji bez czytelnego `verbose_name_plural` (np. `+`)
-  degraduje do sensownego fallbacku (np. `related_model._meta.verbose_name_plural`).
-
 ### 2. Warstwa admina — `JednostkaAdmin`
 
 Override `get_deleted_objects(self, objs, request)`:
 
 - Woła `super().get_deleted_objects(objs, request)` →
-  `(deletable_objects, model_count, perms_needed, protected)`.
+  `(deletable_objects, model_count, perms_needed, protected)`. Potwierdzone:
+  w Django 5.2 `protected` to lista renderowana w szablonie przez
+  `{{ protected|unordered_list }}`; niepuste `protected` powoduje że zarówno
+  `_delete_view` (`if request.POST and not protected`) jak i akcja
+  `delete_selected` (`if request.POST.get("post") and not protected`)
+  NIE wykonują kasowania i chowają przycisk potwierdzenia.
 - Dla każdej `obj` w `objs`, jeśli `obj.przeszkody_w_kasowaniu()` nie jest
-  puste, dokłada do `protected` czytelny wpis, np.:
+  puste, dokłada do `protected` czytelny, **zescapowany** wpis, np.:
   *„Jednostka «X» — nie można usunąć: 3× powiązania autor-jednostka,
   2× jednostki podrzędne"*.
-- Zwraca zmodyfikowaną krotkę. Django renderuje `protected` na stronie
-  potwierdzenia i chowa przycisk potwierdzenia. Ten sam kod obsługuje delete
-  pojedynczy i akcję masową (obie ścieżki wołają `get_deleted_objects`).
+  - `jednostka.nazwa` (do 512 znaków, dowolny tekst) trafia do HTML przez
+    `unordered_list` — buduj wpis przez `format_html` / `escape`
+    (i `gettext` na stałych fragmentach), by uniknąć XSS.
+- Zwraca zmodyfikowaną krotkę. Ten sam kod obsługuje delete pojedynczy
+  i akcję masową (obie ścieżki wołają `get_deleted_objects`); dla akcji
+  masowej daje to natywną blokadę całej partii (decyzja 2).
 
-Defense-in-depth — guard w `delete_model` i `delete_queryset`:
-- Jeśli jakąś inną drogą (skrypt, przyszły kod) trafi tam niepusta
-  jednostka, odmów (pomiń/`messages.error`) zamiast po cichu kaskadować.
-  Filtruje niepuste z que/pojedynczego usuwania.
+Defense-in-depth — guard w `delete_model` (i ewentualnie `delete_queryset`):
+- Skoro `protected` blokuje dojście do kasowania w ścieżce admina, guard
+  jest **wyłącznie** siatką bezpieczeństwa dla wywołań programistycznych
+  (skrypt, przyszły kod). Jeśli mimo wszystko trafi tam niepusta jednostka,
+  odmów (`log` / wyjątek) zamiast po cichu kaskadować.
+- **Nie** opisujemy guardu jako mechanizmu „częściowego" kasowania masowego —
+  akcja masowa jest wszystko-albo-nic (decyzja 2), więc `delete_queryset`
+  w praktyce dostaje albo same puste, albo nic.
 
-`has_delete_permission` — **bez zmian** (istniejąca bramka grupy).
+`has_delete_permission` — **bez zmian** (istniejąca bramka grupy;
+potwierdzone: żaden mixin w łańcuchu MRO `JednostkaAdmin` nie override'uje
+`get_deleted_objects` / `delete_model` / `delete_queryset`, więc `super()`
+trafia do `ModelAdmin`).
 
 ### 3. Testy (TDD, pytest + `model_bakery.baker`)
 
@@ -107,14 +156,24 @@ Model (`przeszkody_w_kasowaniu` / `czy_mozna_skasowac`):
   `is False`.
 - Z podjednostką (`parent=jednostka`) → wpis „jednostki podrzędne".
 - Z wpisem `Jednostka_Rodzic` (własna historia) → wpis blokujący
-  (potwierdza semantykę „ściśle zero").
+  (potwierdza semantykę „ściśle zero" dla realnych tabel).
+- **Regresja O2O/widoki:** metoda NIE rzuca wyjątku dla jednostki bez
+  wiersza w odwrotnym O2O (`Nowe_Sumy_View`) i NIE liczy niezarządzanych
+  widoków jako blokad.
 
 Admin (przez `client` zalogowany jako user w grupie `administracja`):
 - POST delete na PUSTEJ jednostce → znika z bazy (`DoesNotExist`).
 - GET/POST delete na NIEPUSTEJ → strona potwierdzenia zawiera wpis
   `protected`; obiekt NADAL istnieje po próbie.
-- Akcja masowa „Usuń wybrane" na mieszance pusta+niepusta → pusta skasowana,
-  niepusta zostaje.
+- **Akcja masowa** „Usuń wybrane" na mieszance pusta+niepusta → cała partia
+  zablokowana: NIC nie skasowane (także pusta), strona listuje blokady
+  (spójne z decyzją 2). Osobny przypadek: same puste w zaznaczeniu → wszystkie
+  skasowane.
+
+Uwaga do testów (poboczne): `get_deleted_objects` przepuszcza kaskadowane
+obiekty przez `has_delete_permission` ich adminów; brak uprawnień daje
+`perms_needed`. Testy admina uruchamiać jako superuser/pełnoprawny członek
+`administracja`, by nie mylić `perms_needed` z naszą blokadą `protected`.
 
 ## Świadomie poza zakresem (YAGNI)
 
@@ -122,14 +181,25 @@ Admin (przez `client` zalogowany jako user w grupie `administracja`):
 - Brak „trybu wymuszonego kaskadowego kasowania" — jeśli coś wisi, użytkownik
   musi to najpierw ręcznie odpiąć/przenieść.
 - Brak luzowania bramki grupy `administracja`.
+- Brak częściowego kasowania w akcji masowej (decyzja 2: wszystko-albo-nic).
 
 ## Pliki
 
 - `src/bpp/models/jednostka.py` — metody `przeszkody_w_kasowaniu`,
   `czy_mozna_skasowac`.
 - `src/bpp/admin/jednostka.py` — override `get_deleted_objects`,
-  guardy `delete_model` / `delete_queryset` (możliwe wydzielenie do mixinu
-  w `src/bpp/admin/core.py`, jeśli okaże się reużywalne).
+  guard `delete_model` (możliwe wydzielenie do mixinu w
+  `src/bpp/admin/core.py`, jeśli okaże się reużywalne).
 - Testy: `src/bpp/tests/` (model) + test admina obok istniejących testów
   `JednostkaAdmin`.
 - Newsfragment towncriera (feature).
+
+## Ślad po review
+
+Adwersaryjny self-review (czysty subagent, Django 5.2.15) wykrył i naprawiono
+w tym specu: sprzeczność akcji masowej z mechanizmem `protected` (→ decyzja 2
+wszystko-albo-nic), crash na odwrotnym O2O `Nowe_Sumy_View` (→ liczenie przez
+`rel.field.name`), błędną uwagę o `wydzial` w `related_objects` (relacja
+hidden), przeobiecujące „ściśle zero wszystkiego" (→ tylko zarządzane tabele,
+bez widoków i relacji generycznych), podwójne liczenie M2M `autor` vs
+model-łączący, oraz ryzyko XSS w wpisach `protected` (→ escape/format_html).

--- a/docs/superpowers/specs/2026-07-07-kasowanie-pustych-jednostek-design.md
+++ b/docs/superpowers/specs/2026-07-07-kasowanie-pustych-jednostek-design.md
@@ -78,30 +78,34 @@ def przeszkody_w_kasowaniu(self) -> list[tuple[str, int]]:
     Pusta lista ⇔ jednostkę można skasować."""
 ```
 
-Zasady iteracji (wynik adwersaryjnego review):
+Zasady iteracji (wynik dwóch adwersaryjnych review — spec + implementacja Fable):
 
-- Iteruj po `self._meta.related_objects` (odwrotne FK/O2O oraz odwrotne M2M).
+- Iteruj po `get_candidate_relations_to_delete(self._meta)` — DOKŁADNIE tym
+  zbiorze, który widzi kolektor kasowania Django (`include_hidden=True`).
+  **NIE** po `self._meta.related_objects`: ten POMIJA ukryte relacje odwrotne
+  (`related_name="+"`, np. realny managed FK `Import_Dyscyplin_Row.wydzial`),
+  które kolektor mimo to kaskaduje — użycie `related_objects` przepuściłoby
+  taką jednostkę jako „pustą" i po cichu zrobiło SET_NULL/CASCADE (Fable B1).
+  Kandydaci to tylko FK/O2O (bez M2M), więc znika osobny skip M2M.
 - **Liczenie jednolicie przez POLE, nie akcesor** — kluczowe, bo:
   - odwrotny **O2O** (`Nowe_Sumy_View`, accessor `nowe_sumy_view`) NIE ma
     `.count()`, a samo dotknięcie akcesora rzuca `RelatedObjectDoesNotExist`;
   - dlatego licz: `rel.related_model._base_manager.filter(**{rel.field.name:
-    self}).count()` — działa jednakowo dla FK, O2O i M2M-through.
+    self}).count()` — działa jednakowo dla FK i O2O (i zgadza się z managerem,
+    którego używa sam kolektor kasowania).
 - **Pomiń modele niezarządzane** (`rel.related_model._meta.managed is False`)
-  — to widoki SQL (patrz decyzja 1), tanio je wyklucza i skraca listę
-  z ~35 relacji do garstki realnych.
-- **Pomiń zduplikowany odwrotny M2M**: `related_objects` zawiera i odwrotny
-  M2M `autor` (accessor `autor_set`, `auto_created` przez `Autor.jednostki`),
-  i FK modelu-łączącego `Autor_Jednostka`. Ta sama więź trafiłaby na listę
-  dwa razy. Pomiń `rel.many_to_many and rel.field.auto_created` — model
-  łączący (`Autor_Jednostka`) i tak pokrywa tę relację.
+  — u nas to warstwa odczytowa cache (widoki SQL oraz alias-y na tabele
+  bazowe, patrz decyzja 1). Realne wiersze publikacji i tak trzymają
+  zarządzane tabele (`Wydawnictwo_*_Autor`, `Cache_Punktacja_Autora`), więc
+  jednostka z publikacjami zostaje zablokowana przez nie. Pomija to też
+  odwrotny O2O do widoku (`Nowe_Sumy_View`), którego liczenie przez akcesor
+  rzucałoby `DoesNotExist`.
 - Podjednostki (`children`, self-FK `parent`) pojawiają się tu naturalnie
-  jako jedna z relacji — NIE ma osobnej gałęzi kodu „czy ma dzieci".
-- Denorm self-FK `wydzial` (`related_name="+"`) jest HIDDEN i `related_objects`
-  go POMIJA (nie ma go tam — wbrew pierwotnej, błędnej uwadze w tym specu).
-  To nieszkodliwe dla „ściśle zero": węzeł, na który wskazuje cudzy `wydzial`,
-  jest korzeniem z poddrzewem, więc blokuje go bezpośrednie `children`.
-  NIE używać `get_fields(include_hidden=True)` — trafiłoby na akcesor `+`
-  bez managera i crashowało.
+  jako jedna z relacji-kandydatów — NIE ma osobnej gałęzi kodu „czy ma dzieci".
+- Ukryte FK (`related_name="+"`, np. denorm self-FK `wydzial`,
+  `Import_Dyscyplin_Row.wydzial`) SĄ objęte, bo `get_candidate_relations_to_
+  delete` używa `include_hidden=True` — dokładnie jak kolektor kasowania.
+  Liczymy je przez `rel.field.name` (nie przez akcesor `+`, który nie istnieje).
 - Etykieta krotki = `rel.related_model._meta.verbose_name_plural`
   (już zlokalizowane), zwracana dla każdej relacji z `count() > 0`.
 
@@ -209,10 +213,20 @@ obiekty przez `has_delete_permission` ich adminów; brak uprawnień daje
 
 ## Ślad po review
 
-Adwersaryjny self-review (czysty subagent, Django 5.2.15) wykrył i naprawiono
-w tym specu: sprzeczność akcji masowej z mechanizmem `protected` (→ decyzja 2
-wszystko-albo-nic), crash na odwrotnym O2O `Nowe_Sumy_View` (→ liczenie przez
-`rel.field.name`), błędną uwagę o `wydzial` w `related_objects` (relacja
-hidden), przeobiecujące „ściśle zero wszystkiego" (→ tylko zarządzane tabele,
-bez widoków i relacji generycznych), podwójne liczenie M2M `autor` vs
-model-łączący, oraz ryzyko XSS w wpisach `protected` (→ escape/format_html).
+Adwersaryjny self-review speca (czysty subagent, Django 5.2.15) wykrył i
+naprawiono w specu: sprzeczność akcji masowej z mechanizmem `protected`
+(→ decyzja 2 wszystko-albo-nic), crash na odwrotnym O2O `Nowe_Sumy_View`
+(→ liczenie przez `rel.field.name`), przeobiecujące „ściśle zero wszystkiego"
+(→ tylko zarządzane tabele), podwójne liczenie M2M `autor`, oraz ryzyko XSS
+w `protected` (→ escape/format_html).
+
+Adwersaryjny review IMPLEMENTACJI (Fable) wykrył BLOCKER B1: skan po
+`_meta.related_objects` POMIJAŁ ukryte FK (`related_name="+"`), które kolektor
+kasowania mimo to kaskaduje — realny przypadek `Import_Dyscyplin_Row.wydzial`
+przechodził jako „pusty". Naprawa: iteracja po `get_candidate_relations_to_
+delete` (`include_hidden=True`), plus test-regres. Ponadto: guard
+`delete_model` rzuca teraz `PermissionDenied` (a nie `message_user`+`return`,
+który zostawiał fałszywy „usunięto" + wpis DELETION), oraz dodano test bramki
+grupy `administracja` (superuser bez grupy nie kasuje). Znane, świadomie
+NIEnaprawione (pomijalne): mikro-race w `delete_selected_tree` oraz koszt
+~24 COUNT/jednostkę na ścieżce kasowania (nie hot-path).

--- a/docs/superpowers/specs/2026-07-07-kasowanie-pustych-jednostek-design.md
+++ b/docs/superpowers/specs/2026-07-07-kasowanie-pustych-jednostek-design.md
@@ -134,7 +134,20 @@ Override `get_deleted_objects(self, objs, request)`:
   i akcję masową (obie ścieżki wołają `get_deleted_objects`); dla akcji
   masowej daje to natywną blokadę całej partii (decyzja 2).
 
-Defense-in-depth — guard w `delete_model` (i ewentualnie `delete_queryset`):
+**Wrinkle MPTT (odkryty przy implementacji).** `JednostkaAdmin` dziedziczy po
+`DraggableMPTTAdmin`, który podmienia akcję masową na
+`MPTTModelAdmin.delete_selected_tree`. Ta akcja na PIERWSZYM przejściu (strona
+potwierdzenia) deleguje do standardowego `delete_selected` → nasz
+`get_deleted_objects` pokazuje blokady i chowa przycisk (OK). Ale na
+POTWIERDZENIU (`post`) kasuje pętlą `obj.delete()` z per-obiektowym
+`has_delete_permission` — **omija** `get_deleted_objects` i `delete_queryset`.
+Dlatego akcję masową gatujemy dodatkowo, nadpisując `delete_selected_tree`:
+jeśli w zaznaczeniu jest choć jedna niepusta jednostka, całą partię routujemy
+do `delete_selected` (blokada przez `protected`, nic nie kasujemy) —
+realizując decyzję 2 (wszystko-albo-nic) także dla spreparowanego POST-a
+z pominięciem strony potwierdzenia. Gdy wszystkie puste — delegacja do MPTT.
+
+Defense-in-depth — guard w `delete_model`:
 - Skoro `protected` blokuje dojście do kasowania w ścieżce admina, guard
   jest **wyłącznie** siatką bezpieczeństwa dla wywołań programistycznych
   (skrypt, przyszły kod). Jeśli mimo wszystko trafi tam niepusta jednostka,

--- a/src/bpp/admin/jednostka.py
+++ b/src/bpp/admin/jednostka.py
@@ -1,9 +1,11 @@
 import sys
 
 from django import forms
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.contrib.admin.actions import delete_selected
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.translation import gettext
 from import_export.admin import ImportMixin
 from mptt.admin import DraggableMPTTAdmin
 
@@ -192,6 +194,68 @@ class JednostkaAdmin(
     def changelist_view(self, request, *args, **kwargs):
         self.request = request
         return super().changelist_view(request, *args, **kwargs)
+
+    #
+    # Bezpieczne kasowanie: tylko puste jednostki (spec 2026-07-07).
+    #
+
+    def get_deleted_objects(self, objs, request):
+        """Bramkuj kasowanie niepustych jednostek przez listę ``protected``.
+
+        Dla każdej jednostki z odwrotnymi referencjami (patrz
+        ``Jednostka.przeszkody_w_kasowaniu``) dokładamy czytelny wpis do
+        ``protected`` — Django renderuje go na stronie potwierdzenia i CHOWA
+        przycisk potwierdzenia. Obsługuje pojedynczy delete ORAZ stronę
+        potwierdzenia akcji masowej (MPTT ``delete_selected_tree`` na pierwszym
+        przejściu deleguje do standardowego ``delete_selected``)."""
+        deletable, model_count, perms_needed, protected = super().get_deleted_objects(
+            objs, request
+        )
+        protected = list(protected)
+        for obj in objs:
+            przeszkody = obj.przeszkody_w_kasowaniu()
+            if not przeszkody:
+                continue
+            szczegoly = ", ".join(
+                f"{liczba}× {etykieta}" for etykieta, liczba in przeszkody
+            )
+            protected.append(
+                format_html(
+                    gettext(
+                        "Jednostka „{}” — nie można usunąć, bo są do niej "
+                        "przypięte inne obiekty (odepnij je najpierw): {}"
+                    ),
+                    obj.nazwa,
+                    szczegoly,
+                )
+            )
+        return deletable, model_count, perms_needed, protected
+
+    def delete_selected_tree(self, modeladmin, request, queryset):
+        """Akcja masowa: wszystko-albo-nic.
+
+        MPTT ``delete_selected_tree`` na potwierdzeniu (``post``) kasuje pętlą
+        ``obj.delete()`` z per-obiektowym ``has_delete_permission`` — omija
+        nasz ``get_deleted_objects``. Dlatego: jeśli w zaznaczeniu jest CHOĆ
+        JEDNA niepusta jednostka, routujemy CAŁĄ partię do standardowego
+        ``delete_selected`` (który przez nasz ``get_deleted_objects`` pokaże
+        listę blokad i nie skasuje niczego). Gdy wszystkie puste — normalne
+        kasowanie drzewa MPTT."""
+        if any(not obj.czy_mozna_skasowac() for obj in queryset):
+            return delete_selected(modeladmin, request, queryset)
+        return super().delete_selected_tree(modeladmin, request, queryset)
+
+    def delete_model(self, request, obj):
+        """Defense-in-depth dla pojedynczego kasowania: nie kasuj niepustej
+        jednostki nawet gdyby ścieżka ominęła ``get_deleted_objects``."""
+        if not obj.czy_mozna_skasowac():
+            self.message_user(
+                request,
+                gettext("Nie skasowano „%s” — jednostka nie jest pusta.") % obj,
+                level=messages.ERROR,
+            )
+            return
+        super().delete_model(request, obj)
 
     def indented_title(self, item):
         """

--- a/src/bpp/admin/jednostka.py
+++ b/src/bpp/admin/jednostka.py
@@ -1,8 +1,9 @@
 import sys
 
 from django import forms
-from django.contrib import admin, messages
+from django.contrib import admin
 from django.contrib.admin.actions import delete_selected
+from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext
@@ -247,14 +248,15 @@ class JednostkaAdmin(
 
     def delete_model(self, request, obj):
         """Defense-in-depth dla pojedynczego kasowania: nie kasuj niepustej
-        jednostki nawet gdyby ścieżka ominęła ``get_deleted_objects``."""
+        jednostki nawet gdyby ścieżka ominęła ``get_deleted_objects``.
+
+        Rzucamy ``PermissionDenied`` (a nie ``message_user`` + ``return``) —
+        inaczej Django ``_delete_view`` domknąłby flow komunikatem „usunięto
+        pomyślnie" i wpisem DELETION w LogEntry mimo braku kasowania."""
         if not obj.czy_mozna_skasowac():
-            self.message_user(
-                request,
-                gettext("Nie skasowano „%s” — jednostka nie jest pusta.") % obj,
-                level=messages.ERROR,
+            raise PermissionDenied(
+                gettext("Nie skasowano „%s” — jednostka nie jest pusta.") % obj
             )
-            return
         super().delete_model(request, obj)
 
     def indented_title(self, item):

--- a/src/bpp/models/jednostka.py
+++ b/src/bpp/models/jednostka.py
@@ -284,6 +284,51 @@ class Jednostka(ModelZAdnotacjami, ModelZPBN_ID, ModelZPBN_UID, MPTTModel):
             return False
         return True
 
+    def przeszkody_w_kasowaniu(self):
+        """Lista ``(etykieta, liczba)`` niepustych odwrotnych relacji FK
+        wskazujących na tę jednostkę z REALNYCH, zarządzanych tabel.
+
+        Pusta lista ⇔ jednostkę można bezpiecznie skasować (nic się przez nią
+        nie kaskaduje). Zasada „ściśle zero": każda referencja z tabeli blokuje
+        (podjednostki ``children``, ``Autor_Jednostka``, własna historia
+        ``Jednostka_Rodzic`` itd.). Świadomie POMIJANE:
+
+        * odwrotne relacje M2M (``rel.many_to_many``) — model łączący (np.
+          ``Autor_Jednostka``) i tak pokrywa tę samą więź osobnym FK, więc bez
+          tego liczylibyśmy ją podwójnie;
+        * modele niezarządzane (``managed=False``) — to widoki SQL cache
+          (``AutorzyView``, ``Cache_Punktacja_Autora_*``, ``Nowe_Sumy_View``);
+          widok nie przechowuje danych (przelicza się z tabel bazowych), więc
+          fizycznie nie może „blokować" kasowania. Pomija to też odwrotny O2O
+          do widoku, którego liczenie przez akcesor rzucałoby ``DoesNotExist``.
+
+        Relacje generyczne (reversion/easyaudit/cacheops) nie mają tu
+        ``GenericRelation``, więc nie pojawiają się w ``related_objects`` i nie
+        blokują — log audytu nie powinien wstrzymywać kasowania pustej
+        jednostki.
+        """
+        przeszkody = []
+        for rel in self._meta.related_objects:
+            if rel.many_to_many:
+                continue
+            related_model = rel.related_model
+            if not related_model._meta.managed:
+                continue
+            # Liczymy przez POLE (nie akcesor) — jednolicie dla FK i O2O,
+            # bez ryzyka ``DoesNotExist`` na pustym odwrotnym O2O.
+            liczba = related_model._base_manager.filter(
+                **{rel.field.name: self}
+            ).count()
+            if liczba:
+                przeszkody.append(
+                    (str(related_model._meta.verbose_name_plural), liczba)
+                )
+        return przeszkody
+
+    def czy_mozna_skasowac(self):
+        """True ⇔ jednostka jest w pełni pusta (brak przeszkód w kasowaniu)."""
+        return not self.przeszkody_w_kasowaniu()
+
     def dodaj_autora(
         self, autor, funkcja=None, rozpoczal_prace=None, zakonczyl_prace=None
     ):

--- a/src/bpp/models/jednostka.py
+++ b/src/bpp/models/jednostka.py
@@ -293,24 +293,31 @@ class Jednostka(ModelZAdnotacjami, ModelZPBN_ID, ModelZPBN_UID, MPTTModel):
         (podjednostki ``children``, ``Autor_Jednostka``, własna historia
         ``Jednostka_Rodzic`` itd.). Świadomie POMIJANE:
 
-        * odwrotne relacje M2M (``rel.many_to_many``) — model łączący (np.
-          ``Autor_Jednostka``) i tak pokrywa tę samą więź osobnym FK, więc bez
-          tego liczylibyśmy ją podwójnie;
-        * modele niezarządzane (``managed=False``) — to widoki SQL cache
-          (``AutorzyView``, ``Cache_Punktacja_Autora_*``, ``Nowe_Sumy_View``);
-          widok nie przechowuje danych (przelicza się z tabel bazowych), więc
-          fizycznie nie może „blokować" kasowania. Pomija to też odwrotny O2O
-          do widoku, którego liczenie przez akcesor rzucałoby ``DoesNotExist``.
+        * modele NIEzarządzane w Django (``managed=False``) — u nas to warstwa
+          odczytowa cache (widoki SQL ``AutorzyView``, ``Nowe_Sumy_View`` oraz
+          alias-y na tabele bazowe ``Cache_Punktacja_Autora_*``). Nie są
+          samodzielnym źródłem danych blokujących kasowanie (realne wiersze
+          publikacji i tak trzymają je zarządzane tabele ``Wydawnictwo_*_Autor``
+          / ``Cache_Punktacja_Autora``), a liczenie odwrotnego O2O do widoku
+          przez akcesor rzucałoby ``DoesNotExist``.
+
+        KLUCZOWE: iterujemy po ``get_candidate_relations_to_delete`` — DOKŁADNIE
+        tym samym zbiorze relacji, który widzi kolektor kasowania Django
+        (``include_hidden=True``). ``_meta.related_objects`` POMIJA ukryte
+        relacje (``related_name="+"``, np. ``Import_Dyscyplin_Row.wydzial``),
+        które kolektor mimo to kaskaduje — użycie ich pominęłoby realne
+        referencje i pozwoliło na ciche SET_NULL/CASCADE. Kandydaci to tylko
+        FK/O2O (bez M2M), więc znika też potrzeba osobnego skipu M2M.
 
         Relacje generyczne (reversion/easyaudit/cacheops) nie mają tu
-        ``GenericRelation``, więc nie pojawiają się w ``related_objects`` i nie
+        ``GenericRelation``, więc nie są kandydatami do kasowania i nie
         blokują — log audytu nie powinien wstrzymywać kasowania pustej
         jednostki.
         """
+        from django.db.models.deletion import get_candidate_relations_to_delete
+
         przeszkody = []
-        for rel in self._meta.related_objects:
-            if rel.many_to_many:
-                continue
+        for rel in get_candidate_relations_to_delete(self._meta):
             related_model = rel.related_model
             if not related_model._meta.managed:
                 continue

--- a/src/bpp/newsfragments/+kasowanie-pustych-jednostek.feature
+++ b/src/bpp/newsfragments/+kasowanie-pustych-jednostek.feature
@@ -1,0 +1,1 @@
+Kasowanie jednostek w panelu administracyjnym jest teraz bezpieczne — usunąć można wyłącznie jednostkę w pełni pustą (bez podjednostek i bez żadnych obiektów przypiętych do niej przez klucze obce). Przy próbie skasowania niepustej jednostki system wyświetla listę tego, co ją blokuje, zamiast po cichu kasować powiązane dane w kaskadzie.

--- a/src/bpp/tests/test_admin/test_jednostka_kasowanie.py
+++ b/src/bpp/tests/test_admin/test_jednostka_kasowanie.py
@@ -1,0 +1,96 @@
+"""Testy admina: bezpieczne kasowanie pustych jednostek (spec 2026-07-07).
+
+``JednostkaAdmin`` pozwala skasować jednostkę tylko gdy jest pusta. Niepusta
+jest bramkowana przez ``get_deleted_objects`` (wpis na liście ``protected`` →
+Django chowa przycisk potwierdzenia). Akcja masowa jest wszystko-albo-nic:
+jedna niepusta w zaznaczeniu blokuje całą partię.
+"""
+
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.models import Autor, BppUser, Jednostka
+
+
+@pytest.fixture
+def administracja_client(client, db):
+    """Zalogowany klient superusera należącego do grupy ``administracja``
+    (obie przesłanki ``has_delete_permission`` spełnione)."""
+    grupa, _ = Group.objects.get_or_create(name="administracja")
+    user = BppUser.objects.create_superuser(
+        username="kasownik", password="haslo", email="k@example.org"
+    )
+    user.groups.add(grupa)
+    client.force_login(user)
+    return client
+
+
+def _delete_url(jednostka: Jednostka) -> str:
+    return reverse("admin:bpp_jednostka_delete", args=(jednostka.pk,))
+
+
+@pytest.mark.django_db
+def test_kasowanie_pustej_jednostki_usuwa(administracja_client, jednostka: Jednostka):
+    pk = jednostka.pk
+    resp = administracja_client.post(_delete_url(jednostka), {"post": "yes"})
+
+    assert resp.status_code == 302
+    assert not Jednostka.objects.filter(pk=pk).exists()
+
+
+@pytest.mark.django_db
+def test_kasowanie_niepustej_jednostki_zablokowane(
+    administracja_client, jednostka: Jednostka
+):
+    jednostka.dodaj_autora(baker.make(Autor))
+    pk = jednostka.pk
+
+    # Próba potwierdzenia kasowania niepustej jednostki NIE usuwa jej.
+    resp = administracja_client.post(_delete_url(jednostka), {"post": "yes"})
+
+    assert Jednostka.objects.filter(pk=pk).exists()
+    # Strona potwierdzenia sygnalizuje blokadę (lista ``protected``).
+    assert b"nie mo\xc5\xbcna usun\xc4\x85\xc4\x87" in resp.content.lower()
+
+
+@pytest.mark.django_db
+def test_kasowanie_masowe_blokuje_cala_partie(
+    administracja_client, jednostka: Jednostka, druga_jednostka: Jednostka
+):
+    # Jedna pusta (druga_jednostka), jedna niepusta (jednostka) w zaznaczeniu.
+    jednostka.dodaj_autora(baker.make(Autor))
+    pusta_pk, niepusta_pk = druga_jednostka.pk, jednostka.pk
+
+    resp = administracja_client.post(
+        reverse("admin:bpp_jednostka_changelist"),
+        {
+            "action": "delete_selected",
+            "_selected_action": [pusta_pk, niepusta_pk],
+            "post": "yes",
+        },
+    )
+
+    # Wszystko-albo-nic: obie jednostki nadal istnieją (nawet pusta).
+    assert Jednostka.objects.filter(pk=pusta_pk).exists()
+    assert Jednostka.objects.filter(pk=niepusta_pk).exists()
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_kasowanie_masowe_samych_pustych_usuwa(
+    administracja_client, jednostka: Jednostka, druga_jednostka: Jednostka
+):
+    pk1, pk2 = jednostka.pk, druga_jednostka.pk
+
+    administracja_client.post(
+        reverse("admin:bpp_jednostka_changelist"),
+        {
+            "action": "delete_selected",
+            "_selected_action": [pk1, pk2],
+            "post": "yes",
+        },
+    )
+
+    assert not Jednostka.objects.filter(pk__in=[pk1, pk2]).exists()

--- a/src/bpp/tests/test_admin/test_jednostka_kasowanie.py
+++ b/src/bpp/tests/test_admin/test_jednostka_kasowanie.py
@@ -79,6 +79,23 @@ def test_kasowanie_masowe_blokuje_cala_partie(
 
 
 @pytest.mark.django_db
+def test_superuser_bez_grupy_nie_skasuje(client, jednostka: Jednostka):
+    # Regresja: bramka grupy `administracja` (RestrictDeletionToAdministracja-
+    # GroupMixin) MUSI zostać nienaruszona — sam superuser (bez grupy) nie
+    # kasuje pustej jednostki. Nowy warunek „pusta" jest DODATKOWY, nie
+    # zastępuje grupowego.
+    user = BppUser.objects.create_superuser(
+        username="bezgrupy", password="haslo", email="b@example.org"
+    )
+    client.force_login(user)
+    pk = jednostka.pk
+
+    client.post(_delete_url(jednostka), {"post": "yes"})
+
+    assert Jednostka.objects.filter(pk=pk).exists()
+
+
+@pytest.mark.django_db
 def test_kasowanie_masowe_samych_pustych_usuwa(
     administracja_client, jednostka: Jednostka, druga_jednostka: Jednostka
 ):

--- a/src/bpp/tests/test_models/test_jednostka_kasowanie.py
+++ b/src/bpp/tests/test_models/test_jednostka_kasowanie.py
@@ -1,0 +1,63 @@
+"""Testy bezpiecznego kasowania jednostek (spec 2026-07-07).
+
+Logika modelu: ``Jednostka.przeszkody_w_kasowaniu`` /
+``Jednostka.czy_mozna_skasowac`` — jednostkę można skasować wyłącznie gdy
+ma ZERO odwrotnych referencji z realnych, zarządzanych tabel (podjednostki,
+Autor_Jednostka, własna historia Jednostka_Rodzic, ...). Niezarządzane widoki
+SQL i relacje generyczne NIE blokują.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Autor, Jednostka
+
+
+@pytest.mark.django_db
+def test_przeszkody_w_kasowaniu_pusta_jednostka(jednostka: Jednostka):
+    assert jednostka.przeszkody_w_kasowaniu() == []
+    assert jednostka.czy_mozna_skasowac() is True
+
+
+@pytest.mark.django_db
+def test_przeszkody_w_kasowaniu_z_autorem(jednostka: Jednostka):
+    autor = baker.make(Autor)
+    jednostka.dodaj_autora(autor)
+
+    przeszkody = jednostka.przeszkody_w_kasowaniu()
+
+    assert przeszkody != []
+    assert jednostka.czy_mozna_skasowac() is False
+    # Dodanie autora tworzy DWIE realne referencje: samo powiązanie
+    # Autor_Jednostka ORAZ (przez trigger) denorm ``Autor.aktualna_jednostka``.
+    # Obie liczą się jako przeszkoda — potwierdza to semantykę „ściśle zero".
+    etykiety = {etykieta for etykieta, _ in przeszkody}
+    assert any("autor-jednostka" in e for e in etykiety)
+
+
+@pytest.mark.django_db
+def test_przeszkody_w_kasowaniu_z_podjednostka(
+    jednostka: Jednostka, jednostka_podrzedna: Jednostka
+):
+    przeszkody = jednostka.przeszkody_w_kasowaniu()
+
+    assert jednostka.czy_mozna_skasowac() is False
+    # Podjednostka pojawia się jako odwrotna relacja self-FK ``parent``.
+    assert any("jednostk" in etykieta.lower() for etykieta, _ in przeszkody)
+
+
+@pytest.mark.django_db
+def test_przeszkody_w_kasowaniu_z_wlasna_historia(jednostka: Jednostka):
+    # Ściśle zero: własna historia (Jednostka_Rodzic) też blokuje.
+    jednostka.jednostka_rodzic_set.create(parent=None)
+
+    assert jednostka.czy_mozna_skasowac() is False
+
+
+@pytest.mark.django_db
+def test_przeszkody_w_kasowaniu_nie_rzuca_na_odwrotnym_o2o(jednostka: Jednostka):
+    # Regresja: Jednostka ma odwrotny O2O do niezarządzanego widoku
+    # (Nowe_Sumy_View). Liczenie przez akcesor rzuciłoby DoesNotExist —
+    # metoda musi liczyć przez pole i pomijać widoki. Pusta jednostka bez
+    # publikacji nie ma wiersza w widoku, więc pozostaje kasowalna.
+    assert jednostka.czy_mozna_skasowac() is True

--- a/src/bpp/tests/test_models/test_jednostka_kasowanie.py
+++ b/src/bpp/tests/test_models/test_jednostka_kasowanie.py
@@ -55,6 +55,20 @@ def test_przeszkody_w_kasowaniu_z_wlasna_historia(jednostka: Jednostka):
 
 
 @pytest.mark.django_db
+def test_przeszkody_w_kasowaniu_lapie_ukryty_fk(jednostka: Jednostka):
+    # Regresja (Fable B1): FK z ``related_name="+"`` (np.
+    # ``Import_Dyscyplin_Row.wydzial``) jest niewidoczny w
+    # ``_meta.related_objects``, ale kolektor kasowania Django go kaskaduje
+    # (SET_NULL/CASCADE). Jednostka wskazywana WYŁĄCZNIE przez ukryty FK NIE
+    # może przejść jako „pusta" — inaczej kasowanie po cichu ruszyłoby te dane.
+    from import_dyscyplin.models import Import_Dyscyplin_Row
+
+    baker.make(Import_Dyscyplin_Row, wydzial=jednostka, jednostka=None)
+
+    assert jednostka.czy_mozna_skasowac() is False
+
+
+@pytest.mark.django_db
 def test_przeszkody_w_kasowaniu_nie_rzuca_na_odwrotnym_o2o(jednostka: Jednostka):
     # Regresja: Jednostka ma odwrotny O2O do niezarządzanego widoku
     # (Nowe_Sumy_View). Liczenie przez akcesor rzuciłoby DoesNotExist —


### PR DESCRIPTION
## Cel

Kasowanie jednostek w panelu administracyjnym staje się **bezpieczne**: usunąć można wyłącznie jednostkę w pełni pustą — bez podjednostek i bez żadnych obiektów przypiętych do niej przez odwrotne klucze obce. Wcześniej kasowanie po cichu **kaskadowało** (Autor_Jednostka, historia `Jednostka_Rodzic`, cache, całe poddrzewo MPTT) — utrata danych bez ostrzeżenia.

## Rozwiązanie

**Warstwa modelu** (`Jednostka`):
- `przeszkody_w_kasowaniu()` → lista `(etykieta, liczba)` niepustych odwrotnych FK z **realnych, zarządzanych** tabel. Pomija niezarządzane widoki SQL cache, zduplikowany odwrotny M2M; liczy przez `rel.field.name`, więc odwrotny O2O (`Nowe_Sumy_View`) nie crashuje.
- `czy_mozna_skasowac()`.

**Warstwa admina** (`JednostkaAdmin`):
- `get_deleted_objects` → blokady na liście `protected` (pojedyncze kasowanie + strona potwierdzenia akcji masowej); Django chowa przycisk potwierdzenia i pokazuje **co** blokuje.
- `delete_selected_tree` (MPTT) nadpisane: jedna niepusta w zaznaczeniu blokuje **całą partię** (wszystko-albo-nic) — bo MPTT kasuje pętlą `obj.delete()` omijając `protected`.
- `delete_model` jako defense-in-depth.
- Bramka grupy `administracja` bez zmian (warunek dodatkowy).

## Decyzje projektowe

- **Ściśle zero** referencji z realnych tabel (własna historia i puste `Autor_Jednostka` też blokują). Widoki cache i relacje generyczne (reversion/audyt) **nie** blokują.
- Akcja masowa: **wszystko-albo-nic** (natywna semantyka `protected`).

Spec: `docs/superpowers/specs/2026-07-07-kasowanie-pustych-jednostek-design.md` (z adwersaryjnym self-review).

## Testy (9, TDD)

- Model: pusta / z autorem / z podjednostką / z historią / regresja odwrotnego O2O.
- Admin (realny HTTP przez klienta w grupie `administracja`): pusta kasuje, niepusta zablokowana z komunikatem, bulk mieszany blokuje wszystko, bulk samych pustych kasuje.

Weryfikacja: `ruff format`/`check` czysto, `manage.py check` bez problemów, brak regresji w istniejących testach `JednostkaAdmin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
