### PR TITLE
fix(import-pracownikow): poprawki z self-review stacka (Fazy 0–5)

### DIFF
--- a/src/import_common/sources.py
+++ b/src/import_common/sources.py
@@ -120,7 +120,12 @@ class CSVSource:
         with open(self.path, "rb") as f:
             tekst = _zdekoduj(f.read())
         delimiter = _wykryj_delimiter(tekst)
-        reader = csv.reader(io.StringIO(tekst), delimiter=delimiter)
+        # `newline=""` — kontrakt modułu `csv`: bez tego goły `\r` (końce linii
+        # CR-only ze starych Maków / eksportów kadrowych albo zabłąkany `\r` po
+        # ręcznej edycji) rzuca `_csv.Error: new-line character seen in unquoted
+        # field` i wywala CAŁĄ analizę surowym tracebackiem. Z nim csv.reader
+        # sam obsługuje wszystkie warianty końców linii wg dialektu.
+        reader = csv.reader(io.StringIO(tekst, newline=""), delimiter=delimiter)
         return [list(r) for r in reader]
 
     @cached_property

--- a/src/import_common/tests/test_sources.py
+++ b/src/import_common/tests/test_sources.py
@@ -152,3 +152,30 @@ def test_csvsource_crlf_realny_excel(tmp_path):
     wiersz = list(src.data())[0]
     assert wiersz["nazwa_jednostki"] == "Katedra Chorób"
     assert wiersz["__xls_loc_row__"] == 1
+
+
+def test_csvsource_cr_only_konce_linii(tmp_path):
+    # Końce linii CR-only (\r, stare Maki / niektóre eksporty kadrowe) — bez
+    # `newline=""` w StringIO `csv.reader` rzuca `_csv.Error: new-line character
+    # seen in unquoted field` i wywala CAŁĄ analizę surowym tracebackiem. Musi
+    # sparsować się poprawnie (a nie-CSV śmieć degradować do domenowego wyjątku).
+    tresc = f"{_CSV_NAGLOWEK}\r" "1;Kowalski;Jan;;Asystent;Katedra Chorób\r"
+    path = _zapisz(tmp_path, tresc, encoding="utf-8")
+    src = CSVSource(path)
+    assert src.count() == 1
+    wiersz = list(src.data())[0]
+    assert wiersz["nazwisko"] == "Kowalski"
+    assert wiersz["nazwa_jednostki"] == "Katedra Chorób"
+
+
+def test_csvsource_stray_cr_w_polu(tmp_path):
+    # Zabłąkany \r w niecytowanym polu (mieszane końce linii po ręcznej edycji)
+    # — z `newline=""` csv.reader traktuje \r jako koniec rekordu (rozbija wiersz)
+    # ZAMIAST rzucać `_csv.Error`. Kluczowe: analiza NIE wywala się surowym
+    # tracebackiem; degradacja (rozbity rekord) jest akceptowalna wobec crasha.
+    tresc = f"{_CSV_NAGLOWEK}\n" "1;Kowal\rski;Jan;;Asystent;Katedra\n"
+    path = _zapisz(tmp_path, tresc, encoding="utf-8")
+    src = CSVSource(path)
+    # nie rzuca `_csv.Error` (przed fixem: crash całej analizy)
+    wiersze = list(src.data())
+    assert wiersze  # coś się sparsowało bez wyjątku

--- a/src/import_pracownikow/models.py
+++ b/src/import_pracownikow/models.py
@@ -442,21 +442,35 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
         self.save()
 
     def sformatowany_log_zmian(self):
+        # Renderuje WSZYSTKIE klucze audytu (#513 F1 / #508 M4). Faza integracji
+        # zapisuje obok `autor`/`autor_jednostka` także `utworzono` (m.in. „nowy
+        # autor: …"), `przepiecie` (raport przepięcia prac) i
+        # `przepiecie_pominiete` — bez ich renderu utworzenie autora i
+        # przepięcie dorobku były niewidoczne w jedynym widoku log_zmian po
+        # integracji. `.get()` bo starsze rekordy mogą nie mieć niektórych kluczy.
         if self.log_zmian is None:
             return
+        log = self.log_zmian
 
