### PR TITLE
fix(promote): finalna wersja w obrazie prod (patch-layer zamiast imagetools)

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -288,11 +288,17 @@ jobs:
             echo "final_tag=${INPUT_VERSION_TAG}" >> "$GITHUB_OUTPUT"
             echo "channel_tag=${INPUT_CHANNEL}" >> "$GITHUB_OUTPUT"
             echo "branch_tag=" >> "$GITHUB_OUTPUT"
+            # RC jest staging-flavored → stopka pokazuje wersję rcN + git SHA.
+            # BPP_IMAGE_TAG (footer_image_tag) zostaje PUSTY: tag obrazu = ta
+            # sama wersja rcN, więc duplikowałby "wersję" w stopce. Prod (po
+            # promote) jest release-flavored i tak chowa image_tag.
+            echo "footer_image_tag=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$PR_NUMBER" ]; then
             echo "final_tag=${PR_NUMBER}-merge" >> "$GITHUB_OUTPUT"
+            echo "footer_image_tag=${PR_NUMBER}-merge" >> "$GITHUB_OUTPUT"
             BRANCH_TAG=$(echo "$HEAD_REF" \
               | sed 's/[^a-zA-Z0-9._-]/-/g' \
               | tr '[:upper:]' '[:lower:]')
@@ -303,6 +309,7 @@ jobs:
               | sed 's/[^a-zA-Z0-9._-]/-/g' \
               | tr '[:upper:]' '[:lower:]')
             echo "final_tag=${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
+            echo "footer_image_tag=${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
             echo "branch_tag=" >> "$GITHUB_OUTPUT"
             echo "channel_tag=" >> "$GITHUB_OUTPUT"
           fi
@@ -320,15 +327,22 @@ jobs:
           DOCKER_VERSION: ${{ steps.tag.outputs.staging_tag }}
           TAG_LATEST: "false"
           PUSH: "true"
-          # Wynikiem ekspresji jest literal "release" albo "dev" — nie ma
+          # Wynikiem ekspresji jest literal "staging"/"release"/"dev" — nie ma
           # tu untrusted input z github.event.*. Ref name jest weryfikowane
-          # przez równość z literałem, więc nie ma ryzyka injection. Reusable
-          # RC build też jest release-flavored, bo te same bajty idą na prod.
-          BPP_BUILD_FLAVOR: ${{ inputs.version_tag != '' && 'release' || (github.ref_name == 'master' && 'release' || 'dev') }}
-          # Kanoniczny tag finalny — wpisany do obrazu jako BPP_IMAGE_TAG
-          # ENV, żeby stopka dla dev buildów wyświetlała "119-merge" obok
-          # commit SHA. Wartość pochodzi ze stepa `tag` powyżej.
-          BPP_IMAGE_TAG: ${{ steps.tag.outputs.final_tag }}
+          # przez równość z literałem, więc nie ma ryzyka injection.
+          #
+          # RC build (version_tag != '') jest STAGING-flavored, NIE release:
+          # te obrazy trafiają na :staging, a deployment staging pokazuje w
+          # stopce wersję rcN + git SHA (release-flavor chowałby te "atrakcje").
+          # Produkcyjny obraz powstaje dopiero w promote.yml, który nakłada
+          # patch-layer: finalny version.py (bez rc) + BPP_BUILD_FLAVOR=release.
+          # Patrz docker/promote-patch/Dockerfile.
+          BPP_BUILD_FLAVOR: ${{ inputs.version_tag != '' && 'staging' || (github.ref_name == 'master' && 'release' || 'dev') }}
+          # Tag obrazu wpisany do stopki (dev buildy: "119-merge" obok commit
+          # SHA). Dla RC pusty (footer_image_tag w stepie `tag`) — tag obrazu =
+          # wersja rcN, więc byłby redundantny ze "wersją". Prod (release) i tak
+          # chowa image_tag.
+          BPP_IMAGE_TAG: ${{ steps.tag.outputs.footer_image_tag }}
           # Alias nazwy brancha (np. "feature-nowe-zglos-publikacje") —
           # ustawiany przez step `tag` tylko dla pull_request eventów,
           # pusty inaczej. Stopka pokaże ten alias obok PR#-merge.

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,7 +1,11 @@
 name: Promote (RC → produkcja)
 
