### PR TITLE
FD#373: dwa warianty eksportu XLSX z multiseeka

### DIFF
--- a/docs/superpowers/plans/2026-07-09-multiseek-xlsx-warianty-eksportu.md
+++ b/docs/superpowers/plans/2026-07-09-multiseek-xlsx-warianty-eksportu.md
@@ -1,0 +1,814 @@
+# Multiseek XLSX — dwa warianty eksportu — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dodać drugi wariant eksportu XLSX wyników multiseeka („opis
+bibliograficzny" w jednej kolumnie) i wzbogacić istniejący eksport kolumnowy
+o kolumny Źródło + Typ MNiSW/MEiN — realizacja Freshdesk #373.
+
+**Architecture:** Wydzielamy logikę eksportu z `bpp/views/mymultiseek.py` do
+nowego modułu `bpp/views/multiseek_export.py` (commit bez zmiany zachowania),
+potem dokładamy dwie kolumny do wariantu `dane` i nowy wariant `opis`
+wybierany query-paramem `?wariant=`, a UI dostaje dropdown Foundation
+w paginatorze. Kluczowe ryzyko — N+1 przy do 5000 wierszy — adresujemy
+per-wariant `select_related` + `only('…__nazwa')` i pilnujemy testem
+query-count.
+
+**Tech Stack:** Django, openpyxl, multiseek, Foundation (frontend), pytest +
+model_bakery.
+
+## Global Constraints
+
+- Python `uv run` prefix dla WSZYSTKICH komend Pythona (`uv run pytest …`).
+- Max długość linii: 88 znaków (ruff).
+- NIE modyfikować istniejących migracji; tu migracji nie ma (wszystkie pola
+  już istnieją na `Rekord`).
+- Django template comments `{# … #}` — każda linia własne `{# … #}`.
+- Ikony frontendu publicznego: Foundation-Icons (`<i class="fi-…">`), nie emoji.
+- Eksport ograniczony do `MULTISEEK_EXPORT_MAX_ROWS = 5000` (bez zmian).
+- Sanityzacja formuł XLSX/CSV (`=`, `+`, `-`, `@`, Tab/CR/LF) — zachować.
+- Spec źródłowy: `docs/superpowers/specs/2026-07-08-multiseek-xlsx-warianty-eksportu-design.md`.
+
+---
+
+## File Structure
+
+- **Create** `src/bpp/views/multiseek_export.py` — cała logika serializacji
+  eksportu: stałe nagłówków/pól, helpery tekstowe/URL, dwa iteratory wierszy,
+  dwa buildery odpowiedzi. Jedna odpowiedzialność: „zamień queryset Rekordów
+  na plik CSV/XLSX".
+- **Modify** `src/bpp/views/mymultiseek.py` — usunąć przeniesioną logikę,
+  importować z nowego modułu; `MyMultiseekExport.get` zyskuje odczyt `wariant`.
+- **Modify** `src/django_bpp/templates/multiseek/paginator.html` — dwa linki
+  (CSV, XLS) → dropdown „Eksport ▾" z trzema pozycjami.
+- **Modify** `src/bpp/tests/test_views/test_mymultiseek.py` — przepisać
+  hardkodowane asercje układu XLSX; dodać testy nowych kolumn, wariantu `opis`,
+  degradacji CSV, nieznanego wariantu, query-count, `print-removed`+`wariant`.
+- **Create** `src/bpp/newsfragments/fd373.feature.rst` — nota wydaniowa.
+
+---
+
+### Task 1: Refactor — wydzielenie logiki eksportu (bez zmiany zachowania)
+
+Czysto mechaniczne przeniesienie. Zero zmian w kolumnach, formatach, routingu.
+Cel: `git`-owy diff kolejnych tasków pokazuje logikę, nie „szum przenoszenia".
+Istniejące testy `test_mymultiseek.py` muszą przejść bez modyfikacji.
+
+**Files:**
+- Create: `src/bpp/views/multiseek_export.py`
+- Modify: `src/bpp/views/mymultiseek.py` (usuń przeniesione symbole, dodaj import)
+- Test: `src/bpp/tests/test_views/test_mymultiseek.py` (bez zmian — regresja)
+
+**Interfaces:**
+- Produces (publiczna powierzchnia nowego modułu, używana przez widok):
+  - `MULTISEEK_EXPORT_MAX_ROWS: int` — zostaje w widoku (używa go
+    `get_context_data`); NIE przenosić.
+  - `csv_export_response(queryset, request, report_title: str) -> HttpResponse`
+  - `xlsx_export_response(queryset, request, report_title: str, wariant: str) -> HttpResponse`
+    — w Tasku 1 sygnatura jeszcze bez `wariant` (dodany w Tasku 3); na razie
+    `xlsx_export_response(queryset, request, report_title) -> HttpResponse`.
+  - `plain_multiseek_report_title(value) -> str` (był `_plain_multiseek_report_title`)
+  - `MULTISEEK_DEFAULT_REPORT_TITLE: str`
+  - `MULTISEEK_EXPORT_DANE_FIELDS: tuple[str, ...]` (był `MULTISEEK_EXPORT_FIELDS`)
+
+**Przenoszone symbole (verbatim, BEZ modyfikacji treści) z `mymultiseek.py`:**
+stałe `MULTISEEK_EXPORT_HEADERS`, `MULTISEEK_EXPORT_XLSX_HEADERS`,
+`MULTISEEK_EXPORT_XLSX_URL_COLUMNS`, `EXPORT_FILENAME_INVALID_CHARS_RE`,
+`MULTISEEK_REPORT_TITLE_HTML_BREAK_RE`, `XLSX_WORKSHEET_TITLE_INVALID_CHARS_RE`,
+`SPREADSHEET_FORMULA_INJECTION_LEAD`, `XLSX_WORKSHEET_TITLE_MAX_LENGTH`,
+`MULTISEEK_DEFAULT_REPORT_TITLE`; funkcje `_export_value`, `_single_line_text`,
+`_plain_multiseek_report_title`→`plain_multiseek_report_title`,
+`_export_filename`, `_xlsx_worksheet_title`, `_sanitize_spreadsheet_cell`,
+`_sanitize_spreadsheet_row`, `_pbn_publication_url`, `_admin_change_url`,
+`_iter_export_rows`, `_csv_export_response`→`csv_export_response`,
+`_xlsx_export_response`→`xlsx_export_response`. Zmienić `MULTISEEK_EXPORT_FIELDS`
+→ `MULTISEEK_EXPORT_DANE_FIELDS` (nazwa pod przyszły drugi zestaw).
+
+**Zostaje w `mymultiseek.py`:** `MULTISEEK_REPORT_TITLE_SESSION_KEY`,
+`MULTISEEK_EXPORT_MAX_ROWS`, `_multiseek_report_title` (czyta sesję; woła
+`plain_multiseek_report_title` z modułu), klasy widoków.
+
+- [ ] **Step 1: Utwórz `multiseek_export.py` z przeniesioną treścią**
+
+Utwórz `src/bpp/views/multiseek_export.py`. Nagłówek modułu + importy:
+
+```python
+"""Serializacja wyników Multiseek do plików eksportu (CSV / XLSX).
+
+Wydzielone z bpp/views/mymultiseek.py — widok trzyma routing i stan sesji,
+ten moduł zamienia queryset Rekordów na gotową odpowiedź HTTP z plikiem.
+"""
+
+import csv
+import html
+import io
+import re
+
+from django.http import HttpResponse
+from django.urls import reverse
+from django.utils.html import strip_tags
+from django.utils.http import content_disposition_header
+
+from bpp import const
+from bpp.models import Uczelnia
+```
+
+Następnie **przenieś verbatim** wszystkie stałe i funkcje wymienione wyżej
+(z `mymultiseek.py`, obecne linie 40-93 dla stałych oraz 235-397 dla
+funkcji), zmieniając tylko:
+- `MULTISEEK_EXPORT_FIELDS` → `MULTISEEK_EXPORT_DANE_FIELDS`,
+- `_plain_multiseek_report_title` → `plain_multiseek_report_title` (public),
+- `_csv_export_response` → `csv_export_response` (public),
+- `_xlsx_export_response` → `xlsx_export_response` (public).
+
+Wewnętrzne wywołania między przeniesionymi funkcjami zaktualizuj do nowych
+nazw. `_iter_export_rows` zostaje prywatne (na razie).
+
+- [ ] **Step 2: Zaktualizuj `mymultiseek.py` — usuń przeniesione, dodaj import**
+
+Usuń z `mymultiseek.py` przeniesione stałe i funkcje. Zostaw
+`MULTISEEK_REPORT_TITLE_SESSION_KEY = "MULTISEEK_TITLE"`,
+`MULTISEEK_EXPORT_MAX_ROWS = 5000`, oraz `_multiseek_report_title`. Dodaj import:
+
+```python
+from bpp.views.multiseek_export import (
+    MULTISEEK_DEFAULT_REPORT_TITLE,
+    csv_export_response,
+    plain_multiseek_report_title,
+    xlsx_export_response,
+)
+```
+
+Zaktualizuj `_multiseek_report_title`, by wołało `plain_multiseek_report_title`:
+
+```python
+def _multiseek_report_title(request):
+    return plain_multiseek_report_title(
+        request.session.get(
+            MULTISEEK_REPORT_TITLE_SESSION_KEY,
+            MULTISEEK_DEFAULT_REPORT_TITLE,
+        )
+    )
+```
+
+W `MyMultiseekExport.get` podmień wołania na publiczne nazwy z modułu:
+
+```python
+        report_title = _multiseek_report_title(request)
+        queryset = queryset.select_related(None).only(*MULTISEEK_EXPORT_DANE_FIELDS)
+        if export_format == "csv":
+            return csv_export_response(queryset, request, report_title)
+        return xlsx_export_response(queryset, request, report_title)
+```
+
+Dodaj import `MULTISEEK_EXPORT_DANE_FIELDS` do listy powyżej.
+
+- [ ] **Step 3: Uruchom istniejące testy eksportu — regresja**
+
+Run: `uv run pytest src/bpp/tests/test_views/test_mymultiseek.py -q`
+Expected: PASS (ta sama liczba testów co przed refactorem; zero zmian zachowania).
+
+- [ ] **Step 4: Sprawdź brak innych importów starych symboli**
+
+Run: `grep -rn "_csv_export_response\|_xlsx_export_response\|MULTISEEK_EXPORT_FIELDS\|_plain_multiseek_report_title" src/ --include=*.py`
+Expected: brak trafień poza definicjami w `multiseek_export.py` (i ich
+publicznymi odpowiednikami). Jeśli coś jeszcze importowało stare nazwy — popraw.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bpp/views/multiseek_export.py src/bpp/views/mymultiseek.py
+git commit -m "refactor(multiseek): wydziel logikę eksportu do multiseek_export.py
+
+Bez zmiany zachowania — przeniesienie stałych, helperów, iteratora wierszy
+i builderów odpowiedzi. Przygotowanie pod drugi wariant eksportu (FD#373)."
+```
+
+---
+
+### Task 2: Wariant `dane` — dodaj kolumny Źródło + Typ MNiSW/MEiN
+
+Czysta insercja: `Źródło` po `Autorzy` (kol. 3), `Typ MNiSW/MEiN` po
+`Typ rekordu` (kol. 9). `BPP ID` zostaje przed `Typ rekordu`. Dotyczy CSV i XLSX.
+Naprawiamy N+1 (per-wariant `select_related`/`only`) i przestajemy hardkodować
+indeksy kolumn-linków / formatów liczb (liczymy z nagłówków).
+
+**Files:**
+- Modify: `src/bpp/views/multiseek_export.py`
+- Modify: `src/bpp/views/mymultiseek.py` (queryset dla wariantu `dane`)
+- Test: `src/bpp/tests/test_views/test_mymultiseek.py`
+
+**Interfaces:**
+- Consumes: `MULTISEEK_EXPORT_XLSX_HEADERS`, `_iter_export_rows`,
+  `xlsx_export_response`, `MULTISEEK_EXPORT_DANE_FIELDS` (z Taska 1).
+- Produces: `MULTISEEK_EXPORT_DANE_FIELDS` rozszerzone o `zrodlo__nazwa`,
+  `typ_kbn__nazwa`; helper `_xlsx_column_index(headers, predicate) -> list[int]`
+  (1-based) do wyliczania kolumn linków/liczb.
+
+- [ ] **Step 1: Napisz failing testy nowych kolumn (CSV + XLSX)**
+
+Dodaj do `test_mymultiseek.py` (dostosuj fixtures do istniejących w pliku —
+użyj `baker.make("bpp.Wydawnictwo_Ciagle", ...)` ze źródłem i typem KBN,
+zaloguj usera jak w istniejących testach eksportu):
+
+```python
+def test_export_dane_csv_ma_zrodlo_i_typ_mnisw(admin_client, wydawnictwo_ciagle):
+    resp = admin_client.get("/multiseek/export/csv/")
+    assert resp.status_code == 200
+    text = resp.content.decode("utf-8")
+    header = text.splitlines()[0]
+    cols = header.split(",")
+    assert cols[2] == "zrodlo"
+    assert cols[8] == "typ_mnisw_mein"
+    assert cols[6] == "bpp_id"  # BPP ID nadal przed typ_rekordu (kol. 8)
+    assert cols[7] == "typ_rekordu"
+
+
+def test_export_dane_xlsx_ma_zrodlo_i_typ_mnisw(admin_client, wydawnictwo_ciagle):
+    from openpyxl import load_workbook
+
+    resp = admin_client.get("/multiseek/export/xlsx/")
+    assert resp.status_code == 200
+    wb = load_workbook(io.BytesIO(resp.content))
+    ws = wb.active
+    headers = [c.value for c in ws[1]]
+    assert headers[2] == "Źródło"
+    assert headers[8] == "Typ MNiSW/MEiN"
+    assert headers[6] == "BPP ID"
+    assert headers[7] == "Typ rekordu"
+```
+
+- [ ] **Step 2: Uruchom — ma FAIL**
+
+Run: `uv run pytest src/bpp/tests/test_views/test_mymultiseek.py -k "zrodlo_i_typ" -q`
+Expected: FAIL (kolumny nie istnieją / zła kolejność).
+
+- [ ] **Step 3: Rozszerz nagłówki i pola w `multiseek_export.py`**
+
+Podmień stałe na wersje z insercją (dwie nowe kolumny):
+
+```python
+MULTISEEK_EXPORT_HEADERS = (
+    "tytul_oryginalny",
+    "autorzy",
+    "zrodlo",
+    "rok",
+    "impact_factor",
+    "pk",
+    "bpp_id",
+    "typ_rekordu",
+    "typ_mnisw_mein",
+    "id_rekordu",
+    "pbn_uid_id",
+    "link_do_bpp_url",
+    "link_do_bpp_admin_url",
+    "link_do_pbn_url",
+)
+
+MULTISEEK_EXPORT_XLSX_HEADERS = (
+    "Tytuł oryginalny",
+    "Autorzy",
+    "Źródło",
+    "Rok",
+    "Impact Factor",
+    "PK",
+    "BPP ID",
+    "Typ rekordu",
+    "Typ MNiSW/MEiN",
+    "ID rekordu",
+    "PBN UID",
+    "Link do BPP",
+    "Link do edycji w BPP",
+    "Link do PBN",
+)
+
+MULTISEEK_EXPORT_DANE_FIELDS = (
+    "id",
+    "tytul_oryginalny",
+    "opis_bibliograficzny_zapisani_autorzy_cache",
+    "zrodlo__nazwa",
+    "rok",
+    "impact_factor",
+    "punkty_kbn",
+    "typ_kbn__nazwa",
+    "pbn_uid_id",
+)
+```
+
+Usuń stałą `MULTISEEK_EXPORT_XLSX_URL_COLUMNS` (zastąpi ją wyliczanie z nazw).
+
+- [ ] **Step 4: Wstaw wartości Źródło + Typ MNiSW/MEiN w `_iter_export_rows`**
+
+`Zrodlo`/`Typ_KBN` mogą być `None` → pusty string. Używamy `zrodlo.nazwa`
+(NIE `str(zrodlo)` — patrz spec §2). Zaktualizuj `_iter_export_rows`:
+
+```python
+def _iter_export_rows(queryset, request):
+    uczelnia = Uczelnia.objects.get_for_request(request)
+    pbn_api_root = uczelnia.pbn_api_root if uczelnia is not None else ""
+
+    for rekord in queryset.iterator(chunk_size=1000):
+        zrodlo = rekord.zrodlo
+        typ_kbn = rekord.typ_kbn
+        yield (
+            rekord.tytul_oryginalny,
+            rekord.opis_bibliograficzny_zapisani_autorzy_cache,
+            zrodlo.nazwa if zrodlo is not None else "",
+            rekord.rok,
+            rekord.impact_factor,
+            rekord.punkty_kbn,
+            str(tuple(rekord.pk)),
+            str(rekord.describe_content_type),
+            typ_kbn.nazwa if typ_kbn is not None else "",
+            rekord.object_id,
+            _export_value(rekord.pbn_uid_id),
+            request.build_absolute_uri(rekord.get_absolute_url()),
+            _admin_change_url(rekord, request),
+            _pbn_publication_url(rekord.pbn_uid_id, pbn_api_root),
+        )
+```
+
+- [ ] **Step 5: Wylicz indeksy kolumn z nagłówków (koniec hardkodowania)**
+
+Dodaj helper i użyj go w `xlsx_export_response`:
+
+```python
+def _xlsx_columns_where(headers, predicate):
+    """1-based indeksy kolumn XLSX, których nagłówek spełnia predykat."""
+    return [i for i, h in enumerate(headers, start=1) if predicate(h)]
+```
+
+W `xlsx_export_response` zastąp hardkodowane `(10, 11, 12)` oraz kolumny
+`min_col=4, max_col=5` (IF/PK) wyliczeniem z `MULTISEEK_EXPORT_XLSX_HEADERS`:
+
+```python
+    headers = MULTISEEK_EXPORT_XLSX_HEADERS
+    url_cols = _xlsx_columns_where(headers, lambda h: h.startswith("Link"))
+    if_cols = _xlsx_columns_where(headers, lambda h: h == "Impact Factor")
+    pk_cols = _xlsx_columns_where(headers, lambda h: h == "PK")
+
+    for row in worksheet.iter_rows(min_row=2):
+        for cell in row:
+            cell.alignment = Alignment(vertical="top", wrap_text=True)
+
+    for col in if_cols:
+        for row in worksheet.iter_rows(min_row=2, min_col=col, max_col=col):
+            row[0].number_format = "0.000"
+    for col in pk_cols:
+        for row in worksheet.iter_rows(min_row=2, min_col=col, max_col=col):
+            row[0].number_format = "0.00"
+
+    for row_idx in range(2, worksheet.max_row + 1):
+        for col_idx in url_cols:
+            cell = worksheet.cell(row=row_idx, column=col_idx)
+            if cell.value:
+                cell.value = f'=HYPERLINK("{cell.value}", "[link]")'
+```
+
+(Reszta `xlsx_export_response` — nagłówek fill/font, `freeze_panes="B1"`,
+autosize, tabela — bez zmian.)
+
+- [ ] **Step 6: Napraw N+1 — `select_related` dla wariantu `dane` w widoku**
+
+W `mymultiseek.py`, `MyMultiseekExport.get`, zamień linię budującą queryset
+eksportu tak, by po zdjęciu `select_related(None)` przywrócić potrzebne relacje:
+
+```python
+        queryset = (
+            queryset.select_related(None)
+            .select_related("zrodlo", "typ_kbn")
+            .only(*MULTISEEK_EXPORT_DANE_FIELDS)
+        )
+```
+
+- [ ] **Step 7: Przepisz stare hardkodowane asercje układu XLSX**
+
+W `test_mymultiseek.py` istniejące asercje (`worksheet["D2"].number_format ==
+"0.000"`, `["E2"] == "0.00"`, pozycje `=HYPERLINK`) są teraz przesunięte o dwie
+kolumny: IF→E, PK→F, linki→L/M/N. Zaktualizuj je:
+
+```python
+    assert ws["E2"].number_format == "0.000"  # Impact Factor (było D)
+    assert ws["F2"].number_format == "0.00"   # PK (było E)
+    # kolumny linków (L, M, N) zawierają =HYPERLINK
+    for col in ("L", "M", "N"):
+        assert ws[f"{col}2"].value.startswith("=HYPERLINK(")
+```
+
+(Jeśli konkretny test asertuje wartości danych po indeksie krotki — przesuń
+indeksy: źródło wchodzi na pozycję 2 (0-based), typ MNiSW na pozycję 8.)
+
+- [ ] **Step 8: Test query-count dla `dane` (strażnik N+1)**
+
+```python
+def test_export_dane_xlsx_nie_ma_n_plus_1(admin_client, django_assert_max_num_queries):
+    from openpyxl import load_workbook
+
+    # dwa rekordy o RÓŻNYCH źródłach i typach — gdyby był N+1,
+    # liczba zapytań rosłaby z liczbą wierszy
+    baker.make("bpp.Wydawnictwo_Ciagle", _quantity=3)
+    with django_assert_max_num_queries(15):
+        resp = admin_client.get("/multiseek/export/xlsx/")
+    assert resp.status_code == 200
+    load_workbook(io.BytesIO(resp.content))
+```
+
+(Dobierz próg do realnej liczby zapytań zmierzonej lokalnie — ma być STAŁY
+względem liczby wierszy; jeśli 15 jest za ciasne/luźne, ustaw wartość tuż nad
+zmierzoną. Kluczowe: dodanie kolejnych rekordów NIE zwiększa liczby zapytań.)
+
+- [ ] **Step 9: Uruchom testy**
+
+Run: `uv run pytest src/bpp/tests/test_views/test_mymultiseek.py -q`
+Expected: PASS (nowe + przepisane).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/bpp/views/multiseek_export.py src/bpp/views/mymultiseek.py \
+        src/bpp/tests/test_views/test_mymultiseek.py
+git commit -m "feat(multiseek): kolumny Źródło + Typ MNiSW/MEiN w eksporcie (FD#373)
+
+Czysta insercja dwóch kolumn (CSV i XLSX), indeksy kolumn liczone z nagłówków
+zamiast hardkodowanych, per-wariant select_related+only przeciw N+1."
+```
+
+---
+
+### Task 3: Wariant `opis` (XLSX-only) + routing `?wariant=`
+
+Nowy układ: Lp. | Opis bibliograficzny | IF | PK | Charakter | Typ MNiSW/MEiN.
+Opis w jednej komórce (HTML → czysty tekst). Wybór query-paramem.
+
+**Files:**
+- Modify: `src/bpp/views/multiseek_export.py`
+- Modify: `src/bpp/views/mymultiseek.py` (routing + queryset opis)
+- Test: `src/bpp/tests/test_views/test_mymultiseek.py`
+
+**Interfaces:**
+- Consumes: `MULTISEEK_REPORT_TITLE_HTML_BREAK_RE`, `_single_line_text`,
+  `sanitize_xlsx_row`, `xlsx_export_response` (z Tasków 1-2).
+- Produces:
+  - `MULTISEEK_EXPORT_OPIS_XLSX_HEADERS: tuple[str, ...]`
+  - `MULTISEEK_EXPORT_OPIS_FIELDS: tuple[str, ...]`
+  - `_plain_opis_bibliograficzny(value) -> str`
+  - `_iter_export_rows_opis(queryset, request) -> Iterator[tuple]`
+  - `xlsx_export_response(queryset, request, report_title, wariant="dane")`
+    — rozszerzona sygnatura.
+
+- [ ] **Step 1: Napisz failing testy wariantu `opis`**
+
+```python
+def test_export_opis_xlsx_uklad(admin_client, wydawnictwo_ciagle):
+    from openpyxl import load_workbook
+
+    resp = admin_client.get("/multiseek/export/xlsx/?wariant=opis")
+    assert resp.status_code == 200
+    wb = load_workbook(io.BytesIO(resp.content))
+    ws = wb.active
+    headers = [c.value for c in ws[1]]
+    assert headers == [
+        "Lp.", "Opis bibliograficzny", "IF", "PK", "Charakter", "Typ MNiSW/MEiN",
+    ]
+    assert ws["A2"].value == 1  # numeracja Lp.
+
+
+def test_export_opis_czysci_html(admin_client):
+    from openpyxl import load_workbook
+
+    baker.make(
+        "bpp.Wydawnictwo_Ciagle",
+        opis_bibliograficzny_cache="Tytuł <i>Źródła</i> 2026<br>s. 1-2",
+    )
+    resp = admin_client.get("/multiseek/export/xlsx/?wariant=opis")
+    wb = load_workbook(io.BytesIO(resp.content))
+    opis = wb.active["B2"].value
+    assert "<" not in opis and ">" not in opis
+    assert "Źródła" in opis
+    assert "  " not in opis  # spacje skolapsowane, <br> nie sklejone
+
+
+def test_export_opis_csv_degraduje_do_dane(admin_client, wydawnictwo_ciagle):
+    resp = admin_client.get("/multiseek/export/csv/?wariant=opis")
+    assert resp.status_code == 200
+    header = resp.content.decode("utf-8").splitlines()[0]
+    assert header.split(",")[0] == "tytul_oryginalny"  # układ dane, nie opis
+
+
+def test_export_nieznany_wariant_to_dane(admin_client, wydawnictwo_ciagle):
+    from openpyxl import load_workbook
+
+    resp = admin_client.get("/multiseek/export/xlsx/?wariant=cokolwiek")
+    assert resp.status_code == 200
+    ws = load_workbook(io.BytesIO(resp.content)).active
+    assert ws[1][0].value == "Tytuł oryginalny"  # układ dane
+```
+
+- [ ] **Step 2: Uruchom — ma FAIL**
+
+Run: `uv run pytest src/bpp/tests/test_views/test_mymultiseek.py -k "opis or nieznany_wariant" -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Dodaj stałe wariantu `opis`**
+
+```python
+MULTISEEK_EXPORT_OPIS_XLSX_HEADERS = (
+    "Lp.",
+    "Opis bibliograficzny",
+    "IF",
+    "PK",
+    "Charakter",
+    "Typ MNiSW/MEiN",
+)
+
+MULTISEEK_EXPORT_OPIS_FIELDS = (
+    "id",
+    "opis_bibliograficzny_cache",
+    "impact_factor",
+    "punkty_kbn",
+    "charakter_formalny__nazwa",
+    "typ_kbn__nazwa",
+)
+```
+
+- [ ] **Step 4: Dodaj helper `_plain_opis_bibliograficzny`**
+
+```python
+def _plain_opis_bibliograficzny(value):
+    """opis_bibliograficzny_cache (HTML) -> jednoliniowy czysty tekst.
+
+    Bez fallbacku na tytuł domyślny (w przeciwieństwie do
+    plain_multiseek_report_title): puste wejście -> "". Sanityzacja formuł
+    dzieje się później, w sanitize_xlsx_row — tu jej NIE wołamy.
+    """
+    if not value:
+        return ""
+    value = MULTISEEK_REPORT_TITLE_HTML_BREAK_RE.sub(" ", value)
+    value = html.unescape(strip_tags(value))
+    return _single_line_text(value)
+```
+
+- [ ] **Step 5: Dodaj iterator wierszy `opis`**
+
+```python
+def _iter_export_rows_opis(queryset, request):
+    for lp, rekord in enumerate(queryset.iterator(chunk_size=1000), start=1):
+        charakter = rekord.charakter_formalny
+        typ_kbn = rekord.typ_kbn
+        yield (
+            lp,
+            _plain_opis_bibliograficzny(rekord.opis_bibliograficzny_cache),
+            rekord.impact_factor,
+            rekord.punkty_kbn,
+            charakter.nazwa if charakter is not None else "",
+            typ_kbn.nazwa if typ_kbn is not None else "",
+        )
+```
+
+- [ ] **Step 6: Rozgałęź `xlsx_export_response` per wariant**
+
+Zmień sygnaturę na `xlsx_export_response(queryset, request, report_title,
+wariant="dane")`. Na początku wybierz nagłówki + iterator:
+
+```python
+    if wariant == "opis":
+        headers = MULTISEEK_EXPORT_OPIS_XLSX_HEADERS
+        rows = _iter_export_rows_opis(queryset, request)
+        freeze = "A2"
+    else:
+        headers = MULTISEEK_EXPORT_XLSX_HEADERS
+        rows = _iter_export_rows(queryset, request)
+        freeze = "B1"
+```
+
+Użyj `headers` przy `worksheet.append(headers)` i przy wyliczaniu
+`url_cols`/`if_cols`/`pk_cols` (Task 2, Step 5). Dla `opis` `url_cols` wyjdzie
+puste (brak kolumn „Link…") — pętla HYPERLINK nic nie zrobi, i słusznie.
+Ustaw `worksheet.freeze_panes = freeze`. Reszta (fill/font nagłówka, autosize,
+tabela, `worksheet.append(sanitize_xlsx_row(row)) for row in rows`) — wspólna.
+
+- [ ] **Step 7: Routing + queryset per wariant w widoku**
+
+W `mymultiseek.py`, `MyMultiseekExport.get`:
+
+```python
+    def get(self, request, export_format, *args, **kwargs):
+        if export_format not in {"csv", "xlsx"}:
+            return HttpResponseBadRequest("Nieznany format eksportu.")
+
+        wariant = request.GET.get("wariant", "dane")
+        if wariant not in {"dane", "opis"}:
+            wariant = "dane"
+        # opis to format czytelny (raportowy) — CSV opisu nie robimy
+        if export_format == "csv":
+            wariant = "dane"
+
+        queryset = self.get_queryset_for_current_mode()
+        count = queryset.count()
+        if count > MULTISEEK_EXPORT_MAX_ROWS:
+            return HttpResponseBadRequest(
+                "Eksport Multiseek jest dostępny dla maksymalnie "
+                f"{MULTISEEK_EXPORT_MAX_ROWS} rekordów."
+            )
+
+        report_title = _multiseek_report_title(request)
+        if wariant == "opis":
+            queryset = (
+                queryset.select_related(None)
+                .select_related("charakter_formalny", "typ_kbn")
+                .only(*MULTISEEK_EXPORT_OPIS_FIELDS)
+            )
+            return xlsx_export_response(queryset, request, report_title, "opis")
+
+        queryset = (
+            queryset.select_related(None)
+            .select_related("zrodlo", "typ_kbn")
+            .only(*MULTISEEK_EXPORT_DANE_FIELDS)
+        )
+        if export_format == "csv":
+            return csv_export_response(queryset, request, report_title)
+        return xlsx_export_response(queryset, request, report_title, "dane")
+```
+
+Dodaj `MULTISEEK_EXPORT_OPIS_FIELDS` do importu z `multiseek_export`.
+
+- [ ] **Step 8: Test query-count dla `opis`**
+
+```python
+def test_export_opis_nie_ma_n_plus_1(admin_client, django_assert_max_num_queries):
+    from openpyxl import load_workbook
+
+    baker.make("bpp.Wydawnictwo_Ciagle", _quantity=3)
+    with django_assert_max_num_queries(15):
+        resp = admin_client.get("/multiseek/export/xlsx/?wariant=opis")
+    assert resp.status_code == 200
+    load_workbook(io.BytesIO(resp.content))
+```
+
+(Próg jak w Task 2 Step 8 — stały względem liczby wierszy.)
+
+- [ ] **Step 9: Uruchom testy**
+
+Run: `uv run pytest src/bpp/tests/test_views/test_mymultiseek.py -q`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/bpp/views/multiseek_export.py src/bpp/views/mymultiseek.py \
+        src/bpp/tests/test_views/test_mymultiseek.py
+git commit -m "feat(multiseek): wariant eksportu 'opis bibliograficzny' XLSX (FD#373)
+
+Nowy układ (opis w jednej kolumnie + IF/PK/Charakter/Typ MNiSW/MEiN) wybierany
+?wariant=opis; CSV degraduje do 'dane'; helper czyszczący HTML bez fallbacku;
+select_related+only przeciw N+1 z testem query-count."
+```
+
+---
+
+### Task 4: UI — dropdown „Eksport ▾" w paginatorze
+
+Dwa linki (CSV, XLS) → jeden trigger + dropdown-pane z trzema pozycjami.
+Najpierw weryfikacja dostępności Foundation Dropdown JS.
+
+**Files:**
+- Modify: `src/django_bpp/templates/multiseek/paginator.html`
+
+**Interfaces:** brak (czysto szablon). Linki statyczne — patrz Task 3 routing.
+
+- [ ] **Step 1: Zweryfikuj Foundation Dropdown JS na stronie multiseeka**
+
+Run: `grep -rn "data-dropdown\|Foundation.Dropdown\|dropdown-pane" src/django_bpp/templates/ src/bpp/static/ src/django_bpp/static_root* 2>/dev/null | head`
+Oraz sprawdź, czy layout multiseeka inicjuje Foundation (`$(document).foundation()`
+lub odpowiednik). Jeśli `dropdown-pane` jest już używany gdzieś w publicznym
+frontendzie — użyj go (Step 2a). Jeśli NIE ma pewności — użyj natywnego
+`<details>` (Step 2b, zero JS). Decyzja binarna, udokumentuj w commicie.
+
+- [ ] **Step 2a: Wariant Foundation dropdown-pane (jeśli JS dostępny)**
+
+W `paginator.html` zastąp blok linii ~32-45 (dwa `<li>` CSV/XLS):
+
+```django
+{% if request.user.is_authenticated and paginator_count > 0 and paginator_count <= multiseek_export_max_rows %}
+    {% url "multiseek-export" "csv" as ex_csv %}
+    {% url "multiseek-export" "xlsx" as ex_xlsx %}
+    <li>
+        <a data-toggle="multiseek-export-menu"><i class="fi-download"></i> Eksport <span aria-hidden="true">▾</span></a>
+    </li>
+    <div class="dropdown-pane" id="multiseek-export-menu" data-dropdown data-auto-focus="true">
+        <ul class="menu vertical" style="margin-bottom:0;">
+            <li><a href="{{ ex_csv }}{% if print_removed %}?print-removed=1{% endif %}"><i class="fi-download"></i> CSV</a></li>
+            <li><a href="{{ ex_xlsx }}{% if print_removed %}?print-removed=1{% endif %}"><i class="fi-download"></i> XLS: dane</a></li>
+            <li><a href="{{ ex_xlsx }}?wariant=opis{% if print_removed %}&print-removed=1{% endif %}"><i class="fi-download"></i> XLS: opis bibliograficzny</a></li>
+        </ul>
+    </div>
+{% endif %}
+```
+
+- [ ] **Step 2b: Wariant natywny `<details>` (jeśli brak pewności co do JS)**
+
+```django
+{% if request.user.is_authenticated and paginator_count > 0 and paginator_count <= multiseek_export_max_rows %}
+    {% url "multiseek-export" "csv" as ex_csv %}
+    {% url "multiseek-export" "xlsx" as ex_xlsx %}
+    <li>
+        <details class="multiseek-export-details">
+            <summary><i class="fi-download"></i> Eksport ▾</summary>
+            <ul class="menu vertical" style="margin:0;">
+                <li><a href="{{ ex_csv }}{% if print_removed %}?print-removed=1{% endif %}"><i class="fi-download"></i> CSV</a></li>
+                <li><a href="{{ ex_xlsx }}{% if print_removed %}?print-removed=1{% endif %}"><i class="fi-download"></i> XLS: dane</a></li>
+                <li><a href="{{ ex_xlsx }}?wariant=opis{% if print_removed %}&print-removed=1{% endif %}"><i class="fi-download"></i> XLS: opis bibliograficzny</a></li>
+            </ul>
+        </details>
+    </li>
+{% endif %}
+```
+
+- [ ] **Step 3: Weryfikacja wizualna (run-site)**
+
+Uruchom stack i obejrzyj paginator wyników multiseeka:
+
+Run: `uv run run-site run --no-browser` (w tle), potem otwórz `/multiseek/results/`
+zalogowany (snippet z CLAUDE.md „Autologin"). Sprawdź: dropdown otwiera się,
+trzy linki działają, wiersz akcji krótszy niż wcześniej.
+Expected: trzy pozycje pobierają odpowiednio CSV / XLS dane / XLS opis.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/django_bpp/templates/multiseek/paginator.html
+git commit -m "feat(multiseek): dropdown eksportu w paginatorze (FD#373)
+
+Dwa linki (CSV, XLS) zastąpione jednym triggerem 'Eksport ▾' z trzema
+pozycjami (CSV, XLS: dane, XLS: opis bibliograficzny) — wiersz akcji krótszy."
+```
+
+---
+
+### Task 5: Newsfragment
+
+**Files:**
+- Create: `src/bpp/newsfragments/fd373.feature.rst`
+
+- [ ] **Step 1: Utwórz newsfragment**
+
+```rst
+Eksport wyników wyszukiwania (multiseek) do XLSX zyskał kolumny „Źródło" oraz
+„Typ MNiSW/MEiN", a także drugi wariant, w którym cały opis bibliograficzny
+jest w jednej kolumnie (obok IF, PK, Charakter, Typ MNiSW/MEiN). Wybór wariantu
+odbywa się z rozwijanego przycisku „Eksport" nad listą wyników (FD#373).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/bpp/newsfragments/fd373.feature.rst
+git commit -m "docs(newsfragment): eksport multiseek — kolumny i wariant opisu (FD#373)"
+```
+
+---
+
+## Full-suite validation (po wszystkich taskach)
+
+- [ ] Run: `uv run pytest src/bpp/tests/test_views/test_mymultiseek.py -q` → PASS
+- [ ] Run: `ruff format src/bpp/views/multiseek_export.py src/bpp/views/mymultiseek.py`
+- [ ] Run: `ruff check src/bpp/views/multiseek_export.py src/bpp/views/mymultiseek.py` → czysto
+- [ ] Run: `uv run pytest src/bpp/tests/test_views/ -q` (szerszy regres) → PASS
+
+---
+
+## Self-Review (autor planu)
+
+**Spec coverage:**
+- §2 dane (Źródło + Typ MNiSW/MEiN, czysta insercja, CSV+XLSX) → Task 2 ✓
+- §2 opis (6 kolumn, helper bez fallbacku, HTML→tekst) → Task 3 ✓
+- §3 routing `?wariant=`, degradacja CSV, nieznany→dane → Task 3 Step 7 ✓
+- §4 refactor do multiseek_export.py → Task 1 ✓
+- §4 select_related/only per wariant (N+1) → Task 2 Step 6, Task 3 Step 7 ✓
+- §4 indeksy z nagłówków (startswith „Link", 1-based) → Task 2 Step 5 ✓
+- §4 freeze_panes A2 (opis) / B1 (dane) → Task 3 Step 6 ✓
+- §5 dropdown UI + fallback `<details>` + print-removed w query → Task 4 ✓
+- §6 testy: nowe kolumny, opis, degradacja CSV, nieznany wariant, query-count,
+  print-removed → Task 2/3 (uwaga: test print-removed+wariant dopisać w Task 3
+  Step 1, patrz niżej) ✓
+- §6 przepisanie starych asercji XLSX → Task 2 Step 7 ✓
+- §7 newsfragment → Task 5 ✓
+
+**Luka wykryta w self-review:** spec §6 test 6 (`print-removed` + `wariant`
+współistnieją) nie ma własnego kroku. Dopisać do Task 3 jako dodatkowy test:
+
+```python
+def test_export_print_removed_z_wariantem(admin_client, wydawnictwo_ciagle):
+    resp = admin_client.get("/multiseek/export/xlsx/?wariant=opis&print-removed=1")
+    assert resp.status_code == 200
+```
+
+**Placeholder scan:** brak „TBD/TODO"; progi query-count świadomie kalibrowane
+lokalnie (opisane, nie placeholder).
+
+**Type consistency:** `xlsx_export_response(... , wariant="dane")` — sygnatura
+spójna między Task 1 (bez `wariant`), Task 3 (dodaje `wariant`); Task 1 celowo
+tworzy wersję bez parametru, Task 3 ją rozszerza (zgodne, nie kolizja). Nazwy
+`MULTISEEK_EXPORT_DANE_FIELDS` / `MULTISEEK_EXPORT_OPIS_FIELDS` spójne w Task
+1/2/3. Helpery `_iter_export_rows` (dane) vs `_iter_export_rows_opis` (opis) —
+rozróżnialne.

--- a/docs/superpowers/specs/2026-07-08-multiseek-xlsx-warianty-eksportu-design.md
+++ b/docs/superpowers/specs/2026-07-08-multiseek-xlsx-warianty-eksportu-design.md
@@ -1,0 +1,315 @@
+# Multiseek — dwa warianty eksportu XLSX (Źródło/Typ MNiSW/MEiN + „opis bibliograficzny")
+
+Data: 2026-07-08
+Zgłoszenie: Freshdesk #373 („Rezultat wyszukiwania — export do excel", Ewa Matczuk)
+Status: zaakceptowany zarys, do przełożenia na plan implementacji.
+
+## 1. Problem
+
+Multiseek ma dziś **jeden** eksport XLSX/CSV (`MyMultiseekExport`
+w `src/bpp/views/mymultiseek.py`) — układ **kolumnowy** (jedna dana na kolumnę:
+Tytuł, Autorzy, Rok, IF, PK, identyfikatory, linki). Klientka prosi o dwie
+rzeczy:
+
+1. **Wzbogacić istniejący eksport** o dwie kolumny: `Źródło`
+   i `Typ MNiSW/MEiN`.
+2. **Dodać drugi wariant** eksportu, w którym cały opis bibliograficzny jest
+   w **jednej** kolumnie, a po nim kolumny: `IF`, `PK`, `Charakter`,
+   `Typ MNiSW/MEiN` (odpowiednik ekranowego raportu „lista").
+
+Decyzja projektowa: **NIE** scalać obu układów w jeden arkusz („wszystkie
+kolumny naraz") — to dublowałoby dane (Autorzy/Źródło/Tytuł są już zawarte
+w „Opis bibliograficzny"), dawało szeroki, nieczytelny arkusz i ignorowało
+intencję Klientki, która sama prosi o „drugi wariant". Zamiast tego: **dwa
+odrębne, wąskie warianty**, każdy pod swój cel.
+
+## 2. Dwa warianty
+
+### Wariant `dane` (obecny układ, wzbogacony — realizuje prośbę #1)
+
+Układ kolumnowy. **Czysta insercja** dwóch nowych kolumn — `Źródło` tuż po
+`Autorzy`, `Typ MNiSW/MEiN` tuż po `Typ rekordu` — bez zmiany wzajemnej
+kolejności dotychczasowych kolumn (w szczególności `BPP ID` **zostaje** przed
+`Typ rekordu`, gdzie jest dziś). Dzięki temu istniejący układ CSV nie łamie
+się dla ewentualnych konsumentów downstream; jedyna zmiana to dwie nowe
+kolumny wsunięte w środek i związane z nią przesunięcie indeksów kolumn-linków
+o **dwie** pozycje (patrz §4). Docelowa kolejność nagłówków:
+
+| # | Nagłówek XLSX | Nagłówek CSV (ASCII) | Źródło danych (`Rekord`) |
+|---|---|---|---|
+| 1 | Tytuł oryginalny | `tytul_oryginalny` | `tytul_oryginalny` |
+| 2 | Autorzy | `autorzy` | `opis_bibliograficzny_zapisani_autorzy_cache` |
+| 3 | **Źródło** | **`zrodlo`** | `zrodlo.nazwa` (FK `Zrodlo`, nullable → `""`) |
+| 4 | Rok | `rok` | `rok` |
+| 5 | Impact Factor | `impact_factor` | `impact_factor` |
+| 6 | PK | `pk` | `punkty_kbn` |
+| 7 | BPP ID | `bpp_id` | `str(tuple(pk))` |
+| 8 | Typ rekordu | `typ_rekordu` | `describe_content_type` |
+| 9 | **Typ MNiSW/MEiN** | **`typ_mnisw_mein`** | `typ_kbn.nazwa` (nullable → `""`) |
+| 10 | ID rekordu | `id_rekordu` | `object_id` |
+| 11 | PBN UID | `pbn_uid_id` | `pbn_uid_id` |
+| 12 | Link do BPP | `link_do_bpp_url` | `get_absolute_url()` (absolutny) |
+| 13 | Link do edycji w BPP | `link_do_bpp_admin_url` | `_admin_change_url()` |
+| 14 | Link do PBN | `link_do_pbn_url` | `_pbn_publication_url()` |
+
+Uwaga o „nazwie":
+- `Typ_KBN` i `Charakter_Formalny` dziedziczą po `NazwaISkrot`, którego
+  `__str__` zwraca `nazwa` — więc `str(obj)` == `obj.nazwa`.
+- `Zrodlo` **nie** dziedziczy po `NazwaISkrot`; ma własne pola `nazwa`/`skrot`
+  i własny `__str__`, który **dopisuje `poprzednia_nazwa`** (`zrodlo.py:202-211`).
+Dlatego dla źródła preferujemy jawne `zrodlo.nazwa` (a nie `str(zrodlo)`) —
+`str()` czytałoby `poprzednia_nazwa`, kolejny deferred field → dodatkowe
+zapytanie przy `.only()`. Patrz wymagania `select_related`/`only` w §4.
+
+Wariant `dane` obowiązuje **zarówno CSV jak i XLSX** — obie ścieżki dzielą
+wspólny builder wierszy, więc dwie nowe kolumny wchodzą do obu naraz. CSV
+używa nagłówków ASCII snake_case (kolumna wyżej), XLSX — polskich etykiet.
+
+### Wariant `opis` (nowy — realizuje prośbę #2)
+
+Układ raportowy, **tylko XLSX**. Sześć kolumn:
+
+| # | Nagłówek XLSX | Źródło danych (`Rekord`) |
+|---|---|---|
+| 1 | Lp. | licznik wiersza (1..N) |
+| 2 | Opis bibliograficzny | `opis_bibliograficzny_cache` |
+| 3 | IF | `impact_factor` |
+| 4 | PK | `punkty_kbn` |
+| 5 | Charakter | `charakter_formalny.nazwa` (nullable → `""`) |
+| 6 | Typ MNiSW/MEiN | `typ_kbn.nazwa` (nullable → `""`) |
+
+Uwaga: `opis_bibliograficzny_cache` bywa HTML-em (kursywa w tytule źródła,
+`<br>`, `<div>` itp.). Do komórki XLSX wchodzi **czysty tekst**. Potrzebny
+**dedykowany helper** `_plain_opis_bibliograficzny(html_str)` — NIE reużywać
+`_plain_multiseek_report_title` w całości, bo ono ma fallback na
+„Rezultat wyszukiwania" dla pustego wejścia (wstrzyknąłby domyślny tytuł do
+komórek z pustym opisem). Sekwencja helpera, w tej kolejności:
+1. zamiana tagów blokowych na spację (`MULTISEEK_REPORT_TITLE_HTML_BREAK_RE`
+   — istniejące regex, żeby `<br>`/`<div>` nie sklejały słów),
+2. `strip_tags`,
+3. `html.unescape`,
+4. `_single_line_text` (kolaps białych znaków),
+5. **bez** fallbacku — puste wejście → `""`.
+Helper zwraca czysty tekst; **nie** woła `sanitize_xlsx_cell` sam — builder
+odpowiedzi XLSX i tak przepuszcza każdy wiersz przez `sanitize_xlsx_row`
+(`mymultiseek.py:357`), więc sanityzacja formuł dzieje się raz, w jednym
+miejscu (unikamy podwójnej warstwy).
+
+## 3. Routing
+
+URL bez zmian:
+`^multiseek/export/(?P<export_format>[\w-]+)/$` → `MyMultiseekExport`.
+
+Wariant wybieramy query-paramem **`wariant`** (`dane` | `opis`,
+domyślnie `dane`). Każdy link w dropdownie to statyczny `href` — pobieranie
+nie wymaga JS-a:
+
+- CSV → `…/multiseek/export/csv/`
+- XLS: dane → `…/multiseek/export/xlsx/`
+- XLS: opis → `…/multiseek/export/xlsx/?wariant=opis`
+
+Walidacja w widoku:
+
+- `export_format ∉ {csv, xlsx}` → `HttpResponseBadRequest` (jak dziś).
+- `wariant ∉ {dane, opis}` → potraktuj jak `dane` (defensywnie, bez 400 —
+  nieznany wariant nie jest błędem klienta wartym twardej odmowy).
+- `wariant == opis` przy `export_format == csv` → **degraduje do `dane`**
+  (opis to format czytelny/raportowy; CSV opisu nie zamawiano — YAGNI).
+
+Parametr `print-removed` współistnieje z `wariant` (oba jako query-params) —
+istniejące `{% if print_removed %}?print-removed=1{% endif %}` w szablonie
+trzeba uogólnić na łączenie dwóch parametrów (patrz §5).
+
+## 4. Refactor: wydzielenie logiki eksportu
+
+`src/bpp/views/mymultiseek.py` ma ~488 linii i dokładamy drugi zestaw
+nagłówków + iterator + formatowanie XLSX. Wydzielamy **całą logikę eksportu**
+do nowego modułu `src/bpp/views/multiseek_export.py`, zostawiając widok
+cienki (routing + walidacja + wybór wariantu).
+
+### Do `multiseek_export.py` przenosimy (i rozszerzamy):
+
+Stałe nagłówków / pól:
+- `MULTISEEK_EXPORT_HEADERS`, `MULTISEEK_EXPORT_XLSX_HEADERS`
+  (rozszerzone o Źródło + Typ MNiSW/MEiN),
+- **nowe**: `MULTISEEK_EXPORT_OPIS_XLSX_HEADERS`,
+- `MULTISEEK_EXPORT_FIELDS` — rozbić na `..._DANE_FIELDS`
+  i `..._OPIS_FIELDS` (różne `.only(...)`; szczegóły + krytyczna kwestia
+  `select_related` niżej). **Uwaga**: obecne `MULTISEEK_EXPORT_FIELDS`
+  (`mymultiseek.py:74-82`) zawiera `opis_bibliograficzny_zapisani_autorzy_cache`
+  (kolumna „Autorzy" wariantu `dane`), a **nie** `opis_bibliograficzny_cache`.
+  Wariant `opis` renderuje `opis_bibliograficzny_cache` — jego lista `only()`
+  **musi jawnie** zawierać `opis_bibliograficzny_cache` (i nie potrzebuje
+  `..._zapisani_autorzy_cache`). Skopiowanie bazowej listy „w ciemno" zostawi
+  `opis_bibliograficzny_cache` jako deferred → N+1 przy 5000 wierszy, dokładnie
+  to, przed czym broni sekcja niżej,
+- helpery: `_export_value`, `_single_line_text`, `_sanitize_spreadsheet_*`,
+  `_pbn_publication_url`, `_admin_change_url`, `_export_filename`,
+  `_xlsx_worksheet_title`, `_plain_multiseek_report_title` i pokrewne
+  (albo import z jednego miejsca — nie duplikować).
+
+Buildery wierszy (dwa, zamiast rozgałęzień w jednym):
+- `iter_export_rows_dane(queryset, request)` — obecny `_iter_export_rows`
+  + dwie nowe kolumny we właściwych pozycjach,
+- `iter_export_rows_opis(queryset, request)` — `enumerate(…, start=1)` dla Lp.,
+  `opis_bibliograficzny_cache` przez strip_tags/unescape.
+
+Buildery odpowiedzi:
+- `csv_export_response(queryset, request, report_title)` — zawsze `dane`,
+- `xlsx_export_response(queryset, request, report_title, wariant)` — wybiera
+  nagłówki + iterator + reguły formatowania wg wariantu.
+
+### Zapytanie — `select_related` obowiązkowe (inaczej N+1 przy 5000 wierszy)
+
+**Krytyczne.** Obecny widok w `MyMultiseekExport.get` (`mymultiseek.py:416`)
+robi `queryset.select_related(None).only(*MULTISEEK_EXPORT_FIELDS)` — to
+**zdejmuje** `select_related` ustawiony wcześniej w `get_queryset`. Jeśli w tym
+stanie sięgniemy po `rekord.zrodlo.nazwa` / `rekord.typ_kbn.nazwa` /
+`rekord.charakter_formalny.nazwa`, każdy wiersz odpali osobne zapytanie — przy
+`MULTISEEK_EXPORT_MAX_ROWS = 5000` to tysiące zapytań na jeden eksport.
+
+Dlatego builder odpowiedzi musi ustawić `select_related` **per wariant** i
+odpowiednie `only(...)` po polach relacji:
+
+- wariant `dane`: `select_related("zrodlo", "typ_kbn")`,
+  `only(..., "zrodlo__nazwa", "zrodlo__poprzednia_nazwa", "typ_kbn__nazwa")`
+  — `zrodlo__poprzednia_nazwa` jest konieczne, bo `Zrodlo.__str__` je czyta;
+  jeśli użyjemy jawnie `zrodlo.nazwa` (rekomendowane, §2) i **nie** wołamy
+  `str(zrodlo)`, wtedy `zrodlo__poprzednia_nazwa` można pominąć.
+- wariant `opis`: `select_related("charakter_formalny", "typ_kbn")`,
+  `only("id", "opis_bibliograficzny_cache", "impact_factor", "punkty_kbn",
+  "charakter_formalny__nazwa", "typ_kbn__nazwa")` — `opis_bibliograficzny_cache`
+  **jawnie** (patrz uwaga wyżej), bez `..._zapisani_autorzy_cache`.
+
+Precedens jest w tym samym pliku: `get_queryset` (`mymultiseek.py:133`) już
+robi dokładnie `select_related("charakter_formalny", "typ_kbn")` dla raportów
+ekranowych — skopiować ten wzorzec. Uwaga: `.only()` musi listować pola relacji
+(`typ_kbn__nazwa`), a nie samo FK (`typ_kbn`), bo samo FK zostawia tylko id.
+
+### Indeksy kolumn — nie hardkodować
+
+`MULTISEEK_EXPORT_XLSX_URL_COLUMNS = (10, 11, 12)` to dziś twarde numery
+kolumn z linkami. Po wstawieniu **dwóch** kolumn (`Źródło`, `Typ MNiSW/MEiN`)
+linki przesuną się o dwie pozycje (lądują na 12/13/14). Zamiast przepisać
+liczby, **wyliczać indeksy z nazw nagłówków**
+(nagłówki linków **zaczynają się** od „Link" — więc `startswith("Link")`,
+NIE `endswith`; albo jawna mapa nazwa→indeks). openpyxl indeksuje kolumny
+**od 1**, a `list.index()` liczy **od 0** — konwersja to `headers.index(name) + 1`.
+Analogicznie reguły `number_format` (IF `0.000`, PK `0.00`) — liczyć indeksy
+IF/PK z nagłówków, bo w wariancie `opis` siedzą pod innymi numerami niż
+w `dane`.
+
+Formatowanie per-wariant:
+- `dane`: kolumny-linki → `=HYPERLINK(...)`, `freeze_panes="B1"`, format
+  liczb dla IF/PK.
+- `opis`: brak kolumn-linków, format liczb dla IF/PK (inne indeksy niż
+  w `dane` — liczone z nagłówków), `freeze_panes = "A2"` (zamraża **tylko
+  wiersz nagłówka**; celowo NIE „C2"/„B2", które zamroziłyby też szeroką
+  kolumnę Opis). Nota: `dane` używa `"B1"`, co zamraża kolumnę A (Tytuł),
+  a nie wiersz — to inna semantyka i celowo różna między wariantami.
+
+Obie ścieżki nadal używają `worksheet_columns_autosize`,
+`worksheet_create_table`, nagłówkowego fill/font — te helpery zostają
+w `bpp/util/xlsx.py` (bez zmian).
+
+## 5. UI — dropdown w `paginator.html`
+
+Plik: `src/django_bpp/templates/multiseek/paginator.html`, blok eksportu
+(dziś linie ~32–45, wspólny dla gałęzi `is_live` i nie-`is_live`).
+
+Zamieniamy dwa `<li>` (CSV, XLS) na **jeden** trigger + `dropdown-pane`:
+
+```
+[⬇ Eksport ▾]
+   ├ ⬇ CSV
+   ├ ⬇ XLS: dane
+   └ ⬇ XLS: opis bibliograficzny
+```
+
+Efekt: widoczny wiersz akcji **skraca się** (dwa elementy → jeden), a wybór
+formatu żyje w popoverze (zero kosztu poziomego).
+
+Zależność techniczna: **Foundation Dropdown JS**. Przed implementacją
+zweryfikować, czy Foundation JS (`Foundation.Dropdown`/`data-dropdown`) jest
+zainicjowany na stronie multiseeka (publiczny frontend). Jeśli tak —
+`dropdown-pane` z `data-toggle`. Jeśli nie — **fallback na natywny
+`<details>/<summary>`** (zero JS, działa wszędzie), ostylowany pod istniejący
+`menu`. Wybór fallbacku nie zmienia niczego w backendzie (linki i tak
+statyczne).
+
+Query-params: linki muszą składać `wariant` + ewentualne `print-removed`.
+Uogólnić dzisiejsze `{% if print_removed %}?print-removed=1{% endif %}` na
+budowę query-stringa z obu parametrów (np. mały pattern łączenia albo
+`?wariant=opis{% if print_removed %}&print-removed=1{% endif %}`).
+
+Widoczność bloku bez zmian: `request.user.is_authenticated and
+paginator_count > 0 and paginator_count <= multiseek_export_max_rows`.
+
+## 6. Testy
+
+Rozszerzyć `src/bpp/tests/test_views/test_mymultiseek.py`:
+
+1. **`dane` — nowe kolumny**: XLSX zawiera nagłówki `Źródło` i `Typ MNiSW/MEiN`,
+   CSV zawiera nagłówki ASCII `zrodlo` i `typ_mnisw_mein` (różne tokeny —
+   patrz tabela §2), obie na właściwych pozycjach (czysta insercja, `BPP ID`
+   nadal przed `Typ rekordu`). Dla rekordu z przypisanym źródłem/typem wartości
+   wypełnione, dla rekordu bez — puste (`""`).
+2. **`opis` — układ**: `?wariant=opis` na `xlsx` daje dokładnie 6 kolumn
+   w kolejności [Lp., Opis bibliograficzny, IF, PK, Charakter, Typ MNiSW/MEiN];
+   opis w jednej komórce; numeracja Lp. rośnie 1..N; HTML w opisie
+   wyczyszczony do tekstu.
+3. **Degradacja CSV**: `?wariant=opis` na `csv` zwraca układ `dane`
+   (opis nie przecieka do CSV).
+4. **Nieznany wariant**: `?wariant=cokolwiek` → układ `dane`, status 200.
+5. **Regresja indeksów linków**: kolumny-linki w `dane` faktycznie zawierają
+   `=HYPERLINK(...)` po przesunięciu przez `Źródło` (łapie pomyłkę
+   hardkodowanych numerów).
+6. **`print-removed` + `wariant`**: oba parametry współistnieją (eksport
+   trybu „usunięte ręcznie" z wariantem).
+7. **Query-count (regresja N+1)**: `django_assert_num_queries` (lub
+   `CaptureQueriesContext`) nad zestawem wielu wierszy o **różnych** źródłach,
+   typach i charakterach — liczba zapytań ograniczona i **nie rośnie z liczbą
+   wierszy**. To jedyny strażnik przed cichym powrotem N+1 z §4 (bez niego
+   regresja `.only()`/`select_related` przejdzie na zielono). Osobny test dla
+   `dane` (zrodlo/typ_kbn) i dla `opis` (charakter_formalny/typ_kbn).
+
+**Uwaga o istniejących testach XLSX**: `test_mymultiseek.py` (obecnie ~254-276)
+hardkoduje układ wiersza danych — `worksheet["D2"].number_format == "0.000"`
+(IF), `["E2"] == "0.00"` (PK) i pozycje komórek `=HYPERLINK`. Wstawienie
+`Źródło` na kolumnę 3 **przesuwa** IF→E, PK→F i linki o dwie pozycje, więc
+te asercje **trzeba przepisać** (nie „zachować"). Bez zmian zostają jedynie
+asercje sanityzacji formuł (`=`, `+`, `-`, `@`) i limitu
+`MULTISEEK_EXPORT_MAX_ROWS`, które nie zależą od pozycji kolumn.
+
+## 7. Newsfragment
+
+`src/bpp/newsfragments/fd373.feature.rst` — krótka nota: eksport wyników
+multiseeka do XLSX zyskał kolumny Źródło i Typ MNiSW/MEiN oraz drugi wariant
+z opisem bibliograficznym w jednej kolumnie.
+
+## 8. Kolejność implementacji
+
+Sekwencja tak dobrana, by każdy krok był osobno weryfikowalny, a diff
+czytelny:
+
+1. **Weryfikacja Foundation Dropdown JS** — sprawdzić (grep/przeglądarka),
+   czy `data-dropdown`/`Foundation.Dropdown` działa na stronie multiseeka.
+   Wynik determinuje wybór dropdown-pane vs natywny `<details>` w §5. To
+   pierwszy, samodzielny krok — nie otwarte pytanie w trakcie kodowania.
+2. **Refactor bez zmiany zachowania** — przeniesienie logiki eksportu do
+   `src/bpp/views/multiseek_export.py` jako **osobny commit, zielone
+   istniejące testy**, zero zmian w kolumnach/wariantach. Dzięki temu review
+   oddziela „szum przenoszenia" od logiki.
+3. **Wariant `dane` + dwie kolumny** (z `select_related`!) — CSV i XLSX.
+4. **Wariant `opis`** — XLSX, helper `_plain_opis_bibliograficzny`, routing
+   `?wariant=`.
+5. **UI dropdown** w `paginator.html`.
+6. **Testy + newsfragment.**
+
+## 9. Poza zakresem (YAGNI)
+
+- Brak wariantu `opis` dla CSV.
+- Brak scalonego „mega-arkusza".
+- Brak konfigurowalnego wyboru kolumn przez użytkownika.
+- Brak zmian w limicie `MULTISEEK_EXPORT_MAX_ROWS` ani w migracjach
+  (wszystkie pola już istnieją na `Rekord`).

--- a/src/bpp/newsfragments/fd373.feature.rst
+++ b/src/bpp/newsfragments/fd373.feature.rst
@@ -1,0 +1,4 @@
+Eksport wyników wyszukiwania (multiseek) do XLSX zyskał kolumny „Źródło" oraz
+„Typ MNiSW/MEiN", a także drugi wariant, w którym cały opis bibliograficzny
+jest w jednej kolumnie (obok IF, PK, Charakter, Typ MNiSW/MEiN). Wybór wariantu
+odbywa się z rozwijanego przycisku „Eksport" nad listą wyników (FD#373).

--- a/src/bpp/tests/test_views/test_mymultiseek.py
+++ b/src/bpp/tests/test_views/test_mymultiseek.py
@@ -16,6 +16,10 @@ from multiseek.views import MULTISEEK_SESSION_KEY, MULTISEEK_SESSION_KEY_REMOVED
 from bpp.models import Wydawnictwo_Ciagle
 from bpp.models.cache import Rekord
 from bpp.tests.util import any_ciagle
+from bpp.views.multiseek_export import (
+    MULTISEEK_EXPORT_OPIS_XLSX_HEADERS,
+    _plain_opis_bibliograficzny,
+)
 from bpp.views.mymultiseek import (
     MULTISEEK_DEFAULT_REPORT_TITLE,
     MULTISEEK_EXPORT_HEADERS,
@@ -471,6 +475,139 @@ def test_export_dane_xlsx_nie_ma_n_plus_1(
     with django_assert_max_num_queries(18):
         response = logged_in_client.get(
             reverse("multiseek-export", kwargs={"export_format": "xlsx"})
+        )
+
+    assert response.status_code == 200
+
+    from openpyxl import load_workbook
+
+    load_workbook(io.BytesIO(response.content))
+
+
+def test_plain_opis_bibliograficzny_czysci_html():
+    value = "Tytuł <i>Źródła</i> 2026<br>s. 1-2"
+
+    opis = _plain_opis_bibliograficzny(value)
+
+    assert "<" not in opis and ">" not in opis
+    assert "Źródła" in opis
+    assert "  " not in opis  # spacje skolapsowane, <br> nie sklejone
+
+
+def test_plain_opis_bibliograficzny_puste_wejscie_bez_fallbacku():
+    assert _plain_opis_bibliograficzny("") == ""
+    assert _plain_opis_bibliograficzny(None) == ""
+
+
+@pytest.mark.django_db
+def test_multiseek_export_opis_xlsx_uklad(logged_in_client, multiseek_export_rekord):
+    from openpyxl import load_workbook
+
+    _set_multiseek_title_filter(logged_in_client)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "xlsx"}) + "?wariant=opis"
+    )
+
+    assert response.status_code == 200
+    wb = load_workbook(io.BytesIO(response.content))
+    ws = wb.active
+    headers = [c.value for c in ws[1]]
+    assert headers == list(MULTISEEK_EXPORT_OPIS_XLSX_HEADERS)
+    assert ws["A2"].value == 1  # numeracja Lp.
+    assert ws.freeze_panes == "A2"
+
+
+@pytest.mark.django_db
+def test_multiseek_export_opis_xlsx_wiersz(logged_in_client, multiseek_export_rekord):
+    from openpyxl import load_workbook
+
+    _set_multiseek_title_filter(logged_in_client)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "xlsx"}) + "?wariant=opis"
+    )
+
+    assert response.status_code == 200
+    ws = load_workbook(io.BytesIO(response.content)).active
+    rows = list(ws.iter_rows(values_only=True))
+    assert rows[1] == (
+        1,
+        _plain_opis_bibliograficzny(multiseek_export_rekord.opis_bibliograficzny_cache),
+        1.23,
+        42,
+        multiseek_export_rekord.charakter_formalny.nazwa,
+        multiseek_export_rekord.typ_kbn.nazwa,
+    )
+
+
+@pytest.mark.django_db
+def test_multiseek_export_opis_csv_degraduje_do_dane(
+    logged_in_client, multiseek_export_rekord
+):
+    _set_multiseek_title_filter(logged_in_client)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "csv"}) + "?wariant=opis"
+    )
+
+    assert response.status_code == 200
+    header = response.content.decode("utf-8").splitlines()[0]
+    assert header.split(",")[0] == "tytul_oryginalny"  # układ dane, nie opis
+
+
+@pytest.mark.django_db
+def test_multiseek_export_nieznany_wariant_to_dane(
+    logged_in_client, multiseek_export_rekord
+):
+    from openpyxl import load_workbook
+
+    _set_multiseek_title_filter(logged_in_client)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "xlsx"})
+        + "?wariant=cokolwiek"
+    )
+
+    assert response.status_code == 200
+    ws = load_workbook(io.BytesIO(response.content)).active
+    assert ws[1][0].value == "Tytuł oryginalny"  # układ dane
+
+
+@pytest.mark.django_db
+def test_multiseek_export_opis_print_removed_wspolistnieja(
+    logged_in_client, multiseek_export_pair
+):
+    visible, removed = multiseek_export_pair
+    _set_multiseek_title_filter(logged_in_client)
+    session = logged_in_client.session
+    session[MULTISEEK_SESSION_KEY_REMOVED] = [removed.pk]
+    session.save()
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "xlsx"})
+        + "?wariant=opis&print-removed=1"
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_multiseek_export_opis_xlsx_nie_ma_n_plus_1(
+    logged_in_client, standard_data, denorms, django_assert_max_num_queries
+):
+    # Analogicznie do test_export_dane_xlsx_nie_ma_n_plus_1 — próg stały
+    # względem liczby wierszy. Zmierzone lokalnie: 15 zapytań niezależnie
+    # od liczby rekordów (3 vs 8) — próg 18 z marginesem.
+    for _ in range(3):
+        any_ciagle(tytul_oryginalny=f"{EXPORT_TITLE_PREFIX} - opis n plus 1")
+    denorms.flush()
+    _set_multiseek_title_filter(logged_in_client)
+
+    with django_assert_max_num_queries(18):
+        response = logged_in_client.get(
+            reverse("multiseek-export", kwargs={"export_format": "xlsx"})
+            + "?wariant=opis"
         )
 
     assert response.status_code == 200

--- a/src/bpp/tests/test_views/test_mymultiseek.py
+++ b/src/bpp/tests/test_views/test_mymultiseek.py
@@ -7,6 +7,8 @@ from decimal import Decimal
 
 import pytest
 from django.conf import settings
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import translation
 from model_bakery import baker
@@ -15,7 +17,7 @@ from multiseek.views import MULTISEEK_SESSION_KEY, MULTISEEK_SESSION_KEY_REMOVED
 
 from bpp.models import Wydawnictwo_Ciagle
 from bpp.models.cache import Rekord
-from bpp.tests.util import any_ciagle
+from bpp.tests.util import any_ciagle, any_zwarte
 from bpp.views.multiseek_export import (
     MULTISEEK_EXPORT_OPIS_XLSX_HEADERS,
     _plain_opis_bibliograficzny,
@@ -435,6 +437,28 @@ def test_export_dane_csv_ma_zrodlo_i_typ_mnisw(
 
 
 @pytest.mark.django_db
+def test_export_dane_csv_ksiazka_bez_zrodla_ma_puste_pole(
+    logged_in_client, standard_data, denorms
+):
+    """Wydawnictwo_Zwarte (książka/monografia) nie ma pola ``zrodlo`` — w
+    cache Rekord to ``zrodlo=None``. Każda książka w produkcji trafia w tę
+    gałąź _iter_export_rows (``zrodlo.nazwa if zrodlo is not None else
+    ""``); żaden dotychczasowy test jej nie ćwiczył."""
+    any_zwarte(tytul_oryginalny=f"{EXPORT_TITLE_PREFIX} - książka")
+    denorms.flush()
+    _set_multiseek_title_filter(logged_in_client)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "csv"})
+    )
+
+    assert response.status_code == 200
+    rows = list(csv.DictReader(io.StringIO(response.content.decode("utf-8"))))
+    assert len(rows) == 1
+    assert rows[0]["zrodlo"] == ""
+
+
+@pytest.mark.django_db
 def test_export_dane_xlsx_ma_zrodlo_i_typ_mnisw(
     logged_in_client, multiseek_export_rekord
 ):
@@ -460,28 +484,61 @@ def test_export_dane_xlsx_ma_zrodlo_i_typ_mnisw(
     assert rows[1][8] == multiseek_export_rekord.typ_kbn.nazwa
 
 
-@pytest.mark.django_db
-def test_export_dane_xlsx_nie_ma_n_plus_1(
-    logged_in_client, standard_data, denorms, django_assert_max_num_queries
-):
-    # Kilka rekordów o różnych źródłach i typach — gdyby był N+1,
-    # liczba zapytań rosłaby z liczbą wierszy. Zmierzone lokalnie: 15
-    # zapytań niezależnie od liczby rekordów (3 vs 8) — próg z marginesem.
-    for _ in range(3):
-        any_ciagle(tytul_oryginalny=f"{EXPORT_TITLE_PREFIX} - n plus 1")
-    denorms.flush()
-    _set_multiseek_title_filter(logged_in_client)
+def _make_n_plus_1_rows(prefix, count):
+    """``count`` rekordów, każdy z WŁASNYM zrodlo/typ_kbn/charakter_formalny.
 
-    with django_assert_max_num_queries(18):
-        response = logged_in_client.get(
-            reverse("multiseek-export", kwargs={"export_format": "xlsx"})
-        )
+    ``any_ciagle()`` bez jawnych kwargs tworzy te FK-i od zera przy każdym
+    wywołaniu (model_bakery nie współdzieli/nie cache'uje instancji FK
+    między wywołaniami) — dzięki temu ewentualny N+1 na dostępie do tych
+    pól faktycznie odpali osobne zapytanie na wiersz, zamiast schować się
+    za pamięcią podręczną kluczoną po (współdzielonej) wartości FK.
+    """
+    for i in range(count):
+        any_ciagle(tytul_oryginalny=f"{prefix} - {i}")
 
+
+def _query_count_for_export(client, url):
+    # Rozgrzewka: pierwsze zapytanie w sesji odpala dodatkowy, jednorazowy
+    # SELECT z niepowiązanego middleware'u password_policies (sprawdzenie
+    # historii haseł raz na sesję) — bez tego call'a porównanie N1 vs N2
+    # byłoby fałszywie różne o 1 zapytanie, mimo braku N+1 w eksporcie.
+    client.get(url)
+    with CaptureQueriesContext(connection) as ctx:
+        response = client.get(url)
     assert response.status_code == 200
+    return response, len(ctx.captured_queries)
 
+
+@pytest.mark.django_db
+def test_export_dane_xlsx_nie_ma_n_plus_1(logged_in_client, standard_data, denorms):
+    """Liczba zapytań SQL dla eksportu 'dane' jest STAŁA względem liczby
+    wierszy — to jest definicja braku N+1. Samo sprawdzenie górnego progu
+    (max_num_queries) przepuściłoby częściowy N+1 (np. +1 zapytanie na
+    wiersz przy dużym marginesie); porównanie N1 vs N2 tego nie przepuści.
+    """
     from openpyxl import load_workbook
 
+    prefix = f"{EXPORT_TITLE_PREFIX} - n plus 1"
+    url = reverse("multiseek-export", kwargs={"export_format": "xlsx"})
+
+    _make_n_plus_1_rows(prefix, 2)
+    denorms.flush()
+    _set_multiseek_title_filter(logged_in_client, title_prefix=prefix)
+
+    response, n1_queries = _query_count_for_export(logged_in_client, url)
     load_workbook(io.BytesIO(response.content))
+
+    _make_n_plus_1_rows(prefix, 4)  # razem 6 rekordów
+    denorms.flush()
+
+    response, n2_queries = _query_count_for_export(logged_in_client, url)
+    load_workbook(io.BytesIO(response.content))
+
+    assert n2_queries == n1_queries, (
+        "Liczba zapytań SQL rośnie wraz z liczbą wierszy "
+        f"({n1_queries} dla 2 wierszy → {n2_queries} dla 6 wierszy) — N+1."
+    )
+    assert n1_queries <= 18  # sensowny górny limit, z marginesem
 
 
 def test_plain_opis_bibliograficzny_czysci_html():
@@ -492,6 +549,23 @@ def test_plain_opis_bibliograficzny_czysci_html():
     assert "<" not in opis and ">" not in opis
     assert "Źródła" in opis
     assert "  " not in opis  # spacje skolapsowane, <br> nie sklejone
+    # <br> (tag blokowy) MUSI zostać zamieniony na spację, a nie po prostu
+    # zniknąć — inaczej "2026" i "s." skleją się w "2026s." (usunięcie kroku
+    # MULTISEEK_REPORT_TITLE_HTML_BREAK_RE.sub(" ", ...) nie zostałoby
+    # wykryte przez samo "  " not in opis, bo sklejenie nie tworzy podwójnej
+    # spacji).
+    assert "2026 s. 1-2" in opis
+
+
+def test_plain_opis_bibliograficzny_dekoduje_encje_html():
+    value = "Kowalski J. &amp; Nowak T. &oacute;wczesny"
+
+    opis = _plain_opis_bibliograficzny(value)
+
+    assert "&amp;" not in opis
+    assert "&" in opis
+    assert "&oacute;" not in opis
+    assert "ó" in opis
 
 
 def test_plain_opis_bibliograficzny_puste_wejscie_bez_fallbacku():
@@ -594,24 +668,32 @@ def test_multiseek_export_opis_print_removed_wspolistnieja(
 
 @pytest.mark.django_db
 def test_multiseek_export_opis_xlsx_nie_ma_n_plus_1(
-    logged_in_client, standard_data, denorms, django_assert_max_num_queries
+    logged_in_client, standard_data, denorms
 ):
-    # Analogicznie do test_export_dane_xlsx_nie_ma_n_plus_1 — próg stały
-    # względem liczby wierszy. Zmierzone lokalnie: 15 zapytań niezależnie
-    # od liczby rekordów (3 vs 8) — próg 18 z marginesem.
-    for _ in range(3):
-        any_ciagle(tytul_oryginalny=f"{EXPORT_TITLE_PREFIX} - opis n plus 1")
-    denorms.flush()
-    _set_multiseek_title_filter(logged_in_client)
-
-    with django_assert_max_num_queries(18):
-        response = logged_in_client.get(
-            reverse("multiseek-export", kwargs={"export_format": "xlsx"})
-            + "?wariant=opis"
-        )
-
-    assert response.status_code == 200
-
+    """Analogicznie do test_export_dane_xlsx_nie_ma_n_plus_1 — liczba zapytań
+    SQL musi być stała względem liczby wierszy (nie tylko poniżej progu)."""
     from openpyxl import load_workbook
 
+    prefix = f"{EXPORT_TITLE_PREFIX} - opis n plus 1"
+    url = (
+        reverse("multiseek-export", kwargs={"export_format": "xlsx"}) + "?wariant=opis"
+    )
+
+    _make_n_plus_1_rows(prefix, 2)
+    denorms.flush()
+    _set_multiseek_title_filter(logged_in_client, title_prefix=prefix)
+
+    response, n1_queries = _query_count_for_export(logged_in_client, url)
     load_workbook(io.BytesIO(response.content))
+
+    _make_n_plus_1_rows(prefix, 4)  # razem 6 rekordów
+    denorms.flush()
+
+    response, n2_queries = _query_count_for_export(logged_in_client, url)
+    load_workbook(io.BytesIO(response.content))
+
+    assert n2_queries == n1_queries, (
+        "Liczba zapytań SQL rośnie wraz z liczbą wierszy "
+        f"({n1_queries} dla 2 wierszy → {n2_queries} dla 6 wierszy) — N+1."
+    )
+    assert n1_queries <= 18  # sensowny górny limit, z marginesem

--- a/src/bpp/tests/test_views/test_mymultiseek.py
+++ b/src/bpp/tests/test_views/test_mymultiseek.py
@@ -162,11 +162,13 @@ def test_multiseek_export_csv(logged_in_client, multiseek_export_rekord):
     assert rows[1] == [
         multiseek_export_rekord.tytul_oryginalny,
         "Kowalski Jan",
+        multiseek_export_rekord.zrodlo.nazwa,
         "2024",
         "1.230",
         "42.00",
         str(tuple(multiseek_export_rekord.pk)),
         "wydawnictwo ciągłe",
+        multiseek_export_rekord.typ_kbn.nazwa,
         str(multiseek_export_rekord.object_id),
         "507f1f77bcf86cd799439011",
         f"http://testserver{multiseek_export_rekord.get_absolute_url()}",
@@ -254,11 +256,13 @@ def test_multiseek_export_xlsx(logged_in_client, multiseek_export_rekord):
     assert rows[1] == (
         multiseek_export_rekord.tytul_oryginalny,
         "Kowalski Jan",
+        multiseek_export_rekord.zrodlo.nazwa,
         2024,
         1.23,
         42,
         str(tuple(multiseek_export_rekord.pk)),
         "wydawnictwo ciągłe",
+        multiseek_export_rekord.typ_kbn.nazwa,
         multiseek_export_rekord.object_id,
         "507f1f77bcf86cd799439011",
         '=HYPERLINK("'
@@ -270,10 +274,13 @@ def test_multiseek_export_xlsx(logged_in_client, multiseek_export_rekord):
         '507f1f77bcf86cd799439011/current", "[link]")',
     )
     assert worksheet.freeze_panes == "B1"
-    assert worksheet["D2"].data_type == "n"
     assert worksheet["E2"].data_type == "n"
-    assert worksheet["D2"].number_format == "0.000"
-    assert worksheet["E2"].number_format == "0.00"
+    assert worksheet["F2"].data_type == "n"
+    assert worksheet["E2"].number_format == "0.000"  # Impact Factor (było D)
+    assert worksheet["F2"].number_format == "0.00"  # PK (było E)
+    # kolumny linków (L, M, N) zawierają =HYPERLINK
+    for col in ("L", "M", "N"):
+        assert worksheet[f"{col}2"].value.startswith("=HYPERLINK(")
 
 
 @pytest.mark.django_db
@@ -397,3 +404,77 @@ def test_multiseek_export_does_not_match_unfiltered_records(
 
     rows = list(csv.DictReader(io.StringIO(response.content.decode("utf-8"))))
     assert [row["bpp_id"] for row in rows] == [str(tuple(multiseek_export_rekord.pk))]
+
+
+@pytest.mark.django_db
+def test_export_dane_csv_ma_zrodlo_i_typ_mnisw(
+    logged_in_client, multiseek_export_rekord
+):
+    _set_multiseek_title_filter(logged_in_client)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "csv"})
+    )
+
+    assert response.status_code == 200
+    text = response.content.decode("utf-8")
+    header = text.splitlines()[0]
+    cols = header.split(",")
+    assert cols[2] == "zrodlo"
+    assert cols[8] == "typ_mnisw_mein"
+    assert cols[6] == "bpp_id"  # BPP ID nadal przed typ_rekordu (kol. 8)
+    assert cols[7] == "typ_rekordu"
+
+    rows = list(csv.DictReader(io.StringIO(text)))
+    assert rows[0]["zrodlo"] == multiseek_export_rekord.zrodlo.nazwa
+    assert rows[0]["typ_mnisw_mein"] == multiseek_export_rekord.typ_kbn.nazwa
+
+
+@pytest.mark.django_db
+def test_export_dane_xlsx_ma_zrodlo_i_typ_mnisw(
+    logged_in_client, multiseek_export_rekord
+):
+    from openpyxl import load_workbook
+
+    _set_multiseek_title_filter(logged_in_client)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "xlsx"})
+    )
+
+    assert response.status_code == 200
+    wb = load_workbook(io.BytesIO(response.content))
+    ws = wb.active
+    headers = [c.value for c in ws[1]]
+    assert headers[2] == "Źródło"
+    assert headers[8] == "Typ MNiSW/MEiN"
+    assert headers[6] == "BPP ID"
+    assert headers[7] == "Typ rekordu"
+
+    rows = list(ws.iter_rows(values_only=True))
+    assert rows[1][2] == multiseek_export_rekord.zrodlo.nazwa
+    assert rows[1][8] == multiseek_export_rekord.typ_kbn.nazwa
+
+
+@pytest.mark.django_db
+def test_export_dane_xlsx_nie_ma_n_plus_1(
+    logged_in_client, standard_data, denorms, django_assert_max_num_queries
+):
+    # Kilka rekordów o różnych źródłach i typach — gdyby był N+1,
+    # liczba zapytań rosłaby z liczbą wierszy. Zmierzone lokalnie: 15
+    # zapytań niezależnie od liczby rekordów (3 vs 8) — próg z marginesem.
+    for _ in range(3):
+        any_ciagle(tytul_oryginalny=f"{EXPORT_TITLE_PREFIX} - n plus 1")
+    denorms.flush()
+    _set_multiseek_title_filter(logged_in_client)
+
+    with django_assert_max_num_queries(18):
+        response = logged_in_client.get(
+            reverse("multiseek-export", kwargs={"export_format": "xlsx"})
+        )
+
+    assert response.status_code == 200
+
+    from openpyxl import load_workbook
+
+    load_workbook(io.BytesIO(response.content))

--- a/src/bpp/views/multiseek_export.py
+++ b/src/bpp/views/multiseek_export.py
@@ -1,0 +1,228 @@
+"""Serializacja wyników Multiseek do plików eksportu (CSV / XLSX).
+
+Wydzielone z bpp/views/mymultiseek.py — widok trzyma routing i stan sesji,
+ten moduł zamienia queryset Rekordów na gotową odpowiedź HTTP z plikiem.
+"""
+
+import csv
+import html
+import io
+import re
+
+from django.http import HttpResponse
+from django.urls import reverse
+from django.utils.html import strip_tags
+from django.utils.http import content_disposition_header
+
+from bpp import const
+from bpp.models import Uczelnia
+
+MULTISEEK_DEFAULT_REPORT_TITLE = "Rezultat wyszukiwania"
+XLSX_WORKSHEET_TITLE_MAX_LENGTH = 31
+
+MULTISEEK_EXPORT_HEADERS = (
+    "tytul_oryginalny",
+    "autorzy",
+    "rok",
+    "impact_factor",
+    "pk",
+    "bpp_id",
+    "typ_rekordu",
+    "id_rekordu",
+    "pbn_uid_id",
+    "link_do_bpp_url",
+    "link_do_bpp_admin_url",
+    "link_do_pbn_url",
+)
+
+MULTISEEK_EXPORT_XLSX_HEADERS = (
+    "Tytuł oryginalny",
+    "Autorzy",
+    "Rok",
+    "Impact Factor",
+    "PK",
+    "BPP ID",
+    "Typ rekordu",
+    "ID rekordu",
+    "PBN UID",
+    "Link do BPP",
+    "Link do edycji w BPP",
+    "Link do PBN",
+)
+
+MULTISEEK_EXPORT_DANE_FIELDS = (
+    "id",
+    "tytul_oryginalny",
+    "opis_bibliograficzny_zapisani_autorzy_cache",
+    "rok",
+    "impact_factor",
+    "punkty_kbn",
+    "pbn_uid_id",
+)
+
+MULTISEEK_EXPORT_XLSX_URL_COLUMNS = (10, 11, 12)
+EXPORT_FILENAME_INVALID_CHARS_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+MULTISEEK_REPORT_TITLE_HTML_BREAK_RE = re.compile(
+    r"</?(?:br|hr|p|div|h[1-6])\b[^>]*>",
+    re.IGNORECASE,
+)
+XLSX_WORKSHEET_TITLE_INVALID_CHARS_RE = re.compile(
+    r"[\[\]:*?/\\\x00-\x08\x0b\x0c\x0e-\x1f]"
+)
+SPREADSHEET_FORMULA_INJECTION_LEAD = ("=", "+", "-", "@", "\t", "\r", "\n")
+
+
+def _export_value(value):
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _single_line_text(value):
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def plain_multiseek_report_title(value):
+    value = _export_value(value)
+    value = MULTISEEK_REPORT_TITLE_HTML_BREAK_RE.sub(" ", value)
+    value = html.unescape(strip_tags(value))
+    return _single_line_text(value) or MULTISEEK_DEFAULT_REPORT_TITLE
+
+
+def _export_filename(export_format, report_title):
+    title = EXPORT_FILENAME_INVALID_CHARS_RE.sub(" ", report_title)
+    title = _single_line_text(title).strip(". ")
+    if not title:
+        title = "multiseek"
+    return f"eksport-{title}.{export_format}"
+
+
+def _xlsx_worksheet_title(report_title):
+    title = XLSX_WORKSHEET_TITLE_INVALID_CHARS_RE.sub(" ", report_title)
+    title = _single_line_text(title).strip("'")
+    if not title:
+        title = "Multiseek"
+    return title[:XLSX_WORKSHEET_TITLE_MAX_LENGTH]
+
+
+def _sanitize_spreadsheet_cell(value):
+    if isinstance(value, str) and value.startswith(SPREADSHEET_FORMULA_INJECTION_LEAD):
+        return "'" + value
+    return value
+
+
+def _sanitize_spreadsheet_row(row):
+    return tuple(_sanitize_spreadsheet_cell(value) for value in row)
+
+
+def _pbn_publication_url(pbn_uid_id, pbn_api_root):
+    if not pbn_uid_id or not pbn_api_root:
+        return ""
+    return const.LINK_PBN_DO_PUBLIKACJI.format(
+        pbn_api_root=pbn_api_root,
+        pbn_uid_id=pbn_uid_id,
+    )
+
+
+def _admin_change_url(rekord, request):
+    content_type = rekord.content_type
+    url = reverse(
+        f"admin:{content_type.app_label}_{content_type.model}_change",
+        args=(rekord.object_id,),
+    )
+    return request.build_absolute_uri(url)
+
+
+def _iter_export_rows(queryset, request):
+    uczelnia = Uczelnia.objects.get_for_request(request)
+    pbn_api_root = uczelnia.pbn_api_root if uczelnia is not None else ""
+
+    for rekord in queryset.iterator(chunk_size=1000):
+        yield (
+            rekord.tytul_oryginalny,
+            rekord.opis_bibliograficzny_zapisani_autorzy_cache,
+            rekord.rok,
+            rekord.impact_factor,
+            rekord.punkty_kbn,
+            str(tuple(rekord.pk)),
+            str(rekord.describe_content_type),
+            rekord.object_id,
+            _export_value(rekord.pbn_uid_id),
+            request.build_absolute_uri(rekord.get_absolute_url()),
+            _admin_change_url(rekord, request),
+            _pbn_publication_url(rekord.pbn_uid_id, pbn_api_root),
+        )
+
+
+def csv_export_response(queryset, request, report_title):
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(MULTISEEK_EXPORT_HEADERS)
+    writer.writerows(
+        _sanitize_spreadsheet_row(row) for row in _iter_export_rows(queryset, request)
+    )
+
+    response = HttpResponse(output.getvalue(), content_type="text/csv; charset=utf-8")
+    response["Content-Disposition"] = content_disposition_header(
+        as_attachment=True,
+        filename=_export_filename("csv", report_title),
+    )
+    return response
+
+
+def xlsx_export_response(queryset, request, report_title):
+    from openpyxl import Workbook
+    from openpyxl.styles import Alignment, Font, PatternFill
+
+    from bpp.util import (
+        sanitize_xlsx_row,
+        worksheet_columns_autosize,
+        worksheet_create_table,
+    )
+
+    workbook = Workbook()
+    worksheet = workbook.active
+    worksheet.title = _xlsx_worksheet_title(report_title)
+    worksheet.append(MULTISEEK_EXPORT_XLSX_HEADERS)
+    for row in _iter_export_rows(queryset, request):
+        worksheet.append(sanitize_xlsx_row(row))
+
+    header_fill = PatternFill("solid", fgColor="1F4E78")
+    header_font = Font(color="FFFFFF", bold=True)
+    for cell in worksheet[1]:
+        cell.fill = header_fill
+        cell.font = header_font
+        cell.alignment = Alignment(horizontal="center", vertical="center")
+
+    for row in worksheet.iter_rows(min_row=2):
+        for cell in row:
+            cell.alignment = Alignment(vertical="top", wrap_text=True)
+
+    for row in worksheet.iter_rows(min_row=2, min_col=4, max_col=5):
+        row[0].number_format = "0.000"
+        row[1].number_format = "0.00"
+
+    for row_idx in range(2, worksheet.max_row + 1):
+        for col_idx in MULTISEEK_EXPORT_XLSX_URL_COLUMNS:
+            cell = worksheet.cell(row=row_idx, column=col_idx)
+            if cell.value:
+                cell.value = f'=HYPERLINK("{cell.value}", "[link]")'
+
+    worksheet.freeze_panes = "B1"
+    worksheet_columns_autosize(worksheet)
+    if worksheet.max_row > 1:
+        worksheet_create_table(worksheet, title="MultiseekExport")
+
+    output = io.BytesIO()
+    workbook.save(output)
+    response = HttpResponse(
+        output.getvalue(),
+        content_type=(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        ),
+    )
+    response["Content-Disposition"] = content_disposition_header(
+        as_attachment=True,
+        filename=_export_filename("xlsx", report_title),
+    )
+    return response

--- a/src/bpp/views/multiseek_export.py
+++ b/src/bpp/views/multiseek_export.py
@@ -66,6 +66,24 @@ MULTISEEK_EXPORT_DANE_FIELDS = (
     "pbn_uid_id",
 )
 
+MULTISEEK_EXPORT_OPIS_XLSX_HEADERS = (
+    "Lp.",
+    "Opis bibliograficzny",
+    "IF",
+    "PK",
+    "Charakter",
+    "Typ MNiSW/MEiN",
+)
+
+MULTISEEK_EXPORT_OPIS_FIELDS = (
+    "id",
+    "opis_bibliograficzny_cache",
+    "impact_factor",
+    "punkty_kbn",
+    "charakter_formalny__nazwa",
+    "typ_kbn__nazwa",
+)
+
 EXPORT_FILENAME_INVALID_CHARS_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 MULTISEEK_REPORT_TITLE_HTML_BREAK_RE = re.compile(
     r"</?(?:br|hr|p|div|h[1-6])\b[^>]*>",
@@ -92,6 +110,20 @@ def plain_multiseek_report_title(value):
     value = MULTISEEK_REPORT_TITLE_HTML_BREAK_RE.sub(" ", value)
     value = html.unescape(strip_tags(value))
     return _single_line_text(value) or MULTISEEK_DEFAULT_REPORT_TITLE
+
+
+def _plain_opis_bibliograficzny(value):
+    """opis_bibliograficzny_cache (HTML) -> jednoliniowy czysty tekst.
+
+    Bez fallbacku na tytuł domyślny (w przeciwieństwie do
+    plain_multiseek_report_title): puste wejście -> "". Sanityzacja formuł
+    dzieje się później, w sanitize_xlsx_row — tu jej NIE wołamy.
+    """
+    if not value:
+        return ""
+    value = MULTISEEK_REPORT_TITLE_HTML_BREAK_RE.sub(" ", value)
+    value = html.unescape(strip_tags(value))
+    return _single_line_text(value)
 
 
 def _export_filename(export_format, report_title):
@@ -163,6 +195,20 @@ def _iter_export_rows(queryset, request):
         )
 
 
+def _iter_export_rows_opis(queryset, request):
+    for lp, rekord in enumerate(queryset.iterator(chunk_size=1000), start=1):
+        charakter = rekord.charakter_formalny
+        typ_kbn = rekord.typ_kbn
+        yield (
+            lp,
+            _plain_opis_bibliograficzny(rekord.opis_bibliograficzny_cache),
+            rekord.impact_factor,
+            rekord.punkty_kbn,
+            charakter.nazwa if charakter is not None else "",
+            typ_kbn.nazwa if typ_kbn is not None else "",
+        )
+
+
 def _xlsx_columns_where(headers, predicate):
     """1-based indeksy kolumn XLSX, których nagłówek spełnia predykat."""
     return [i for i, h in enumerate(headers, start=1) if predicate(h)]
@@ -198,7 +244,7 @@ def csv_export_response(queryset, request, report_title):
     return response
 
 
-def xlsx_export_response(queryset, request, report_title):
+def xlsx_export_response(queryset, request, report_title, wariant="dane"):
     from openpyxl import Workbook
     from openpyxl.styles import Alignment, Font, PatternFill
 
@@ -208,11 +254,20 @@ def xlsx_export_response(queryset, request, report_title):
         worksheet_create_table,
     )
 
+    if wariant == "opis":
+        headers = MULTISEEK_EXPORT_OPIS_XLSX_HEADERS
+        rows = _iter_export_rows_opis(queryset, request)
+        freeze = "A2"
+    else:
+        headers = MULTISEEK_EXPORT_XLSX_HEADERS
+        rows = _iter_export_rows(queryset, request)
+        freeze = "B1"
+
     workbook = Workbook()
     worksheet = workbook.active
     worksheet.title = _xlsx_worksheet_title(report_title)
-    worksheet.append(MULTISEEK_EXPORT_XLSX_HEADERS)
-    for row in _iter_export_rows(queryset, request):
+    worksheet.append(headers)
+    for row in rows:
         worksheet.append(sanitize_xlsx_row(row))
 
     header_fill = PatternFill("solid", fgColor="1F4E78")
@@ -222,9 +277,8 @@ def xlsx_export_response(queryset, request, report_title):
         cell.font = header_font
         cell.alignment = Alignment(horizontal="center", vertical="center")
 
-    headers = MULTISEEK_EXPORT_XLSX_HEADERS
     url_cols = _xlsx_columns_where(headers, lambda h: h.startswith("Link"))
-    if_cols = _xlsx_columns_where(headers, lambda h: h == "Impact Factor")
+    if_cols = _xlsx_columns_where(headers, lambda h: h in ("Impact Factor", "IF"))
     pk_cols = _xlsx_columns_where(headers, lambda h: h == "PK")
 
     for row in worksheet.iter_rows(min_row=2):
@@ -235,7 +289,7 @@ def xlsx_export_response(queryset, request, report_title):
     _apply_xlsx_number_format(worksheet, pk_cols, "0.00")
     _apply_xlsx_hyperlinks(worksheet, url_cols)
 
-    worksheet.freeze_panes = "B1"
+    worksheet.freeze_panes = freeze
     worksheet_columns_autosize(worksheet)
     if worksheet.max_row > 1:
         worksheet_create_table(worksheet, title="MultiseekExport")

--- a/src/bpp/views/multiseek_export.py
+++ b/src/bpp/views/multiseek_export.py
@@ -23,11 +23,13 @@ XLSX_WORKSHEET_TITLE_MAX_LENGTH = 31
 MULTISEEK_EXPORT_HEADERS = (
     "tytul_oryginalny",
     "autorzy",
+    "zrodlo",
     "rok",
     "impact_factor",
     "pk",
     "bpp_id",
     "typ_rekordu",
+    "typ_mnisw_mein",
     "id_rekordu",
     "pbn_uid_id",
     "link_do_bpp_url",
@@ -38,11 +40,13 @@ MULTISEEK_EXPORT_HEADERS = (
 MULTISEEK_EXPORT_XLSX_HEADERS = (
     "Tytuł oryginalny",
     "Autorzy",
+    "Źródło",
     "Rok",
     "Impact Factor",
     "PK",
     "BPP ID",
     "Typ rekordu",
+    "Typ MNiSW/MEiN",
     "ID rekordu",
     "PBN UID",
     "Link do BPP",
@@ -54,13 +58,14 @@ MULTISEEK_EXPORT_DANE_FIELDS = (
     "id",
     "tytul_oryginalny",
     "opis_bibliograficzny_zapisani_autorzy_cache",
+    "zrodlo__nazwa",
     "rok",
     "impact_factor",
     "punkty_kbn",
+    "typ_kbn__nazwa",
     "pbn_uid_id",
 )
 
-MULTISEEK_EXPORT_XLSX_URL_COLUMNS = (10, 11, 12)
 EXPORT_FILENAME_INVALID_CHARS_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 MULTISEEK_REPORT_TITLE_HTML_BREAK_RE = re.compile(
     r"</?(?:br|hr|p|div|h[1-6])\b[^>]*>",
@@ -138,20 +143,43 @@ def _iter_export_rows(queryset, request):
     pbn_api_root = uczelnia.pbn_api_root if uczelnia is not None else ""
 
     for rekord in queryset.iterator(chunk_size=1000):
+        zrodlo = rekord.zrodlo
+        typ_kbn = rekord.typ_kbn
         yield (
             rekord.tytul_oryginalny,
             rekord.opis_bibliograficzny_zapisani_autorzy_cache,
+            zrodlo.nazwa if zrodlo is not None else "",
             rekord.rok,
             rekord.impact_factor,
             rekord.punkty_kbn,
             str(tuple(rekord.pk)),
             str(rekord.describe_content_type),
+            typ_kbn.nazwa if typ_kbn is not None else "",
             rekord.object_id,
             _export_value(rekord.pbn_uid_id),
             request.build_absolute_uri(rekord.get_absolute_url()),
             _admin_change_url(rekord, request),
             _pbn_publication_url(rekord.pbn_uid_id, pbn_api_root),
         )
+
+
+def _xlsx_columns_where(headers, predicate):
+    """1-based indeksy kolumn XLSX, których nagłówek spełnia predykat."""
+    return [i for i, h in enumerate(headers, start=1) if predicate(h)]
+
+
+def _apply_xlsx_number_format(worksheet, columns, number_format):
+    for col in columns:
+        for row in worksheet.iter_rows(min_row=2, min_col=col, max_col=col):
+            row[0].number_format = number_format
+
+
+def _apply_xlsx_hyperlinks(worksheet, url_cols):
+    for row_idx in range(2, worksheet.max_row + 1):
+        for col_idx in url_cols:
+            cell = worksheet.cell(row=row_idx, column=col_idx)
+            if cell.value:
+                cell.value = f'=HYPERLINK("{cell.value}", "[link]")'
 
 
 def csv_export_response(queryset, request, report_title):
@@ -194,19 +222,18 @@ def xlsx_export_response(queryset, request, report_title):
         cell.font = header_font
         cell.alignment = Alignment(horizontal="center", vertical="center")
 
+    headers = MULTISEEK_EXPORT_XLSX_HEADERS
+    url_cols = _xlsx_columns_where(headers, lambda h: h.startswith("Link"))
+    if_cols = _xlsx_columns_where(headers, lambda h: h == "Impact Factor")
+    pk_cols = _xlsx_columns_where(headers, lambda h: h == "PK")
+
     for row in worksheet.iter_rows(min_row=2):
         for cell in row:
             cell.alignment = Alignment(vertical="top", wrap_text=True)
 
-    for row in worksheet.iter_rows(min_row=2, min_col=4, max_col=5):
-        row[0].number_format = "0.000"
-        row[1].number_format = "0.00"
-
-    for row_idx in range(2, worksheet.max_row + 1):
-        for col_idx in MULTISEEK_EXPORT_XLSX_URL_COLUMNS:
-            cell = worksheet.cell(row=row_idx, column=col_idx)
-            if cell.value:
-                cell.value = f'=HYPERLINK("{cell.value}", "[link]")'
+    _apply_xlsx_number_format(worksheet, if_cols, "0.000")
+    _apply_xlsx_number_format(worksheet, pk_cols, "0.00")
+    _apply_xlsx_hyperlinks(worksheet, url_cols)
 
     worksheet.freeze_panes = "B1"
     worksheet_columns_autosize(worksheet)

--- a/src/bpp/views/mymultiseek.py
+++ b/src/bpp/views/mymultiseek.py
@@ -1,18 +1,11 @@
-import csv
 import hashlib
-import html
-import io
 import json
 import logging
-import re
 
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.db.models import Count, Sum
-from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
-from django.urls import reverse
-from django.utils.html import strip_tags
-from django.utils.http import content_disposition_header
+from django.http import HttpResponseBadRequest, JsonResponse
 from django.views.decorators.cache import never_cache
 from django.views.generic import View
 from multiseek.logic import get_registry
@@ -22,10 +15,19 @@ from multiseek.views import (
     manually_add_or_remove,
 )
 
-from bpp import const
 from bpp.models import Uczelnia
 from bpp.multiseek_registry import registry as multiseek_registry
 from bpp.multiseek_registry.djangoql_export import multiseek_form_to_djangoql
+from bpp.views.multiseek_export import (
+    MULTISEEK_DEFAULT_REPORT_TITLE,
+    MULTISEEK_EXPORT_DANE_FIELDS,
+    MULTISEEK_EXPORT_HEADERS,  # noqa: F401 - re-eksport, uzywane w testach
+    MULTISEEK_EXPORT_XLSX_HEADERS,  # noqa: F401 - re-eksport, uzywane w testach
+    XLSX_WORKSHEET_TITLE_MAX_LENGTH,  # noqa: F401 - re-eksport, uzywane w testach
+    csv_export_response,
+    plain_multiseek_report_title,
+    xlsx_export_response,
+)
 from bpp.views.zapytanie import WprowadzanieDanychOrSuperuserMixin
 
 logger = logging.getLogger(__name__)
@@ -38,59 +40,6 @@ MULTISEEK_EXPORT_MAX_ROWS = 5000
 # TTL cache agregatów wyników (count + sumy) — patrz get_context_data.
 MULTISEEK_AGGREGATE_CACHE_TIMEOUT = 30 * 60
 MULTISEEK_REPORT_TITLE_SESSION_KEY = "MULTISEEK_TITLE"
-MULTISEEK_DEFAULT_REPORT_TITLE = "Rezultat wyszukiwania"
-XLSX_WORKSHEET_TITLE_MAX_LENGTH = 31
-
-MULTISEEK_EXPORT_HEADERS = (
-    "tytul_oryginalny",
-    "autorzy",
-    "rok",
-    "impact_factor",
-    "pk",
-    "bpp_id",
-    "typ_rekordu",
-    "id_rekordu",
-    "pbn_uid_id",
-    "link_do_bpp_url",
-    "link_do_bpp_admin_url",
-    "link_do_pbn_url",
-)
-
-MULTISEEK_EXPORT_XLSX_HEADERS = (
-    "Tytuł oryginalny",
-    "Autorzy",
-    "Rok",
-    "Impact Factor",
-    "PK",
-    "BPP ID",
-    "Typ rekordu",
-    "ID rekordu",
-    "PBN UID",
-    "Link do BPP",
-    "Link do edycji w BPP",
-    "Link do PBN",
-)
-
-MULTISEEK_EXPORT_FIELDS = (
-    "id",
-    "tytul_oryginalny",
-    "opis_bibliograficzny_zapisani_autorzy_cache",
-    "rok",
-    "impact_factor",
-    "punkty_kbn",
-    "pbn_uid_id",
-)
-
-MULTISEEK_EXPORT_XLSX_URL_COLUMNS = (10, 11, 12)
-EXPORT_FILENAME_INVALID_CHARS_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
-MULTISEEK_REPORT_TITLE_HTML_BREAK_RE = re.compile(
-    r"</?(?:br|hr|p|div|h[1-6])\b[^>]*>",
-    re.IGNORECASE,
-)
-XLSX_WORKSHEET_TITLE_INVALID_CHARS_RE = re.compile(
-    r"[\[\]:*?/\\\x00-\x08\x0b\x0c\x0e-\x1f]"
-)
-SPREADSHEET_FORMULA_INJECTION_LEAD = ("=", "+", "-", "@", "\t", "\r", "\n")
 
 EXTRA_TYPES = [
     PKT_WEWN,
@@ -232,169 +181,13 @@ class MyMultiseekResults(MultiseekResults):
         return ctx
 
 
-def _export_value(value):
-    if value is None:
-        return ""
-    return str(value)
-
-
-def _single_line_text(value):
-    return re.sub(r"\s+", " ", value).strip()
-
-
-def _plain_multiseek_report_title(value):
-    value = _export_value(value)
-    value = MULTISEEK_REPORT_TITLE_HTML_BREAK_RE.sub(" ", value)
-    value = html.unescape(strip_tags(value))
-    return _single_line_text(value) or MULTISEEK_DEFAULT_REPORT_TITLE
-
-
 def _multiseek_report_title(request):
-    return _plain_multiseek_report_title(
+    return plain_multiseek_report_title(
         request.session.get(
             MULTISEEK_REPORT_TITLE_SESSION_KEY,
             MULTISEEK_DEFAULT_REPORT_TITLE,
         )
     )
-
-
-def _export_filename(export_format, report_title):
-    title = EXPORT_FILENAME_INVALID_CHARS_RE.sub(" ", report_title)
-    title = _single_line_text(title).strip(". ")
-    if not title:
-        title = "multiseek"
-    return f"eksport-{title}.{export_format}"
-
-
-def _xlsx_worksheet_title(report_title):
-    title = XLSX_WORKSHEET_TITLE_INVALID_CHARS_RE.sub(" ", report_title)
-    title = _single_line_text(title).strip("'")
-    if not title:
-        title = "Multiseek"
-    return title[:XLSX_WORKSHEET_TITLE_MAX_LENGTH]
-
-
-def _sanitize_spreadsheet_cell(value):
-    if isinstance(value, str) and value.startswith(SPREADSHEET_FORMULA_INJECTION_LEAD):
-        return "'" + value
-    return value
-
-
-def _sanitize_spreadsheet_row(row):
-    return tuple(_sanitize_spreadsheet_cell(value) for value in row)
-
-
-def _pbn_publication_url(pbn_uid_id, pbn_api_root):
-    if not pbn_uid_id or not pbn_api_root:
-        return ""
-    return const.LINK_PBN_DO_PUBLIKACJI.format(
-        pbn_api_root=pbn_api_root,
-        pbn_uid_id=pbn_uid_id,
-    )
-
-
-def _admin_change_url(rekord, request):
-    content_type = rekord.content_type
-    url = reverse(
-        f"admin:{content_type.app_label}_{content_type.model}_change",
-        args=(rekord.object_id,),
-    )
-    return request.build_absolute_uri(url)
-
-
-def _iter_export_rows(queryset, request):
-    uczelnia = Uczelnia.objects.get_for_request(request)
-    pbn_api_root = uczelnia.pbn_api_root if uczelnia is not None else ""
-
-    for rekord in queryset.iterator(chunk_size=1000):
-        yield (
-            rekord.tytul_oryginalny,
-            rekord.opis_bibliograficzny_zapisani_autorzy_cache,
-            rekord.rok,
-            rekord.impact_factor,
-            rekord.punkty_kbn,
-            str(tuple(rekord.pk)),
-            str(rekord.describe_content_type),
-            rekord.object_id,
-            _export_value(rekord.pbn_uid_id),
-            request.build_absolute_uri(rekord.get_absolute_url()),
-            _admin_change_url(rekord, request),
-            _pbn_publication_url(rekord.pbn_uid_id, pbn_api_root),
-        )
-
-
-def _csv_export_response(queryset, request, report_title):
-    output = io.StringIO()
-    writer = csv.writer(output)
-    writer.writerow(MULTISEEK_EXPORT_HEADERS)
-    writer.writerows(
-        _sanitize_spreadsheet_row(row) for row in _iter_export_rows(queryset, request)
-    )
-
-    response = HttpResponse(output.getvalue(), content_type="text/csv; charset=utf-8")
-    response["Content-Disposition"] = content_disposition_header(
-        as_attachment=True,
-        filename=_export_filename("csv", report_title),
-    )
-    return response
-
-
-def _xlsx_export_response(queryset, request, report_title):
-    from openpyxl import Workbook
-    from openpyxl.styles import Alignment, Font, PatternFill
-
-    from bpp.util import (
-        sanitize_xlsx_row,
-        worksheet_columns_autosize,
-        worksheet_create_table,
-    )
-
-    workbook = Workbook()
-    worksheet = workbook.active
-    worksheet.title = _xlsx_worksheet_title(report_title)
-    worksheet.append(MULTISEEK_EXPORT_XLSX_HEADERS)
-    for row in _iter_export_rows(queryset, request):
-        worksheet.append(sanitize_xlsx_row(row))
-
-    header_fill = PatternFill("solid", fgColor="1F4E78")
-    header_font = Font(color="FFFFFF", bold=True)
-    for cell in worksheet[1]:
-        cell.fill = header_fill
-        cell.font = header_font
-        cell.alignment = Alignment(horizontal="center", vertical="center")
-
-    for row in worksheet.iter_rows(min_row=2):
-        for cell in row:
-            cell.alignment = Alignment(vertical="top", wrap_text=True)
-
-    for row in worksheet.iter_rows(min_row=2, min_col=4, max_col=5):
-        row[0].number_format = "0.000"
-        row[1].number_format = "0.00"
-
-    for row_idx in range(2, worksheet.max_row + 1):
-        for col_idx in MULTISEEK_EXPORT_XLSX_URL_COLUMNS:
-            cell = worksheet.cell(row=row_idx, column=col_idx)
-            if cell.value:
-                cell.value = f'=HYPERLINK("{cell.value}", "[link]")'
-
-    worksheet.freeze_panes = "B1"
-    worksheet_columns_autosize(worksheet)
-    if worksheet.max_row > 1:
-        worksheet_create_table(worksheet, title="MultiseekExport")
-
-    output = io.BytesIO()
-    workbook.save(output)
-    response = HttpResponse(
-        output.getvalue(),
-        content_type=(
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        ),
-    )
-    response["Content-Disposition"] = content_disposition_header(
-        as_attachment=True,
-        filename=_export_filename("xlsx", report_title),
-    )
-    return response
 
 
 class MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults):
@@ -413,10 +206,10 @@ class MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults):
             )
 
         report_title = _multiseek_report_title(request)
-        queryset = queryset.select_related(None).only(*MULTISEEK_EXPORT_FIELDS)
+        queryset = queryset.select_related(None).only(*MULTISEEK_EXPORT_DANE_FIELDS)
         if export_format == "csv":
-            return _csv_export_response(queryset, request, report_title)
-        return _xlsx_export_response(queryset, request, report_title)
+            return csv_export_response(queryset, request, report_title)
+        return xlsx_export_response(queryset, request, report_title)
 
 
 def _normalize_session_removed(request):

--- a/src/bpp/views/mymultiseek.py
+++ b/src/bpp/views/mymultiseek.py
@@ -206,7 +206,11 @@ class MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults):
             )
 
         report_title = _multiseek_report_title(request)
-        queryset = queryset.select_related(None).only(*MULTISEEK_EXPORT_DANE_FIELDS)
+        queryset = (
+            queryset.select_related(None)
+            .select_related("zrodlo", "typ_kbn")
+            .only(*MULTISEEK_EXPORT_DANE_FIELDS)
+        )
         if export_format == "csv":
             return csv_export_response(queryset, request, report_title)
         return xlsx_export_response(queryset, request, report_title)

--- a/src/bpp/views/mymultiseek.py
+++ b/src/bpp/views/mymultiseek.py
@@ -22,6 +22,7 @@ from bpp.views.multiseek_export import (
     MULTISEEK_DEFAULT_REPORT_TITLE,
     MULTISEEK_EXPORT_DANE_FIELDS,
     MULTISEEK_EXPORT_HEADERS,  # noqa: F401 - re-eksport, uzywane w testach
+    MULTISEEK_EXPORT_OPIS_FIELDS,
     MULTISEEK_EXPORT_XLSX_HEADERS,  # noqa: F401 - re-eksport, uzywane w testach
     XLSX_WORKSHEET_TITLE_MAX_LENGTH,  # noqa: F401 - re-eksport, uzywane w testach
     csv_export_response,
@@ -197,6 +198,13 @@ class MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults):
         if export_format not in {"csv", "xlsx"}:
             return HttpResponseBadRequest("Nieznany format eksportu.")
 
+        wariant = request.GET.get("wariant", "dane")
+        if wariant not in {"dane", "opis"}:
+            wariant = "dane"
+        # opis to format czytelny (raportowy) — CSV opisu nie robimy
+        if export_format == "csv":
+            wariant = "dane"
+
         queryset = self.get_queryset_for_current_mode()
         count = queryset.count()
         if count > MULTISEEK_EXPORT_MAX_ROWS:
@@ -206,6 +214,14 @@ class MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults):
             )
 
         report_title = _multiseek_report_title(request)
+        if wariant == "opis":
+            queryset = (
+                queryset.select_related(None)
+                .select_related("charakter_formalny", "typ_kbn")
+                .only(*MULTISEEK_EXPORT_OPIS_FIELDS)
+            )
+            return xlsx_export_response(queryset, request, report_title, "opis")
+
         queryset = (
             queryset.select_related(None)
             .select_related("zrodlo", "typ_kbn")
@@ -213,7 +229,7 @@ class MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults):
         )
         if export_format == "csv":
             return csv_export_response(queryset, request, report_title)
-        return xlsx_export_response(queryset, request, report_title)
+        return xlsx_export_response(queryset, request, report_title, "dane")
 
 
 def _normalize_session_removed(request):

--- a/src/django_bpp/templates/multiseek/paginator.html
+++ b/src/django_bpp/templates/multiseek/paginator.html
@@ -30,40 +30,47 @@
             {% endif %}
         {% endif %}
         {% if request.user.is_authenticated and paginator_count > 0 and paginator_count <= multiseek_export_max_rows %}
-            {% url "multiseek-export" "csv" as multiseek_export_csv_url %}
-            {% url "multiseek-export" "xlsx" as multiseek_export_xlsx_url %}
             {# paginator.html is included twice per page (top + bottom, see #}
             {# common-results.html) — 'magellan' is only set ("no") on the #}
             {# bottom include, so it doubles as a reliable top/bottom flag. #}
             {# Used here to keep the dropdown-pane id/data-toggle unique #}
             {# when both instances render on the same page. #}
             <li>
-                <a data-toggle="multiseek-export-menu{% if magellan %}-bottom{% endif %}">
-                    <i class="fi-download"></i> Eksport <span aria-hidden="true">▾</span>
-                </a>
+                <button type="button" class="button dropdown"
+                        data-toggle="multiseek-export-menu{% if magellan %}-bottom{% endif %}"
+                        aria-haspopup="menu">
+                    <i class="fi-download"></i> Eksport
+                </button>
             </li>
-            <div class="dropdown-pane" id="multiseek-export-menu{% if magellan %}-bottom{% endif %}"
-                 data-dropdown data-auto-focus="true">
-                <ul class="menu vertical" style="margin-bottom:0;">
-                    <li>
-                        <a href="{{ multiseek_export_csv_url }}{% if print_removed %}?print-removed=1{% endif %}">
-                            <i class="fi-download"></i> CSV
-                        </a>
-                    </li>
-                    <li>
-                        <a href="{{ multiseek_export_xlsx_url }}{% if print_removed %}?print-removed=1{% endif %}">
-                            <i class="fi-download"></i> XLS: dane
-                        </a>
-                    </li>
-                    <li>
-                        <a href="{{ multiseek_export_xlsx_url }}?wariant=opis{% if print_removed %}&print-removed=1{% endif %}">
-                            <i class="fi-download"></i> XLS: opis bibliograficzny
-                        </a>
-                    </li>
-                </ul>
-            </div>
         {% endif %}
     </ul>
+    {% if request.user.is_authenticated and paginator_count > 0 and paginator_count <= multiseek_export_max_rows %}
+        {% url "multiseek-export" "csv" as multiseek_export_csv_url %}
+        {% url "multiseek-export" "xlsx" as multiseek_export_xlsx_url %}
+        {# <ul class="menu"> może zawierać wyłącznie <li> — dropdown-pane #}
+        {# jest tu świadomie poza <ul> (siostra), zgodnie ze wzorcem z #}
+        {# multiseek/index.html (przycisk .dropdown wyzwala pane po id). #}
+        <div class="dropdown-pane" id="multiseek-export-menu{% if magellan %}-bottom{% endif %}"
+             data-dropdown data-auto-focus="true">
+            <ul class="menu vertical" style="margin-bottom:0;">
+                <li>
+                    <a href="{{ multiseek_export_csv_url }}{% if print_removed %}?print-removed=1{% endif %}">
+                        <i class="fi-download"></i> CSV
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ multiseek_export_xlsx_url }}{% if print_removed %}?print-removed=1{% endif %}">
+                        <i class="fi-download"></i> XLS: dane
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ multiseek_export_xlsx_url }}?wariant=opis{% if print_removed %}&print-removed=1{% endif %}">
+                        <i class="fi-download"></i> XLS: opis bibliograficzny
+                    </a>
+                </li>
+            </ul>
+        </div>
+    {% endif %}
     {% if paginator.num_pages > 1 %}
     <div class="multiseek-pagination-pager">
         {% paginate %}

--- a/src/django_bpp/templates/multiseek/paginator.html
+++ b/src/django_bpp/templates/multiseek/paginator.html
@@ -32,16 +32,36 @@
         {% if request.user.is_authenticated and paginator_count > 0 and paginator_count <= multiseek_export_max_rows %}
             {% url "multiseek-export" "csv" as multiseek_export_csv_url %}
             {% url "multiseek-export" "xlsx" as multiseek_export_xlsx_url %}
+            {# paginator.html is included twice per page (top + bottom, see #}
+            {# common-results.html) — 'magellan' is only set ("no") on the #}
+            {# bottom include, so it doubles as a reliable top/bottom flag. #}
+            {# Used here to keep the dropdown-pane id/data-toggle unique #}
+            {# when both instances render on the same page. #}
             <li>
-                <a href="{{ multiseek_export_csv_url }}{% if print_removed %}?print-removed=1{% endif %}">
-                    <i class="fi-download"></i> CSV
+                <a data-toggle="multiseek-export-menu{% if magellan %}-bottom{% endif %}">
+                    <i class="fi-download"></i> Eksport <span aria-hidden="true">▾</span>
                 </a>
             </li>
-            <li>
-                <a href="{{ multiseek_export_xlsx_url }}{% if print_removed %}?print-removed=1{% endif %}">
-                    <i class="fi-download"></i> XLS
-                </a>
-            </li>
+            <div class="dropdown-pane" id="multiseek-export-menu{% if magellan %}-bottom{% endif %}"
+                 data-dropdown data-auto-focus="true">
+                <ul class="menu vertical" style="margin-bottom:0;">
+                    <li>
+                        <a href="{{ multiseek_export_csv_url }}{% if print_removed %}?print-removed=1{% endif %}">
+                            <i class="fi-download"></i> CSV
+                        </a>
+                    </li>
+                    <li>
+                        <a href="{{ multiseek_export_xlsx_url }}{% if print_removed %}?print-removed=1{% endif %}">
+                            <i class="fi-download"></i> XLS: dane
+                        </a>
+                    </li>
+                    <li>
+                        <a href="{{ multiseek_export_xlsx_url }}?wariant=opis{% if print_removed %}&print-removed=1{% endif %}">
+                            <i class="fi-download"></i> XLS: opis bibliograficzny
+                        </a>
+                    </li>
+                </ul>
+            </div>
         {% endif %}
     </ul>
     {% if paginator.num_pages > 1 %}


### PR DESCRIPTION
## Kontekst

Freshdesk **#373** (Ewa Matczuk) — rozbudowa eksportu wyników wyszukiwania
(multiseek) do Excela:

1. **Wzbogacenie** istniejącego eksportu kolumnowego o kolumny `Źródło`
   i `Typ MNiSW/MEiN`.
2. **Drugi wariant** — cały opis bibliograficzny w jednej kolumnie, obok
   `IF`, `PK`, `Charakter`, `Typ MNiSW/MEiN` (odpowiednik raportu „lista").

## Co jest w tym PR

Pełna implementacja + dokumenty projektowe (spec + plan).

| Plik | Zmiana |
|------|--------|
| `src/bpp/views/multiseek_export.py` | **nowy** — cała logika serializacji eksportu (stałe, helpery, dwa iteratory wierszy, buildery odpowiedzi) |
| `src/bpp/views/mymultiseek.py` | routing `?wariant=`, per-wariant `select_related`/`only`; odchudzony po wydzieleniu |
| `src/django_bpp/templates/multiseek/paginator.html` | dropdown „Eksport ▾" (CSV / XLS: dane / XLS: opis) |
| `src/bpp/tests/test_views/test_mymultiseek.py` | testy nowych kolumn, wariantu opis, degradacji CSV, N+1, sanityzacji, książek |
| `src/bpp/newsfragments/fd373.feature.rst` | nota wydaniowa |

## Warianty

- **`dane`** (kolumnowy, wzbogacony) — CSV i XLSX. Czysta insercja: `Źródło`
  po `Autorzy`, `Typ MNiSW/MEiN` po `Typ rekordu` (bez reorderu `BPP ID`).
- **`opis`** (nowy, XLSX-only) — `Lp. | Opis bibliograficzny | IF | PK |
  Charakter | Typ MNiSW/MEiN`. Wybór `?wariant=opis`; CSV degraduje do `dane`.

UI: dwa linki (CSV, XLS) zastąpione jednym Foundation-dropdownem „Eksport ▾"
— wiersz akcji krótszy.

## Jakość

- **Spec: dwa niezależne self-review sub-agentami** (Fable + drugi) —
  naprawiony blocker N+1 (`.select_related(None).only(...)` zdejmował prefetch
  przed pętlą ≤5000 wierszy), czysta insercja kolumn, helper opisu bez
  fallbacku, indeksy kolumn z nagłówków zamiast hardkodowanych.
- **Implementacja: subagent-driven (TDD), review po każdym tasku + finalny
  whole-branch review (opus)** → `READY-WITH-NITS`, zero defektów correctness/
  security. Wszystkie niti (test-robustness + walidacja HTML) naprawione
  w jednej fali.
- **N+1 pilnowany testem**: query-count **niezmienny** względem liczby wierszy
  (2 vs 6) dla obu wariantów — zweryfikowane revert-testem (usunięcie
  `select_related` → test failuje).
- Sanityzacja formuł (`=`,`+`,`-`,`@`) na wszystkich komórkach obu wariantów;
  eksport za `LoginRequiredMixin`.
- `test_mymultiseek.py`: **28 passed**; `ruff` + `manage.py check` czyste.

## Poza zakresem (YAGNI)

Brak wariantu `opis` dla CSV, brak scalonego arkusza, brak konfigurowalnego
wyboru kolumn, brak migracji (wszystkie pola już na `Rekord`).

## Dokumenty

- `docs/superpowers/specs/2026-07-08-multiseek-xlsx-warianty-eksportu-design.md`
- `docs/superpowers/plans/2026-07-09-multiseek-xlsx-warianty-eksportu.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)