### PR TITLE
test(xdist): izolacja współbieżna testów — media, teardown Playwright, reruny, cache'e

### DIFF
--- a/docs/deweloper/audyt-testy-rownoleglosc-2026-07.md
+++ b/docs/deweloper/audyt-testy-rownoleglosc-2026-07.md
@@ -1,0 +1,342 @@
+# Audyt testów pod kątem współbieżności (pytest-xdist / sharding CI / live servery)
+
+Data: 2026-07-08. Zakres: cała suita pytest (testy „zwykłe" + Playwright),
+konfiguracja `pytest.ini`, `settings/test.py`→`local.py`→`base.py`, fixtures,
+`channels_live_server`, workflow CI (12 shardów). Audyt wykonany czterema
+równoległymi skanami: (1) współdzielony stan Redis/channel-layers,
+(2) anty-wzorce DB/fixtures, (3) timing/synchronizacja Playwright,
+(4) filesystem/porty/env/CI.
+
+## Fakty środowiskowe (rama dla wszystkich znalezisk)
+
+- **PostgreSQL: izolowany per worker.** Każdy worker xdist ma własną bazę
+  `test_bpp_gwN` (klon z template). Sekwencje jitterowane losowo
+  +50k..500k przy starcie sesji (`src/conftest.py::django_db_setup`).
+- **Redis: JEDEN, współdzielony przez wszystkie workery.** Plugin
+  `pytest-testcontainers-django` startuje kontenery tylko w kontrolerze
+  pytest (workery wykrywają `PYTEST_XDIST_WORKER` i dziedziczą
+  `DJANGO_BPP_REDIS_PORT` z env). Na CI analogicznie: jeden Redis per shard
+  (`docker-compose.test.yml`), shardy na osobnych VM-kach — brak
+  współdzielenia między shardami.
+- **Łańcuch settings testowych:** `--ds=django_bpp.settings.test` →
+  `test.py` → `from .local import *` → `local.py` → `base.py`. Testy
+  dziedziczą **dev-owe** MEDIA_ROOT, cache'e i flagi Celery.
+- **Teardown testów transakcyjnych:** monkey-patch
+  `TransactionTestCase._fixture_teardown` (`src/conftest.py:92-144`) —
+  `flush --allow-cascade`, `reset_sequences=False`, retry z backoffem na
+  deadlocki. Nikt nie używa `serialized_rollback`.
+- **Daphne (channels_live_server):** session-scoped, jeden subprocess per
+  worker, losowy port; konsumenci używają `transactional_db` (TRUNCATE
+  między testami); w subprocesie per-request czyszczony jest cache
+  ContentType (`src/channels_live_server.py:80-103`).
+
+## Co jest zrobione dobrze (utrzymać)
+
+- Baza per worker + jitter sekwencji (demaskuje testy zależne od małych ID).
+- **Channel layers: per-worker prefix `asgi-test-gwN`**
+  (`src/django_bpp/channels_prefix.py:35-58`, `base.py:983-991`), spójny
+  z pollerem testowym `wait_for_channel_subscription`
+  (`src/django_bpp/playwright_util.py:67-76`). Historia nieudanej próby
+  i naprawy: `docs/deweloper/testy-channels-broadcast.md`, commit
+  `ece1b586b`. Pilnowane testem `src/django_bpp/tests/test_channels_prefix.py`.
+- **cacheops rozbrojony w testach** (`settings/test.py:34,45` — usunięcie
+  z INSTALLED_APPS + `CACHEOPS_ENABLED=False`, z komentarzem opisującym
+  cross-worker leak przez Redis DB 7, który kiedyś powodował 404-ki).
+- **Sesje w testach są DB-backed** (nikt poza `production.py`/`auth_server.py`
+  nie ustawia `SESSION_ENGINE`) — czyli per-worker Postgres;
+  `SESSION_REDIS_*` to martwa konfiguracja.
+- Cache domyślny = DummyCache; Redis locks DB 6 — nieużywane w kodzie.
+- **Zero stałych portów** w testach (Daphne: port od kernela; testcontainers:
+  losowe porty). Zero `networkidle` (w 5 miejscach komentarze, czemu go nie ma).
+- **VCR w trybie `none`** (pytest-recording, brak override) — testy nigdy nie
+  idą w sieć; reszta HTTP mockowana.
+- Login w Playwright przez wstrzyknięcie cookie z `Client.force_login`
+  (nie przez UI); session-scoped browser + function-scoped context/page.
+- Izolacja shardów CI: świeży checkout, dedykowana VM, własny compose,
+  tmpfs na PG, `down -v` na końcu.
+
+---
+
+## Znaleziska KRYTYCZNE
+
+### 1. `MEDIA_ROOT = src/media` — współdzielony, niesprzątany, importowany przez pytest
+
+- `src/django_bpp/settings/local.py:46-49` (dziedziczone przez testy) — stała
+  ścieżka w drzewie źródeł, wspólna dla wszystkich workerów.
+- W katalogu leży **~1800 wyciekłych plików (~62 MB)**, mnóstwo kopii
+  z sufiksami dedupe Django (`test1_*.xlsx`, `conftest_*.py`) — dowód, że
+  kolizje między workerami już zachodzą i są maskowane przez
+  `FileSystemStorage`.
+- Test „zły typ pliku" uploaduje **prawdziwy `conftest.py`**
+  (`src/import_dyscyplin/tests/conftest.py:68`, konsumowany przez
+  `test_core.py:8` i `test_views.py:35`), który ląduje w
+  `src/media/protected/import_dyscyplin/conftest.py` — obok istnieje
+  `__pycache__`, czyli pytest faktycznie go zaimportował przy kolekcji.
+  Stary uploadowany plik z innej gałęzi może wywalić kolekcję całej suity
+  (`ImportError`) albo zdublować fixtures.
+- `norecursedirs` w `pytest.ini:53` pilnuje ZŁEJ ścieżki (`src/bpp/media/`,
+  a MEDIA_ROOT to `src/media`); `--ignore` też nie zawiera `src/media`.
+- Asercje na dokładne nazwy plików / `os.path.exists` po delete
+  (`import_dyscyplin/tests/test_models.py:23-36`) działają tylko dzięki
+  losowości sufiksów.
+- Wzorzec poprawny istnieje w repo:
+  `src/zglos_publikacje/tests/test_admin/test_zgloszenie_publikacji.py:13`
+  (`settings.MEDIA_ROOT = str(tmp_path)`).
+
+**Fix:** w `settings/test.py` MEDIA_ROOT → tempdir per proces (klucz
+`PYTEST_XDIST_WORKER`); `src/media` do `--ignore` i `norecursedirs`;
+czystka wyciekłych plików; testy „złego pliku" bez rozszerzenia `.py`.
+
+### 2. Teardown fixture'ów Playwright: TRUNCATE przed zamknięciem przeglądarki
+
+- Wszystkie fixture'y auth-page (`src/fixtures/playwright_fixtures.py:8,39,70,112,138`)
+  mają `page` jako PIERWSZY parametr, `transactional_db` jako ostatni.
+  Pytest finalizuje w odwrotnej kolejności instancjacji → flush/TRUNCATE
+  biegnie, gdy żywa strona wciąż trzyma websocket i może mieć request
+  in-flight do sesyjnego Daphne (reconnect WS, redirect po POST, wpis do
+  `django_admin_log`) → `ForeignKeyViolation`/deadlock.
+- Pasuje do IntegrityError w CI (GitHub Actions run 28946185913) i do
+  istnienia retry-loopa na deadlocki w `src/conftest.py:104-141`.
+- Testy „toz/tamze" pogarszają sprawę: kończą się w momencie zaobserwowania
+  `count()==2` w DB, gdy odpowiedź HTTP / LogEntry / follow-up GET jeszcze
+  lecą (`src/bpp/tests/test_playwright/test_admin/test_toz_tamze.py:126-141,
+  172-187, 216-234`). `admin_page.wait_for_function("() => true")` to no-op,
+  niczego nie synchronizuje.
+
+**Fix:** `transactional_db` jako pierwszy parametr fixture'ów (TRUNCATE po
+zamknięciu kontekstu); po klikach zapisujących `page.expect_navigation()` /
+`wait_for_url` zanim assertuje się DB; usunąć no-op `wait_for_function`.
+
+### 3. `--only-rerun` wyłącza reruny `@pytest.mark.flaky` dla AssertionError
+
+- `pytest.ini` ma `--only-rerun TimeoutError/TimeoutException/...` BEZ
+  globalnego `--reruns`. pytest-rerunfailures stosuje ten filtr RÓWNIEŻ do
+  rerunów z markera `@pytest.mark.flaky(reruns=3)`.
+- `src/integration_tests/test_bpp_with_notifications.py:116,141` —
+  `test_bpp_notifications` failuje przez `AssertionError`
+  (`expect().to_contain_text`), która nie pasuje do żadnego wzorca → rerun
+  się NIE wykonuje, mimo że komentarz w teście zakłada „0.2^4 combined".
+- `test_channels_live_server` (`:96-113`) ma ten sam lossy push WS
+  (~20% miss-rate udokumentowany w docs), okno tylko 1000 ms i brak
+  markera flaky w ogóle.
+
+**Fix:** dodać `AssertionError` do `--only-rerun` (lub per-marker
+`only_rerun=[...]`); ujednolicić testy notyfikacji (marker + timeout).
+
+### 4. Stan bazy per worker jest historia-zależny; `worksteal` czyni historię losową
+
+- Pierwszy test transakcyjny na workerze TRUNCATE-uje dane referencyjne
+  istniejące tylko w `baseline.sql` (`bpp_jezyk`, `bpp_charakter_formalny`,
+  `bpp_status_korekty`, custom `auth_group`...) — `post_migrate` odtwarza
+  tylko contenttypes/permissions/default site. Późniejsze testy czytające
+  „ambient data" dostają pustkę:
+  `src/importer_publikacji/tests/test_source_form.py:151-153`,
+  `test_views_create_publication.py:34-36`
+  (`Charakter_Formalny.objects.first()` → None).
+- `--timeout 90` (pytest-timeout) może ubić test PO commitach a PRZED
+  flushem → osierocone wiersze na resztę sesji workera (z `--reuse-db`
+  przeżywają lokalnie do następnej sesji). To psuje globalne asserty:
+  `src/integration_tests/test_conftest.py:88-90`
+  (`Rekord.objects.all().count() == 1`),
+  `src/nowe_raporty/tests/test_seed_raporty.py:23-25`,
+  `src/import_dyscyplin/tests/test_models.py:77-140`.
+
+**Fix:** zakaz gołego `.first()`/globalnych count-ów na danych
+referencyjnych — zawsze fixture seedujący + count skope'owany do
+relacji/PK. Rozważyć `serialized_rollback` albo autouse re-seed po flushu.
+
+---
+
+## Znaleziska ŚREDNIE
+
+### 5. `@pytest.mark.serial` nie daje obiecanej gwarancji
+
+- `src/conftest.py:362-372` mapuje marker na
+  `xdist_group("serial_<4-segmenty-ścieżki>")` — serializacja tylko
+  WEWNĄTRZ grupy katalogowej. Testy serial z różnych katalogów biegną
+  równolegle ze sobą i z niemarkowanymi. Docstring w `pytest.ini`
+  („nie może być uruchomiony równolegle z innymi testami") obiecuje więcej.
+- Skutek uboczny: wszystkie `src/bpp/tests/test_multiseek_*` lądują w JEDNEJ
+  grupie `src_bpp_tests` — bezpieczne, ale psuje balans shardów.
+
+**Fix:** poprawić dokumentację markera ALBO wprowadzić prawdziwą
+serializację (dedykowany worker / filelock) dla testów, które jej
+naprawdę potrzebują.
+
+### 6. Sprzeczne flagi Celery eager; fallback = współdzielony broker bez konsumenta
+
+- `base.py:362-365` ustawia `CELERY_ALWAYS_EAGER`/`CELERY_TASK_ALWAYS_EAGER`
+  = True pod TESTING; `local.py:64` potem bezwarunkowo resetuje
+  `CELERY_ALWAYS_EAGER = False`; `settings/test.py` nie przywraca.
+  Łaty siedzą późno: `src/fixtures/conftest.py:37-38` (pytest_configure)
+  i `src/channels_live_server.py:64` (subprocess Daphne).
+- Jeśli rozstrzygnięcie eager kiedykolwiek przechyli się źle, `.delay()`
+  cicho publikuje do Redis DB 1 współdzielonego przez wszystkie workery —
+  task nigdy się nie wykona (silent no-op zależny od kolejności).
+
+**Fix:** obie flagi jawnie w `settings/test.py`; usunąć późny re-set
+z `fixtures/conftest.py`.
+
+### 7. Constance cache (Redis DB 8) bez per-worker KEY_PREFIX — regresja
+
+- Historia: `469507eb1` (Redis-DB-per-worker) → `137fec4df`
+  (`KEY_PREFIX = PYTEST_XDIST_WORKER` na aliasie `constance_cache`) →
+  **`55e0b1aa6`** (refaktor test/local) USUNĄŁ blok KEY_PREFIX.
+  Dziś `local.py:89-99` definiuje `constance_cache` = redis DB 8 bez
+  prefiksu, `test.py` nie przywraca.
+- Dziś nieszkodliwe: `CONSTANCE_CONFIG = {}` (`base.py:1736`), fixture
+  `constance_cache_warmed_up` iteruje pusty dict, nikt nie pisze
+  `config.X = ...`. Ale pierwszy nowy klucz constance wskrzesza
+  cross-worker leak (worker A cache'uje wartość, worker B ją czyta, choć
+  jego własna baza mówi co innego). Ślad ugryzienia:
+  `src/bpp/tests/test_models/test_struktura/test_uczelnia.py:31-40`
+  lokalnie override'uje `constance_cache` na locmem.
+
+**Fix:** w `settings/test.py` przywrócić KEY_PREFIX per worker albo
+przestawić alias na LocMemCache.
+
+### 8. `_clear_caches` w Daphne czyści tylko ContentType — SITE_CACHE przeżywa TRUNCATE
+
+- `src/channels_live_server.py:80-103` czyści per-request wyłącznie
+  `ContentType.objects.clear_cache()`. Projekt używa `django.contrib.sites`
+  + `get_current_site()` (`src/bpp/admin/uczelnia.py:310-312`,
+  `src/bpp_setup_wizard/forms.py:133-135`). Po flushu ID w `django_site`
+  się zmieniają, a `SITE_CACHE` w sesyjnym Daphne trzyma stare obiekty →
+  sporadyczne 500/`DoesNotExist` zależne od kolejności testów na workerze.
+  Ten sam wektor co naprawiony KeyError na ContentType.
+
+**Fix:** dodać `Site.objects.clear_cache()` w `_clear_caches`; przejrzeć
+inne module-level cache (dbtemplates, cache Uczelni).
+
+### 9. Mieszanie `admin_page` (Daphne) z `live_server` (WSGI) — dwa serwery per test
+
+- Pliki: `src/bpp/tests/test_admin/test_crossref_api_sync_playwright.py:34-37`,
+  `test_toz_tamze.py` (wszystkie), `test_wydawnictwo_autor.py`,
+  `test_autor_inline_wydawnictwo.py`, `test_oswiadczenie_ken.py`,
+  `test_clarivate.py`, `test_wydawnictwo_ciagle.py`,
+  `src/raport_slotow/tests/test_playwright/test_raport_slotow_autor/test_form.py`.
+- `admin_page` stawia Daphne, a test nawiguje na `live_server` —
+  podwójna presja na zasoby (dokładnie ta, którą docstring
+  `channels_live_server.py:185-191` wskazuje jako źródło kaskadowych
+  timeoutów `page.goto`), plus WSGI serwer nie ma per-request czyszczenia
+  ContentType/Site.
+
+**Fix:** nawigować na `channels_live_server.url` (już wstrzyknięty).
+
+### 10. Wyścigi we wzorcach fixture'owych `get_or_create`
+
+- `pbn_dyscyplina2` (`src/conftest.py:390-399`): `uuid=uuid4()` w LOOKUPIE
+  (nie w defaults) — `Discipline` nie ma unique na `code`, więc każde
+  wywołanie INSERT-uje nowy wiersz `code="202"` → `MultipleObjectsReturned`
+  w kodzie produkcyjnym (`import_common/core/dyscyplina.py:59,64,79`,
+  `pbn_integrator/utils/dictionaries.py:155`). `pbn_dyscyplina1` robi to
+  dobrze (uuid w defaults).
+- `pbn_discipline_group` (`src/conftest.py:402-416`): klucz zawiera
+  `validityDateFrom=today-7d` — leftover z sesji rozpoczętej wczoraj
+  (reuse-db + crash) już nie matchuje → drugi group → dyscypliny
+  rozszczepione między grupy; fallback `.first()` bez `order_by`.
+- `jezyki`/`tytuly`/`charaktery_formalne`
+  (`src/fixtures/conftest_system.py:63-90`) + `bpp/tests/util.py:152`:
+  `get_or_create(pk=1, skrot=...)` — pk I klucz naturalny razem w lookupie;
+  gdy wiersz o tym samym skrocie istnieje pod innym pk → INSERT →
+  IntegrityError. Działa tylko dzięki sprzężeniu z zawartością baseline'u
+  (`assert pl.pk == 1`).
+
+**Fix:** uuid do defaults; stały klucz naturalny bez daty bieżącej;
+lookup po kluczu naturalnym, nigdy po pk; usunąć `assert pl.pk == 1`.
+
+### 11. `content_type_id=1` na sztywno
+
+- `src/bpp/tests/test_tasks.py:48-49` — po pierwszym flushu na workerze
+  content types odtwarzają się na zjitterowanych sekwencjach →
+  `ForeignKeyViolation` zależny od kolejności worksteal.
+
+**Fix:** `ContentType.objects.get_for_model(...)` (dobry wzorzec:
+`pbn_wysylka_oswiadczen/tests/test_views.py:308`).
+
+### 12. `PYTEST_TESTCONTAINERS_REUSE=1`: dwie sesje pytest na jednym hoście kolidują
+
+- Stałe nazwy kontenerów `bpp-tc-*` + stałe nazwy baz `test_bpp_gwN` —
+  dwie równoległe sesje (człowiek + agent, dwa worktree) robią sobie
+  nawzajem TRUNCATE.
+
+**Fix:** udokumentować „jedna sesja reuse per host" albo kluczyć nazwy
+po ścieżce checkoutu.
+
+---
+
+## Znaleziska POMNIEJSZE
+
+- **Sleepy jako synchronizacja pusha WS**:
+  `test_bpp_with_notifications.py:129,137,157,160` (2 s + 1 s per test);
+  `:72` — `time.sleep(1)` po `form.submit()` w teście webtestowym (eager
+  = synchroniczne; sleep nic nie robi). Docelowo: deterministyczne ACK
+  doręczenia zamiast buforów.
+- **`click` + `wait_for_load_state("domcontentloaded")` = race** (wraca
+  natychmiast na STAREJ stronie): `test_wydawnictwo_autor.py:73-76`,
+  `test_toz_tamze.py:89-96`, `test_wydawnictwo_zwarte.py:49-50`.
+  → `expect_navigation()` albo `expect(...).to_contain_text(...)`.
+- **`time.sleep`-polling blokujący event loop Playwrighta**:
+  `test_crossref_api_sync_playwright.py:12-19`, `test_toz_tamze.py:14-21`.
+  Poprawny wzorzec już jest w `test_clarivate.py:16-18`
+  (`page.wait_for_timeout` w pętli deadline).
+- **`locator.count() == 3` bez auto-waita**: `test_embed_widget.py:38-41`
+  → `expect(...).to_have_count(3)`.
+- **Czas**: `CURRENT_YEAR = datetime.now().year` zamrożony przy imporcie
+  (`bpp/tests/util.py:129`) vs `rok` fixture liczony w call-time;
+  `test_multiseek_basic.py:139` assertuje `str(datetime.now().date())` —
+  flake o północy. → time_machine/freezegun albo jedno źródło zegara.
+- **`test_google_analytics.py:20-31,44-53`** — ręczna mutacja settings
+  z try/finally zamiast fixture'a `settings` (jedyny prawdziwy przypadek;
+  pozostałe ~40 hitów używa fixture'a poprawnie).
+- **`Cookielaw.accept()` bez guarda w fixture'ach**
+  (`playwright_fixtures.py:91,160`) — jeśli skrypt nie zdąży się
+  załadować, cały test pada na setupie.
+- **Martwy finalizer** `normal_django_user`
+  (`src/fixtures/conftest_browser.py:28-31`) — `fin()` zdefiniowane,
+  nigdy nie zarejestrowane.
+- **`test_smoke.py:140-201`** — rekurencyjny crawler z `except: pass`,
+  najdłuższy kandydat na timeout-kill; limit stron/czasu + marker slow.
+- **Budżet czasu**: `--timeout 90` vs pojedyncze waity po 30 s
+  (`test_podpowiedzi_dyscyplin.py:36-38`, `test_smoke.py:168`) — trzy
+  wolne kroki = pytest-timeout ubija test w środku wywołania Playwrighta,
+  co potrafi zostawić zombie-context psujący kolejne testy.
+- **Brak `--tracing retain-on-failure`** — debugowanie flaków CI opiera
+  się na ręcznych dumpach `page.content()` (`test_global_search.py:105-110`).
+- **`refresh_sitemap`** pisze do `src/django_bpp/staticroot`
+  (`test_sitemaps.py:25`, dziś xfail) + `STATICSITEMAPS_ROOT_DIR` liczony
+  z `os.getcwd()` przy imporcie (`base.py:1516`).
+- **`NamedTemporaryFile(delete=False)`** w `src/oswiadczenia/tasks.py:523` —
+  leak pliku przy wyjątku (unikalne nazwy, tylko śmiecenie).
+- **`.test_durations`**: `tests-without-playwright` i `tests-only-playwright`
+  oba mergują plik — nie odpalać dwóch duration-storing suitów naraz
+  w jednym checkoucie.
+- **`import_pracownikow` `Autor.objects.get(pk=50)`**
+  (`tests/test_models/test_models.py:26,36`) — pk zaszyty w XLSX fixture;
+  odporny na jitter (explicit-pk insert), kruchy na zmianę pliku.
+- **Znany in-worker flake pusha channels** (~20% miss między `group_send`
+  a handlerem konsumenta) — udokumentowany w
+  `docs/deweloper/testy-channels-broadcast.md`; NIE jest cross-worker,
+  przeżywa nawet z prefiksem per worker. Wymaga naprawy przyczynowej
+  w warstwie channels, nie w testach.
+
+---
+
+## Plan działań (priorytety)
+
+1. **MEDIA_ROOT → tmp per worker** w `settings/test.py` + `src/media` do
+   `--ignore`/`norecursedirs` + czystka katalogu + test „złego pliku" bez
+   `.py`. (usuwa całą klasę kolizji plikowych i ryzyko importu obcego
+   conftest)
+2. **Kolejność parametrów fixture'ów Playwright** (`transactional_db`
+   przed `page`) + `expect_navigation` w toz/tamze + usunięcie no-op
+   `wait_for_function("() => true")`. (prawdopodobna przyczyna
+   IntegrityError z CI run 28946185913)
+3. **`AssertionError` do `--only-rerun`** + marker flaky dla
+   `test_channels_live_server`. (odzyskuje reruny, na które testy już liczą)
+4. **Jednoznaczne flagi Celery eager + KEY_PREFIX constance**
+   w `settings/test.py`.
+5. **`Site.objects.clear_cache()`** w `_clear_caches` Daphne.
+6. Dalej, stopniowo: fixture'y get_or_create (pkt 10), `content_type_id=1`
+   (pkt 11), globalne count-y (pkt 4), sleepy WS, semantyka markera
+   `serial` (pkt 5), tracing retain-on-failure.

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,11 @@ addopts =
     # PRZED importem Django settings przez pytest-django. Konfiguracja:
     # `[tool.pytest-testcontainers-django]` w pyproject.toml.
     --ignore=dist --ignore=build --ignore=node_modules --ignore=src/django_bpp/staticroot/ --ignore=src/ewaluacja2021/tests/
