### PR TITLE
import_polon: zawęź raport niezmatchowanych do realnej jednostki uczelni

### DIFF
--- a/src/bpp/models/autor.py
+++ b/src/bpp/models/autor.py
@@ -83,6 +83,31 @@ class AutorQuerySet(models.QuerySet):
             | Q(autor_jednostka__jednostka__uczelnia=uczelnia)
         ).distinct()
 
+    def kiedykolwiek_zatrudnieni(self, uczelnia):
+        """Autorzy zatrudnieni w uczelni obecnie LUB historycznie, w REALNEJ
+        jednostce (``skupia_pracownikow=True``).
+
+        Różnica względem ``kiedykolwiek_zwiazani``: liczą się TYLKO powiązania
+        przez jednostki skupiające pracowników — jednostki obce/techniczne
+        (``skupia_pracownikow=False``) są pomijane, także gdy ich uczelnia to
+        bieżąca uczelnia (lustrzana jednostka obca o nazwie naszej uczelni NIE
+        kwalifikuje autora). Realność sprawdzana per-strona OR: albo aktualna
+        jednostka jest realna, albo któraś jednostka historyczna jest realna —
+        powiązanie wyłącznie przez jednostkę obcą nie łapie autora.
+        """
+        if uczelnia is None:
+            return self.none()
+        return self.filter(
+            Q(
+                aktualna_jednostka__uczelnia=uczelnia,
+                aktualna_jednostka__skupia_pracownikow=True,
+            )
+            | Q(
+                autor_jednostka__jednostka__uczelnia=uczelnia,
+                autor_jednostka__jednostka__skupia_pracownikow=True,
+            )
+        ).distinct()
+
 
 class AutorManager(FulltextSearchMixin, models.Manager.from_queryset(AutorQuerySet)):
     # Nie włączaj websearch gdy podano minus (podwójne nazwiska z myślnikiem)

--- a/src/bpp/tests/test_models/test_autor_scope.py
+++ b/src/bpp/tests/test_models/test_autor_scope.py
@@ -1,9 +1,12 @@
 """Zakresy wyszukiwania autora na ``AutorQuerySet`` (spec 2026-07-02).
 
-Trzy zakresy jako czytelne API managera:
+Zakresy jako czytelne API managera:
 - ``aktualnie_zatrudnieni(uczelnia)`` — aktualna jednostka w uczelni, realna
   (``skupia_pracownikow=True``),
-- ``kiedykolwiek_zwiazani(uczelnia)`` — obecnie LUB historycznie,
+- ``kiedykolwiek_zatrudnieni(uczelnia)`` — obecnie LUB historycznie, ale tylko
+  przez realną jednostkę (``skupia_pracownikow=True``); pomija jednostki obce,
+- ``kiedykolwiek_zwiazani(uczelnia)`` — obecnie LUB historycznie, dowolna
+  jednostka (także obca),
 - WSZYSCY = ``Autor.objects.all()`` (bez metody).
 """
 
@@ -104,12 +107,93 @@ def test_kiedykolwiek_zwiazani_bez_duplikatow(uczelnia, jednostka):
 
 
 @pytest.mark.django_db
