### PR TITLE
feat(importer_publikacji): DSpace — wykrywanie listy (kolekcja/community/discover) → multi-import

### DIFF
--- a/docs/superpowers/handoffs/2026-07-10-importer-patenty-www-dspace-listy.md
+++ b/docs/superpowers/handoffs/2026-07-10-importer-patenty-www-dspace-listy.md
@@ -1,0 +1,233 @@
+# Handoff — importer publikacji: patenty + wykrywanie list (WWW/DSpace/PPM)
+
+**Data:** 2026-07-10
+**Autor kontekstu:** sesja po zbudowaniu `MultipleWorksImport` (PR #511)
+**Worktree:** `~/Programowanie/bpp-bibtex-import-wiele-prac`
+**Gałąź bazowa:** `feat-bibtex-import-wiele-prac` (PR #511 → `dev`, **jeszcze niezmergowany**)
+
+## 0. TL;DR — o co chodzi
+
+Trzy powiązane pomysły, wszystkie stoją na **tej samej dźwigni** zbudowanej w PR #511:
+
+> `FetchView.post` woła `provider.split_input(normalized)`; jeśli zwróci ≥2
+> `SplitRecord`, powstaje paczka `MultipleWorksImport` + N dzieci i multi-import
+> „dzieje się sam". Domyślne `split_input` zwraca 1 rekord; tylko `BibTeXProvider`
+> je nadpisuje. **Każdy provider, który nadpisze `split_input`, dostaje
+> multi-import za darmo.** `SplitRecord.raw` = wartość, którą *ten sam* provider
+> `fetch()` już umie rozwiązać.
+
+Trzy tracki, wg rosnącej trudności:
+
+| Track | Co | Trudność | Zależność od PR #511 |
+|---|---|---|---|
+| **A. DSpace-lista** | wklejasz URL kolekcji/browse DSpace → multi-import | **łatwe** | tak (split_input/batch) |
+| **B. Patenty w BibTeX** | wklejasz `@patent{...}` → tworzy `bpp.Patent` | **średnie/trudne** | nie (osobny wątek, ale ten sam moduł) |
+| **C. PPM-lista** | wklejasz URL `globalResultList.seam` → multi-import | **trudne / ryzyko** | tak |
+
+**Uwaga o zależności:** tracki A i C stoją na `split_input`+batch z PR #511.
+Dopóki #511 nie jest w `dev`, nową pracę rób **na gałęzi off
+`feat-bibtex-import-wiele-prac`** (albo poczekaj na merge). Track B (patenty)
+technicznie nie zależy od batcha, ale dotyka tych samych plików — najczyściej
+też off tej gałęzi lub po jej merge.
+
+**Wspólny wzorzec (precedens w kodzie):** `WWWProvider.fetch()` już sniffuje URL
+po kształcie i skacze do dedykowanej ścieżki (Omega-PSIR:
+`providers/www/omega_psir.py`, dispatch w `providers/www/provider.py:129-136`).
+To dokładnie kształt, jaki przyjmie „wykryj stronę-listę" — tyle że w
+`split_input`, nie `fetch`.
+
+---
+
+## Track A — DSpace: wykrycie listy → multi-import (NAJŁATWIEJSZE)
+
+### Stan dziś (fakty)
+- `providers/dspace.py` — klient **pojedynczego itemu** przez REST: DSpace 7
+  (`/items/{uuid}` → `/server/api/core/items/{uuid}`, `_fetch_dspace7`
+  `:155-202`) lub DSpace 6 (`/handle/{prefix}/{suffix}` →
+  `/rest/handle/{h}?expand=metadata`, `_fetch_dspace6` `:205-279`).
+- `validate_identifier` (`:313-320` → `_parse_dspace_url` `:136-152`)
+  **twardo odrzuca** URL-e nie-itemowe (kolekcja/browse/discover). To jest
+  bramka PRZED `split_input` (`views/wizard.py:177-187`), więc **musi być
+  poluzowana**, inaczej `split_input` się nie odpali.
+- Cel `dspace.piwet.pulawy.pl` = **DSpace 6 XMLUI** (server-rendered, nie SPA).
+  URL-e prac `/handle/123456789/N` **już działają dziś** w pojedynczym imporcie.
+- `split_input` nienadpisane (dziedziczy default 1-rekord).
+- **Latentny bug (osobny):** `_parse_handle_url` regex `r"/handle/(\d+/\d+)"`
+  (`:127`) nie odróżnia handle *itemu* od *kolekcji/community* — dziś
+  wrzucenie handle kolekcji do `fetch()` po cichu potraktuje ją jak item.
+
+### Co zrobić
+1. Poluzuj `validate_identifier`, żeby akceptował URL-e listowe
+   (kolekcja/community/browse/discover) — inaczej batch nigdy nie ruszy.
+2. Nadpisz `DSpaceProvider.split_input(url)`:
+   - jeśli URL to lista → uderz **REST** (`GET /rest/collections/{uuid}/items`
+     dla DSpace 6, albo `/server/api/discover/search/objects` dla 7), albo
+     **OAI-PMH** (`/oai/request?verb=ListRecords&set=...`) — DUŻO pewniejsze niż
+     scraping HTML (paginacja przez `offset`/`limit` lub `resumptionToken`),
+   - zwróć `SplitRecord(raw=<item_handle_or_uuid_url>)` per item.
+   - inaczej → `return [SplitRecord(raw=url)]` (dzisiejsze zachowanie).
+3. `fetch()` **bez zmian** — już rozwiązuje item-handle jeden po drugim.
+
+### Otwarte pytania
+- Czy `piwet` ma włączony OAI-PMH (`/oai/request`)? (standard w DSpace 6, ale
+  zweryfikować na żywo). Jeśli tak — najczystsza droga.
+- Jak user wskaże „którą kolekcję/zapytanie" — wkleja URL kolekcji? browse?
+  całe repo? Zdecydować zakres (kolekcja vs cały serwer).
+- Przy okazji naprawić latentny bug item-vs-collection handle.
+
+### Werdykt
+Najłatwiejszy z trzech. REST/OAI omija JS i kruchość scrapingu; `fetch()` gotowy.
+
+---
+
+## Track B — Patenty w BibTeX (`@patent` → `bpp.Patent`) (ŚREDNIE/TRUDNE)
+
+### Stan dziś (fakty) — patentów NIE da się zaimportować
+- `BIBTEX_TYPE_MAP` (`providers/bibtex.py:20-34`) **nie ma** klucza `patent`.
+  `@patent` to typ biblatexowy; standardowy BibTeX go nie ma (ludzie fudge’ują
+  `@misc`/`@techreport`). `bibtexparser` v2 parsuje dowolne `@xxx{}` generycznie,
+  więc `@patent{}` wchodzi jako zwykły `Entry` z `entry_type=="patent"`.
+- `fetch()` (`:117-181`): `publication_type = BIBTEX_TYPE_MAP.get("patent")` →
+  **`None`** (cicho, bez wyjątku). Dalej `_get_crossref_mapper(None)`
+  (`views/helpers.py:122-128`) zwraca `None` → brak auto-podpowiedzi. **Nic się
+  nie wywala** — operator ląduje na Verify z pustym `charakter_formalny`.
+- Ścieżka tworzenia = **twardy binarny switch** (`views/publikacja.py:266-269`)
+  na `session.jest_wydawnictwem_zwartym` → `Wydawnictwo_Ciagle`/`Zwarte`.
+  **Brak trzeciej gałęzi. `Patent` nigdzie nie jest importowany.**
+
+### Pułapka / bug (warto naprawić NIEZALEŻNIE od feature’a)
+- W Verify `charakter_formalny` jest filtrowany tylko `ukryty=False`
+  (`forms.py:98`), a wiersz **"Patent"** ma `publikacja=false`, `ukryty` default
+  `False` → **jest widoczny i wybieralny** (`fixtures/charakter_formalny.json`).
+- Model-level guard `ZapobiegajNiewlasciwymCharakterom.clean_fields()`
+  (`bpp/models/util.py:278-308`) blokuje `skrot in ["D","H","PAT"]` na
+  `Wydawnictwo_*` — ale odpala się tylko w `full_clean()` (admin ModelForm),
+  a importer woła `.objects.create()` → **guard omijany**. Efekt: operator może
+  dziś stworzyć zmieszany `Wydawnictwo_Ciagle/Zwarte` otagowany „Patent",
+  który potem **utknie** (edycja w adminie rzuci błąd „kliknij tutaj").
+- **Fix niezależny:** w `VerifyForm` wyklucz `skrot__in=["D","H","PAT"]` z
+  queryseta `charakter_formalny` dla ścieżki ciagle/zwarte (mirror guardu).
+
+### Model `Patent` (`bpp/models/patent.py`) — impedancja
+- `tytul_oryginalny` (pojedynczy tytuł, NIE `DwaTytuly`), `data_zgloszenia`,
+  `numer_zgloszenia`, `data_decyzji`, `numer_prawa_wylacznego`,
+  `rodzaj_prawa` (FK `Rodzaj_Prawa_Patentowego`), `wdrozenie` (bool),
+  `wydzial` (FK `Jednostka`, NIE „applicant/holder" — takiego pola brak).
+- **NIE ma `typ_kbn`** (brak `ModelTypowany`) i **`charakter_formalny` NIE jest
+  settable** (hardcoded `@cached_property` → `Charakter_Formalny(skrot="PAT")`,
+  `:127-129`; brak `ModelZCharakterem`).
+  → `_create_publication` buduje `common_fields` z `typ_kbn` i
+  `charakter_formalny` (`publikacja.py:237-254`); przekazanie ich do
+  `Patent.objects.create(**common_fields)` **rzuci TypeError**. Nowy
+  `_create_patent()` MUSI je odfiltrować.
+- **Autorzy: gotowe.** `Patent_Autor` dzieli `BazaModeluOdpowiedzialnosciAutorow`
+  z `Wydawnictwo_*_Autor`; `Patent.dodaj_autora()` (via `DodajAutoraMixin`,
+  `autor_rekordu_klass=Patent_Autor`) jest wołalne przez
+  `_add_authors_to_record()` (`publikacja.py:111-154`) **bez zmian**.
+- `ImportSession.created_record` to już `GenericForeignKey` — schema sesji jest
+  polimorficzna, trzeci typ modelu nie wymaga zmiany tego pola.
+
+### Luka mapowania pól (biblatex `@patent` → `Patent`)
+biblatex `@patent`: `number`(zgłoszenie), `holder`(uprawniony), `date`,
+`location`(kraj), `type`(patent/wzór). `fetch()` **nic z tego nie czyta**
+patentowo dziś (`number`→`issue`). BPP własny **eksport** patentu
+(`bpp/export/bibtex.py:279-311`) emituje `@misc` z polami wrzuconymi w
+free-text `note` („Numer zgłoszenia: X…") — więc nawet round-trip własnego
+eksportu jest **stratny**; nie ma w repo strukturalnej konwencji do importu.
+
+### Co zrobić
+- (a) `BIBTEX_TYPE_MAP += {"patent": ...}` + mechanizm routingu (uwaga:
+  „patent" nie jest typem CrossRef, a `Crossref_Mapper` jest CrossRef-flavored —
+  rozważyć osobny tor, nie wciskać w mapper).
+- (b) `FetchedPublication` + pola patentowe (`patent_number`, `patent_holder`,
+  `filing_date`, `grant_date`, `patent_type`/`jurisdiction`); `fetch()` czyta je
+  z biblatex gdy `bibtex_type=="patent"`.
+- (c) `_create_patent(session, common_fields, normalized_data)` w
+  `publikacja.py` — **odfiltruj `typ_kbn` i `charakter_formalny`**, wypełnij
+  `numer_zgloszenia`/`data_zgloszenia`/`numer_prawa_wylacznego`/`data_decyzji`/
+  `rodzaj_prawa`/`tytul_oryginalny`/`rok`. Dispatch (`:266-269`) potrzebuje
+  trzeciej gałęzi → `ImportSession` potrzebuje realnego pola „rodzaj rekordu"
+  (dziś tylko boolean `jest_wydawnictwem_zwartym`).
+- (d) Wizard: nowe pole typu na `ImportSession` + pola patentowe w `VerifyForm`
+  / warunkowe w `step_verify.html` (albo osobny pod-krok patentowy).
+- (e) Autorzy: bez zmian.
+
+### Werdykt
+Parsowanie łatwe; **cała praca to plumbing wizarda/tworzenia**: nowe pole typu
+na sesji, trzecia gałąź dispatchu, pola patentowe w formularzu/UI, `_create_patent`
+z odfiltrowaniem `typ_kbn`/`charakter_formalny`. Model `Patent` odstaje
+(brak typ_kbn/charakter, daty/numery, brak pola holder). Rozważyć: czy w ogóle
+mapować z biblatex `@patent`, czy raczej dać operatorowi pola ręcznie (bo źródeł
+BibTeX brak/stratne).
+
+---
+
+## Track C — PPM `globalResultList` → multi-import (NAJTRUDNIEJSZE / RYZYKO)
+
+### Stan dziś (fakty)
+- `providers/www/provider.py` — generyczny scraper meta-tagów (citation_*,
+  Schema.org JSON-LD, Dublin Core, OpenGraph) + jeden adapter site’owy
+  (Omega-PSIR). `input_mode=IDENTIFIER` (URL). `validate_identifier` akceptuje
+  **dowolny** poprawny URL (`network.py:31-51`) — więc URL listy przejdzie
+  walidację, ale `fetch()` zwróci 0/1 rekord (brak pojęcia „lista").
+- `https://ppm.umlub.pl/globalResultList.seam?...` = **JBoss Seam/JSF**. Pobrany
+  HTML dla tego URL pokazuje tylko zakładki z licznikami, **brak linków do
+  pojedynczych prac** — grid wyników renderowany prawdopodobnie AJAX-em
+  (JSF/RichFaces) na bazie server-side `javax.faces.ViewState`, którego
+  `requests.get` (bezstanowy, jak wszędzie w kodzie) **nie odtworzy**.
+- Brak PPM-owego kodu w repo; nieznany kształt URL-a strony-detalu.
+
+### Co zrobić / ryzyka
+- `split_input` musiałby albo (i) sparsować grid Seam — ale jest AJAX/ViewState,
+  `requests.get` nie wystarczy; albo (ii) znaleźć pod-endpoint JSON/REST grida
+  (nieodkryty — wymaga devtools na żywej sesji).
+- `fetch()` na stronie-detalu PPM **niezweryfikowany** (zadziała, jeśli detal ma
+  citation_*/DC/Schema.org — wtedy fallback WWW „po prostu działa").
+- **Zalecenie:** najpierw prototyp na żywej sesji przeglądarki (Chrome DevTools
+  MCP / Playwright) — znaleźć (a) kształt URL-a detalu, (b) czy grid ma
+  underlying JSON endpoint, (c) czy `requests.get` w ogóle coś zwróci —
+  ZANIM zaczniesz pisać `split_input`.
+
+### Werdykt
+Materialnie ryzykowniejsze niż DSpace przez statefulność Seam/ViewState.
+Nie commitować się w scraping HTML bez wcześniejszego reverse-engineeringu.
+
+---
+
+## Rekomendowana kolejność
+
+1. **Track A (DSpace)** — najszybszy ROI, REST/OAI, `fetch()` gotowy. Dobry
+   pierwszy „prawdziwy" dowód, że `split_input` skaluje się poza BibTeX.
+2. **Bug niezależny (charakter_formalny trap)** — tani fix, realne dane-ryzyko
+   (mislabeled/utknięte rekordy). Można zrobić przy okazji Track B albo od razu.
+3. **Track B (patenty)** — większy plumbing; wart osobnego spec/planu. Zdecydować
+   najpierw *product*: mapować z biblatex `@patent` czy pola ręczne w wizardzie.
+4. **Track C (PPM)** — dopiero po prototypie przeglądarkowym; może się okazać
+   niewykonalne bez headless browsera w imporcie (duża zmiana architektury).
+
+## Pierwszy krok w nowej sesji
+- Wejść w worktree `~/Programowanie/bpp-bibtex-import-wiele-prac`, gałąź off
+  `feat-bibtex-import-wiele-prac` (lub po merge #511 — off `dev`).
+- Odpalić **brainstorming** dla wybranego tracku (to nowy feature → design przed
+  kodem). Dla Track A pierwsze pytania: OAI-PMH vs REST discovery? zakres
+  (kolekcja vs zapytanie vs całe repo)? jak operator wskazuje listę?
+- Ten worktree ma zbudowany `MultipleWorksImport`/`split_input` — nowe providery
+  tylko nadpisują `split_input`, reszta batcha działa.
+
+## Pliki-klucze
+**Batch/dźwignia:** `providers/__init__.py` (`split_input`, `SplitRecord`),
+`providers/bibtex.py` (jedyny override — wzorzec), `views/wizard.py:114-226`
+(`_create_batch`, `FetchView.post` — bramka `validate_identifier`/`split_input`),
+`tests/test_split_input.py` (kontrakt testów).
+**DSpace:** `providers/dspace.py`, `providers/dspace_common.py`.
+**WWW/PPM:** `providers/www/provider.py`, `providers/www/network.py`,
+`providers/www/omega_psir.py` (precedens URL-sniff).
+**Patenty:** `providers/bibtex.py`, `providers/__init__.py`,
+`views/publikacja.py` (`_create_*`, dispatch `:266-269`), `views/steps.py`
+(`_verify_context`), `forms.py` (`VerifyForm`), `models.py` (ImportSession),
+`bpp/models/patent.py`, `bpp/models/abstract/authors.py`,
+`bpp/models/abstract/metadata.py` (`ModelZCharakterem`),
+`bpp/models/util.py` (`ZapobiegajNiewlasciwymCharakterom`),
+`bpp/models/system/crossref_mapper.py`, `bpp/admin/patent.py` (referencja pól
+formularza), `bpp/export/bibtex.py` (stratny round-trip), `forms.py:98`
+(trap charakter_formalny), `fixtures/charakter_formalny.json` (wiersz PAT).

--- a/src/bpp/newsfragments/importer-dspace-lista.feature.rst
+++ b/src/bpp/newsfragments/importer-dspace-lista.feature.rst
@@ -1,0 +1,7 @@
+Importer publikacji: wklejenie adresu strony-listy z repozytorium DSpace
+(kolekcja, community albo wynik wyszukiwania/discover — zarówno stare
+DSpace 6 XMLUI, jak i nowe DSpace 7+ Angular UI) rozpoznaje teraz stronę
+jako listę prac, pobiera jej zawartość przez REST i tworzy "paczkę"
+(``MultipleWorksImport``) do zaimportowania po jednej pozycji — dokładnie
+tak samo jak przy wklejeniu wielu wpisów BibTeX naraz. Wklejenie adresu
+pojedynczej publikacji działa bez zmian.

--- a/src/importer_publikacji/providers/dspace.py
+++ b/src/importer_publikacji/providers/dspace.py
@@ -3,10 +3,16 @@
 URL format determines which API is used:
 - /items/{uuid} → DSpace 7+ REST API
 - /handle/{prefix}/{suffix} → DSpace 6 REST API
+
+Ponadto provider rozpoznaje URL-e LIST (kolekcja/community/discover/
+search — patrz ``split_input``) i enumeruje ich itemy przez REST, żeby
+paczka wielo-prac (``MultipleWorksImport``, patrz ``providers/bibtex.py``
+za wzorzec) zadziałała też dla DSpace.
 """
 
+import logging
 import re
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, parse_qs, urlparse
 
 import requests
 
@@ -14,6 +20,7 @@ from . import (
     DataProvider,
     FetchedPublication,
     InputMode,
+    SplitRecord,
     register_provider,
 )
 from .dspace_common import (
@@ -31,11 +38,20 @@ from .dspace_common import (
     _resolve_url,
 )
 
+logger = logging.getLogger(__name__)
+
 UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}"
     r"-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
 )
+
+# Bezpiecznik na paginacje enumeracji list (kolekcja/community/discover):
+# kolekcje bywaja duze (setki-tysiace pozycji), a kazda strona to osobne
+# zapytanie REST. Cap zapobiega niekontrolowanej liczbie requestow; przy
+# obcieciu logujemy ostrzezenie (nie milczymy o utracie danych).
+MAX_SPLIT_ITEMS = 500
+_PAGE_SIZE = 100
 
 
 def _fallback_to_www(identifier: str) -> FetchedPublication | None:
@@ -49,6 +65,31 @@ def _fallback_to_www(identifier: str) -> FetchedPublication | None:
     from .www.provider import WWWProvider
 
     return WWWProvider().fetch(identifier)
+
+
+def _ensure_scheme_and_parse(url: str) -> ParseResult | None:
+    """Doklej domyślny schemat i sparsuj URL; None jeśli oczywisty śmieć.
+
+    Wspólny pierwszy krok dla wszystkich parserów URL w tym module —
+    normalizuje "repo.example.com/..." do "https://repo.example.com/..."
+    i odrzuca od razu wejście bez sensownego ``scheme``/``netloc``.
+    """
+    url = url.strip()
+    if not url:
+        return None
+
+    if "://" not in url:
+        url = "https://" + url
+
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+
+    if not parsed.scheme or not parsed.netloc:
+        return None
+
+    return parsed
 
 
 def _parse_dspace7_url(
@@ -66,19 +107,8 @@ def _parse_dspace7_url(
     (generic view) na ten sam obiekt — REST API endpoint dla obu to
     /server/api/core/items/{uuid}.
     """
-    url = url.strip()
-    if not url:
-        return None
-
-    if "://" not in url:
-        url = "https://" + url
-
-    try:
-        parsed = urlparse(url)
-    except ValueError:
-        return None
-
-    if not parsed.scheme or not parsed.netloc:
+    parsed = _ensure_scheme_and_parse(url)
+    if parsed is None:
         return None
 
     path = parsed.path.rstrip("/")
@@ -106,20 +136,15 @@ def _parse_handle_url(
     Formats:
     - https://repo.example.com/handle/123456789/922
     - https://repo.example.com/xmlui/handle/123/456
+
+    Uwaga: handle w DSpace 6 XMLUI jest DWUZNACZNY — ten sam kształt
+    URL adresuje item, kolekcję i community (nie ma tego w ścieżce).
+    Ten parser tylko wyciąga handle; rozstrzygnięcie typu (i routing
+    item-vs-lista) należy do ``split_input``/``fetch`` wyżej, przez
+    zapytanie REST ``/rest/handle/{handle}``.
     """
-    url = url.strip()
-    if not url:
-        return None
-
-    if "://" not in url:
-        url = "https://" + url
-
-    try:
-        parsed = urlparse(url)
-    except ValueError:
-        return None
-
-    if not parsed.scheme or not parsed.netloc:
+    parsed = _ensure_scheme_and_parse(url)
+    if parsed is None:
         return None
 
     path = parsed.path.rstrip("/")
@@ -131,6 +156,83 @@ def _parse_handle_url(
     handle = match.group(1)
     base_url = f"{parsed.scheme}://{parsed.netloc}"
     return base_url, handle
+
+
+def _parse_dspace7_container_url(
+    url: str,
+) -> tuple[str, str, str] | None:
+    """Parse DSpace 7+ container (list) URL.
+
+    Formats:
+    - https://repo.example.com/collections/{uuid}
+    - https://repo.example.com/communities/{uuid}
+
+    Returns (base_url, kind, uuid) where kind is "collections" or
+    "communities", or None. Strukturalnie odrębny kształt od
+    ``/items/{uuid}``/``/entities/...`` — DSpace 7+ Angular UI nie
+    myli itemu z kontenerem (w przeciwieństwie do DSpace 6 handle).
+    """
+    parsed = _ensure_scheme_and_parse(url)
+    if parsed is None:
+        return None
+
+    path = parsed.path.rstrip("/")
+
+    match = re.match(
+        r"^/(collections|communities)/"
+        r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}"
+        r"-[0-9a-f]{4}-[0-9a-f]{12})$",
+        path,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+
+    base_url = f"{parsed.scheme}://{parsed.netloc}"
+    return base_url, match.group(1), match.group(2)
+
+
+def _parse_dspace7_discover_url(
+    url: str,
+) -> tuple[str, dict[str, str]] | None:
+    """Parse DSpace 7+ discover/browse (search result) URL.
+
+    Formats:
+    - https://repo.example.com/search?query=...&scope=...
+    - https://repo.example.com/browse/title?scope=...
+
+    Zwraca (base_url, params) z opcjonalnymi kluczami "query"/"scope"
+    przekazanymi dalej do REST ``/server/api/discover/search/objects``.
+    Pozostałe parametry fasetowania (np. filtry ``f.*`` z ``/browse``)
+    są świadomie pomijane — odtworzenie pełnej semantyki fasetowania
+    UI nie jest celem tej funkcji, tylko enumeracja wynikowego zbioru
+    itemów.
+    """
+    parsed = _ensure_scheme_and_parse(url)
+    if parsed is None:
+        return None
+
+    path = parsed.path.rstrip("/") or "/"
+    if path != "/search" and not path.startswith("/browse"):
+        return None
+
+    base_url = f"{parsed.scheme}://{parsed.netloc}"
+    qs = parse_qs(parsed.query)
+    params: dict[str, str] = {}
+    if qs.get("query"):
+        params["query"] = qs["query"][0]
+    if qs.get("scope"):
+        params["scope"] = qs["scope"][0]
+    return base_url, params
+
+
+def _canonical_discover7_url(base_url: str, params: dict[str, str]) -> str:
+    """Kanoniczna postać znormalizowanego URL-a discover/search."""
+    ordered = [(k, params[k]) for k in ("query", "scope") if params.get(k)]
+    if not ordered:
+        return f"{base_url}/search"
+    qs = "&".join(f"{k}={v}" for k, v in ordered)
+    return f"{base_url}/search?{qs}"
 
 
 def _parse_dspace_url(
@@ -279,6 +381,293 @@ def _fetch_dspace6(base_url: str, handle: str) -> FetchedPublication | None:
     )
 
 
+def _dspace6_resolve_handle_type(base_url: str, handle: str) -> dict | None:
+    """GET /rest/handle/{handle} (bez expand) — tylko żeby poznać "type".
+
+    Zwraca dict z co najmniej "type" ("item"/"collection"/"community")
+    i "uuid", albo None przy błędzie sieci/HTTP. Rozstrzyga latentny bug:
+    handle w DSpace 6 nie odróżnia w URL-u itemu od kontenera.
+    """
+    url = f"{base_url}/rest/handle/{handle}"
+    try:
+        resp = requests.get(url, timeout=FETCH_TIMEOUT)
+        resp.raise_for_status()
+    except requests.RequestException:
+        logger.warning(
+            "DSpace6: nie udalo sie rozpoznac typu handle %s na %s",
+            handle,
+            base_url,
+        )
+        return None
+    return resp.json()
+
+
+def _dspace6_paginate_items(
+    base_url: str,
+    collection_uuid: str,
+    max_items: int = MAX_SPLIT_ITEMS,
+    page_size: int = _PAGE_SIZE,
+) -> list[dict]:
+    """Enumeruj itemy kolekcji DSpace 6 przez REST, z paginacją.
+
+    ``GET /rest/collections/{uuid}/items?limit=&offset=``. Zatrzymuje
+    się, gdy strona jest krótsza niż żądany limit (koniec danych), przy
+    błędzie REST (log + zwrot dotychczasowego wyniku), albo po
+    osiągnięciu ``max_items`` (log ostrzeżenia o obcięciu).
+    """
+    items: list[dict] = []
+    offset = 0
+    while len(items) < max_items:
+        limit = min(page_size, max_items - len(items))
+        try:
+            resp = requests.get(
+                f"{base_url}/rest/collections/{collection_uuid}/items",
+                params={"limit": limit, "offset": offset},
+                timeout=FETCH_TIMEOUT,
+            )
+            resp.raise_for_status()
+        except requests.RequestException:
+            logger.warning(
+                "DSpace6: blad pobierania items kolekcji %s (offset=%d)",
+                collection_uuid,
+                offset,
+            )
+            break
+        page = resp.json() or []
+        if not page:
+            break
+        items.extend(page)
+        if len(page) < limit:
+            break
+        offset += len(page)
+
+    if len(items) >= max_items:
+        logger.warning(
+            "DSpace6: kolekcja %s ma wiecej niz %d pozycji — wynik obcieto.",
+            collection_uuid,
+            max_items,
+        )
+    return items[:max_items]
+
+
+def _dspace6_community_collection_uuids(
+    base_url: str, community_uuid: str
+) -> list[str]:
+    """GET /rest/communities/{uuid}/collections — uuidy kolekcji-dzieci."""
+    try:
+        resp = requests.get(
+            f"{base_url}/rest/communities/{community_uuid}/collections",
+            timeout=FETCH_TIMEOUT,
+        )
+        resp.raise_for_status()
+    except requests.RequestException:
+        logger.warning(
+            "DSpace6: blad pobierania kolekcji community %s",
+            community_uuid,
+        )
+        return []
+    return [c["uuid"] for c in (resp.json() or []) if c.get("uuid")]
+
+
+def _items_to_dspace6_records(base_url: str, items: list[dict]) -> list[SplitRecord]:
+    records = []
+    for item in items:
+        handle = item.get("handle")
+        if not handle:
+            continue
+        records.append(
+            SplitRecord(raw=f"{base_url}/handle/{handle}", title=item.get("name", ""))
+        )
+    return records
+
+
+def _split_dspace6_collection(
+    base_url: str, collection_uuid: str, fallback_url: str
+) -> list[SplitRecord]:
+    items = _dspace6_paginate_items(base_url, collection_uuid)
+    records = _items_to_dspace6_records(base_url, items)
+    return records or [SplitRecord(raw=fallback_url)]
+
+
+def _split_dspace6_community(
+    base_url: str, community_uuid: str, fallback_url: str
+) -> list[SplitRecord]:
+    collection_uuids = _dspace6_community_collection_uuids(base_url, community_uuid)
+    all_items: list[dict] = []
+    for coll_uuid in collection_uuids:
+        if len(all_items) >= MAX_SPLIT_ITEMS:
+            break
+        remaining = MAX_SPLIT_ITEMS - len(all_items)
+        all_items.extend(
+            _dspace6_paginate_items(base_url, coll_uuid, max_items=remaining)
+        )
+    records = _items_to_dspace6_records(base_url, all_items)
+    return records or [SplitRecord(raw=fallback_url)]
+
+
+def _dspace7_discover_page(
+    base_url: str,
+    scope: str | None,
+    query: str | None,
+    page: int,
+    size: int,
+) -> dict | None:
+    """Pobierz jedną stronę ``discover/search/objects``, albo None przy
+    błędzie REST (log ostrzeżenia)."""
+    params = {"dsoType": "item", "page": page, "size": size}
+    if scope:
+        params["scope"] = scope
+    if query:
+        params["query"] = query
+    try:
+        resp = requests.get(
+            f"{base_url}/server/api/discover/search/objects",
+            params=params,
+            timeout=FETCH_TIMEOUT,
+        )
+        resp.raise_for_status()
+    except requests.RequestException:
+        logger.warning(
+            "DSpace7: blad discover search (scope=%s, query=%s, page=%d)",
+            scope,
+            query,
+            page,
+        )
+        return None
+    data = resp.json()
+    return data.get("_embedded", {}).get("searchResult", {})
+
+
+def _dspace7_discover_items(
+    base_url: str,
+    scope: str | None = None,
+    query: str | None = None,
+    max_items: int = MAX_SPLIT_ITEMS,
+    page_size: int = 20,
+) -> list[dict]:
+    """Enumeruj wyniki discover DSpace 7+ przez REST, z paginacją.
+
+    ``GET /server/api/discover/search/objects?dsoType=item&page=&size=``,
+    opcjonalnie ``scope=``/``query=``. Zatrzymuje się na ``page >=
+    totalPages`` (z odpowiedzi HAL) albo krótszej niż żądana stronie,
+    przy błędzie REST (log + zwrot dotychczasowego wyniku), albo po
+    osiągnięciu ``max_items`` (log ostrzeżenia o obcięciu).
+    """
+    items: list[dict] = []
+    page = 0
+    while len(items) < max_items:
+        size = min(page_size, max_items - len(items))
+        search_result = _dspace7_discover_page(base_url, scope, query, page, size)
+        if search_result is None:
+            break
+        objects = search_result.get("_embedded", {}).get("objects", [])
+        if not objects:
+            break
+        items.extend(
+            dso
+            for obj in objects
+            if (dso := obj.get("_embedded", {}).get("indexableObject"))
+        )
+        total_pages = search_result.get("page", {}).get("totalPages")
+        page += 1
+        if total_pages is not None and page >= total_pages:
+            break
+        if len(objects) < size:
+            break
+
+    if len(items) >= max_items:
+        logger.warning(
+            "DSpace7: discover (scope=%s, query=%s) ma wiecej niz %d "
+            "pozycji — wynik obcieto.",
+            scope,
+            query,
+            max_items,
+        )
+    return items[:max_items]
+
+
+def _items_to_dspace7_records(base_url: str, items: list[dict]) -> list[SplitRecord]:
+    records = []
+    for item in items:
+        uuid = item.get("uuid")
+        if not uuid:
+            continue
+        records.append(
+            SplitRecord(raw=f"{base_url}/items/{uuid}", title=item.get("name", ""))
+        )
+    return records
+
+
+def _split_dspace7_list(
+    base_url: str,
+    fallback_url: str,
+    scope: str | None = None,
+    query: str | None = None,
+) -> list[SplitRecord]:
+    items = _dspace7_discover_items(base_url, scope=scope, query=query)
+    records = _items_to_dspace7_records(base_url, items)
+    return records or [SplitRecord(raw=fallback_url)]
+
+
+def _split_dspace_input(url: str) -> list[SplitRecord]:
+    """Rdzeń ``DSpaceProvider.split_input`` — wyodrębniona funkcja modułu,
+    żeby ``fetch()`` mogła jej użyć jako siatki bezpieczeństwa (patrz
+    ``_resolve_single_item_from_list``) bez rekurencyjnego tworzenia
+    instancji providera.
+    """
+    url = url.strip()
+    if not url:
+        return [SplitRecord(raw=url)]
+
+    container7 = _parse_dspace7_container_url(url)
+    if container7 is not None:
+        base_url, _kind, uuid = container7
+        return _split_dspace7_list(base_url, url, scope=uuid)
+
+    discover7 = _parse_dspace7_discover_url(url)
+    if discover7 is not None:
+        base_url, params = discover7
+        return _split_dspace7_list(
+            base_url, url, scope=params.get("scope"), query=params.get("query")
+        )
+
+    handle_result = _parse_handle_url(url)
+    if handle_result is not None:
+        base_url, handle = handle_result
+        resolved = _dspace6_resolve_handle_type(base_url, handle)
+        if resolved is not None:
+            kind = resolved.get("type")
+            uuid = resolved.get("uuid")
+            if kind == "collection" and uuid:
+                return _split_dspace6_collection(base_url, uuid, url)
+            if kind == "community" and uuid:
+                return _split_dspace6_community(base_url, uuid, url)
+        # kind == "item" (albo siec padla, resolved is None) -> traktuj
+        # jak pojedynczy item; fetch() go rozwiaze normalnie nizej.
+
+    return [SplitRecord(raw=url)]
+
+
+def _resolve_single_item_from_list(url: str) -> str | None:
+    """Siatka bezpieczeństwa dla ``FetchView.post`` (``views/wizard.py``).
+
+    Gdy ``split_input()`` zwróci dokładnie 1 ``SplitRecord`` (np. lista
+    z dokładnie jednym itemem), wywołanie idzie ścieżką pojedynczej sesji
+    z ``identifier=<oryginalny URL listy>`` — NIE z URL-em itemu (patrz
+    ``_create_batch``/próg ``len(records) >= 2`` w ``FetchView.post``).
+    Bez tej funkcji ``fetch()`` próbowałby (błędnie) potraktować URL listy
+    jak URL itemu. Zwraca URL rozwiązanego itemu, albo None gdy ``url``
+    strukturalnie nie jest listą (żeby nie robić zbędnych zapytań REST).
+    """
+    records = _split_dspace_input(url)
+    if len(records) != 1:
+        return None
+    candidate = records[0].raw
+    if candidate == url:
+        return None
+    return candidate
+
+
 @register_provider
 class DSpaceProvider(DataProvider):
     @property
@@ -312,17 +701,55 @@ class DSpaceProvider(DataProvider):
 
     def validate_identifier(self, identifier: str) -> str | None:
         result = _parse_dspace_url(identifier)
-        if result is None:
-            return None
-        base_url, ident, version = result
-        if version == "7":
-            return f"{base_url}/items/{ident}"
-        return f"{base_url}/handle/{ident}"
+        if result is not None:
+            base_url, ident, version = result
+            if version == "7":
+                return f"{base_url}/items/{ident}"
+            return f"{base_url}/handle/{ident}"
+
+        # URL-e listowe (kolekcja/community/discover/search) DSpace 7+ —
+        # mają odrębny kształt ścieżki od /items/ i /entities/, więc
+        # dotąd twardo odrzucane. Handle-based URL-e DSpace 6 (item vs.
+        # kolekcja vs. community) już dziś przechodzą powyższy branch
+        # (regex nie odróżnia typu) — routing pojedynczy-item-vs-lista
+        # dzieje się w ``split_input``, nie tutaj.
+        container7 = _parse_dspace7_container_url(identifier)
+        if container7 is not None:
+            base_url, kind, uuid = container7
+            return f"{base_url}/{kind}/{uuid}"
+
+        discover7 = _parse_dspace7_discover_url(identifier)
+        if discover7 is not None:
+            base_url, params = discover7
+            return _canonical_discover7_url(base_url, params)
+
+        return None
+
+    def split_input(self, text: str) -> list[SplitRecord]:
+        """Rozbij URL listy DSpace (kolekcja/community/discover/search)
+        na jeden ``SplitRecord`` per item; URL pojedynczego itemu (albo
+        cokolwiek nierozpoznane) → 1 rekord, dzisiejsze zachowanie."""
+        return _split_dspace_input(text)
 
     def fetch(self, identifier: str) -> FetchedPublication | None:
+        fetch_identifier = identifier
         parsed = _parse_dspace_url(identifier)
         if parsed is None:
-            return None
+            # Moze to byc URL listy (kolekcja/community/discover), ktora
+            # split_input() rozwiazuje do dokladnie JEDNEGO itemu — wtedy
+            # FetchView.post idzie sciezka pojedynczej sesji z
+            # identifier=<oryginalny URL listy> (patrz
+            # _resolve_single_item_from_list). W przeciwnym razie (0 lub
+            # ident nierozpoznany) fetch po prostu nie ma czego pobrac.
+            single_item_url = _resolve_single_item_from_list(identifier)
+            if single_item_url is None:
+                return None
+            parsed = _parse_dspace_url(single_item_url)
+            if parsed is None:
+                return None
+            # WWW fallback nizej ma probowac itemu, nie oryginalnego
+            # URL-a listy (ktorego HTML nie zawiera metadanych publikacji).
+            fetch_identifier = single_item_url
 
         base_url, ident, version = parsed
         if version == "7":
@@ -337,4 +764,4 @@ class DSpaceProvider(DataProvider):
         # SPA bez metadanych w API). Spróbuj sparsować stronę HTML
         # przez WWW provider — często strona zawiera DOI/citation_*
         # metatagi nawet gdy REST API nie odpowiada.
-        return _fallback_to_www(identifier)
+        return _fallback_to_www(fetch_identifier)

--- a/src/importer_publikacji/tests/test_dspace_split_input.py
+++ b/src/importer_publikacji/tests/test_dspace_split_input.py
@@ -1,0 +1,437 @@
+"""Tests for ``DSpaceProvider.split_input`` — wykrywanie stron-list
+(kolekcja/community/discover/search) i enumeracja ich itemów przez REST,
+oraz rozszerzenie ``validate_identifier`` o akceptację takich URL-i.
+
+Cały HTTP jest mockowany (``requests.get`` w module ``dspace``) — brak
+połączeń do żywej sieci. Kształty odpowiedzi REST (DSpace 6 ``/rest/...``
+i DSpace 7 ``/server/api/discover/search/objects``) zweryfikowano na
+żywo na ``dspace.piwet.pulawy.pl`` (DSpace 6 XMLUI) i
+``repozytorium.wsb-nlu.edu.pl`` (DSpace 7+ Angular UI) podczas budowy tego
+providera — patrz PR/handoff.
+"""
+
+from unittest.mock import patch
+
+import requests
+
+from importer_publikacji.providers import SplitRecord
+from importer_publikacji.providers.dspace import DSpaceProvider
+
+from ._dspace_provider_samples import (
+    BASE_URL,
+    SAMPLE_HANDLE_URL,
+    SAMPLE_URL,
+    _mock_response,
+)
+
+OLD_BASE = "https://dspace.piwet.pulawy.pl"
+OLD_COLLECTION_HANDLE_URL = f"{OLD_BASE}/handle/123456789/6"
+OLD_COLLECTION_UUID = "09e84d85-18d7-41f9-b339-d65d87f35c56"
+OLD_COMMUNITY_HANDLE_URL = f"{OLD_BASE}/handle/123456789/5"
+OLD_COMMUNITY_UUID = "118f19ee-907d-4084-9a98-ef6dc526b712"
+
+NEW_COLLECTION_UUID = "d7d434e3-794c-4e84-b2b9-6b2767665644"
+NEW_COLLECTION_URL = f"{BASE_URL}/collections/{NEW_COLLECTION_UUID}"
+NEW_COMMUNITY_URL = f"{BASE_URL}/communities/{NEW_COLLECTION_UUID}"
+NEW_SEARCH_URL = f"{BASE_URL}/search?query=test&scope={NEW_COLLECTION_UUID}"
+
+
+def _hal_discover_page(objects, total_pages=1):
+    return _mock_response(
+        {
+            "_embedded": {
+                "searchResult": {
+                    "page": {
+                        "number": 0,
+                        "size": 20,
+                        "totalPages": total_pages,
+                        "totalElements": len(objects),
+                    },
+                    "_embedded": {
+                        "objects": [
+                            {"_embedded": {"indexableObject": obj}} for obj in objects
+                        ]
+                    },
+                }
+            }
+        }
+    )
+
+
+# --- (a) DSpace 6 (old): kolekcja/community handle -> enumeracja REST ---
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_old_dspace_collection_returns_n_records(mock_get):
+    handle_resp = _mock_response(
+        {"type": "collection", "uuid": OLD_COLLECTION_UUID, "handle": "123456789/6"}
+    )
+    items_resp = _mock_response(
+        [
+            {"uuid": "u1", "handle": "123456789/58", "name": "Praca 1"},
+            {"uuid": "u2", "handle": "123456789/59", "name": "Praca 2"},
+            {"uuid": "u3", "handle": "123456789/60", "name": "Praca 3"},
+        ]
+    )
+    mock_get.side_effect = [handle_resp, items_resp]
+
+    records = DSpaceProvider().split_input(OLD_COLLECTION_HANDLE_URL)
+
+    assert len(records) == 3
+    assert all(r.ok for r in records)
+    assert records[0].raw == f"{OLD_BASE}/handle/123456789/58"
+    assert records[0].title == "Praca 1"
+    assert records[1].raw == f"{OLD_BASE}/handle/123456789/59"
+    assert records[2].raw == f"{OLD_BASE}/handle/123456789/60"
+    assert records[2].title == "Praca 3"
+
+    assert mock_get.call_count == 2
+    assert mock_get.call_args_list[0].args[0] == f"{OLD_BASE}/rest/handle/123456789/6"
+    assert (
+        mock_get.call_args_list[1].args[0]
+        == f"{OLD_BASE}/rest/collections/{OLD_COLLECTION_UUID}/items"
+    )
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_old_dspace_collection_paginates(mock_get):
+    """Kolekcja z wiecej niz jedna strona wynikow — druga strona krotsza
+    niz limit => petla konczy sie naturalnie (bez zapytan w nieskonczonosc).
+    """
+    handle_resp = _mock_response(
+        {"type": "collection", "uuid": OLD_COLLECTION_UUID, "handle": "123456789/6"}
+    )
+    page1 = _mock_response(
+        [
+            {"uuid": f"u{i}", "handle": f"123456789/{i}", "name": f"P{i}"}
+            for i in range(100)
+        ]
+    )
+    page2 = _mock_response(
+        [{"uuid": "u100", "handle": "123456789/100", "name": "Ostatnia"}]
+    )
+    mock_get.side_effect = [handle_resp, page1, page2]
+
+    records = DSpaceProvider().split_input(OLD_COLLECTION_HANDLE_URL)
+
+    assert len(records) == 101
+    assert records[-1].title == "Ostatnia"
+    assert mock_get.call_count == 3
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_old_dspace_community_returns_items_from_all_collections(mock_get):
+    collections_resp = _mock_response(
+        [
+            {"uuid": "col-a", "handle": "123456789/347"},
+            {"uuid": "col-b", "handle": "123456789/12"},
+        ]
+    )
+    items_a = _mock_response(
+        [{"uuid": "ia1", "handle": "123456789/900", "name": "Item A1"}]
+    )
+    items_b = _mock_response(
+        [{"uuid": "ib1", "handle": "123456789/901", "name": "Item B1"}]
+    )
+    handle_resp = _mock_response(
+        {"type": "community", "uuid": OLD_COMMUNITY_UUID, "handle": "123456789/5"}
+    )
+    mock_get.side_effect = [handle_resp, collections_resp, items_a, items_b]
+
+    records = DSpaceProvider().split_input(OLD_COMMUNITY_HANDLE_URL)
+
+    assert len(records) == 2
+    assert {r.raw for r in records} == {
+        f"{OLD_BASE}/handle/123456789/900",
+        f"{OLD_BASE}/handle/123456789/901",
+    }
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_old_dspace_collection_rest_error_falls_back_to_single(mock_get):
+    handle_resp = _mock_response(
+        {"type": "collection", "uuid": OLD_COLLECTION_UUID, "handle": "123456789/6"}
+    )
+    mock_get.side_effect = [handle_resp, requests.exceptions.ConnectionError()]
+
+    records = DSpaceProvider().split_input(OLD_COLLECTION_HANDLE_URL)
+
+    assert records == [SplitRecord(raw=OLD_COLLECTION_HANDLE_URL)]
+
+
+# --- (b) DSpace 7+ (new): discover/search -> enumeracja REST ---
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_new_dspace_discover_returns_n_records(mock_get):
+    mock_get.return_value = _hal_discover_page(
+        [
+            {"uuid": "aaa1", "handle": "11199/1", "name": "Item A"},
+            {"uuid": "bbb2", "handle": "11199/2", "name": "Item B"},
+        ]
+    )
+
+    records = DSpaceProvider().split_input(NEW_SEARCH_URL)
+
+    assert len(records) == 2
+    assert records[0].raw == f"{BASE_URL}/items/aaa1"
+    assert records[0].title == "Item A"
+    assert records[1].raw == f"{BASE_URL}/items/bbb2"
+
+    call = mock_get.call_args_list[0]
+    assert call.args[0] == f"{BASE_URL}/server/api/discover/search/objects"
+    assert call.kwargs["params"]["dsoType"] == "item"
+    assert call.kwargs["params"]["scope"] == NEW_COLLECTION_UUID
+    assert call.kwargs["params"]["query"] == "test"
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_new_dspace_collection_url_returns_n_records(mock_get):
+    mock_get.return_value = _hal_discover_page(
+        [{"uuid": "ccc3", "handle": "11199/3", "name": "Item C"}]
+    )
+
+    records = DSpaceProvider().split_input(NEW_COLLECTION_URL)
+
+    assert len(records) == 1
+    assert records[0].raw == f"{BASE_URL}/items/ccc3"
+    call = mock_get.call_args_list[0]
+    assert call.kwargs["params"]["scope"] == NEW_COLLECTION_UUID
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_new_dspace_community_url_returns_n_records(mock_get):
+    mock_get.return_value = _hal_discover_page(
+        [{"uuid": "ddd4", "handle": "11199/4", "name": "Item D"}]
+    )
+
+    records = DSpaceProvider().split_input(NEW_COMMUNITY_URL)
+
+    assert len(records) == 1
+    assert records[0].raw == f"{BASE_URL}/items/ddd4"
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_new_dspace_discover_paginates(mock_get):
+    page1 = _hal_discover_page(
+        [{"uuid": f"u{i}", "handle": f"11199/{i}", "name": f"P{i}"} for i in range(20)],
+        total_pages=2,
+    )
+    page2 = _hal_discover_page(
+        [{"uuid": "u20", "handle": "11199/20", "name": "Ostatni"}],
+        total_pages=2,
+    )
+    mock_get.side_effect = [page1, page2]
+
+    records = DSpaceProvider().split_input(NEW_COLLECTION_URL)
+
+    assert len(records) == 21
+    assert records[-1].title == "Ostatni"
+    assert mock_get.call_count == 2
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_new_dspace_discover_rest_error_falls_back_to_single(mock_get):
+    mock_get.side_effect = requests.exceptions.ConnectionError()
+
+    records = DSpaceProvider().split_input(NEW_COLLECTION_URL)
+
+    assert records == [SplitRecord(raw=NEW_COLLECTION_URL)]
+
+
+# --- (c) pojedynczy item -> dokladnie 1 rekord (fallthrough) ---
+
+
+def test_split_input_dspace7_item_url_returns_single_record_no_network():
+    records = DSpaceProvider().split_input(SAMPLE_URL)
+    assert records == [SplitRecord(raw=SAMPLE_URL)]
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_dspace6_item_handle_returns_single_record(mock_get):
+    mock_get.return_value = _mock_response(
+        {"type": "item", "uuid": "some-item-uuid", "handle": "123456789/922"}
+    )
+
+    records = DSpaceProvider().split_input(SAMPLE_HANDLE_URL)
+
+    assert records == [SplitRecord(raw=SAMPLE_HANDLE_URL)]
+    mock_get.assert_called_once_with(
+        f"{OLD_BASE}/rest/handle/123456789/922",
+        timeout=15,
+    )
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_split_input_dspace6_handle_type_network_error_falls_through(mock_get):
+    mock_get.side_effect = requests.exceptions.ConnectionError()
+
+    records = DSpaceProvider().split_input(SAMPLE_HANDLE_URL)
+
+    assert records == [SplitRecord(raw=SAMPLE_HANDLE_URL)]
+
+
+def test_split_input_garbage_returns_single_record_no_network():
+    records = DSpaceProvider().split_input("not a url")
+    assert records == [SplitRecord(raw="not a url")]
+
+
+def test_split_input_empty_string():
+    records = DSpaceProvider().split_input("")
+    assert records == [SplitRecord(raw="")]
+
+
+# --- (d) validate_identifier: akceptacja list, odrzucenie smieci ---
+
+
+def test_validate_identifier_accepts_new_dspace_collection_url():
+    p = DSpaceProvider()
+    assert p.validate_identifier(NEW_COLLECTION_URL) == NEW_COLLECTION_URL
+
+
+def test_validate_identifier_accepts_new_dspace_community_url():
+    p = DSpaceProvider()
+    assert p.validate_identifier(NEW_COMMUNITY_URL) == NEW_COMMUNITY_URL
+
+
+def test_validate_identifier_accepts_new_dspace_search_url():
+    p = DSpaceProvider()
+    result = p.validate_identifier(NEW_SEARCH_URL)
+    assert result is not None
+    assert result.startswith(f"{BASE_URL}/search?")
+    assert "query=test" in result
+    assert f"scope={NEW_COLLECTION_UUID}" in result
+
+
+def test_validate_identifier_accepts_new_dspace_browse_url():
+    p = DSpaceProvider()
+    url = f"{BASE_URL}/browse/title?scope={NEW_COLLECTION_UUID}"
+    result = p.validate_identifier(url)
+    assert result is not None
+    assert f"scope={NEW_COLLECTION_UUID}" in result
+
+
+def test_validate_identifier_accepts_old_dspace_collection_handle_url():
+    """Handle URL kolekcji DSpace 6 juz dzis przechodzi regex (item i
+    kolekcja dziela ten sam ksztalt URL) — potwierdzamy ze dalej dziala,
+    routing item/lista dzieje sie pozniej w split_input."""
+    p = DSpaceProvider()
+    assert p.validate_identifier(OLD_COLLECTION_HANDLE_URL) == OLD_COLLECTION_HANDLE_URL
+
+
+def test_validate_identifier_still_rejects_garbage():
+    p = DSpaceProvider()
+    assert p.validate_identifier("not a url") is None
+    assert p.validate_identifier("") is None
+    assert p.validate_identifier(f"{BASE_URL}/some/random/path") is None
+
+
+# --- fetch(): siatka bezpieczenstwa gdy lista ma dokladnie 1 wynik ---
+#
+# FetchView.post (views/wizard.py) idzie sciezka pojedynczej sesji, gdy
+# split_input() zwroci < 2 rekordy — z identifier=<oryginalny URL listy>,
+# nie URL itemu. fetch() musi wiec sam sobie poradzic z takim URL-em.
+
+
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_fetch_resolves_single_item_new_dspace_collection_via_rest(mock_get):
+    """Kolekcja DSpace 7+ z dokladnie 1 wynikiem, trafiajaca do fetch()
+    bezposrednio (patrz docstring _resolve_single_item_from_list) —
+    rozwiazuje sie do prawdziwego itemu (REST /collections/{uuid} ma
+    odrebny ksztalt URL od /items/{uuid}, wiec _parse_dspace_url() od
+    razu zwraca None i uruchamia siatke bezpieczenstwa)."""
+    discover_resp = _hal_discover_page(
+        [
+            {
+                "uuid": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                "handle": "11199/999",
+                "name": "Jedyna praca",
+            }
+        ]
+    )
+    item_fetch_resp = _mock_response(
+        {
+            "uuid": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            "metadata": {"dc.title": [{"value": "Jedyna praca"}]},
+        }
+    )
+    mock_get.side_effect = [discover_resp, item_fetch_resp]
+
+    pub = DSpaceProvider().fetch(NEW_COLLECTION_URL)
+
+    assert pub is not None
+    assert pub.title == "Jedyna praca"
+    # Ostatnie wywolanie (rzeczywisty fetch) musi trafic w URL itemu,
+    # nie w oryginalny URL kolekcji.
+    assert mock_get.call_args_list[-1].args[0] == (
+        f"{BASE_URL}/server/api/core/items/f47ac10b-58cc-4372-a567-0e02b2c3d479"
+    )
+
+
+@patch(
+    "importer_publikacji.providers.dspace._fallback_to_www",
+    return_value=None,
+)
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_fetch_single_item_new_collection_www_fallback_targets_item(
+    mock_get, mock_fallback
+):
+    """Gdy REST fetch itemu (rozwiazanego z kolekcji 1-elementowej)
+    zawiedzie, WWW fallback ma probowac URL itemu — nie URL-a
+    oryginalnej kolekcji (ktorej HTML nie ma metadanych publikacji)."""
+    discover_resp = _hal_discover_page(
+        [
+            {
+                "uuid": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                "handle": "11199/999",
+                "name": "Jedyna praca",
+            }
+        ]
+    )
+    item_fetch_resp = _mock_response({}, status_code=404)
+    mock_get.side_effect = [discover_resp, item_fetch_resp]
+
+    pub = DSpaceProvider().fetch(NEW_COLLECTION_URL)
+
+    assert pub is None
+    mock_fallback.assert_called_once_with(
+        f"{BASE_URL}/items/f47ac10b-58cc-4372-a567-0e02b2c3d479"
+    )
+
+
+@patch(
+    "importer_publikacji.providers.dspace._fallback_to_www",
+    return_value=None,
+)
+@patch("importer_publikacji.providers.dspace.requests.get")
+def test_fetch_old_dspace_single_item_collection_known_limitation(
+    mock_get, mock_fallback
+):
+    """Znane, udokumentowane ograniczenie: handle w DSpace 6 XMLUI jest
+    niejednoznaczny (ten sam ksztalt URL dla itemu i kolekcji), a
+    fetch() na POJEDYNCZYM URL-u celowo NIE robi dodatkowego zapytania
+    REST "jaki to typ" przed proba pobrania — kontrakt "1 zapytanie REST
+    per fetch" dla zwyklego itemu jest juz zagwarantowany istniejacym
+    testem (test_fetch_dspace6_success, ktory sprawdza
+    assert_called_once_with). Dla ekstremalnie rzadkiego przypadku
+    kolekcji z DOKLADNIE 1 pozycja trafiajacej do fetch() bezposrednio
+    (FetchView.post, sciezka pojedynczej sesji gdy split_input() zwrocil
+    < 2 rekordy), fetch() nadal probuje pobrac kolekcje jak item — REST
+    zwroci pusty tytul (kolekcje nie maja dc.title), wiec konczy sie na
+    WWW-fallbacku strony kolekcji (bez metadanych publikacji). To
+    zachowanie jest identyczne z tym sprzed tej zmiany — nie regresja,
+    tylko nieusunieta w tym PR (dla DSpace 7+ analogiczny przypadek JEST
+    poprawnie obsluzony, patrz
+    test_fetch_resolves_single_item_new_dspace_collection_via_rest, bo
+    /collections/{uuid} ma odrebny ksztalt URL od /items/{uuid})."""
+    collection_resp = _mock_response({"handle": "123456789/6", "metadata": []})
+    mock_get.return_value = collection_resp
+
+    pub = DSpaceProvider().fetch(OLD_COLLECTION_HANDLE_URL)
+
+    assert pub is None
+    mock_fallback.assert_called_once_with(OLD_COLLECTION_HANDLE_URL)
+
+
+def test_fetch_garbage_returns_none_no_network():
+    assert DSpaceProvider().fetch("not a valid url") is None


### PR DESCRIPTION
## Summary

Stacks on #511 (`feat-bibtex-import-wiele-prac` — `MultipleWorksImport`
batch infra). Track A from
`docs/superpowers/handoffs/2026-07-10-importer-patenty-www-dspace-listy.md`.

- `DSpaceProvider.split_input()` now recognizes DSpace **list** URLs
  (collection / community / discover / search page) and enumerates the
  items inside via REST, returning one `SplitRecord` per item. When it
  returns ≥2 records, `FetchView.post()` creates a `MultipleWorksImport`
  batch — the exact same mechanism already built for pasting multiple
  BibTeX entries at once. A single-item URL (or anything unrecognized)
  still returns exactly 1 record — no behavior change there.
- **Old DSpace 6 (XMLUI)**: handle URLs are ambiguous (item, collection,
  and community all share the `/handle/{prefix}/{suffix}` shape).
  `split_input()` now resolves the handle's real type via
  `GET /rest/handle/{handle}` first; `collection`/`community` → enumerate
  items via `GET /rest/collections/{uuid}/items` (paginated,
  `limit`/`offset`), community additionally walks
  `GET /rest/communities/{uuid}/collections` first. `item` → falls
  through to today's single-fetch behavior unchanged.
- **New DSpace 7+ (Angular UI)**: `/collections/{uuid}` and
  `/communities/{uuid}` have a URL shape structurally distinct from
  `/items/{uuid}`/`/entities/.../{uuid}`, so no REST round-trip is
  needed to disambiguate. `/search` and `/browse/*` are treated as a
  discover result set (optional `query`/`scope` query params passed
  through). Enumeration via
  `GET /server/api/discover/search/objects?dsoType=item&scope=&query=`,
  paginated via `page`/`size` using the HAL `page.totalPages` field.
- `validate_identifier()` now accepts the new-DSpace list URL shapes
  (previously hard-rejected since they don't match `/items/`or
  `/entities/`). Old-DSpace handle URLs for collections/communities
  already passed validation before this PR (the regex couldn't tell
  item from container) — no change needed there.
- **Fixed a latent bug**: `_parse_handle_url` never distinguished an
  item handle from a collection/community handle, so a collection URL
  routed straight to `fetch()` would silently be treated as a
  (broken) single item. `split_input()` now owns that disambiguation
  and routes collection/community handles to the list path.
  `fetch()` also gained a small safety net for the rare edge case of a
  list URL that resolves to *exactly* one item reaching the
  single-session code path (`FetchView.post`'s `len(records) < 2`
  branch uses the original list URL as the session identifier, not
  the item URL) — new-DSpace list URLs resolve correctly there; the
  equivalent case for old-DSpace ambiguous handles is a known,
  documented, pre-existing limitation (see below).
- Pagination is capped at 500 items (`MAX_SPLIT_ITEMS`) with a logged
  warning if the cap is hit — no silent truncation.

### Hosts validated live during development (read-only reconnaissance only)

- `dspace.piwet.pulawy.pl` — DSpace 6 XMLUI. Verified `/rest/handle/{h}`
  (type disambiguation), `/rest/collections/{uuid}/items` (pagination),
  `/rest/communities/{uuid}/collections`, OAI-PMH `Identify` (available
  but not used — REST was sufficient and simpler to test).
- `repozytorium.wsb-nlu.edu.pl` — DSpace 7+ Angular UI (reports as
  DSpace 9.1 in `/server/api`). Verified `/server/api` root HAL
  response, `/server/api/discover/search/objects` scoped to a community
  and paginated via `page`/`size`/`totalPages`.

All tests use mocked HTTP (`requests.get` patched in the `dspace`
module) — no live network calls in the test suite itself.

### Known limitations (documented, not fixed here)

- Old-DSpace (6) bare `/browse` or `/discover` **without** a container
  handle (i.e. "browse the whole repository") is not enumerated — DSpace
  6's REST API has no single "all items" endpoint short of walking the
  full community/collection tree, which felt like disproportionate
  complexity/risk for a rare input shape. Paste a specific
  collection/community URL instead. (New DSpace 7+ handles this natively
  since `/server/api/discover/search/objects` supports a scope-less,
  repo-wide query.)
- Old-DSpace ambiguous handle for a collection with **exactly one**
  item, when it reaches `fetch()` directly (the rare edge case above):
  still degrades to the pre-existing behavior (WWW-fallback on the
  collection page) rather than resolving to the real item. Fixing this
  would require an extra REST round-trip on *every* single-item DSpace 6
  fetch to disambiguate item-vs-container up front, which conflicts with
  the existing test contract (`test_fetch_dspace6_success` asserts
  exactly one REST call for a normal item fetch). Documented with a
  passing test
  (`test_fetch_old_dspace_single_item_collection_known_limitation`).

## Test plan

- [x] `PYTEST_TESTCONTAINERS_REUSE=1 uv run pytest src/importer_publikacji/ -q`
      → 571 passed, 1 skipped (includes 22 new tests in
      `test_dspace_split_input.py`, all HTTP-mocked).
- [x] `uv run ruff format` + `uv run ruff check` on changed files — clean.
- [x] New-DSpace collection/community/search list detection, pagination,
      REST-error fallback.
- [x] Old-DSpace collection/community handle detection (via
      `/rest/handle` type resolution), pagination, REST-error fallback.
- [x] Single-item URL (old + new) still returns exactly 1 record,
      no unnecessary network calls for structurally non-list URLs.
- [x] `validate_identifier` accepts new list URL shapes, still rejects
      garbage.
