### PR TITLE
fix(importer): book-chapter oznaczany jako wydawnictwo zwarte

### DIFF
--- a/src/bpp/migrations/0467_seed_crossref_mapper_rows.py
+++ b/src/bpp/migrations/0467_seed_crossref_mapper_rows.py
@@ -1,0 +1,50 @@
+"""Zaseeduj wszystkie wiersze Crossref_Mapper z poprawnym
+``jest_wydawnictwem_zwartym``.
+
+Dotychczas wiersze Crossref_Mapper powstawały wyłącznie leniwie
+(``get_or_create`` przy pierwszym imporcie danego typu), a migracja 0409
+ustawiała ``jest_wydawnictwem_zwartym=True`` tylko dla wierszy JUŻ
+istniejących. W efekcie pierwszy import ``book-chapter`` tworzył świeży
+wiersz z modelowym defaultem ``False`` — ptaszek „jest wydawnictwem
+zwartym" w importerze się nie zaznaczał.
+
+Ta migracja jawnie tworzy komplet 16 wierszy (idempotentnie) z właściwą
+wartością, tak by tabela była w pełni zainicjowana i edytowalna w adminie
+(``charakter_formalny_bpp`` pozostaje do konfiguracji przez uczelnię).
+"""
+
+from django.db import migrations
+
+# Wartości enum CHARAKTER_CROSSREF, które są wydawnictwami zwartymi.
+# Zsynchronizowane z Crossref_Mapper.BOOK_TYPES (hardcode tutaj, bo migracje
+# muszą być odporne na przyszłe zmiany kodu modelu).
+BOOK_TYPES = {3, 4, 5, 7, 8, 9, 10, 11, 12, 13}
+ALL_TYPES = range(1, 17)
+
+
+def seed_crossref_mapper_rows(apps, schema_editor):
+    Crossref_Mapper = apps.get_model("bpp", "Crossref_Mapper")
+    for charakter_crossref in ALL_TYPES:
+        Crossref_Mapper.objects.get_or_create(
+            charakter_crossref=charakter_crossref,
+            defaults={
+                "jest_wydawnictwem_zwartym": charakter_crossref in BOOK_TYPES,
+            },
+        )
+
+
+def reverse_seed(apps, schema_editor):
+    """Nie usuwamy wierszy — mogły zostać skonfigurowane (charakter_formalny)."""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0466_bppuser_zwijaj_dlugie_listy_autorow_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            seed_crossref_mapper_rows,
+            reverse_seed,
+        ),
+    ]

--- a/src/bpp/models/system/crossref_mapper.py
+++ b/src/bpp/models/system/crossref_mapper.py
@@ -20,6 +20,26 @@ class Crossref_Mapper(models.Model):
         PEER_REVIEW = 15, "peer-review"
         OTHER = 16, "other"
 
+    # Typy CrossRef, które w BPP są wydawnictwami zwartymi (książki,
+    # rozdziały, monografie, dysertacje). Reszta to wydawnictwa ciągłe
+    # (artykuły). Jedno źródło prawdy dla domyślnej wartości pola
+    # ``jest_wydawnictwem_zwartym`` — używane przy leniwym tworzeniu
+    # mapperów (``get_or_create(defaults=...)``) oraz w migracji seedującej.
+    BOOK_TYPES = frozenset(
+        {
+            CHARAKTER_CROSSREF.BOOK,
+            CHARAKTER_CROSSREF.BOOK_CHAPTER,
+            CHARAKTER_CROSSREF.EDITED_BOOK,
+            CHARAKTER_CROSSREF.MONOGRAPH,
+            CHARAKTER_CROSSREF.REFERENCE_BOOK,
+            CHARAKTER_CROSSREF.BOOK_SERIES,
+            CHARAKTER_CROSSREF.BOOK_SET,
+            CHARAKTER_CROSSREF.BOOK_SECTION,
+            CHARAKTER_CROSSREF.BOOK_PART,
+            CHARAKTER_CROSSREF.DISSERTATION,
+        }
+    )
+
     charakter_crossref = models.PositiveSmallIntegerField(
         "Charakter w CrossRef",
         choices=CHARAKTER_CROSSREF.choices,
@@ -48,3 +68,8 @@ class Crossref_Mapper(models.Model):
             v = self.charakter_formalny_bpp.nazwa
 
         return f"{self.CHARAKTER_CROSSREF(self.charakter_crossref).label} -> {v}"
+
+    @staticmethod
+    def default_jest_wydawnictwem_zwartym(charakter_crossref) -> bool:
+        """Czy dany typ CrossRef domyślnie jest wydawnictwem zwartym."""
+        return charakter_crossref in Crossref_Mapper.BOOK_TYPES

--- a/src/bpp/newsfragments/+crossref-mapper-book-chapter-zwarte.bugfix.rst
+++ b/src/bpp/newsfragments/+crossref-mapper-book-chapter-zwarte.bugfix.rst
@@ -1,0 +1,5 @@
+Importer CrossRef: przy imporcie rozdziałów i innych publikacji książkowych
+(``book-chapter``, ``book``, ``monograph`` itd.) automatycznie zaznaczany jest
+ptaszek „jest wydawnictwem zwartym". Wcześniej nowo utworzone mapowania typów
+CrossRef dostawały domyślnie wartość „nie", przez co rozdziały trafiały do
+formularza jako wydawnictwa ciągłe.

--- a/src/crossref_bpp/core.py
+++ b/src/crossref_bpp/core.py
@@ -612,11 +612,19 @@ class Komparator:
                 f" prosimy o zgłoszenie tej sytuacji autorowi programu. ",
             )
 