-        if self.log_zmian["autor"]:
-            yield "Zmiany obiektu Autor: " + ", ".join(
-                [elem for elem in self.log_zmian["autor"]]
+        if log.get("autor"):
+            yield "Zmiany obiektu Autor: " + ", ".join(log["autor"])
+
+        if log.get("autor_jednostka"):
+            yield "Zmiany obiektu Autor_Jednostka: " + ", ".join(log["autor_jednostka"])
+
+        if log.get("utworzono"):
+            yield "Utworzono: " + ", ".join(log["utworzono"])
+
+        przepiecie = log.get("przepiecie")
+        if przepiecie:
+            yield (
+                f"Przepięto prace: {przepiecie.get('prace_ciagle', 0)} ciągłych, "
+                f"{przepiecie.get('prace_zwarte', 0)} zwartych "
+                f"z „{przepiecie.get('z', '?')}” do „{przepiecie.get('do', '?')}”."
             )
 
-        if self.log_zmian["autor_jednostka"]:
-            yield "Zmiany obiektu Autor_Jednostka: " + ", ".join(
-                [elem for elem in self.log_zmian["autor_jednostka"]]
-            )
-
-        if not self.log_zmian:
-            return "bez zmian!"
+        if log.get("przepiecie_pominiete"):
+            yield "Przepięcie pominięte: " + log["przepiecie_pominiete"]
 
 
 class ProfilMapowania(models.Model):

--- a/src/import_pracownikow/parsers/osoba.py
+++ b/src/import_pracownikow/parsers/osoba.py
@@ -52,17 +52,23 @@ def _zdejmij_tytuly(tokeny: list[str], tytuly: set[str]):
     start = 0
     koniec = len(tokeny)
     fragmenty: list[str] = []
+    # Guard #512 F1: nie zdejmuj dopasowania tytułu, jeśli zostałoby < 2 tokenów
+    # nazwy. Jednowyrazowe nazwy tytułów z bazy (`doktor`, `lekarz`, `magister`,
+    # `profesor`) KOLIDUJĄ z realnymi polskimi nazwiskami — bez tego guardu
+    # „Anna Doktor"/„Jan Lekarz" (poprawna para imię+nazwisko) traci część jako
+    # „tytuł", zostaje 1 token → puste imię → `XLSParseError` wywala CAŁY plik.
+    # Preferujemy interpretację „to nazwisko/imię" (rozstrzygną sygnały 1-5).
     while start < koniec:
         lower = [t.lower() for t in tokeny[start:koniec]]
         d = _dopasuj_od_przodu(lower, tytuly)
-        if d == 0:
+        if d == 0 or (koniec - (start + d)) < 2:
             break
         fragmenty.append(" ".join(tokeny[start : start + d]))
         start += d
     while koniec > start:
         lower = [t.lower() for t in tokeny[start:koniec]]
         d = _dopasuj_od_tylu(lower, tytuly)
-        if d == 0:
+        if d == 0 or ((koniec - d) - start) < 2:
             break
         fragmenty.append(" ".join(tokeny[koniec - d : koniec]))
         koniec -= d

--- a/src/import_pracownikow/pipeline/analyze.py
+++ b/src/import_pracownikow/pipeline/analyze.py
@@ -164,6 +164,24 @@ def _dopasuj_autora_i_status(data, jednostka, tytul_str):
     return autor, status, kandydaci
 
 
+def _wybierz_autor_jednostka(autor, jednostka):
+    """Wybiera ``Autor_Jednostka`` (autor, jednostka) do aktualizacji w commicie.
+
+    Multi-etat / historia zatrudnienia: autor może mieć >1 AJ w TEJ SAMEJ
+    jednostce (``unique_together`` to ``(autor, jednostka, rozpoczal_prace)``).
+    Ten AJ jest w commicie aktualizowany (daty/funkcja/etat/podstawowe), więc
+    ``.first()`` bez porządku (losowy wybór) mógł trafić w HISTORYCZNY rekord i
+    nadpisać zamknięte zatrudnienie — korupcja (#508 F6). Deterministycznie
+    preferujemy AKTYWNY etat (bez ``zakonczyl_prace``), najnowszy startem; w
+    ostateczności najnowszy AJ. Zwraca ``None``, gdy autor nie ma AJ w jednostce.
+    """
+    aj_qs = Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka)
+    return (
+        aj_qs.filter(zakonczyl_prace__isnull=True).order_by("-rozpoczal_prace").first()
+        or aj_qs.order_by("-rozpoczal_prace").first()
+    )
+
+
 def _przetworz_wiersz(parent, elem, parser_ctx=None):
     dane_form = normalizuj_wartosci_wiersza(elem)
     rozbicie = _rozbij_osoba_sklejona(dane_form, parser_ctx)
@@ -220,7 +238,7 @@ def _przetworz_wiersz(parent, elem, parser_ctx=None):
     # (autor None) nie ma jak policzyć AJ — pomijamy.
     aj = None
     if autor is not None:
-        aj = Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka).first()
+        aj = _wybierz_autor_jednostka(autor, jednostka)
         if aj is None:
             diff["autor_jednostka"] = {"autor": autor.pk, "jednostka": jednostka.pk}
 

--- a/src/import_pracownikow/pipeline/integrate.py
+++ b/src/import_pracownikow/pipeline/integrate.py
@@ -107,6 +107,16 @@ def _opisz_utworzone(diff):
 
 
 def _integruj_wiersz(row):
+    # Idempotencja (#508 F2): faza integracji może ruszyć drugi raz na tym
+    # samym parencie (restart liveops / podwójne „Zatwierdź" — stan
+    # zatwierdzony/zintegrowany NIE kasuje wierszy podglądu), a `integruj`
+    # nie zeruje `zmiany_potrzebne`, więc wiersz wraca do worklisty. `log_zmian`
+    # ustawia WYŁĄCZNIE integracja (analiza zostawia None) — więc jest pewnym
+    # markerem „już zintegrowany". Bez tego guardu drugi przebieg albo nadpisuje
+    # audyt `log_zmian` (gałąź materializacji), albo fałszywie oznacza wiersz
+    # `pominiety_bo_nieaktualny` (świeży recheck nie widzi już driftu).
+    if row.log_zmian is not None:
+        return
     with transaction.atomic():
         # Sprawdzone PRZED materializacją — po niej `diff_do_utworzenia`
         # nadal jest niepuste (nic go nie czyści), więc to jest jedyny

