### PR TITLE
fix(pbn): strumieniowa integracja źródeł (integruj_zrodla) — mniejszy ślad pamięciowy

### DIFF
--- a/src/bpp/newsfragments/+integruj-zrodla-iterator.bugfix.rst
+++ b/src/bpp/newsfragments/+integruj-zrodla-iterator.bugfix.rst
@@ -1,0 +1,4 @@
+Integracja źródeł z PBN (``integruj_zrodla``, Faza 2 pobierania źródeł)
+iteruje teraz strumieniowo po źródłach bez dopasowania PBN (server-side
+cursor) zamiast ładować wszystkie naraz do pamięci — mniejszy i stały ślad
+pamięciowy przy pełnym imporcie.

--- a/src/pbn_integrator/tests/test_c901_dict_transforms.py
+++ b/src/pbn_integrator/tests/test_c901_dict_transforms.py
@@ -469,6 +469,32 @@ def test_zrodla_no_match_leaves_pbn_uid_none():
 
 
 @pytest.mark.django_db
+def test_zrodla_integruje_wiele_zrodel_w_jednym_przebiegu():
+    """Wszystkie pasujące źródła dostają ``pbn_uid`` w jednym przebiegu.
+
+    Guard strumieniowej iteracji: ``integruj_zrodla`` iteruje po
+    ``Zrodlo.objects.filter(pbn_uid_id=None)`` i JEDNOCZEŚNIE w pętli zapisuje
+    ``pbn_uid`` (co usuwa wiersz ze zbioru pasującego do filtra). Migawka
+    kursora musi wydać wszystkie wiersze niezależnie od tych zapisów —
+    inaczej część źródeł zostałaby pominięta.
+    """
+    from pbn_integrator.utils import integruj_zrodla
+
+    pary = []
+    for i in range(5):
+        issn = f"55{i}0-000{i}"
+        j = _journal(issn=issn, eissn="", title=f"Tytul {i}", mniswId=100 + i)
+        z = baker.make(Zrodlo, nazwa=f"Zrodlo {i}", issn=issn, e_issn="", pbn_uid=None)
+        pary.append((z, j))
+
+    integruj_zrodla(disable_progress_bar=True)
+
+    for z, j in pary:
+        z.refresh_from_db()
+        assert z.pbn_uid_id == j.pk
+
+
+@pytest.mark.django_db
 def test_zrodla_multiple_matches_prefers_one_with_mniswid():
     """Multiple PBN journals match -> the one with a mniswId wins."""
     from pbn_integrator.utils import integruj_zrodla

--- a/src/pbn_integrator/utils/journals.py
+++ b/src/pbn_integrator/utils/journals.py
@@ -120,8 +120,15 @@ def integruj_zrodla(disable_progress_bar=False):
     Args:
         disable_progress_bar: Whether to disable progress bar.
     """
+    # Strumieniowo (server-side cursor) zamiast materializować wszystkie
+    # źródła-bez-PBN naraz do RAM: przy pełnym imporcie takich źródeł bywają
+    # dziesiątki tysięcy. ``count`` liczymy osobnym zapytaniem, bo iterator
+    # nie ma ``len()``. Migawka kursora jest niezależna od zapisów ``pbn_uid``
+    # w pętli, więc wszystkie wiersze zostają wydane mimo mutacji.
+    qs = Zrodlo.objects.filter(pbn_uid_id=None)
     for zrodlo in pbar(
-        Zrodlo.objects.filter(pbn_uid_id=None),
+        qs.iterator(chunk_size=1000),
+        count=qs.count(),
         label="Integracja zrodel",
         disable_progress_bar=disable_progress_bar,
     ):


### PR DESCRIPTION
Kontynuacja hardeningu pamięciowego pobierania źródeł PBN po #489.

## Kontekst

W #489 naprawiłem faktyczny OOM (skan brakujących dyscyplin, `Journal.objects.all()` × wielki JSON). Przy okazji prześledziłem całą ścieżkę `download_journals`:

- **Faza 1 — pobieranie (`threaded_page_getter`)**: już strumieniowa (`imap_unordered` po stronach, `page_size=8`) — bez zmian.
- **Faza 2 — integracja (`integruj_zrodla`)**: materializowała cały `Zrodlo.objects.filter(pbn_uid_id=None)` do RAM. Wiersze `Zrodlo` są małe (bez wielkiego JSON), więc to **nie był** OOM-culprit — ale przy pełnym imporcie takich źródeł bywają dziesiątki tysięcy, więc to niepotrzebny ślad.

## Zmiana

- `integruj_zrodla`: `qs.iterator(chunk_size=1000)` + `count=qs.count()` (`pbar` przyjmuje jawny `count`, bo iterator nie ma `len()`). Stały footprint zamiast całej tabeli w `_result_cache`.
- Test guardujący **wiele źródeł w jednym przebiegu**: iterujemy server-side cursor po `pbn_uid_id=None` i JEDNOCZEŚNIE zapisujemy `pbn_uid` w pętli — test potwierdza, że migawka kursora wydaje wszystkie wiersze mimo mutacji.

## Testy

- `src/pbn_integrator/tests/test_c901_dict_transforms.py` + `src/pbn_downloader_app/tests_tasks.py` → **47 passed**, ruff czysto.

## Poza zakresem

N+1 w `integruj_zrodla` (jeden `Journal.objects.get()` na źródło) to oś *czasu*, nie pamięci — osobno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)