+def test_kiedykolwiek_zatrudnieni_zwraca_aktualnie_zatrudnionego(uczelnia, jednostka):
+    autor = baker.make(Autor, aktualna_jednostka=jednostka)  # skupia_pracownikow=True
+
+    wynik = Autor.objects.kiedykolwiek_zatrudnieni(uczelnia)
+
+    assert autor in wynik
+
+
+@pytest.mark.django_db
+def test_kiedykolwiek_zatrudnieni_zwraca_historycznie_zatrudnionego(
+    uczelnia, jednostka
+):
+    """Kluczowa różnica względem ``aktualnie_zatrudnieni``: autor związany z
+    realną jednostką uczelni TYLKO w przeszłości też się łapie."""
+    autor = baker.make(Autor, aktualna_jednostka=None)
+    _wpis_historyczny(autor, jednostka)
+
+    wynik = Autor.objects.kiedykolwiek_zatrudnieni(uczelnia)
+
+    assert autor in wynik
+
+
+@pytest.mark.django_db
+def test_kiedykolwiek_zatrudnieni_pomija_aktualna_jednostke_obca(
+    uczelnia, obca_jednostka_uczelni
+):
+    """Aktualna jednostka obca (``skupia_pracownikow=False``) NIE kwalifikuje,
+    nawet gdy należy do bieżącej uczelni (lustrzana jednostka obca)."""
+    autor = baker.make(Autor, aktualna_jednostka=obca_jednostka_uczelni)
+
+    wynik = Autor.objects.kiedykolwiek_zatrudnieni(uczelnia)
+
+    assert autor not in wynik
+
+
+@pytest.mark.django_db
+def test_kiedykolwiek_zatrudnieni_pomija_tylko_historycznie_w_jednostce_obcej(
+    uczelnia, obca_jednostka_uczelni
+):
+    """Powiązanie WYŁĄCZNIE przez historyczną jednostkę obcą nie łapie autora —
+    to główny przypadek, który odróżnia ``kiedykolwiek_zatrudnieni`` od
+    ``kiedykolwiek_zwiazani`` (ta druga by go zwróciła)."""
+    autor = baker.make(Autor, aktualna_jednostka=None)
+    _wpis_historyczny(autor, obca_jednostka_uczelni)
+
+    assert autor not in Autor.objects.kiedykolwiek_zatrudnieni(uczelnia)
+    assert autor in Autor.objects.kiedykolwiek_zwiazani(uczelnia)
+
+
+@pytest.mark.django_db
+def test_kiedykolwiek_zatrudnieni_realna_jednostka_wygrywa_nad_obca(
+    uczelnia, jednostka, obca_jednostka_uczelni
+):
+    """Autor z historią i w realnej, i w obcej jednostce — łapie się przez
+    realną (bez duplikatów)."""
+    autor = baker.make(Autor, aktualna_jednostka=None)
+    _wpis_historyczny(autor, obca_jednostka_uczelni)
+    _wpis_historyczny(autor, jednostka)
+
+    wynik = list(Autor.objects.kiedykolwiek_zatrudnieni(uczelnia))
+
+    assert wynik.count(autor) == 1
+
+
+@pytest.mark.django_db
+def test_kiedykolwiek_zatrudnieni_izolacja_miedzy_uczelniami(uczelnia, jednostka):
+    """Realna jednostka historyczna INNEJ uczelni nie łapie autora."""
+    from bpp.models import Uczelnia
+
+    druga = baker.make(Uczelnia, skrot="U2", nazwa="Druga uczelnia")
+    druga_jednostka = baker.make(
+        "bpp.Jednostka", uczelnia=druga, skupia_pracownikow=True
+    )
+    autor = baker.make(Autor, aktualna_jednostka=None)
+    _wpis_historyczny(autor, druga_jednostka)
+
+    assert autor not in Autor.objects.kiedykolwiek_zatrudnieni(uczelnia)
+
+
+@pytest.mark.django_db
 def test_uczelnia_none_fail_closed(jednostka):
     """Brak ustalonej uczelni → pusty queryset (nie fail-open)."""
     baker.make(Autor, aktualna_jednostka=jednostka)
 
     assert not Autor.objects.aktualnie_zatrudnieni(None).exists()
     assert not Autor.objects.kiedykolwiek_zwiazani(None).exists()
+    assert not Autor.objects.kiedykolwiek_zatrudnieni(None).exists()
 
 
 @pytest.mark.django_db

