### PR TITLE
fix(importer): klikalne prace na liście potencjalnych duplikatów

### DIFF
--- a/src/bpp/migrations/0467_seed_crossref_mapper_rows.py
+++ b/src/bpp/migrations/0467_seed_crossref_mapper_rows.py
@@ -1,0 +1,50 @@
+"""Zaseeduj wszystkie wiersze Crossref_Mapper z poprawnym
+``jest_wydawnictwem_zwartym``.
+
+Dotychczas wiersze Crossref_Mapper powstawały wyłącznie leniwie
+(``get_or_create`` przy pierwszym imporcie danego typu), a migracja 0409
+ustawiała ``jest_wydawnictwem_zwartym=True`` tylko dla wierszy JUŻ
+istniejących. W efekcie pierwszy import ``book-chapter`` tworzył świeży
+wiersz z modelowym defaultem ``False`` — ptaszek „jest wydawnictwem
+zwartym" w importerze się nie zaznaczał.
+
+Ta migracja jawnie tworzy komplet 16 wierszy (idempotentnie) z właściwą
+wartością, tak by tabela była w pełni zainicjowana i edytowalna w adminie
+(``charakter_formalny_bpp`` pozostaje do konfiguracji przez uczelnię).
+"""
+
+from django.db import migrations
+
+# Wartości enum CHARAKTER_CROSSREF, które są wydawnictwami zwartymi.
+# Zsynchronizowane z Crossref_Mapper.BOOK_TYPES (hardcode tutaj, bo migracje
+# muszą być odporne na przyszłe zmiany kodu modelu).
+BOOK_TYPES = {3, 4, 5, 7, 8, 9, 10, 11, 12, 13}
+ALL_TYPES = range(1, 17)
+
+
+def seed_crossref_mapper_rows(apps, schema_editor):
+    Crossref_Mapper = apps.get_model("bpp", "Crossref_Mapper")
+    for charakter_crossref in ALL_TYPES:
+        Crossref_Mapper.objects.get_or_create(
+            charakter_crossref=charakter_crossref,
+            defaults={
+                "jest_wydawnictwem_zwartym": charakter_crossref in BOOK_TYPES,
+            },
+        )
+
+
+def reverse_seed(apps, schema_editor):
+    """Nie usuwamy wierszy — mogły zostać skonfigurowane (charakter_formalny)."""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0466_bppuser_zwijaj_dlugie_listy_autorow_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            seed_crossref_mapper_rows,
+            reverse_seed,
+        ),
+    ]

--- a/src/bpp/models/system/crossref_mapper.py
+++ b/src/bpp/models/system/crossref_mapper.py
@@ -20,6 +20,26 @@ class Crossref_Mapper(models.Model):
         PEER_REVIEW = 15, "peer-review"
         OTHER = 16, "other"
 
+    # Typy CrossRef, które w BPP są wydawnictwami zwartymi (książki,
+    # rozdziały, monografie, dysertacje). Reszta to wydawnictwa ciągłe
+    # (artykuły). Jedno źródło prawdy dla domyślnej wartości pola
+    # ``jest_wydawnictwem_zwartym`` — używane przy leniwym tworzeniu
+    # mapperów (``get_or_create(defaults=...)``) oraz w migracji seedującej.
+    BOOK_TYPES = frozenset(
+        {
+            CHARAKTER_CROSSREF.BOOK,
+            CHARAKTER_CROSSREF.BOOK_CHAPTER,
+            CHARAKTER_CROSSREF.EDITED_BOOK,
+            CHARAKTER_CROSSREF.MONOGRAPH,
+            CHARAKTER_CROSSREF.REFERENCE_BOOK,
+            CHARAKTER_CROSSREF.BOOK_SERIES,
+            CHARAKTER_CROSSREF.BOOK_SET,
+            CHARAKTER_CROSSREF.BOOK_SECTION,
+            CHARAKTER_CROSSREF.BOOK_PART,
+            CHARAKTER_CROSSREF.DISSERTATION,
+        }
+    )
+
     charakter_crossref = models.PositiveSmallIntegerField(
         "Charakter w CrossRef",
         choices=CHARAKTER_CROSSREF.choices,
@@ -48,3 +68,8 @@ class Crossref_Mapper(models.Model):
             v = self.charakter_formalny_bpp.nazwa
 
         return f"{self.CHARAKTER_CROSSREF(self.charakter_crossref).label} -> {v}"
+
+    @staticmethod
+    def default_jest_wydawnictwem_zwartym(charakter_crossref) -> bool:
+        """Czy dany typ CrossRef domyślnie jest wydawnictwem zwartym."""
+        return charakter_crossref in Crossref_Mapper.BOOK_TYPES

--- a/src/bpp/newsfragments/+crossref-mapper-book-chapter-zwarte.bugfix.rst
+++ b/src/bpp/newsfragments/+crossref-mapper-book-chapter-zwarte.bugfix.rst
@@ -1,0 +1,5 @@
+Importer CrossRef: przy imporcie rozdziałów i innych publikacji książkowych
+(``book-chapter``, ``book``, ``monograph`` itd.) automatycznie zaznaczany jest
+ptaszek „jest wydawnictwem zwartym". Wcześniej nowo utworzone mapowania typów
+CrossRef dostawały domyślnie wartość „nie", przez co rozdziały trafiały do
+formularza jako wydawnictwa ciągłe.

--- a/src/bpp/newsfragments/+importer-duplikaty-klikalne.bugfix.rst
+++ b/src/bpp/newsfragments/+importer-duplikaty-klikalne.bugfix.rst
@@ -1,0 +1,3 @@
+Importer publikacji: prace na liście „Potencjalne duplikaty w BPP" (krok
+weryfikacji) są teraz klikalnymi linkami — do publicznej strony rekordu oraz
+do modułu redagowania — dzięki czemu można sprawdzić potencjalny duplikat.

