### PR TITLE
fix(pbn-import): obca jednostka bez wymogu podpięcia do wydziału

### DIFF
--- a/docs/superpowers/specs/2026-07-08-obca-jednostka-bez-wydzialu-design.md
+++ b/docs/superpowers/specs/2026-07-08-obca-jednostka-bez-wydzialu-design.md
@@ -1,0 +1,175 @@
+# Obca jednostka bez wymogu podpięcia do wydziału
+
+Data: 2026-07-08
+Obszar: `src/pbn_import/`
+Issue źródłowy: zgłoszenie użytkownika (uczelnia MWSL, konfiguracja bez wydziałów)
+
+## Problem
+
+Gate-check `sprawdz_obca_jednostka` przed importem PBN wymaga, aby obca
+jednostka uczelni była podpięta do wydziału tej uczelni (przez metryczkę
+`Jednostka_Rodzic`). Uczelnie, które **nie używają wydziałów**, dostają
+fałszywy alert „Obca jednostka nie jest podpięta do żadnego wydziału tej
+uczelni", mimo że FK `Uczelnia.obca_jednostka` jest poprawnie ustawiony.
+
+Dodatkowo komunikat myli użytkownika: ustawienie w adminie „Jednostki
+nadrzędnej" (`Jednostka.parent`, MPTT) nie tworzy wiersza `Jednostka_Rodzic`,
+więc ręczna próba naprawy nie skutkuje.
+
+## Ustalenie kluczowe: 4. warunek to martwy kod obronny
+
+Docstring `sprawdz_obca_jednostka` (`institution_import.py:173-174`)
+uzasadnia wymóg wydziału zdaniem: „inaczej import trafiłby na trigger przy
+linkowaniu". To **nieaktualne**:
+
+- Migracja **0455 (Faza B / #438)** zdjęła wszystkie trzy triggery spójności
+  uczelni (`bpp_jednostka_wydzial_sprawdz_uczelnia_id`,
+  `bpp_jednostka_sprawdz_uczelnia_id`,
+  `bpp_jednostka_ustaw_wydzial_aktualna`) **bez zamiennika** — Zasada #4
+  federacji dopuszcza krawędzie między-uczelniane.
+- Tabela `Jednostka_Rodzic` (którą check odpytuje) **nie ma żadnego triggera**.
+- `Jednostka_Rodzic.clean()` (`jednostka.py:724-730`) jawnie dopuszcza
+  krawędzie między-uczelniane.
+- Jednostka-root (`parent=NULL`, denorm `wydzial=NULL`) to w pełni poprawny
+  stan po Fazie B.
+
+Wniosek: usunięcie 4. warunku jest bezpieczne — żaden mechanizm „w dole"
+importu już go nie wymaga.
+
+## Wymaganie
+
+Obca jednostka jest **wymagana**, ale jej pozycja w strukturze
+(wydział / rodzic) **przestaje nas obchodzić**. Wystarczy, że FK jest
+ustawiony na sensowną jednostkę tej uczelni.
+
+## Zmiany
+
+Trzy skoordynowane zmiany, wszystkie w `src/pbn_import/`.
+
+### 1. Gate-check `sprawdz_obca_jednostka` — usuń 4. warunek
+
+Plik: `src/pbn_import/utils/institution_import.py` (obecnie linie 160-199).
+
+Zostają warunki 1-3 (sanity, łapią realne pomyłki konfiguracji):
+
+| # | Warunek                                    | Los            |
+|---|--------------------------------------------|----------------|
+| 1 | `obca_jednostka` FK ustawiony              | **zostaje**    |
+| 2 | obca należy do TEJ uczelni                 | **zostaje**    |
+| 3 | `skupia_pracownikow is False`              | **zostaje**    |
+| 4 | podpięta do wydziału (`Jednostka_Rodzic`)  | **USUWAMY**    |
+
+Dodatkowo:
+- usuń blok `podpieta = Jednostka_Rodzic.objects.filter(...)` i towarzyszący
+  `if not podpieta: return ...`,
+- popraw docstring: usuń nieaktualne uzasadnienie o triggerze i 4. punkt
+  z listy sprawdzeń,
+- `Jednostka_Rodzic` zostaje importowane (używane w
+  `znajdz_lub_utworz_obca_jednostke`), więc importu nie ruszamy.
+
+### 1b. Sprzątanie nieaktualnych komentarzy o triggerze (comment-rot)
+
+Po zdjęciu triggerów w migracji 0455 kilka miejsc opisuje nieistniejące
+zachowanie. Po tej zmianie stają się aktywnie mylące — poprawić:
+
+- `src/pbn_import/views.py:103-105` — komentarz „obca jednostka MUSI być
+  podpięta do wydziału … inaczej import padnie na triggerze spójności".
+- `src/pbn_import/views.py:200-204` — docstring `_bledy_kontekstu_uczelni`:
+  „krok institution_setup padłby na triggerze
+  `bpp_jednostka_wydzial_sprawdz_uczelnia_id`".
+- `src/pbn_import/management/commands/create_obca_jednostka.py:4-7` —
+  docstring modułu („podpięta do wydziału … inaczej import PBN wywala się
+  na triggerze") oraz `:21-22` — `help` komendy („podpiętą do wydziału
+  domyślnego"). Po zmianie #2 komenda już nie tworzy wydziału/linku, więc
+  oba teksty trzeba urealnić.
+
+Wewnątrz `znajdz_lub_utworz_obca_jednostke` docstring do aktualizacji leży
+w liniach ~113-114 (zdanie o triggerze `bpp_jednostka_wydzial_
+sprawdz_uczelnia_id`) — poza zakresem podanym w sekcji 2, ale należy do
+tej samej funkcji; poprawić przy okazji zmiany #2.
+
+### 2. `znajdz_lub_utworz_obca_jednostke` — linkuj do wydziału tylko gdy jawnie podano
+
+Plik: `src/pbn_import/utils/institution_import.py` (obecnie linie 118-157).
+
+Obecny blok linkujący (linie 144-151: `if wydzial is None:
+znajdz_lub_utworz_wydzial_domyslny(...)`, potem `wezel`, potem
+`Jednostka_Rodzic.objects.get_or_create(...)`) wykonuje się **tylko gdy
+`wydzial is not None`**.
+
+Semantyka po zmianie:
+
+- **Ścieżka polecenia** (`create_obca_jednostka`, woła bez `wydzial`) →
+  zapewnia obcą jednostkę + FK, **nie** tworzy „Wydziału Domyślnego" ani
+  linku `Jednostka_Rodzic`. Obca zostaje czystym węzłem-root (`parent=NULL`).
+- **Ścieżka importera** (`InstitutionImporter.run`, linia 325, woła
+  z `wydzial=wydzial`) → zachowanie **bez zmian**: importer buduje realne
+  drzewo wydział+jednostka i podpięcie obcej pod nie jest spójne.
+
+Wybór projektowy: linkowanie **warunkowe od obecności argumentu `wydzial`**,
+nie flaga boolean ani całkowite usunięcie. Jedna funkcja obsługuje dwa
+konteksty (gołe provisioning z CLI vs. pełny setup importera); sygnał
+„czy linkować" niesie sama obecność `wydzial`. Minimalny diff, importer
+i jego testy nietknięte.
+
+Zaktualizować docstring funkcji (opis kroku podpięcia → „opcjonalny,
+tylko gdy podano `wydzial`").
+
+### 3. Dashboard — bez zmian w szablonie
+
+Ustalenie z review: statyczny tekst w `dashboard.html:36-38` **nie wspomina
+o wydziale** („Obca jednostka skupia autorów spoza uczelni i jest wymagana
+do importu. Administrator powinien uruchomić polecenie …"). Jedyna wzmianka
+o wydziale przychodziła dynamicznie przez `{{ obca_jednostka_problem }}`
+(komunikat 4. warunku), która znika wraz z warunkiem. **Zmiana szablonu
+jest zbędna** — nic tam nie ruszamy.
+
+### 4. Testy (TDD — najpierw czerwone)
+
+- `test_institution_import.py:235` `test_sprawdz_obca_jednostka_bez_wydzialu`
+  — **odwraca semantykę**: check ma teraz **przejść** (`None`) mimo braku
+  wydziału. Zmienić nazwę na `test_sprawdz_obca_jednostka_bez_wydzialu_
+  przechodzi`.
+- `test_institution_import.py:132-135`
+  `test_obca_jednostka_helper_creates_uczelnia_scoped` — **odwrócić asercję**:
+  dziś JAWNIE asertuje istnienie `Jednostka_Rodzic.objects.filter(
+  jednostka=obca, parent__uczelnia=uczelnia).exists()`. Po zmianie helper
+  wołany bez `wydzial` **nie** tworzy linku → asercja ma sprawdzać, że
+  linku **nie ma** (rozdzielić: bez `wydzial` brak linku).
+- Nowy test: `znajdz_lub_utworz_obca_jednostke(uczelnia, wydzial=w)`
+  **tworzy** link `Jednostka_Rodzic` (zachowana ścieżka importera).
+- `test_create_obca_jednostka.py` — po komendzie `sprawdz_obca_jednostka`
+  nadal `None` (komenda woła bez `wydzial` → brak linku, a check i tak
+  przechodzi na warunkach 1-3). Przechodzi bez zmian, ale zweryfikować.
+- Zachować testy warunków 2-3: obca z innej uczelni
+  (`test_sprawdz_obca_jednostka_cudza_uczelnia`) oraz
+  `skupia_pracownikow=True` (`test_sprawdz_obca_jednostka_skupia_pracownikow`)
+  nadal wywalają check.
+- 6 wywołań helpera w `test_views_dashboard.py` służy tylko przejściu
+  gate-checku (który po zmianie przechodzi na warunkach 1-3) — nietknięte.
+
+## Poza zakresem (YAGNI)
+
+- Nie ruszamy `znajdz_lub_utworz_wydzial_domyslny` ani ścieżki jednostki
+  domyślnej — ta legalnie potrzebuje wydziału jako korzenia drzewa
+  (`views.py:128`, `run()` linia 292).
+- Nie ruszamy zachowania importera (`InstitutionImporter.run`) — nadal
+  podpina obcą pod wydział, bo ma realny wydział w kontekście.
+- Bez migracji bazodanowych — zmiana wyłącznie w logice Pythona + testy.
+
+## Ryzyka
+
+- Niski. Zmiana rozluźnia walidację (mniej fałszywych negatywów), nie
+  zaostrza. Ścieżki, które dotąd przechodziły, dalej przechodzą.
+- Jedyny realny wektor: gdyby jakiś dalszy krok importu zakładał, że obca
+  jednostka MA wpis `Jednostka_Rodzic`. Zweryfikowano: importer sam podpina
+  (przekazuje `wydzial`), więc w ścieżce importu link istnieje; ścieżka
+  CLI provisioningu nie prowadzi importu, więc brak linku jej nie dotyczy.
+
+## Weryfikacja
+
+- `uv run pytest src/pbn_import/tests/test_institution_import.py
+  src/pbn_import/tests/test_create_obca_jednostka.py
+  src/pbn_import/tests/test_views_dashboard.py`
+- Ręcznie: uczelnia bez wydziałów + `create_obca_jednostka` →
+  `sprawdz_obca_jednostka` zwraca `None`, dashboard bez alertu.

--- a/src/bpp/newsfragments/obca-jednostka-bez-wydzialu.bugfix
+++ b/src/bpp/newsfragments/obca-jednostka-bez-wydzialu.bugfix
@@ -1,0 +1,1 @@
+Import PBN: obca jednostka uczelni nie musi już być podpięta do wydziału. Uczelnie nieużywające wydziałów nie dostają fałszywego alertu „Obca jednostka nie jest podpięta do żadnego wydziału tej uczelni" — wystarczy poprawnie ustawiony FK ``Uczelnia.obca_jednostka``.

--- a/src/pbn_import/management/commands/create_obca_jednostka.py
+++ b/src/pbn_import/management/commands/create_obca_jednostka.py
@@ -2,9 +2,10 @@
 
 W multi-hosted wszystkie uczelnie współdzielą jedną bazę, a ``Jednostka.nazwa`` /
 ``skrot`` są ``unique=True`` globalnie. Obca jednostka MUSI więc być per-uczelnia
-(nazwa "Obca jednostka <SKRÓT>") i podpięta do wydziału tej samej uczelni —
-inaczej import PBN wywala się na triggerze ``bpp_jednostka_wydzial_
-sprawdz_uczelnia_id``. To polecenie provisionuje / naprawia ten stan hurtem.
+(nazwa "Obca jednostka <SKRÓT>") i ustawiona jako ``Uczelnia.obca_jednostka``.
+To polecenie provisionuje / naprawia ten stan hurtem. Nie wymusza podpięcia
+obcej jednostki do wydziału — uczelnie mogą nie używać wydziałów, a gate
+``sprawdz_obca_jednostka`` tego nie wymaga (triggery spójności zdjęto w #438).
 """
 
 from django.core.management.base import BaseCommand, CommandError
@@ -18,8 +19,9 @@ from pbn_import.utils.institution_import import (
 
 class Command(BaseCommand):
     help = (
-        "Zapewnia obcą jednostkę (per-uczelnia, podpiętą do wydziału domyślnego) "
-        "dla każdej uczelni. Idempotentne. --dry-run tylko raportuje braki."
+        "Zapewnia obcą jednostkę (per-uczelnia) i ustawia FK "
+        "Uczelnia.obca_jednostka dla każdej uczelni. Idempotentne. "
+        "--dry-run tylko raportuje braki."
     )
 
     def add_arguments(self, parser):

--- a/src/pbn_import/tests/test_institution_import.py
+++ b/src/pbn_import/tests/test_institution_import.py
@@ -129,6 +129,22 @@ def test_obca_jednostka_helper_creates_uczelnia_scoped(uczelnia):
     assert obca.skupia_pracownikow is False
     assert obca.uczelnia == uczelnia
     assert uczelnia.obca_jednostka == obca
+    # Bez jawnego `wydzial` helper NIE podpina obcej jednostki do wydziału —
+    # obca zostaje czystym węzłem-root (uczelnie bez wydziałów są OK).
+    assert not Jednostka_Rodzic.objects.filter(
+        jednostka=obca,
+        parent__uczelnia=uczelnia,
+    ).exists()
+
+
+def test_obca_jednostka_helper_links_when_wydzial_passed(uczelnia):
+    # Ścieżka importera: gdy podamy jawny `wydzial`, helper podpina obcą
+    # jednostkę do jego węzła-lustra (zachowana spójność drzewa struktury).
+    wydzial, _ = znajdz_lub_utworz_wydzial_domyslny(uczelnia)
+
+    obca, created = znajdz_lub_utworz_obca_jednostke(uczelnia, wydzial=wydzial)
+
+    assert created is True
     assert Jednostka_Rodzic.objects.filter(
         jednostka=obca,
         parent__uczelnia=uczelnia,
@@ -232,12 +248,14 @@ def test_sprawdz_obca_jednostka_skupia_pracownikow(uczelnia):
     assert sprawdz_obca_jednostka(uczelnia) is not None
 
 
-def test_sprawdz_obca_jednostka_bez_wydzialu(uczelnia):
+def test_sprawdz_obca_jednostka_bez_wydzialu_przechodzi(uczelnia):
+    # Uczelnia bez wydziałów: obca jednostka NIE musi być podpięta do wydziału.
+    # Wystarczy poprawny FK + sanity (należy do uczelni, skupia_pracownikow=False).
     obca = baker.make(Jednostka, uczelnia=uczelnia, skupia_pracownikow=False)
     uczelnia.obca_jednostka = obca
     uczelnia.save(update_fields=["obca_jednostka"])
 
-    assert sprawdz_obca_jednostka(uczelnia) is not None
+    assert sprawdz_obca_jednostka(uczelnia) is None
 
 
 def test_institution_importer_does_not_collide_with_other_uczelnia_obca(session, db):

--- a/src/pbn_import/utils/institution_import.py
+++ b/src/pbn_import/utils/institution_import.py
@@ -106,15 +106,19 @@ def znajdz_lub_utworz_obca_jednostke(uczelnia, wydzial=None):
        ``Jednostka.nazwa``/``skrot`` są ``unique=True`` GLOBALNIE, a w multi-hosted
        wszystkie uczelnie współdzielą jedną bazę (stąd kolizja "Obca jednostka").
 
-    Następnie (zawsze, idempotentnie): podpięcie do wydziału tej uczelni i
-    ustawienie ``uczelnia.obca_jednostka``. ``wydzial`` można podać jawnie (krok
-    importu podpina obcą jednostkę pod TEN sam wydział co jednostkę domyślną);
-    przy ``None`` helper sam ustala/tworzy "Wydział Domyślny" uczelni. Obca
-    jednostka i wydział należą do tej samej uczelni, więc trigger
-    ``bpp_jednostka_wydzial_sprawdz_uczelnia_id`` przechodzi.
+    Następnie (zawsze, idempotentnie) ustawia ``uczelnia.obca_jednostka``.
+
+    Podpięcie do wydziału jest OPCJONALNE i wykonuje się TYLKO gdy podano
+    jawny ``wydzial``: krok importu (``InstitutionImporter.run``) buduje realne
+    drzewo wydział+jednostka i podpina obcą pod TEN sam wydział co jednostkę
+    domyślną. Przy ``wydzial=None`` (np. komenda ``create_obca_jednostka`` na
+    uczelni bez wydziałów) obca jednostka zostaje czystym węzłem-root — nie
+    tworzymy "Wydziału Domyślnego" ani metryczki ``Jednostka_Rodzic``, bo gate
+    ``sprawdz_obca_jednostka`` już tego nie wymaga (triggery spójności uczelni
+    zdjęto w Fazie B, #438).
 
     Zwraca ``(jednostka, created)`` — ``created`` mówi tylko o utworzeniu samej
-    Jednostki (krok 3), nie o ubocznym utworzeniu wydziału / linku / FK.
+    Jednostki (krok 3), nie o ubocznym utworzeniu linku / FK.
     """
     obca = None
     created = False
@@ -141,14 +145,14 @@ def znajdz_lub_utworz_obca_jednostke(uczelnia, wydzial=None):
         )
         created = True
 
-    # Podepnij do wydziału tej uczelni (idempotentnie). Oba obiekty należą do
-    # `uczelnia`, więc trigger spójności uczelni przechodzi.
-    if wydzial is None:
-        wydzial, _ = znajdz_lub_utworz_wydzial_domyslny(uczelnia)
-    # Faza B (#438): metryczka wskazuje węzeł-rodzic; LAZY resolve wydział →
-    # węzeł-lustro (tworzony w tym miejscu linkowania, jeśli jeszcze go nie ma).
-    wezel, _ = znajdz_lub_utworz_wezel_wydzialu(wydzial)
-    Jednostka_Rodzic.objects.get_or_create(jednostka=obca, parent=wezel)
+    # Podpięcie do wydziału TYLKO gdy caller poda jawny `wydzial` (ścieżka
+    # importera). Bez niego (komenda / uczelnia bez wydziałów) obca jednostka
+    # zostaje węzłem-root — gate `sprawdz_obca_jednostka` nie wymaga linku.
+    if wydzial is not None:
+        # Faza B (#438): metryczka wskazuje węzeł-rodzic; LAZY resolve wydział →
+        # węzeł-lustro (tworzony przy linkowaniu, jeśli jeszcze go nie ma).
+        wezel, _ = znajdz_lub_utworz_wezel_wydzialu(wydzial)
+        Jednostka_Rodzic.objects.get_or_create(jednostka=obca, parent=wezel)
 
     if uczelnia.obca_jednostka_id != obca.pk:
         uczelnia.obca_jednostka = obca
@@ -169,9 +173,12 @@ def sprawdz_obca_jednostka(uczelnia):
 
     - FK ustawiony,
     - target należy do tej uczelni,
-    - ``skupia_pracownikow is False`` (invariant z ``Uczelnia.clean()``),
-    - obca jednostka podpięta do wydziału tej samej uczelni (inaczej import
-      trafiłby na trigger przy linkowaniu).
+    - ``skupia_pracownikow is False`` (invariant z ``Uczelnia.clean()``).
+
+    Pozycja obcej jednostki w strukturze (wydział / rodzic) świadomie NIE jest
+    sprawdzana — uczelnie mogą nie używać wydziałów, a triggery spójności
+    uczelni, które dawniej wymuszały podpięcie, zdjęto w Fazie B (#438,
+    migracja 0455). Obca jednostka jako czysty węzeł-root jest w pełni OK.
     """
     napraw = " Uruchom: python src/manage.py create_obca_jednostka"
 
@@ -187,14 +194,6 @@ def sprawdz_obca_jednostka(uczelnia):
         return (
             "Obca jednostka ma skupia_pracownikow=True — musi być faktycznie "
             "obca." + napraw
-        )
-    podpieta = Jednostka_Rodzic.objects.filter(
-        jednostka=obca,
-        parent__uczelnia=uczelnia,
-    ).exists()
-    if not podpieta:
-        return (
-            "Obca jednostka nie jest podpięta do żadnego wydziału tej uczelni." + napraw
         )
     return None
 

--- a/src/pbn_import/views.py
+++ b/src/pbn_import/views.py
@@ -100,9 +100,10 @@ class ImportDashboardView(LoginRequiredMixin, ImportPermissionMixin, TemplateVie
         context["uczelnia"] = uczelnia
         context["uzywaj_wydzialow"] = uczelnia.uzywaj_wydzialow if uczelnia else False
 
-        # Gate-check multi-hosted: obca jednostka MUSI istnieć i być podpięta do
-        # wydziału tej uczelni, inaczej import padnie na triggerze spójności.
-        # Sygnalizujemy to już przy wejściu na stronę (baner w szablonie).
+        # Gate-check multi-hosted: obca jednostka MUSI istnieć, należeć do tej
+        # uczelni i mieć skupia_pracownikow=False (jej pozycja w strukturze /
+        # wydział nas nie obchodzi). Sygnalizujemy to już przy wejściu na
+        # stronę (baner w szablonie).
         context["obca_jednostka_problem"] = (
             sprawdz_obca_jednostka(uczelnia) if uczelnia else None
         )
@@ -199,8 +200,9 @@ class StartImportView(LoginRequiredMixin, ImportPermissionMixin, View):
         autorów/prace do encji obcej uczelni (cichy wyciek danych między
         tenantami). Egzekwujemy nawet przy zmanipulowanym formularzu (encje
         zawężamy też w GET, ale POST musi się bronić sam). Dodatkowo obca
-        jednostka uczelni musi być skonfigurowana, bo krok institution_setup
-        padłby na triggerze ``bpp_jednostka_wydzial_sprawdz_uczelnia_id``.
+        jednostka uczelni musi być poprawnie skonfigurowana (patrz
+        ``sprawdz_obca_jednostka``) — bez niej import nie ma gdzie umieścić
+        autorów spoza uczelni.
 
         Zwraca listę komunikatów błędów (pustą, gdy wszystko OK).
         """


### PR DESCRIPTION
## Problem

Gate-check `sprawdz_obca_jednostka` (przed importem PBN) wymagał, by obca jednostka uczelni była **podpięta do wydziału** tej uczelni (metryczka `Jednostka_Rodzic`). Uczelnie, które **nie używają wydziałów**, dostawały fałszywy alert:

> Obca jednostka nie jest podpięta do żadnego wydziału tej uczelni. Uruchom: python src/manage.py create_obca_jednostka

— mimo że FK `Uczelnia.obca_jednostka` był poprawnie ustawiony. Dodatkowo ręczna próba naprawy przez ustawienie „Jednostki nadrzędnej" w adminie (`Jednostka.parent`, MPTT) nie skutkowała, bo check patrzy na inną relację (`Jednostka_Rodzic`).

## Ustalenie kluczowe: 4. warunek to martwy kod obronny

Docstring uzasadniał wymóg wydziału zdaniem *„inaczej import trafiłby na trigger przy linkowaniu"*. To **nieaktualne**:

- Migracja **0455 (Faza B / #438)** zdjęła wszystkie trzy triggery spójności uczelni **bez zamiennika** (Zasada #4 federacji dopuszcza krawędzie między-uczelniane).
- Tabela `Jednostka_Rodzic`, którą check odpytuje, **nie ma żadnego triggera**.
- `Jednostka_Rodzic.clean()` jawnie dopuszcza krawędzie między-uczelniane; jednostka-root (`parent=NULL`) to poprawny stan.

Usunięcie warunku jest więc bezpieczne — nic „w dole" importu go nie wymaga.

## Zmiany

- **`sprawdz_obca_jednostka`**: usunięty 4. warunek (podpięcie do wydziału). Zostają sanity 1-3: FK ustawiony, obca należy do tej uczelni, `skupia_pracownikow=False`.
- **`znajdz_lub_utworz_obca_jednostke`**: podpięcie do wydziału **tylko** gdy podano jawny `wydzial`. Ścieżka importera (`InstitutionImporter.run`, przekazuje `wydzial=`) — bez zmian. Ścieżka komendy `create_obca_jednostka` (bez `wydzial`) — obca zostaje węzłem-root, bez „Wydziału Domyślnego" i bez linku.
- **Comment-rot**: sprzątnięte komentarze/docstringi o nieistniejącym już triggerze (`views.py` ×2, docstring + `help` komendy).

## Testy

- TDD: 2 asercje odwrócone (`test_sprawdz_obca_jednostka_bez_wydzialu` → `..._przechodzi`; `test_obca_jednostka_helper_creates_uczelnia_scoped`) + nowy `test_obca_jednostka_helper_links_when_wydzial_passed` (strzeże ścieżki importera).
- **62 passed** (`test_institution_import` + `test_create_obca_jednostka` + `test_views_dashboard`), ruff clean.
- Zachowane testy warunków 2-3 (obca z innej uczelni, `skupia_pracownikow=True`) nadal wywalają check.

## Poza zakresem

Bez migracji DB. `znajdz_lub_utworz_wydzial_domyslny` i ścieżka jednostki domyślnej nietknięte (legalnie potrzebują wydziału jako korzenia drzewa).

Spec: `docs/superpowers/specs/2026-07-08-obca-jednostka-bez-wydzialu-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)