--- a/src/import_pracownikow/tests/test_auth_gate.py
+++ b/src/import_pracownikow/tests/test_auth_gate.py
@@ -1,0 +1,63 @@
+"""#508 F4: destrukcyjne wyzwalacze fazy integracji (Zatwierdź / Restart
+analizy) muszą być za bramką grupy „wprowadzanie danych", nie za samym
+``login_required``.
+
+``ZatwierdzImportView``/``RestartAnalizaView`` dziedziczą po liveops
+``RestartView`` (``BaseLiveOperationMixin``), którego bramka grupy zależy od
+ustawienia ``LIVEOPS["REQUIRED_GROUP"]`` — a to w BPP jest NIEUSTAWIONE
+(``get_setting`` zwraca ``None`` → gałąź gatingu to no-op). Reszta widoków
+importu gejtuje się przez braces ``GroupRequiredMixin`` (konwencja projektu,
+np. ``import_punktacji_zrodel``); te dwa widoki jej nie miały, więc dowolny
+zalogowany user mógł odpalić integrację / restart cudzego-schematu importu.
+"""
+
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+from import_pracownikow.models import ImportPracownikow
+
+
+@pytest.mark.django_db
+def test_zatwierdz_bez_grupy_nie_zmienia_stanu(client, django_user_model):
+    u = django_user_model.objects.create_user(username="plain", password="pass")
+    client.force_login(u)
+    imp = baker.make(
+        ImportPracownikow, owner=u, stan=ImportPracownikow.STAN_PRZEANALIZOWANY
+    )
+    url = reverse("import_pracownikow:zatwierdz", kwargs={"pk": imp.pk})
+    client.post(url)
+    imp.refresh_from_db()
+    # Bramka zablokowała POST — stan NIE ruszył na „zatwierdzony"/„zintegrowany".
+    assert imp.stan == ImportPracownikow.STAN_PRZEANALIZOWANY
+
+
+@pytest.mark.django_db
+def test_restart_analiza_bez_grupy_nie_zmienia_stanu(client, django_user_model):
+    u = django_user_model.objects.create_user(username="plain2", password="pass")
+    client.force_login(u)
+    imp = baker.make(
+        ImportPracownikow, owner=u, stan=ImportPracownikow.STAN_PRZEANALIZOWANY
+    )
+    url = reverse("import_pracownikow:restart-analiza", kwargs={"pk": imp.pk})
+    client.post(url)
+    imp.refresh_from_db()
+    assert imp.stan == ImportPracownikow.STAN_PRZEANALIZOWANY
+
+
+@pytest.mark.django_db
+def test_zatwierdz_z_grupa_przechodzi(client, django_user_model):
+    u = django_user_model.objects.create_user(username="entry", password="pass")
+    grupa, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    u.groups.add(grupa)
+    client.force_login(u)
+    imp = baker.make(
+        ImportPracownikow, owner=u, stan=ImportPracownikow.STAN_PRZEANALIZOWANY
+    )
+    url = reverse("import_pracownikow:zatwierdz", kwargs={"pk": imp.pk})
+    client.post(url)
+    imp.refresh_from_db()
+    # Członek grupy przechodzi bramkę — POST wykonał się (stan ruszył dalej).
+    assert imp.stan != ImportPracownikow.STAN_PRZEANALIZOWANY

--- a/src/import_pracownikow/tests/test_parsers/test_osoba.py
+++ b/src/import_pracownikow/tests/test_parsers/test_osoba.py
@@ -146,6 +146,32 @@ PRZYPADKI = [
         "Kowalski",
         CONF_LOW,
     ),
+    (
+        # #512 F1: jednowyrazowa nazwa tytułu z bazy (doktor/lekarz/magister)
+        # KOLIDUJE z realnym nazwiskiem. „Anna Doktor" to poprawna para
+        # imię+nazwisko — NIE wolno zdjąć „Doktor" jako tytułu (zostałby
+        # 1 token → puste imię → XLSParseError wywala CAŁY plik). Guard <2
+        # zostawia obie części; leksykon imion daje imiona="Anna".
+        "Anna Doktor",
+        {"doktor"},
+        {"anna"},
+        _bez,
+        None,
+        "Anna",
+        "Doktor",
+        CONF_MEDIUM,
+    ),
+    (
+        # #512 F1: analogicznie „Jan Lekarz".
+        "Jan Lekarz",
+        {"lekarz"},
+        {"jan"},
+        _bez,
+        None,
+        "Jan",
+        "Lekarz",
+        CONF_MEDIUM,
+    ),
 ]
 
 