+    # src/media = MEDIA_ROOT dziedziczony z local.py; historycznie wyciekaly
+    # tam uploadowane pliki (w tym conftest.py), ktore pytest probowal
+    # kolektowac. test.py przekierowuje MEDIA_ROOT do tempdir, ale ignorujemy
+    # katalog na wypadek starych/lokalnych pozostalosci (patrz audyt pkt 1).
+    --ignore=src/media
     --reuse-db
     -l
     --durations=50 --durations-min=1.0
@@ -25,6 +30,10 @@ addopts =
     --only-rerun ElementClickInterceptedException
     --only-rerun ElementDoesNotExist
     --only-rerun OperationalError
+    # AssertionError: bez tego wpisu globalny filtr --only-rerun blokuje
+    # rowniez reruny z markera @pytest.mark.flaky(reruns=N) — a porazki
+    # Playwrightowego expect() to wlasnie AssertionError (audyt pkt 3).
+    --only-rerun AssertionError
     --dist=worksteal
 
 filterwarnings =
@@ -50,7 +59,7 @@ filterwarnings =
     # find_all); nie mamy forku — zgłoszenie upstream (Pylons/webtest).
     ignore:.*findAll.*:DeprecationWarning:webtest\.forms
 
-norecursedirs = src/bpp/media/ .worktrees
+norecursedirs = src/bpp/media/ src/media .worktrees
 
 markers =
     serial: test musi byc wykonany sekwencyjnie (nie moze byc uruchomiony rownolegle z innymi testami)

