### PR TITLE
fix(import_punktacji_zrodel): rozróżniaj źródła o tym samym tytule po ISSN

### DIFF
--- a/src/bpp/newsfragments/import-punktacji-zrodel-issn-disambiguacja.bugfix.rst
+++ b/src/bpp/newsfragments/import-punktacji-zrodel-issn-disambiguacja.bugfix.rst
@@ -1,0 +1,4 @@
+Import punktacji źródeł: gdy w bazie są dwa źródła o tym samym tytule,
+dopasowanie rozstrzyga teraz po ISSN/e-ISSN zamiast rezygnować z wiersza.
+Numer ISSN z pliku jest przy tym porównywany krzyżowo z oboma polami
+źródła (issn oraz e_issn), bo JCR bywa niespójny w kolumnach ISSN/eISSN.

--- a/src/import_common/core/zrodlo.py
+++ b/src/import_common/core/zrodlo.py
@@ -52,25 +52,53 @@ def _try_match_zrodlo_by_mnisw_id(mnisw_id: int | str | None) -> Zrodlo | None:
     return None
 
 
+def _disambiguate_by_issn(qs, issn: str | None, e_issn: str | None) -> Zrodlo | None:
+    """Zawęża niejednoznaczny zbiór źródeł po ISSN/e-ISSN (cross-field).
+
+    JCR bywa niespójny w kolumnach ISSN/eISSN, więc numer z dowolnego pola
+    pliku dopasowujemy do dowolnego pola źródła (issn ORAZ e_issn). Zwraca
+    źródło tylko wtedy, gdy filtr zawęzi zbiór do dokładnie jednego — przy
+    zerze lub nadal wielu kandydatach zwraca None (nie zgadujemy).
+    """
+    numery = [n for n in (issn, e_issn) if n]
+    if not numery:
+        return None
+    kandydaci = list(qs.filter(Q(issn__in=numery) | Q(e_issn__in=numery))[:2])
+    if len(kandydaci) == 1:
+        return kandydaci[0]
+    return None
+
+
 def _try_match_zrodlo_by_title_single(
-    elem: str, disable_skrot: bool, disable_fuzzy: bool
+    elem: str,
+    disable_skrot: bool,
+    disable_fuzzy: bool,
+    issn: str | None = None,
+    e_issn: str | None = None,
 ) -> Zrodlo | None:
-    """Próbuje dopasować pojedynczy tytuł źródła."""
+    """Próbuje dopasować pojedynczy tytuł źródła.
+
+    Gdy tytuł pasuje do wielu źródeł, próbuje je rozróżnić po ISSN/e-ISSN
+    zamiast od razu rezygnować — bez tego dwa źródła o tym samym tytule
+    nigdy nie zostałyby dopasowane, mimo że ISSN jednoznacznie wskazuje jedno.
+    """
     elem = normalize_tytul_zrodla(elem)
+    filtr = Q(nazwa__iexact=elem)
+    if not disable_skrot:
+        filtr |= Q(skrot__iexact=elem)
     try:
-        if disable_skrot:
-            return Zrodlo.objects.get(nazwa__iexact=elem)
-        return Zrodlo.objects.get(Q(nazwa__iexact=elem) | Q(skrot__iexact=elem))
+        return Zrodlo.objects.get(filtr)
     except Zrodlo.MultipleObjectsReturned:
-        pass
+        return _disambiguate_by_issn(Zrodlo.objects.filter(filtr), issn, e_issn)
     except Zrodlo.DoesNotExist:
         if not disable_fuzzy and elem.endswith("."):
+            fuzzy = Q(nazwa__istartswith=elem[:-1]) | Q(skrot__istartswith=elem[:-1])
             try:
-                return Zrodlo.objects.get(
-                    Q(nazwa__istartswith=elem[:-1]) | Q(skrot__istartswith=elem[:-1])
-                )
-            except (Zrodlo.DoesNotExist, Zrodlo.MultipleObjectsReturned):
+                return Zrodlo.objects.get(fuzzy)
+            except Zrodlo.DoesNotExist:
                 pass
+            except Zrodlo.MultipleObjectsReturned:
+                return _disambiguate_by_issn(Zrodlo.objects.filter(fuzzy), issn, e_issn)
 
     return None
 
