### PR TITLE
fix(import): matchowanie autora po inicjale imienia (CrossRef)

### DIFF
--- a/src/bpp/newsfragments/+matchowanie-inicjal-autora.bugfix.rst
+++ b/src/bpp/newsfragments/+matchowanie-inicjal-autora.bugfix.rst
@@ -1,0 +1,5 @@
+Import z CrossRef: autor podany samym inicjałem imienia (np. "Lech-Maranda
+E.") jest teraz dopasowywany do pełnego imienia w BPP ("Lech-Marańda Ewa").
+Inicjał + nazwisko (z pominięciem polskich znaków diakrytycznych) trafia na
+listę kandydatów z niską pewnością — importer pokazuje go jako sugestię do
+potwierdzenia, nie wiąże automatycznie.

--- a/src/import_common/core/autor.py
+++ b/src/import_common/core/autor.py
@@ -3,6 +3,7 @@ system kadrowy / PBN id) oraz po imieniu+nazwisku z kontekstem
 (jednostka, tytuł).
 """
 
+import re
 from dataclasses import dataclass
 
 from django.contrib.postgres.lookups import Unaccent
@@ -36,10 +37,22 @@ class KandydatAutora:
 POWOD_IEXACT = "iexact"
 POWOD_IEXACT_PIERWSZE_IMIE = "iexact_pierwsze_imie"
 POWOD_POLISH_ENGLISH = "polish_english"
+POWOD_INICJAL = "inicjal"
 
 PEWNOSC_IEXACT = 1.0
 PEWNOSC_IEXACT_PIERWSZE_IMIE = 0.95
 PEWNOSC_POLISH_ENGLISH = 0.85
+PEWNOSC_INICJAL = 0.5
+
+# Próg pewności, poniżej którego ``matchuj_autora`` NIE wiąże autora
+# automatycznie — kandydat trafia tylko na listę do potwierdzenia przez
+# użytkownika. Dopasowanie po samym inicjale (0.5) jest za słabe na auto-bind;
+# warianty PL↔EN (0.85) i mocniejsze — wystarczające.
+PEWNOSC_MIN_AUTOMATYCZNA = PEWNOSC_POLISH_ENGLISH
+
+# Inicjał imienia: pojedyncza litera z opcjonalną kropką (np. "E" albo "E.").
+# Litera unicode (\w bez cyfry/podkreślenia) — ``Ł.`` też jest inicjałem.
+_INICJAL_RE = re.compile(r"^([^\W\d_])\.?$")
 
 
 def _try_get_autor_by_bpp_id(bpp_id: int | None) -> Autor | None:
@@ -321,6 +334,49 @@ def _strategia_polish_english(
     }
 
 
+def _pierwszy_inicjal(imiona: str) -> str | None:
+    """Zwraca pierwszą literę (ASCII-fold, lowercase), jeśli ``imiona``
+    zaczynają się od inicjału — np. ``"E."`` → ``"e"``, ``"E. M."`` → ``"e"``.
+
+    Zwraca ``None``, gdy pierwszy token to pełne imię (``"Ewa"``) — wtedy
+    obsługują je mocniejsze strategie iexact / PL↔EN, a nie ta.
+    """
+    parts = imiona.split()
+    if not parts:
+        return None
+    m = _INICJAL_RE.match(parts[0])
+    if not m:
+        return None
+    return remove_polish_diacritics(m.group(1)).lower()
+
+
+def _strategia_inicjal(imiona: str, nazwisko: str) -> dict[int, tuple[float, str]]:
+    """Inicjał imienia + nazwisko (z Unaccent) — najsłabszy sygnał.
+
+    Źródła anglojęzyczne (CrossRef) potrafią podać tylko inicjał imienia
+    (``"Lech-Maranda E."``), gdy w BPP siedzi pełne imię (``"Ewa"``).
+    Dopasowujemy nazwisko po ``Unaccent`` (Marańda↔Maranda) oraz pierwszą
+    literę imienia (``startswith`` po Unaccent). Niska pewność (0.5) i brak
+    auto-bindu w ``matchuj_autora`` — decyzję o powiązaniu podejmuje user.
+    """
+    litera = _pierwszy_inicjal(imiona)
+    if not litera:
+        return {}
+
+    nazwisko_norm = remove_polish_diacritics(nazwisko).lower()
+    qs = (
+        Autor.objects.annotate(
+            naz_n=Lower(Unaccent("nazwisko")),
+            im_n=Lower(Unaccent("imiona")),
+        )
+        .filter(naz_n=nazwisko_norm)
+        .filter(im_n__startswith=litera)
+    )
+    return {
+        pk: (PEWNOSC_INICJAL, POWOD_INICJAL) for pk in qs.values_list("pk", flat=True)
+    }
+
+
 def _publikacji_counts_bulk(pks: list[int]) -> dict[int, int]:
     """Zwraca {autor_pk: liczba_publikacji} dla podanych pk autorów.
 