--- a/src/bpp/newsfragments/+testy-rownoleglosc-xdist.bugfix.rst
+++ b/src/bpp/newsfragments/+testy-rownoleglosc-xdist.bugfix.rst
@@ -1,0 +1,7 @@
+Poprawiona stabilność testów przy uruchamianiu współbieżnym (pytest-xdist,
+sharding CI): izolowany per-worker ``MEDIA_ROOT`` w tempdirze (zamiast
+współdzielonego ``src/media``), poprawna kolejność teardownu fixture'ów
+Playwright (TRUNCATE bazy dopiero po zamknięciu przeglądarki), reruny
+``@flaky`` działające także dla ``AssertionError``, jednoznaczne flagi
+eager Celery, przywrócony per-worker ``KEY_PREFIX`` cache'a constance
+oraz czyszczenie cache ``Site`` w testowym serwerze Daphne.

--- a/src/bpp/tests/test_playwright/test_admin/test_toz_tamze.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_toz_tamze.py
@@ -11,20 +11,24 @@ from bpp.tests import any_ciagle
 from bpp.tests.util import any_patent, any_zwarte
 
 
-def _wait_for(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool:
-    """Poll ``predicate`` until truthy or timeout elapses."""
+def _wait_for(page, predicate, timeout: float = 5.0, interval_ms: int = 50) -> bool:
+    """Pompuj event-loop Playwrighta, aż ``predicate`` stanie się prawdziwy.
+
+    Do pollingu MUSIMY użyć ``page.wait_for_timeout`` (nie ``time.sleep``) —
+    ``time.sleep`` blokuje wątek testu, więc handlery dialogów/route
+    Playwrighta nie mają szansy odpalić w trakcie pollingu i predykat
+    nigdy nie zmienia stanu. Wzorzec: patrz ``test_clarivate._wait_for_dialog``.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if predicate():
             return True
-        time.sleep(interval)
+        page.wait_for_timeout(interval_ms)
     return predicate()
 
 
 @pytest.mark.django_db(transaction=True)
-def test_admin_wydawnictwo_zwarte_tamze(
-    live_server, admin_page: Page, wydawca
-):
+def test_admin_wydawnictwo_zwarte_tamze(live_server, admin_page: Page, wydawca):
     """Test the 'tamze' (ibidem) button for wydawnictwo_zwarte.
 
     The 'tamze' button creates a new publication form pre-populated with
@@ -42,8 +46,7 @@ def test_admin_wydawnictwo_zwarte_tamze(
     )
 
     admin_page.goto(
-        live_server.url
-        + reverse("admin:bpp_wydawnictwo_zwarte_change", args=(c.pk,))
+        live_server.url + reverse("admin:bpp_wydawnictwo_zwarte_change", args=(c.pk,))
     )
     admin_page.wait_for_load_state("domcontentloaded")
 
@@ -80,9 +83,7 @@ def test_admin_patent_tamze(live_server, admin_page: Page):
     """
     c = any_patent(informacje="TO INFORMACJE")
 
-    admin_page.goto(
-        live_server.url + reverse("admin:bpp_patent_change", args=(c.pk,))
-    )
+    admin_page.goto(live_server.url + reverse("admin:bpp_patent_change", args=(c.pk,)))
     admin_page.wait_for_load_state("domcontentloaded")
 
     # Click the "tamze" button
@@ -105,8 +106,7 @@ def test_admin_wydawnictwo_zwarte_toz(live_server, admin_page: Page):
     c = any_zwarte(informacje="TO INFOMRACJE")
 
     admin_page.goto(
-        live_server.url
-        + reverse("admin:bpp_wydawnictwo_zwarte_change", args=(c.pk,))
+        live_server.url + reverse("admin:bpp_wydawnictwo_zwarte_change", args=(c.pk,))
     )
     admin_page.wait_for_load_state("domcontentloaded")
 
@@ -122,22 +122,20 @@ def test_admin_wydawnictwo_zwarte_toz(live_server, admin_page: Page):
 
     admin_page.on("dialog", handle_dialog)
 
-    # Click the "toz" button
-    admin_page.click("#toz")
-
-    # Wait for the copy to be created
-    admin_page.wait_for_function(
-        "() => true",  # Just wait for dialog to be processed
-        timeout=5000,
-    )
+    # #toz: dialog confirm → location.href="../../toz/<pk>" → widok tworzy
+    # kopię (commit) i przekierowuje na change-form kopii. Blokujemy do
+    # zakończenia tej nawigacji, żeby GET/toz + insert + redirect + finalny
+    # GET zdążyły się dokończyć ZANIM czytamy bazę i ZANIM teardown truncuje.
+    with admin_page.expect_navigation(wait_until="domcontentloaded"):
+        admin_page.click("#toz")
 
     # Verify the dialog contained the expected text
-    assert any(
-        "Utworzysz kopię tego rekordu" in text for text in dialog_text
-    ), f"Expected dialog with 'Utworzysz kopię tego rekordu', got: {dialog_text}"
+    assert any("Utworzysz kopię tego rekordu" in text for text in dialog_text), (
+        f"Expected dialog with 'Utworzysz kopię tego rekordu', got: {dialog_text}"
+    )
 
-    # Wait for the new record to be created
-    _wait_for(lambda: wcc() == 2)
+    # Po zakończonej nawigacji kopia jest już scommitowana.
+    _wait_for(admin_page, lambda: wcc() == 2)
     assert wcc() == 2, f"Expected 2 records, got {wcc()}"
 
 
@@ -147,12 +145,17 @@ def test_admin_wydawnictwo_ciagle_toz(live_server, admin_page: Page):
 
     The 'toz' button creates a copy of the publication record.
     """
+    # Defensywny guard przeciw wyciekowi scommitowanych Wydawnictwo_Ciagle z
+    # innych testów (transaction=True → dane lądują w realnej bazie, a jeśli
+    # TRUNCATE poprzedniego testu zawiódł/wyścignął się — patrz audyt
+    # równoległości — zostawał sierocy rekord). Pod poprawną izolacją to no-op;
+    # ZOSTAWIAMY, bo dopóki izolacja Playwright/Daphne nie jest w 100% pewna,
+    # usunięcie tego przywróciłoby flaka (assert wcc()==1 niżej padał).
     Wydawnictwo_Ciagle.objects.all().delete()
     c = any_ciagle(informacje="TO INFORMACJE")
 
     admin_page.goto(
-        live_server.url
-        + reverse("admin:bpp_wydawnictwo_ciagle_change", args=(c.pk,))
+        live_server.url + reverse("admin:bpp_wydawnictwo_ciagle_change", args=(c.pk,))
     )
     admin_page.wait_for_load_state("domcontentloaded")
 
@@ -168,22 +171,20 @@ def test_admin_wydawnictwo_ciagle_toz(live_server, admin_page: Page):
 
     admin_page.on("dialog", handle_dialog)
 
-    # Click the "toz" button
-    admin_page.click("#toz")
-
-    # Wait for the copy to be created
-    admin_page.wait_for_function(
-        "() => true",  # Just wait for dialog to be processed
-        timeout=5000,
-    )
+    # #toz: dialog confirm → location.href="../../toz/<pk>" → widok tworzy
+    # kopię (commit) i przekierowuje na change-form kopii. Blokujemy do
+    # zakończenia tej nawigacji, żeby GET/toz + insert + redirect + finalny
+    # GET zdążyły się dokończyć ZANIM czytamy bazę i ZANIM teardown truncuje.
+    with admin_page.expect_navigation(wait_until="domcontentloaded"):
+        admin_page.click("#toz")
 
     # Verify the dialog contained the expected text
-    assert any(
-        "Utworzysz kopię tego rekordu" in text for text in dialog_text
-    ), f"Expected dialog with 'Utworzysz kopię tego rekordu', got: {dialog_text}"
+    assert any("Utworzysz kopię tego rekordu" in text for text in dialog_text), (
+        f"Expected dialog with 'Utworzysz kopię tego rekordu', got: {dialog_text}"
+    )
 
-    # Wait for the new record to be created
-    _wait_for(lambda: wcc() == 2)
+    # Po zakończonej nawigacji kopia jest już scommitowana.
+    _wait_for(admin_page, lambda: wcc() == 2)
     assert wcc() == 2, f"Expected 2 Wydawnictwo_Ciagle records, got {wcc()}"
 
 
@@ -195,9 +196,7 @@ def test_admin_patent_toz(live_server, admin_page: Page):
     """
     c = any_patent(informacje="TO INFORMACJE")
 
-    admin_page.goto(
-        live_server.url + reverse("admin:bpp_patent_change", args=(c.pk,))
-    )
+    admin_page.goto(live_server.url + reverse("admin:bpp_patent_change", args=(c.pk,)))
     admin_page.wait_for_load_state("domcontentloaded")
 
     wcc = Patent.objects.count
@@ -212,25 +211,20 @@ def test_admin_patent_toz(live_server, admin_page: Page):
 
     admin_page.on("dialog", handle_dialog)
 
-    # Click the "toz" button
-    admin_page.click("#toz")
-
-    # Wait for the copy to be created
-    admin_page.wait_for_function(
-        "() => true",  # Just wait for dialog to be processed
-        timeout=5000,
-    )
+    # #toz: dialog confirm → location.href="../../toz/<pk>" → widok tworzy
+    # kopię (commit) i przekierowuje na change-form kopii. Blokujemy do
+    # zakończenia tej nawigacji, żeby GET/toz + insert + redirect + finalny
+    # GET zdążyły się dokończyć ZANIM czytamy bazę i ZANIM teardown truncuje.
+    with admin_page.expect_navigation(wait_until="domcontentloaded"):
+        admin_page.click("#toz")
 
     # Verify the dialog contained the expected text
-    assert any(
-        "Utworzysz kopię tego rekordu" in text for text in dialog_text
-    ), f"Expected dialog with 'Utworzysz kopię tego rekordu', got: {dialog_text}"
+    assert any("Utworzysz kopię tego rekordu" in text for text in dialog_text), (
+        f"Expected dialog with 'Utworzysz kopię tego rekordu', got: {dialog_text}"
+    )
 
-    # Wait for the navigation to complete
-    admin_page.wait_for_selector("#navigation-menu", timeout=10000)
-
-    # Wait for the new record to be created
-    _wait_for(lambda: wcc() == 2)
+    # Po zakończonej nawigacji kopia jest już scommitowana.
+    _wait_for(admin_page, lambda: wcc() == 2)
     assert wcc() == 2, f"Expected 2 Patent records, got {wcc()}"
 
 
@@ -244,8 +238,7 @@ def test_admin_wydawnictwo_ciagle_tamze(live_server, admin_page: Page):
     c = any_ciagle(informacje="TO INFORMACJE", uwagi="te uwagi", www="te www")
 
     admin_page.goto(
-        live_server.url
-        + reverse("admin:bpp_wydawnictwo_ciagle_change", args=(c.pk,))
+        live_server.url + reverse("admin:bpp_wydawnictwo_ciagle_change", args=(c.pk,))
     )
     admin_page.wait_for_load_state("domcontentloaded")
 

--- a/src/channels_live_server.py
+++ b/src/channels_live_server.py
@@ -92,13 +92,26 @@ def _wire_per_request_cache_invalidation():
       ``content_type_id=70`` którego już nie ma w bazie (np.
       ``test_Wydawnictwo_Zwarte_Autor_Admin_forwarding_works``).
 
-    Overhead clear_cache to single dict.clear() — pomijalny.
+    ``Site.objects.clear_cache()`` z tej samej klasy problemu — Django
+    trzyma ``SITE_CACHE`` (dict ``id`` → ``Site``) na poziomie modułu
+    ``django.contrib.sites.models`` procesu. Projekt woła
+    ``get_current_site()`` (``bpp/admin/uczelnia.py``,
+    ``bpp_setup_wizard/forms.py``), a po ``transactional_db`` TRUNCATE
+    wiersze w ``django_site`` odtwarzają się na innych ID-ach.
+    Session-scoped Daphne trzymający stary obiekt ``Site`` daje
+    sporadyczne ``Site.DoesNotExist`` / 500-ki zależne od kolejności
+    testów na workerze — dokładnie ten sam wektor co KeyError na
+    ContentType, tylko na innym module-level cache.
+
+    Overhead obu clear_cache to dwa ``dict.clear()`` — pomijalny.
     """
     from django.contrib.contenttypes.models import ContentType
+    from django.contrib.sites.models import Site
     from django.core.signals import request_started
 
     def _clear_caches(sender, **kwargs):
         ContentType.objects.clear_cache()
+        Site.objects.clear_cache()
 
     request_started.connect(_clear_caches, weak=False)
 

--- a/src/django_bpp/settings/test.py
+++ b/src/django_bpp/settings/test.py
@@ -10,8 +10,60 @@
 # (dev + testy). Po rozdzieleniu strażnik jest zbędny: ten plik ładuje się
 # tylko dla testów, więc nakładamy je bezwarunkowo.
 
+import os
+import tempfile
+
 from .local import *  # noqa
-from .local import INSTALLED_APPS, LIVEOPS, MIDDLEWARE  # noqa
+from .local import CACHES, INSTALLED_APPS, LIVEOPS, MIDDLEWARE  # noqa
+
+# MEDIA_ROOT per-proces (worker xdist). Domyślnie testy dziedziczyły
+# MEDIA_ROOT = <repo>/src/media z local.py — JEDEN wspólny katalog w drzewie
+# źródeł dla wszystkich workerów. Skutki (audyt
+# docs/deweloper/audyt-testy-rownoleglosc-2026-07.md, pkt 1): kolizje plików
+# między workerami (maskowane sufiksami dedupe FileSystemStorage — ~1800
+# wyciekłych plików) oraz, groźniejsze, pytest importował uploadowany do
+# MEDIA_ROOT conftest.py (obok powstawał __pycache__), co potrafiło wywalić
+# kolekcję całej suity ImportError-em. Każdy worker dostaje własny izolowany
+# tempdir (mkdtemp — dwie równoległe sesje pytest na jednym hoście się nie
+# zderzą), a ścieżka jest PINOWANA w zmiennej środowiskowej per worker.
+# Env var (a nie PID w nazwie katalogu): subprocess Daphne
+# (channels_live_server) na macOS startuje przez multiprocessing *spawn*
+# i RE-IMPORTUJE settings z nowym PID-em — klucz z PID-em dałby mu inny
+# MEDIA_ROOT niż workerowi pytest (a na Linuksie/CI fork dziedziczy moduł
+# → ten sam; rozjazd mac-vs-CI). Env var dziedziczą oba mechanizmy, więc
+# worker i jego dzieci widzą ten sam katalog. Nazwa zmiennej zawiera id
+# workera, bo kontroler xdist też importuje settings (jako "master")
+# i jego wartość nie może przeciec do workerów gwN przez dziedziczone
+# środowisko.
+_media_worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+_media_env = f"DJANGO_BPP_TEST_MEDIA_ROOT_{_media_worker}"
+MEDIA_ROOT = os.environ.get(_media_env)
+if not MEDIA_ROOT:
+    MEDIA_ROOT = tempfile.mkdtemp(prefix=f"bpp-test-media-{_media_worker}-")
+    os.environ[_media_env] = MEDIA_ROOT
+os.makedirs(MEDIA_ROOT, exist_ok=True)
+SENDFILE_ROOT = MEDIA_ROOT
+
+# Flagi eager Celery jawnie i jednoznacznie w testach. base.py ustawia je pod
+# TESTING, ale local.py:64 bezwarunkowo resetuje CELERY_ALWAYS_EAGER = False
+# (podwójna rola local.py: dev + testy). Fallback = .delay() cicho publikuje do
+# wspólnego brokera Redis DB 1 bez konsumenta → task nigdy się nie wykona
+# (silent no-op zależny od kolejności). Patrz audyt pkt 6.
+CELERY_ALWAYS_EAGER = True
+CELERY_TASK_ALWAYS_EAGER = True
+CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+
+# constance_cache (Redis DB 8) — per-worker KEY_PREFIX. Prefiks istniał
+# (commit 137fec4df) i zginął w refaktorze test/local 55e0b1aa6 — regresja z
+# audytu pkt 7. Bez niego pierwszy realny klucz constance wskrzesza
+# cross-worker leak (worker A cache'uje wartość, worker B ją czyta mimo innej
+# własnej bazy). Kopiujemy strukturę, by nie mutować obiektów współdzielonych
+# z local.py.
+CACHES = {**CACHES}
+CACHES["constance_cache"] = {
+    **CACHES["constance_cache"],
+    "KEY_PREFIX": os.environ.get("PYTEST_XDIST_WORKER", "master"),
+}
 
 # django-liveops: w testach uruchamiaj operacje SYNCHRONICZNIE w wątku
 # żądania (bez Redis/Celery workera). run() biegnie od razu, p.track/p.result

--- a/src/fixtures/conftest.py
+++ b/src/fixtures/conftest.py
@@ -34,8 +34,9 @@ def pytest_configure():
         del settings.RAVEN_CONFIG
 
     settings.TESTING = True
-    settings.CELERY_ALWAYS_EAGER = True
-    settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+    # Flagi eager Celery ustawia teraz jednoznacznie settings/test.py
+    # (CELERY_ALWAYS_EAGER / _TASK_ALWAYS_EAGER / _EAGER_PROPAGATES_EXCEPTIONS);
+    # dawny re-set w tym hooku był redundantny — patrz audyt pkt 6.
 
     from bpp.models.cache import Autorzy, Rekord
 
@@ -79,15 +80,20 @@ def szablony():
 
     def instaluj_szablony():
         from dbtemplates.models import Template
+
         create_template(Template, "opis_bibliograficzny.html")
         create_template(Template, "browse/praca_tabela.html")
 
-        from bpp.models.szablondlaopisubibliograficznego import SzablonDlaOpisuBibliograficznego
+        from bpp.models.szablondlaopisubibliograficznego import (
+            SzablonDlaOpisuBibliograficznego,
+        )
+
         SzablonDlaOpisuBibliograficznego.objects.create(
             model=None,
             template=Template.objects.get(name="opis_bibliograficzny.html"),
         )
 
     from dbtemplates.models import Template
+
     instaluj_szablony()
     return Template.objects

--- a/src/fixtures/playwright_fixtures.py
+++ b/src/fixtures/playwright_fixtures.py
@@ -3,9 +3,34 @@
 import pytest
 from playwright.sync_api import Page
 
+# =============================================================================
+# INWARIANT KOLEJNOŚCI PARAMETRÓW — NIE PRZESTAWIAĆ `transactional_db`!
+#
+# `transactional_db` MUSI być PIERWSZYM parametrem każdej z poniższych
+# fikstur. Pytest tworzy fikstury o tym samym zasięgu (function) w kolejności
+# lewa→prawa z sygnatury i finalizuje je w ODWROTNEJ kolejności (LIFO):
+# fikstura utworzona jako ostatnia jest sprzątana jako pierwsza.
+#
+# `transactional_db` na końcu sygnatury → sprzątany PIERWSZY → jego
+# TRUNCATE/flush bazy leci, GDY przeglądarka (page/context) jeszcze żyje i
+# może mieć in-flight requesty do session-scoped Daphne. Serwer widzi
+# częściowo wyczyszczoną bazę → ForeignKeyViolation / deadlock (realny
+# IntegrityError z CI — audyt: docs/deweloper/audyt-testy-rownoleglosc-2026-07.md).
+#
+# `transactional_db` na POCZĄTKU sygnatury → tworzony PIERWSZY → sprzątany
+# OSTATNI. Wtedy pytest-playwright zdąży zamknąć browser context (finalizer
+# fikstury `new_context`, który woła `context.close()`) ZANIM baza zostanie
+# wyczyszczona. Sam context.close() nie jest tu potrzebny — wystarczy
+# kolejność parametrów, bo pytest-playwright zamyka context w swoim własnym
+# finalizerze, a ten biegnie przed finalizerem `transactional_db`.
+#
+# `channels_live_server` jest session-scoped, więc jego pozycja w sygnaturze
+# nie wpływa na sprzątanie między-testowe (żyje przez cały worker xdist).
+# =============================================================================
+
 
 @pytest.fixture
-def admin_page(page: Page, admin_user, channels_live_server, transactional_db):
+def admin_page(transactional_db, page: Page, admin_user, channels_live_server):
     """Provide a pre-authenticated admin page."""
     # Import here to avoid Django app loading issues
     from django.test import Client
@@ -36,7 +61,7 @@ def admin_page(page: Page, admin_user, channels_live_server, transactional_db):
 
 
 @pytest.fixture
-def preauth_page(page: Page, normal_django_user, live_server, transactional_db):
+def preauth_page(transactional_db, page: Page, normal_django_user, live_server):
     """Provide a pre-authenticated regular user page."""
     # Import here to avoid Django app loading issues
     from django.test import Client
@@ -67,7 +92,7 @@ def preauth_page(page: Page, normal_django_user, live_server, transactional_db):
 
 
 @pytest.fixture
-def preauth_asgi_page(preauth_page: Page, channels_live_server, transactional_db):
+def preauth_asgi_page(transactional_db, preauth_page: Page, channels_live_server):
     """Provide a pre-authenticated page with WebSocket connection."""
     # Import here to avoid Django app loading issues
     import time
@@ -110,7 +135,7 @@ def preauth_asgi_page(preauth_page: Page, channels_live_server, transactional_db
 
 @pytest.fixture
 def admin_page_per_test(
-    page: Page, admin_user, channels_live_server_per_test, transactional_db
+    transactional_db, page: Page, admin_user, channels_live_server_per_test
 ):
     """Function-scoped wariant `admin_page` — fresh Daphne per test."""
     from django.test import Client
@@ -136,7 +161,7 @@ def admin_page_per_test(
 
 @pytest.fixture
 def preauth_asgi_page_per_test(
-    preauth_page: Page, channels_live_server_per_test, transactional_db
+    transactional_db, preauth_page: Page, channels_live_server_per_test
 ):
     """Function-scoped wariant `preauth_asgi_page` — fresh Daphne per test."""
     import time

--- a/src/import_dyscyplin/tests/conftest.py
+++ b/src/import_dyscyplin/tests/conftest.py
@@ -65,8 +65,15 @@ def test5_kasowanie_subdyscypliny(parent_path):
 
 
 @pytest.fixture
-def conftest_py(parent_path):
-    return str(parent_path / "conftest.py")
+def zly_plik(tmp_path):
+    # Plik, który NIE jest arkuszem XLSX — testy sprawdzają odrzucenie złego
+    # typu pliku. Wcześniej uploadowano tu prawdziwy conftest.py tego katalogu,
+    # który lądował w MEDIA_ROOT i bywał importowany przez pytest przy kolekcji
+    # (obok powstawał __pycache__) — patrz audyt pkt 1. Śmieciowy .txt w
+    # tmp_path zachowuje semantykę „to nie XLSX", bez ryzyka importu.
+    p = tmp_path / "zly_plik.txt"
+    p.write_bytes(b"To nie jest arkusz XLSX \x00\x01\x02 losowe smieci")
+    return str(p)
 
 
 @pytest.fixture

--- a/src/import_dyscyplin/tests/test_core.py
+++ b/src/import_dyscyplin/tests/test_core.py
@@ -5,9 +5,9 @@ from import_dyscyplin.core import przeanalizuj_plik_xls
 from import_dyscyplin.models import Import_Dyscyplin_Row
 
 
-def test_przeanalizuj_plik_xls_zly_plik(conftest_py):
+def test_przeanalizuj_plik_xls_zly_plik(zly_plik):
     with pytest.raises(ImproperFileException):
-        przeanalizuj_plik_xls(conftest_py, parent=None)
+        przeanalizuj_plik_xls(zly_plik, parent=None)
 
 
 def test_przeanalizuj_plik_xls_wiele_skoroszytow(test3_multiple_sheets_xlsx):

--- a/src/import_dyscyplin/tests/test_views.py
+++ b/src/import_dyscyplin/tests/test_views.py
@@ -32,9 +32,9 @@ def wyslij_i_przeanalizuj(wd_app, plik):
     return i
 
 
-def test_CreateImport_DyscyplinView_bledny_plik(wd_app, conftest_py, transactional_db):
+def test_CreateImport_DyscyplinView_bledny_plik(wd_app, zly_plik, transactional_db):
     with transaction.atomic():
-        wyslij_i_przeanalizuj(wd_app, conftest_py)
+        wyslij_i_przeanalizuj(wd_app, zly_plik)
 
     assert Import_Dyscyplin.objects.all().count() == 1
     i = Import_Dyscyplin.objects.all().first()

--- a/src/integration_tests/test_bpp_with_notifications.py
+++ b/src/integration_tests/test_bpp_with_notifications.py
@@ -92,13 +92,21 @@ def test_live_server(live_server, page: Page):
     expect(page.locator("body")).not_to_contain_text("Wystąpił błąd")
 
 
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.django_db(transaction=True)
 def test_channels_live_server(preauth_asgi_page: Page):
+    # Ten sam probabilistyczny flake (~20% per run) co `test_bpp_notifications`
+    # i `test_bpp_notifications_and_messages`: notyfikacja ginie gdzies miedzy
+    # `send_notification` (`group_send`) a `chat_message` handlerem consumera w
+    # Daphne, mimo udowodnionej subskrypcji WS w fixture
+    # (wait_for_channel_subscription). 2-sekundowy bufor PRZED wyslaniem obniza
+    # miss-rate z ~80% do ~20%, `@flaky(reruns=3)` lapie reszte. Patrz
+    # docs/deweloper/testy-channels-broadcast.md.
     s = "test notyfikacji 123 456"
 
     page = preauth_asgi_page
 
-    page.wait_for_timeout(500)
+    page.wait_for_timeout(2000)  # Pozwol subskrypcji WS sie ustabilizowac
 
     call_command(
         "send_notification",
@@ -109,7 +117,7 @@ def test_channels_live_server(preauth_asgi_page: Page):
     )
 
     page.wait_for_function(
-        f"() => document.body.textContent.includes('{s}')", timeout=1000
+        f"() => document.body.textContent.includes('{s}')", timeout=15000
     )
 
 


### PR DESCRIPTION
## Co i po co

Wdrożenie punktów 1–5 audytu testów pod kątem współbieżności (pytest-xdist, sharding CI, live servery). Pełny raport audytu w repo: `docs/deweloper/audyt-testy-rownoleglosc-2026-07.md`.

### 1. MEDIA_ROOT per worker (settings/test.py, pytest.ini, import_dyscyplin)
- Dotąd wszystkie workery xdist współdzieliły `src/media` w drzewie źródeł — ~1800 wyciekłych plików (62 MB), kolizje maskowane sufiksami dedupe, a **pytest importował uploadowany do media `conftest.py`** (obok leżał `__pycache__`).
- Teraz: tempdir per worker, pinowany env varem (spawn-owany na macOS subprocess Daphne widzi ten sam katalog co worker; na Linuksie fork — bez różnicy). `src/media` w `--ignore`/`norecursedirs`. Testy „złego pliku" uploadują junk `.txt`.

### 2. Kolejność teardownu fixture'ów Playwright (playwright_fixtures.py, test_toz_tamze.py)
- `transactional_db` jako pierwszy parametr fixture'ów auth-page → TRUNCATE dopiero po zamknięciu kontekstu przeglądarki. Dotąd flush biegł przy żywej stronie z in-flight requestami do sesyjnego Daphne → `ForeignKeyViolation`/deadlock (pasuje do IntegrityError z runu 28946185913).
- toz/tamze: `expect_navigation` po klikach, usunięte no-op `wait_for_function("() => true")`, polling bez blokującego `time.sleep`.

### 3. Reruny flaków (pytest.ini, test_bpp_with_notifications.py)
- `AssertionError` dodany do `--only-rerun` — globalny filtr pytest-rerunfailures obejmuje też reruny z markera `@flaky`, więc failujące `expect()` Playwrighta nigdy się nie rerunowały.
- `test_channels_live_server` ujednolicony z sąsiadami (marker flaky, timeouty 1 s → 15 s).

### 4. Celery eager + constance (settings/test.py, fixtures/conftest.py)
- Trzy flagi eager jawnie `True` (local.py bezwarunkowo resetował `CELERY_ALWAYS_EAGER=False`; fallback = cichy no-op przez wspólny broker Redis DB 1 bez konsumenta).
- Przywrócony per-worker `KEY_PREFIX` dla `constance_cache` (regresja z refaktoru 55e0b1aa6).

### 5. Site cache w Daphne (channels_live_server.py)
- `Site.objects.clear_cache()` per request — `SITE_CACHE` przeżywał TRUNCATE między testami (ten sam wektor co naprawiony wcześniej cache ContentType).

## Weryfikacja lokalna
- `test_toz_tamze.py`: 7 passed (kontenery + chromium)
- `import_dyscyplin` core+views+**integracyjny Playwright z uploadem przez Daphne**: 13 passed — potwierdza pinowanie MEDIA_ROOT przez granicę spawn
- `src/media` po realnym uploadzie: 0 plików
- strażnicy infra (`test_channels_prefix`, `test_conftest_preload_safety`): 6 passed
- ruff format/check czyste

Pełne `make tests` leci lokalnie równolegle z CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)