-# Druga komenda wydania. Finalizuje otwarte wydanie i przepina :latest na
-# zatwierdzony obraz RC — BEZ rebuildu (imagetools). Wywołanie:
+# Druga komenda wydania. Finalizuje otwarte wydanie i publikuje produkcyjny
+# obraz przez cienki patch-layer na zatwierdzonym RC: podmienia version.py na
+# finalny (bez rc) i ustawia BPP_BUILD_FLAVOR=release (patrz
+# docker/promote-patch/Dockerfile). NIE imagetools — bo kopia manifestu
+# odziedziczyłaby zapieczoną w RC wersję rcN (stopka/Rollbar). Warstwy bazowe
+# = te same przetestowane warstwy RC (dedup w rejestrze). Wywołanie:
 #   gh workflow run promote.yml
 # Gdy otwartych jest >1 gałęzi release/* — podaj którą:
 #   gh workflow run promote.yml -f version=v202606.1392
@@ -156,10 +160,18 @@ jobs:
             "refs/tags/v${BASE}" \
             ":refs/heads/${RELEASE_REF}"
 
-      - name: Promote obrazów :rc → :wersja + :latest (imagetools)
+      - name: Promote obrazów :rc → :wersja + :latest (patch version.py + flavor)
         env:
           BASE: ${{ steps.detect.outputs.base }}
           RC_TAG: ${{ steps.detect.outputs.rc_tag }}
+        # NIE imagetools: obraz RC ma zapieczoną wersję rcN + BPP_BUILD_FLAVOR=
+        # staging (żeby stopka na :staging pokazywała rcN + git SHA). Promote
+        # nakłada cienki patch-layer na przetestowany RC — podmienia
+        # src/django_bpp/version.py na finalny (sfinalizowany krokiem "Finalizuj
+        # wersję", więc jest już w drzewie roboczym _dev) i ustawia
+        # BPP_BUILD_FLAVOR=release. Warstwy bazowe = te same przetestowane
+        # warstwy RC (dedup w rejestrze; push dokłada tylko 2 malutkie).
+        # Patrz docker/promote-patch/Dockerfile.
         run: |
           set -euo pipefail
           images=(
@@ -171,17 +183,26 @@ jobs:
             iplweb/bpp_denorm_queue
           )
           for img in "${images[@]}"; do
