### PR TITLE
feat(importer): ręczne wpisanie/poprawa roku publikacji na kroku weryfikacji

### DIFF
--- a/docs/superpowers/specs/2026-07-08-importer-reczny-rok-publikacji-design.md
+++ b/docs/superpowers/specs/2026-07-08-importer-reczny-rok-publikacji-design.md
@@ -1,0 +1,86 @@
+# Ręczne wpisanie roku publikacji w importerze publikacji
+
+**Data:** 2026-07-08
+**Status:** zaakceptowany
+
+## Problem
+
+Importer publikacji przerywa pracę, gdy dane źródłowe nie zawierają roku
+publikacji. Przykład: DOI `10.1007/0-306-46843-3_60` (rozdział książki,
+Kluwer/Springer). CrossRef nie zwraca dla niego roku publikacji — wszystkie
+realne pola dat są puste:
+
+- `published`, `published-print`, `published-online` → `None`
+- `issued` → `{'date-parts': [[None]]}` (jawnie puste)
+- `created` → 2006, `deposited` → 2021 — to znaczniki **metadanych**, nie rok
+  publikacji; nie wolno ich traktować jako roku wydania.
+
+`session.normalized_data["year"]` jest pojedynczym źródłem prawdy o roku i
+czytają go co najmniej: sugestia punktacji, punktacja źródła
+(`Punktacja_Zrodla` wg roku), **auto-dopasowanie dyscyplin autorów**
+(`Autor_Dyscyplina` wg roku), pole `miejsce_i_rok` oraz tworzenie rekordu
+(`_create_publication` rzuca `ValidationError` bez roku).
+
+Obecny komunikat radzi operatorowi „uzupełnij rok w źródle
+(BibTeX/CrossRef/PBN)" — dla CrossRef to zewnętrzne API, którego operator nie
+edytuje. Ślepy zaułek.
+
+## Rozwiązanie
+
+Rok staje się edytowalnym, **wymaganym** polem na kroku **Weryfikacja** —
+zawsze widocznym, prefillowanym wartością pobraną ze źródła (o ile jest).
+Operator może zarówno uzupełnić brakujący rok, jak i **poprawić** błędny.
+
+Krok Weryfikacja jest najwcześniejszym edytowalnym krokiem po pobraniu danych,
+więc ustawienie roku tutaj sprawia, że działają wszystkie kroki zależne od roku
+(źródło, autorzy/dyscypliny, punktacja, tworzenie rekordu).
+
+### Zmiany
+
+1. **`src/importer_publikacji/forms.py` — `VerifyForm`**
+   Dodać pole:
+   ```python
+   rok = forms.IntegerField(
+       label="Rok publikacji",
+       required=True,
+       min_value=1900,
+       max_value=2100,
+   )
+   ```
+
+2. **`src/importer_publikacji/views/steps.py` — `_verify_context`**
+   Prefill: `initial["rok"] = session.normalized_data.get("year")`.
+
+3. **`src/importer_publikacji/views/wizard.py` — `VerifyView.post`**
+   Po `form.is_valid()` zapisać rok do jedynego źródła prawdy przed
+   `session.save()`:
+   ```python
+   session.normalized_data["year"] = form.cleaned_data["rok"]
+   ```
+
+4. **`src/importer_publikacji/templates/.../partials/step_verify.html`**
+   Dodać input `rok` do siatki formularza (obok języka/charakteru). Usunąć
+   nadmiarowy wiersz „Rok" (tylko-do-odczytu) z tabeli danych źródłowych —
+   edytowalne pole go zastępuje.
+
+### Zachowane jako zabezpieczenia (nie usuwane)
+
+- Gałąź `RodzajBraku.BRAK_ROKU` w `_oblicz_sugestie`.
+- `ValidationError("Brak roku publikacji…")` w `_create_publication`.
+
+Sesja może nadal mieć pusty rok (starsze sesje, inne ścieżki), więc guardy
+zostają jako backstop; w nowym przepływie stają się nieosiągalne.
+
+## Testy (TDD)
+
+- **Repro:** sesja bez `year` w `normalized_data` → `VerifyForm` nieważny bez
+  `rok`; POST z `rok` ustawia `normalized_data["year"]` i przechodzi do kroku
+  źródła.
+- **Prefill:** sesja z rokiem → initial formularza/kontekst zawiera rok.
+- **Korekta:** POST z innym `rok` nadpisuje `normalized_data["year"]`.
+
+## Poza zakresem (YAGNI)
+
+- Brak nowego statusu/kroku sesji.
+- Brak dynamicznego „bieżącego roku" jako `max_value`.
+- Brak migracji/backfillu istniejących sesji.