--- a/src/import_pracownikow/tests/test_pipeline/test_integrate_idempotencja.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_integrate_idempotencja.py
@@ -1,0 +1,114 @@
+"""#508 F2: dwukrotny commit (restart / podwójne „Zatwierdź") musi być
+idempotentny.
+
+``integrate.integruj`` nie zeruje ``zmiany_potrzebne`` ani ``diff_do_utworzenia``
+po integracji wiersza, a ``ZatwierdzImportView`` / ``RestartView`` pozwalają
+uruchomić fazę integracji ponownie na tym samym parencie (stan zatwierdzony/
+zintegrowany NIE kasuje wierszy podglądu). Bez guardu drugi przebieg:
+
+  * dla wiersza czysto aktualizującego (drift zaaplikowany w 1. przebiegu) —
+    świeży ``check_if_integration_needed()`` zwraca już False → wiersz jest
+    fałszywie oznaczany ``pominiety_bo_nieaktualny`` i licznik ``zintegrowano``
+    maleje;
+  * dla wiersza materializującego create'y — wpada w gałąź „materializowano"
+    i NADPISUJE ``log_zmian`` (realny audyt zmian Autor_Jednostka ginie).
+
+Guard: ``_integruj_wiersz`` pomija wiersz już zintegrowany (``log_zmian is not
+None``) — ``log_zmian`` ustawia wyłącznie integracja, analiza zostawia je None.
+"""
+
+import pytest
+from liveops.testing import MockProgress
+from model_bakery import baker
+
+from bpp.models import Autor_Jednostka, Funkcja_Autora
+from import_pracownikow.models import ImportPracownikow, ImportPracownikowRow
+from import_pracownikow.pipeline.integrate import integruj
+
+
+def _ponow_commit(imp):
+    """Symuluje restart fazy integracji: stan wraca na ZATWIERDZONY (jak po
+    ``ZatwierdzImportView``/``RestartView``), wiersze podglądu NIE są kasowane."""
+    imp.stan = ImportPracownikow.STAN_ZATWIERDZONY
+    imp.save(update_fields=["stan"])
+
+
+@pytest.mark.django_db
+def test_dwukrotny_commit_nie_falszuje_pominiety_bo_nieaktualny(
+    autor_jednostka_fixture,
+):
+    # Wiersz czysto aktualizujący: AJ istnieje z funkcja=None, wiersz ustawia
+    # funkcja_autora=asystent (istniejący FK → diff pusty, materializowano=False).
+    autor, jednostka = autor_jednostka_fixture
+    funkcja = Funkcja_Autora.objects.get(nazwa="asystent")
+    aj = baker.make(Autor_Jednostka, autor=autor, jednostka=jednostka, funkcja=None)
+    imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
+    row = ImportPracownikowRow.objects.create(
+        parent=imp,
+        autor=autor,
+        jednostka=jednostka,
+        autor_jednostka=aj,
+        funkcja_autora=funkcja,
+        grupa_pracownicza=None,
+        wymiar_etatu=None,
+        tytul=None,
+        dane_znormalizowane={"stanowisko": "Asystent"},
+        diff_do_utworzenia={},
+        zmiany_potrzebne=True,
+    )
+
+    integruj(imp, MockProgress(imp))
+    row.refresh_from_db()
+    aj.refresh_from_db()
+    assert aj.funkcja == funkcja
+    assert row.pominiety_bo_nieaktualny is False
+    log_po_pierwszym = row.log_zmian
+    assert log_po_pierwszym is not None
+    assert any("funkcja" in x for x in log_po_pierwszym["autor_jednostka"])
+
+    # Drugi commit (restart) — NIE wolno fałszywie oznaczyć wiersza jako
+    # nieaktualnego ani ruszyć audytu; licznik zintegrowano ma być stabilny.
+    _ponow_commit(imp)
+    p2 = MockProgress(imp)
+    integruj(imp, p2)
+    row.refresh_from_db()
+    assert row.pominiety_bo_nieaktualny is False
+    assert row.log_zmian == log_po_pierwszym
+    assert p2.result_context["zintegrowano"] == 1
+    assert p2.result_context["pominieto_nieaktualne"] == 0
+
+
+@pytest.mark.django_db
+def test_dwukrotny_commit_nie_nadpisuje_log_zmian_audytu(autor_jednostka_fixture):
+    # Wiersz z prawdziwym driftem AJ (funkcja=None → asystent), materializowany
+    # z istniejącego FK: 1. przebieg zapisuje realny ślad w log_zmian.
+    autor, jednostka = autor_jednostka_fixture
+    funkcja = Funkcja_Autora.objects.get(nazwa="asystent")
+    aj = baker.make(Autor_Jednostka, autor=autor, jednostka=jednostka, funkcja=None)
+    imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
+    row = ImportPracownikowRow.objects.create(
+        parent=imp,
+        autor=autor,
+        jednostka=jednostka,
+        autor_jednostka=aj,
+        funkcja_autora=funkcja,
+        grupa_pracownicza=None,
+        wymiar_etatu=None,
+        tytul=None,
+        dane_znormalizowane={"stanowisko": "Asystent"},
+        diff_do_utworzenia={"funkcja_autora": "asystent"},
+        zmiany_potrzebne=True,
+    )
+
+    integruj(imp, MockProgress(imp))
+    row.refresh_from_db()
+    log_po_pierwszym = row.log_zmian
+    assert log_po_pierwszym is not None
+    assert any("funkcja" in x for x in log_po_pierwszym["autor_jednostka"])
+
+    # Drugi commit — realny audyt zmian Autor_Jednostka NIE może zostać
+    # wymazany przez ponowne wejście w gałąź „materializowano".
+    _ponow_commit(imp)
+    integruj(imp, MockProgress(imp))
+    row.refresh_from_db()
+    assert row.log_zmian == log_po_pierwszym

