### PR TITLE
fix(cache): filter_rekord z tuple-pk wybuchał na PostgreSQL

### DIFF
--- a/src/bpp/models/cache/autorzy.py
+++ b/src/bpp/models/cache/autorzy.py
@@ -8,7 +8,17 @@ from bpp.models.fields import TupleField
 
 class AutorzyManager(models.Manager):
     def filter_rekord(self, rekord):
-        return self.filter(rekord_id=rekord.pk)
+        pk = rekord.pk
+        if isinstance(pk, tuple):
+            # ``TupleField.from_db_value`` zwraca tuple, a lookup
+            # ``rekord_id=<tuple>`` na kolumnie FK przechodzi przez
+            # ``RelatedExact.get_normalized_value``, które traktuje tuplę
+            # jako wartość wielokolumnową (composite FK) i wysyła do SQL
+            # samo ``pk[0]`` → PG: „operator nie istnieje:
+            # integer[] = integer". Lista idzie normalną ścieżką
+            # adaptacji ArrayField.
+            pk = list(pk)
+        return self.filter(rekord_id=pk)
 
 
 class AutorzyBase(models.Model):

--- a/src/bpp/newsfragments/+filter-rekord-tuple-pk.bugfix.rst
+++ b/src/bpp/newsfragments/+filter-rekord-tuple-pk.bugfix.rst
@@ -1,0 +1,5 @@
+Naprawiono ``Autorzy.objects.filter_rekord()`` wywoływane z rekordem
+pobranym z bazy: klucz główny z ``TupleField`` (tuple) trafiał w ścieżkę
+lookupów wielokolumnowych FK i kończył się błędem PostgreSQL „operator
+nie istnieje: integer[] = integer". Manager normalizuje teraz tuple do
+listy.

--- a/src/bpp/tests/test_cache/test_cache.py
+++ b/src/bpp/tests/test_cache/test_cache.py
@@ -158,6 +158,25 @@ def test_deletion_cache(doktorat):
 
 
 @pytest.mark.django_db
+def test_autorzy_filter_rekord_rekordem_pobranym_z_bazy(
+    wydawnictwo_ciagle_z_dwoma_autorami, denorms
+):
+    """``filter_rekord()`` z Rekordem POBRANYM z bazy (pk = tuple).
+
+    Regresja: ``TupleField.from_db_value`` zwraca TUPLE, a lookup
+    ``rekord_id=<tuple>`` na kolumnie FK przechodzi przez
+    ``RelatedExact.get_normalized_value``, które traktuje tuplę jako
+    wartość WIELOKOLUMNOWĄ (composite FK) i bierze ``pk[0]`` — do SQL
+    idzie pojedynczy integer i PostgreSQL odpowiada „operator nie
+    istnieje: integer[] = integer". Lista przechodzi normalną ścieżką
+    adaptacji ArrayField i działa.
+    """
+    denorms.flush()
+    rekord = Rekord.objects.get_for_model(wydawnictwo_ciagle_z_dwoma_autorami)
+    assert Autorzy.objects.filter_rekord(rekord).count() == 2
+
+
+@pytest.mark.django_db
 def test_wca_delete_cache(wydawnictwo_ciagle_z_dwoma_autorami, denorms):
     """Czy skasowanie obiektu Wydawnictwo_Ciagle_Autor zmieni opis
     wydawnictwa ciągłego w Rekordy materialized view?"""

--- a/src/integration_tests/test_conftest.py
+++ b/src/integration_tests/test_conftest.py
@@ -92,8 +92,7 @@ def test_wydawnictwo_ciagle_z_dwoma_autorami(wydawnictwo_ciagle_z_dwoma_autorami
     # (.get() pod spodem) sam waliduje istnienie i unikalnosc rekordu cache.
     rekord = Rekord.objects.get_for_model(wc)
     assert Wydawnictwo_Ciagle_Autor.objects.filter(rekord=wc).count() == 2
-    # filter_rekord przekazuje rekord.pk wprost do lookupu rekord_id;
-    # TupleField.from_db_value zwraca TUPLE, a lookup exact ArrayField
-    # wymaga LISTY (tuple konczy sie bledem "operator nie istnieje:
-    # integer[] = integer" po stronie PG) - stad jawne list().
-    assert Autorzy.objects.filter(rekord_id=list(rekord.pk)).count() == 2
+    # filter_rekord normalizuje tuple-pk z TupleField do listy (regresja:
+    # bpp/tests/test_cache/test_cache.py::
+    # test_autorzy_filter_rekord_rekordem_pobranym_z_bazy).
+    assert Autorzy.objects.filter_rekord(rekord).count() == 2

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "bpp-iplweb"
-version = "202607.1396"
+version = "202607.1397"
 source = { editable = "." }
 dependencies = [
     { name = "arrow", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
## Problem

`Autorzy.objects.filter_rekord(rekord)` z `Rekord`-em **pobranym z bazy** kończył się błędem PostgreSQL:

```
operator nie istnieje: integer[] = integer
```

Mechanizm: `TupleField.from_db_value` zwraca **tuple**, a lookup `rekord_id=<tuple>` na kolumnie **FK** przechodzi przez `RelatedExact.get_normalized_value`, które interpretuje tuplę jako wartość wielokolumnową (composite FK) i wysyła do SQL samo `pk[0]`. Lista przechodzi normalną ścieżką adaptacji ArrayField i działa.

Bug wyszedł przy okazji audytu testów (PR #487 obszedł go w teście jawnym `list(rekord.pk)`); tu naprawa u źródła.

## Dlaczego nikt tego wcześniej nie zauważył

Jedyny istniejący caller (`test_wca_delete_cache`) woła `filter_rekord(aca)` **po** `aca.delete()` — pk jest wtedy `None`, lookup degeneruje się do `IS NULL` i zwraca 0 wierszy „poprawnie".

## Zakres

- `src/bpp/models/cache/autorzy.py` — manager normalizuje `tuple → list` (z komentarzem wyjaśniającym mechanizm).
- Test regresyjny `test_autorzy_filter_rekord_rekordem_pobranym_z_bazy` (TDD: najpierw obserwowany RED z dokładnie tym błędem PG).
- `test_conftest.py` — workaround z #487 wrócił na kanoniczny manager.
- Newsfragment.

Sprawdziłem pozostałe lookupy `rekord_id=` w kodzie produkcyjnym (`oswiadczenia/views.py:354`, `ewaluacja_optymalizacja`) — bezpieczne: `Cache_Punktacja_Autora.rekord_id` to goły `TupleField` (nie FK), a exact na zwykłym ArrayField konwertuje tuple w `get_db_prep_value`.

## Weryfikacja

`test_cache.py` (40) + `test_conftest.py` (16) — 56 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)