### PR TITLE
build(release): lokalne bramkowanie make release-candidate (branch==dev + skan CVE)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -640,7 +640,19 @@ release: check-clean-tree full-tests new-release ## Pełny release (tree clean +
 
 .PHONY: release-candidate release-promote
 release-candidate: ## Faza 1: utnij kandydata (RC → :staging) i obserwuj run [SKIP_TESTS=1 SKIP_SCAN=1 WEB=1]
-	@FLAGS=""; \
+	@BRANCH=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null); \
+	if [ "$$BRANCH" != "dev" ]; then \
+		echo "BŁĄD: RC tnie kandydata z 'dev' (--ref dev), a lokalnie jesteś na '$$BRANCH'."; \
+		echo "      Przełącz się:  git switch dev && git pull  — potem ponów."; \
+		exit 1; \
+	fi; \
+	if [ -z "$$SKIP_SCAN" ]; then \
+		echo "==> Lokalny gate CVE (./bin/scan-deps.sh) — HIGH/CRITICAL zatrzyma RC przed CI..."; \
+		./bin/scan-deps.sh || { echo "BŁĄD: lokalny skan CVE znalazł HIGH/CRITICAL — przerywam przed RC (SKIP_SCAN=1 by pominąć awaryjnie)."; exit 1; }; \
+	else \
+		echo "==> SKIP_SCAN=1 — pomijam lokalny skan CVE (awaryjnie)."; \
+	fi; \
+	FLAGS=""; \
 	if [ -n "$$SKIP_TESTS" ]; then FLAGS="$$FLAGS -f skip_tests=true"; fi; \
 	if [ -n "$$SKIP_SCAN" ]; then FLAGS="$$FLAGS -f skip_scan=true"; fi; \
 	echo "Odpalam release-candidate.yml (--ref dev)$$FLAGS ..."; \


### PR DESCRIPTION
## Cel

`make release-candidate` dostaje dwa **lokalne gate'y pre-flight**, ZANIM
odpali workflow `release-candidate.yml` (na prośbę maintainera):

1. **Branch == dev.** RC zawsze tnie z `--ref dev`; odpalanie z innej
   lokalnej gałęzi to zwykle pomyłka. Twardy abort z podpowiedzią
   (`git switch dev && git pull`) — zanim cokolwiek pójdzie do CI.
2. **Lokalny skan CVE** (`./bin/scan-deps.sh`) — ten sam skrypt-bramka co
   w CI (OSV + Grype + Trivy + pip-audit, gate na HIGH/CRITICAL). Łapie
   dramatyczne CVE lokalnie, zanim spalimy CI na RC, który i tak padłby na
   bramce skanu. `SKIP_SCAN=1` pomija go awaryjnie (ten sam flag pomija
   już skan w CI — zachowana spójność).

Oba przez `|| exit 1` (recipe Make nie ma `set -e`), więc realnie
zatrzymują target przed dispatchem.

## Uwaga o zakresie skanu

Lokalny skan czyta deps z LOKALNEGO drzewa (`uv export --no-dev`). Jeśli
lokalny `dev` jest za `origin/dev`, skan jest przybliżony — ale
**autorytatywny gate to i tak `scan-deps.sh` w CI** na realnym drzewie RC
(krok „Skan CVE (bramka)" w `prepare`). Lokalny to fail-fast, nie
zastępstwo. (Dlatego celowo nie wymuszam tu `dev == origin/dev` —
niepotrzebny fetch; powiedz, jeśli chcesz twardszy wariant.)

## Weryfikacja

- Abort na nie-dev: `make release-candidate` na `ci/rc-local-preflight`
  → `BŁĄD: ... jesteś na 'ci/rc-local-preflight'` + `exit 1`, **bez**
  dispatchu. Makefile parsuje się (brak błędów tabów).
- Stub control-flow scan-gate: fail→stop (rc=1), `SKIP_SCAN=1`→dispatch
  (rc=0), pass→dispatch (rc=0).
- `./bin/scan-deps.sh` odpalony realnie na deps dev (osv/grype/trivy/uv
  obecne lokalnie) — wynik w wątku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)