--- a/src/import_polon/models.py
+++ b/src/import_polon/models.py
@@ -78,11 +78,16 @@ class ImportPlikuPolon(ASGINotificationMixin, Operation):
         """Autor_Dyscyplina dla roku importu, których autora NIE było w pliku.
 
         Multi-hosted: gdy znana jest ``uczelnia`` importu, lista jest zawężona
-        do autorów AKTUALNIE ZATRUDNIONYCH w tej uczelni (``aktualna_jednostka``
-        w uczelni + jednostka ``skupia_pracownikow``). Bez tego zawężenia raport
-        wyciekałby autorów innych uczelni współistniejących w bazie. Gdy
-        ``uczelnia`` nieznana (stare importy / brak rozstrzygnięcia) — zachowanie
-        wsteczne: wszyscy z dyscypliną dla roku, bez zawężenia.
+        do autorów ZWIĄZANYCH Z TĄ UCZELNIĄ przez realną jednostkę — obecnie
+        LUB historycznie (``aktualna_jednostka`` albo któryś wpis
+        ``Autor_Jednostka`` w uczelni, w obu przypadkach jednostka musi mieć
+        ``skupia_pracownikow=True``). Jednostki obce/techniczne
+        (``skupia_pracownikow=False``) NIE kwalifikują autora, nawet jeśli ich
+        uczelnia to bieżąca uczelnia (lustrzana jednostka obca o nazwie naszej
+        uczelni jest pomijana). Bez tego zawężenia raport wyciekałby autorów
+        innych uczelni współistniejących w bazie. Gdy ``uczelnia`` nieznana
+        (stare importy / brak rozstrzygnięcia) — zachowanie wsteczne: wszyscy
+        z dyscypliną dla roku, bez zawężenia.
         """
         from bpp.models import Autor_Dyscyplina
 
@@ -94,7 +99,9 @@ class ImportPlikuPolon(ASGINotificationMixin, Operation):
 
         qs = Autor_Dyscyplina.objects.filter(rok=self.rok)
         if self.uczelnia_id is not None:
