### PR TITLE
feat(zglos_publikacje): przycisk "Użyj importera" nad tabelą (FD#430)

### DIFF
--- a/src/bpp/newsfragments/+fd430-importer-nad-tabela.feature.rst
+++ b/src/bpp/newsfragments/+fd430-importer-nad-tabela.feature.rst
@@ -1,0 +1,6 @@
+Na stronie edycji zgłoszenia publikacji w adminie przycisk „Użyj importera"
+znajduje się teraz w pasku akcji nad tabelą (obok „Zwróć do autora"), a nie
+w wierszu tabeli. Gdy zgłoszenie ma rozpoznany numer DOI, importer otwiera się
+z wypełnionym providerem CrossRef; gdy jest tylko adres strony — z importem
+z ogólnej strony WWW; gdy zgłoszenie nie ma żadnego adresu, przycisk się nie
+pojawia (FD#430).

--- a/src/zglos_publikacje/admin/zgloszenie_publikacji.py
+++ b/src/zglos_publikacje/admin/zgloszenie_publikacji.py
@@ -117,7 +117,6 @@ class Zgloszenie_PublikacjiAdmin(
         + (
             "email",
             "strona_www",
-            "importer_z_adresu",
             "pliki_do_pobrania",
             "wydawca_zgloszenia",
             "wydawca_bpp",
@@ -132,7 +131,7 @@ class Zgloszenie_PublikacjiAdmin(
         )
     )
 
-    readonly_fields = ["pliki_do_pobrania", "importer_z_adresu"]
+    readonly_fields = ["pliki_do_pobrania"]
 
     inlines = [
         Zgloszenie_Publikacji_AutorInline,
@@ -177,6 +176,16 @@ class Zgloszenie_PublikacjiAdmin(
         super_urls = super().get_urls()
 
         return urls + super_urls
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        # Udostępnij szablonowi URL importera, by przycisk „Użyj importera"
+        # mógł stanąć w pasku akcji nad tabelą (blok object-tools), a nie w
+        # readonly wierszu tabeli (Freshdesk #430).
+        extra_context = extra_context or {}
+        obj = self.get_object(request, object_id)
+        if obj is not None:
+            extra_context["importer_url"] = self.importer_url(obj)
+        return super().change_view(request, object_id, form_url, extra_context)
 
     zwroc_view_template = (
         "admin/zglos_publikacje/zgloszenie_publikacji/zwroc_zgloszenie.html"
@@ -377,45 +386,34 @@ class Zgloszenie_PublikacjiAdmin(
 
         return format_html_join("<br/>", "{}", ((part,) for part in parts))
 
-    @admin.display(description="Importer publikacji")
-    def importer_z_adresu(self, obj: Zgloszenie_Publikacji):
-        """Przycisk „użyj importera" przekazujący adres pracy do importera.
+    def importer_url(self, obj: Zgloszenie_Publikacji) -> str | None:
+        """Zbuduj URL importera dla adresu zgłoszenia albo zwróć ``None``.
 
-        Jeśli z pola „Dostępna w sieci pod adresem" (lub z pola DOI
-        zgłoszenia) da się wyłuskać DOI, importer dostanie go w polu
-        identyfikatora. Jeśli adres nie jest DOI-em — importer otwiera się
-        z pustym polem DOI (bez błędu), import kontynuujemy ręcznie.
+        Priorytet: jeśli z pola „Dostępna w sieci pod adresem" (lub z pola
+        DOI zgłoszenia) da się wyłuskać DOI — importer z providerem CrossRef
+        i wypełnionym identyfikatorem. W przeciwnym razie, jeśli adres w
+        ogóle jest — importer z providerem „Pozostałe strony WWW" (import z
+        ogólnej strony), z adresem w polu identyfikatora. Gdy adresu nie ma
+        — ``None`` (przycisku importera nie pokazujemy).
         """
         doi = extract_doi_from_url(obj.strona_www) or extract_doi_from_url(
             getattr(obj, "doi", None)
         )
 
-        params = {"provider": "CrossRef"}
         if doi:
-            params["identifier"] = doi
+            params = {"provider": "CrossRef", "identifier": doi}
+        elif obj.strona_www:
+            # Nazwa providera musi zgadzać się z WWWProvider.name.
+            params = {
+                "provider": "Pozostałe strony WWW",
+                "identifier": obj.strona_www,
+            }
+        else:
+            return None
 
-        url = "{}?{}".format(
+        return "{}?{}".format(
             reverse("importer_publikacji:index"),
             urlencode(params),
-        )
-
-        if doi:
-            etykieta = format_html(
-                "Rozpoznano DOI: <strong>{}</strong>",
-                doi,
-            )
-        else:
-            etykieta = format_html(
-                "{}",
-                "Adresu nie rozpoznano jako DOI — importer otworzy się "
-                "z pustym polem DOI.",
-            )
-
-        return format_html(
-            '<a class="button" href="{}" target="_blank" '
-            'rel="noopener">📥 Użyj importera</a><br/>{}',
-            url,
-            etykieta,
         )
 
     def wydzial_pierwszego_autora(self, obj: Zgloszenie_Publikacji):

--- a/src/zglos_publikacje/templates/admin/zglos_publikacje/zgloszenie_publikacji/change_form.html
+++ b/src/zglos_publikacje/templates/admin/zglos_publikacje/zgloszenie_publikacji/change_form.html
@@ -1,6 +1,9 @@
 {% extends "admin/change_form.html" %}
 
 {% block object-tools-items %}
+    {% if importer_url %}
+        <li><a href="{{ importer_url }}" target="_blank" rel="noopener">📥 Użyj importera</a></li>
+    {% endif %}
     {% if original.moze_zostac_zwrocony %}
         <li><a href="../zwroc/">Zwróć do autora</a></li>
     {% endif %}

--- a/src/zglos_publikacje/tests/test_admin/test_repro_fd430.py
+++ b/src/zglos_publikacje/tests/test_admin/test_repro_fd430.py
@@ -1,0 +1,91 @@
+"""Freshdesk #430 — przycisk „Użyj importera" nad tabelą, nie w wierszu.
+
+Oczekiwane zachowanie na stronie edycji zgłoszenia publikacji w adminie:
+
+* przycisk „Użyj importera" ma być w pasku akcji NAD tabelą (blok
+  ``object-tools``), a nie renderowany jako readonly wiersz tabeli;
+* gdy z adresu da się wyłuskać DOI → importer z providerem CrossRef;
+* gdy adres nie jest DOI-em, ale jest — importer z providerem „Pozostałe
+  strony WWW" (import z ogólnej strony), a nie CrossRef;
+* gdy zgłoszenie nie ma żadnego adresu — przycisku nie ma w ogóle.
+"""
+
+import re
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+
+from zglos_publikacje.models import Zgloszenie_Publikacji
+
+
+def _change_html(admin_client, zgloszenie):
+    change_url = reverse(
+        "admin:zglos_publikacje_zgloszenie_publikacji_change",
+        args=[zgloszenie.pk],
+    )
+    response = admin_client.get(change_url)
+    assert response.status_code == 200
+    return response.content.decode()
+
+
+def _object_tools_fragment(html):
+    """Wytnij zawartość paska akcji ``<ul class="…object-tools">…</ul>``.
+
+    Grappelli renderuje pasek jako ``grp-object-tools`` — dopuszczamy oba.
+    """
+    match = re.search(
+        r'<ul class="[^"]*object-tools">(.*?)</ul>', html, flags=re.DOTALL
+    )
+    assert match, "Brak paska object-tools na stronie edycji"
+    return match.group(1)
+
+
+@pytest.mark.django_db
+def test_repro_fd430_przycisk_nad_tabela_z_doi(admin_client):
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca z DOI",
+        strona_www="https://doi.org/10.1234/abc.def",
+    )
+
+    html = _change_html(admin_client, zgloszenie)
+
+    # Przycisk jest w pasku akcji nad tabelą…
+    tools = _object_tools_fragment(html)
+    assert "Użyj importera" in tools
+    assert "provider=CrossRef" in tools
+    assert "10.1234%2Fabc.def" in tools
+
+    # …i wyłącznie tam — nie jako readonly wiersz w tabeli formularza.
+    assert "Użyj importera" not in html.replace(tools, "")
+
+
+@pytest.mark.django_db
+def test_repro_fd430_www_provider_gdy_adres_nie_jest_doi(admin_client):
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca bez DOI, ze stroną WWW",
+        strona_www="https://example.com/papers/123",
+    )
+
+    tools = _object_tools_fragment(_change_html(admin_client, zgloszenie))
+
+    assert "Użyj importera" in tools
+    # Nie CrossRef, tylko import z ogólnej strony WWW.
+    assert "provider=CrossRef" not in tools
+    assert "provider=Pozosta%C5%82e+strony+WWW" in tools
+    assert "identifier=https%3A%2F%2Fexample.com%2Fpapers%2F123" in tools
+
+
+@pytest.mark.django_db
+def test_repro_fd430_brak_przycisku_bez_adresu(admin_client):
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca bez adresu",
+        strona_www="",
+    )
+
+    html = _change_html(admin_client, zgloszenie)
+
+    assert "Użyj importera" not in html

--- a/src/zglos_publikacje/tests/test_admin/test_zgloszenie_publikacji.py
+++ b/src/zglos_publikacje/tests/test_admin/test_zgloszenie_publikacji.py
@@ -106,7 +106,7 @@ def test_zgloszenie_publikacji_admin_przycisk_uzyj_importera_z_doi(admin_client)
 
 @pytest.mark.django_db
 def test_zgloszenie_publikacji_admin_przycisk_uzyj_importera_bez_doi(admin_client):
-    """Freshdesk #380: adres niebędący DOI -> importer bez identyfikatora, bez błędu."""
+    """Freshdesk #380/#430: adres niebędący DOI -> importer z providerem WWW."""
     zgloszenie = baker.make(
         Zgloszenie_Publikacji,
         tytul_oryginalny="Praca bez DOI",
@@ -122,5 +122,7 @@ def test_zgloszenie_publikacji_admin_przycisk_uzyj_importera_bez_doi(admin_clien
     assert response.status_code == 200
     html = response.content.decode()
     assert "Użyj importera" in html
-    assert "provider=CrossRef" in html
-    assert "identifier=" not in html
+    # FD#430: import z ogólnej strony WWW, nie CrossRef.
+    assert "provider=CrossRef" not in html
+    assert "provider=Pozosta%C5%82e+strony+WWW" in html
+    assert "identifier=https%3A%2F%2Fexample.com%2Fpapers%2F123" in html


### PR DESCRIPTION
## Cel

Fixes Freshdesk **FD#430** — https://iplweb.freshdesk.com/a/tickets/430
(oryginalne zgłoszenie: https://support.iplweb.pl/a/tickets/425)

Na stronie edycji zgłoszenia publikacji w adminie
(`/admin/zglos_publikacje/zgloszenie_publikacji/<id>/change/`) przycisk
**„Użyj importera"** renderował się jako **wiersz tabeli** (readonly field
`importer_z_adresu`). Zgłoszenie prosi, by trafił do **paska akcji nad tabelą**
— tam gdzie „Zwróć do autora", „Dodaj wyd. zwarte" itp.

## Co zmienia

- Przycisk „Użyj importera" jest teraz w bloku `object-tools` **nad tabelą**,
  a nie jako wiersz w tabeli formularza.
- Logika wyboru providera (na życzenie zgłaszającego):
  - **rozpoznany DOI** → importer z providerem `CrossRef` + wypełniony
    identyfikator DOI,
  - **adres nie-DOI** → importer z providerem `Pozostałe strony WWW` (import
    z ogólnej strony) + adres w polu identyfikatora,
  - **brak adresu** → przycisku nie ma w ogóle.
- URL importera liczony w `Zgloszenie_PublikacjiAdmin.importer_url()` i
  wstrzykiwany do szablonu przez `change_view()` (`extra_context`); szablon
  `change_form.html` renderuje `<li>` tylko gdy `importer_url` istnieje.
- Usunięty readonly wiersz `importer_z_adresu` (metoda + wpisy w
  `fields`/`readonly_fields`).

## Testy

- Nowy `test_repro_fd430.py`: przycisk w `object-tools` i **wyłącznie** tam
  (nie w tabeli); provider CrossRef przy DOI; provider WWW przy adresie
  nie-DOI; brak przycisku bez adresu.
- Zaktualizowany `test_...uzyj_importera_bez_doi` (FD#380) na nowe zachowanie
  (WWW zamiast CrossRef-bez-identyfikatora).
- `uv run pytest src/zglos_publikacje/` → **63 passed** (bez regresji, w tym
  Playwright).

Bez migracji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)