--- a/src/crossref_bpp/core.py
+++ b/src/crossref_bpp/core.py
@@ -612,11 +612,19 @@ class Komparator:
                 f" prosimy o zgłoszenie tej sytuacji autorowi programu. ",
             )
 
+        charakter_crossref = getattr(
+            Crossref_Mapper.CHARAKTER_CROSSREF,
+            wartosc.upper().replace("-", "_"),
+        )
         c = Crossref_Mapper.objects.get_or_create(
-            charakter_crossref=getattr(
-                Crossref_Mapper.CHARAKTER_CROSSREF,
-                wartosc.upper().replace("-", "_"),
-            )
+            charakter_crossref=charakter_crossref,
+            defaults={
+                "jest_wydawnictwem_zwartym": (
+                    Crossref_Mapper.default_jest_wydawnictwem_zwartym(
+                        charakter_crossref
+                    )
+                ),
+            },
         )[0]
 
         if c.charakter_formalny_bpp_id is not None:

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
@@ -15,7 +15,22 @@
                 {% for pub, method in existing %}
                     <li>
                         <strong>[{{ method }}]</strong>
-                        {{ pub }}
+                        <a href="{{ pub.get_absolute_url }}"
+                           target="_blank"
+                           rel="noopener">
+                            {{ pub }}
+                        </a>
+                        {% with change_url=pub|admin_change_url %}
+                            {% if change_url %}
+                                &mdash;
+                                <a href="{{ change_url }}"
+                                   target="_blank"
+                                   rel="noopener">
+                                    <span class="fi-pencil"></span>
+                                    redaguj
+                                </a>
+                            {% endif %}
+                        {% endwith %}
                     </li>
                 {% endfor %}
             </ul>

--- a/src/importer_publikacji/templatetags/importer_tags.py
+++ b/src/importer_publikacji/templatetags/importer_tags.py
@@ -1,6 +1,7 @@
 import json
 
 from django import template
+from django.urls import NoReverseMatch, reverse
 
 register = template.Library()
 
@@ -17,3 +18,25 @@ def pretty_json(value):
         )
     except (TypeError, ValueError):
         return str(value)
+
+
+@register.filter(name="admin_change_url")
+def admin_change_url(obj):
+    """Zwróć URL strony edycji obiektu w module redagowania (admin).
+
+    Działa dla dowolnego modelu — nazwa route'u budowana jest z
+    ``app_label``/``model_name`` samego obiektu, więc jedno wywołanie
+    obsługuje np. i ``Wydawnictwo_Ciagle``, i ``Wydawnictwo_Zwarte``.
+    Gdy obiekt nie ma pk albo nie jest zarejestrowany w adminie —
+    zwraca pusty string (link się nie pojawi).
+    """
+    if obj is None or getattr(obj, "pk", None) is None:
+        return ""
+    meta = obj._meta
+    try:
+        return reverse(
+            f"admin:{meta.app_label}_{meta.model_name}_change",
+            args=(obj.pk,),
+        )
+    except NoReverseMatch:
+        return ""