@@ -368,6 +424,8 @@ def znajdz_kandydatow_autora(
     - 1.00 — exact iexact pełne imiona + nazwisko
     - 0.95 — exact iexact pierwsze imię + nazwisko
     - 0.85 — PL↔EN: warianty v↔w + klastry imion + Unaccent nazwiska
+    - 0.50 — inicjał imienia + Unaccent nazwiska (tylko na listę
+      kandydatów; ``matchuj_autora`` nie wiąże tego automatycznie)
 
     Autor wpadający w kilka strategii zwracany jest **raz**, z najwyższą
     pewnością. Sortowanie DESC po: (pewnosc, ma ORCID, ma tytuł, liczba
@@ -391,6 +449,7 @@ def znajdz_kandydatow_autora(
         _strategia_iexact_pelne(imiona, nazwisko),
         _strategia_iexact_pierwsze_imie(imiona, nazwisko),
         _strategia_polish_english(imiona, nazwisko),
+        _strategia_inicjal(imiona, nazwisko),
     ):
         for pk, (pewnosc, powod) in strategia.items():
             existing = scores.get(pk)
@@ -485,15 +544,18 @@ def matchuj_autora(
     if result:
         return result
 
-    # 2. Discovery
+    # 2. Discovery. Auto-bind tylko dla pewności >= progu — kandydat oparty
+    # o sam inicjał (0.5) nie wiąże się automatycznie, trafia jedynie na
+    # listę do potwierdzenia (patrz PEWNOSC_MIN_AUTOMATYCZNA).
     kandydaci = znajdz_kandydatow_autora(imiona, nazwisko, max_wyniki=10)
-    if len(kandydaci) == 1:
-        return kandydaci[0].autor
-    if len(kandydaci) >= 2:
+    if kandydaci and kandydaci[0].pewnosc >= PEWNOSC_MIN_AUTOMATYCZNA:
+        if len(kandydaci) == 1:
+            return kandydaci[0].autor
         # Najlepszy z wyższą pewnością niż reszta wygrywa bez disambiguacji
         if kandydaci[0].pewnosc > kandydaci[1].pewnosc:
             return kandydaci[0].autor
-        # Inaczej spróbuj kontekstem (jednostka/tytuł)
+    if len(kandydaci) >= 2:
+        # Ambiguity (równa pewność) — spróbuj rozstrzygnąć kontekstem
         result = _disambiguate_kandydatow(kandydaci, jednostka, tytul_str)
         if result:
             return result

--- a/src/import_common/tests/test_autor_pl_en_matching.py
+++ b/src/import_common/tests/test_autor_pl_en_matching.py
@@ -11,6 +11,11 @@ from model_bakery import baker
 
 from bpp.models import Autor
 from import_common.core import matchuj_autora
+from import_common.core.autor import (
+    PEWNOSC_INICJAL,
+    POWOD_INICJAL,
+    znajdz_kandydatow_autora,
+)
 
 
 @pytest.mark.django_db
@@ -161,3 +166,73 @@ def test_match_lech_maranda_literal():
     """Dokladny przypadek zgloszenia: Lech-Maranda Eva ↔ Lech-Marańda Ewa."""
     autor = baker.make(Autor, imiona="Ewa", nazwisko="Lech-Marańda")
     assert matchuj_autora(imiona="Eva", nazwisko="Lech-Maranda") == autor
+
+
+# ---------------------------------------------------------------------------
+# Inicjał imienia (CrossRef daje "E.", BPP ma pełne "Ewa")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_inicjal_znajduje_kandydata():
+    """Zgłoszenie: CrossRef 'Lech-Maranda E.' vs BPP 'Lech-Marańda Ewa'.
+
+    Inicjał + nazwisko (z unaccent) zwraca autora jako kandydata o
+    NISKIEJ pewności — importer pokaże go jako sugestię do potwierdzenia.
+    """
+    autor = baker.make(Autor, imiona="Ewa", nazwisko="Lech-Marańda")
+    kandydaci = znajdz_kandydatow_autora("E.", "Lech-Maranda")
+    assert [k.autor for k in kandydaci] == [autor]
+    assert kandydaci[0].powod == POWOD_INICJAL
+    assert kandydaci[0].pewnosc == PEWNOSC_INICJAL
+
+
+@pytest.mark.django_db
+def test_inicjal_bez_kropki():
+    """Inicjał bez kropki ('E') działa tak samo jak z kropką ('E.')."""
+    autor = baker.make(Autor, imiona="Ewa", nazwisko="Lech-Marańda")
+    kandydaci = znajdz_kandydatow_autora("E", "Lech-Maranda")
+    assert [k.autor for k in kandydaci] == [autor]
+
+
+@pytest.mark.django_db
+def test_inicjal_zla_litera_nie_pasuje():
+    """Inicjał 'A.' nie pasuje do 'Ewa' — pierwsza litera się nie zgadza."""
+    baker.make(Autor, imiona="Ewa", nazwisko="Lech-Marańda")
+    assert znajdz_kandydatow_autora("A.", "Lech-Maranda") == []
+
+
+@pytest.mark.django_db
+def test_inicjal_nie_auto_wiaze_pojedynczego():
+    """matchuj_autora NIE wiąże automatycznie samego inicjału.
+
+    Sam inicjał to za słaby sygnał na auto-przypisanie — decyzja należy
+    do użytkownika (importer pokazuje listę / sugestię).
+    """
+    baker.make(Autor, imiona="Ewa", nazwisko="Lech-Marańda")
+    assert matchuj_autora(imiona="E.", nazwisko="Lech-Maranda") is None
+
+
+@pytest.mark.django_db
+def test_inicjal_wielu_kandydatow():
+    """'E.' przy dwóch osobach (Ewa, Elżbieta) → obaj jako kandydaci."""
+    ewa = baker.make(Autor, imiona="Ewa", nazwisko="Lech-Marańda")
+    elzbieta = baker.make(Autor, imiona="Elżbieta", nazwisko="Lech-Marańda")
+    kandydaci = znajdz_kandydatow_autora("E.", "Lech-Maranda")
+    assert {k.autor for k in kandydaci} == {ewa, elzbieta}
+    assert matchuj_autora(imiona="E.", nazwisko="Lech-Maranda") is None
+
+
+@pytest.mark.django_db
+def test_pelne_imie_nie_degradowane_do_inicjalu():
+    """Regresja: pełne imię wciąż matchuje z wysoką pewnością (nie 0.5)."""
+    baker.make(Autor, imiona="Ewa", nazwisko="Lech-Marańda")
+    kandydaci = znajdz_kandydatow_autora("Ewa", "Lech-Marańda")
+    assert kandydaci[0].pewnosc > PEWNOSC_INICJAL
+
+
+@pytest.mark.django_db
+def test_inicjal_nie_laczy_z_innym_nazwiskiem():
+    """Inicjał nie łączy w poprzek nazwisk: 'E. Kowalska' ≠ 'Ewa Nowak'."""
+    baker.make(Autor, imiona="Ewa", nazwisko="Nowak")
+    assert znajdz_kandydatow_autora("E.", "Kowalska") == []


### PR DESCRIPTION
## Problem

Import z CrossRef nie dopasowywał autora podanego **samym inicjałem imienia** do pełnego imienia w BPP:

> `Lech-Maranda E.` (CrossRef) ≠ `Lech-Marańda Ewa` (BPP)

Wbrew pierwszemu wrażeniu **problemem nie były diakrytyki** — `Unaccent` już obsługuje `Marańda`↔`Maranda`, a pełny przypadek `Eva`↔`Ewa` był zielony (istniejący `test_match_lech_maranda_literal`). Brakującym elementem był **inicjał**: wszystkie trzy dotychczasowe strategie matchera (`iexact` pełne / pierwsze imię / warianty PL↔EN) porównują **cały** token imienia, więc `"E."` nie łapało się do niczego → `BRAK_DOPASOWANIA`.

## Rozwiązanie

- Nowa, najsłabsza strategia `_strategia_inicjal` w `znajdz_kandydatow_autora` (pewność **0.50**): inicjał (litera ± kropka, także `Ł.`) + nazwisko po `Unaccent`, pierwsza litera imienia przez `startswith`.
- `matchuj_autora` dostaje próg `PEWNOSC_MIN_AUTOMATYCZNA = 0.85`: **sam inicjał nie wiąże autora automatycznie** — trafia jedynie na listę kandydatów do potwierdzenia przez użytkownika (w CrossRef renderowaną jako *LUŹNE* / *WYMAGA_INGERENCJI*).
- Zero regresji: mocniejsze strategie (1.0 / 0.95 / 0.85) nadal auto-bindują jak dotąd.

## Testy (TDD, RED→GREEN)

7 nowych testów w `test_autor_pl_en_matching.py`:
- inicjał `E.` / `E` znajduje kandydata (niska pewność, powód `inicjal`),
- zła litera (`A.`) nie pasuje, inne nazwisko nie łączy w poprzek,
- wielu kandydatów (Ewa + Elżbieta) → lista, `matchuj_autora` zwraca `None`,
- `matchuj_autora` nie auto-wiąże pojedynczego inicjału,
- regresja: pełne imię wciąż matchuje z wysoką pewnością (nie degraduje do 0.5).

`test_autor_pl_en_matching.py` + `test_znajdz_kandydatow_autora.py`: **53 passed**. Pre-commit: czysto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)