### PR TITLE
fix(promote): uvx zamiast uv run dla bumpver/towncrier

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -114,9 +114,18 @@ jobs:
           set -euo pipefail
           # --set-version (NIE --tag final): --tag final dodatkowo bumpnąłby
           # BUILD (1394→1395), rozjeżdżając wersję finalną z testowanym RC.
-          uv run bumpver update --no-fetch --commit --no-push \
+          #
+          # UWAGA: `uvx` (izolowany tool env), a NIE `uv run`. `uv run` na
+          # gołym hoście runnera synchronizowałby CAŁY projekt bpp (300+
+          # pakietów) tylko po to, by odpalić utility do wersjonowania — a to
+          # buduje natywne rozszerzenia ze źródeł (pycairo przez
+          # xhtml2pdf→svglib→rlpycairo) i wywala się na runnerze bez nagłówków
+          # cairo. bumpver/towncrier czytają tylko ./pyproject.toml i edytują
+          # pliki — nie potrzebują env projektu. (Ten sam wzorzec i uzasadnienie
+          # co w release-candidate.yml.)
+          uvx bumpver update --no-fetch --commit --no-push \
             --set-version "v${BASE}"
-          uv run towncrier build --yes || echo "towncrier: brak newsfragmentów."
+          uvx towncrier build --yes || echo "towncrier: brak newsfragmentów."
           git add -A
           git commit -m "Changelog dla v${BASE}" || echo "Brak zmian changelogu."
 


### PR DESCRIPTION
## Problem

`make release-promote` (workflow `promote.yml`) padł na kroku **„Finalizuj wersję + towncrier”** — [run 28959987746](https://github.com/iplweb/bpp/actions/runs/28959987746):

```
Run-time dependency cairo found: NO (tried pkg-config and cmake)
ERROR: Dependency "cairo" not found (tried pkg-config and cmake)
hint: `pycairo` (v1.29.0) was included because `bpp-iplweb` depends on
`xhtml2pdf` → `svglib` → `rlpycairo` → `pycairo`
```

Krok robił `uv run bumpver …` / `uv run towncrier …`. `uv run` **najpierw synchronizuje CAŁY projekt bpp** (300+ pakietów) do świeżego `.venv` na runnerze — tylko po to, by odpalić dwa narzędzia do wersjonowania. Ten sync buduje `pycairo` 1.29.0 ze źródeł (brak wheela), a runner nie ma nagłówków cairo/pkg-config → build fail → `uv` exit 1.

Padło **przed** ruszeniem `master`/`dev` (finalizacja jest wcześniej niż `git push`), więc żadne wydanie nie zostało half-applied — obrazy RC czekają w rejestrze nietknięte.

## Fix

`uv run` → `uvx` dla obu narzędzi. `uvx` odpala je w izolowanym tool env, bez syncu projektu bpp. bumpver/towncrier czytają tylko `./pyproject.toml` i edytują pliki w repo — nie potrzebują env projektu.

To **ten sam wzorzec i uzasadnienie**, które `release-candidate.yml` już stosuje (i przed którym jawnie ostrzega w komentarzu przy `uvx bumpver`). `promote.yml` był jedynym miejscem, które zostało z `uv run`.

## Dlaczego bez zmiany zachowania

- `bumpver` file_pattern `'version = "{pep440_version}"'` rewrite'uje **globalnie** wszystkie linie `version = "…"` w `pyproject.toml`, w tym `[tool.towncrier] version`. Więc po `bumpver update` towncrier dostaje finalny numer **z configu** — bez importu pakietu `bpp` (którego w izolowanym env nie ma).
- Katalog fragmentów (`src/bpp/newsfragments`) towncrier lokalizuje ścieżką, nie importem.
- Wywołanie `uvx bumpver update --set-version` jest identyczne jak już-używane w `release-candidate.yml`.

## Po zmergowaniu

Ponowić promocję: `make release-promote` (RC `202607.1397rc1` nadal w rejestrze, więc bez rebuildu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)