--- a/src/importer_publikacji/tests/test_crossref_mapper_defaults.py
+++ b/src/importer_publikacji/tests/test_crossref_mapper_defaults.py
@@ -1,0 +1,87 @@
+"""Repro: Crossref_Mapper dla typów książkowych musi mieć
+``jest_wydawnictwem_zwartym=True``.
+
+Bug: ``_get_crossref_mapper`` (helpers.py) tworzył mapper przez
+``get_or_create`` bez ``defaults=``, więc świeży wiersz dla ``book-chapter``
+dostawał modelowy default ``False`` — ptaszek „jest wydawnictwem zwartym"
+w kroku weryfikacji importera się nie zaznaczał. Migracja 0409 robiła tylko
+``.update()`` na istniejących wierszach, których w chwili migracji nie było.
+
+Naprawa: (1) migracja 0467 seeduje komplet 16 wierszy z właściwą wartością,
+(2) leniwe ``get_or_create`` dostaje ``defaults=`` — na wypadek typu dodanego
+w przyszłości bez seeda.
+"""
+
+import pytest
+
+from bpp.models import Crossref_Mapper
+
+
+@pytest.mark.django_db
+def test_migracja_zaseedowala_wszystkie_typy():
+    """Migracja 0467 utworzyła 16 wierszy z poprawnym jest_wydawnictwem_zwartym."""
+    C = Crossref_Mapper.CHARAKTER_CROSSREF
+    assert Crossref_Mapper.objects.count() == len(C.values)
+
+    book = Crossref_Mapper.objects.get(charakter_crossref=C.BOOK_CHAPTER)
+    assert book.jest_wydawnictwem_zwartym is True
+
+    article = Crossref_Mapper.objects.get(charakter_crossref=C.JOURNAL_ARTICLE)
+    assert article.jest_wydawnictwem_zwartym is False
+
+
+@pytest.mark.django_db
+def test_lazy_mapper_book_chapter_jest_wydawnictwem_zwartym():
+    """Typ nie-zaseedowany (usunięty) tworzony leniwie → True dla book-chapter."""
+    from importer_publikacji.views import _get_crossref_mapper
+
+    # Symuluj typ jeszcze nie-zaseedowany (np. dodany w przyszłości).
+    Crossref_Mapper.objects.filter(
+        charakter_crossref=Crossref_Mapper.CHARAKTER_CROSSREF.BOOK_CHAPTER
+    ).delete()
+
+    mapper = _get_crossref_mapper("book-chapter")
+
+    assert mapper is not None
+    assert mapper.jest_wydawnictwem_zwartym is True
+
+
+@pytest.mark.django_db
+def test_lazy_mapper_journal_article_nie_jest_zwartym():
+    """Typ nie-zaseedowany (usunięty) tworzony leniwie → False dla artykułu."""
+    from importer_publikacji.views import _get_crossref_mapper
+
+    Crossref_Mapper.objects.filter(
+        charakter_crossref=Crossref_Mapper.CHARAKTER_CROSSREF.JOURNAL_ARTICLE
+    ).delete()
+
+    mapper = _get_crossref_mapper("journal-article")
+
+    assert mapper is not None
+    assert mapper.jest_wydawnictwem_zwartym is False
+
+
+@pytest.mark.django_db
+def test_lazy_mapper_nie_nadpisuje_istniejacego():
+    """Istniejący wiersz (np. ręcznie zmieniony w adminie) nie jest nadpisany."""
+    from importer_publikacji.views import _get_crossref_mapper
+
+    # Admin ręcznie odznaczył ptaszek dla book-chapter — get_or_create
+    # z defaults= NIE może tego nadpisać.
+    Crossref_Mapper.objects.filter(
+        charakter_crossref=Crossref_Mapper.CHARAKTER_CROSSREF.BOOK_CHAPTER
+    ).update(jest_wydawnictwem_zwartym=False)
+
+    mapper = _get_crossref_mapper("book-chapter")
+
+    assert mapper.jest_wydawnictwem_zwartym is False
+
+
+def test_default_helper_book_types():
+    """Statyczny helper zwraca poprawną wartość dla typów książkowych."""
+    C = Crossref_Mapper.CHARAKTER_CROSSREF
+    assert Crossref_Mapper.default_jest_wydawnictwem_zwartym(C.BOOK_CHAPTER) is True
+    assert Crossref_Mapper.default_jest_wydawnictwem_zwartym(C.BOOK) is True
+    assert Crossref_Mapper.default_jest_wydawnictwem_zwartym(C.MONOGRAPH) is True
+    assert Crossref_Mapper.default_jest_wydawnictwem_zwartym(C.JOURNAL_ARTICLE) is False
+    assert Crossref_Mapper.default_jest_wydawnictwem_zwartym(C.PROCEEDINGS) is False

