### PR TITLE
test(xdist): mniejsze poprawki z audytu współbieżności (runda 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ src/bpp/static/rollbar/
 
 # SDD workflow scratch (briefs, reports, ledger, diffs)
 .superpowers/
+
+# pytest-playwright: katalog na trace/screenshot/video z --tracing itp.
+test-results/

--- a/docs/deweloper/audyt-testy-rownoleglosc-2026-07.md
+++ b/docs/deweloper/audyt-testy-rownoleglosc-2026-07.md
@@ -223,6 +223,25 @@ inne module-level cache (dbtemplates, cache Uczelni).
 
 **Fix:** nawigować na `channels_live_server.url` (już wstrzyknięty).
 
+**UZUPEŁNIENIE (po wdrożeniu):** przełączenie NIE jest bezwarunkowe.
+Kryterium wyboru serwera:
+
+- `channels_live_server` (Daphne, **subprocess**) — domyślnie; wymagany
+  dla WebSocket/notyfikacji.
+- `live_server` (WSGI, **wątek w procesie testu**) — WYMAGANY, gdy test
+  opiera się na stanie żyjącym tylko w procesie testu: `mocker.patch` /
+  `monkeypatch` na kodzie serwerowym (np. `test_clarivate.py` patchuje
+  `Uczelnia.wosclient`), fixture `settings` pytest-django (np.
+  `test_oswiadczenie_ken.py` zmienia `BPP_POKAZUJ_OSWIADCZENIE_KEN`),
+  kasety VCR dla server-side HTTP (np.
+  `test_crossref_api_sync_playwright.py` — widok „pobierz z crossref"
+  woła api.crossref.org). Subprocess Daphne ma własną kopię settings
+  i nie widzi monkeypatchy — test z Daphne wykonuje PRAWDZIWY kod
+  (albo idzie w prawdziwą sieć) zamiast mocka.
+
+Pliki wymagające `live_server` mają komentarz „UWAGA: celowo
+live_server" przy fiksturach.
+
 ### 10. Wyścigi we wzorcach fixture'owych `get_or_create`
 
 - `pbn_dyscyplina2` (`src/conftest.py:390-399`): `uuid=uuid4()` w LOOKUPIE

--- a/pytest.ini
+++ b/pytest.ini
@@ -35,12 +35,11 @@ addopts =
     # Playwrightowego expect() to wlasnie AssertionError (audyt pkt 3).
     --only-rerun AssertionError
     --dist=worksteal
-    # Playwright: przy porazce testu zapisz trace (zip do podgladu w
-    # trace.playwright.dev) do domyslnego katalogu test-results/. Bezpieczne
-    # pod xdist — pytest-playwright tworzy per-test podkatalog z unikalnego
-    # (slugowanego) nodeid, a pliki trace maja nazwy GUID, wiec workery sie
-    # nie nadpisuja (audyt: debugowalnosc flakow Playwrighta).
-    --tracing retain-on-failure
+    # Playwright tracing celowo WYLACZONY (nagrywanie trace kazdego testu
+    # podwaja czas kroku Playwright: ~2 min → ~4 min). Do debugowania
+    # pojedynczego flaka wlacz recznie:
+    #   uv run pytest <test> --tracing retain-on-failure
+    # (trace zip laduje w test-results/, podglad: playwright show-trace).
 
 filterwarnings =
     default

--- a/pytest.ini
+++ b/pytest.ini
@@ -35,6 +35,12 @@ addopts =
     # Playwrightowego expect() to wlasnie AssertionError (audyt pkt 3).
     --only-rerun AssertionError
     --dist=worksteal
+    # Playwright: przy porazce testu zapisz trace (zip do podgladu w
+    # trace.playwright.dev) do domyslnego katalogu test-results/. Bezpieczne
+    # pod xdist — pytest-playwright tworzy per-test podkatalog z unikalnego
+    # (slugowanego) nodeid, a pliki trace maja nazwy GUID, wiec workery sie
+    # nie nadpisuja (audyt: debugowalnosc flakow Playwrighta).
+    --tracing retain-on-failure
 
 filterwarnings =
     default
@@ -62,7 +68,7 @@ filterwarnings =
 norecursedirs = src/bpp/media/ src/media .worktrees
 
 markers =
-    serial: test musi byc wykonany sekwencyjnie (nie moze byc uruchomiony rownolegle z innymi testami)
+    serial: testy z tej samej grupy katalogowej (4 pierwsze skladniki sciezki) sa laczone w jeden xdist_group i wykonuja sie sekwencyjnie na tym samym workerze xdist; NIE gwarantuje globalnej wylacznosci wzgledem testow spoza tej grupy (patrz src/conftest.py pytest_collection_modifyitems)
     xdist_group: grupuje testy do wykonania na tym samym workerze w pytest-xdist (uzywa pytest-xdist)
     slow: wolne testy, pomijane przy szybkim przebiegu
     playwright: testy wymagajace przegladarki (Playwright)

--- a/src/bpp/tests/test_admin/test_crossref_api_sync_playwright.py
+++ b/src/bpp/tests/test_admin/test_crossref_api_sync_playwright.py
@@ -9,13 +9,20 @@ from playwright.sync_api import Page
 from bpp.models import Autor, Wydawnictwo_Ciagle
 
 
-def _poll_until(predicate, timeout: float = 10.0, interval: float = 0.1) -> bool:
-    """Poll ``predicate`` until truthy or timeout elapses; return last result."""
+def _poll_until(page, predicate, timeout: float = 10.0, interval_ms: int = 100) -> bool:
+    """Pompuj event-loop Playwrighta, aż ``predicate`` stanie się prawdziwy.
+
+    Do pollingu MUSIMY użyć ``page.wait_for_timeout`` (nie ``time.sleep``) —
+    ``time.sleep`` blokuje wątek testu, więc handlery route/dialogów
+    Playwrighta nie mają szansy odpalić w trakcie pollingu i predykat
+    (zależny od efektów po stronie serwera) nigdy nie zmienia stanu.
+    Wzorzec: patrz ``test_clarivate._wait_for_dialog``.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if predicate():
             return True
-        time.sleep(interval)
+        page.wait_for_timeout(interval_ms)
     return predicate()
 
 
@@ -29,6 +36,11 @@ def autor_m():
     )
 
 
+# UWAGA: testy w tym pliku celowo uzywaja ``live_server`` (WSGI, watek
+# W PROCESIE testu), NIE ``channels_live_server`` (Daphne, subprocess).
+# Kasety VCR (@pytest.mark.vcr) patchuja HTTP tylko w procesie testu —
+# widok "pobierz z crossref" wykonuje zapytania do api.crossref.org
+# server-side, wiec pod Daphne leci prawdziwy ruch sieciowy zamiast kaset.
 @pytest.mark.vcr(ignore_localhost=True)
 def test_crossref_api_autor_sync(
     admin_page: Page, live_server, transactional_db, autor_m
@@ -54,7 +66,7 @@ def test_crossref_api_autor_sync(
             return autor_m.orcid == "0000-0003-2575-3642"
 
         # Poll until ORCID is updated (max 10 seconds, 100ms granularity).
-        _poll_until(check_orcid)
+        _poll_until(admin_page, check_orcid)
 
         assert check_orcid(), (
             f"Expected ORCID to be '0000-0003-2575-3642', got '{autor_m.orcid}'"
@@ -101,7 +113,6 @@ def admin_page_strona_porownania(admin_page: Page, live_server):
 def test_crossref_api_strony_sync_browser(
     transactional_db,
     wydawnictwo_ciagle_jehs_2022,
-    live_server,
     admin_page_strona_porownania: Page,
     id_przycisku,
     atrybut,
@@ -116,7 +127,7 @@ def test_crossref_api_strony_sync_browser(
         wydawnictwo_ciagle_jehs_2022.refresh_from_db()
         return getattr(wydawnictwo_ciagle_jehs_2022, atrybut, None) == wynik
 
-    _poll_until(check_attribute)
+    _poll_until(admin_page_strona_porownania, check_attribute)
 
     assert check_attribute(), (
         f"Expected {atrybut} to be '{wynik}', "
@@ -128,7 +139,6 @@ def test_crossref_api_strony_sync_browser(
 def test_crossref_api_streszczenie_sync_browser(
     transactional_db,
     wydawnictwo_ciagle_jehs_2022,
-    live_server,
     admin_page_strona_porownania: Page,
 ):
     """Test clicking button to sync streszczenie (abstract) from CrossRef."""
@@ -140,6 +150,6 @@ def test_crossref_api_streszczenie_sync_browser(
         wydawnictwo_ciagle_jehs_2022.refresh_from_db()
         return wydawnictwo_ciagle_jehs_2022.streszczenia.exists()
 
-    _poll_until(check_streszczenie)
+    _poll_until(admin_page_strona_porownania, check_streszczenie)
 
     assert check_streszczenie(), "Expected streszczenie to be created"

--- a/src/bpp/tests/test_google_analytics.py
+++ b/src/bpp/tests/test_google_analytics.py
@@ -1,5 +1,4 @@
 import pytest
-from django.conf import settings
 from django.core.cache import cache
 from django.core.cache.utils import make_template_fragment_key
 from django.http import SimpleCookie
@@ -7,47 +6,34 @@ from django.http import SimpleCookie
 
 @pytest.fixture
 def remove_key():
+    # Czyscimy cache fragmentu "google" przed ORAZ po tescie — inaczej
+    # nagrzany (zacache'owany) fragment wyciekłby na innego testu na tym
+    # samym workerze xdist i zaburzył jego wynik.
     key = make_template_fragment_key("google")
+    cache.delete(key)
+    yield
     cache.delete(key)
 
 
 @pytest.mark.django_db
-def test_google_analytics_disabled(remove_key, client):
-    orig_DEBUG = settings.DEBUG
-    orig_GAPID = settings.GOOGLE_ANALYTICS_PROPERTY_ID
+def test_google_analytics_disabled(remove_key, client, settings):
+    settings.DEBUG = True
+    res = client.get("/")
+    assert b"https://www.googletagmanager.com/gtag/js" not in res.content
 
-    try:
-        settings.DEBUG = True
-        res = client.get("/")
-        assert b"https://www.googletagmanager.com/gtag/js" not in res.content
-
-        settings.DEBUG = False
-        settings.GOOGLE_ANALYTICS_PROPERTY_ID = ""
-        res = client.get("/")
-        assert b"https://www.googletagmanager.com/gtag/js" not in res.content
-
-    finally:
-        settings.DEBUG = orig_DEBUG
-        settings.GOOGLE_ANALYTICS_PROPERTY_ID = orig_GAPID
+    settings.DEBUG = False
+    settings.GOOGLE_ANALYTICS_PROPERTY_ID = ""
+    res = client.get("/")
+    assert b"https://www.googletagmanager.com/gtag/js" not in res.content
 
 
 @pytest.mark.django_db
-def test_google_analytics_enabled(remove_key, client):
-    from django.conf import settings
-
-    orig_DEBUG = settings.DEBUG
-    orig_GAPID = settings.GOOGLE_ANALYTICS_PROPERTY_ID
-
+def test_google_analytics_enabled(remove_key, client, settings):
     client.cookies = SimpleCookie({"cookielaw_accepted": "1"})
 
-    try:
-        settings.DEBUG = False
-        settings.GOOGLE_ANALYTICS_PROPERTY_ID = "foobar"
+    settings.DEBUG = False
+    settings.GOOGLE_ANALYTICS_PROPERTY_ID = "foobar"
 
-        res = client.get("/")
+    res = client.get("/")
 
-        assert b"https://www.googletagmanager.com/gtag/js" in res.content
-
-    finally:
-        settings.DEBUG = orig_DEBUG
-        settings.GOOGLE_ANALYTICS_PROPERTY_ID = orig_GAPID
+    assert b"https://www.googletagmanager.com/gtag/js" in res.content

--- a/src/bpp/tests/test_multiseek/test_multiseek_basic.py
+++ b/src/bpp/tests/test_multiseek/test_multiseek_basic.py
@@ -15,7 +15,7 @@ Ten moduł zawiera testy dla podstawowych QueryObject:
 - JezykQueryObject - wyszukiwanie po języku
 """
 
-from datetime import datetime
+from datetime import date
 
 import pytest
 from model_bakery import baker
@@ -136,7 +136,11 @@ def test_multiseek_charakter_formalny_ogolny(wydawnictwo_zwarte, ksiazka_polska)
 
 def test_DataUtworzeniaQueryObject():
     d = DataUtworzeniaQueryObject()
-    assert d.value_for_description('[""]') == str(datetime.now().date())
+    # Odporne na przeskok o polnocy: akceptuj date sprzed i po wywolaniu.
+    before = date.today()
+    rendered = d.value_for_description('[""]')
+    after = date.today()
+    assert rendered in {str(before), str(after)}
     assert d.value_for_description('["2018-01-01 12:00:00"]') == "2018-01-01"
     assert (
         d.value_for_description('["2018-01-01 12:00:00", "2018-01-01 12:00:00"]')

--- a/src/bpp/tests/test_playwright/test_admin/test_autor_inline_wydawnictwo.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_autor_inline_wydawnictwo.py
@@ -13,13 +13,13 @@ def test_autor_inline_wydawnictwo_dyscyplina(
     jednostka,
     rok,
     admin_page: Page,
-    live_server,
+    channels_live_server,
     standard_data,
     wyd,
     zrodlo,
 ):
     """Test that author discipline auto-fills when adding autor inline."""
-    url = live_server.url + reverse(f"admin:bpp_wydawnictwo_{wyd}_add")
+    url = channels_live_server.url + reverse(f"admin:bpp_wydawnictwo_{wyd}_add")
     admin_page.goto(url)
     admin_page.wait_for_load_state("domcontentloaded")
 
@@ -27,9 +27,7 @@ def test_autor_inline_wydawnictwo_dyscyplina(
     admin_page.fill("#id_tytul_oryginalny", "123")
 
     if wyd == "ciagle":
-        select_select2_autocomplete(
-            admin_page, "id_zrodlo", zrodlo.nazwa, timeout=4000
-        )
+        select_select2_autocomplete(admin_page, "id_zrodlo", zrodlo.nazwa, timeout=4000)
 
     admin_page.fill("#id_rok", str(rok))
 

--- a/src/bpp/tests/test_playwright/test_admin/test_clarivate.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_clarivate.py
@@ -28,7 +28,14 @@ def _wait_for_dialog(page, predicate, timeout: float = 5.0, interval_ms: int = 5
 
 @pytest.fixture(scope="function")
 def page_z_wydawnictwem(admin_page: Page, live_server, wydawnictwo_ciagle):
-    """Set up admin page with an existing wydawnictwo_ciagle record."""
+    """Set up admin page with an existing wydawnictwo_ciagle record.
+
+    UWAGA: celowo ``live_server`` (WSGI, watek W PROCESIE testu), NIE
+    ``channels_live_server`` (Daphne, subprocess). Testy w tym pliku
+    patchuja ``Uczelnia.wosclient`` przez ``mocker.patch`` — monkeypatch
+    zyje tylko w procesie testu, subprocess Daphne go nie widzi i strona
+    wykonalaby prawdziwy kod (ImproperlyConfigured zamiast mocka).
+    """
     admin_page.goto(
         live_server.url
         + reverse("admin:bpp_wydawnictwo_ciagle_change", args=(wydawnictwo_ciagle.pk,))

--- a/src/bpp/tests/test_playwright/test_admin/test_oswiadczenie_ken.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_oswiadczenie_ken.py
@@ -5,6 +5,13 @@ from playwright.sync_api import Page
 
 from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Zwarte
 
+# UWAGA: testy w tym pliku celowo uzywaja ``live_server`` (WSGI, watek
+# W PROCESIE testu), NIE ``channels_live_server`` (Daphne, subprocess).
+# Fikstury nizej zmieniaja ``settings.BPP_POKAZUJ_OSWIADCZENIE_KEN``
+# fikstura pytest-django ``settings`` — zmiana zyje tylko w procesie
+# testu; subprocess Daphne ma wlasna kopie ustawien i renderowalby
+# formularz z wartoscia domyslna.
+
 
 @pytest.fixture
 def nie_pokazuj_oswiadczen_ken(settings):

--- a/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_autor.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_autor.py
@@ -1,24 +1,24 @@
 import pytest
 from django.urls import reverse
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 from bpp.tests import normalize_html
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("klass", ["wydawnictwo_ciagle", "wydawnictwo_zwarte"])
-def test_changelist_no_argument(klass, live_server, admin_page: Page):
+def test_changelist_no_argument(klass, channels_live_server, admin_page: Page):
     url = f"admin:bpp_{klass}_autor_changelist"
-    admin_page.goto(live_server.url + reverse(url))
+    admin_page.goto(channels_live_server.url + reverse(url))
     assert "Musisz wejść w edycję" in normalize_html(admin_page.content())
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("klass", ["wydawnictwo_ciagle", "wydawnictwo_zwarte"])
-def test_edit_btn_invisible(klass, live_server, admin_page: Page):
+def test_edit_btn_invisible(klass, channels_live_server, admin_page: Page):
     # Przy dodawaniu publikacji -- brak przycisku "edytuj autorów"
     url = f"admin:bpp_{klass}_add"
-    admin_page.goto(live_server.url + reverse(url))
+    admin_page.goto(channels_live_server.url + reverse(url))
     assert "Edytuj autorów" not in normalize_html(admin_page.content())
 
 
@@ -29,17 +29,19 @@ def test_edit_btn_invisible(klass, live_server, admin_page: Page):
         ("wydawnictwo_zwarte", "Wydawnictwo_Zwarte"),
     ],
 )
-def test_edit_btn_appears(klass, model, live_server, admin_page: Page):
+def test_edit_btn_appears(klass, model, channels_live_server, admin_page: Page):
     # Przy edytowaniu publikacji -- przycisk "edytuj autorów" jest
     from model_bakery import baker
 
     from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Zwarte
 
-    model_class = Wydawnictwo_Ciagle if model == "Wydawnictwo_Ciagle" else Wydawnictwo_Zwarte
+    model_class = (
+        Wydawnictwo_Ciagle if model == "Wydawnictwo_Ciagle" else Wydawnictwo_Zwarte
+    )
     res = baker.make(model_class)
 
     url = f"admin:bpp_{klass}_change"
-    admin_page.goto(live_server.url + reverse(url, args=(res.pk,)))
+    admin_page.goto(channels_live_server.url + reverse(url, args=(res.pk,)))
 
     baker.make(model_class)
 
@@ -53,25 +55,29 @@ def test_edit_btn_appears(klass, model, live_server, admin_page: Page):
         ("wydawnictwo_zwarte", "Wydawnictwo_Zwarte"),
     ],
 )
-def test_changeform_save(klass, model, admin_page: Page, live_server):
+def test_changeform_save(klass, model, admin_page: Page, channels_live_server):
     from model_bakery import baker
 
     from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Zwarte
 
-    model_class = Wydawnictwo_Ciagle if model == "Wydawnictwo_Ciagle" else Wydawnictwo_Zwarte
+    model_class = (
+        Wydawnictwo_Ciagle if model == "Wydawnictwo_Ciagle" else Wydawnictwo_Zwarte
+    )
     rec = baker.make(model_class)
     wa = baker.make(model_class.autorzy.through, rekord=rec)
 
     url = f"admin:bpp_{klass}_autor_change"
-    admin_page.goto(live_server.url + reverse(url, args=(wa.pk,)))
+    admin_page.goto(channels_live_server.url + reverse(url, args=(wa.pk,)))
 
     admin_page.wait_for_selector('input[name="_save"]', state="visible")
 
-    # wchodzimy z okreslonym ID na okreslony rekord, zapisujmey, czy jest OK ?
-    admin_page.click('input[name="_save"]')
-    admin_page.wait_for_load_state("domcontentloaded")
+    # wchodzimy z okreslonym ID na okreslony rekord, zapisujemy, czy jest OK ?
+    # Zapis inline'u przekierowuje na changelist; blokujemy do zakończenia
+    # nawigacji, żeby wait nie wracał od razu na STAREJ stronie (race).
+    with admin_page.expect_navigation(wait_until="domcontentloaded"):
+        admin_page.click('input[name="_save"]')
 
-    assert "Dodaj powiązanie" in normalize_html(admin_page.content())
+    expect(admin_page.locator("body")).to_contain_text("Dodaj powiązanie")
 
 
 @pytest.mark.parametrize(
@@ -81,15 +87,19 @@ def test_changeform_save(klass, model, admin_page: Page, live_server):
         ("wydawnictwo_zwarte", "Wydawnictwo_Zwarte"),
     ],
 )
