### PR TITLE
fix(pbn_api): przyjmuj literówkowe warianty URL-a callback (z/bez ukośnika)

### DIFF
--- a/src/pbn_api/urls.py
+++ b/src/pbn_api/urls.py
@@ -7,7 +7,39 @@ from .views import TokenLandingPage, TokenRedirectPage
 
 app_name = "pbn_api"
 
+# Kanoniczny redirect_uri to ".../pbn_api/callback". W praktyce jednak bywa
+# wpisywany recznie po stronie PBN i regularnie trafiaja sie literowki
+# ("calback", "kalbak", ...). Zamiast liczyc na bezbledna konfiguracje,
+# przyjmujemy komplet typowych przekrecen tego samego slowa — kazdy wariant,
+# z ukosnikiem i bez, laduje na tym samym TokenLandingPage. Wersja "callback"
+# jako jedyna ma name=, zeby reverse("pbn_api:callback") zwracalo
+# deterministycznie poprawny URL; aliasy sa wylacznie "przychodzace".
+CALLBACK_ALIASES = [
+    "callback",  # kanoniczna forma
+    "calback",  # jedno "l"
+    "calbak",  # jedno "l" + "ck" -> "k"
+    "calbac",  # jedno "l" + brak "k"
+    "callbak",  # "ck" -> "k"
+    "callbac",  # brak "k"
+    "callbck",  # brak "a"
+    "callbakc",  # przestawione "ck" -> "kc"
+    "kallback",  # "c" -> "k"
+    "kallbak",  # "c" -> "k" + "ck" -> "k"
+    "kalback",  # "c" -> "k" + jedno "l"
+    "kalbak",  # "c" -> "k" + jedno "l" + "ck" -> "k"
+    "kalbac",  # "c" -> "k" + jedno "l" + brak "k"
+    "collback",  # "a" -> "o"
+    "colback",  # "a" -> "o" + jedno "l"
+]
+
 urlpatterns = [
-    path("callback", TokenLandingPage.as_view(), name="callback"),
     path("authorize", TokenRedirectPage.as_view(), name="authorize"),
 ]
+
+for _alias in CALLBACK_ALIASES:
+    _kwargs = {"name": "callback"} if _alias == "callback" else {}
+    urlpatterns += [
+        # bez ukosnika oraz z ukosnikiem — patrz komentarz wyzej
+        path(_alias, TokenLandingPage.as_view(), **_kwargs),
+        path(f"{_alias}/", TokenLandingPage.as_view()),
+    ]


### PR DESCRIPTION
## Problem

`redirect_uri` PBN-a bywa wpisywany ręcznie po stronie PBN i regularnie
trafiają się literówki. Realny przypadek z instancji `nauka.mwsl.eu`:

```
https://nauka.mwsl.eu/pbn_api/calback?ott=...
                              ^^^^^^^  (jedno "l")
```

`/pbn_api/calback` nie pasował do żadnego wzorca URLconf → Django zwracał
**404** i użytkownik nie kończył autoryzacji tokenem PBN.

## Rozwiązanie

`src/pbn_api/urls.py` przyjmuje teraz komplet typowych przekręceń słowa
`callback` — każdy wariant **z ukośnikiem i bez** — kierując wszystkie na
ten sam `TokenLandingPage`:

`callback` (kanoniczna), `calback`, `calbak`, `calbac`, `callbak`,
`callbac`, `callbck`, `callbakc`, `kallback`, `kallbak`, `kalback`,
`kalbak`, `kalbac`, `collback`, `colback`.

Warianty generowane są w pętli z jawnej listy `CALLBACK_ALIASES`, więc
dopisanie kolejnej literówki to jedna linia.

### Uwagi projektowe

- Kanoniczna forma `callback` jako **jedyna** ma `name=`, więc
  `reverse("pbn_api:callback")` nadal deterministycznie zwraca
  `/pbn_api/callback`. Aliasy są wyłącznie "przychodzące".
- Warianty z/bez ukośnika dopasowane są bezpośrednio (bez polegania na
  `APPEND_SLASH`, które usuwa-nie-dokleja i nie ratuje wersji z ukośnikiem),
  więc token `?ott=...` nie przechodzi przez zbędne 302.

## Weryfikacja

- 30/30 tras (15 aliasów × 2 warianty) rozwiązuje się do `TokenLandingPage`.
- `reverse("pbn_api:callback")` → `/pbn_api/callback`.
- Realny literówkowy URL `/pbn_api/calback` → już trafia w widok.
- `ruff check` + `ruff format --check`: czysto.

## Do rozważenia osobno (nie w tym PR)

Źródło literówki może siedzieć po stronie **konfiguracji PBN** (panel PBN),
a nie w kodzie BPP — ten PR łata objaw (BPP nie odbija 404). Warto sprawdzić,
czy `redirect_uri` nie jest generowany błędnie po stronie BPP dla instancji
`nauka.mwsl.eu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)