--- a/src/import_pracownikow/tests/test_pipeline/test_integrate_przepiecie_snapshot.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_integrate_przepiecie_snapshot.py
@@ -1,0 +1,95 @@
+"""#514 F-2: niezmiennik przepięcia — snapshot ``stare_jednostki`` MUSI złapać
+starą ``aktualna_jednostka`` PRZED tym, jak pętla integracji odpali trigger DB
+``bpp_autor_ustaw_jednostka_aktualna`` (który przestawia ją na jednostkę z
+pliku).
+
+Wszystkie pozostałe testy przepięć używają ``zmiany_potrzebne=False`` — pętla
+integracji ich NIE dotyka, więc trigger nigdy się nie odpala i snapshot ma
+trywialnie tę samą wartość co stan bieżący. Ten test celowo integruje wiersz z
+prawdziwym driftem (ustawienie ``podstawowe_miejsce_pracy`` na AJ w NOWEJ
+jednostce), przez co trigger FAKTYCZNIE przestawia ``aktualna_jednostka`` na
+nową jednostkę w trakcie pętli — i sprawdza, że przepięcie i tak użyło STAREJ
+jednostki jako ``jednostka_z``. Gdyby snapshot był brany PO pętli, ``jednostka_z``
+== ``jednostka_do`` (F5) → brak przepięcia.
+"""
+
+import pytest
+from liveops.testing import MockProgress
+from model_bakery import baker
+
+from bpp.models import (
+    Autor,
+    Autor_Jednostka,
+    Jednostka,
+    Wydawnictwo_Ciagle,
+    Wydawnictwo_Ciagle_Autor,
+)
+from import_pracownikow.models import ImportPracownikow, ImportPracownikowRow
+from import_pracownikow.pipeline.integrate import integruj
+from przemapuj_prace_autora.models import PrzemapoaniePracAutora
+
+
+@pytest.mark.django_db
+def test_snapshot_lapie_stara_jednostke_przed_triggerem(admin_user):
+    stara = baker.make(Jednostka, nazwa="Stara", skrot="ST")
+    nowa = baker.make(Jednostka, nazwa="Nowa", skrot="NW")
+    autor = baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
+    # AJ w starej = podstawowe → aktualna_jednostka = stara (trigger: podstawowe
+    # bije wszystko). AJ w nowej istnieje, ale NIE podstawowe.
+    baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=stara,
+        podstawowe_miejsce_pracy=True,
+    )
+    aj_nowa = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=nowa,
+        podstawowe_miejsce_pracy=False,
+    )
+    autor.refresh_from_db()
+    assert autor.aktualna_jednostka_id == stara.pk
+
+    # praca w starej jednostce — kandydat do przepięcia stara → nowa
+    wc = baker.make(Wydawnictwo_Ciagle, tytul_oryginalny="Art", rok=2023)
+    pa = baker.make(Wydawnictwo_Ciagle_Autor, rekord=wc, autor=autor, jednostka=stara)
+
+    imp = baker.make(
+        ImportPracownikow, owner=admin_user, stan=ImportPracownikow.STAN_ZATWIERDZONY
+    )
+    # Wiersz REALNIE integrujący: ustawia podstawowe na AJ w nowej jednostce →
+    # integrate() → ustaw_podstawowe_miejsce_pracy() → trigger przestawia
+    # aktualna_jednostka autora na NOWĄ w trakcie pętli integracji.
+    row = ImportPracownikowRow.objects.create(
+        parent=imp,
+        autor=autor,
+        jednostka=nowa,
+        autor_jednostka=aj_nowa,
+        dane_znormalizowane={},
+        diff_do_utworzenia={},
+        podstawowe_miejsce_pracy=True,
+        zmiany_potrzebne=True,
+        przepnij_prace=True,
+    )
+
+    p = MockProgress(imp)
+    integruj(imp, p)
+
+    # Trigger FAKTYCZNIE się odpalił w pętli — aktualna przestawiona na nową.
+    autor.refresh_from_db()
+    assert autor.aktualna_jednostka_id == nowa.pk
+
+    # Sedno niezmiennika: mimo że aktualna to teraz NOWA, przepięcie użyło
+    # STAREJ jako jednostka_z (snapshot sprzed pętli). Gdyby snapshot był po
+    # pętli, jednostka_z == nowa == jednostka_do → F5 pominięcie, brak rekordu.
+    prz = PrzemapoaniePracAutora.objects.get(autor=autor)
+    assert prz.jednostka_z_id == stara.pk
+    assert prz.jednostka_do_id == nowa.pk
+    pa.refresh_from_db()
+    assert pa.jednostka_id == nowa.pk
+    assert p.result_context["przepieto_wierszy"] == 1
+    assert p.result_context["przepieto_prac"] == 1
+
+    row.refresh_from_db()
+    assert row.log_zmian["przepiecie"]["pk"] == prz.pk