@@ -101,7 +129,7 @@ def matchuj_zrodlo(
             if elem is None:
                 continue
             result = _try_match_zrodlo_by_title_single(
-                elem, disable_skrot, disable_fuzzy
+                elem, disable_skrot, disable_fuzzy, issn=issn, e_issn=e_issn
             )
             if result:
                 return result

--- a/src/import_common/tests/test_core.py
+++ b/src/import_common/tests/test_core.py
@@ -645,3 +645,65 @@ def test_matchuj_publikacje_kandidat_bez_isbn_matchuje():
         isbn="978-83-7430-668-3",
     )
     assert result == pub
+
+
+@pytest.mark.django_db
+def test_matchuj_zrodlo_dwa_tytuly_disambiguacja_po_issn():
+    """Dwa źródła o tym samym tytule → ISSN z pliku rozstrzyga (pole issn)."""
+    a = baker.make(Zrodlo, nazwa="Duplikat Czasopismo", issn="1111-1111")
+    baker.make(Zrodlo, nazwa="Duplikat Czasopismo", issn="2222-2222")
+
+    result = matchuj_zrodlo("Duplikat Czasopismo", issn="1111-1111")
+    assert result == a
+
+
+@pytest.mark.django_db
+def test_matchuj_zrodlo_dwa_tytuly_disambiguacja_issn_pliku_w_polu_eissn():
+    """Cross-field: ISSN z pliku JCR trafia do pola e_issn źródła w BPP.
+
+    JCR miesza kolumny ISSN/eISSN, więc numer podany w pliku jako ISSN
+    bywa w BPP zapisany jako e-ISSN. Przy dwóch źródłach o tym samym
+    tytule dopasowanie musi to uwzględnić.
+    """
+    a = baker.make(Zrodlo, nazwa="Duplikat Czasopismo", issn="", e_issn="2222-2222")
+    baker.make(Zrodlo, nazwa="Duplikat Czasopismo", issn="", e_issn="3333-3333")
+
+    result = matchuj_zrodlo("Duplikat Czasopismo", issn="2222-2222")
+    assert result == a
+
+
+@pytest.mark.django_db
+def test_matchuj_zrodlo_dwa_tytuly_disambiguacja_eissn_pliku_w_polu_issn():
+    """Cross-field w drugą stronę: e-ISSN z pliku trafia do pola issn."""
+    a = baker.make(Zrodlo, nazwa="Duplikat Czasopismo", issn="4444-4444")
+    baker.make(Zrodlo, nazwa="Duplikat Czasopismo", issn="5555-5555")
+
+    result = matchuj_zrodlo("Duplikat Czasopismo", e_issn="4444-4444")
+    assert result == a
+
+
+@pytest.mark.django_db
+def test_matchuj_zrodlo_dwa_tytuly_bez_pasujacego_issn_zwraca_none():
+    """Dwa źródła o tym samym tytule + ISSN nie pasujący do żadnego → None.
+
+    Bez jednoznacznego rozstrzygnięcia nie wolno zgadywać — brak fałszywego
+    dopasowania jest tu zachowaniem poprawnym.
+    """
+    baker.make(Zrodlo, nazwa="Duplikat Czasopismo", issn="1111-1111")
+    baker.make(Zrodlo, nazwa="Duplikat Czasopismo", issn="2222-2222")
+
+    result = matchuj_zrodlo("Duplikat Czasopismo", issn="9999-9999")
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_matchuj_zrodlo_dwa_tytuly_issn_niejednoznaczny_zwraca_none():
+    """ISSN z pliku pasuje do OBU źródeł o tym samym tytule → None.
+
+    Filtr po ISSN nie zawęża do jednego, więc nadal nie ma podstaw do wyboru.
+    """
+    baker.make(Zrodlo, nazwa="Duplikat Czasopismo", issn="1111-1111")
+    baker.make(Zrodlo, nazwa="Duplikat Czasopismo", issn="1111-1111")
+
+    result = matchuj_zrodlo("Duplikat Czasopismo", issn="1111-1111")
+    assert result is None

