### PR TITLE
fix(pbn): strumieniowy skan brakujących dyscyplin — fix zawieszania pobierania źródeł na 90% (OOM)

### DIFF
--- a/src/bpp/newsfragments/+pbn-dyscypliny-oom.bugfix.rst
+++ b/src/bpp/newsfragments/+pbn-dyscypliny-oom.bugfix.rst
@@ -1,0 +1,4 @@
+Pobieranie źródeł z PBN nie zawiesza się już na 90% (krok „Aktualizacja
+brakujących dyscyplin..."). Skan dyscyplin iteruje teraz strumieniowo po
+źródłach PBN (server-side cursor, tylko potrzebne kolumny) zamiast ładować
+całą tabelę do pamięci — poprzednio worker Celery bywał ubijany przez OOM.

--- a/src/pbn_komparator_zrodel/tests/test_brakujace_dyscypliny.py
+++ b/src/pbn_komparator_zrodel/tests/test_brakujace_dyscypliny.py
@@ -1,0 +1,108 @@
+"""Testy skanu brakujących dyscyplin PBN.
+
+Pokrywają ``znajdz_brakujace_dyscypliny_pbn`` i
+``aktualizuj_brakujace_dyscypliny_pbn`` — funkcje wołane na końcu
+``download_journals`` (krok „Aktualizacja brakujących dyscyplin...", 90%).
+Pinują poprawność zanim zmienimy iterację po ``Journal`` na strumieniową
+(``.iterator()``) i zdedupujemy obie funkcje do jednego źródła prawdy.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Dyscyplina_Naukowa
+from pbn_api.models import Journal
+
+from ..models import BrakujacaDyscyplinaPBN
+from ..utils import (
+    aktualizuj_brakujace_dyscypliny_pbn,
+    znajdz_brakujace_dyscypliny_pbn,
+)
+
+
+def _journal(mongo_id, disciplines, current=True):
+    """Minimalny Journal PBN z listą dyscyplin w bieżącej wersji."""
+    return Journal.objects.create(
+        mongoId=mongo_id,
+        versions=[{"current": current, "object": {"disciplines": disciplines}}],
+    )
+
+
+@pytest.mark.django_db
+def test_znajdz_wykrywa_dyscypliny_nieobecne_w_bpp():
+    # W BPP istnieje tylko 1.1; źródło PBN deklaruje 1.1 (kod 11) oraz 2.3 (kod 23).
+    baker.make(Dyscyplina_Naukowa, kod="1.1", nazwa="Matematyka")
+    _journal(
+        "j1",
+        [
+            {"code": "11", "name": "Matematyka"},
+            {"code": "23", "name": "Nauki chemiczne"},
+        ],
+    )
+
+    brakujace = znajdz_brakujace_dyscypliny_pbn()
+
+    assert set(brakujace) == {"23"}
+    assert brakujace["23"]["kod_bpp"] == "2.3"
+    assert brakujace["23"]["nazwa"] == "Nauki chemiczne"
+    assert brakujace["23"]["count"] == 1
+
+
+@pytest.mark.django_db
+def test_znajdz_zlicza_wystapienia_w_wielu_zrodlach():
+    baker.make(Dyscyplina_Naukowa, kod="1.1")
+    _journal("j1", [{"code": "23", "name": "Chem"}])
+    _journal("j2", [{"code": "23", "name": "Chem"}])
+
+    brakujace = znajdz_brakujace_dyscypliny_pbn()
+
+    assert brakujace["23"]["count"] == 2
+
+
+@pytest.mark.django_db
+def test_znajdz_pomija_zrodla_bez_current_version_i_bez_dyscyplin():
+    baker.make(Dyscyplina_Naukowa, kod="1.1")
+    # brak wersji oznaczonej current -> value(..., return_none=True) zwraca None
+    Journal.objects.create(mongoId="nocur", versions=[{"current": False, "object": {}}])
+    # obecna wersja, ale pusta lista dyscyplin
+    _journal("empty", [])
+
+    assert znajdz_brakujace_dyscypliny_pbn() == {}
+
+
+@pytest.mark.django_db
+def test_aktualizuj_zapisuje_do_bazy_i_zastepuje_stare():
+    baker.make(Dyscyplina_Naukowa, kod="1.1")
+    # Nieaktualny wpis, który musi zniknąć po ponownym skanie.
+    BrakujacaDyscyplinaPBN.objects.create(
+        kod_pbn="99", kod_bpp="9.9", nazwa="Stare", liczba_zrodel=5
+    )
+    _journal("j1", [{"code": "23", "name": "Chem"}])
+
+    ile = aktualizuj_brakujace_dyscypliny_pbn()
+
+    assert ile == 1
+    wpisy = {b.kod_pbn: b for b in BrakujacaDyscyplinaPBN.objects.all()}
+    assert set(wpisy) == {"23"}  # stary "99" usunięty
+    assert wpisy["23"].kod_bpp == "2.3"
+    assert wpisy["23"].nazwa == "Chem"
+    assert wpisy["23"].liczba_zrodel == 1
+
+
+@pytest.mark.django_db
+def test_aktualizuj_zapisuje_dokladnie_to_co_zwraca_znajdz():
+    """Jedno źródło prawdy: zapis do bazy == wynik ``znajdz_...``."""
+    baker.make(Dyscyplina_Naukowa, kod="1.1")
+    _journal(
+        "j1",
+        [{"code": "23", "name": "Chem"}, {"code": "31", "name": "Bio"}],
+    )
+
+    znalezione = znajdz_brakujace_dyscypliny_pbn()
+    aktualizuj_brakujace_dyscypliny_pbn()
+
+    zapisane = {
+        b.kod_pbn: {"kod_bpp": b.kod_bpp, "nazwa": b.nazwa, "count": b.liczba_zrodel}
+        for b in BrakujacaDyscyplinaPBN.objects.all()
+    }
+    assert zapisane == znalezione

--- a/src/pbn_komparator_zrodel/utils.py
+++ b/src/pbn_komparator_zrodel/utils.py
@@ -20,6 +20,14 @@ from .models import BrakujacaDyscyplinaPBN, KomparatorZrodelMeta, RozbieznoscZro
 
 logger = logging.getLogger(__name__)
 
+# Liczba rekordów Journal ściąganych naraz przy strumieniowym skanie
+# dyscyplin. Tabela pbn_api.Journal potrafi mieć dziesiątki tysięcy wierszy,
+# a każdy trzyma w polu ``versions`` kilkukilobajtowy JSON. ``.iterator()``
+# z tym chunk_size trzyma w pamięci tylko jeden blok naraz (server-side
+# cursor) zamiast całej tabeli — bez tego worker Celery był ubijany przez
+# OOM (Rollbar #151) na kroku „Aktualizacja brakujących dyscyplin...".
+JOURNAL_SCAN_CHUNK_SIZE = 2000
+
 # Re-export for backwards compatibility
 __all__ = [
     "is_pbn_journals_data_fresh",
@@ -46,7 +54,13 @@ def znajdz_brakujace_dyscypliny_pbn():
 
     brakujace = {}
 
-    for journal in Journal.objects.all():
+    # Strumieniowo (server-side cursor) i tylko z potrzebnymi kolumnami:
+    # ``.value("object", "disciplines")`` czyta wyłącznie z pola ``versions``,
+    # więc resztę kolumn (title/issn/eissn/...) nie ma sensu ściągać.
+    journale = Journal.objects.only("mongoId", "versions").iterator(
+        chunk_size=JOURNAL_SCAN_CHUNK_SIZE
+    )
+    for journal in journale:
         disciplines = journal.value("object", "disciplines", return_none=True)
         if not disciplines:
             continue
@@ -77,32 +91,9 @@ def aktualizuj_brakujace_dyscypliny_pbn():
     Returns:
         int: Liczba znalezionych brakujących dyscyplin.
     """
-    from pbn_api.models import Journal
-
-    # Cache dyscyplin BPP
-    bpp_kody = set(Dyscyplina_Naukowa.objects.values_list("kod", flat=True))
-
-    brakujace = {}
-
-    for journal in Journal.objects.all():
-        disciplines = journal.value("object", "disciplines", return_none=True)
-        if not disciplines:
-            continue
-
-        for disc in disciplines:
-            code = disc.get("code")
-            name = disc.get("name", "")
-            if not code:
-                continue
-
-            kod_bpp = normalize_kod_dyscypliny(str(code))
-            if not kod_bpp:
-                continue
-
-            if kod_bpp not in bpp_kody:
-                if code not in brakujace:
-                    brakujace[code] = {"kod_bpp": kod_bpp, "nazwa": name, "count": 0}
-                brakujace[code]["count"] += 1
+    # Jedno źródło prawdy dla skanu — patrz ``znajdz_brakujace_dyscypliny_pbn``
+    # (strumieniowa iteracja po Journal, bez ładowania całej tabeli do RAM).
+    brakujace = znajdz_brakujace_dyscypliny_pbn()
 
     # Zapisz do bazy (usuń stare, dodaj nowe)
     with transaction.atomic():


### PR DESCRIPTION
## Problem

Pobieranie źródeł z PBN (`pbn_downloader_app.tasks.download_journals`) wieszało się na **90%**, krok „**Aktualizacja brakujących dyscyplin...**" — zgłoszone z produkcji (`bpp.apoz.edu.pl`), „już drugi raz".

## Przyczyna źródłowa

`znajdz_/aktualizuj_brakujace_dyscypliny_pbn` iterowały po `Journal.objects.all()`. Domyślny `QuerySet` **cache'uje wszystkie wiersze**, a każdy `Journal` trzyma kilkukilobajtowy JSON w polu `versions`. Przy pełnym mirrorze PBN (dziesiątki tys. źródeł) worker Celery puchł i był **ubijany przez OOM** — `WorkerLostError: signal 9 (SIGKILL)`, sender `download_journals` (Rollbar #151).

SIGKILL omija `try/except`, więc `mark_task_failed` nigdy się nie wykonywał → `task_record` zostawał na wieki `status="running"` @ 90% i UI pokazywało zamrożony pasek, choć proces już nie żył.

## Fix

- **`znajdz_brakujace_dyscypliny_pbn`** — iteracja strumieniowa `.only("mongoId","versions").iterator(chunk_size=2000)`: PostgreSQL server-side cursor trzyma w RAM tylko jeden chunk zamiast całej tabeli, a `.only(...)` odcina zbędne kolumny (`value()` czyta wyłącznie z `versions`).
- **`aktualizuj_brakujace_dyscypliny_pbn`** — deleguje do `znajdz_...` (**dedup**: wcześniej identyczna pętla była skopiowana w dwóch miejscach).
- Testy pinujące poprawność skanu i persystencji (`test_brakujace_dyscypliny.py`, 5 przypadków).

## Zakres — post import (get_tier)

Bug `AttributeError: 'NoneType' object has no attribute 'get_tier'` w post-imporcie (Rollbar #436) jest **już naprawiony osobno** commitem `cd2801ada` („fix(pbn): punktacja zwartych pomija rekordy bez wydawcy (#436)") i jest w `dev`. Deployed `202607.1397rc1` po prostu jeszcze go nie zawiera — wejdzie z następnym wydaniem. Tu nietknięty.

## Testy

- `src/pbn_komparator_zrodel/tests/` → **35 passed**
- `src/pbn_downloader_app/tests_tasks.py` → **24 passed**

## Uwaga operacyjna (poza tym PR)

Osobno na apoz widać unieważniony token PBN (`AccessDeniedException 403`, app „Ak.Pozar.", Rollbar #433/#434) — to konfiguracja po stronie uczelni, nie kod. Warto też rozważyć heartbeat/soft-time-limit, by przy śmierci workera task lądował jako `failed`, a nie wisiał „running".

🤖 Generated with [Claude Code](https://claude.com/claude-code)