-def test_changelist_with_argument(klass, model, admin_page: Page, live_server):
+def test_changelist_with_argument(klass, model, admin_page: Page, channels_live_server):
     from model_bakery import baker
 
     from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Zwarte
 
-    model_class = Wydawnictwo_Ciagle if model == "Wydawnictwo_Ciagle" else Wydawnictwo_Zwarte
+    model_class = (
+        Wydawnictwo_Ciagle if model == "Wydawnictwo_Ciagle" else Wydawnictwo_Zwarte
+    )
     rec = baker.make(model_class)
     url = f"admin:bpp_{klass}_autor_changelist"
-    admin_page.goto(live_server.url + reverse(url) + f"?rekord__id__exact={rec.pk}")
+    admin_page.goto(
+        channels_live_server.url + reverse(url) + f"?rekord__id__exact={rec.pk}"
+    )
 
     assert "Dodaj powiązanie" in normalize_html(admin_page.content())
 
@@ -111,7 +121,7 @@ def test_changelist_with_argument(klass, model, admin_page: Page, live_server):
 def test_changeform_add_form_renders(
     klass,
     model,
-    live_server,
+    channels_live_server,
     admin_page: Page,
 ):
     from model_bakery import baker
@@ -124,7 +134,7 @@ def test_changeform_add_form_renders(
     rec = baker.make(model_class)
     url = f"admin:bpp_{klass}_autor_changelist"
     admin_page.goto(
-        live_server.url + reverse(url) + f"?rekord__id__exact={rec.pk}"
+        channels_live_server.url + reverse(url) + f"?rekord__id__exact={rec.pk}"
     )
 
     admin_page.wait_for_selector('a[name="_add_wa"]', state="visible")
@@ -148,7 +158,7 @@ def test_changeform_add_form_renders(
 def test_changeform_add_full_flow(
     klass,
     model,
-    live_server,
+    channels_live_server,
     admin_page: Page,
     autor_jan_nowak,
     jednostka,
@@ -167,7 +177,7 @@ def test_changeform_add_full_flow(
     rec = baker.make(model_class)
     url = f"admin:bpp_{klass}_autor_changelist"
     admin_page.goto(
-        live_server.url + reverse(url) + f"?rekord__id__exact={rec.pk}"
+        channels_live_server.url + reverse(url) + f"?rekord__id__exact={rec.pk}"
     )
 
     admin_page.wait_for_selector('a[name="_add_wa"]', state="visible")

--- a/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_ciagle.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_ciagle.py
@@ -12,7 +12,7 @@ def test_Wydawnictwo_Ciagle_Autor_Admin_forwarding_works(
     autor_jan_kowalski,
     dyscyplina1,
     jednostka,
-    live_server,
+    channels_live_server,
 ):
     """Test editing Wydawnictwo_Ciagle_Autor inline with discipline selection."""
     rok = 2022
@@ -36,7 +36,7 @@ def test_Wydawnictwo_Ciagle_Autor_Admin_forwarding_works(
         f"?_changelist_filters=rekord__id__exact%3D{wydawnictwo_ciagle.pk}"
     )
 
-    admin_page.goto(live_server.url + url)
+    admin_page.goto(channels_live_server.url + url)
     admin_page.wait_for_load_state("domcontentloaded")
 
     # Wait for the page to be fully loaded (rok field is hidden type=hidden)

--- a/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_zwarte.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_zwarte.py
@@ -16,6 +16,9 @@ def test_Wydawnictwo_Zwarte_Autor_Admin_forwarding_works(
 ):
     rok = 2022
 
+    # Defensywny guard: baseline lub wcześniejszy test mógł zostawić wiersze
+    # Autor_Dyscyplina — czyścimy, by poniższy create dał deterministyczny
+    # stan (mirror toz/tamze).
     Autor_Dyscyplina.objects.all().delete()
 
     Autor_Dyscyplina.objects.create(
@@ -45,9 +48,11 @@ def test_Wydawnictwo_Zwarte_Autor_Admin_forwarding_works(
         admin_page, "id_dyscyplina_naukowa", dyscyplina1.nazwa, timeout=30000
     )
 
-    # Submit form
-    admin_page.click("input[type=submit][name='_save']")
-    admin_page.wait_for_load_state("domcontentloaded", timeout=10000)
+    # Submit form. Zapis przekierowuje na changelist — blokujemy do
+    # zakończenia nawigacji, żeby kolejne waity nie wracały od razu na
+    # STAREJ stronie (race z domcontentloaded).
+    with admin_page.expect_navigation(wait_until="domcontentloaded"):
+        admin_page.click("input[type=submit][name='_save']")
 
     # Check success message
     admin_page.wait_for_function(

--- a/src/bpp/tests/test_tasks.py
+++ b/src/bpp/tests/test_tasks.py
@@ -37,6 +37,7 @@ def test_zaktualizuj_liczbe_cytowan(uczelnia, wydawnictwo_ciagle, mocker):
 def test_usun_stare_logi_logowania_easyaudit():
     """Kasuje LoginEvent starsze niż 24 mies., zostawia nowsze, nie rusza
     CRUDEvent (historia edycji)."""
+    from django.contrib.contenttypes.models import ContentType
     from easyaudit.models import CRUDEvent, LoginEvent
 
     now = timezone.now()
@@ -46,7 +47,10 @@ def test_usun_stare_logi_logowania_easyaudit():
         event_type=CRUDEvent.CREATE,
         object_repr="x",
         object_id=1,
-        content_type_id=1,
+        # content_type_id na sztywno łamie się po pierwszym flushu na workerze
+        # (content types odtwarzają się na zjitterowanych sekwencjach) — bierzemy
+        # realny ContentType istniejącego modelu.
+        content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
     )
     # auto_now_add ustawia datetime na teraz — przestawiamy ręcznie przez update()
     cutoff = now - relativedelta(months=EASYAUDIT_LOGINEVENT_RETENTION_MONTHS)

--- a/src/bpp/tests/util.py
+++ b/src/bpp/tests/util.py
@@ -149,7 +149,9 @@ def any_wydawnictwo(klass, rok=None, **kw):
     for key, value in list(kw_wyd.items()):
         set_default(key, value, kw)
 
-    Status_Korekty.objects.get_or_create(pk=1, nazwa="przed korektą")
+    # Lookup po kluczu naturalnym (nazwa jest unique), nigdy po pk — inaczej
+    # wiersz o tej samej nazwie pod innym pk => INSERT => IntegrityError.
+    Status_Korekty.objects.get_or_create(nazwa="przed korektą")
 
     return baker.make(klass, rok=rok, **kw)
 

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,6 +1,6 @@
 import random
 import time
-from datetime import timedelta
+from datetime import date
 from uuid import uuid4
 
 import pytest
@@ -12,7 +12,6 @@ from django.db import connections
 from django.db.utils import OperationalError
 from django.test import TransactionTestCase
 from django.test.client import Client, RequestFactory
-from django.utils import timezone
 from model_bakery import baker
 
 from bpp.tests.helpers import (  # noqa: F401 - re-export helpers
@@ -392,10 +391,10 @@ def pbn_dyscyplina2(db, pbn_discipline_group):
 
     return Discipline.objects.get_or_create(
         parent_group=pbn_discipline_group,
-        uuid=uuid4(),
         code="202",
         name="druga dyscyplina",
         scientificFieldName="Dziedzina drugich dyscyplin",
+        defaults=dict(uuid=uuid4()),
     )[0]
 
 
@@ -403,18 +402,27 @@ def pbn_dyscyplina2(db, pbn_discipline_group):
 def pbn_discipline_group(db):
     from pbn_api.models import DisciplineGroup
 
-    n = timezone.now().date()
+    # Stały klucz naturalny (nie data bieżąca): leftover z sesji rozpoczętej
+    # wczoraj (reuse-db + crash teardown) nadal matchuje, więc nie powstaje
+    # drugi słownik. Data w przeszłości + validityDateTo=None => słownik jest
+    # ciągle „aktualny" wg DisciplineGroupManager.get_current (validityDateFrom
+    # <= dziś oraz validityDateTo IS NULL).
+    stala_data_od = date(2020, 1, 1)
     try:
         return DisciplineGroup.objects.get_or_create(
             validityDateTo=None,
-            validityDateFrom=n - timedelta(days=7),
+            validityDateFrom=stala_data_od,
             defaults=dict(uuid=uuid4()),
         )[0]
     except DisciplineGroup.MultipleObjectsReturned:
-        return DisciplineGroup.objects.filter(
-            validityDateTo=None,
-            validityDateFrom=n - timedelta(days=7),
-        ).first()
+        return (
+            DisciplineGroup.objects.filter(
+                validityDateTo=None,
+                validityDateFrom=stala_data_od,
+            )
+            .order_by("pk")
+            .first()
+        )
 
 
 @pytest.fixture

--- a/src/fixtures/conftest_browser.py
+++ b/src/fixtures/conftest_browser.py
@@ -16,17 +16,18 @@ from .const import NORMAL_DJANGO_USER_LOGIN, NORMAL_DJANGO_USER_PASSWORD
 
 
 @pytest.fixture
-def normal_django_user(request, db, django_user_model):
+def normal_django_user(db, django_user_model):
     """A normal Django user"""
+    # Fikstura jest function-scoped na `db` — pytest-django rolluje back
+    # transakcję po teście, więc ręczny teardown (usuwanie usera) jest
+    # zbędny. Wcześniejszy lokalny `fin()` nigdy nie był rejestrowany
+    # przez `request.addfinalizer`, więc był martwym kodem — usunięty.
     try:
         obj = django_user_model.objects.get(username=NORMAL_DJANGO_USER_LOGIN)
     except django_user_model.DoesNotExist:
         obj = django_user_model.objects.create_user(
             username=NORMAL_DJANGO_USER_LOGIN, password=NORMAL_DJANGO_USER_PASSWORD
         )
-
-    def fin():
-        obj.delete()
 
     return obj
 
@@ -102,6 +103,4 @@ def csrf_exempt_django_admin_app(django_app_factory, admin_user):
 @pytest.fixture
 def csrf_exempt_wd_app(django_app_factory, wprowadzanie_danych_user):
     app = django_app_factory(csrf_checks=False)
-    return _webtest_login(
-        app, NORMAL_DJANGO_USER_LOGIN, NORMAL_DJANGO_USER_PASSWORD
-    )
+    return _webtest_login(app, NORMAL_DJANGO_USER_LOGIN, NORMAL_DJANGO_USER_PASSWORD)

--- a/src/fixtures/conftest_system.py
+++ b/src/fixtures/conftest_system.py
@@ -54,27 +54,29 @@ def typy_odpowiedzialnosci(db):
 
 @pytest.fixture(scope="function")
 def tytuly():
+    # Lookup po kluczu naturalnym (skrot jest unique), NIGDY po pk — inaczej
+    # wiersz o tym samym skrocie pod innym pk => INSERT => IntegrityError.
     for elem in fixture("tytul.json"):
-        Tytul.objects.get_or_create(pk=elem["pk"], **elem["fields"])
+        fields = dict(elem["fields"])
+        skrot = fields.pop("skrot")
+        Tytul.objects.get_or_create(skrot=skrot, defaults=fields)
 
 
 @pytest.fixture(scope="function")
 def jezyki():
-    pl, created = Jezyk.objects.get_or_create(pk=1, skrot="pol.", nazwa="polski")
+    pl, created = Jezyk.objects.get_or_create(
+        skrot="pol.", defaults=dict(nazwa="polski")
+    )
     pl.skrot_dla_pbn = "PL"
     pl.skrot_crossref = "pl"
     pl.save()
-    assert pl.pk == 1
 
     ang, created = Jezyk.objects.get_or_create(
-        pk=2,
-        skrot="ang.",
-        nazwa="angielski",
+        skrot="ang.", defaults=dict(nazwa="angielski")
     )
     ang.skrot_dla_pbn = "EN"
     ang.skrot_crossref = "en"
     ang.save()
-    assert ang.pk == 2
 
     for elem in fixture("jezyk.json"):
         Jezyk.objects.get_or_create(**elem["fields"])
@@ -85,8 +87,13 @@ def jezyki():
 @pytest.fixture(scope="function")
 def charaktery_formalne():
     Charakter_Formalny.objects.all().delete()
+    # Lookup po kluczu naturalnym (skrot jest unique), NIGDY po pk (w JSON-ie
+    # pk bywa null) — inaczej wiersz o tym samym skrocie/nazwie pod innym pk
+    # => INSERT => IntegrityError.
     for elem in fixture("charakter_formalny.json"):
-        Charakter_Formalny.objects.get_or_create(pk=elem["pk"], **elem["fields"])
+        fields = dict(elem["fields"])
+        skrot = fields.pop("skrot")
+        Charakter_Formalny.objects.get_or_create(skrot=skrot, defaults=fields)
 
     chf_ksp = Charakter_Formalny.objects.get(skrot="KSP")
     chf_ksp.rodzaj_pbn = const.RODZAJ_PBN_KSIAZKA

--- a/src/fixtures/playwright_fixtures.py
+++ b/src/fixtures/playwright_fixtures.py
@@ -61,8 +61,17 @@ def admin_page(transactional_db, page: Page, admin_user, channels_live_server):
 
 
 @pytest.fixture
-def preauth_page(transactional_db, page: Page, normal_django_user, live_server):
-    """Provide a pre-authenticated regular user page."""
+def preauth_page(transactional_db, page: Page, normal_django_user):
+    """Provide a pre-authenticated regular user page.
+
+    Uwaga: fikstura sama NIE startuje żadnego serwera — tylko wstrzykuje
+    cookie sesji. Test, który nawiguje, musi sam zażądać `live_server`
+    ALBO `channels_live_server`. Wcześniej `live_server` był tu zaszyty
+    jako zależność, przez co `preauth_asgi_page` (budujący na tej
+    fiksturze + `channels_live_server`) stawiał DWA serwery na test —
+    dokładnie ta presja zasobowa, którą docstring `channels_live_server`
+    wskazuje jako źródło kaskadowych timeoutów `page.goto`.
+    """
     # Import here to avoid Django app loading issues
     from django.test import Client
 
@@ -113,7 +122,10 @@ def preauth_asgi_page(transactional_db, preauth_page: Page, channels_live_server
     wait_for_channel_subscription(
         get_channel_name_for_user(page.authorized_user), since=pre_goto
     )
-    page.evaluate("Cookielaw.accept();")
+    # Guard na wypadek, gdyby skrypt Cookielaw nie zdążył się załadować —
+    # bez guarda gołe `Cookielaw.accept()` rzuca ReferenceError i cały test
+    # pada na setupie fikstury.
+    page.evaluate("if (window.Cookielaw) Cookielaw.accept();")
     # Cookielaw.accept() removes #CookielawBanner synchronously; wait for
     # the DOM to reflect that instead of sleeping a fixed second.
     page.wait_for_selector("#CookielawBanner", state="detached", timeout=2000)
@@ -182,6 +194,7 @@ def preauth_asgi_page_per_test(
     wait_for_channel_subscription(
         get_channel_name_for_user(page.authorized_user), since=pre_goto
     )
-    page.evaluate("Cookielaw.accept();")
+    # Guard na wypadek, gdyby skrypt Cookielaw nie zdążył się załadować.
+    page.evaluate("if (window.Cookielaw) Cookielaw.accept();")
     page.wait_for_selector("#CookielawBanner", state="detached", timeout=2000)
     return page

--- a/src/import_dyscyplin/tests/test_models.py
+++ b/src/import_dyscyplin/tests/test_models.py
@@ -74,10 +74,13 @@ def id_row_2(import_dyscyplin, autor_jan_nowak):
 def test_Import_Dyscyplin_integruj_dyscypliny_pusta_baza(import_dyscyplin, id_row_1):
     import_dyscyplin.integruj_dyscypliny()
 
-    assert Dyscyplina_Naukowa.objects.all().count() == 2
+    # Count skope'owany do dyscyplin importowanych przez ten test — globalny
+    # count na calej tabeli zalezy od czystej bazy (audyt sekcja 4).
+    dyscypliny = Dyscyplina_Naukowa.objects.filter(nazwa__in=["Testowa", "Jakaś"])
+    assert dyscypliny.count() == 2
     Dyscyplina_Naukowa.objects.get(nazwa="Testowa")
 
-    for elem in Dyscyplina_Naukowa.objects.all():
+    for elem in dyscypliny:
         assert elem.widoczna
 
 
@@ -88,7 +91,9 @@ def test_Import_Dyscyplin_integruj_dyscypliny_ta_sama_nazwa_inny_kod(
 
     import_dyscyplin.integruj_dyscypliny()
 
-    assert Dyscyplina_Naukowa.objects.all().count() == 1
+    # Count skope'owany do dyscyplin tego testu (audyt sekcja 4).
+    dyscypliny = Dyscyplina_Naukowa.objects.filter(nazwa__in=["Testowa", "Jakaś"])
+    assert dyscypliny.count() == 1
 
     id_row_1.refresh_from_db()
     assert id_row_1.stan == Import_Dyscyplin_Row.STAN.BLEDNY
@@ -101,7 +106,9 @@ def test_Import_Dyscyplin_integruj_dyscypliny_ta_sama_nazwa_inny_kod_sub(
 
     import_dyscyplin.integruj_dyscypliny()
 
-    assert Dyscyplina_Naukowa.objects.all().count() == 2
+    # Count skope'owany do dyscyplin tego testu (audyt sekcja 4).
+    dyscypliny = Dyscyplina_Naukowa.objects.filter(nazwa__in=["Testowa", "Jakaś"])
+    assert dyscypliny.count() == 2
 
     id_row_1.refresh_from_db()
     assert id_row_1.stan == Import_Dyscyplin_Row.STAN.BLEDNY
@@ -112,32 +119,37 @@ def test_Import_Dyscyplin_integruj_dyscypliny_ukryj_nieuzywane_brak_dyscyplin(
 ):
     import_dyscyplin.integruj_dyscypliny()
     Autor_Dyscyplina.objects.ukryj_nieuzywane()
-    assert Dyscyplina_Naukowa.objects.all().count() == 2
-    for elem in Dyscyplina_Naukowa.objects.all():
+    # Count skope'owany do dyscyplin tego testu (audyt sekcja 4).
+    dyscypliny = Dyscyplina_Naukowa.objects.filter(nazwa__in=["Testowa", "Jakaś"])
+    assert dyscypliny.count() == 2
+    for elem in dyscypliny:
         assert not elem.widoczna
 
 
 def test_Import_Dyscyplin_integruj_dyscypliny_ukryj_nieuzywane_uzywana_nadrzedna(
     import_dyscyplin, id_row_2, autor_jan_nowak, testowe_dyscypliny
 ):
-    assert Autor_Dyscyplina.objects.count() == 0
+    # Count skope'owany do autora tego testu — Autor_Dyscyplina nie jest
+    # danymi baseline, ale osierocone wiersze psuja globalny count (sekcja 4).
+    assert Autor_Dyscyplina.objects.filter(autor=autor_jan_nowak).count() == 0
 
     import_dyscyplin.integruj_dyscypliny()
     import_dyscyplin._integruj_wiersze()
 
-    assert Autor_Dyscyplina.objects.count() == 1
+    assert Autor_Dyscyplina.objects.filter(autor=autor_jan_nowak).count() == 1
     assert Dyscyplina_Naukowa.objects.get(nazwa="Testowa").widoczna
     assert not Dyscyplina_Naukowa.objects.get(nazwa="Jakaś").widoczna
 
 
 def test_Import_Dyscyplin_integruj_dyscypliny_ukryj_nieuzywane_uzywana_podrzedna(
-    import_dyscyplin, id_row_1, testowe_dyscypliny
+    import_dyscyplin, id_row_1, autor_jan_nowak, testowe_dyscypliny
 ):
-    assert Autor_Dyscyplina.objects.count() == 0
+    # Count skope'owany do autora tego testu (audyt sekcja 4).
+    assert Autor_Dyscyplina.objects.filter(autor=autor_jan_nowak).count() == 0
 
     import_dyscyplin.integruj_dyscypliny()
     import_dyscyplin._integruj_wiersze()
-    assert Autor_Dyscyplina.objects.count() == 1
+    assert Autor_Dyscyplina.objects.filter(autor=autor_jan_nowak).count() == 1
 
     assert Dyscyplina_Naukowa.objects.get(nazwa="Testowa").widoczna
     assert Dyscyplina_Naukowa.objects.get(nazwa="Jakaś").widoczna

--- a/src/importer_publikacji/tests/test_source_form.py
+++ b/src/importer_publikacji/tests/test_source_form.py
@@ -134,7 +134,7 @@ def test_source_step_renders_autocomplete(
     """Krok 3 powinien renderować widgety autocomplete."""
     from django.urls import reverse
 
-    from bpp.models import Charakter_Formalny, Jezyk, Typ_KBN
+    from bpp.models import Typ_KBN
 
     session = ImportSession.objects.create(
         created_by=importer_user,
@@ -148,9 +148,9 @@ def test_source_step_renders_autocomplete(
             "source_abbreviation": None,
             "publisher": None,
         },
-        charakter_formalny=Charakter_Formalny.objects.first(),
-        typ_kbn=Typ_KBN.objects.first(),
-        jezyk=Jezyk.objects.filter(widoczny=True).first(),
+        charakter_formalny=charaktery_formalne["AC"],
+        typ_kbn=Typ_KBN.objects.get(skrot="PO"),
+        jezyk=jezyki["pol."],
         status=ImportSession.Status.VERIFIED,
     )
     url = reverse(
@@ -174,7 +174,7 @@ def test_source_step_post_with_zrodlo(
     """POST z wybranym źródłem powinien przejść dalej."""
     from django.urls import reverse
 
-    from bpp.models import Charakter_Formalny, Jezyk, Typ_KBN
+    from bpp.models import Typ_KBN
 
     zrodlo = baker.make(Zrodlo)
     session = ImportSession.objects.create(
@@ -191,9 +191,9 @@ def test_source_step_post_with_zrodlo(
             "publisher": None,
             "year": 2024,
         },
-        charakter_formalny=Charakter_Formalny.objects.first(),
-        typ_kbn=Typ_KBN.objects.first(),
-        jezyk=Jezyk.objects.filter(widoczny=True).first(),
+        charakter_formalny=charaktery_formalne["AC"],
+        typ_kbn=Typ_KBN.objects.get(skrot="PO"),
+        jezyk=jezyki["pol."],
         status=ImportSession.Status.VERIFIED,
         jest_wydawnictwem_zwartym=False,
     )
@@ -222,7 +222,7 @@ def test_source_step_post_with_wydawca(
     """POST z wydawcą dla wydawnictwa zwartego."""
     from django.urls import reverse
 
-    from bpp.models import Charakter_Formalny, Jezyk, Typ_KBN
+    from bpp.models import Typ_KBN
 
     wydawca = baker.make(Wydawca)
     session = ImportSession.objects.create(
@@ -239,9 +239,9 @@ def test_source_step_post_with_wydawca(
             "publisher": "Some Publisher",
             "year": 2024,
         },
-        charakter_formalny=Charakter_Formalny.objects.first(),
-        typ_kbn=Typ_KBN.objects.first(),
-        jezyk=Jezyk.objects.filter(widoczny=True).first(),
+        charakter_formalny=charaktery_formalne["AC"],
+        typ_kbn=Typ_KBN.objects.get(skrot="PO"),
+        jezyk=jezyki["pol."],
         status=ImportSession.Status.VERIFIED,
         jest_wydawnictwem_zwartym=True,
     )

--- a/src/importer_publikacji/tests/test_views_create_publication.py
+++ b/src/importer_publikacji/tests/test_views_create_publication.py
@@ -25,15 +25,14 @@ def _make_session_for_publication(
     abstract=None,
 ):
     """Helper: sesja gotowa do _create_publication."""
-    from bpp.models import (
-        Charakter_Formalny,
-        Jezyk,
-        Typ_KBN,
-    )
+    from bpp.models import Typ_KBN
 
-    cf = Charakter_Formalny.objects.first()
-    tk = Typ_KBN.objects.first()
-    jez = Jezyk.objects.filter(widoczny=True).first()
+    # Deterministyczne odczyty z fixture'ow (dane referencyjne bywaja
+    # TRUNCATE-owane przez wczesniejsze testy transakcyjne na tym samym
+    # workerze — gole .first() zwracalo wtedy None; patrz audyt sekcja 4).
+    cf = charaktery_formalne["AC"]
+    tk = Typ_KBN.objects.get(skrot="PO")
+    jez = jezyki["pol."]
 
     nd = {
         "title": "Test Publication",

--- a/src/integration_tests/test_conftest.py
+++ b/src/integration_tests/test_conftest.py
@@ -85,6 +85,15 @@ def test_patent_view(patent):
 
 @pytest.mark.django_db
 def test_wydawnictwo_ciagle_z_dwoma_autorami(wydawnictwo_ciagle_z_dwoma_autorami):
-    assert Rekord.objects.all().count() == 1
-    assert Wydawnictwo_Ciagle_Autor.objects.all().count() == 2
-    assert Autorzy.objects.count() == 2
+    wc = wydawnictwo_ciagle_z_dwoma_autorami
+    # Count-y skope'owane do rekordu utworzonego przez fixture — globalny
+    # count na Rekord/Autorzy zaklada czysta baze, a osierocone wiersze po
+    # ubitych testach transakcyjnych to psuja (audyt sekcja 4). get_for_model
+    # (.get() pod spodem) sam waliduje istnienie i unikalnosc rekordu cache.
+    rekord = Rekord.objects.get_for_model(wc)
+    assert Wydawnictwo_Ciagle_Autor.objects.filter(rekord=wc).count() == 2
+    # filter_rekord przekazuje rekord.pk wprost do lookupu rekord_id;
+    # TupleField.from_db_value zwraca TUPLE, a lookup exact ArrayField
+    # wymaga LISTY (tuple konczy sie bledem "operator nie istnieje:
+    # integer[] = integer" po stronie PG) - stad jawne list().
+    assert Autorzy.objects.filter(rekord_id=list(rekord.pk)).count() == 2

--- a/src/integration_tests/test_embed_widget.py
+++ b/src/integration_tests/test_embed_widget.py
@@ -7,7 +7,7 @@ Loader ładowany jest z ``/static/embed/bpp-publikacje.js`` (serwowany przez
 
 import pytest
 from model_bakery import baker
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 from bpp.models import Autor, Rekord, Wydawnictwo_Ciagle, Wydawnictwo_Ciagle_Autor
 
@@ -22,7 +22,9 @@ def _strona_z_widgetem(page: Page, base_url: str, script_attrs: str) -> None:
     )
 
 
-def test_embed_widget_renderuje_liste(channels_live_server, page: Page, transactional_db):
+def test_embed_widget_renderuje_liste(
+    channels_live_server, page: Page, transactional_db
+):
     """Widget pobiera publikacje autora z API i renderuje listę pozycji."""
     autor = baker.make(Autor, nazwisko="Widgetowy", imiona="Wiktor")
     for i in range(3):
@@ -30,14 +32,12 @@ def test_embed_widget_renderuje_liste(channels_live_server, page: Page, transact
         baker.make(Wydawnictwo_Ciagle_Autor, rekord=pub, autor=autor)
     Rekord.objects.full_refresh()
 
-    _strona_z_widgetem(
-        page, channels_live_server.url, f'data-autor="{autor.slug}"'
-    )
+    _strona_z_widgetem(page, channels_live_server.url, f'data-autor="{autor.slug}"')
 
-    page.wait_for_selector(".bpp-publikacje__item", timeout=15000)
-    assert page.locator(".bpp-publikacje__item").count() == 3
+    # to_have_count auto-waituje — nie potrzebujemy osobnego wait_for_selector.
+    expect(page.locator(".bpp-publikacje__item")).to_have_count(3, timeout=15000)
     # Stopka z linkiem do pełnego profilu
-    assert page.locator(".bpp-publikacje__stopka").count() == 1
+    expect(page.locator(".bpp-publikacje__stopka")).to_have_count(1)
 
 
 def test_embed_widget_pusta_lista(channels_live_server, page: Page, transactional_db):
@@ -51,7 +51,9 @@ def test_embed_widget_pusta_lista(channels_live_server, page: Page, transactiona
     assert page.locator(".bpp-publikacje__item").count() == 0
 
 
-def test_embed_widget_sanityzuje_xss(channels_live_server, page: Page, transactional_db):
+def test_embed_widget_sanityzuje_xss(
+    channels_live_server, page: Page, transactional_db
+):
     """Sanitizer loadera usuwa niebezpieczny HTML (allowlist), zachowuje
     tagi formatujące, i nigdy nie wykonuje wstrzykniętego kodu."""
     autor = baker.make(Autor, nazwisko="Pusty", imiona="Piotr")

--- a/src/nowe_raporty/tests/test_seed_raporty.py
+++ b/src/nowe_raporty/tests/test_seed_raporty.py
@@ -19,8 +19,9 @@ def test_seed_pusta_baza_tworzy_komplet():
     call_command("seed_raporty")
 
     assert set(Report.objects.values_list("slug", flat=True)) >= DEFAULT_SLUGS
-    # jedna wspolna tabela
-    assert Table.objects.count() == 1
+    # jedna wspolna tabela (count skope'owany do labela seeda — globalny
+    # count zaklada czysta baze; audyt sekcja 4)
+    assert Table.objects.filter(label="Publikacje autorów").count() == 1
     # tabela ma komplet kolumn (7 z dumpu)
     assert Column.objects.filter(parent__label="Publikacje autorów").count() == 7
 

--- a/src/raport_slotow/tests/test_playwright/test_raport_slotow_autor/test_form.py
+++ b/src/raport_slotow/tests/test_playwright/test_raport_slotow_autor/test_form.py
@@ -4,8 +4,8 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.django_db
-def test_AutorRaportSlotowForm_javascript(admin_page: Page, live_server):
-    url = live_server.url + reverse("raport_slotow:index")
+def test_AutorRaportSlotowForm_javascript(admin_page: Page, channels_live_server):
+    url = channels_live_server.url + reverse("raport_slotow:index")
     admin_page.goto(url)
     elem = admin_page.locator("#id_slot")
     elem.type("12")


### PR DESCRIPTION
## Co i po co

Runda 2 po #485 — punkt 6 planu z audytu (`docs/deweloper/audyt-testy-rownoleglosc-2026-07.md`): mniejsze poprawki wyścigów i anty-wzorców pod pytest-xdist/sharding.

### Fixture'y DB (wyścigi get_or_create)
- `pbn_dyscyplina2`: `uuid4()` z lookupu → `defaults` (każde wywołanie INSERT-owało duplikat `code="202"` → `MultipleObjectsReturned` w `import_common`/`pbn_integrator`).
- `pbn_discipline_group`: stały klucz `date(2020,1,1)` zamiast `today-7d` (leftover z wczorajszej sesji + reuse-db tworzył drugą grupę), `order_by("pk")` w fallbacku.
- `jezyki`/`tytuly`/`charaktery_formalne`/`Status_Korekty`: lookup po kluczu naturalnym, bez `pk=1` i bez `assert pl.pk == 1` (grep potwierdził brak testów zależnych od literalnych pk).
- `test_tasks`: `content_type_id=1` → `ContentType.objects.get_for_model(...)`.

### Playwright
- Koniec podwójnych serwerów (`admin_page` + `live_server`) w 5 plikach → nawigacja na `channels_live_server.url`; `preauth_page` bez zaszytego `live_server`.
- **Ważny wyjątek** (wykryty przy weryfikacji — 4 testy padły po ślepej zamianie): `test_clarivate`, `test_oswiadczenie_ken`, `test_crossref_api_sync_playwright` **muszą** zostać na `live_server`, bo polegają na stanie żyjącym tylko w procesie testu (`mocker.patch` na `Uczelnia.wosclient` / fixture `settings` / kasety VCR dla server-side HTTP) — subprocess Daphne ich nie widzi. Komentarze w plikach + kryterium wyboru serwera dopisane do audytu.
- `expect_navigation` przy zapisach, `to_have_count()` zamiast `count()==N`, guard na `Cookielaw.accept()`, `_poll_until` bez blokującego `time.sleep`, usunięty martwy finalizer.

### Konfiguracja i pozostałe
- `--tracing retain-on-failure` (ślady Playwright przy failach do `test-results/`, w `.gitignore`). **Uwaga:** wydłuża krok Playwright lokalnie ~2× (1:55 → 4:10) — nagrywa trace każdego testu i wyrzuca przy passie. Jeśli koszt uznamy za zbyt duży, można przenieść flagę tylko do CI.
- Opis markera `serial` w `pytest.ini` mówi teraz prawdę (xdist_group per katalog, nie globalna wyłączność).
- `test_google_analytics` na fixture `settings` + czyszczenie fragment-cache w teardownie; assert daty w multiseek odporny na północ.
- Ambient `.first()` na danych referencyjnych → deterministyczne fixtures; globalne `count() == N` skope'owane do obiektów testu (importer_publikacji, integration_tests, nowe_raporty, import_dyscyplin).
- `test_conftest`: lookup `rekord_id` jawną listą (`TupleField.from_db_value` zwraca tuple, a exact na ArrayField wymaga listy — PG: „operator nie istnieje: integer[] = integer").

## Weryfikacja lokalna
Pełne `make tests`: **6109 passed** (bez Playwright, 2:22) + **151 passed** (Playwright, 4:10) + **46 passed** (JS). Wcześniejszy batch 18 dotkniętych plików testowych: zielony po poprawkach opisanych wyżej.

🤖 Generated with [Claude Code](https://claude.com/claude-code)