--- a/src/import_pracownikow/tests/test_pipeline/test_wybor_autor_jednostka.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_wybor_autor_jednostka.py
@@ -1,0 +1,64 @@
+"""#508 F6: deterministyczny wybór Autor_Jednostka przy multi-etacie."""
+
+from datetime import date
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Autor, Autor_Jednostka, Jednostka
+from import_pracownikow.pipeline.analyze import _wybierz_autor_jednostka
+
+
+@pytest.mark.django_db
+def test_wybiera_aktywny_etat_nie_historyczny():
+    # Autor z DWOMA AJ w TEJ SAMEJ jednostce: historyczny (zamknięty) i aktywny.
+    # `.first()` bez porządku wybierał losowo — a ten AJ commit aktualizuje, więc
+    # trafienie w historyczny nadpisywało zamknięte zatrudnienie. Musi wybrać
+    # AKTYWNY.
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+    historyczny = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2015, 12, 31),
+    )
+    aktywny = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2020, 1, 1),
+        zakonczyl_prace=None,
+    )
+    wybrany = _wybierz_autor_jednostka(autor, jednostka)
+    assert wybrany == aktywny
+    assert wybrany != historyczny
+
+
+@pytest.mark.django_db
+def test_bez_aktywnego_wybiera_najnowszy_startem():
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+    baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2005, 1, 1),
+        zakonczyl_prace=date(2008, 1, 1),
+    )
+    nowszy = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2012, 1, 1),
+        zakonczyl_prace=date(2015, 1, 1),
+    )
+    assert _wybierz_autor_jednostka(autor, jednostka) == nowszy
+
+
+@pytest.mark.django_db
+def test_brak_aj_zwraca_none():
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+    assert _wybierz_autor_jednostka(autor, jednostka) is None

--- a/src/import_pracownikow/tests/test_sformatowany_log_zmian.py
+++ b/src/import_pracownikow/tests/test_sformatowany_log_zmian.py
@@ -1,0 +1,90 @@
+"""#513 F1 / #508 M4: ``sformatowany_log_zmian`` musi renderować WSZYSTKIE
+klucze audytu, nie tylko ``autor``/``autor_jednostka``.
+
+Faza integracji zapisuje też ``utworzono`` (m.in. „nowy autor: …"),
+``przepiecie`` (raport przepięcia prac) i ``przepiecie_pominiete``. Bez ich
+renderu utworzenie nowego autora i przepięcie dorobku były NIEWIDOCZNE w
+audycie UI (jedyny widok log_zmian po integracji — partial _wiersz_preview).
+"""
+
+from import_pracownikow.models import ImportPracownikowRow
+
+
+def _linie(log_zmian):
+    return list(ImportPracownikowRow(log_zmian=log_zmian).sformatowany_log_zmian())
+
+
+def test_log_none_nic_nie_zwraca():
+    assert _linie(None) == []
+
+
+def test_renderuje_zmiany_autor_i_autor_jednostka():
+    linie = _linie(
+        {"autor": ["nazwisko -> Kowalski"], "autor_jednostka": ["funkcja na asystent"]}
+    )
+    assert any("Kowalski" in x for x in linie)
+    assert any("asystent" in x for x in linie)
+
+
+def test_renderuje_utworzono_nowego_autora():
+    # #513 F1: nowy autor był niewidoczny w audycie.
+    linie = _linie(
+        {
+            "autor": [],
+            "autor_jednostka": [],
+            "utworzono": ["nowy autor: Jan Kowalski", "powiązanie autor-jednostka"],
+        }
+    )
+    tekst = " ".join(linie)
+    assert "nowy autor: Jan Kowalski" in tekst
+    assert "powiązanie autor-jednostka" in tekst
+
+
+def test_renderuje_przepiecie():
+    linie = _linie(
+        {
+            "autor": [],
+            "autor_jednostka": [],
+            "przepiecie": {
+                "pk": 7,
+                "prace_ciagle": 3,
+                "prace_zwarte": 2,
+                "z": "ST",
+                "do": "NW",
+            },
+        }
+    )
+    tekst = " ".join(linie)
+    assert "3" in tekst and "2" in tekst
+    assert "ST" in tekst and "NW" in tekst
+
+
+def test_renderuje_przepiecie_pominiete():
+    linie = _linie(
+        {
+            "autor": [],
+            "autor_jednostka": [],
+            "przepiecie_pominiete": "pominięto — już przepięte w innym wierszu",
+        }
+    )
+    assert any("już przepięte" in x for x in linie)
+
+
+def test_wszystkie_klucze_naraz():
+    linie = _linie(
+        {
+            "autor": ["tytuł naukowy -> dr"],
+            "autor_jednostka": ["wymiar_etatu na pełny etat"],
+            "utworzono": ["nowy autor: Anna Nowak"],
+            "przepiecie": {
+                "pk": 1,
+                "prace_ciagle": 1,
+                "prace_zwarte": 0,
+                "z": "AA",
+                "do": "BB",
+            },
+        }
+    )
+    tekst = " ".join(linie)
+    for oczekiwane in ("dr", "pełny etat", "Anna Nowak", "AA", "BB"):
+        assert oczekiwane in tekst

--- a/src/import_pracownikow/views.py
+++ b/src/import_pracownikow/views.py
@@ -615,12 +615,20 @@ class ImportPracownikowResultsView(GroupRequiredMixin, ListView):
         return ctx
 
 