-            qs = qs.filter(autor__in=Autor.objects.aktualnie_zatrudnieni(self.uczelnia))
+            qs = qs.filter(
+                autor__in=Autor.objects.kiedykolwiek_zatrudnieni(self.uczelnia)
+            )
 
         return (
             qs.exclude(autor_id__in=matched_authors)

--- a/src/import_polon/tests/test_multi_uczelnia_scoping.py
+++ b/src/import_polon/tests/test_multi_uczelnia_scoping.py
@@ -12,11 +12,15 @@ POLON dla uczelni X nie może „widzieć" ani dotykać autorów uczelni Y:
   uczelni (mutacja cudzych danych).
 """
 
+from datetime import timedelta
+
 import pandas as pd
 import pytest
+from django.utils import timezone
 from model_bakery import baker
 
 from bpp.models import Autor, Jednostka, Uczelnia, Wydzial
+from bpp.models.autor import Autor_Jednostka
 from bpp.models.struktura_konwersja import znajdz_lub_utworz_wezel_wydzialu
 from import_polon.core import analyze_file_import_polon
 from import_polon.models import ImportPlikuPolon
@@ -24,18 +28,38 @@ from import_polon.models import ImportPlikuPolon
 ROK = 2020
 
 
-def _autor_zatrudniony(uczelnia, nazwisko, imiona="Jan"):
-    """Autor aktualnie zatrudniony w ``uczelnia`` (realna jednostka)."""
+def _jednostka(uczelnia, skupia_pracownikow=True):
     wydzial = baker.make(Wydzial, uczelnia=uczelnia)
-    jednostka = baker.make(
+    return baker.make(
         Jednostka,
         uczelnia=uczelnia,
         parent=znajdz_lub_utworz_wezel_wydzialu(wydzial)[0],
-        skupia_pracownikow=True,
+        skupia_pracownikow=skupia_pracownikow,
     )
+
+
+def _autor_zatrudniony(uczelnia, nazwisko, imiona="Jan"):
+    """Autor aktualnie zatrudniony w ``uczelnia`` (realna jednostka)."""
     return baker.make(
-        Autor, nazwisko=nazwisko, imiona=imiona, aktualna_jednostka=jednostka
+        Autor,
+        nazwisko=nazwisko,
+        imiona=imiona,
+        aktualna_jednostka=_jednostka(uczelnia),
     )
+
+
+def _autor_historyczny(uczelnia, nazwisko, imiona="Jan", skupia_pracownikow=True):
+    """Autor związany z ``uczelnia`` TYLKO historycznie (zakończone
+    zatrudnienie → trigger 0046 zeruje ``aktualna_jednostka``)."""
+    autor = baker.make(Autor, nazwisko=nazwisko, imiona=imiona, aktualna_jednostka=None)
+    Autor_Jednostka.objects.create(
+        autor=autor,
+        jednostka=_jednostka(uczelnia, skupia_pracownikow=skupia_pracownikow),
+        rozpoczal_prace=timezone.now() - timedelta(days=60),
+        zakonczyl_prace=timezone.now() - timedelta(days=30),
+    )
+    autor.refresh_from_db()
+    return autor
 
 
 # --- Finding 1: raport niezmatchowanych zawężony do uczelni importu ---------
@@ -90,6 +114,50 @@ def test_autorzy_niezmatchowani_bez_uczelni_bez_zawezenia(rodzaj_autora_n, dyscy
 
     assert autor_x.pk in autor_ids
     assert autor_y.pk in autor_ids
+
+
+@pytest.mark.django_db
+def test_autorzy_niezmatchowani_lapie_historycznie_zwiazanego(
+    rodzaj_autora_n, dyscyplina1
+):
+    """Autor związany z uczelnią importu przez realną jednostkę TYLKO w
+    przeszłości (już nie zatrudniony) musi być na liście — samo
+    ``aktualnie_zatrudnieni`` by go pominęło."""
+    uczelnia_x = baker.make(Uczelnia, nazwa="Uczelnia X", skrot="UX")
+
+    autor_h = _autor_historyczny(uczelnia_x, "HistorycznyH")
+    autor_h.autor_dyscyplina_set.create(
+        rok=ROK, dyscyplina_naukowa=dyscyplina1, rodzaj_autora=rodzaj_autora_n
+    )
+
+    import_object = baker.make(ImportPlikuPolon, rok=ROK, uczelnia=uczelnia_x)
+
+    autor_ids = {ad.autor_id for ad in import_object.autorzy_niezmatchowani()}
+
+    assert autor_h.pk in autor_ids, (
+        "autor historycznie związany z uczelnią importu musi być na liście"
+    )
+
+
+@pytest.mark.django_db
+def test_autorzy_niezmatchowani_pomija_jednostke_obca(rodzaj_autora_n, dyscyplina1):
+    """Autor związany z uczelnią importu WYŁĄCZNIE przez jednostkę obcą
+    (``skupia_pracownikow=False``) nie może wyciekać do raportu — nawet gdy ta
+    jednostka formalnie należy do uczelni importu (lustrzana jednostka obca)."""
+    uczelnia_x = baker.make(Uczelnia, nazwa="Uczelnia X", skrot="UX")
+
+    autor_obcy = _autor_historyczny(uczelnia_x, "ObcyO", skupia_pracownikow=False)
+    autor_obcy.autor_dyscyplina_set.create(
+        rok=ROK, dyscyplina_naukowa=dyscyplina1, rodzaj_autora=rodzaj_autora_n
+    )
+
+    import_object = baker.make(ImportPlikuPolon, rok=ROK, uczelnia=uczelnia_x)
+
+    autor_ids = {ad.autor_id for ad in import_object.autorzy_niezmatchowani()}
+
+    assert autor_obcy.pk not in autor_ids, (
+        "autor związany tylko przez jednostkę obcą nie może być na liście"
+    )
 
 
 # --- Finding 2: walidacja ZATRUDNIENIE zawężona do nazwy uczelni importu -----

--- a/src/import_polon/views/plik_polon.py
+++ b/src/import_polon/views/plik_polon.py
@@ -118,8 +118,9 @@ class ImportPolonResultsView(BaseImportPlikuPolonMixin, LongRunningResultsView):
         )
 
         # Autorzy z dyscyplinami dla roku importu, których nie było w pliku.
-        # Multi-hosted: zawężone do aktualnie zatrudnionych w uczelni importu
-        # (patrz ImportPlikuPolon.autorzy_niezmatchowani) — bez tego raport
+        # Multi-hosted: zawężone do autorów związanych z uczelnią importu przez
+        # realną jednostkę (obecnie lub historycznie; jednostki obce pomijane —
+        # patrz ImportPlikuPolon.autorzy_niezmatchowani) — bez tego raport
         # wyciekałby autorów innych uczelni współistniejących w bazie.
         import_object = ImportPlikuPolon.objects.get(pk=self.kwargs["pk"])
         unmatched_autor_dyscyplina = import_object.autorzy_niezmatchowani()


### PR DESCRIPTION
## Problem

Raport **„Autorzy z przypisaniami dyscyplin w BPP, którzy nie byli w pliku Excel"** (`ImportPlikuPolon.autorzy_niezmatchowani`) był zawężany przez `Autor.objects.aktualnie_zatrudnieni(uczelnia)`, które sprawdza **wyłącznie aktualną jednostkę** autora (`aktualna_jednostka`). Skutki:

- **pomijał** autorów związanych z uczelnią importu tylko **historycznie** (byłe zatrudnienie),
- nie wyrażał wymogu „**bez jednostek obcych**" jako czytelnego zakresu.

Wymóg: na liście ma się znaleźć autor **tylko** wtedy, gdy jego **aktualna LUB któraś historyczna** jednostka należy do bieżącej uczelni i jest **realna** (`skupia_pracownikow=True`). Jednostka obca (nawet lustrzana, o nazwie naszej uczelni) ani jednostka innej uczelni nie kwalifikują.

## Rozwiązanie

Nowy, równoległy zakres na `AutorQuerySet` (`src/bpp/models/autor.py`) domykający istniejącą taksonomię:

| zakres | aktualna jednostka | jednostka historyczna | jednostki obce (`skupia_pracownikow=False`) |
|---|---|---|---|
| `aktualnie_zatrudnieni` | ✓ | — | pomijane |
| **`kiedykolwiek_zatrudnieni`** (nowy) | ✓ | ✓ | **pomijane** |
| `kiedykolwiek_zwiazani` | ✓ | ✓ | uwzględniane |

Warunek `skupia_pracownikow=True` stosowany **per-strona OR**, więc powiązanie wyłącznie przez jednostkę obcą nie łapie autora. `autorzy_niezmatchowani()` korzysta teraz z nowego zakresu.

`kiedykolwiek_zwiazani` (konsumowane przez `AutorAdmin` i autocomplete autorów, które celowo uwzględniają jednostki obce) **świadomie pozostaje bez zmian** — każdy zakres jednofunkcyjny, bez cichych regresji.

## Testy (22 passed lokalnie)

- `test_autor_scope.py` — 7 nowych przypadków dla `kiedykolwiek_zatrudnieni`: aktualny, historyczny, obca-aktualna pominięta, tylko-historyczna-obca pominięta (z kontrastem do `kiedykolwiek_zwiazani`), realna-wygrywa-nad-obcą (bez duplikatów), izolacja między uczelniami, `None` → fail-closed.
- `test_multi_uczelnia_scoping.py` — 2 przypadki integracyjne na granicy `autorzy_niezmatchowani()`: autor historycznie związany **jest** na liście; autor związany tylko przez jednostkę obcą **nie jest**.

`ruff format` + `ruff check` czysto. Brak migracji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)