+        charakter_crossref = getattr(
+            Crossref_Mapper.CHARAKTER_CROSSREF,
+            wartosc.upper().replace("-", "_"),
+        )
         c = Crossref_Mapper.objects.get_or_create(
-            charakter_crossref=getattr(
-                Crossref_Mapper.CHARAKTER_CROSSREF,
-                wartosc.upper().replace("-", "_"),
-            )
+            charakter_crossref=charakter_crossref,
+            defaults={
+                "jest_wydawnictwem_zwartym": (
+                    Crossref_Mapper.default_jest_wydawnictwem_zwartym(
+                        charakter_crossref
+                    )
+                ),
+            },
         )[0]
 
         if c.charakter_formalny_bpp_id is not None:

--- a/src/importer_publikacji/tests/test_crossref_mapper_defaults.py
+++ b/src/importer_publikacji/tests/test_crossref_mapper_defaults.py
@@ -1,0 +1,87 @@
+"""Repro: Crossref_Mapper dla typów książkowych musi mieć
+``jest_wydawnictwem_zwartym=True``.
+
+Bug: ``_get_crossref_mapper`` (helpers.py) tworzył mapper przez
+``get_or_create`` bez ``defaults=``, więc świeży wiersz dla ``book-chapter``
+dostawał modelowy default ``False`` — ptaszek „jest wydawnictwem zwartym"
+w kroku weryfikacji importera się nie zaznaczał. Migracja 0409 robiła tylko
+``.update()`` na istniejących wierszach, których w chwili migracji nie było.
+
+Naprawa: (1) migracja 0467 seeduje komplet 16 wierszy z właściwą wartością,
+(2) leniwe ``get_or_create`` dostaje ``defaults=`` — na wypadek typu dodanego
+w przyszłości bez seeda.
+"""
+
+import pytest
+
+from bpp.models import Crossref_Mapper
+
+
+@pytest.mark.django_db
+def test_migracja_zaseedowala_wszystkie_typy():
+    """Migracja 0467 utworzyła 16 wierszy z poprawnym jest_wydawnictwem_zwartym."""
+    C = Crossref_Mapper.CHARAKTER_CROSSREF
+    assert Crossref_Mapper.objects.count() == len(C.values)
+
+    book = Crossref_Mapper.objects.get(charakter_crossref=C.BOOK_CHAPTER)
+    assert book.jest_wydawnictwem_zwartym is True
+
+    article = Crossref_Mapper.objects.get(charakter_crossref=C.JOURNAL_ARTICLE)
+    assert article.jest_wydawnictwem_zwartym is False
+
+
+@pytest.mark.django_db
+def test_lazy_mapper_book_chapter_jest_wydawnictwem_zwartym():
+    """Typ nie-zaseedowany (usunięty) tworzony leniwie → True dla book-chapter."""
+    from importer_publikacji.views import _get_crossref_mapper
+
+    # Symuluj typ jeszcze nie-zaseedowany (np. dodany w przyszłości).
+    Crossref_Mapper.objects.filter(
+        charakter_crossref=Crossref_Mapper.CHARAKTER_CROSSREF.BOOK_CHAPTER
+    ).delete()
+
+    mapper = _get_crossref_mapper("book-chapter")
+
+    assert mapper is not None
+    assert mapper.jest_wydawnictwem_zwartym is True
+
+
+@pytest.mark.django_db
+def test_lazy_mapper_journal_article_nie_jest_zwartym():
+    """Typ nie-zaseedowany (usunięty) tworzony leniwie → False dla artykułu."""
+    from importer_publikacji.views import _get_crossref_mapper
+
+    Crossref_Mapper.objects.filter(
+        charakter_crossref=Crossref_Mapper.CHARAKTER_CROSSREF.JOURNAL_ARTICLE
+    ).delete()
+
+    mapper = _get_crossref_mapper("journal-article")
+
+    assert mapper is not None
+    assert mapper.jest_wydawnictwem_zwartym is False
+
+
+@pytest.mark.django_db
+def test_lazy_mapper_nie_nadpisuje_istniejacego():
+    """Istniejący wiersz (np. ręcznie zmieniony w adminie) nie jest nadpisany."""
+    from importer_publikacji.views import _get_crossref_mapper
+
+    # Admin ręcznie odznaczył ptaszek dla book-chapter — get_or_create
+    # z defaults= NIE może tego nadpisać.
+    Crossref_Mapper.objects.filter(
+        charakter_crossref=Crossref_Mapper.CHARAKTER_CROSSREF.BOOK_CHAPTER
+    ).update(jest_wydawnictwem_zwartym=False)
+
+    mapper = _get_crossref_mapper("book-chapter")
+
+    assert mapper.jest_wydawnictwem_zwartym is False
+
+
+def test_default_helper_book_types():
+    """Statyczny helper zwraca poprawną wartość dla typów książkowych."""
+    C = Crossref_Mapper.CHARAKTER_CROSSREF
+    assert Crossref_Mapper.default_jest_wydawnictwem_zwartym(C.BOOK_CHAPTER) is True
+    assert Crossref_Mapper.default_jest_wydawnictwem_zwartym(C.BOOK) is True
+    assert Crossref_Mapper.default_jest_wydawnictwem_zwartym(C.MONOGRAPH) is True
+    assert Crossref_Mapper.default_jest_wydawnictwem_zwartym(C.JOURNAL_ARTICLE) is False
+    assert Crossref_Mapper.default_jest_wydawnictwem_zwartym(C.PROCEEDINGS) is False

