### PR TITLE
spike(importer_publikacji): PPM/Omega-PSIR — lista publikacji przez articles-xml.seam

### DIFF
--- a/docs/superpowers/handoffs/2026-07-10-importer-patenty-www-dspace-listy.md
+++ b/docs/superpowers/handoffs/2026-07-10-importer-patenty-www-dspace-listy.md
@@ -1,0 +1,233 @@
+# Handoff — importer publikacji: patenty + wykrywanie list (WWW/DSpace/PPM)
+
+**Data:** 2026-07-10
+**Autor kontekstu:** sesja po zbudowaniu `MultipleWorksImport` (PR #511)
+**Worktree:** `~/Programowanie/bpp-bibtex-import-wiele-prac`
+**Gałąź bazowa:** `feat-bibtex-import-wiele-prac` (PR #511 → `dev`, **jeszcze niezmergowany**)
+
+## 0. TL;DR — o co chodzi
+
+Trzy powiązane pomysły, wszystkie stoją na **tej samej dźwigni** zbudowanej w PR #511:
+
+> `FetchView.post` woła `provider.split_input(normalized)`; jeśli zwróci ≥2
+> `SplitRecord`, powstaje paczka `MultipleWorksImport` + N dzieci i multi-import
+> „dzieje się sam". Domyślne `split_input` zwraca 1 rekord; tylko `BibTeXProvider`
+> je nadpisuje. **Każdy provider, który nadpisze `split_input`, dostaje
+> multi-import za darmo.** `SplitRecord.raw` = wartość, którą *ten sam* provider
+> `fetch()` już umie rozwiązać.
+
+Trzy tracki, wg rosnącej trudności:
+
+| Track | Co | Trudność | Zależność od PR #511 |
+|---|---|---|---|
+| **A. DSpace-lista** | wklejasz URL kolekcji/browse DSpace → multi-import | **łatwe** | tak (split_input/batch) |
+| **B. Patenty w BibTeX** | wklejasz `@patent{...}` → tworzy `bpp.Patent` | **średnie/trudne** | nie (osobny wątek, ale ten sam moduł) |
+| **C. PPM-lista** | wklejasz URL `globalResultList.seam` → multi-import | **trudne / ryzyko** | tak |
+
+**Uwaga o zależności:** tracki A i C stoją na `split_input`+batch z PR #511.
+Dopóki #511 nie jest w `dev`, nową pracę rób **na gałęzi off
+`feat-bibtex-import-wiele-prac`** (albo poczekaj na merge). Track B (patenty)
+technicznie nie zależy od batcha, ale dotyka tych samych plików — najczyściej
+też off tej gałęzi lub po jej merge.
+
+**Wspólny wzorzec (precedens w kodzie):** `WWWProvider.fetch()` już sniffuje URL
+po kształcie i skacze do dedykowanej ścieżki (Omega-PSIR:
+`providers/www/omega_psir.py`, dispatch w `providers/www/provider.py:129-136`).
+To dokładnie kształt, jaki przyjmie „wykryj stronę-listę" — tyle że w
+`split_input`, nie `fetch`.
+
+---
+
+## Track A — DSpace: wykrycie listy → multi-import (NAJŁATWIEJSZE)
+
+### Stan dziś (fakty)
+- `providers/dspace.py` — klient **pojedynczego itemu** przez REST: DSpace 7
+  (`/items/{uuid}` → `/server/api/core/items/{uuid}`, `_fetch_dspace7`
+  `:155-202`) lub DSpace 6 (`/handle/{prefix}/{suffix}` →
+  `/rest/handle/{h}?expand=metadata`, `_fetch_dspace6` `:205-279`).
+- `validate_identifier` (`:313-320` → `_parse_dspace_url` `:136-152`)
+  **twardo odrzuca** URL-e nie-itemowe (kolekcja/browse/discover). To jest
+  bramka PRZED `split_input` (`views/wizard.py:177-187`), więc **musi być
+  poluzowana**, inaczej `split_input` się nie odpali.
+- Cel `dspace.piwet.pulawy.pl` = **DSpace 6 XMLUI** (server-rendered, nie SPA).
+  URL-e prac `/handle/123456789/N` **już działają dziś** w pojedynczym imporcie.
+- `split_input` nienadpisane (dziedziczy default 1-rekord).
+- **Latentny bug (osobny):** `_parse_handle_url` regex `r"/handle/(\d+/\d+)"`
+  (`:127`) nie odróżnia handle *itemu* od *kolekcji/community* — dziś
+  wrzucenie handle kolekcji do `fetch()` po cichu potraktuje ją jak item.
+
+### Co zrobić
+1. Poluzuj `validate_identifier`, żeby akceptował URL-e listowe
+   (kolekcja/community/browse/discover) — inaczej batch nigdy nie ruszy.
+2. Nadpisz `DSpaceProvider.split_input(url)`:
+   - jeśli URL to lista → uderz **REST** (`GET /rest/collections/{uuid}/items`
+     dla DSpace 6, albo `/server/api/discover/search/objects` dla 7), albo
+     **OAI-PMH** (`/oai/request?verb=ListRecords&set=...`) — DUŻO pewniejsze niż
+     scraping HTML (paginacja przez `offset`/`limit` lub `resumptionToken`),
+   - zwróć `SplitRecord(raw=<item_handle_or_uuid_url>)` per item.
+   - inaczej → `return [SplitRecord(raw=url)]` (dzisiejsze zachowanie).
+3. `fetch()` **bez zmian** — już rozwiązuje item-handle jeden po drugim.
+
+### Otwarte pytania
+- Czy `piwet` ma włączony OAI-PMH (`/oai/request`)? (standard w DSpace 6, ale
+  zweryfikować na żywo). Jeśli tak — najczystsza droga.
+- Jak user wskaże „którą kolekcję/zapytanie" — wkleja URL kolekcji? browse?
+  całe repo? Zdecydować zakres (kolekcja vs cały serwer).
+- Przy okazji naprawić latentny bug item-vs-collection handle.
+
+### Werdykt
+Najłatwiejszy z trzech. REST/OAI omija JS i kruchość scrapingu; `fetch()` gotowy.
+
+---
+
+## Track B — Patenty w BibTeX (`@patent` → `bpp.Patent`) (ŚREDNIE/TRUDNE)
+
+### Stan dziś (fakty) — patentów NIE da się zaimportować
+- `BIBTEX_TYPE_MAP` (`providers/bibtex.py:20-34`) **nie ma** klucza `patent`.
+  `@patent` to typ biblatexowy; standardowy BibTeX go nie ma (ludzie fudge’ują
+  `@misc`/`@techreport`). `bibtexparser` v2 parsuje dowolne `@xxx{}` generycznie,
+  więc `@patent{}` wchodzi jako zwykły `Entry` z `entry_type=="patent"`.
+- `fetch()` (`:117-181`): `publication_type = BIBTEX_TYPE_MAP.get("patent")` →
+  **`None`** (cicho, bez wyjątku). Dalej `_get_crossref_mapper(None)`
+  (`views/helpers.py:122-128`) zwraca `None` → brak auto-podpowiedzi. **Nic się
+  nie wywala** — operator ląduje na Verify z pustym `charakter_formalny`.
+- Ścieżka tworzenia = **twardy binarny switch** (`views/publikacja.py:266-269`)
+  na `session.jest_wydawnictwem_zwartym` → `Wydawnictwo_Ciagle`/`Zwarte`.
+  **Brak trzeciej gałęzi. `Patent` nigdzie nie jest importowany.**
+
+### Pułapka / bug (warto naprawić NIEZALEŻNIE od feature’a)
+- W Verify `charakter_formalny` jest filtrowany tylko `ukryty=False`
+  (`forms.py:98`), a wiersz **"Patent"** ma `publikacja=false`, `ukryty` default
+  `False` → **jest widoczny i wybieralny** (`fixtures/charakter_formalny.json`).
+- Model-level guard `ZapobiegajNiewlasciwymCharakterom.clean_fields()`
+  (`bpp/models/util.py:278-308`) blokuje `skrot in ["D","H","PAT"]` na
+  `Wydawnictwo_*` — ale odpala się tylko w `full_clean()` (admin ModelForm),
+  a importer woła `.objects.create()` → **guard omijany**. Efekt: operator może
+  dziś stworzyć zmieszany `Wydawnictwo_Ciagle/Zwarte` otagowany „Patent",
+  który potem **utknie** (edycja w adminie rzuci błąd „kliknij tutaj").
+- **Fix niezależny:** w `VerifyForm` wyklucz `skrot__in=["D","H","PAT"]` z
+  queryseta `charakter_formalny` dla ścieżki ciagle/zwarte (mirror guardu).
+
+### Model `Patent` (`bpp/models/patent.py`) — impedancja
+- `tytul_oryginalny` (pojedynczy tytuł, NIE `DwaTytuly`), `data_zgloszenia`,
+  `numer_zgloszenia`, `data_decyzji`, `numer_prawa_wylacznego`,
+  `rodzaj_prawa` (FK `Rodzaj_Prawa_Patentowego`), `wdrozenie` (bool),
+  `wydzial` (FK `Jednostka`, NIE „applicant/holder" — takiego pola brak).
+- **NIE ma `typ_kbn`** (brak `ModelTypowany`) i **`charakter_formalny` NIE jest
+  settable** (hardcoded `@cached_property` → `Charakter_Formalny(skrot="PAT")`,
+  `:127-129`; brak `ModelZCharakterem`).
+  → `_create_publication` buduje `common_fields` z `typ_kbn` i
+  `charakter_formalny` (`publikacja.py:237-254`); przekazanie ich do
+  `Patent.objects.create(**common_fields)` **rzuci TypeError**. Nowy
+  `_create_patent()` MUSI je odfiltrować.
+- **Autorzy: gotowe.** `Patent_Autor` dzieli `BazaModeluOdpowiedzialnosciAutorow`
+  z `Wydawnictwo_*_Autor`; `Patent.dodaj_autora()` (via `DodajAutoraMixin`,
+  `autor_rekordu_klass=Patent_Autor`) jest wołalne przez
+  `_add_authors_to_record()` (`publikacja.py:111-154`) **bez zmian**.
+- `ImportSession.created_record` to już `GenericForeignKey` — schema sesji jest
+  polimorficzna, trzeci typ modelu nie wymaga zmiany tego pola.
+
+### Luka mapowania pól (biblatex `@patent` → `Patent`)
+biblatex `@patent`: `number`(zgłoszenie), `holder`(uprawniony), `date`,
+`location`(kraj), `type`(patent/wzór). `fetch()` **nic z tego nie czyta**
+patentowo dziś (`number`→`issue`). BPP własny **eksport** patentu
+(`bpp/export/bibtex.py:279-311`) emituje `@misc` z polami wrzuconymi w
+free-text `note` („Numer zgłoszenia: X…") — więc nawet round-trip własnego
+eksportu jest **stratny**; nie ma w repo strukturalnej konwencji do importu.
+
+### Co zrobić
+- (a) `BIBTEX_TYPE_MAP += {"patent": ...}` + mechanizm routingu (uwaga:
+  „patent" nie jest typem CrossRef, a `Crossref_Mapper` jest CrossRef-flavored —
+  rozważyć osobny tor, nie wciskać w mapper).
+- (b) `FetchedPublication` + pola patentowe (`patent_number`, `patent_holder`,
+  `filing_date`, `grant_date`, `patent_type`/`jurisdiction`); `fetch()` czyta je
+  z biblatex gdy `bibtex_type=="patent"`.
+- (c) `_create_patent(session, common_fields, normalized_data)` w
+  `publikacja.py` — **odfiltruj `typ_kbn` i `charakter_formalny`**, wypełnij
+  `numer_zgloszenia`/`data_zgloszenia`/`numer_prawa_wylacznego`/`data_decyzji`/
+  `rodzaj_prawa`/`tytul_oryginalny`/`rok`. Dispatch (`:266-269`) potrzebuje
+  trzeciej gałęzi → `ImportSession` potrzebuje realnego pola „rodzaj rekordu"
+  (dziś tylko boolean `jest_wydawnictwem_zwartym`).
+- (d) Wizard: nowe pole typu na `ImportSession` + pola patentowe w `VerifyForm`
+  / warunkowe w `step_verify.html` (albo osobny pod-krok patentowy).
+- (e) Autorzy: bez zmian.
+
+### Werdykt
+Parsowanie łatwe; **cała praca to plumbing wizarda/tworzenia**: nowe pole typu
+na sesji, trzecia gałąź dispatchu, pola patentowe w formularzu/UI, `_create_patent`
+z odfiltrowaniem `typ_kbn`/`charakter_formalny`. Model `Patent` odstaje
+(brak typ_kbn/charakter, daty/numery, brak pola holder). Rozważyć: czy w ogóle
+mapować z biblatex `@patent`, czy raczej dać operatorowi pola ręcznie (bo źródeł
+BibTeX brak/stratne).
+
+---
+
+## Track C — PPM `globalResultList` → multi-import (NAJTRUDNIEJSZE / RYZYKO)
+
+### Stan dziś (fakty)
+- `providers/www/provider.py` — generyczny scraper meta-tagów (citation_*,
+  Schema.org JSON-LD, Dublin Core, OpenGraph) + jeden adapter site’owy
+  (Omega-PSIR). `input_mode=IDENTIFIER` (URL). `validate_identifier` akceptuje
+  **dowolny** poprawny URL (`network.py:31-51`) — więc URL listy przejdzie
+  walidację, ale `fetch()` zwróci 0/1 rekord (brak pojęcia „lista").
+- `https://ppm.umlub.pl/globalResultList.seam?...` = **JBoss Seam/JSF**. Pobrany
+  HTML dla tego URL pokazuje tylko zakładki z licznikami, **brak linków do
+  pojedynczych prac** — grid wyników renderowany prawdopodobnie AJAX-em
+  (JSF/RichFaces) na bazie server-side `javax.faces.ViewState`, którego
+  `requests.get` (bezstanowy, jak wszędzie w kodzie) **nie odtworzy**.
+- Brak PPM-owego kodu w repo; nieznany kształt URL-a strony-detalu.
+
+### Co zrobić / ryzyka
+- `split_input` musiałby albo (i) sparsować grid Seam — ale jest AJAX/ViewState,
+  `requests.get` nie wystarczy; albo (ii) znaleźć pod-endpoint JSON/REST grida
+  (nieodkryty — wymaga devtools na żywej sesji).
+- `fetch()` na stronie-detalu PPM **niezweryfikowany** (zadziała, jeśli detal ma
+  citation_*/DC/Schema.org — wtedy fallback WWW „po prostu działa").
+- **Zalecenie:** najpierw prototyp na żywej sesji przeglądarki (Chrome DevTools
+  MCP / Playwright) — znaleźć (a) kształt URL-a detalu, (b) czy grid ma
+  underlying JSON endpoint, (c) czy `requests.get` w ogóle coś zwróci —
+  ZANIM zaczniesz pisać `split_input`.
+
+### Werdykt
+Materialnie ryzykowniejsze niż DSpace przez statefulność Seam/ViewState.
+Nie commitować się w scraping HTML bez wcześniejszego reverse-engineeringu.
+
+---
+
+## Rekomendowana kolejność
+
+1. **Track A (DSpace)** — najszybszy ROI, REST/OAI, `fetch()` gotowy. Dobry
+   pierwszy „prawdziwy" dowód, że `split_input` skaluje się poza BibTeX.
+2. **Bug niezależny (charakter_formalny trap)** — tani fix, realne dane-ryzyko
+   (mislabeled/utknięte rekordy). Można zrobić przy okazji Track B albo od razu.
+3. **Track B (patenty)** — większy plumbing; wart osobnego spec/planu. Zdecydować
+   najpierw *product*: mapować z biblatex `@patent` czy pola ręczne w wizardzie.
+4. **Track C (PPM)** — dopiero po prototypie przeglądarkowym; może się okazać
+   niewykonalne bez headless browsera w imporcie (duża zmiana architektury).
+
+## Pierwszy krok w nowej sesji
+- Wejść w worktree `~/Programowanie/bpp-bibtex-import-wiele-prac`, gałąź off
+  `feat-bibtex-import-wiele-prac` (lub po merge #511 — off `dev`).
+- Odpalić **brainstorming** dla wybranego tracku (to nowy feature → design przed
+  kodem). Dla Track A pierwsze pytania: OAI-PMH vs REST discovery? zakres
+  (kolekcja vs zapytanie vs całe repo)? jak operator wskazuje listę?
+- Ten worktree ma zbudowany `MultipleWorksImport`/`split_input` — nowe providery
+  tylko nadpisują `split_input`, reszta batcha działa.
+
+## Pliki-klucze
+**Batch/dźwignia:** `providers/__init__.py` (`split_input`, `SplitRecord`),
+`providers/bibtex.py` (jedyny override — wzorzec), `views/wizard.py:114-226`
+(`_create_batch`, `FetchView.post` — bramka `validate_identifier`/`split_input`),
+`tests/test_split_input.py` (kontrakt testów).
+**DSpace:** `providers/dspace.py`, `providers/dspace_common.py`.
+**WWW/PPM:** `providers/www/provider.py`, `providers/www/network.py`,
+`providers/www/omega_psir.py` (precedens URL-sniff).
+**Patenty:** `providers/bibtex.py`, `providers/__init__.py`,
+`views/publikacja.py` (`_create_*`, dispatch `:266-269`), `views/steps.py`
+(`_verify_context`), `forms.py` (`VerifyForm`), `models.py` (ImportSession),
+`bpp/models/patent.py`, `bpp/models/abstract/authors.py`,
+`bpp/models/abstract/metadata.py` (`ModelZCharakterem`),
+`bpp/models/util.py` (`ZapobiegajNiewlasciwymCharakterom`),
+`bpp/models/system/crossref_mapper.py`, `bpp/admin/patent.py` (referencja pól
+formularza), `bpp/export/bibtex.py` (stratny round-trip), `forms.py:98`
+(trap charakter_formalny), `fixtures/charakter_formalny.json` (wiersz PAT).

--- a/docs/superpowers/handoffs/2026-07-10-ppm-lista-spike-findings.md
+++ b/docs/superpowers/handoffs/2026-07-10-ppm-lista-spike-findings.md
@@ -1,0 +1,214 @@
+# Spike — Track C: PPM `globalResultList` → multi-import
+
+**Data:** 2026-07-10
+**Worktree:** `~/Programowanie/bpp-ppm-lista`, gałąź `feat-ppm-lista-import`
+**Gałąź bazowa:** `feat-bibtex-import-wiele-prac` (PR #511, jeszcze niezmergowany)
+**Poprzedni handoff:** [`2026-07-10-importer-patenty-www-dspace-listy.md`](2026-07-10-importer-patenty-www-dspace-listy.md)
+— sekcja "Track C" z rekomendacją: zrobić prototyp na żywej sesji ZANIM
+zacznie się pisać `split_input`. Ten dokument jest wynikiem tego prototypu.
+
+## TL;DR — werdykt
+
+**DOWORKS_WITH_CAVEAT.** Literalny URL z zadania
+(`globalResultList.seam?r=projectmain&tab=PROJECT` — zakładka **projektów**)
+pozostaje **BLOCKED**: to JSF/Seam AJAX grid ze statefulnym
+`javax.faces.ViewState`, którego `requests.get` nie odtworzy, i nie ma dla
+niego żadnego odkrytego publicznego REST/OAI/eksportu.
+
+Ale w trakcie reconu znalazłem **realny, stateless, działający** endpoint
+listy — tyle że dla zakładki **publikacji** (`PUBLICATION`), czyli
+dokładnie tego, czym BPP się zajmuje (Bibliografia Publikacji Pracowników):
+SEO-sitemapa `articles-xml.seam?year=YYYY`, wpisana w `robots.txt` instancji
+Omega-PSIR. To zaimplementowałem (TDD, mocki, zero live-network w testach).
+
+| Widok PPM | Endpoint listy | Stan |
+|---|---|---|
+| Publikacje (`tab=PUBLICATION`) | `articles-xml.seam?year=YYYY` | **DZIAŁA** — zaimplementowane |
+| Projekty (`tab=PROJECT`, z zadania) | brak odkrytego | **BLOCKED** |
+| Patenty, doktoraty, dane badawcze, ... | brak odkrytego | **BLOCKED** (nie sprawdzane głębiej — poza zakresem BPP) |
+| `globalResultList.seam` (dowolna zakładka, filtrowane wyszukiwanie) | brak — JS/ViewState grid | **BLOCKED** |
+
+## 1. Czy PPM to Omega-PSIR? TAK, potwierdzone
+
+- Nagłówek `Set-Cookie: JSESSIONID=...omegaprod` (cookie *domain suffix*
+  `omegaprod`).
+- Motyw PrimeFaces: `primefaces-omega`.
+- Stopka strony: „© 2026 Obsługiwany przez Omega-PSIR”.
+- Strona `/api.seam` (link w menu): „Ta platforma posiada API. Aby otrzymać
+  dokumentację oraz klucz do API prosimy wysłać zapytanie na
+  **api@omegapsir.io**” — a więc **istnieje** REST API, ale jest **gated**
+  (trzeba pisać maila, dostać klucz) — nie nadaje się do stateless
+  auto-detekcji bez interakcji człowieka z administracją PPM.
+
+To znaczy: repo już ma adapter Omega-PSIR (`providers/www/omega_psir.py`,
+regex `OMEGA_ARTICLE_RE = r"/info/article/([A-Za-z]{2,5}[0-9a-f]{32})"`) i
+**on faktycznie pasuje** do kształtu URL-i PPM (`/info/article/UML<32hex>/`)
+— potwierdzone na żywej stronie szczegółów (patrz sekcja 3). Test
+`test_fetch_omega_psir_url` w repo już to pokrywał (z fikcyjnym hostem
+`ppm.edu.pl`) — teraz mamy **potwierdzenie na prawdziwej instancji**.
+
+## 2. `globalResultList.seam` — potwierdzone BLOCKED
+
+Pobrane na żywo (`curl`, `2026-07-10`):
+
+```
+GET https://ppm.umlub.pl/globalResultList.seam?r=projectmain&tab=PROJECT&lang=pl
+→ HTTP 200, Content-Type: text/html;charset=UTF-8, 69183 znaków
+```
+
+Fakty z body:
+
+- **5 osobnych `javax.faces.ViewState` hidden-inputów** (jeden per `<form>`
+  na stronie) — jednoznaczny odcisk palca statefulnego JSF/Seam. Bez
+  poprawnego ViewState token-a serwer odrzuci/ zignoruje próbę
+  „kolejnej strony”/AJAX-owego dociągnięcia wyników.
+- **Zero** linków `/info/article/...` (ani żadnego innego per-wpis linku)
+  w server-rendered HTML — tylko zakładki z licznikami
+  (`Publikacje (N)`, `Projekty (N)`, `Patenty (N)`, ...) prowadzące do
+  innych `globalResultList.seam?r=...&tab=...` (czyli tego samego problemu
+  dla każdej zakładki).
+- Próby oczywistych REST/JSON pod-endpointów (`/oai/request?verb=Identify`,
+  `/seam/resource/rest/accesspoint/rdf/jsonld/<fake-id>`) → **404** (OAI-PMH
+  nie jest wystawiony; REST JSON-LD istnieje, ale tylko per-artykuł, nie
+  jako lista/wyszukiwarka).
+- `sitemap.xml` (zgadywany, standardowa lokalizacja) → 404.
+
+Żadna próba nie próbowała odtworzyć ViewState-owego round-tripu (to
+wymagałoby prawdziwej przeglądarki — w tym środowisku **nie było dostępnego
+Chrome/Chromium** ani dla `chrome-devtools-mcp`, ani dla `playwright`, więc
+nie dało się nawet zweryfikować, czy sam grid faktycznie renderuje się AJAX-em
+zamiast np. zwykłym re-postem formularza — ale zbiór dowodów [statefulny
+ViewState + zero linków w HTML + brak endpointu REST/OAI dla wyszukiwania]
+jest wystarczający, żeby ocenić stateless `requests.get` jako niewykonalny
+dla tego widoku bez dużo większej inwestycji).
+
+**Wniosek:** żeby zrobić `split_input` dla `globalResultList.seam` trzeba by
+albo (a) headless przeglądarki wewnątrz importera (spory skok architektury —
+Celery worker odpalający Playwright per-request), albo (b) uzyskania klucza
+do gated API PPM (wymaga maila do `api@omegapsir.io` + prawdopodobnie umowy/
+zgody instytucjonalnej — nie coś, co da się zdobyć w spike'u), albo (c)
+współpracy z administratorem PPM o inny eksport. Żadne z tych nie jest
+"cichym" fixem kodu — to decyzja produktowa/organizacyjna.
+
+## 3. Odkrycie: `articles-xml.seam?year=YYYY` — DZIAŁA, stateless
+
+`robots.txt` PPM zawiera:
+
+```
+User-agent: *
+Disallow: /
+Crawl-delay: 10
+
+User-agent: googlebot
+Allow: /
+Disallow: /stats/
+Disallow: /SearchExpert.seam*
+Disallow: /SearchGlobal.seam*
+
+Sitemap: https://ppm.umlub.pl/years-xml.seam
+```
+
+`years-xml.seam` to `<sitemapindex>` (standard sitemaps.org) z jednym
+`<sitemap><loc>` per rok (potwierdzone 2007–2026), każdy wskazujący na
+`articles-xml.seam?year=YYYY`. Ten z kolei to zwykły `<urlset>` z **1467
+`<loc>`** dla roku 2026 — każdy `<loc>` to URL strony szczegółowej artykułu w
+kształcie `https://ppm.umlub.pl/info/article/UML<32hex>/` — **dokładnie**
+kształt, który `omega_psir.py` już rozpoznaje.
+
+Sprawdzone na żywo, że strona szczegółowa faktycznie niesie dane do
+sparsowania (bez potrzeby REST JSON-LD nawet — `citation_*` meta tagi
+wystarczają):
+
+```
+GET https://ppm.umlub.pl/info/article/UML001085ec4f064177b924ac8a993e7701/
+→ 200, <meta name="citation_title" content="Zakażenie HPV u kobiety a
+  zdrowie noworodka - edukacyjna rola położnej">
+  <meta name="citation_author" content="Siemieńczuk, Julia">
+  <meta name="citation_author" content="Winiarczyk, Weronika">
+  <meta name="citation_publication_date" content="2026">
+  ...
+```
+
+`WWWProvider.fetch()` już to sparsuje bez żadnych zmian (fallback-chain
+citation_meta → schema_jsonld → dublin_core → opengraph, plus Omega-PSIR
+REST JSON-LD jeśli URL pasuje regexowi — tu wystarczy sam citation_meta).
+
+**Ograniczenia tego, co odkryte:**
+
+- Sitemapa jest per **rok kalendarzowy**, nie per zapytanie/filtr — wklejenie
+  jej daje **wszystkie** artykuły z danego roku w PPM, nie przefiltrowany
+  wynik wyszukiwania. To jest świadomy kompromis: dokładny i kompletny (nic
+  nie ginie, nic nie jest zgadywane), ale operator nie może np. dociągnąć
+  "tylko prac z mojej jednostki" tą drogą.
+- Sprawdzone tylko dla zakładki **PUBLICATION** (`articles-xml.seam`).
+  Próby analogicznych nazw dla innych zakładek (`projects-xml`,
+  `projectmain-xml`, `patents-xml`, `patent-xml`, `phd-xml`,
+  `doctorates-xml`, `publications-xml`, `theses-xml`) → wszystkie 404. Może
+  istnieć inna nazwa dla innych typów, ale nie została odkryta w tym
+  spike'u (i patenty/projekty/doktoraty to i tak drugorzędne w BPP wobec
+  publikacji).
+- Rozmiar: rok 2026 to już 1467 wpisów **w połowie roku** — starsze,
+  pełne lata będą prawdopodobnie większe. `split_input` dziś **nie ogranicza**
+  liczby zwracanych rekordów (spójne z `BibTeXProvider`, który też nie ma
+  cappa) — ale w przeciwieństwie do BibTeX-a (parsowanie w pamięci, brak
+  sieci) to jest **synchroniczny fetch sieciowy w request/response cyklu
+  widoku** (`FetchView.post` woła `split_input` przed enqueue Celery). Dla
+  bardzo dużych lat to może być zauważalne opóźnienie odpowiedzi HTTP —
+  **nie zmierzone tu na żywo** (żeby nie obciążać cudzej produkcyjnej
+  instancji powtarzalnymi testami wydajnościowymi). Realna implementacja
+  produkcyjna powinna rozważyć: cap + ostrzeżenie, albo przesunięcie fetchu
+  sitemapy do Celery zamiast do widoku.
+
+## 4. Co zaimplementowano (ten branch)
+
+- `providers/www/omega_psir_sitemap.py` — nowy moduł:
+  `_detect_omega_articles_sitemap(url)` (rozpoznanie po kształcie URL:
+  ścieżka `/articles-xml.seam` + parametr `year=YYYY`, bez allow-listy
+  hostów — ten sam styl co `OMEGA_ARTICLE_RE` w `omega_psir.py`) oraz
+  `_fetch_omega_articles_sitemap(url)` (GET + parsowanie XML przez
+  `defusedxml.ElementTree` — **nie** stdlib `xml.etree`, bo XML z
+  zewnętrznego serwera to potencjalny wektor XXE/billion-laughs).
+- `WWWProvider.split_input()` (nadpisane, wcześniej dziedziczyło default
+  1-rekordowy): jeśli URL pasuje do kształtu sitemapy → fetch + N
+  `SplitRecord(raw=<article_url>)`; w każdym innym przypadku (w tym
+  `globalResultList.seam`) → **niezmieniony fallback do 1 rekordu**,
+  identyczny jak default `DataProvider.split_input`. Świadomie NIE robimy
+  nic "sprytnego" dla `globalResultList.seam` (np. zgadywania roku z query
+  stringa i cichego przełączenia na sitemapę) — to dawałoby operatorowi
+  wynik niezgodny z tym, co faktycznie wkleił (przefiltrowane wyszukiwanie
+  vs. cały rok), czyli dokładnie ten rodzaj "fake" feature'u, którego zadanie
+  zabraniało.
+- Testy (`tests/test_www_provider_ppm_split_input.py`, wszystkie z mockami,
+  zero live-network):
+  - sitemapa → 3 `SplitRecord` (happy path + weryfikacja że fetch poszedł
+    dokładnie na URL sitemapy),
+  - błąd HTTP / malformed XML → bezpieczny fallback do 1 rekordu,
+  - URL spoza kształtu → **zero requestów sieciowych** (sprawdzone
+    `mock_get.assert_not_called()`),
+  - `globalResultList.seam` (fixture zbudowany na bazie realnej odpowiedzi:
+    ViewState + zakładki + zero per-wpis linków) → dokumentuje dzisiejszy
+    bezpieczny fallback (1 rekord, zero requestów),
+  - `xfail(strict=True)` dokumentujący **docelowe** zachowanie dla
+    `globalResultList.seam` (≥2 rekordy) — celowo czerwony dziś, żeby ktoś w
+    przyszłości, kto to naprawi, dostał przypomnienie usunąć xfail.
+- `pyproject.toml`: dodano `defusedxml>=0.7.1` (bezpieczny parser XML).
+
+## 5. Rekomendacja na przyszłość
+
+1. Jeśli operator PPM/BPP chce importować **publikacje** z PPM hurtowo:
+   wkleja URL eksportu roku (`articles-xml.seam?year=2026`) — działa dziś.
+   Warto rozważyć UX: `input_help_text` `WWWProvider` mogłoby wspomnieć o tym
+   sposobie dla Omega-PSIR (na razie nie dodane w tym spike'u — do decyzji
+   produktowej, czy eksponować to wprost w UI, czy zostawić jako "ukrytą"
+   zdolność techniczną odkrywaną przez dokumentację/support).
+2. `globalResultList.seam` (przefiltrowane wyszukiwanie, dowolna zakładka)
+   pozostaje niewykonalne bez (a) headless browsera w pipeline importu, albo
+   (b) gated API PPM (`api@omegapsir.io`), albo (c) współpracy z
+   administratorem PPM o dedykowany eksport. To decyzja **poza zakresem
+   inżynierskim** tego repo — ktoś (product/management) musi zdecydować,
+   czy inwestycja w headless browser lub pozyskanie klucza API jest warta
+   ROI, zanim ruszy dalsza praca.
+3. Warto sprawdzić (osobny, krótki spike), czy inne instytucje z Omega-PSIR
+   (są ich dziesiątki w Polsce — POL-on, wiele uczelni medycznych) mają ten
+   sam `articles-xml.seam` — jeśli tak, obecna implementacja "za darmo"
+   obsługuje je wszystkie (URL-sniff nie jest hostname-gated).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ dependencies = [
     "bibtexparser>=2.0.0b7", # BibTeX import
     "langdetect>=1.0.9", # Language detection for imports
     "beautifulsoup4>=4.15.0", # importer_publikacji.providers.www imports at app-ready time
+    "defusedxml>=0.7.1", # bezpieczny parser XML (PPM sitemap, XXE-safe)
     "gunicorn>=26.0.0", # authserver WSGI runner (moved from docker/authserver build-time uv pip install)
     "watchdog>=5.0.3", # --reload mode dla uvicorn/celery w dev compose (moved from entrypoint `uv pip install`)
     "sqlparse>=0.5.4", # Dependabot: transitive via Django, bumped to fix DoS in format_list_of_tuples

--- a/src/bpp/newsfragments/importer-ppm-lista-artykulow.feature.rst
+++ b/src/bpp/newsfragments/importer-ppm-lista-artykulow.feature.rst
@@ -1,0 +1,8 @@
+Importer publikacji: wklejenie linku do rocznego eksportu XML publikacji z
+platformy Omega-PSIR (np. Polska Platforma Medyczna,
+``.../articles-xml.seam?year=2026``) tworzy teraz "paczkę" prac — po jednej
+pozycji na każdy artykuł z danego roku. Strona wyników wyszukiwania PPM
+(``globalResultList.seam``) pozostaje na razie nieobsługiwana — to widok
+renderowany dynamicznie (JSF/Seam AJAX), z którego nie da się wyciągnąć
+listy prac bez przeglądarki; szczegóły w
+``docs/superpowers/handoffs/2026-07-10-ppm-lista-spike-findings.md``.

--- a/src/importer_publikacji/providers/www/omega_psir_sitemap.py
+++ b/src/importer_publikacji/providers/www/omega_psir_sitemap.py
@@ -1,0 +1,82 @@
+"""Detekcja i pobranie listy artykułów z eksportu XML Omega-PSIR.
+
+Instancje platformy Omega-PSIR (np. PPM UMLUB — ``ppm.umlub.pl``)
+publikują w ``robots.txt`` SEO-sitemapę (``<host>/years-xml.seam`` jako
+indeks, a pod nim per-rok ``<host>/articles-xml.seam?year=YYYY``) z
+listą URL-i stron szczegółowych artykułów (``/info/article/{id}``).
+
+To jedyna **stateless** (bez JS/ViewState) droga do listy prac
+znaleziona podczas spike'u Track C — w przeciwieństwie do
+``globalResultList.seam`` (siatka wyników wyszukiwania), która jest
+renderowana AJAX-em JSF/Seam i wymaga statefulnego
+``javax.faces.ViewState``, którego ``requests.get`` nie odtworzy.
+Szczegóły: ``docs/superpowers/handoffs/2026-07-10-ppm-lista-spike-findings.md``.
+
+URL-e zwrócone stąd trafiają do ``WWWProvider.fetch()``, który już
+rozpoznaje kształt ``/info/article/{id}`` (``omega_psir.py``) i
+parsuje ``citation_*``/JSON-LD z tych stron.
+"""
+
+import re
+from urllib.parse import parse_qs, urlparse
+
+import defusedxml.ElementTree as ElementTree
+import requests
+from defusedxml.common import DefusedXmlException
+
+FETCH_TIMEOUT = 15
+
+SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+
+# Ścieżka eksportu XML listy artykułów (rozpoznanie po kształcie URL,
+# tak jak OMEGA_ARTICLE_RE w omega_psir.py — bez allow-listy hostów).
+ARTICLES_SITEMAP_PATH_RE = re.compile(r"/articles-xml\.seam$")
+YEAR_RE = re.compile(r"^\d{4}$")
+
+
+def _detect_omega_articles_sitemap(url: str) -> str | None:
+    """Rozpoznaj URL eksportu XML listy artykułów Omega-PSIR.
+
+    Wymaga ścieżki ``/articles-xml.seam`` + parametru ``year=YYYY``.
+    Zwraca ten sam URL (do dalszego fetch'u) albo ``None``.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    if not ARTICLES_SITEMAP_PATH_RE.search(parsed.path):
+        return None
+    years = parse_qs(parsed.query).get("year")
+    if not years or not YEAR_RE.match(years[0]):
+        return None
+    return url
+
+
+def _fetch_omega_articles_sitemap(url: str) -> list[str] | None:
+    """Pobierz i sparsuj eksport XML — zwróć listę URL-i stron szczegółowych.
+
+    ``None`` przy błędzie sieci/HTTP/parsowania — wołający ma wtedy
+    spaść do zachowania domyślnego (1 rekord), a nie wyrzucić wyjątek
+    do widoku.
+    """
+    try:
+        resp = requests.get(
+            url,
+            timeout=FETCH_TIMEOUT,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; BPP-Importer/1.0)"},
+        )
+        resp.raise_for_status()
+    except requests.RequestException:
+        return None
+
+    try:
+        root = ElementTree.fromstring(resp.content)
+    except (ElementTree.ParseError, DefusedXmlException):
+        return None
+
+    urls = [
+        loc.text.strip()
+        for loc in root.findall(".//sm:url/sm:loc", SITEMAP_NS)
+        if loc.text and loc.text.strip()
+    ]
+    return urls or None

--- a/src/importer_publikacji/providers/www/provider.py
+++ b/src/importer_publikacji/providers/www/provider.py
@@ -6,6 +6,7 @@ from .. import (
     DataProvider,
     FetchedPublication,
     InputMode,
+    SplitRecord,
     register_provider,
 )
 from .body_abstracts import _extract_body_abstracts
@@ -17,6 +18,10 @@ from .omega_psir import (
     _detect_omega_psir,
     _fetch_omega_psir_jsonld,
     _parse_omega_jsonld,
+)
+from .omega_psir_sitemap import (
+    _detect_omega_articles_sitemap,
+    _fetch_omega_articles_sitemap,
 )
 from .opengraph import _extract_opengraph
 from .schema_jsonld import _extract_schema_jsonld
@@ -52,6 +57,29 @@ class WWWProvider(DataProvider):
 
     def validate_identifier(self, identifier: str) -> str | None:
         return _validate_url(identifier)
+
+    def split_input(self, text: str) -> list[SplitRecord]:
+        """Rozbij wejście na rekordy — obsługuje listę Omega-PSIR (PPM).
+
+        Jedyna dziś rozpoznawana lista to eksport XML
+        ``articles-xml.seam?year=YYYY`` instancji Omega-PSIR (np. PPM
+        UMLUB) — statyczny, bez JS/ViewState (patrz
+        ``omega_psir_sitemap.py``). Strona wyników wyszukiwania
+        (``globalResultList.seam``) renderuje siatkę AJAX-em i **nie
+        jest** tu rozpoznawana — celowo, żeby nie fingować listy, której
+        nie umiemy odtworzyć statelessowym ``requests.get`` (patrz
+        findings w ``docs/superpowers/handoffs/``). Dla niej (i dla
+        każdego innego URL-a) zachowanie jest identyczne jak domyślne:
+        1 rekord, dalej idzie zwykły pojedynczy fetch.
+        """
+        url = _validate_url(text)
+        if url:
+            sitemap_url = _detect_omega_articles_sitemap(url)
+            if sitemap_url:
+                article_urls = _fetch_omega_articles_sitemap(sitemap_url)
+                if article_urls:
+                    return [SplitRecord(raw=u) for u in article_urls]
+        return [SplitRecord(raw=text)]
 
     def fetch(self, identifier: str) -> FetchedPublication | None:
         url = _validate_url(identifier)

--- a/src/importer_publikacji/tests/_www_provider_samples.py
+++ b/src/importer_publikacji/tests/_www_provider_samples.py
@@ -152,6 +152,51 @@ SAMPLE_HTML_MIXED = """
 """
 
 
+# Eksport XML "articles-xml.seam?year=YYYY" instancji Omega-PSIR (np. PPM
+# UMLUB) — SEO sitemapa z listą URL-i stron szczegółowych artykułów,
+# wpisana w robots.txt (`Sitemap: .../years-xml.seam` -> index per rok).
+# Skrócona wersja realnej odpowiedzi (potwierdzone na żywo 2026-07-10,
+# ~1467 wpisów dla roku 2026 na ppm.umlub.pl).
+SAMPLE_OMEGA_ARTICLES_SITEMAP_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://ppm.umlub.pl/info/article/UML001085ec4f064177b924ac8a993e7701/</loc>
+    </url>
+    <url>
+        <loc>https://ppm.umlub.pl/info/article/UML0057c12f802b4ae7a8ef45ba8aaad38a/</loc>
+    </url>
+    <url>
+        <loc>https://ppm.umlub.pl/info/article/UML00cc39550a89431597f0949c8c467ef4/</loc>
+    </url>
+</urlset>
+"""
+
+# Fragment strony `globalResultList.seam` (siatka wyników wyszukiwania
+# Omega-PSIR/JSF-Seam) — trzy hidden-input ViewState (statefulny AJAX,
+# jeden ViewState per <form> na stronie) i ZERO linków do pojedynczych
+# prac w server-rendered HTML. Zweryfikowane na żywo 2026-07-10 na
+# https://ppm.umlub.pl/globalResultList.seam?r=projectmain&tab=PROJECT —
+# realna odpowiedź miała 69183 znaki, 5 ViewState, 0 dopasowań
+# /info/article/ ani żadnego innego per-wpis linku. Ten fixture to
+# minimalna reprezentatywna próbka tego kształtu (nie cała strona).
+SAMPLE_HTML_PPM_GLOBAL_RESULT_LIST = """
+<html><head><title>Wyniki wyszukiwania</title></head>
+<body>
+<form id="tabsForm">
+<input type="hidden" name="javax.faces.ViewState"
+  id="j_id__v_0:javax.faces.ViewState:1" value="opaque-viewstate-token" />
+<div class="tabs">
+  <a href="/globalResultList.seam?r=publication&amp;tab=PUBLICATION">
+    Publikacje (1467)</a>
+  <a href="/globalResultList.seam?r=projectmain&amp;tab=PROJECT">
+    Projekty (42)</a>
+</div>
+<div id="resultGrid" data-widget="primefaces-datatable-ajax"></div>
+</form>
+</body></html>
+"""
+
+
 def _make_soup(html: str) -> BeautifulSoup:
     return BeautifulSoup(html, "html.parser")
 
@@ -159,6 +204,7 @@ def _make_soup(html: str) -> BeautifulSoup:
 def _mock_response(text="", status_code=200, json_data=None):
     resp = MagicMock()
     resp.text = text
+    resp.content = text.encode("utf-8") if text else b""
     resp.status_code = status_code
     resp.raise_for_status = MagicMock()
     if json_data is not None:

--- a/src/importer_publikacji/tests/test_www_provider_ppm_split_input.py
+++ b/src/importer_publikacji/tests/test_www_provider_ppm_split_input.py
@@ -1,0 +1,131 @@
+"""``WWWProvider.split_input`` dla list Omega-PSIR/PPM — Track C spike.
+
+Werdykt (patrz findings doc pod
+``docs/superpowers/handoffs/2026-07-10-ppm-lista-spike-findings.md``):
+
+- ``articles-xml.seam?year=YYYY`` (SEO-sitemapa Omega-PSIR, statyczna,
+  bez JS) -> DZIAŁA: rozpoznajemy kształt URL-a, pobieramy XML, zwracamy
+  N ``SplitRecord`` z URL-ami stron szczegółowych, które
+  ``WWWProvider.fetch()`` już umie rozwiązać (citation_*/omega_psir).
+- ``globalResultList.seam`` (siatka wyników wyszukiwania) -> BLOCKED:
+  renderowana AJAX-em JSF/Seam z statefulnym ``javax.faces.ViewState``,
+  server-rendered HTML nie niesie linków do prac. Celowo NIE rozpoznajemy
+  tego kształtu — dostajemy bezpieczny fallback do 1 rekordu (identyczny
+  jak zachowanie domyślne), zamiast fingować listę.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from importer_publikacji.providers import SplitRecord
+from importer_publikacji.providers.www import WWWProvider
+
+from ._www_provider_samples import (
+    SAMPLE_HTML_PPM_GLOBAL_RESULT_LIST,
+    SAMPLE_OMEGA_ARTICLES_SITEMAP_XML,
+    _mock_response,
+)
+
+SITEMAP_URL = "https://ppm.umlub.pl/articles-xml.seam?year=2026"
+GLOBAL_RESULT_LIST_URL = (
+    "https://ppm.umlub.pl/globalResultList.seam?r=projectmain&tab=PROJECT&lang=pl"
+)
+
+
+@patch("importer_publikacji.providers.www.requests.get")
+def test_split_input_ppm_articles_sitemap_returns_one_record_per_article(mock_get):
+    mock_get.return_value = _mock_response(text=SAMPLE_OMEGA_ARTICLES_SITEMAP_XML)
+
+    provider = WWWProvider()
+    records = provider.split_input(SITEMAP_URL)
+
+    assert len(records) == 3
+    assert all(isinstance(r, SplitRecord) and r.ok for r in records)
+    assert records[0].raw == (
+        "https://ppm.umlub.pl/info/article/UML001085ec4f064177b924ac8a993e7701/"
+    )
+    assert records[1].raw == (
+        "https://ppm.umlub.pl/info/article/UML0057c12f802b4ae7a8ef45ba8aaad38a/"
+    )
+    assert records[2].raw == (
+        "https://ppm.umlub.pl/info/article/UML00cc39550a89431597f0949c8c467ef4/"
+    )
+    # Fetch faktycznie zostal wywolany na URL-u sitemapy, nie na czyms
+    # zgadywanym.
+    mock_get.assert_called_once()
+    assert mock_get.call_args.args[0] == SITEMAP_URL
+
+
+@patch("importer_publikacji.providers.www.requests.get")
+def test_split_input_ppm_sitemap_http_error_falls_back_to_single_record(mock_get):
+    mock_get.return_value = _mock_response(status_code=500)
+
+    provider = WWWProvider()
+    records = provider.split_input(SITEMAP_URL)
+
+    assert records == [SplitRecord(raw=SITEMAP_URL)]
+
+
+@patch("importer_publikacji.providers.www.requests.get")
+def test_split_input_ppm_sitemap_malformed_xml_falls_back_to_single_record(mock_get):
+    mock_get.return_value = _mock_response(text="<not><valid</not>")
+
+    provider = WWWProvider()
+    records = provider.split_input(SITEMAP_URL)
+
+    assert records == [SplitRecord(raw=SITEMAP_URL)]
+
+
+def test_split_input_non_ppm_url_is_unaffected():
+    """URL-e spoza kształtu articles-xml.seam nie ruszają sieci wcale."""
+    provider = WWWProvider()
+    records = provider.split_input("https://example.com/article/1")
+    assert records == [SplitRecord(raw="https://example.com/article/1")]
+
+
+@patch("importer_publikacji.providers.www.requests.get")
+def test_split_input_ppm_global_result_list_falls_through_today(mock_get):
+    """Dokumentuje dzisiejszy bezpieczny fallback dla siatki AJAX.
+
+    Nie zgadujemy: 1 rekord, identycznie jak default. Ten sam URL trafi
+    potem do zwykłego single-fetch, ktory (bo strona nie niesie
+    citation_*/DC/JSON-LD) zwroci ``None`` — operator zobaczy czytelny
+    blad "nie znaleziono danych", a nie fikcyjny import.
+    """
+    mock_get.return_value = _mock_response(text=SAMPLE_HTML_PPM_GLOBAL_RESULT_LIST)
+
+    provider = WWWProvider()
+    records = provider.split_input(GLOBAL_RESULT_LIST_URL)
+
+    assert records == [SplitRecord(raw=GLOBAL_RESULT_LIST_URL)]
+    # split_input dla nierozpoznanego ksztaltu nie robi ZADNEGO requesta —
+    # tylko validate_identifier parsuje sam URL lokalnie.
+    mock_get.assert_not_called()
+
+
+@pytest.mark.xfail(
+    reason=(
+        "BLOKADA (Track C, spike 2026-07-10): globalResultList.seam "
+        "renderuje siatke wynikow przez JSF/Seam AJAX z statefulnym "
+        "javax.faces.ViewState - stateless requests.get widzi tylko "
+        "zakladki z licznikami, zero linkow do prac w server-rendered "
+        "HTML. Brak odkrytego publicznego REST/OAI dla TEGO widoku "
+        "(w odroznieniu od articles-xml.seam, ktory dziala). Ten test "
+        "dokumentuje DOCELOWE zachowanie na przyszlosc: split_input "
+        "powinien kiedys umiec rozbic tez wyniki wyszukiwania z grida, "
+        "nie tylko roczny eksport XML. Wymaga albo (a) headless "
+        "przegladarki odtwarzajacej ViewState, albo (b) odkrycia "
+        "prywatnego API PPM (dostepne tylko na wniosek, patrz "
+        "api@omegapsir.io), albo (c) wspolpracy z administratorem PPM."
+    ),
+    strict=True,
+)
+@patch("importer_publikacji.providers.www.requests.get")
+def test_split_input_ppm_global_result_list_target_behavior_xfail(mock_get):
+    mock_get.return_value = _mock_response(text=SAMPLE_HTML_PPM_GLOBAL_RESULT_LIST)
+
+    provider = WWWProvider()
+    records = provider.split_input(GLOBAL_RESULT_LIST_URL)
+
+    assert len(records) >= 2

--- a/uv.lock
+++ b/uv.lock
@@ -372,6 +372,7 @@ dependencies = [
     { name = "cryptography", marker = "platform_python_implementation != 'PyPy'" },
     { name = "cssmin", marker = "platform_python_implementation != 'PyPy'" },
     { name = "dbfread", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "defusedxml", marker = "platform_python_implementation != 'PyPy'" },
     { name = "dj-pagination", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-admin-sortable2", marker = "platform_python_implementation != 'PyPy'" },
@@ -553,6 +554,7 @@ requires-dist = [
     { name = "cryptography" },
     { name = "cssmin", specifier = "==0.2.0" },
     { name = "dbfread", specifier = ">=2.0.7" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "dj-pagination", specifier = "==2.5.0" },
     { name = "django", specifier = ">=5.2.15,<5.3" },
     { name = "django-admin-sortable2", specifier = ">=2.3.1,<3" },
@@ -1402,6 +1404,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Werdykt

**DZIAŁA (z zastrzeżeniem) / DONE_WITH_CONCERNS** — spike Track C z handoffu
[`2026-07-10-importer-patenty-www-dspace-listy.md`](https://github.com/iplweb/bpp/blob/dev/docs/superpowers/handoffs/2026-07-10-importer-patenty-www-dspace-listy.md).

Literalny URL z zadania (`globalResultList.seam?r=projectmain&tab=PROJECT`
— zakładka **projektów**, siatka wyników wyszukiwania) pozostaje
**BLOCKED**: potwierdzone na żywo, że to JSF/Seam AJAX grid ze statefulnym
`javax.faces.ViewState` — `requests.get` go nie odtworzy, i nie ma dla
niego publicznego REST/OAI (próby `/oai/request`, REST JSON-LD z fałszywym
ID → 404).

Ale recon znalazł **realny, stateless, działający** endpoint listy — dla
zakładki **publikacji** (czyli dokładnie tego, czym BPP się zajmuje):
`articles-xml.seam?year=YYYY`, SEO-sitemapa wpisana w `robots.txt`
instancji Omega-PSIR. **To zaimplementowałem** (TDD, mocki, zero
live-network w testach) zamiast fingować obsługę niewykonalnego widoku.

## Co znaleziono na żywej instancji (ppm.umlub.pl, 2026-07-10)

- **PPM to potwierdzona instancja Omega-PSIR** (cookie `...omegaprod`,
  motyw `primefaces-omega`, stopka „Obsługiwany przez Omega-PSIR”). Repo
  już miało adapter (`providers/www/omega_psir.py`) dla kształtu URL-a
  `/info/article/{id}` — teraz potwierdzone na prawdziwej instancji.
- `globalResultList.seam` → 200, 69183 znaków, **5 osobnych
  `javax.faces.ViewState`** hidden-inputów, **zero** linków do prac w
  server-rendered HTML — tylko zakładki z licznikami.
- `robots.txt` → `Sitemap: https://ppm.umlub.pl/years-xml.seam` (sitemap
  index per rok) → `articles-xml.seam?year=2026` → **1467 `<loc>`** z URL-ami
  stron szczegółowych artykułów (`/info/article/UML<32hex>/`).
- Strona szczegółowa artykułu niesie `citation_*` meta tagi —
  `WWWProvider.fetch()` **już** to parsuje bez zmian.
- `/api.seam`: PPM ma REST API, ale **gated** (klucz na wniosek do
  `api@omegapsir.io`) — nieużywalne w automatycznej detekcji.

Pełne findings: [`docs/superpowers/handoffs/2026-07-10-ppm-lista-spike-findings.md`](https://github.com/iplweb/bpp/blob/feat-ppm-lista-import/docs/superpowers/handoffs/2026-07-10-ppm-lista-spike-findings.md)

## Co zaimplementowano

- `providers/www/omega_psir_sitemap.py` — rozpoznanie URL-a
  `articles-xml.seam?year=YYYY` (kształt, bez allow-listy hostów — styl
  spójny z `omega_psir.py`) + fetch/parsowanie XML przez
  `defusedxml.ElementTree` (XXE-safe; dodane jako zależność).
- `WWWProvider.split_input()` (dotąd dziedziczyło domyślne 1-rekordowe
  zachowanie): dla sitemapy → N `SplitRecord` (jeden per artykuł); dla
  **wszystkiego innego, w tym `globalResultList.seam`** → niezmieniony
  fallback do 1 rekordu (identyczny jak dziś) — świadomie NIE zgadujemy
  roku z query stringa wyszukiwania, bo to dałoby operatorowi wynik
  niezgodny z tym, co wkleił.
- Testy: `tests/test_www_provider_ppm_split_input.py` — happy path,
  błąd HTTP/malformed XML → fallback, URL spoza kształtu → **zero
  requestów sieciowych**, `globalResultList.seam` → dokumentuje dzisiejszy
  bezpieczny fallback, plus `xfail(strict=True)` dokumentujący docelowe
  (dziś niewykonalne) zachowanie dla `globalResultList.seam`.

## Test plan

- [x] `PYTEST_TESTCONTAINERS_REUSE=1 uv run pytest src/importer_publikacji/ -q`
      → **552 passed, 1 skipped, 1 xfailed** (xfailed = oczekiwany, dokumentuje blocker)
- [x] `uv run ruff format --check` / `uv run ruff check` na zmienionych plikach — czysto
- [x] Zero live-network w testach (wszystko mockowane); live-site użyty tylko
      podczas reconu (curl/robots.txt/sitemap), nie w test suite

## Następne kroki (poza zakresem tego spike'u)

1. Decyzja produktowa: czy eksponować `articles-xml.seam?year=YYYY` wprost
   w UI (`input_help_text`), czy zostawić jako zdolność techniczną.
2. `globalResultList.seam` wymaga albo headless przeglądarki w pipeline
   importu, albo gated API PPM, albo współpracy z administratorem PPM —
   decyzja poza zakresem inżynierskim.
3. Sprawdzić, czy inne instytucje z Omega-PSIR (dziesiątki w Polsce) mają
   ten sam `articles-xml.seam` — detekcja nie jest hostname-gated, więc
   obecna implementacja może już je obsługiwać "za darmo".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