--- a/src/bpp/newsfragments/+importer-reczny-rok-publikacji.feature.rst
+++ b/src/bpp/newsfragments/+importer-reczny-rok-publikacji.feature.rst
@@ -1,0 +1,4 @@
+Importer publikacji: rok publikacji można wpisać lub poprawić ręcznie na
+kroku weryfikacji. Gdy źródło (np. rekord CrossRef) nie zawiera roku wydania,
+operator uzupełnia go sam, dzięki czemu importer może zaproponować punktację i
+utworzyć rekord zamiast zatrzymywać się na komunikacie „brak roku publikacji".

--- a/src/importer_publikacji/forms.py
+++ b/src/importer_publikacji/forms.py
@@ -113,6 +113,16 @@ class VerifyForm(forms.Form):
         label="Wydawnictwo zwarte (książka/rozdział)",
         required=False,
     )
+    rok = forms.IntegerField(
+        label="Rok publikacji",
+        required=True,
+        min_value=1900,
+        max_value=2100,
+        help_text=(
+            "Uzupełniony automatycznie ze źródła — popraw, jeśli błędny "
+            "lub brakuje (np. rekordy CrossRef bez roku wydania)."
+        ),
+    )
 
 
 class SourceForm(forms.Form):

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
@@ -94,12 +94,6 @@
                     <td>{{ session.normalized_data.doi }}</td>
                 </tr>
             {% endif %}
-            {% if session.normalized_data.year %}
-                <tr>
-                    <th>Rok</th>
-                    <td>{{ session.normalized_data.year }}</td>
-                </tr>
-            {% endif %}
             {% if session.normalized_data.source_title %}
                 <tr>
                     <th>Źródło</th>
@@ -373,6 +367,16 @@
                     {{ form.jest_wydawnictwem_zwartym }}
                     {{ form.jest_wydawnictwem_zwartym.label }}
                 </label>
+            </div>
+        </div>
+
+        <div class="grid-x grid-margin-x">
+            <div class="cell medium-6">
+                <label for="{{ form.rok.id_for_label }}">
+                    {{ form.rok.label }} *
+                </label>
+                {{ form.rok }}
+                <p class="help-text">{{ form.rok.help_text }}</p>
             </div>
         </div>
 

--- a/src/importer_publikacji/tests/test_views_verify.py
+++ b/src/importer_publikacji/tests/test_views_verify.py
@@ -49,6 +49,7 @@ def test_verify_updates_session(
             "typ_kbn": tk.pk if tk else "",
             "jezyk": jez.pk if jez else "",
             "jest_wydawnictwem_zwartym": "",
+            "rok": "2023",
         },
     )
     assert response.status_code == 200
