### PR TITLE
ci(release): przestań re-lockować uv.lock przy budowie RC (Step 2)

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -89,7 +89,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          enable-cache: true
+          # Bez cache: w tym jobie uv służy wyłącznie do `uvx bumpver`
+          # (drobne narzędzie w izolowanym env) — cache uv-a dawał tu
+          # znikomy zysk, a w JEDNYM jobie z docker/build-push-action
+          # (push obrazu) tworzył wektor cache-poisoning (zizmor). Brak
+          # cache'u = brak wektora, kosztem paru sekund re-downloadu bumpver.
+          enable-cache: false
 
       - name: Bump RC (nowy cykl lub kolejne -rcN)
         id: bump
@@ -150,14 +155,23 @@ jobs:
           echo "release_ref=${RELEASE_REF}" >> "$GITHUB_OUTPUT"
           echo "::notice::Kandydat ${PEP} na gałęzi ${RELEASE_REF}"
 
-          # Zamroź lockfile dla tego RC.
-          uv lock
-          git add uv.lock
-          git commit -m "Aktualizacja uv.lock dla ${PEP}" || echo "uv.lock bez zmian."
+          # NIE re-lockujemy uv.lock dla RC. Gałąź dev jest bramkowana jobem
+          # `lockfile` (tests.yml → `uv lock --check`), więc uv.lock jest już
+          # spójny z pyproject.toml i przetestowany DOKŁADNIE w tej postaci na
+          # dev. Wcześniej stało tu `uv lock` (+ commit), które RE-RESOLVOWAŁO
+          # zależności przy każdym RC — mogło wciągnąć deps, których dev nigdy
+          # nie testował (to był powód, dla którego RC nie mógł pominąć re-testu).
+          # Po wprowadzeniu gate'u `lockfile` jest to zbędne: jedyną zmianą, jaką
+          # `uv lock` by tu jeszcze wniósł, jest bump wersji root-pakietu w locku
+          # (bumpver podniósł [project].version). To pole ignoruje `uv sync
+          # --frozen` (Dockerfile), a zainstalowana wersja pakietu i tak jest
+          # budowana z pyproject.toml (=zbumpowana), więc pominięcie jest
+          # bezpieczne. Efekt: obraz test-runner RC bazuje na tym samym zamku
+          # zależności co zielony dev — co odblokowuje pomijanie re-testu rc1.
 
-          # SHA commita RC (po bumpie + uv.lock) — obraz test-runner buduje się
-          # z TEGO drzewa, więc tag obrazu i GIT_SHA (busta warstwę COPY src/)
-          # muszą wskazywać ten commit, nie github.sha (= dev tip, przed bumpem).
+          # SHA commita RC (po bumpie) — obraz test-runner buduje się z TEGO
+          # drzewa, więc tag obrazu i GIT_SHA (busta warstwę COPY src/) muszą
+          # wskazywać ten commit, nie github.sha (= dev tip, przed bumpem).
           echo "rc_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Zainstaluj skanery CVE
@@ -266,10 +280,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Testujemy RC commit (bump + uv.lock), nie dev tip. Bez tego
-          # .test_durations (mount) i ewentualne compose-refy byłyby ze złego
-          # drzewa. Obraz i tak bakuje źródła, ale checkout musi być spójny.
+          # Testujemy RC commit (bump), nie dev tip. Bez tego .test_durations
+          # (mount) i ewentualne compose-refy byłyby ze złego drzewa. Obraz i
+          # tak bakuje źródła, ale checkout musi być spójny.
           ref: ${{ needs.prepare.outputs.release_ref }}
+          # Ten job nie robi żadnych operacji git po checkoucie (mount
+          # .test_durations + pull obrazu przez osobny docker/login), więc
+          # nie utrwalamy tokena w .git/config (zizmor: artipacked).
+          persist-credentials: false
 
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0


### PR DESCRIPTION
## Kontekst

Step 2 serii uv.lock-gate. **Step 1** (job `lockfile` = `uv lock --check`
na dev + hook pre-commit `uv-lock`) zmergowany w #479.

## Problem

Job `prepare` w `release-candidate.yml` robił `uv lock` (+ osobny commit)
przy **każdym** RC:

```yaml
# Zamroź lockfile dla tego RC.
uv lock
git add uv.lock
git commit -m "Aktualizacja uv.lock dla ${PEP}" || echo "uv.lock bez zmian."
```

To **re-resolvowało** zależności w momencie wydania — mogło wciągnąć deps,
których zielony dev nigdy nie testował. To był powód, dla którego re-testu
RC nie dało się pominąć.

## Zmiana

Po Step 1 uv.lock na dev jest **gwarantowanie spójny** z pyproject.toml
i przetestowany dokładnie w tej postaci — RC nie musi re-lockować.

Empirycznie zweryfikowane: po bumpie wersji przez bumpver jedyną zmianą,
jaką `uv lock` by jeszcze wniósł, jest **1 linia** — wersja root-pakietu
w locku (`bpp-iplweb`). Zero churnu zależności:

```
 uv.lock | 2 +-
-version = "202607.1396"
+version = "202607.1396rc1"
```

To pole ignoruje `uv sync --frozen` (Dockerfile), a zainstalowana wersja
pakietu i tak jest budowana z pyproject.toml (=zbumpowana):
`importlib.metadata.version("bpp-iplweb") == 202607.1396rc1` mimo stałego
locka. Pominięcie kroku jest więc bezpieczne — obraz test-runner RC bazuje
na **tym samym zamku zależności** co zielony dev.

Odblokowuje to pomijanie re-testu rc1 (**Step 3**, osobno).

## Przy okazji: 2 pre-existing findingi zizmora (naprawione u źródła)

Edycja pliku ujawniła 2 findingi (`release-candidate.yml` nie było w
`zizmor.yml`). Zamiast tłumić — **naprawione u źródła**:

- **cache-poisoning** (high): `prepare` miał w jednym jobie
  `setup-uv enable-cache: true` + `docker/build-push-action`. Cache uv-a
  dawał tu znikomy zysk (job używa uv tylko do `uvx bumpver`) →
  `enable-cache: false`, wektor znika.
- **artipacked** (medium): checkout joba `tests` bez
  `persist-credentials: false`. Job nie robi git-ops po checkoucie (mount
  `.test_durations` + pull obrazu przez osobny `docker/login`) → dodane
  `persist-credentials: false`.

`zizmor.yml` bez zmian (żadnych nowych tłumień).

## Weryfikacja

- `actionlint` + `zizmor` (via pre-commit) na zmienionym pliku → Passed.
- Lokalnie: `uv sync --frozen` toleruje stały root-version w locku (sync OK,
  wersja pakietu poprawna z pyproject).
- `uv lock` po bumpie → dokładnie 1-linijkowy diff (tylko root version).

## Poza zakresem

**Step 3**: pomijanie testów RC dla rc1-off-green-dev (osobna dyskusja/PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)