--- a/src/import_punktacji_zrodel/tests/test_repro_fd388.py
+++ b/src/import_punktacji_zrodel/tests/test_repro_fd388.py
@@ -38,3 +38,37 @@ def test_repro_fd388_pelny_przebieg(admin_user, jcr_xlsx_path):
     assert pz_blood.impact_factor == Decimal("23.900")
     # są też niedopasowane (większość pliku nie ma odpowiednika)
     assert imp.get_details_set().filter(zrodlo__isnull=True).exists()
+
+
+@pytest.mark.django_db
+def test_dwa_zrodla_o_tym_samym_tytule_rozstrzyga_issn(admin_user, jcr_xlsx_path):
+    """Dwa źródła 'LANCET' → import wybiera to wskazane przez ISSN z pliku.
+
+    Poprawny duplikat trzyma ISSN z pliku (0140-6736) w polu e_issn (JCR
+    miesza kolumny ISSN/eISSN), więc dopasowanie po tytule jest niejednoznaczne
+    i musi je rozstrzygnąć ISSN — inaczej wiersz zostałby oznaczony jako
+    'Brak źródła w BPP'.
+    """
+    from bpp.models import Punktacja_Zrodla, Zrodlo
+    from import_punktacji_zrodel.models import ImportPunktacjiZrodel
+
+    wlasciwy = baker.make(Zrodlo, nazwa="LANCET", issn="", e_issn="0140-6736")
+    decoy = baker.make(Zrodlo, nazwa="LANCET", issn="9999-9999")
+
+    imp = baker.make(
+        ImportPunktacjiZrodel,
+        owner=admin_user,
+        rok=2025,
+        zapisz_zmiany_do_bazy=True,
+        importuj_impact_factor=True,
+        importuj_kwartyl_wos=True,
+        ignoruj_zrodla_bez_odpowiednika=False,
+        nie_porownuj_po_tytulach=False,
+    )
+    analyze_jcr_file(jcr_xlsx_path, imp, MockProgress(imp))
+
+    pz = Punktacja_Zrodla.objects.get(zrodlo=wlasciwy, rok=2025)
+    assert pz.impact_factor == Decimal("109.000")
+    assert pz.kwartyl_w_wos == 1
+    # źródło-wabik nie dostało punktacji
+    assert not Punktacja_Zrodla.objects.filter(zrodlo=decoy, rok=2025).exists()


### PR DESCRIPTION
## Problem

Import punktacji źródeł matchował źródła po tytule, a przy **dwóch źródłach o tym samym tytule** nie uwzględniał ISSN — wiersz lądował jako „Brak źródła w BPP".

Przyczyna w `import_common/core/zrodlo.py` (`matchuj_zrodlo`):

1. Dopasowanie po tytule (`_try_match_zrodlo_by_title_single`) łapało `Zrodlo.MultipleObjectsReturned` i po cichu zwracało `None` (`except … : pass`) — ISSN, który jednoznacznie wskazywał jedno ze źródeł, nie był na tym etapie w ogóle użyty.
2. Dopasowanie po ISSN było „pole-w-pole" (ISSN z pliku porównywany tylko do pola `issn`, eISSN tylko do `e_issn`). JCR miesza kolumny ISSN/eISSN, więc numer zapisany w BPP w „nie tym" polu nie był łapany.

## Rozwiązanie

Przy niejednoznacznym dopasowaniu po tytule zbiór kandydatów jest zawężany po ISSN/e-ISSN, porównywanych **krzyżowo** z oboma polami źródła (`issn` **oraz** `e_issn`). Źródło jest wybierane **tylko** gdy filtr zostawia dokładnie jedno — inaczej `None` (bez zgadywania, brak fałszywych trafień).

Zmiana jest addytywna — wywołania bez ISSN (np. `import_list_if`) zachowują dotychczasowe zachowanie.

## Testy (TDD — najpierw czerwone)

- `import_common/tests/test_core.py`: 5 przypadków dla `matchuj_zrodlo` — cross-field ISSN i eISSN, wariant pole-w-pole (regresja), brak pasującego ISSN → `None`, niejednoznaczny ISSN → `None`.
- `import_punktacji_zrodel/tests/test_repro_fd388.py`: test end-to-end przez `analyze_jcr_file` — dwa źródła „LANCET", punktacja trafia do wskazanego przez ISSN.

Uruchomione lokalnie: `import_common`, `import_punktacji_zrodel`, `import_list_ministerialnych`, `import_list_if` — **113 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)