@@ -173,3 +174,132 @@ def test_verify_no_suggest_crossref_without_doi(
     assert response.status_code == 200
     content = response.content.decode()
     assert "Pobierz z CrossRef" not in content
+
+
+def _verify_form_data(cf, tk, jez, **extra):
+    """Zbuduj payload POST dla formularza weryfikacji."""
+    data = {
+        "charakter_formalny": cf.pk if cf else "",
+        "typ_kbn": tk.pk if tk else "",
+        "jezyk": jez.pk if jez else "",
+        "jest_wydawnictwem_zwartym": "",
+    }
+    data.update(extra)
+    return data
+
+
+@pytest.mark.django_db
+def test_verify_wymaga_roku_gdy_brak_w_danych(
+    importer_client,
+    importer_user,
+    charaktery_formalne,
+    typy_kbn,
+    jezyki,
+):
+    """Sesja bez roku w normalized_data: POST bez 'rok' → formularz nieważny,
+    status nie zmienia się na VERIFIED (rok jest wymagany)."""
+    from bpp.models import Charakter_Formalny, Jezyk, Typ_KBN
+
+    session = ImportSession.objects.create(
+        created_by=importer_user,
+        provider_name="CrossRef",
+        identifier="10.1007/0-306-46843-3_60",
+        raw_data={},
+        normalized_data={"title": "Bez roku", "doi": None},
+    )
+    cf = Charakter_Formalny.objects.first()
+    tk = Typ_KBN.objects.first()
+    jez = Jezyk.objects.filter(widoczny=True).first()
+    url = reverse("importer_publikacji:verify", kwargs={"session_id": session.pk})
+
+    response = importer_client.post(url, _verify_form_data(cf, tk, jez))
+
+    assert response.status_code == 200
+    session.refresh_from_db()
+    assert session.status != ImportSession.Status.VERIFIED
+    assert session.normalized_data.get("year") in (None, "")
+
+
+@pytest.mark.django_db
+def test_verify_zapisuje_reczny_rok(
+    importer_client,
+    importer_user,
+    charaktery_formalne,
+    typy_kbn,
+    jezyki,
+):
+    """POST z 'rok' zapisuje go do normalized_data['year'] jako int i
+    przechodzi do kolejnego kroku (status VERIFIED)."""
+    from bpp.models import Charakter_Formalny, Jezyk, Typ_KBN
+
+    session = ImportSession.objects.create(
+        created_by=importer_user,
+        provider_name="CrossRef",
+        identifier="10.1007/0-306-46843-3_60",
+        raw_data={},
+        normalized_data={"title": "Bez roku", "doi": None},
+    )
+    cf = Charakter_Formalny.objects.first()
+    tk = Typ_KBN.objects.first()
+    jez = Jezyk.objects.filter(widoczny=True).first()
+    url = reverse("importer_publikacji:verify", kwargs={"session_id": session.pk})
+
+    response = importer_client.post(url, _verify_form_data(cf, tk, jez, rok="2004"))
+
+    assert response.status_code == 200
+    session.refresh_from_db()
+    assert session.status == ImportSession.Status.VERIFIED
+    assert session.normalized_data.get("year") == 2004
+
+
+@pytest.mark.django_db
+def test_verify_context_prefill_roku(importer_user, jezyki):
+    """_verify_context prefilluje pole 'rok' wartością z normalized_data."""
+    from django.test import RequestFactory
+
+    from importer_publikacji.views import _verify_context
+
+    session = ImportSession.objects.create(
+        created_by=importer_user,
+        provider_name="CrossRef",
+        identifier="10.1234/rok",
+        raw_data={},
+        normalized_data={"title": "Z rokiem", "year": 2019},
+    )
+    request = RequestFactory().get("/")
+    request.user = importer_user
+
+    ctx = _verify_context(request, session)
+
+    assert ctx["form"].initial.get("rok") == 2019
+
+
+@pytest.mark.django_db
+def test_verify_koryguje_bledny_rok(
+    importer_client,
+    importer_user,
+    charaktery_formalne,
+    typy_kbn,
+    jezyki,
+):
+    """POST z innym 'rok' nadpisuje istniejący rok w normalized_data —
+    operator może poprawić błędny rok, nie tylko uzupełnić brakujący."""
+    from bpp.models import Charakter_Formalny, Jezyk, Typ_KBN
+
+    session = ImportSession.objects.create(
+        created_by=importer_user,
+        provider_name="CrossRef",
+        identifier="10.1234/zly-rok",
+        raw_data={},
+        normalized_data={"title": "Zły rok", "year": 2000, "doi": None},
+    )
+    cf = Charakter_Formalny.objects.first()
+    tk = Typ_KBN.objects.first()
+    jez = Jezyk.objects.filter(widoczny=True).first()
+    url = reverse("importer_publikacji:verify", kwargs={"session_id": session.pk})
+
+    response = importer_client.post(url, _verify_form_data(cf, tk, jez, rok="2004"))
+
+    assert response.status_code == 200
+    session.refresh_from_db()
+    assert session.normalized_data.get("year") == 2004

--- a/src/importer_publikacji/views/steps.py
+++ b/src/importer_publikacji/views/steps.py
@@ -106,6 +106,7 @@ def _verify_context(request, session, form=None):
         initial = {
             "typ_kbn": session.typ_kbn_id,
             "jezyk": session.jezyk_id,
+            "rok": session.normalized_data.get("year"),
         }
         # Użyj wartości sesji gdy istnieją (user już submitował)
         if session.charakter_formalny_id:

--- a/src/importer_publikacji/views/wizard.py
+++ b/src/importer_publikacji/views/wizard.py
@@ -201,6 +201,11 @@ class VerifyView(ImporterPermissionMixin, View):
         session.jest_wydawnictwem_zwartym = form.cleaned_data[
             "jest_wydawnictwem_zwartym"
         ]
+        # Rok wpisany/poprawiony przez operatora → jedyne źródło prawdy o roku.
+        # Ustawiamy go tu (najwcześniejszy edytowalny krok), żeby działały
+        # kroki zależne od roku: dopasowanie dyscyplin autorów, punktacja
+        # źródła, sugestia punktów, tworzenie rekordu.
+        session.normalized_data["year"] = form.cleaned_data["rok"]
         session.status = ImportSession.Status.VERIFIED
         session.modified_by = request.user
         session.save()


### PR DESCRIPTION
## Problem

Importer publikacji utykał, gdy dane źródłowe nie zawierają roku publikacji.

Zgłoszony przypadek: DOI `10.1007/0-306-46843-3_60` (rozdział książki,
Kluwer/Springer). CrossRef **nie zwraca dla niego roku** — wszystkie realne
pola dat są puste:

- `published`, `published-print`, `published-online` → `None`
- `issued` → `{'date-parts': [[None]]}` (jawnie puste)
- `created` → 2006, `deposited` → 2021 — to znaczniki **metadanych**, nie rok
  wydania; nie wolno ich traktować jako roku publikacji.

Bez `normalized_data["year"]` importer: nie proponował punktacji („Brak roku
publikacji") i odmawiał utworzenia rekordu (`ValidationError`), odsyłając
operatora do „poprawy roku w źródle" — niewykonalnej dla zewnętrznego API.

## Rozwiązanie

Rok jest teraz **edytowalnym, wymaganym** polem na kroku **Weryfikacja**:
zawsze widocznym, prefillowanym wartością pobraną ze źródła (o ile jest).
Operator uzupełnia brakujący rok albo **poprawia** błędny.

Krok weryfikacji to najwcześniejszy edytowalny krok po pobraniu danych, więc
zapis do `normalized_data["year"]` tutaj sprawia, że działają wszystkie kroki
zależne od roku: dopasowanie dyscyplin autorów (`Autor_Dyscyplina` wg roku),
punktacja źródła (`Punktacja_Zrodla` wg roku), sugestia punktów oraz tworzenie
rekordu.

### Zmiany

- `VerifyForm` — nowe pole `rok` (IntegerField, wymagane, 1900–2100).
- `_verify_context` — prefill `rok` z `normalized_data["year"]`.
- `VerifyView.post` — zapis `normalized_data["year"] = cleaned_data["rok"]`.
- `step_verify.html` — input roku w formularzu; usunięty nadmiarowy wiersz
  „Rok" (tylko-do-odczytu) z tabeli danych źródłowych.

Dotychczasowe guardy (`RodzajBraku.BRAK_ROKU`, `ValidationError` w
`_create_publication`) **pozostają** jako backstop dla starszych sesji.

## Testy

Nowe (TDD, `test_views_verify.py`): rok wymagany gdy brak, zapis ręcznego
roku, prefill z danych, korekta błędnego roku. Zaktualizowano istniejący
`test_verify_updates_session` (rok jest teraz wymagany).

- `474 passed` — pełna suita `importer_publikacji` (bez Playwright).

Spec: `docs/superpowers/specs/2026-07-08-importer-reczny-rok-publikacji-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)