### PR TITLE
ci: gate uv.lock consistency on dev (pre-commit hook + CI job)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,30 @@ jobs:
           uvx pre-commit run ruff-format \
             --from-ref "$DIFF_BASE" --to-ref HEAD --show-diff-on-failure
 
+  lockfile:
+    # Assert uv.lock is resolved against the CURRENT pyproject.toml. The
+    # test image installs deps with `uv sync --frozen`, which applies
+    # uv.lock AS-IS without checking it against pyproject.toml — so a dep
+    # edited without re-running `uv lock` would leave dev CI green while
+    # testing stale deps, and the release pipeline's own `uv lock` step
+    # would then silently re-resolve into deps dev never tested. This
+    # fast standalone gate makes lock consistency a tested invariant on
+    # dev, turning uv.lock into a trustworthy artifact. `uv lock --check`
+    # is read-only: it never writes the lockfile, it only fails on drift.
+    # Mirrors the `lint` job: same pinned uv setup, no project sync.
+    name: uv.lock in sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          enable-cache: true
+      - name: Assert uv.lock matches pyproject.toml
+        run: uv lock --check
+
   baseline-check:
     # Guard repo-state-only: czy baseline-sql/baseline.sql nadaza za migracjami
     # (manage.py baseline_check). Wydzielone z prepare-image i puszczone

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,18 @@ repos:
           args: ["--fix", "--exit-non-zero-on-fix"]
         - id: ruff-format
 
+    - repo: https://github.com/astral-sh/uv-pre-commit
+      # Trzymaj z grubsza w parze z wersją uv w użyciu (obecnie 0.11.14).
+      # Hook bundluje własne uv — nowszy pin potrafi przepisać uv.lock do
+      # nowszego formatu wewnętrznego (churn), więc celowo pinujemy tag
+      # najbliższy uv-owi z tego środowiska zamiast "latest". Domyślny
+      # scope hooka to ^(uv\.lock|pyproject\.toml|uv\.toml)$ — NIE poszerzać.
+      # Gwarantuje, że każdy commit dotykający deps ma spójny uv.lock;
+      # autorytatywnym gate'em (nie do obejścia) jest job `lockfile` w CI.
+      rev: 0.11.15
+      hooks:
+        - id: uv-lock
+
     # djlint: walidacja strukturalna templatów HTML/Django. Konfiguracja
     # w [tool.djlint] w pyproject.toml — egzekwujemy tylko reguły
     # strukturalne (H020 empty-tag-pair, H025 orphan-tag) ktore lapią


### PR DESCRIPTION
## Dlaczego

Dev nie miał **żadnego gate'u spójności lockfile'a**. Konsekwencje:

- Obraz testowy instaluje deps przez `uv sync --frozen`
  (`docker/bpp_base/Dockerfile` L70, L242, L464). `--frozen` stosuje
  `uv.lock` **AS-IS, bez weryfikacji względem `pyproject.toml`** — więc
  dep zmieniony bez `uv lock` zostawia dev CI zielone, testując **stare** deps.
- Dopiero `release-candidate.yml` (job `prepare`) robi `uv lock`
  (**re-resolve**), budując/testując deps, których dev nigdy nie widział.
  Dlatego re-testu na RC nie da się dziś pominąć.

Ten PR czyni „`uv.lock` zgodny z `pyproject.toml`" **testowanym inwariantem
na dev**, robiąc z lockfile'a zaufany, przetestowany artefakt.

## Co

**1a — pre-commit hook** (`.pre-commit-config.yaml`): `astral-sh/uv-pre-commit`
hook `uv-lock`, pin `0.11.15` (najbliższy uv-owi `0.11.14` z tego środowiska,
żeby hook nie przepisywał lockfile'a do nowszego formatu wewnętrznego).
Domyślny scope hooka (`uv.lock`/`pyproject.toml`/`uv.toml`) — nie poszerzany.
Lokalna wygoda, ale **do obejścia** (`--no-verify`).

**1b — CI gate** (`.github/workflows/tests.yml`): standalone job `lockfile`
= `uv lock --check` (~sekundy), mirror joba `lint` (te same piny uv, bez
`uv sync`). To **autorytatywny, nieobchodzony** gate. Odpala się na
push→dev/master i PR→dev (istniejące `on:` już to pokrywa i ignoruje `docs/`).
`uv lock --check` jest read-only — nigdy nie zapisuje lockfile'a, tylko
faluje na drifcie.

Lock jest **obecnie spójny** (`uv lock --check` → exit 0), więc gate wchodzi
na zielono. Ten PR sam dogfooduje nowy job `lockfile`.

## Weryfikacja

- `uv lock --check` lokalnie → exit 0.
- `pre-commit run uv-lock --files pyproject.toml uv.lock` → Passed (no-op).
- `actionlint` + `zizmor` na `tests.yml` → Passed.
- Sanity: wstrzyknięty dummy dep → `uv lock --check` **exit 1** (gate działa);
  po revert → exit 0.

## Poza zakresem (kolejne kroki, osobno)

2. Usunięcie kroku `uv lock` z `release-candidate.yml` (`prepare`) — dopiero
   gdy ten gate wyląduje i sprawdzi się na dev.
3. Uczynienie testów RC opcjonalnymi dla rc1-off-green-dev.

## Nie zrobione (1c, celowo)

`uv sync --frozen` → `--locked` w Dockerfile (L70/242/464) to belt-and-suspenders
raz gdy 1b istnieje. Pominięte, żeby diff był minimalny i nie wymagał pełnego
rebuildu obrazu do walidacji; do rozważenia jako osobny commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)