-            echo "::group::Promote ${img}: ${RC_TAG} → ${BASE} + latest"
-            docker buildx imagetools create \
-              -t "${img}:${BASE}" \
-              -t "${img}:latest" \
-              "${img}:${RC_TAG}"
+            echo "::group::Patch+promote ${img}: ${RC_TAG} → ${BASE} + latest"
+            # --provenance=false: bez tego buildx (driver docker-container)
+            # dokleja atestację provenance i single-platform build staje się
+            # image-indexem z wpisem "unknown/unknown" — niepotrzebna zmiana
+            # względem płaskiego manifestu, który dawał imagetools.
+            docker buildx build \
+              --platform linux/amd64 \
+              --provenance=false \
+              --build-arg "RC_IMAGE=${img}:${RC_TAG}" \
+              --file docker/promote-patch/Dockerfile \
+              --tag "${img}:${BASE}" \
+              --tag "${img}:latest" \
+              --push \
+              .
             echo "::endgroup::"
           done
           {
             echo "## ✅ Promoted v${BASE}"
             echo ""
-            echo "Źródło RC: \`:${RC_TAG}\` → \`:${BASE}\` + \`:latest\` (bez rebuildu)"
+            echo "Źródło RC: \`:${RC_TAG}\` → patch (finalny version.py + flavor=release) → \`:${BASE}\` + \`:latest\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Push master/dev/tag i usuń release branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ skróty `make` (owijają `gh workflow run` + od razu `gh run watch`):
 ```bash
 make release-candidate    # Faza 1: zbuduj RC → :staging (nie rusza prod)
 # … staging pulluje :staging, testujesz …
-make release-promote      # Faza 2: RC → :latest (bez rebuildu, imagetools)
+make release-promote      # Faza 2: RC → :latest (patch version.py + flavor=release)
 ```
 
 Flagi: `make release-candidate SKIP_TESTS=1 SKIP_SCAN=1` (awaryjnie),
@@ -208,10 +208,11 @@ Pod spodem to zwykłe `workflow_dispatch`:
 
 ```bash
 gh workflow run release-candidate.yml --ref dev   # zbuduj RC → :staging
-gh workflow run promote.yml                        # RC → :latest (bez rebuildu)
+gh workflow run promote.yml                        # RC → :latest (patch-layer na RC)
 ```
 
-`push:master` NIE buduje już obrazów produkcyjnych — robi to promote (imagetools).
+`push:master` NIE buduje już obrazów produkcyjnych — robi to promote
+(patch-layer na przetestowanym RC, patrz sekcja niżej).
 
 ## Autologin dla agentów (WebFetch / curl bez logowania)
 
@@ -395,8 +396,22 @@ sa jawnie tymczasowe (nie release).
 `docker buildx imagetools create -t <canonical> <staging>` kopiuje
 manifest w rejestrze. Nie rebuilduje, nie re-pushuje warstw — tylko
 zapisuje metadane z referencja do istniejacych layers. ~sek per obraz.
-Przy `release-candidate.yml` dodatkowo przepina kanal `:staging`.
-Tag `:latest` rusza dopiero w `promote.yml`, z immutable RC tagu.
+Przy `release-candidate.yml` dodatkowo przepina kanal `:staging`. Tak
+powstaja tagi RC (`:<wersja>rcN`, `:staging`) — obrazy RC sa
+**staging-flavored** (`BPP_BUILD_FLAVOR=staging`), zeby deployment `:staging`
+pokazywal w stopce wersje rcN + git SHA.
+
+**Faza 4 — Promote RC → produkcja (patch-layer, `promote.yml`)**
+Kanoniczny `:latest`/`:<wersja>` NIE powstaje przez imagetools — bo kopia
+manifestu bit-w-bit odziedziczylaby zapieczona w RC wersje rcN (stopka,
+panel admina, Rollbar `code_version`). Zamiast tego `promote.yml` naklada
+cienki patch-layer na przetestowany obraz RC (`docker/promote-patch/
+Dockerfile`): podmienia `src/django_bpp/version.py` na finalny (bez sufiksu
+rc), kasuje zapieczony `version.pyc` i ustawia `BPP_BUILD_FLAVOR=release`
+(stopka chowa "atrakcje", pokazuje czysta wersje). Warstwy bazowe pozostaja
+tymi samymi przetestowanymi warstwami RC (dedup w rejestrze; push doklada
+tylko 2 malutkie warstwy). Aplikacja czyta wersje przez `PYTHONPATH=/app/src`
+(`uv sync --no-install-project`), wiec podmiana jednego pliku wystarcza.
 
 **Zastrzezenie o rejestrze:**
 Raz pushniety digest (nawet pod staging tagiem) zyje w Docker Hub do

--- a/docker/promote-patch/Dockerfile
+++ b/docker/promote-patch/Dockerfile
@@ -1,0 +1,34 @@
+# Patch-layer nakładany przez .github/workflows/promote.yml podczas promocji
+# RC → :latest. Bierze NIEZMIENIONY (przetestowany) obraz RC jako bazę i
+# nadpisuje WYŁĄCZNIE to, co odróżnia wydanie od kandydata:
+#
+#   1. src/django_bpp/version.py — finalna wersja (bez sufiksu rcN). Aplikacja
+#      czyta ją przez PYTHONPATH=/app/src (projekt instalowany z
+#      `uv sync --no-install-project`, NIE do site-packages), więc podmiana
+#      tego jednego pliku wystarcza — stopka, panel admina i Rollbar
+#      (ROLLBAR["code_version"]) od razu widzą finalną wersję.
+#
+#   2. usunięcie skompilowanego bytecode'u version.pyc. `collectstatic` w
+#      builder stage importuje django_bpp.settings → `from django_bpp.version
+#      import VERSION`, więc do /app/src/django_bpp/__pycache__/ trafia .pyc
+#      zapieczony z wersją rc i jest kopiowany do runtime. Bez rm Python mógłby
+#      uznać stary .pyc za ważny i serwować wersję rc. rm wymusza rekompilację
+#      z podmienionego .py przy pierwszym imporcie (runtime działa jako root —
+#      brak USER w stage `runtime` — więc rm i rekompilacja mają uprawnienia).
+#
+#   3. BPP_BUILD_FLAVOR=release — obrazy RC są STAGING-flavored (stopka na
+#      deploymencie :staging pokazuje rcN + git SHA). Patch przełącza je w
+#      release, więc prod chowa "atrakcje" (SHA/branch/tag) i pokazuje samą
+#      czystą wersję.
+#
+# Wszystkie warstwy poniżej pozostają bit-w-bit tymi z przetestowanego RC
+# (współdzielone w rejestrze — push dokłada tylko te 2 malutkie warstwy).
+# Kontekst build-u = korzeń repo; drzewo robocze promote.yml ma już
+# sfinalizowany version.py (krok "Finalizuj wersję" via bumpver).
+ARG RC_IMAGE
+FROM ${RC_IMAGE}
+
+COPY src/django_bpp/version.py /app/src/django_bpp/version.py
+RUN rm -f /app/src/django_bpp/__pycache__/version.*.pyc
+
+ENV BPP_BUILD_FLAVOR=release

--- a/src/bpp/newsfragments/stopka-wersja-bez-rc-na-produkcji.bugfix.rst
+++ b/src/bpp/newsfragments/stopka-wersja-bez-rc-na-produkcji.bugfix.rst
@@ -1,0 +1,5 @@
+Stopka serwisu (oraz panel admina i Rollbar ``code_version``) na produkcji
+pokazuje teraz finalną wersję wydania bez sufiksu ``rcN``. Promocja RC →
+produkcja nakłada cienki patch-layer na przetestowany obraz RC, podmieniając
+zapieczoną wersję kandydata na finalną; deployment ``:staging`` nadal pokazuje
+wersję ``rcN`` wraz z git SHA.


### PR DESCRIPTION
## Problem

Stopka serwisu (a także panel admina i Rollbar `code_version`) na **produkcji** pokazywała wersję kandydata (`…rcN`) zamiast wydanej.

**Przyczyna:** `promote.yml` kopiował manifest obrazu RC bit-w-bit (`docker buildx imagetools create`), więc `:latest`/`:wersja` dziedziczyły zapieczony w RC `VERSION = "…rcN"`. `bumpver` w promote finalizuje wersję tylko w gicie (master/dev/tag) — gotowego obrazu nie tyka.

## Rozwiązanie — patch-layer zamiast imagetools

Promote nakłada teraz cienką warstwę na **przetestowany** obraz RC (`docker/promote-patch/Dockerfile`):

1. podmienia `src/django_bpp/version.py` na finalny (bez `rc`) — aplikacja czyta wersję przez `PYTHONPATH=/app/src` (`uv sync --no-install-project`), więc jeden plik wystarcza (stopka + admin + Rollbar);
2. kasuje zapieczony `version.pyc` (`collectstatic` w builder stage generuje go przy imporcie `django_bpp.version` → inaczej stary bytecode mógłby wygrać);
3. ustawia `BPP_BUILD_FLAVOR=release`.

Warstwy bazowe = te same przetestowane warstwy RC (dedup w rejestrze; push dokłada tylko 2 malutkie warstwy).

Dodatkowo obrazy RC są teraz **staging-flavored** (było `release`): deployment `:staging` pokazuje w stopce `rcN` + git SHA, a dopiero patch w promote przełącza prod w `release` (czysta wersja, bez „atrakcji"). `BPP_IMAGE_TAG` dla RC ustawiony na pusty, żeby nie dublować wersji w stopce.

**Zero zmian w kodzie Pythona ani w `bpp-deploy`** — `VERSION` staje się genuinie poprawny w obrazie.

## Weryfikacja

Prawdziwy patch-Dockerfile puszczony na sztucznym obrazie RC (`202607.1396rc1`, staging-flavored, z zapieczonym `version.pyc`):

| | RC (przed) | po patchu (prod) |
|---|---|---|
| `VERSION` | `202607.1396rc1` | `202607.1396` |
| `BPP_BUILD_FLAVOR` | `staging` | `release` |
| `version.pyc` | obecny | usunięty (zostaje `__init__.pyc`) |

## Uwaga

Działa od **następnego wydania**. Bieżący prod (`v202607.1396`) ma już wypchnięty `:latest` starą ścieżką i będzie pokazywał `rc1` do kolejnego promote. Bieżący prod można naprawić jednorazowym patchem istniejącego `:…rc1` tym samym Dockerfilem (push do prod rejestru — osobno).

🤖 Generated with [Claude Code](https://claude.com/claude-code)