### PR TITLE
fix(browse): nie renderuj pustej sekcji autorów na stronie rekordu

### DIFF
--- a/src/bpp/newsfragments/+pusta-sekcja-autorow.bugfix.rst
+++ b/src/bpp/newsfragments/+pusta-sekcja-autorow.bugfix.rst
@@ -1,0 +1,2 @@
+Strona rekordu: gdy praca nie ma autorów, sekcja autorów (szary pasek pod
+tytułem) nie jest już renderowana.

--- a/src/bpp/templates/browse/praca_tabela_mono.html
+++ b/src/bpp/templates/browse/praca_tabela_mono.html
@@ -25,6 +25,7 @@
 
         <!-- Authors Section -->
         {% autorzy_skrocony praca uczelnia as box %}
+        {% if box.liczba %}
         <div class="praca-mono__authors-section{% if box.skrocony %} praca-mono__authors-section--collapsible{% endif %}">
 
             {% if box.skrocony %}
@@ -56,6 +57,7 @@
                 {% endif %}
             </div>
         </div>
+        {% endif %}
     </div>
 
     <!-- Main content in two columns -->

--- a/src/bpp/tests/test_models/test_autorzy_dla_opisu_skrocony.py
+++ b/src/bpp/tests/test_models/test_autorzy_dla_opisu_skrocony.py
@@ -186,6 +186,19 @@ def test_render_krotka_lista_bez_skracania(
 
 
 @pytest.mark.django_db
+def test_render_bez_autorow_brak_sekcji_autorow(client, wydawnictwo_ciagle, denorms):
+    # Rekord bez autorów: sekcja autorów ma szare tło + padding, więc pusta
+    # renderowała się jako goły szary pasek pod tytułem.
+    denorms.flush()
+
+    res = _browse_praca(client, wydawnictwo_ciagle)
+    assert res.status_code == 200
+    # NIE po "praca-mono__authors-section" — ta nazwa siedzi też w inline JS
+    # (querySelector), więc występuje w HTML-u niezależnie od renderu sekcji.
+    assert "praca-mono__authors-full" not in res.content.decode("utf-8")
+
+
+@pytest.mark.django_db
 def test_render_doktorat_nie_wybucha(client, doktorat, denorms):
     # Praca_Doktorska dziedziczy autorzy_dla_opisu_skrocony, ale jej
     # autorzy_set to FakeSet z 1 (fałszywym) autorem — strona rekordu musi


### PR DESCRIPTION
## Problem

Na stronie rekordu bez autorów (np. materiały konferencyjne bez przypisanych autorów) pod tytułem renderował się pusty szary pasek — sekcja `praca-mono__authors-section` ma szare tło (`#f8f9fa`), padding i border-radius, więc nawet bez treści widać ~30px szarego prostokąta.

Przykład: https://publikacje.up.lublin.pl/bpp/rekord/Preparaty-mikrobiologiczne-w-rolnictwie-i-ochronie-srodowiska-Materialy-konferencyjne-Pulawy-27-28-maja-2025-roku-59-51090/

## Poprawka

Sekcja autorów w `praca_tabela_mono.html` jest owinięta w `{% if box.liczba %}` — przy zerowej liczbie autorów nie renderuje się w ogóle.

## Testy

- Nowy test regresyjny `test_render_bez_autorow_brak_sekcji_autorow` (asercja na `praca-mono__authors-full`, bo nazwa `praca-mono__authors-section` występuje też w inline JS i byłaby fałszywie dodatnia).
- Cały plik `test_autorzy_dla_opisu_skrocony.py`: 21 passed lokalnie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)