### PR TITLE
fix(pbn): flaga „bezkosztowa" ma pierwszeństwo w adapterze opłat

### DIFF
--- a/src/bpp/newsfragments/+harden-oplata-adapter.bugfix.md
+++ b/src/bpp/newsfragments/+harden-oplata-adapter.bugfix.md
@@ -1,0 +1,4 @@
+Publikacja oznaczona jako bezkosztowa jest teraz zawsze wysyłana do PBN jako
+bezkosztowa, nawet gdyby w danych pozostała niewyczyszczona kwota opłaty. Wcześniej
+taki sprzeczny stan danych (możliwy przy imporcie lub bezpośrednim zapisie, poza
+formularzem) mógł wygenerować pakiet danych odwracający intencję operatora.

--- a/src/pbn_api/adapters/wydawnictwo.py
+++ b/src/pbn_api/adapters/wydawnictwo.py
@@ -35,6 +35,11 @@ class OplataZaWydawnictwoPBNAdapter:
         if hasattr(self.original, "opl_pub_amount") and hasattr(
             self.original, "opl_pub_cost_free"
         ):
+            # Flaga „bezkosztowa" ma pierwszeństwo: gdy jest ustawiona, nie
+            # pozwalamy zaległej (niewyczyszczonej) kwocie odwrócić intencji
+            # operatora na payload „płatny". ``clean()`` modelu blokuje taki
+            # sprzeczny stan przez formularz, ale bezpośredni zapis ORM /
+            # import / migracja danych mógłby go wprowadzić (elif zamiast if).
             if self.original.opl_pub_cost_free is True:
                 fee["amount"] = 0
                 fee["costFreePublication"] = True
@@ -42,7 +47,7 @@ class OplataZaWydawnictwoPBNAdapter:
                 fee["researchOrDevelopmentProjectsFinancialResources"] = False
                 fee["researchPotentialFinancialResources"] = False
 
-            if (
+            elif (
                 self.original.opl_pub_amount is not None
                 and self.original.opl_pub_amount > 0
             ):

--- a/src/pbn_api/tests/test_adapters.py
+++ b/src/pbn_api/tests/test_adapters.py
@@ -15,7 +15,10 @@ from bpp.models import (
     Wydawnictwo_Zwarte_Autor,
 )
 from fixtures.pbn_api import _zrob_wydawnictwo_pbn
-from pbn_api.adapters.wydawnictwo import WydawnictwoPBNAdapter
+from pbn_api.adapters.wydawnictwo import (
+    OplataZaWydawnictwoPBNAdapter,
+    WydawnictwoPBNAdapter,
+)
 from pbn_api.adapters.wydawnictwo_autor import WydawnictwoAutorToStatementPBNAdapter
 from pbn_api.exceptions import PKZeroExportDisabled, WillNotExportError
 
@@ -381,11 +384,34 @@ def test_WydawnictwoPBNAdapter_oplata_za_publikacje_darmowa(
 
 
 @pytest.mark.django_db
+def test_OplataZaWydawnictwoPBNAdapter_bezkosztowa_ma_pierwszenstwo(
+    pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina,
+):
+    """Sprzeczny stan danych (bezkosztowa=True, ale kwota>0) nie może wygenerować
+    payloadu odwracającego intencję operatora.
+
+    ``clean()`` modelu blokuje taki stan przez formularz, ale bezpośredni zapis
+    ORM / import / migracja danych może go wprowadzić. Adapter musi być na to
+    odporny: flaga „bezkosztowa" ma pierwszeństwo nad zaległą kwotą.
+    """
+    pub = pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina
+    pub.opl_pub_cost_free = True
+    pub.opl_pub_amount = Decimal("1500.00")  # zaległa, niewyczyszczona kwota
+
+    fee = OplataZaWydawnictwoPBNAdapter(pub).pbn_get_json()
+
+    assert fee["costFreePublication"] is True
+    assert fee["amount"] == 0
+
+
+@pytest.mark.django_db
 def test_WydawnictwoAutorToStatementPBNAdapter_nie_zwraca_orcid(
     pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina,
 ):
     """Test that the statement adapter does NOT return 'orcid' key."""
-    wydawnictwo_autor = pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina.autorzy_set.first()
+    wydawnictwo_autor = (
+        pbn_wydawnictwo_ciagle_z_autorem_z_dyscyplina.autorzy_set.first()
+    )
 
     # Even with profil_orcid=True, the orcid key should NOT be in the result
     wydawnictwo_autor.profil_orcid = True


### PR DESCRIPTION
## Kontekst

Wychwycone przy okazji FD#301 (PR #500). Osobne, drobne utwardzenie — nie blokuje ani nie zależy od tamtego.

## Problem

`OplataZaWydawnictwoPBNAdapter.pbn_get_json()` miał **dwie niezależne gałęzie `if`**:

```python
if self.original.opl_pub_cost_free is True:
    fee["costFreePublication"] = True
    fee["amount"] = 0
    ...
if self.original.opl_pub_amount is not None and self.original.opl_pub_amount > 0:
    fee["costFreePublication"] = False   # ← NADPISUJE gałąź wyżej
    fee["amount"] = str(...)
```

Gdy w bazie jednocześnie `opl_pub_cost_free=True` **i** `opl_pub_amount>0` (stan sprzeczny — np. zaznaczono „bezkosztowa", ale nie wyczyszczono kwoty), druga gałąź nadpisywała pierwszą i do PBN szedł payload „**nie** bezkosztowa, kwota X" — odwrotnie do intencji operatora.

`clean()` modelu (`fees.py`) blokuje taki stan **przez formularz** — więc jest to nieosiągalne w normalnym UI. Ale to niezmiennik serializera, nie formularza: omija go `baker`/`.update()`, import masowy, migracja danych, bezpośredni ORM.

## Rozwiązanie

`if` → `elif`: flaga „bezkosztowa" ma pierwszeństwo. Zaległa kwota nie odwróci payloadu.

## Testy

- `test_OplataZaWydawnictwoPBNAdapter_bezkosztowa_ma_pierwszenstwo` — repro (RED→GREEN): stan sprzeczny daje `costFreePublication=True, amount=0`.
- Regresja: `test_adapters.py` (27) + testy opłat model/command (35) — passed, 0 regresji.

Bez migracji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)