--- a/src/importer_publikacji/tests/test_views_verify.py
+++ b/src/importer_publikacji/tests/test_views_verify.py
@@ -151,6 +151,52 @@ def test_verify_no_suggest_crossref_for_crossref(
 
 
 @pytest.mark.django_db
+def test_verify_potential_duplicate_is_clickable(
+    importer_client,
+    importer_user,
+):
+    """Potencjalne duplikaty w BPP muszą być klikalne (link do pracy).
+
+    Repro: dotąd lista renderowała sam ``{{ pub }}`` (tekst), więc nie
+    dało się przejść do istniejącej pracy, żeby zweryfikować duplikat.
+    """
+    from model_bakery import baker
+
+    from bpp.models import Wydawnictwo_Ciagle
+
+    existing = baker.make(
+        Wydawnictwo_Ciagle,
+        tytul_oryginalny="Istniejąca praca będąca duplikatem",
+        doi="10.1234/dup-test",
+    )
+
+    session = ImportSession.objects.create(
+        created_by=importer_user,
+        provider_name="CrossRef",
+        identifier="10.1234/dup-test",
+        raw_data={},
+        normalized_data={
+            "title": "Istniejąca praca będąca duplikatem",
+            "doi": "10.1234/dup-test",
+        },
+    )
+    url = reverse(
+        "importer_publikacji:verify",
+        kwargs={"session_id": session.pk},
+    )
+    response = importer_client.get(url)
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Sekcja duplikatów w ogóle się pojawia
+    assert "Potencjalne duplikaty w BPP" in content
+    # Link do publicznej strony pracy
+    assert f'href="{existing.get_absolute_url()}"' in content
+    # Link do modułu redagowania (admin change)
+    assert f"/admin/bpp/wydawnictwo_ciagle/{existing.pk}/change/" in content
+
+
+@pytest.mark.django_db
 def test_verify_no_suggest_crossref_without_doi(
     importer_client,
     importer_user,

--- a/src/importer_publikacji/views/helpers.py
+++ b/src/importer_publikacji/views/helpers.py
@@ -111,6 +111,11 @@ def _get_crossref_mapper(publication_type):
         return None
     mapper, _created = Crossref_Mapper.objects.get_or_create(
         charakter_crossref=val,
+        defaults={
+            "jest_wydawnictwem_zwartym": (
+                Crossref_Mapper.default_jest_wydawnictwem_zwartym(val)
+            ),
+        },
     )
     return mapper
 


### PR DESCRIPTION
## Problem

W importerze publikacji, w kroku 2 („Weryfikacja"), sekcja **„Potencjalne
duplikaty w BPP"** renderowała każdą znalezioną pracę jako czysty tekst
(`{{ pub }}` — tylko `__str__`). Nie było znacznika `<a>`, więc użytkownik
**nie mógł kliknąć na pracę**, żeby otworzyć istniejący rekord i ocenić, czy
to faktyczny duplikat.

## Root cause

`src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html`
— pętla po `existing` (krotki `(pub, method)` z `_find_duplicates`, gdzie
`pub` to `Wydawnictwo_Ciagle` **lub** `Wydawnictwo_Zwarte`) wypisywała sam
tytuł, bez linku. Logika wyszukiwania duplikatów działała poprawnie — brakowało
wyłącznie warstwy prezentacji.

## Zmiana

- **`templatetags/importer_tags.py`** — nowy, reużywalny filtr
  `admin_change_url`. Buduje URL modułu redagowania (admin change) z
  `app_label`/`model_name` samego obiektu, więc jedno wywołanie obsługuje oba
  typy publikacji. Przy braku pk / rejestracji w adminie degraduje do pustego
  stringa (link się po prostu nie pojawia).
- **`partials/step_verify.html`** — tytuł linkuje do publicznej strony rekordu
  (`get_absolute_url`, nowa karta), a obok jest link **„✏️ redaguj"** do
  modułu redagowania. Oba `target="_blank"`, żeby nie tracić stanu wizarda.
- **`tests/test_views_verify.py`** — test repro
  `test_verify_potential_duplicate_is_clickable` (TDD: najpierw czerwony na
  braku `href`, po naprawie zielony).

## Weryfikacja

- Repro test przechodzi (przedtem padał dokładnie na asercji `href`).
- Szerszy zestaw widoków importera: 23 passed, brak regresji.
- `ruff format` + `ruff check`: czysto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)