-class _PkOwnerRestartMixin(RestartView):
+class _PkOwnerRestartMixin(GroupRequiredMixin, RestartView):
     """Wspólny ``get_object`` dla widoków restartu — URL ma tylko ``pk``
     (bez ``op_type``), więc nadpisujemy ``OpTypeObjectMixin.get_object``
-    i rozwiązujemy konkretny model wprost, owner-scoped."""
+    i rozwiązujemy konkretny model wprost, owner-scoped.
+
+    Bramka grupy (#508 F4): liveops ``BaseLiveOperationMixin`` gejtuje tylko
+    gdy ``LIVEOPS["REQUIRED_GROUP"]`` jest ustawione — w BPP NIE jest, więc
+    tamta bramka to no-op. Dokładamy braces ``GroupRequiredMixin`` (konwencja
+    projektu, jak reszta widoków importu), inaczej dowolny zalogowany user
+    odpaliłby integrację / restart analizy (akcje destrukcyjne, skala importu).
+    """
 
     model = ImportPracownikow
+    group_required = GROUP_REQUIRED
 
     def get_object(self, queryset=None):
         return get_object_or_404(

--- a/src/przemapuj_prace_autora/test_auth_gate.py
+++ b/src/przemapuj_prace_autora/test_auth_gate.py
@@ -1,0 +1,68 @@
+"""#514 F-1: przemapowanie/cofanie prac autora między jednostkami to akcje
+w skali całego dorobku autora — muszą być za bramką grupy „wprowadzanie
+danych", nie za samym ``login_required`` (dowolny zalogowany user).
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import Client
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+from bpp.models import Autor, Jednostka
+from przemapuj_prace_autora.models import PrzemapoaniePracAutora
+
+User = get_user_model()
+
+
+def _przemapowanie():
+    return PrzemapoaniePracAutora.objects.create(
+        autor=baker.make(Autor),
+        jednostka_z=baker.make(Jednostka),
+        jednostka_do=baker.make(Jednostka),
+    )
+
+
+def _klient(username, *, grupa=False):
+    u = User.objects.create_user(username=username, password="pass")
+    if grupa:
+        g, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+        u.groups.add(g)
+    c = Client()
+    c.login(username=username, password="pass")
+    return c
+
+
+@pytest.mark.django_db
+def test_cofnij_bez_grupy_403():
+    prz = _przemapowanie()
+    url = reverse("przemapuj_prace_autora:cofnij_przemapowanie", kwargs={"pk": prz.pk})
+    resp = _klient("plain").post(url)
+    # 403 z braces (zalogowany, zła grupa) — bramka odcięła PRZED service.cofnij.
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_cofnij_z_grupa_przechodzi():
+    prz = _przemapowanie()
+    url = reverse("przemapuj_prace_autora:cofnij_przemapowanie", kwargs={"pk": prz.pk})
+    resp = _klient("entry", grupa=True).post(url)
+    # członek grupy przechodzi bramkę: cofnij wykonuje się i redirectuje (302).
+    assert resp.status_code == 302
+
+
+@pytest.mark.django_db
+def test_przemapuj_prace_bez_grupy_403():
+    autor = baker.make(Autor)
+    url = reverse(
+        "przemapuj_prace_autora:przemapuj_prace", kwargs={"autor_id": autor.pk}
+    )
+    assert _klient("plain2").get(url).status_code == 403
+
+
+@pytest.mark.django_db
+def test_wybierz_autora_bez_grupy_403():
+    url = reverse("przemapuj_prace_autora:wybierz_autora")
+    assert _klient("plain3").get(url).status_code == 403

--- a/src/przemapuj_prace_autora/views.py
+++ b/src/przemapuj_prace_autora/views.py
@@ -1,12 +1,15 @@
 import sys
+from functools import wraps
 
 import rollbar
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
+from django.core.exceptions import PermissionDenied
 from django.db.models import Count, Q
 from django.http import HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404, redirect, render
 
+from bpp.const import GR_WPROWADZANIE_DANYCH
 from bpp.models import Autor, Wydawnictwo_Ciagle_Autor, Wydawnictwo_Zwarte_Autor
 
 from . import service
@@ -14,7 +17,32 @@ from .forms import PrzemapoaniePracAutoraForm
 from .models import PrzemapoaniePracAutora
 
 
-@login_required
+def wymaga_grupy_wprowadzanie(view):
+    """Bramka grupy „wprowadzanie danych" dla widoków funkcyjnych (#514 F-1).
+
+    Semantyka jak braces ``GroupRequiredMixin`` (konwencja projektu): anonim →
+    redirect na login; zalogowany bez grupy → 403 (``PermissionDenied``);
+    superuser lub członek grupy → przechodzi. Przemapowanie/cofanie przenosi
+    cały dorobek autora między jednostkami, więc sam ``login_required`` to za
+    słaba bramka dla tych akcji.
+    """
+
+    @wraps(view)
+    def _opakowany(request, *args, **kwargs):
+        user = request.user
+        if not user.is_authenticated:
+            return redirect_to_login(request.get_full_path())
+        if not (
+            user.is_superuser
+            or user.groups.filter(name=GR_WPROWADZANIE_DANYCH).exists()
+        ):
+            raise PermissionDenied
+        return view(request, *args, **kwargs)
+
+    return _opakowany
+
+
+@wymaga_grupy_wprowadzanie
 def wybierz_autora(request):
     """Widok do wyszukiwania i wyboru autora do przemapowania prac"""
     autorzy = None
@@ -147,7 +175,7 @@ def _render_preview(request, autor, form, jednostki_stats):
     return render(request, "przemapuj_prace_autora/przemapuj_prace.html", context)
 
 
-@login_required
+@wymaga_grupy_wprowadzanie
 def przemapuj_prace(request, autor_id):
     """Główny widok do przemapowania prac autora między jednostkami"""
     autor = get_object_or_404(Autor, pk=autor_id)
@@ -180,7 +208,7 @@ def przemapuj_prace(request, autor_id):
     return render(request, "przemapuj_prace_autora/przemapuj_prace.html", context)
 
 
-@login_required
+@wymaga_grupy_wprowadzanie
 def cofnij_przemapowanie(request, pk):
     """POST: cofnij przemapowanie (``service.cofnij``) i pokaż raport
     (cofnięto N, pominięto M z powodu późniejszych zmian). Redirect na widok


### PR DESCRIPTION
Poprawki z self-review całego stacka „import pracowników" (Fazy 0–5, PR-y
#508/#509/#510/#512/#513/#514), zrobione w kolejności od najistotniejszej.
PR-ka stackowana **nad Fazą 5** (`feat-import-pracownikow-faza-5-przepiecie`) —
merge jako całość razem ze stackiem.

Każda poprawka: TDD (RED → fix → GREEN), test dołączony.

## Ważne (correctness / bezpieczeństwo)

1. **#508 F6 — deterministyczny wybór Autor_Jednostka przy multi-etacie**
   (`d7a9dcd1b`). Analiza wybierała AJ do aktualizacji przez `.first()` bez
   porządku — autor z >1 etatem w tej samej jednostce mógł trafić w rekord
   HISTORYCZNY i nadpisać zamknięte zatrudnienie. Helper `_wybierz_autor_jednostka`
   preferuje aktywny etat, najnowszy startem.

2. **#508 F2 — idempotentny commit integracji** (`8d4b5d922`). Restart liveops /
   podwójne „Zatwierdź" uruchamiały integrację drugi raz na tych samych wierszach
   (stan zatwierdzony/zintegrowany nie kasuje podglądu, a `integruj` nie zeruje
   `zmiany_potrzebne`). Drugi przebieg albo NADPISYWAŁ audyt `log_zmian`, albo
   fałszywie oznaczał wiersz `pominiety_bo_nieaktualny` (psując licznik
   `zintegrowano`). Guard: pomiń wiersz już zintegrowany (`log_zmian is not None`).

3. **#514 F-1 / #508 F4 — bramka grupy na akcje destrukcyjne** (`0e0d04b06`).
   Dwie luki autoryzacji za samym `login_required`:
   - `przemapuj_prace_autora` (przemapuj/cofnij prace autora) — dekorator
     `wymaga_grupy_wprowadzanie` (semantyka jak braces `GroupRequiredMixin`).
   - `ZatwierdzImportView`/`RestartAnalizaView` — liveops `BaseLiveOperationMixin`
     gejtuje tylko gdy `LIVEOPS["REQUIRED_GROUP"]` jest ustawione, a w BPP NIE
     jest (no-op). Dodany braces `GroupRequiredMixin` (konwencja projektu).

4. **#514 F-2 — niezmiennik snapshotu przepięcia** (`51564ec21`, test-only).
   Wszystkie testy przepięć miały `zmiany_potrzebne=False`, więc trigger DB
   nigdy się nie odpalał i snapshot `stare_jednostki` był bez pokrycia. Nowy test
   integruje wiersz z realnym driftem (trigger przestawia `aktualna_jednostka` w
   trakcie pętli) i sprawdza, że przepięcie użyło STAREJ jednostki jako
   `jednostka_z`. Zweryfikowany mutacją (snapshot po pętli → test RED).

5. **#513 F1 / #508 M4 — pełny audyt w `sformatowany_log_zmian`** (`4c2f35e52`).
   Renderowane były tylko klucze `autor`/`autor_jednostka`; `utworzono` (nowy
   autor!), `przepiecie` i `przepiecie_pominiete` były NIEWIDOCZNE w audycie UI.

6. **#512 F1 — parser nie zdejmuje tytułu gdy zostałby <2 tokeny** (`09de64722`).
   Jednowyrazowe nazwy tytułów z bazy (`doktor`/`lekarz`/…) kolidują z realnymi
   nazwiskami — „Anna Doktor" traciło część jako „tytuł", zostawał 1 token → puste
   imię → `XLSParseError` wywalał CAŁY plik. Guard `<2` zostawia obie części.

7. **#509 F1 — CSV `newline=""`** (`867b1fb5a`). `csv.reader` nad `StringIO` bez
   `newline=""` rzucał `_csv.Error` na końcach CR-only / zabłąkanym `\r`, wywalając
   analizę surowym tracebackiem. Teraz parsuje / degraduje łagodnie.

## Testy

498 passed w `src/import_common/`, `src/import_pracownikow/`,
`src/przemapuj_prace_autora/` (lokalnie, testcontainers). Każda poprawka z
własnym testem; #508 F6/F2, #512 F1, #509 F1 + gejty auth przez RED→GREEN,
#514 F-2 dodatkowo zweryfikowany mutacją.

## Uwaga o baseline

Brak nowych migracji — **baseline nie wymaga odświeżenia**. (Reguła stacka:
baseline odświeżamy raz, przy scalaniu.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
