### PR TITLE
fix(importer_publikacji): wstecz/naprzód w przeglądarce (HTMX history restore)

### DIFF
--- a/src/bpp/newsfragments/importer-htmx-history-restore.bugfix.rst
+++ b/src/bpp/newsfragments/importer-htmx-history-restore.bugfix.rst
@@ -1,0 +1,4 @@
+Importer publikacji: przyciski wstecz/naprzód w przeglądarce nie rozbijają już
+kroku wizarda ani nie dublują pól wyboru (select2). Przy przywracaniu historii
+HTMX serwer zwraca teraz pełną, świeżo wyrenderowaną stronę zamiast fragmentu,
+więc np. krok „Dopasowanie źródła" ponownie podpowiada dopasowanego wydawcę.

--- a/src/importer_publikacji/templates/importer_publikacji/index.html
+++ b/src/importer_publikacji/templates/importer_publikacji/index.html
@@ -102,7 +102,11 @@
 
 {% block content %}
 
-    <div id="importer-wizard">
+    {# hx-history="false": nie cache'uj snapshotów DOM wizarda. Przy Back/ #}
+    {# Forward HTMX pyta serwer o pełną stronę (patrz _is_htmx_partial), #}
+    {# zamiast przywracać nieświeży snapshot z zainicjowanym select2 #}
+    {# (co dawało zduplikowany „drugi select"). #}
+    <div id="importer-wizard" hx-history="false">
         {% include step_template %}
     </div>
 

--- a/src/importer_publikacji/tests/test_history_restore.py
+++ b/src/importer_publikacji/tests/test_history_restore.py
@@ -1,0 +1,78 @@
+"""Przyciski wstecz/naprzód w przeglądarce (HTMX history restore).
+
+Gdy HTMX przywraca historię po Back/Forward (cache-miss), wysyła GET z
+NAGŁÓWKAMI ``HX-Request: true`` ORAZ ``HX-History-Restore-Request: true`` i
+oczekuje PEŁNEJ strony (podmienia całe ``<body>``). Widoki kroków, jeśli
+patrzą tylko na ``HX-Request``, zwracały wtedy sam fragment (partial) — co
+niszczyło layout wizarda i podwajało widżety select2 („drugi select").
+
+Regresja: przy przywracaniu historii widok MUSI zwrócić pełną stronę
+(zawierającą kontener ``id="importer-wizard"``), a nie goły partial.
+"""
+
+import pytest
+from django.urls import reverse
+
+from importer_publikacji.models import ImportSession
+
+WIZARD_WRAPPER = 'id="importer-wizard"'
+
+
+def _make_session(user, **extra):
+    defaults = dict(
+        created_by=user,
+        provider_name="CrossRef",
+        identifier="10.1234/hist",
+        raw_data={},
+        normalized_data={"title": "Test", "doi": None},
+        status=ImportSession.Status.VERIFIED,
+    )
+    defaults.update(extra)
+    return ImportSession.objects.create(**defaults)
+
+
+@pytest.mark.django_db
+def test_source_history_restore_returns_full_page(importer_client, importer_user):
+    """Back/Forward na krok źródła → pełna strona z kontenerem wizarda."""
+    session = _make_session(importer_user)
+    url = reverse("importer_publikacji:source", kwargs={"session_id": session.pk})
+
+    resp = importer_client.get(
+        url,
+        HTTP_HX_REQUEST="true",
+        HTTP_HX_HISTORY_RESTORE_REQUEST="true",
+    )
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    assert WIZARD_WRAPPER in body, (
+        "history-restore musi zwrócić PEŁNĄ stronę (z #importer-wizard), "
+        "nie sam partial"
+    )
+
+
+@pytest.mark.django_db
+def test_source_plain_htmx_returns_partial(importer_client, importer_user):
+    """Zwykłe żądanie HTMX (bez history-restore) → sam fragment."""
+    session = _make_session(importer_user)
+    url = reverse("importer_publikacji:source", kwargs={"session_id": session.pk})
+
+    resp = importer_client.get(url, HTTP_HX_REQUEST="true")
+    assert resp.status_code == 200
+    assert WIZARD_WRAPPER not in resp.content.decode(), (
+        "żywy HTMX ma zwracać partial (bez #importer-wizard)"
+    )
+
+
+@pytest.mark.django_db
+def test_verify_history_restore_returns_full_page(importer_client, importer_user):
+    """To samo dla kroku weryfikacji."""
+    session = _make_session(importer_user, status=ImportSession.Status.FETCHED)
+    url = reverse("importer_publikacji:verify", kwargs={"session_id": session.pk})
+
+    resp = importer_client.get(
+        url,
+        HTTP_HX_REQUEST="true",
+        HTTP_HX_HISTORY_RESTORE_REQUEST="true",
+    )
+    assert resp.status_code == 200
+    assert WIZARD_WRAPPER in resp.content.decode()

--- a/src/importer_publikacji/views/helpers.py
+++ b/src/importer_publikacji/views/helpers.py
@@ -97,6 +97,26 @@ def _push_url(response, url):
     return response
 
 
+def _is_htmx_partial(request):
+    """Czy zwrócić partial (fragment) czy pełną stronę dla GET-a kroku.
+
+    ``True`` tylko dla ŻYWEGO żądania HTMX (swap fragmentu do
+    ``#importer-wizard``). ``False`` dla zwykłego GET-a ORAZ dla
+    przywracania historii przez przeglądarkę (Back/Forward).
+
+    HTMX przy przywracaniu historii (cache-miss) wysyła ZARÓWNO
+    ``HX-Request`` jak i ``HX-History-Restore-Request`` — wtedy oczekuje
+    PEŁNEJ strony do podmiany ``<body>``. Zwrócenie partiala rozwalało
+    wtedy layout wizarda i podwajało widżety select2 („drugi select").
+    Dlatego history-restore traktujemy jak zwykłe wejście GET-em (pełna
+    strona). Dodatkowo ``index.html`` ma ``hx-history="false"``, żeby
+    HTMX nie przywracał nieświeżych snapshotów, tylko zawsze pytał serwer.
+    """
+    if request.headers.get("HX-History-Restore-Request"):
+        return False
+    return bool(request.headers.get("HX-Request"))
+
+
 def _get_crossref_mapper(publication_type):
     """Znajdź Crossref_Mapper dla danego typu publikacji.
 

--- a/src/importer_publikacji/views/wizard.py
+++ b/src/importer_publikacji/views/wizard.py
@@ -39,6 +39,7 @@ from .helpers import (
     STEP_DONE,
     STEP_FETCH,
     _fetch_context,
+    _is_htmx_partial,
     _push_url,
     _render_full_page,
     _sessions_list_context,
@@ -60,7 +61,7 @@ class SessionListView(ImporterPermissionMixin, View):
 
     def get(self, request):
         ctx = _sessions_list_context(request)
-        if request.headers.get("HX-Request"):
+        if _is_htmx_partial(request):
             return render(request, SESSIONS_PARTIAL, ctx)
         # Fallback: pełna strona z formularzem fetch
         fetch_ctx = _fetch_context(request=request)
@@ -84,7 +85,7 @@ class IndexView(ImporterPermissionMixin, View):
             form = None
 
         ctx = _fetch_context(form, request=request)
-        if request.headers.get("HX-Request"):
+        if _is_htmx_partial(request):
             ctx.update(_sessions_list_context(request))
             response = render(request, STEP_FETCH, ctx)
             return _with_breadcrumbs_oob(response, request)
@@ -181,7 +182,7 @@ class VerifyView(ImporterPermissionMixin, View):
             ImportSession,
             pk=session_id,
         )
-        if request.headers.get("HX-Request"):
+        if _is_htmx_partial(request):
             return _render_verify_step(request, session)
         return _render_verify_full(request, session)
 
@@ -221,7 +222,7 @@ class SourceView(ImporterPermissionMixin, View):
             ImportSession,
             pk=session_id,
         )
-        if request.headers.get("HX-Request"):
+        if _is_htmx_partial(request):
             return _render_source_step(request, session)
         from .steps import _render_source_full
 
@@ -295,7 +296,7 @@ class AuthorsView(ImporterPermissionMixin, View):
             ImportSession,
             pk=session_id,
         )
-        if request.headers.get("HX-Request"):
+        if _is_htmx_partial(request):
             return _render_authors_step(request, session)
         from .steps import _render_authors_full
 
@@ -568,7 +569,7 @@ class PunktacjaView(ImporterPermissionMixin, View):
 
     def get(self, request, session_id):
         session = get_object_or_404(ImportSession, pk=session_id)
-        if request.headers.get("HX-Request"):
+        if _is_htmx_partial(request):
             return _render_punktacja_step(request, session)
         from .steps import _render_punktacja_full
 
@@ -671,7 +672,7 @@ class ReviewView(ImporterPermissionMixin, View):
             ImportSession,
             pk=session_id,
         )
-        if request.headers.get("HX-Request"):
+        if _is_htmx_partial(request):
             return _render_review_step(request, session)
         from .steps import _render_review_full
 


### PR DESCRIPTION
## Problem

Wizard importera publikacji pushuje URL-e kroków (`HX-Push-Url`), ale **przyciski wstecz/naprzód w przeglądarce** były zepsute. Objaw zgłoszony przez użytkownika: po wciśnięciu *Wstecz* na kroku „Dopasowanie źródła" pojawiał się **zduplikowany „drugi select"**, a wydawca (np. `Kluwer Academic Publishers`) wyglądał na **niedopasowany**, mimo że istniał w bazie.

## Root cause

Diagnoza wykazała, że **matcher wydawcy działał poprawnie** (potwierdzone na danych produkcyjnych: `porownaj_publisher` i auto-match zwracają właściwy rekord). Prawdziwa przyczyna to obsługa historii HTMX:

1. **Błędne wykrywanie żądania restore.** Widoki kroków patrzyły tylko na nagłówek `HX-Request`. HTMX przy przywracaniu historii (cache-miss) wysyła **ZARÓWNO** `HX-Request`, **JAK I** `HX-History-Restore-Request`, i oczekuje **pełnej strony** do podmiany `<body>`. Widok zwracał wtedy sam fragment (partial) → rozpadał się layout wizarda.
2. **Nieświeże snapshoty.** HTMX przywracał zapisany snapshot DOM z już zainicjowanym `select2` → **zduplikowany select** oraz zamrożony, przed-dopasowaniowy stan kroku źródła (stąd złudzenie „wydawca niedopasowany").

## Poprawka

- **`views/helpers.py`** — nowy helper `_is_htmx_partial(request)`: partial tylko dla *żywego* żądania HTMX; history-restore i zwykły GET → pełna strona.
- **`views/wizard.py`** — użyty we wszystkich 7 handlerach GET (`verify`, `source`, `authors`, `punktacja`, `review`, `index`, `sessions`). Back/Forward renderuje teraz **całą świeżą stronę** → chrome w porządku, `select2` inicjuje się raz, krok źródła **ponownie odpala auto-match wydawcy**.
- **`index.html`** — `hx-history="false"` na `#importer-wizard`: brak cache'owania snapshotów, Back/Forward zawsze pyta serwer.

## Testy

- Nowy `test_history_restore.py` — najpierw **failował** (history-restore zwracał goły partial), po poprawce **przechodzi** (TDD). Sprawdza, że restore GET zwraca pełną stronę z `#importer-wizard`, a żywy HTMX nadal zwraca partial.
- Istniejące `test_views*` (verify / punktacja / authors / create_publication / views): **43 passed, 0 failed** lokalnie.
- `ruff format` + `ruff check`: czysto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)