--- a/src/importer_publikacji/views/helpers.py
+++ b/src/importer_publikacji/views/helpers.py
@@ -111,6 +111,11 @@ def _get_crossref_mapper(publication_type):
         return None
     mapper, _created = Crossref_Mapper.objects.get_or_create(
         charakter_crossref=val,
+        defaults={
+            "jest_wydawnictwem_zwartym": (
+                Crossref_Mapper.default_jest_wydawnictwem_zwartym(val)
+            ),
+        },
     )
     return mapper
 


### PR DESCRIPTION
## Problem

Przy imporcie z CrossRef ptaszek **„jest wydawnictwem zwartym"** nie zaznaczał się dla rozdziałów (`book-chapter`) ani innych typów książkowych (`book`, `monograph`, `edited-book`, …). Rozdziały trafiały do formularza jako wydawnictwa ciągłe, a krok „Źródło" pokazywał pole *Źródło* (czasopismo) zamiast *wydawnictwo nadrzędne*.

## Przyczyna

Wiersze `Crossref_Mapper` powstają **leniwie** przez `get_or_create` przy pierwszym imporcie danego typu — **bez `defaults=`**, więc świeży wiersz dostawał modelowy default `jest_wydawnictwem_zwartym=False`.

Migracja `0409_set_default_jest_wydawnictwem_zwartym` chciała ustawić typy książkowe na `True`, ale robiła to przez `.filter().update()` — który dotyka **tylko wierszy już istniejących**. Żadna migracja tych wierszy nie tworzyła, więc w chwili uruchomienia `0409` tabela była pusta i `update()` nie ruszył nic.

## Naprawa

- `Crossref_Mapper.BOOK_TYPES` + `default_jest_wydawnictwem_zwartym()` — jedno źródło prawdy o typach książkowych.
- `get_or_create` w `helpers.py` (nowy importer) i `core.py` (`crossref_bpp`) dostają `defaults=` — przyszłe typy nie wrócą do `False`.
- Migracja `0467` seeduje komplet 16 wierszy z poprawną wartością (idempotentnie; `charakter_formalny_bpp` zostaje do konfiguracji admina).

## Testy

- Repro-test (TDD): czerwony przed → **5/5 zielony po**.
- Regresja crossref/importer: **35/35**.
- `makemigrations --check` bez dryfu, ruff + pre-commit czysto.

## Uwaga (poza zakresem tego PR)

Ptaszek już się zaznaczy, ale konkretny `charakter_formalny_bpp` mappera pozostaje `NULL` — to zależy od słownika charakterów uczelni i ustawia się w *Dane systemowe → Crossref Mapper*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)