### PR TITLE
Dopasowanie autorów po poprzednich nazwiskach (FD#407)

### DIFF
--- a/src/bpp/newsfragments/+fd407.bugfix.rst
+++ b/src/bpp/newsfragments/+fd407.bugfix.rst
@@ -1,0 +1,8 @@
+Dopasowywanie autorów przy imporcie prac (CrossRef, PBN, POL-on, import
+kadr) oraz w deduplikatorze autorów uwzględnia teraz pole "poprzednie
+nazwiska". Dzięki temu osoba, która zmieniła nazwisko (np. z dwuczłonowego
+"Gawlik-Dziki" na jednoczłonowe "Gawlik" albo z panieńskiego na nazwisko po
+mężu), jest poprawnie kojarzona z istniejącym rekordem zamiast tworzyć
+duplikat. Poprzednie nazwisko dopasowywane jest jako dokładny człon listy
+(rozdzielanej przecinkami), więc częste nazwiska nie generują fałszywych
+dopasowań (FD#407).

--- a/src/deduplikator_autorow/tests/test_repro_fd407.py
+++ b/src/deduplikator_autorow/tests/test_repro_fd407.py
@@ -1,0 +1,92 @@
+"""Repro FD#407 — deduplikator autorów uwzględnia ``poprzednie_nazwiska``.
+
+Gdy jedna osoba figuruje w bazie dwa razy pod różnymi nazwiskami (np. przed i
+po zmianie nazwiska), a jeden z rekordów ma starą formę wpisaną w polu
+``poprzednie_nazwiska``, deduplikator powinien skojarzyć te rekordy — również
+gdy nazwiska nie mają wspólnego członu (panieńskie → po mężu).
+
+Pokrywa obie fazy deduplikatora:
+- general (all-pairs, meta-cache) — ``_run_general_phase``,
+- PBN (anchored na OsobaZInstytucji) — ``szukaj_kopii``.
+"""
+
+import pytest
+from model_bakery import baker
+
+from deduplikator_autorow.models import DuplicateCandidate, DuplicateScanRun
+from deduplikator_autorow.utils import szukaj_kopii
+
+# ---------------------------------------------------------------------------
+# Faza general
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_general_laczy_zmiane_nazwiska_bez_wspolnego_czlonu():
+    """Panieńskie → po mężu: "Kowalska" jako obecne u jednego rekordu i jako
+    poprzednie u drugiego. Brak wspólnego członu → bez poprzednich nazwisk
+    nie zostałyby nawet porównane."""
+    a = baker.make(
+        "bpp.Autor",
+        nazwisko="Nowak",
+        imiona="Anna",
+        poprzednie_nazwiska="Kowalska",
+    )
+    b = baker.make("bpp.Autor", nazwisko="Kowalska", imiona="Anna")
+
+    scan = DuplicateScanRun.objects.create()
+    from deduplikator_autorow.tasks import _run_general_phase
+
+    _run_general_phase(scan, min_confidence=50)
+
+    cands = DuplicateCandidate.objects.filter(scan_run=scan, scan_mode="general")
+    assert cands.count() == 1
+    cand = cands.get()
+    assert {cand.main_autor_id, cand.duplicate_autor_id} == {a.pk, b.pk}
+
+
+@pytest.mark.django_db
+def test_general_laczy_po_wspolnym_poprzednim_nazwisku():
+    """Dwa rekordy z różnymi obecnymi nazwiskami, ale wspólnym poprzednim."""
+    a = baker.make(
+        "bpp.Autor",
+        nazwisko="Nowak",
+        imiona="Maria",
+        poprzednie_nazwiska="Panna",
+    )
+    b = baker.make(
+        "bpp.Autor",
+        nazwisko="Kowalski",
+        imiona="Maria",
+        poprzednie_nazwiska="Panna",
+    )
+
+    scan = DuplicateScanRun.objects.create()
+    from deduplikator_autorow.tasks import _run_general_phase
+
+    _run_general_phase(scan, min_confidence=50)
+
+    cands = DuplicateCandidate.objects.filter(scan_run=scan, scan_mode="general")
+    assert cands.count() == 1
+    assert {cands.get().main_autor_id, cands.get().duplicate_autor_id} == {a.pk, b.pk}
+
+
+# ---------------------------------------------------------------------------
+# Faza PBN (szukaj_kopii)
+# ---------------------------------------------------------------------------
+
+
+def test_szukaj_kopii_znajduje_po_poprzednim_nazwisku(
+    osoba_z_instytucji, glowny_autor, autor_maker, tytuly
+):
+    """Kandydat, którego OBECNE nazwisko jest inne, ale w ``poprzednie_nazwiska``
+    ma nazwisko głównego autora (Gal-Cisoń) — powinien zostać znaleziony."""
+    duplikat = autor_maker(
+        imiona="Jan",
+        nazwisko="Zawadzka",
+        poprzednie_nazwiska="Gal-Cisoń",
+    )
+
+    duplikaty = szukaj_kopii(osoba_z_instytucji)
+
+    assert duplikat in duplikaty

--- a/src/deduplikator_autorow/utils/analysis.py
+++ b/src/deduplikator_autorow/utils/analysis.py
@@ -166,6 +166,35 @@ def _ocena_nazwiska(glowny_autor: Autor, duplikat: Autor) -> tuple[int, list[str
     return 0, []
 
 
+def _poprzednie_set(poprzednie_nazwiska: str | None) -> set[str]:
+    """Zbiór znormalizowanych (strip+lower) członów listy CSV poprzednich nazwisk."""
+    if not poprzednie_nazwiska:
+        return set()
+    return {p.strip().lower() for p in poprzednie_nazwiska.split(",") if p.strip()}
+
+
+def _ocena_poprzednich_nazwisk(
+    glowny_autor: Autor, duplikat: Autor
+) -> tuple[int, list[str]]:
+    """Analiza poprzednich nazwisk (FD#407).
+
+    Nazwisko jednego autora figuruje w poprzednich nazwiskach drugiego (zmiana
+    nazwiska: panieńskie → po mężu, dwuczłonowe → jednoczłonowe) albo obaj mają
+    wspólne poprzednie nazwisko.
+    """
+    glw_naz = (glowny_autor.nazwisko or "").strip().lower()
+    dup_naz = (duplikat.nazwisko or "").strip().lower()
+    glw_prev = _poprzednie_set(glowny_autor.poprzednie_nazwiska)
+    dup_prev = _poprzednie_set(duplikat.poprzednie_nazwiska)
+
+    if (glw_naz and glw_naz in dup_prev) or (dup_naz and dup_naz in glw_prev):
+        return 40, ["nazwisko figuruje w poprzednich nazwiskach drugiego autora"]
+    wspolne = glw_prev & dup_prev
+    if wspolne:
+        return 35, [f"wspólne poprzednie nazwisko ({', '.join(sorted(wspolne))})"]
+    return 0, []
+
+
 def _ocena_zamiany_imienia_nazwiska(
     glowny_autor: Autor, duplikat: Autor
 ) -> tuple[int, list[str]]:
@@ -315,6 +344,7 @@ _OCENY = (
     _ocena_tytulu,
     _ocena_orcid,
     _ocena_nazwiska,
+    _ocena_poprzednich_nazwisk,
     _ocena_zamiany_imienia_nazwiska,
     _ocena_imion,
     _ocena_temporalna,

--- a/src/deduplikator_autorow/utils/analysis_meta.py
+++ b/src/deduplikator_autorow/utils/analysis_meta.py
@@ -118,6 +118,25 @@ def _rule_nazwisko(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
     return None
 
 
+def _rule_poprzednie_nazwisko(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
+    """Nazwisko jednego autora figuruje w poprzednich nazwiskach drugiego.
+
+    Łapie zmianę nazwiska (panieńskie → po mężu, dwuczłonowe → jednoczłonowe):
+    to samo nazwisko jako obecne u jednego rekordu i jako poprzednie u drugiego,
+    albo wspólne poprzednie nazwisko po obu stronach (FD#407).
+    """
+    a_naz = a["nazwisko_norm"]
+    b_naz = b["nazwisko_norm"]
+    a_prev = set(a.get("poprzednie_nazwiska_norm") or [])
+    b_prev = set(b.get("poprzednie_nazwiska_norm") or [])
+    if (a_naz and a_naz in b_prev) or (b_naz and b_naz in a_prev):
+        return 40, "nazwisko figuruje w poprzednich nazwiskach drugiego autora"
+    wspolne = a_prev & b_prev
+    if wspolne:
+        return 35, f"wspólne poprzednie nazwisko ({', '.join(sorted(wspolne))})"
+    return None
+
+
 def _rule_swap(a: dict, b: dict, sig: dict) -> tuple[int, str] | None:
     if sig["wykryto_swap"]:
         return 50, "wykryto pełną zamianę imienia z nazwiskiem"
@@ -173,6 +192,7 @@ _RULES = (
     _rule_tytul,
     _rule_orcid,
     _rule_nazwisko,
+    _rule_poprzednie_nazwisko,
     _rule_swap,
     _rule_wspolne_imie,
     _rule_podobne_imie,

--- a/src/deduplikator_autorow/utils/meta.py
+++ b/src/deduplikator_autorow/utils/meta.py
@@ -48,6 +48,19 @@ def _split_compound(nazwisko: str | None) -> list[str]:
     return [p for p in normalized.split("-") if p]
 
 
+def _split_poprzednie(poprzednie: str | None) -> list[str]:
+    """Rozbija ``poprzednie_nazwiska`` (lista CSV) na znormalizowane człony.
+
+    Każdy człon normalizowany jak nazwisko główne (``_normalize``: myślniki
+    Unicode → ASCII, strip, lower). Puste człony pomijane. Człon złożony
+    ("gawlik-dziki") pozostaje w całości — hyphen-split robimy dopiero przy
+    budowie bucketów, spójnie z nazwiskiem głównym.
+    """
+    if not poprzednie:
+        return []
+    return [norm for raw in poprzednie.split(",") if (norm := _normalize(raw))]
+
+
 def _aggregate_publications(model, autorzy_meta: dict[int, dict]) -> None:
     """Doliczy do meta agregaty z jednej tabeli ``*_Autor``.
 
@@ -91,11 +104,12 @@ def build_autor_meta() -> dict[int, dict]:
     Łącznie 6 zapytań, niezależnie od liczby autorów.
     """
     autorzy_meta: dict[int, dict] = {}
-    # NOTE: include `poprzednie_nazwiska`, `pokazuj_poprzednie_nazwiska`
-    # and `pseudonim` because Autor.__str__ reads them — without them
-    # `str(autor)` (used by callers such as
-    # ``_run_general_phase``) triggers a deferred field load per author
-    # (2+ queries per author = O(N) hot-path SQL).
+    # NOTE: `poprzednie_nazwiska` jest używane do matchingu (FD#407 — patrz
+    # `_split_poprzednie` / `build_buckets`) ORAZ czytane przez Autor.__str__.
+    # `pokazuj_poprzednie_nazwiska` i `pseudonim` dołączamy, bo Autor.__str__
+    # je czyta — bez nich `str(autor)` (używane przez callerów takich jak
+    # ``_run_general_phase``) wywoła deferred field load per autor
+    # (2+ zapytania per autor = O(N) SQL na hot-path).
     autor_qs = Autor.objects.only(
         "pk",
         "nazwisko",
@@ -112,6 +126,7 @@ def build_autor_meta() -> dict[int, dict]:
             "obj": a,
             "nazwisko_norm": _normalize(a.nazwisko),
             "nazwisko_parts": _split_compound(a.nazwisko),
+            "poprzednie_nazwiska_norm": _split_poprzednie(a.poprzednie_nazwiska),
             "imiona_norm": [_normalize(i) for i in (a.imiona or "").split() if i],
             "ma_orcid": bool(a.orcid),
             "orcid_value": a.orcid or None,
@@ -152,25 +167,38 @@ def build_autor_meta() -> dict[int, dict]:
     return autorzy_meta
 
 
+def _dodaj_do_bucketow(
+    buckets: dict[str, list[int]], pk: int, nazwisko_norm: str, parts: list[str]
+) -> None:
+    """Dopisuje ``pk`` do bucketu pod pełnym nazwiskiem, pod każdym członem
+    złożonego (split na ``-``) oraz pod odwróconym nazwiskiem dwuczłonowym."""
+    if not nazwisko_norm:
+        return
+    buckets[nazwisko_norm].append(pk)
+    for part in parts:
+        if len(part) > 2 and part != nazwisko_norm:
+            buckets[part].append(pk)
+    if len(parts) == 2:
+        reversed_name = "-".join(reversed(parts))
+        if reversed_name != nazwisko_norm:
+            buckets[reversed_name].append(pk)
+
+
 def build_buckets(meta: dict[int, dict]) -> dict[str, list[int]]:
     """Buckety ``{nazwisko_norm -> [pk1, pk2, ...]}`` dla pair-generation.
 
     Autor trafia do bucketu pod swoim znormalizowanym nazwiskiem,
     pod każdym członem nazwiska złożonego (split na ``-``) oraz pod
     odwróconym nazwiskiem złożonym (np. ``Gal-Cisoń`` → ``cisoń-gal``).
+
+    FD#407: autor trafia RÓWNIEŻ do bucketów swoich poprzednich nazwisk (i ich
+    członów), żeby rekordy sprzed i po zmianie nazwiska — nawet bez wspólnego
+    członu (panieńskie → po mężu) — wpadły do wspólnego bucketu i zostały
+    porównane w ``analiza_pary_meta``.
     """
     buckets: dict[str, list[int]] = defaultdict(list)
     for pk, m in meta.items():
-        nazwisko_norm = m["nazwisko_norm"]
-        if not nazwisko_norm:
-            continue
-        buckets[nazwisko_norm].append(pk)
-        parts = m["nazwisko_parts"]
-        for part in parts:
-            if len(part) > 2 and part != nazwisko_norm:
-                buckets[part].append(pk)
-        if len(parts) == 2:
-            reversed_name = "-".join(reversed(parts))
-            if reversed_name != nazwisko_norm:
-                buckets[reversed_name].append(pk)
+        _dodaj_do_bucketow(buckets, pk, m["nazwisko_norm"], m["nazwisko_parts"])
+        for prev in m.get("poprzednie_nazwiska_norm") or []:
+            _dodaj_do_bucketow(buckets, pk, prev, [p for p in prev.split("-") if p])
     return dict(buckets)

--- a/src/deduplikator_autorow/utils/search.py
+++ b/src/deduplikator_autorow/utils/search.py
@@ -6,6 +6,7 @@ from django.db.models import Q, QuerySet
 
 from bpp.models import Autor
 from deduplikator_autorow.models import NotADuplicate
+from import_common.normalization import poprzednie_nazwiska_token_regex
 from pbn_api.models import OsobaZInstytucji
 
 
@@ -84,6 +85,27 @@ def _nazwisko_query(nazwisko: str) -> Q:
         q |= Q(nazwisko__istartswith=nazwisko + "-")
         q |= Q(nazwisko__iendswith="-" + nazwisko)
 
+    return q
+
+
+def _poprzednie_nazwiska_query(nazwisko: str, poprzednie_nazwiska: str) -> Q:
+    """Buduje warunek Q dopasowujący kandydatów po poprzednich nazwiskach (FD#407).
+
+    Łączy trzy kierunki (nazwisko dopasowywane jako pełny człon listy CSV
+    ``poprzednie_nazwiska``, nie podłańcuch):
+
+    - kandydat ma ``nazwisko`` głównego autora wśród swoich poprzednich nazwisk,
+    - ``nazwisko`` kandydata równe jednemu z poprzednich nazwisk głównego autora,
+    - kandydat dzieli z głównym autorem poprzednie nazwisko.
+    """
+    q = Q()
+    if nazwisko:
+        q |= Q(poprzednie_nazwiska__iregex=poprzednie_nazwiska_token_regex(nazwisko))
+    for prev in (poprzednie_nazwiska or "").split(","):
+        prev = prev.strip()
+        if prev:
+            q |= Q(nazwisko__iexact=prev)
+            q |= Q(poprzednie_nazwiska__iregex=poprzednie_nazwiska_token_regex(prev))
     return q
 
 
@@ -190,7 +212,9 @@ def szukaj_kopii(osoba_z_instytucji: OsobaZInstytucji) -> QuerySet[Autor]:
         return Autor.objects.none()
 
     # Zbuduj zapytanie na podstawie nazwiska + ewentualnej zamiany imię/nazwisko
+    # + poprzednich nazwisk (FD#407 — zmiana nazwiska, np. panieńskie → po mężu)
     q = _nazwisko_query(nazwisko) | _swap_query(nazwisko, imiona)
+    q |= _poprzednie_nazwiska_query(nazwisko, glowny_autor.poprzednie_nazwiska or "")
 
     # Wyszukaj kandydatów na duplikaty
     kandydaci = Autor.objects.filter(q).exclude(pk=glowny_autor.pk)

--- a/src/import_common/core/autor.py
+++ b/src/import_common/core/autor.py
@@ -12,6 +12,7 @@ from django.db.models.functions import Lower
 from bpp.models import Autor, Autor_Jednostka, Jednostka, Tytul
 from import_common.normalization import (
     polish_english_first_name_variants,
+    poprzednie_nazwiska_token_regex,
     remove_polish_diacritics,
 )
 
@@ -108,10 +109,25 @@ def _try_match_autor_by_direct_ids(
     )
 
 
+def _poprzednie_nazwiska_q(nazwisko: str, prefix: str = "") -> Q:
+    """Q dopasowujące ``nazwisko`` jako pełny człon ``poprzednie_nazwiska``.
+
+    Pole ``poprzednie_nazwiska`` to lista rozdzielona przecinkami; dopasowujemy
+    dokładny człon (nie podłańcuch — patrz ``poprzednie_nazwiska_token_regex``),
+    żeby częste nazwiska nie generowały fałszywych trafień (FD#407). ``prefix``
+    pozwala celować w powiązany model (np. ``"autor__"``). Puste ``nazwisko``
+    daje Q, które nigdy nie trafia.
+    """
+    if not nazwisko:
+        return Q(pk__in=[])
+    field = f"{prefix}poprzednie_nazwiska"
+    return Q(**{f"{field}__iregex": poprzednie_nazwiska_token_regex(nazwisko)})
+
+
 def _build_autor_name_query(nazwisko: str, imiona: str) -> Q:
     """Buduje podstawowe zapytanie Q dla nazwiska i imion."""
     return Q(
-        Q(nazwisko__iexact=nazwisko) | Q(poprzednie_nazwiska__icontains=nazwisko),
+        Q(nazwisko__iexact=nazwisko) | _poprzednie_nazwiska_q(nazwisko),
         imiona__iexact=imiona,
     )
 
@@ -161,7 +177,7 @@ def _try_match_autor_in_jednostka(
 
     base_query = Q(
         Q(autor__nazwisko__iexact=nazwisko)
-        | Q(autor__poprzednie_nazwiska__icontains=nazwisko),
+        | _poprzednie_nazwiska_q(nazwisko, prefix="autor__"),
         autor__imiona__iexact=imiona,
     )
     queries = [base_query]
@@ -208,12 +224,18 @@ def _try_match_autor_by_polish_english_variants(
     for v in variants_norm:
         imie_q |= Q(im_n=v) | Q(im_n__startswith=v + " ")
 
+    # Fold nazwiska po aktualnym ORAZ poprzednich nazwiskach (FD#407).
+    nazwisko_q = Q(naz_n=nazwisko_norm) | Q(
+        poprz_n__iregex=poprzednie_nazwiska_token_regex(nazwisko_norm)
+    )
+
     qs = (
         Autor.objects.annotate(
             naz_n=Lower(Unaccent("nazwisko")),
+            poprz_n=Lower(Unaccent("poprzednie_nazwiska")),
             im_n=Lower(Unaccent("imiona")),
         )
-        .filter(naz_n=nazwisko_norm)
+        .filter(nazwisko_q)
         .filter(imie_q)
     )
 
@@ -256,7 +278,7 @@ def _try_match_autor_with_orcid_or_tytul(imiona: str, nazwisko: str) -> Autor | 
 def _strategia_iexact_pelne(imiona: str, nazwisko: str) -> dict[int, tuple[float, str]]:
     """Pełne ``imiona`` + nazwisko/poprzednie_nazwiska (iexact)."""
     qs = Autor.objects.filter(
-        Q(nazwisko__iexact=nazwisko) | Q(poprzednie_nazwiska__icontains=nazwisko),
+        Q(nazwisko__iexact=nazwisko) | _poprzednie_nazwiska_q(nazwisko),
         imiona__iexact=imiona,
     )
     return {
@@ -277,11 +299,11 @@ def _strategia_iexact_pierwsze_imie(
     # w bazie więcej niż w danych (qs2). Dedup z _strategia_iexact_pelne
     # wybierze potem pewnosc=1.0 dla pełnego matchu.
     qs = Autor.objects.filter(
-        Q(nazwisko__iexact=nazwisko) | Q(poprzednie_nazwiska__icontains=nazwisko),
+        Q(nazwisko__iexact=nazwisko) | _poprzednie_nazwiska_q(nazwisko),
         imiona__iexact=pierwsze,
     )
     qs2 = Autor.objects.filter(
-        Q(nazwisko__iexact=nazwisko) | Q(poprzednie_nazwiska__icontains=nazwisko),
+        Q(nazwisko__iexact=nazwisko) | _poprzednie_nazwiska_q(nazwisko),
         imiona__istartswith=pierwsze + " ",
     )
     pks = set(qs.values_list("pk", flat=True)) | set(qs2.values_list("pk", flat=True))
@@ -307,12 +329,20 @@ def _strategia_polish_english(
     for v in variants_norm:
         imie_q |= Q(im_n=v) | Q(im_n__startswith=v + " ")
 
+    # Nazwisko dopasowujemy po foldzie (Unaccent) — zarówno po aktualnym
+    # nazwisku, jak i po poprzednich nazwiskach (FD#407); poprzednie jako
+    # dokładny człon listy CSV (iregex), nie podłańcuch.
+    nazwisko_q = Q(naz_n=nazwisko_norm) | Q(
+        poprz_n__iregex=poprzednie_nazwiska_token_regex(nazwisko_norm)
+    )
+
     qs = (
         Autor.objects.annotate(
             naz_n=Lower(Unaccent("nazwisko")),
+            poprz_n=Lower(Unaccent("poprzednie_nazwiska")),
             im_n=Lower(Unaccent("imiona")),
         )
-        .filter(naz_n=nazwisko_norm)
+        .filter(nazwisko_q)
         .filter(imie_q)
     )
     return {

--- a/src/import_common/normalization.py
+++ b/src/import_common/normalization.py
@@ -469,6 +469,29 @@ def remove_polish_diacritics(s: str) -> str:
     return s
 
 
+def poprzednie_nazwiska_token_regex(nazwisko: str) -> str:
+    r"""Wzorzec regex (Postgres ARE) dopasowujący ``nazwisko`` jako pełny
+    człon listy ``poprzednie_nazwiska`` (wartości oddzielone przecinkami).
+
+    Dopasowuje CAŁY człon (z opcjonalnymi spacjami wokół), a nie podłańcuch —
+    dzięki temu "Gawlik" NIE trafia w "Nowak-Gawlikowski". Przeznaczony do
+    użycia z lookupem Django ``__iregex`` (Postgres operator ``~*``), np.::
+
+        Q(poprzednie_nazwiska__iregex=poprzednie_nazwiska_token_regex(nazwisko))
+
+    Człon złożony ("Gawlik-Dziki") jest dopasowywany jako całość — myślnik
+    jest częścią członu, nie separatorem. Separatorem jest wyłącznie przecinek.
+
+    >>> import re
+    >>> rx = poprzednie_nazwiska_token_regex("Gawlik")
+    >>> bool(re.search(rx, "Kowalska, Gawlik-Dziki", re.IGNORECASE))
+    False
+    >>> bool(re.search(rx, "Kowalska, Gawlik", re.IGNORECASE))
+    True
+    """
+    return r"(^|,)\s*" + re.escape(nazwisko) + r"\s*(,|$)"
+
+
 def normalize_nazwisko_do_porownania(s: str) -> str:
     """Normalizuje nazwisko do porównania.
 

--- a/src/import_common/tests/test_repro_fd407.py
+++ b/src/import_common/tests/test_repro_fd407.py
@@ -1,0 +1,92 @@
+"""Repro FD#407 — matching autora po polu ``poprzednie_nazwiska``.
+
+Autorka zmieniła nazwisko z dwuczłonowego "Gawlik-Dziki" na jednoczłonowe
+"Gawlik" (albo odwrotnie). Rekord w BPP ma nazwisko w jednej z tych form, a
+druga forma siedzi w polu ``poprzednie_nazwiska`` (CSV). Importer powinien
+dopasować przychodzące nazwisko także po poprzednich nazwiskach — jako
+dokładny człon listy (nie podłańcuch), żeby nie generować fałszywych
+dopasowań dla częstych nazwisk.
+"""
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Autor
+from import_common.core import matchuj_autora
+
+
+@pytest.mark.django_db
+def test_matchuje_przychodzace_stare_nazwisko_po_poprzednim():
+    """Rekord: nazwisko="Gawlik" + poprzednie="Gawlik-Dziki".
+
+    Przychodzi stara forma "Gawlik-Dziki" (np. z publikacji sprzed zmiany).
+    """
+    autor = baker.make(
+        Autor,
+        imiona="Urszula",
+        nazwisko="Gawlik",
+        poprzednie_nazwiska="Gawlik-Dziki",
+    )
+    assert matchuj_autora("Urszula", "Gawlik-Dziki") == autor
+
+
+@pytest.mark.django_db
+def test_matchuje_przychodzace_nowe_nazwisko_po_poprzednim():
+    """Rekord: nazwisko="Gawlik-Dziki" + poprzednie="Gawlik".
+
+    Przychodzi nowa, jednoczłonowa forma "Gawlik" (dokładnie case ze
+    zgłoszenia: BPBP przysyła GAWLIK, w bazie Gawlik-Dziki).
+    """
+    autor = baker.make(
+        Autor,
+        imiona="Urszula",
+        nazwisko="Gawlik-Dziki",
+        poprzednie_nazwiska="Gawlik",
+    )
+    assert matchuj_autora("Urszula", "Gawlik") == autor
+
+
+@pytest.mark.django_db
+def test_matchuje_po_jednym_z_wielu_poprzednich_nazwisk():
+    """Pole to lista CSV — każdy człon powinien dać dopasowanie."""
+    autor = baker.make(
+        Autor,
+        imiona="Anna",
+        nazwisko="Nowak",
+        poprzednie_nazwiska="Kowalska, Gawlik-Dziki",
+    )
+    assert matchuj_autora("Anna", "Kowalska") == autor
+    assert matchuj_autora("Anna", "Gawlik-Dziki") == autor
+
+
+@pytest.mark.django_db
+def test_nie_matchuje_fragmentu_poprzedniego_nazwiska():
+    """Dokładny człon, nie podłańcuch: "Gawlik" NIE trafia w "Nowak-Gawlikowska".
+
+    To gwarancja bezpieczeństwa ze zgłoszenia — częste nazwiska nie mogą
+    generować fałszywych dopasowań przez zawieranie się w innym nazwisku.
+    """
+    baker.make(
+        Autor,
+        imiona="Anna",
+        nazwisko="Nowak",
+        poprzednie_nazwiska="Nowak-Gawlikowska",
+    )
+    assert matchuj_autora("Anna", "Gawlik") is None
+
+
+@pytest.mark.django_db
+def test_matchuje_poprzednie_nazwisko_z_wariantem_polsko_angielskim():
+    """Fallback PL↔EN uwzględnia też poprzednie nazwiska (unaccent).
+
+    Rekord: nazwisko="Kowalski", poprzednie="Marańda", imiona="Ewa".
+    Przychodzi "Eva Maranda" (angielska pisownia imienia + nazwisko bez
+    diakrytyków). Match tylko przez fold poprzedniego nazwiska.
+    """
+    autor = baker.make(
+        Autor,
+        imiona="Ewa",
+        nazwisko="Kowalski",
+        poprzednie_nazwiska="Marańda",
+    )
+    assert matchuj_autora("Eva", "Maranda") == autor


### PR DESCRIPTION
## Problem (Freshdesk FD#407)

Autorka zmieniła nazwisko z dwuczłonowego **Gawlik-Dziki** na jednoczłonowe **Gawlik**. BPBP/import przysyła „Gawlik", a w bazie figuruje „Gawlik-Dziki" — BPP nie kojarzył nowej formy z istniejącym rekordem i groził utworzeniem duplikatu. Pole `Autor.poprzednie_nazwiska` istniało, ale **nie było w pełni wykorzystywane** przy dopasowywaniu.

Zgłoszenie: https://iplweb.freshdesk.com/a/tickets/407

## Rozwiązanie

Matching autorów uwzględnia teraz `poprzednie_nazwiska` **jako dokładny człon listy CSV** (nie podłańcuch), w obu ścieżkach wskazanych w zgłoszeniu:

### Importer prac (współdzielony rdzeń `import_common/core/autor.py`)
Obsługuje import ze strony głównej, **CrossRef**, PBN, POL-on i import kadr.
- `poprzednie_nazwiska__icontains` → dokładny człon (`__iregex` przez nowy helper `poprzednie_nazwiska_token_regex`). Dzięki temu „Gawlik" **nie** trafia już w „Nowak-Gawlikowski" (bezpieczeństwo dla częstych nazwisk — wprost wskazane w zgłoszeniu).
- Fallback polsko-angielski (unaccent) też uwzględnia poprzednie nazwiska.

### Deduplikator autorów (`deduplikator_autorow`)
- **Faza general**: autorzy trafiają do bucketów swoich poprzednich nazwisk (i ich członów), więc rekordy sprzed/po zmianie nazwiska — nawet **bez wspólnego członu** (panieńskie → po mężu) — są w ogóle porównywane; nowa reguła scoringu `_rule_poprzednie_nazwisko`.
- **Faza PBN** (`szukaj_kopii`): kandydaci dopasowywani też po poprzednich nazwiskach (oba kierunki) + `_ocena_poprzednich_nazwisk`.

## Kompatybilność wsteczna

Puste `poprzednie_nazwiska` (wartość domyślna) **nie zmienia żadnego zachowania** — nowe dopasowania pojawiają się wyłącznie gdy pole jest wypełnione. Brak migracji.

## Testy

- Nowe repro-testy: `src/import_common/tests/test_repro_fd407.py`, `src/deduplikator_autorow/tests/test_repro_fd407.py` (8, wszystkie zielone; potwierdzone red→green).
- Regresja bez zmian: `deduplikator_autorow` + `import_common` (491 passed), `crossref_bpp` + `importer_publikacji` + `importer_autorow_pbn` (596 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)