### PR TITLE
feat(multiseek): eksport dokumentu HTML / DOCX / BibTeX

### DIFF
--- a/docs/superpowers/specs/2026-07-10-multiseek-eksport-html-docx-design.md
+++ b/docs/superpowers/specs/2026-07-10-multiseek-eksport-html-docx-design.md
@@ -2,6 +2,8 @@
 
 Data: 2026-07-10
 Gałąź: `feat-multiseek-eksport-html-docx` (worktree off `dev`)
+Rewizja: v2 (po review Fable #1 — poprawki N+1, numeracja, pandoc/docker,
+sanityzacja, reuse `export_to_bibtex`)
 
 ## 1. Cel
 
@@ -20,30 +22,41 @@ Istniejące eksporty **danych** (CSV, XLS:dane, XLS:opis) pozostają bez zmian.
 ## 2. Kontekst i stan obecny
 
 - Route: `^multiseek/export/(?P<export_format>[\w-]+)/$` →
-  `bpp.views.mymultiseek.MyMultiseekExport` (`src/django_bpp/urls.py`).
+  `bpp.views.mymultiseek.MyMultiseekExport` (`src/django_bpp/urls.py:308`).
   Regexp `[\w-]+` już przyjmuje nowe formaty — **bez zmian w `urls.py`**.
 - `MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults).get()`
   (`src/bpp/views/mymultiseek.py`): waliduje format ∈ `{csv, xlsx}`, czyta
   `?wariant=` ∈ `{dane, opis}`, sprawdza limit `MULTISEEK_EXPORT_MAX_ROWS`
-  (5000), zawęża queryset (`.only(MULTISEEK_EXPORT_DANE_FIELDS/OPIS_FIELDS)`),
-  woła buildery z `bpp/views/multiseek_export.py`.
+  (5000), zawęża queryset, woła buildery z `bpp/views/multiseek_export.py`.
+- `MyMultiseekResults.get_queryset()` (`mymultiseek.py:58-107`) stosuje
+  `.only()` **dostrojony do renderu ekranowego, nie do eksportu**:
+  - list/numer_list/None → `flds = ("id", "opis_bibliograficzny_cache")`,
+  - EXTRA_TYPES (tabele) → dokłada `charakter_formalny, typ_kbn, punkty_kbn,
+    impact_factor, adnotacje, uwagi, punktacja_wewnetrzna,
+    charakter_formalny__nazwa, typ_kbn__nazwa`.
+  **UWAGA (znalezione w review):** ten zestaw **nie zawiera `liczba_cytowan`**
+  (renderowanej w tabelach `_cytowania`, `common-results.html:200`) ani
+  `uwagi` dla `numer_list` (renderowanej w liście, `common-results.html:132`).
+  Na ekranie (≤25/stronę) to latentny N+1; przy eksporcie **całego** querysetu
+  (do 5000) byłoby do 5000 dodatkowych zapytań. Dlatego eksport dokumentu
+  **nie polega** na projekcji bazowej — patrz D9/§4.4.
 - Buildery `csv_export_response` / `xlsx_export_response`
-  (`src/bpp/views/multiseek_export.py`) budują **własne kolumny** z querysetu —
-  niezależnie od `report_type`.
+  (`src/bpp/views/multiseek_export.py`) budują **własne kolumny** z querysetu.
 - Render ekranowy: `templates/multiseek/common-results.html` renderuje treść
   zależnie od `report_type`:
   - `bibtex` → `<pre>` z `element.original.to_bibtex`,
-  - `list` / `numer_list` / `None` → numerowany `<ol>` z
-    `opis_bibliograficzny_cache`,
+  - `list`/`numer_list`/`None` → numerowany `<ol>` z `opis_bibliograficzny_cache`
+    (+ `uwagi` dla `numer_list`),
   - warianty tabelaryczne (`table`, `pkt_wewn`, `pkt_wewn_bez`, każdy też
     `_cytowania`) → `<table>` z kolumnami zależnymi od `report_type` + stopka
-    `Suma:`.
-  Markup przemieszany z UI (przyciski „❌ usuń", paginator, panele) gated
-  `hide-for-print`.
+    `Suma:` (tylko na ostatniej stronie).
 - **Reuse DOCX:** `src/nowe_raporty/docx_export.py::html_to_docx(html) -> bytes`
-  konwertuje HTML→DOCX: najpierw `pypandoc`, przy błędzie fallback na
-  dockerowy `iplweb/html2docx` (`_convert_using_docker_image`). Post-processing
-  page-breaków przez `python-docx`.
+  — najpierw `pypandoc`, przy `(OSError|RuntimeError)` fallback na dockerowy
+  `iplweb/html2docx`. `DocxConversionError` gdy oba padną. `nh3.clean` jest
+  używane w siostrzanym `as_docx()`, ale **`html_to_docx()` samo nie
+  sanityzuje** — sanityzacja po naszej stronie (D8).
+- **Reuse BibTeX:** `bpp/export/bibtex.py::export_to_bibtex(publications) -> str`
+  (do potwierdzenia sygnatura przy implementacji) — gotowa konkatenacja.
 
 ## 3. Kluczowe decyzje projektowe
 
@@ -53,9 +66,11 @@ Istniejące eksporty **danych** (CSV, XLS:dane, XLS:opis) pozostają bez zmian.
 | D2 | HTML/DOCX **wiernie odwzorowują aktualny `report_type`** (lista lub tabela). | Wybór usera: „biorą to, co się renderuje w multiseeku". |
 | D3 | `report_type == "bibtex"` → eksport jako `.bib` (nie HTML/DOCX). | BibTeX jest tekstowy; `.bib` to kanoniczne rozszerzenie, MIME `application/x-bibtex`. |
 | D4 | **Wydzielić wspólne partiale** z `common-results.html`; render ekranowy i eksport dzielą jedno źródło markupu. | Zero rozjazdu kolumn tabeli przy przyszłych zmianach. |
-| D5 | DOCX przez istniejący `html_to_docx()`; **produkcyjny konwerter to dockerowy `html2docx`**, pandoc jest best-effort (na części instalacji nie działa i nie możemy tego zmienić — fallback dockera to pokrywa). | Reuse przetestowanego kodu; niezawodna ścieżka bez pandoca. |
-| D6 | Wspólny limit **5000** (`MULTISEEK_EXPORT_MAX_ROWS`) także dla HTML/DOCX/BibTeX. | Spójność z CTV/XLSX; ogranicza koszt konwersji dokumentu. Decyzja rewidowalna. |
+| D5 | DOCX przez istniejący `html_to_docx()`. Realnie: **pandoc jest ścieżką pierwszą i produkcyjną** (binarka zapieczona w obrazie, `docker/bpp_base/Dockerfile`), a **dockerowy `html2docx` to rescue na twardej awarii** (brak binarki → OSError, non-zero exit → RuntimeError). Na instalacjach, gdzie „pandoc nie działa" i pada w sposób podnoszący wyjątek, fallback dockera to pokrywa. | Reuse przetestowanego kodu; nie pogarszamy zachowania. Znane ograniczenie: pandoc obecny, ale cicho generujący zły plik (exit 0) **nie** wyzwoli fallbacku — poza zakresem v1 (współdzielony kod z `nowe_raporty`), patrz §10. |
+| D6 | Wspólny limit **5000** (`MULTISEEK_EXPORT_MAX_ROWS`) także dla HTML/DOCX/BibTeX. | Spójność z CSV/XLSX; ogranicza koszt konwersji dokumentu. Decyzja rewidowalna. |
 | D7 | W dokumencie: tylko tytuł tekstowy (bez logo/grafik), bez linków `<a>` wokół opisu (relatywne URL-e psują pobrany plik), bez przycisków „usuń". | YAGNI; czysty, przenośny dokument. |
+| D8 | **Sanityzacja** treści dokumentu przez `nh3.clean` (allowlist rozszerzony o tagi strukturalne `ol/li/table/...`) przed odpowiedzią `.html` i przed `html_to_docx`. | Plik opuszcza serwis (brak CSP, `file://`, re-hosting); DB-sourced HTML z `opis_bibliograficzny_cache` musi być czyszczony — spójnie z siostrzanym `as_docx()` i z sanityzacją CSV/XLSX. |
+| D9 | Eksport dokumentu stosuje **własną projekcję** `.only()`/`select_related` dostrojoną do renderowanego partiala (nie reużywa projekcji bazowej z `get_queryset()`). | Bazowa projekcja gubi `liczba_cytowan`/`uwagi` → N+1 na 5000 rekordach (blocker z review). Nie ruszamy projekcji ekranowej (ryzyko dla `test_mymultiseek_query_count.py`). |
 
 ## 4. Architektura
 
@@ -63,103 +78,145 @@ Istniejące eksporty **danych** (CSV, XLS:dane, XLS:opis) pozostają bez zmian.
 
 Nowe include'y w `src/django_bpp/templates/multiseek/`:
 
-- `report-body-list.html` — numerowany `<ol>` opisów.
+- `report-body-list.html` — numerowany `<ol>` opisów (+ `uwagi` dla numer_list).
 - `report-body-table.html` — tabela punktacyjna (kolumny wg `report_type`) +
   opcjonalna stopka `Suma:`.
 - `report-body-bibtex.html` — `<pre>` z `to_bibtex` (używany tylko na ekranie;
   eksport BibTeX omija HTML).
 
-Parametry include'a (przekazywane przez `{% include ... with %}`):
+Każdy partial **musi mieć własny `{% load i18n %}`** (i inne potrzebne tag-liby
+— `{% trans %}`, `{% url %}`, `prace`) — biblioteki tagów **nie** dziedziczą się
+przez `{% include %}`.
+
+Parametry include'a (`{% include ... with %}`):
 
 - `export_mode` (bool, default `False`) — gdy `True`: chowa przyciski
-  „❌ usuń", opuszcza `<a>`-link wokół opisu (czysty tekst).
-- `start_index` (int, default `0`) — offset numeracji. Ekran przekazuje
-  `page_obj.start_index|add:-1` (lista, `counter-reset`) /
-  `page_obj.start_index` (tabela); eksport `0`.
-- `show_footer` (bool) — tabela: ekran pokazuje stopkę tylko na ostatniej
-  stronie (`page_obj.number == page_obj.paginator.num_pages`), eksport zawsze.
+  „❌ usuń" i opuszcza `<a>`-link wokół opisu (czysty tekst; relatywne
+  `{% url %}` psuje pobrany plik).
+- `start_index` (int, **0-based offset**, default `0`) — **jednolita semantyka
+  w obu partialach**:
+  - lista: `counter-reset: list-counter {{ start_index }}`,
+  - tabela: `{{ start_index|add:forloop.counter }}` (pierwszy wiersz = 1).
+  Ekran przekazuje `page_obj.start_index|add:-1` do **obu**; eksport przekazuje
+  `0` do obu. (Naprawia off-by-one z review — bez tego eksport tabeli
+  numerowałby od „0".)
+- `show_footer` (bool) — tabela: ekran przekazuje
+  `page_obj.number == page_obj.paginator.num_pages`; eksport `True`.
 
-`common-results.html` po refaktorze zawiera partiale z `export_mode=False`,
-zachowując render on-screen **bez zmian** (weryfikacja: istniejące
-`test_mymultiseek.py`).
+`common-results.html` po refaktorze zawiera partiale z `export_mode=False`
+i dotychczasowymi wartościami `start_index`/`show_footer`, zachowując render
+on-screen **bez zmian** (regression gate: `test_mymultiseek.py`,
+`test_mymultiseek_query_count.py`). Refaktor mechaniczny: przeniesienie markupu
+1:1 + parametryzacja numeracji/chrome.
 
-### 4.2 Szablon dokumentu eksportu
+### 4.2 Szablon dokumentu eksportu (shell + wstrzyknięty body)
 
-Nowy `src/django_bpp/templates/multiseek/export-document.html`:
+Nowy `src/django_bpp/templates/multiseek/export-document.html` = **zaufana
+skorupa**:
 
 - pełny `<!doctype html>` + `<meta charset="utf-8">`,
 - `<title>` i `<h1>` = tytuł raportu z sesji (`_multiseek_report_title`),
 - minimalny inline CSS (obramowania tabeli, odstępy listy),
-- właściwy `report-body-*` z `export_mode=True`, `start_index=0`,
-  `show_footer=True`.
+- `{{ body_html|safe }}` — **już zsanityzowany** fragment (patrz §4.3).
 
-Bez logo, paginatora, paneli, skryptów.
+Skorupa jest w pełni pod naszą kontrolą (nie zawiera DB-content poza
+`report_title`, który sanityzujemy jak dotąd przez `plain_multiseek_report_title`),
+więc `|safe` na `body_html` jest bezpieczne **dopiero po** `nh3.clean`.
 
-### 4.3 Buildery odpowiedzi (`bpp/views/multiseek_export.py`)
+### 4.3 Buildery i render (`bpp/views/multiseek_export.py`)
 
-Nowe funkcje:
+Krok renderu (w widoku — potrzebny `request`):
+1. `body_html = render_to_string("multiseek/report-body-<list|table>.html",
+   ctx, request=request)` (ctx: `object_list`, `report_type`, `sumy`,
+   `export_mode=True`, `start_index=0`, `show_footer=True`),
+2. `clean_body = sanitize_export_html(body_html)` — `nh3.clean` z allowlistą
+   pokrywającą strukturę dokumentu i inline-formatowanie opisu
+   (`table, thead, tbody, tfoot, tr, td, th, ol, ul, li, p, div, span, h1, h2,
+   h3, br, hr, b, strong, i, em, u, sub, sup, pre, code`; atrybuty:
+   `td/th → colspan`). Rozszerza `DEFAULT_ALLOWED_TAGS` z `docx_export.py`.
+3. `document_html = render_to_string("multiseek/export-document.html",
+   {"body_html": clean_body, "report_title": report_title}, request)`.
 
-- `html_export_response(html: str, report_title: str) -> HttpResponse`
+Nowe funkcje builderów:
+
+- `html_export_response(document_html, report_title) -> HttpResponse`
   — `text/html; charset=utf-8`, załącznik `eksport-<tytuł>.html`
-  (reuse `_export_filename`).
-- `docx_export_response(html: str, report_title: str) -> HttpResponse`
-  — woła `nowe_raporty.docx_export.html_to_docx(html)` (import lokalny w ciele
-  funkcji, jak w `xlsx_export_response`), zwraca
+  (reuse `_export_filename("html", ...)`).
+- `docx_export_response(document_html, report_title) -> HttpResponse`
+  — import lokalny `from nowe_raporty.docx_export import html_to_docx`
+  (jak `xlsx_export_response` importuje openpyxl lokalnie), zwraca
   `application/vnd.openxmlformats-officedocument.wordprocessingml.document`,
-  załącznik `.docx`. `DocxConversionError` propaguje (widok mapuje na 500 —
-  standardowe, nie tłumimy po cichu).
-- `bibtex_export_response(queryset, request, report_title) -> HttpResponse`
-  — konkatenacja `rekord.original.to_bibtex` (rozdzielone pustą linią, jak na
-  ekranie), `application/x-bibtex; charset=utf-8`, załącznik `.bib`.
+  załącznik `.docx`. `DocxConversionError` **propaguje** (500) — nie tłumimy.
+- `bibtex_export_response(queryset, report_title) -> HttpResponse`
+  — **reuse** `bpp.export.bibtex.export_to_bibtex((r.original for r in
+  queryset.iterator(chunk_size=1000)))` (sygnaturę potwierdzić przy
+  implementacji); `application/x-bibtex; charset=utf-8`, załącznik
+  `eksport-<tytuł>.bib`.
+- `sanitize_export_html(html) -> str` — helper `nh3.clean` z allowlistą wyżej.
 
-Render HTML dokumentu (`render_to_string("multiseek/export-document.html",
-ctx, request=request)`) trzymamy w **widoku** (potrzebny `request`/kontekst),
-nie w builderze — builder dostaje gotowy string.
-
-### 4.4 Widok `MyMultiseekExport.get`
-
-Rozgałęzienie na starcie wg rodziny formatu:
+### 4.4 Widok `MyMultiseekExport.get` (+ projekcja eksportowa)
 
 ```
 DATA_FORMATS = {"csv", "xlsx"}
 DOCUMENT_FORMATS = {"html", "docx", "bib"}
+
+# projekcje dostrojone do renderu (naprawiają N+1 z review):
+MULTISEEK_RENDER_LIST_FIELDS = ("id", "opis_bibliograficzny_cache", "uwagi")
+MULTISEEK_RENDER_TABLE_FIELDS = (
+    "id", "opis_bibliograficzny_cache", "impact_factor", "punkty_kbn",
+    "liczba_cytowan", "punktacja_wewnetrzna",
+    "charakter_formalny", "typ_kbn",
+    "charakter_formalny__nazwa", "typ_kbn__nazwa",
+)
+TABLE_REPORT_TYPES = set(EXTRA_TYPES)  # pkt_wewn*, table* (+ _cytowania)
 ```
 
-- format spoza sumy tych zbiorów → `HttpResponseBadRequest`.
+Rozgałęzienie na starcie:
+
+- format ∉ (DATA_FORMATS ∪ DOCUMENT_FORMATS) → `HttpResponseBadRequest`.
 - Wspólnie: limit 5000 (`queryset.count()`), `LoginRequiredMixin`.
-- **csv/xlsx**: istniejąca ścieżka bez zmian (zawężenie
-  `MULTISEEK_EXPORT_DANE_FIELDS`/`OPIS_FIELDS`, `wariant`).
+- **csv/xlsx**: istniejąca ścieżka bez zmian.
 - **html/docx/bib** (eksport dokumentu):
-  - queryset **report_type-aware** z bazowego
-    `get_queryset_for_current_mode()` (NIE zawężamy do pól CSV — bazowy
-    `get_queryset()` już ma właściwe `.only()`/`select_related` dla EXTRA_TYPES),
+  - `queryset = self.get_queryset_for_current_mode()` (report_type-aware
+    filtrowanie/status/distinct z bazy),
   - `report_type = registry.get_report_type(self.get_multiseek_data(),
     request=self.request)`,
-  - jeśli `report_type == "bibtex"`:
-    - format `bib` → `bibtex_export_response`,
-    - format `html`/`docx` w widoku bibtex nie występuje w dropdownie, ale
-      gdyby ktoś trafił URL-em ręcznie → degradacja do `.bib` (spójne z D3).
-  - w innym razie (lista/tabela):
-    - dla typów tabelarycznych (EXTRA_TYPES) doliczamy `sumy`
-      (`qset.aggregate(Sum(...), ...)` — reuse logiki z `get_context_data`),
-    - `ctx = {"object_list": queryset, "report_type": report_type,
-      "sumy": sumy, "report_title": report_title}`,
-    - `html = render_to_string("multiseek/export-document.html", ctx,
-      request)`,
-    - format `html` → `html_export_response`,
-    - format `docx` → `docx_export_response`,
-    - format `bib` poza widokiem bibtex → `HttpResponseBadRequest`
-      („BibTeX dostępny tylko dla widoku BibTeX").
+  - **bibtex-view** (`report_type == "bibtex"`):
+    - `bib` → `bibtex_export_response(queryset, report_title)`,
+    - `html`/`docx` (nie występują w dropdownie tego widoku, ale gdyby ktoś
+      trafił URL-em) → degradacja do `.bib`; **nazwa pliku i MIME wg realnego
+      formatu `bib`** (nie `export_format`),
+  - **inne widoki** (lista/tabela):
+    - `bib` → `HttpResponseBadRequest` („BibTeX dostępny tylko w widoku BibTeX"),
+    - jeśli `report_type in TABLE_REPORT_TYPES`:
+      - `queryset = queryset.select_related("charakter_formalny", "typ_kbn")
+        .only(*MULTISEEK_RENDER_TABLE_FIELDS)`,
+      - `sumy = queryset.aggregate(Sum("impact_factor"), Sum("liczba_cytowan"),
+        Sum("punkty_kbn"), Sum("punktacja_wewnetrzna"))` (klucze `*__sum`
+        zgodne z `report-body-table.html`; agregat liczony **przed** iteracją
+        renderu — osobne zapytanie, ale bez N+1),
+      - partial = `report-body-table.html`,
+    - w innym razie (list/numer_list/None):
+      - `queryset = queryset.only(*MULTISEEK_RENDER_LIST_FIELDS)`,
+      - `sumy = None`, partial = `report-body-list.html`,
+    - render (§4.3 kroki 1-3) → `html`/`docx` builder.
 
-URL bez zmian (`[\w-]+`). Filenames generyczne przez `_export_filename`.
+Uwaga: ponowne `.only()` na querysecie z `get_queryset()` **zastępuje** zestaw
+pól bazowych (semantyka Django), zachowując `select_related`/`distinct`
+z bazy. URL bez zmian (`[\w-]+`). Filenames generyczne (`_export_filename`).
 
 ### 4.5 Adaptacyjny dropdown (`templates/multiseek/paginator.html`)
 
-CSV / XLS:dane / XLS:opis — zawsze (bez zmian). Dodatkowo, `report_type`
-dostępny w kontekście include'a:
+`report_type` jest w kontekście include'a (dziedziczone przez `{% include ...
+with %}` bez `only`; już używane w `common-results.html:103`). Nowe pozycje
+**wewnątrz istniejącego `dropdown-pane`** (`paginator.html:53`), którego id/toggle
+są już zdezambiguowane sufiksem `magellan` (top/bottom) — dzięki temu podwójny
+include (górny+dolny) nie łamie unikalności id.
 
-- `report_type == "bibtex"` → jedna pozycja **„BibTeX (.bib)"**
-  (`{% url "multiseek-export" "bib" %}`),
+Zawartość:
+- CSV / XLS:dane / XLS:opis — zawsze (bez zmian),
+- `report_type == "bibtex"` → **„BibTeX (.bib)"** (`{% url "multiseek-export"
+  "bib" %}`),
 - w każdym innym widoku → **„HTML"** (`... "html"`) + **„DOCX (Word)"**
   (`... "docx"`).
 
@@ -172,14 +229,17 @@ user klika [Eksport ▸ HTML|DOCX|BibTeX]
   → GET /multiseek/export/<fmt>/[?print-removed=1]
   → MyMultiseekExport.get(fmt)
      ├─ walidacja fmt, limit 5000, login
-     ├─ queryset = get_queryset_for_current_mode()   # report_type-aware
+     ├─ queryset = get_queryset_for_current_mode()
      ├─ report_type = registry.get_report_type(...)
-     ├─ bibtex? → bibtex_export_response → .bib
+     ├─ bibtex-view → bibtex_export_response → .bib (export_to_bibtex)
      └─ inaczej:
-          ├─ sumy (jeśli tabela)
-          ├─ html = render_to_string("export-document.html", ctx, request)
-          ├─ fmt == html → html_export_response(html) → .html
-          └─ fmt == docx → docx_export_response(html)
+          ├─ tabela? → .only(TABLE_FIELDS)+select_related, sumy=aggregate
+          │  inaczej → .only(LIST_FIELDS), sumy=None
+          ├─ body = render_to_string("report-body-<list|table>", ctx, request)
+          ├─ clean = sanitize_export_html(body)          # nh3.clean (D8)
+          ├─ doc = render_to_string("export-document.html", {body_html: clean})
+          ├─ fmt == html → html_export_response(doc) → .html
+          └─ fmt == docx → docx_export_response(doc)
                             → html_to_docx() [pandoc→docker html2docx] → .docx
 ```
 
@@ -189,52 +249,65 @@ user klika [Eksport ▸ HTML|DOCX|BibTeX]
   `HttpResponseBadRequest` (spójne z obecnym `csv/xlsx`).
 - Anonim → redirect na login (`LoginRequiredMixin`, bez zmian).
 - `DocxConversionError` (pandoc i docker padły) → propaguje jako 500; NIE
-  tłumimy po cichu (zgodnie z regułą projektu o wyjątkach). Logowanie już
-  w `docx_export.py`.
+  tłumimy po cichu (reguła projektu o wyjątkach; logowanie już w
+  `docx_export.py`).
+- Sanityzacja (D8) `nh3.clean` biegnie na body PRZED odpowiedzią `.html`
+  i przed `html_to_docx`.
 
 ## 7. Testy (TDD)
 
-Plik: `src/bpp/tests/test_views/test_mymultiseek.py` (rozszerzenie) +
-ewentualnie nowy `test_multiseek_export_document.py`.
+Pliki: rozszerzenie `src/bpp/tests/test_views/test_mymultiseek.py`,
+`src/bpp/tests/test_views/test_mymultiseek_query_count.py`, ewentualny nowy
+`test_multiseek_export_document.py`.
 
-**Buildery odpowiedzi (unit):**
+**Buildery/helper (unit):**
 - `html_export_response`: Content-Type `text/html`, Content-Disposition
   `attachment; filename="eksport-*.html"`, treść zawiera markup listy/tabeli.
 - `docx_export_response`: monkeypatch `html_to_docx` → sentinel bytes (wzorzec
-  z `nowe_raporty/tests/test_docx_export.py`); Content-Type docx, `.docx`
-  w Content-Disposition. Dodatkowo **jeden** realny przebieg (pandoc dostępny
-  lokalnie) sprawdzający nagłówek ZIP `PK\x03\x04`.
+  z `nowe_raporty/tests/test_docx_export.py`); Content-Type docx, `.docx`.
+  Dodatkowo **jeden** realny przebieg (pandoc lokalnie) → nagłówek ZIP
+  `PK\x03\x04`. Test fallbacku: monkeypatch `pypandoc.convert_text` → `OSError`,
+  monkeypatch `_convert_using_docker_image` → sentinel; assert docker-branch użyty.
 - `bibtex_export_response`: Content-Type `application/x-bibtex`, `.bib`, treść
   zawiera `@` wpisy.
+- `sanitize_export_html`: `<script>`/on-atrybuty usunięte; `<i>/<sub>/<sup>`
+  w opisie zachowane; `<table>/<ol>/<li>` zachowane.
 
 **Routing widoku (integration, `@pytest.mark.django_db`):**
 - każdy format (`html`, `docx`, `bib`) → 200 + poprawny Content-Type;
-- `report_type` → właściwy render: list vs table (obecność `<ol>` vs `<table>`
-  i kolumny wg wariantu tabeli);
-- widok bibtex: dropdown/endpoint `bib` → `.bib`; `html`/`docx` degradują do
-  `.bib`;
+- `report_type` → właściwy render: list vs table (`<ol>` vs `<table>`
+  + kolumny wg wariantu tabeli), parametryzacja po `list`, `numer_list`,
+  `table`, `pkt_wewn`, `pkt_wewn_cytowania`, `table_cytowania`;
+- **numeracja tabeli**: pierwszy wiersz eksportu = „1." (regression off-by-one);
+- **numer_list**: render zawiera `uwagi`;
+- widok bibtex: endpoint `bib` → `.bib`; `html`/`docx` degradują do `.bib`
+  (nazwa `*.bib`);
 - `bib` w widoku nie-bibtex → 400;
 - >5000 rekordów → 400 (mock count);
-- anon → redirect;
-- nieznany format → 400.
+- `?print-removed=1` eksport dokumentu → 200, render tylko usuniętych;
+- anon → redirect; nieznany format → 400.
+
+**Query-count (regression N+1, guard dla D9):**
+- eksport `table_cytowania` (z `liczba_cytowan`) i `numer_list` (z `uwagi`) na
+  N rekordach → liczba zapytań **stała** (nie rośnie z N); wzorzec
+  z `test_mymultiseek_query_count.py`. To złapałoby blocker z review.
+- eksport ekranowy (partial extraction) — istniejące query-count testy bez zmian.
 
 **Regresja partiali:**
-- istniejące testy renderu ekranowego (`test_mymultiseek.py`) przechodzą bez
-  zmian — potwierdza, że wydzielenie partiali nie zmieniło on-screen output.
-- Test „smoke" że `report-body-table.html` renderuje właściwe kolumny dla
-  `pkt_wewn` / `pkt_wewn_cytowania` / `table_cytowania` (parametryzowany).
+- istniejące testy renderu ekranowego przechodzą bez zmian (dowód, że
+  wydzielenie partiali nie zmieniło on-screen output).
 
-**Uruchomienie lokalnie:** `make tests-without-playwright` + docelowo
-`uv run pytest src/bpp/tests/test_views/test_mymultiseek.py`. DOCX-test realny
-wymaga pandoca (lokalnie jest); w CI fallback docker lub monkeypatch.
+**Uruchomienie lokalnie:** `make tests-without-playwright` +
+`uv run pytest src/bpp/tests/test_views/test_mymultiseek*.py`.
 
 ## 8. Pliki (create/modify)
 
 **Modify:**
 - `src/bpp/views/mymultiseek.py` — rozgałęzienie `get()`, ścieżka dokumentu,
-  liczenie `sumy`, import `render_to_string`.
+  projekcje `MULTISEEK_RENDER_*`, liczenie `sumy`, `render_to_string`.
 - `src/bpp/views/multiseek_export.py` — `html_export_response`,
-  `docx_export_response`, `bibtex_export_response`.
+  `docx_export_response`, `bibtex_export_response`, `sanitize_export_html`
+  (import `nh3`).
 - `src/django_bpp/templates/multiseek/common-results.html` — zamiana inline
   markupu listy/tabeli/bibtex na `{% include %}` partiali.
 - `src/django_bpp/templates/multiseek/paginator.html` — adaptacyjny dropdown.
@@ -258,9 +331,11 @@ wymaga pandoca (lokalnie jest); w CI fallback docker lub monkeypatch.
 ## 10. Ryzyka
 
 - **Wydzielenie partiali** dotyka gorącego widoku ekranowego — mitigacja:
-  istniejące testy renderu jako regression gate; refaktor czysto mechaniczny
-  (przeniesienie markupu 1:1 + parametry).
-- **DOCX na 5000 wierszach** przez pandoc/docker — koszt czasu; limit 5000
-  ogranicza, ale realny render dużej tabeli może być wolny. Akceptowalne w v1.
-- **`to_bibtex` per rekord** dla BibTeX — potencjalne N+1; ograniczone limitem
-  5000. Ewentualna optymalizacja poza zakresem v1.
+  istniejące testy renderu + query-count jako regression gate; refaktor
+  mechaniczny (markup 1:1 + parametry numeracji).
+- **Pandoc „cicho" zły (exit 0, zły plik)** nie wyzwoli fallbacku dockera
+  (`html_to_docx` łapie tylko wyjątki, brak walidacji outputu pandoca) —
+  współdzielone z `nowe_raporty`, poza zakresem v1; udokumentowane (D5).
+- **DOCX/BibTeX na 5000 wierszach** — koszt czasu (pandoc/docker; `to_bibtex`
+  = 1 pełny obiekt + autorzy per rekord). Ograniczone limitem 5000, `iterator()`
+  tnie pamięć. Akceptowalne w v1.

--- a/docs/superpowers/specs/2026-07-10-multiseek-eksport-html-docx-design.md
+++ b/docs/superpowers/specs/2026-07-10-multiseek-eksport-html-docx-design.md
@@ -92,7 +92,13 @@ Parametry include'a (`{% include ... with %}`):
 
 - `export_mode` (bool, default `False`) — gdy `True`: chowa przyciski
   „❌ usuń" i opuszcza `<a>`-link wokół opisu (czysty tekst; relatywne
-  `{% url %}` psuje pobrany plik).
+  `{% url %}` psuje pobrany plik). **Gate przycisku usuwania musi brzmieć
+  `{% if not export_mode and not print_removed %}`** — nie sam
+  `not print_removed`. Powód (review #2): w kontekście eksportu `print_removed`
+  jest nieustawione (falsy), więc branch by się wyrenderował; `nh3.clean`
+  usunie `<a data-remove-result>`, ale **zostawi tekst „❌"** jako węzeł
+  tekstowy. Gate na `export_mode` jest więc wymagany dla poprawności, nie
+  kosmetyki.
 - `start_index` (int, **0-based offset**, default `0`) — **jednolita semantyka
   w obu partialach**:
   - lista: `counter-reset: list-counter {{ start_index }}`,
@@ -100,14 +106,20 @@ Parametry include'a (`{% include ... with %}`):
   Ekran przekazuje `page_obj.start_index|add:-1` do **obu**; eksport przekazuje
   `0` do obu. (Naprawia off-by-one z review — bez tego eksport tabeli
   numerowałby od „0".)
-- `show_footer` (bool) — tabela: ekran przekazuje
-  `page_obj.number == page_obj.paginator.num_pages`; eksport `True`.
+- Stopka `Suma:` (tabela) — **NIE** przez parametr `show_footer` z `{% include
+  with %}`: Django `token_kwargs` przyjmuje tylko wyrażenia filtrowe, **nie
+  operator `==`**, więc `show_footer=page_obj.number == …` to TemplateSyntaxError
+  (blocker z review #2). Zamiast tego warunek **wewnątrz partiala**, z gate na
+  `export_mode` jako pierwszym członie (żeby nie dotknąć `page_obj` w eksporcie,
+  gdzie jest nieustawiony):
+  `{% if export_mode or page_obj.number == page_obj.paginator.num_pages %}`
+  wokół `<tfoot>`. Eksport (`export_mode=True`) zawsze pokazuje sumę; ekran —
+  jak dotąd, tylko na ostatniej stronie.
 
 `common-results.html` po refaktorze zawiera partiale z `export_mode=False`
-i dotychczasowymi wartościami `start_index`/`show_footer`, zachowując render
-on-screen **bez zmian** (regression gate: `test_mymultiseek.py`,
-`test_mymultiseek_query_count.py`). Refaktor mechaniczny: przeniesienie markupu
-1:1 + parametryzacja numeracji/chrome.
+i dotychczasowym `start_index`, zachowując render on-screen **bez zmian**
+(regression gate: `test_mymultiseek.py`, `test_mymultiseek_query_count.py`).
+Refaktor mechaniczny: przeniesienie markupu 1:1 + parametryzacja numeracji/chrome.
 
 ### 4.2 Szablon dokumentu eksportu (shell + wstrzyknięty body)
 
@@ -116,12 +128,18 @@ skorupa**:
 
 - pełny `<!doctype html>` + `<meta charset="utf-8">`,
 - `<title>` i `<h1>` = tytuł raportu z sesji (`_multiseek_report_title`),
-- minimalny inline CSS (obramowania tabeli, odstępy listy),
+- minimalny inline CSS — **selektory elementowe** (`table, td, th { border… }`),
+  NIE klasy: `nh3.clean` usuwa atrybuty `class`/`style` z wstrzykniętego body,
+  więc stylowanie po klasach nie zadziała (review #2). Natywne `<ol>` w eksporcie
+  (bez paginacji) i tak numeruje 1..N poprawnie bez `counter-reset`.
+- `{{ report_title }}` w `<title>`/`<h1>` **bez `|safe`** — autoescaping. Powód
+  (review #2): `plain_multiseek_report_title` robi `html.unescape` **po**
+  `strip_tags`, więc tytuł może zawierać literalny `<`; `|safe` byłoby XSS.
 - `{{ body_html|safe }}` — **już zsanityzowany** fragment (patrz §4.3).
 
 Skorupa jest w pełni pod naszą kontrolą (nie zawiera DB-content poza
-`report_title`, który sanityzujemy jak dotąd przez `plain_multiseek_report_title`),
-więc `|safe` na `body_html` jest bezpieczne **dopiero po** `nh3.clean`.
+`report_title`, renderowanym z autoescapingiem), więc `|safe` na `body_html`
+jest bezpieczne **dopiero po** `nh3.clean`.
 
 ### 4.3 Buildery i render (`bpp/views/multiseek_export.py`)
 
@@ -130,10 +148,12 @@ Krok renderu (w widoku — potrzebny `request`):
    ctx, request=request)` (ctx: `object_list`, `report_type`, `sumy`,
    `export_mode=True`, `start_index=0`, `show_footer=True`),
 2. `clean_body = sanitize_export_html(body_html)` — `nh3.clean` z allowlistą
-   pokrywającą strukturę dokumentu i inline-formatowanie opisu
-   (`table, thead, tbody, tfoot, tr, td, th, ol, ul, li, p, div, span, h1, h2,
-   h3, br, hr, b, strong, i, em, u, sub, sup, pre, code`; atrybuty:
-   `td/th → colspan`). Rozszerza `DEFAULT_ALLOWED_TAGS` z `docx_export.py`.
+   będącą **unią** (nie podzbiorem — review #2) `set(DEFAULT_ALLOWED_TAGS)`
+   z `docx_export.py` (zawiera m.in. `h4, strike, font`, ważne bo markup opisu
+   pochodzi z per-instalacyjnych, DB-konfigurowalnych szablonów) i tagów
+   strukturalnych: `{table, thead, tbody, tfoot, tr, td, th, ol, ul, li, p,
+   div, span, h1, h2, h3, br, hr, pre, code}`. Atrybuty: `td/th → colspan`
+   (`class`/`style` celowo odrzucone).
 3. `document_html = render_to_string("multiseek/export-document.html",
    {"body_html": clean_body, "report_title": report_title}, request)`.
 
@@ -279,6 +299,10 @@ Pliki: rozszerzenie `src/bpp/tests/test_views/test_mymultiseek.py`,
   + kolumny wg wariantu tabeli), parametryzacja po `list`, `numer_list`,
   `table`, `pkt_wewn`, `pkt_wewn_cytowania`, `table_cytowania`;
 - **numeracja tabeli**: pierwszy wiersz eksportu = „1." (regression off-by-one);
+- **stopka tabeli**: eksport zawiera `<tfoot>` z `Suma:` (bo `export_mode`),
+  niezależnie od paginacji; ekran — bez zmian (tylko ostatnia strona);
+- **tytuł z `<`**: title sesji `<b>x` → w eksporcie zescape'owany (`&lt;b&gt;`),
+  nie surowy tag;
 - **numer_list**: render zawiera `uwagi`;
 - widok bibtex: endpoint `bib` → `.bib`; `html`/`docx` degradują do `.bib`
   (nazwa `*.bib`);

--- a/docs/superpowers/specs/2026-07-10-multiseek-eksport-html-docx-design.md
+++ b/docs/superpowers/specs/2026-07-10-multiseek-eksport-html-docx-design.md
@@ -1,0 +1,266 @@
+# Eksport Multiseek do HTML i DOCX (+ BibTeX `.bib`) — design
+
+Data: 2026-07-10
+Gałąź: `feat-multiseek-eksport-html-docx` (worktree off `dev`)
+
+## 1. Cel
+
+Rozszerzyć dropdown eksportu wyników Multiseek o trzy nowe formaty **eksportu
+dokumentu**, odwzorowujące to, co user faktycznie widzi na ekranie
+(`common-results.html`):
+
+- **HTML** — samodzielny plik `.html` z aktualnym renderem (lista opisów /
+  tabela punktacyjna),
+- **DOCX** — ten sam render skonwertowany do Worda,
+- **BibTeX (`.bib`)** — gdy aktualny `report_type == "bibtex"`, surowy plik
+  `.bib` zamiast HTML/DOCX.
+
+Istniejące eksporty **danych** (CSV, XLS:dane, XLS:opis) pozostają bez zmian.
+
+## 2. Kontekst i stan obecny
+
+- Route: `^multiseek/export/(?P<export_format>[\w-]+)/$` →
+  `bpp.views.mymultiseek.MyMultiseekExport` (`src/django_bpp/urls.py`).
+  Regexp `[\w-]+` już przyjmuje nowe formaty — **bez zmian w `urls.py`**.
+- `MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults).get()`
+  (`src/bpp/views/mymultiseek.py`): waliduje format ∈ `{csv, xlsx}`, czyta
+  `?wariant=` ∈ `{dane, opis}`, sprawdza limit `MULTISEEK_EXPORT_MAX_ROWS`
+  (5000), zawęża queryset (`.only(MULTISEEK_EXPORT_DANE_FIELDS/OPIS_FIELDS)`),
+  woła buildery z `bpp/views/multiseek_export.py`.
+- Buildery `csv_export_response` / `xlsx_export_response`
+  (`src/bpp/views/multiseek_export.py`) budują **własne kolumny** z querysetu —
+  niezależnie od `report_type`.
+- Render ekranowy: `templates/multiseek/common-results.html` renderuje treść
+  zależnie od `report_type`:
+  - `bibtex` → `<pre>` z `element.original.to_bibtex`,
+  - `list` / `numer_list` / `None` → numerowany `<ol>` z
+    `opis_bibliograficzny_cache`,
+  - warianty tabelaryczne (`table`, `pkt_wewn`, `pkt_wewn_bez`, każdy też
+    `_cytowania`) → `<table>` z kolumnami zależnymi od `report_type` + stopka
+    `Suma:`.
+  Markup przemieszany z UI (przyciski „❌ usuń", paginator, panele) gated
+  `hide-for-print`.
+- **Reuse DOCX:** `src/nowe_raporty/docx_export.py::html_to_docx(html) -> bytes`
+  konwertuje HTML→DOCX: najpierw `pypandoc`, przy błędzie fallback na
+  dockerowy `iplweb/html2docx` (`_convert_using_docker_image`). Post-processing
+  page-breaków przez `python-docx`.
+
+## 3. Kluczowe decyzje projektowe
+
+| # | Decyzja | Uzasadnienie |
+|---|---------|--------------|
+| D1 | Dwie rozłączne rodziny: eksport **danych** (CSV/XLSX, stałe kolumny) vs eksport **dokumentu** (HTML/DOCX/BibTeX, wg `report_type`). | Odmienna semantyka; HTML/DOCX renderują prezentację, nie kolumny — nie pasują do modelu `wariant=`. |
+| D2 | HTML/DOCX **wiernie odwzorowują aktualny `report_type`** (lista lub tabela). | Wybór usera: „biorą to, co się renderuje w multiseeku". |
+| D3 | `report_type == "bibtex"` → eksport jako `.bib` (nie HTML/DOCX). | BibTeX jest tekstowy; `.bib` to kanoniczne rozszerzenie, MIME `application/x-bibtex`. |
+| D4 | **Wydzielić wspólne partiale** z `common-results.html`; render ekranowy i eksport dzielą jedno źródło markupu. | Zero rozjazdu kolumn tabeli przy przyszłych zmianach. |
+| D5 | DOCX przez istniejący `html_to_docx()`; **produkcyjny konwerter to dockerowy `html2docx`**, pandoc jest best-effort (na części instalacji nie działa i nie możemy tego zmienić — fallback dockera to pokrywa). | Reuse przetestowanego kodu; niezawodna ścieżka bez pandoca. |
+| D6 | Wspólny limit **5000** (`MULTISEEK_EXPORT_MAX_ROWS`) także dla HTML/DOCX/BibTeX. | Spójność z CTV/XLSX; ogranicza koszt konwersji dokumentu. Decyzja rewidowalna. |
+| D7 | W dokumencie: tylko tytuł tekstowy (bez logo/grafik), bez linków `<a>` wokół opisu (relatywne URL-e psują pobrany plik), bez przycisków „usuń". | YAGNI; czysty, przenośny dokument. |
+
+## 4. Architektura
+
+### 4.1 Wydzielenie partiali (refaktor `common-results.html`)
+
+Nowe include'y w `src/django_bpp/templates/multiseek/`:
+
+- `report-body-list.html` — numerowany `<ol>` opisów.
+- `report-body-table.html` — tabela punktacyjna (kolumny wg `report_type`) +
+  opcjonalna stopka `Suma:`.
+- `report-body-bibtex.html` — `<pre>` z `to_bibtex` (używany tylko na ekranie;
+  eksport BibTeX omija HTML).
+
+Parametry include'a (przekazywane przez `{% include ... with %}`):
+
+- `export_mode` (bool, default `False`) — gdy `True`: chowa przyciski
+  „❌ usuń", opuszcza `<a>`-link wokół opisu (czysty tekst).
+- `start_index` (int, default `0`) — offset numeracji. Ekran przekazuje
+  `page_obj.start_index|add:-1` (lista, `counter-reset`) /
+  `page_obj.start_index` (tabela); eksport `0`.
+- `show_footer` (bool) — tabela: ekran pokazuje stopkę tylko na ostatniej
+  stronie (`page_obj.number == page_obj.paginator.num_pages`), eksport zawsze.
+
+`common-results.html` po refaktorze zawiera partiale z `export_mode=False`,
+zachowując render on-screen **bez zmian** (weryfikacja: istniejące
+`test_mymultiseek.py`).
+
+### 4.2 Szablon dokumentu eksportu
+
+Nowy `src/django_bpp/templates/multiseek/export-document.html`:
+
+- pełny `<!doctype html>` + `<meta charset="utf-8">`,
+- `<title>` i `<h1>` = tytuł raportu z sesji (`_multiseek_report_title`),
+- minimalny inline CSS (obramowania tabeli, odstępy listy),
+- właściwy `report-body-*` z `export_mode=True`, `start_index=0`,
+  `show_footer=True`.
+
+Bez logo, paginatora, paneli, skryptów.
+
+### 4.3 Buildery odpowiedzi (`bpp/views/multiseek_export.py`)
+
+Nowe funkcje:
+
+- `html_export_response(html: str, report_title: str) -> HttpResponse`
+  — `text/html; charset=utf-8`, załącznik `eksport-<tytuł>.html`
+  (reuse `_export_filename`).
+- `docx_export_response(html: str, report_title: str) -> HttpResponse`
+  — woła `nowe_raporty.docx_export.html_to_docx(html)` (import lokalny w ciele
+  funkcji, jak w `xlsx_export_response`), zwraca
+  `application/vnd.openxmlformats-officedocument.wordprocessingml.document`,
+  załącznik `.docx`. `DocxConversionError` propaguje (widok mapuje na 500 —
+  standardowe, nie tłumimy po cichu).
+- `bibtex_export_response(queryset, request, report_title) -> HttpResponse`
+  — konkatenacja `rekord.original.to_bibtex` (rozdzielone pustą linią, jak na
+  ekranie), `application/x-bibtex; charset=utf-8`, załącznik `.bib`.
+
+Render HTML dokumentu (`render_to_string("multiseek/export-document.html",
+ctx, request=request)`) trzymamy w **widoku** (potrzebny `request`/kontekst),
+nie w builderze — builder dostaje gotowy string.
+
+### 4.4 Widok `MyMultiseekExport.get`
+
+Rozgałęzienie na starcie wg rodziny formatu:
+
+```
+DATA_FORMATS = {"csv", "xlsx"}
+DOCUMENT_FORMATS = {"html", "docx", "bib"}
+```
+
+- format spoza sumy tych zbiorów → `HttpResponseBadRequest`.
+- Wspólnie: limit 5000 (`queryset.count()`), `LoginRequiredMixin`.
+- **csv/xlsx**: istniejąca ścieżka bez zmian (zawężenie
+  `MULTISEEK_EXPORT_DANE_FIELDS`/`OPIS_FIELDS`, `wariant`).
+- **html/docx/bib** (eksport dokumentu):
+  - queryset **report_type-aware** z bazowego
+    `get_queryset_for_current_mode()` (NIE zawężamy do pól CSV — bazowy
+    `get_queryset()` już ma właściwe `.only()`/`select_related` dla EXTRA_TYPES),
+  - `report_type = registry.get_report_type(self.get_multiseek_data(),
+    request=self.request)`,
+  - jeśli `report_type == "bibtex"`:
+    - format `bib` → `bibtex_export_response`,
+    - format `html`/`docx` w widoku bibtex nie występuje w dropdownie, ale
+      gdyby ktoś trafił URL-em ręcznie → degradacja do `.bib` (spójne z D3).
+  - w innym razie (lista/tabela):
+    - dla typów tabelarycznych (EXTRA_TYPES) doliczamy `sumy`
+      (`qset.aggregate(Sum(...), ...)` — reuse logiki z `get_context_data`),
+    - `ctx = {"object_list": queryset, "report_type": report_type,
+      "sumy": sumy, "report_title": report_title}`,
+    - `html = render_to_string("multiseek/export-document.html", ctx,
+      request)`,
+    - format `html` → `html_export_response`,
+    - format `docx` → `docx_export_response`,
+    - format `bib` poza widokiem bibtex → `HttpResponseBadRequest`
+      („BibTeX dostępny tylko dla widoku BibTeX").
+
+URL bez zmian (`[\w-]+`). Filenames generyczne przez `_export_filename`.
+
+### 4.5 Adaptacyjny dropdown (`templates/multiseek/paginator.html`)
+
+CSV / XLS:dane / XLS:opis — zawsze (bez zmian). Dodatkowo, `report_type`
+dostępny w kontekście include'a:
+
+- `report_type == "bibtex"` → jedna pozycja **„BibTeX (.bib)"**
+  (`{% url "multiseek-export" "bib" %}`),
+- w każdym innym widoku → **„HTML"** (`... "html"`) + **„DOCX (Word)"**
+  (`... "docx"`).
+
+Zachowany wzorzec `print_removed` w query-stringu.
+
+## 5. Przepływ danych
+
+```
+user klika [Eksport ▸ HTML|DOCX|BibTeX]
+  → GET /multiseek/export/<fmt>/[?print-removed=1]
+  → MyMultiseekExport.get(fmt)
+     ├─ walidacja fmt, limit 5000, login
+     ├─ queryset = get_queryset_for_current_mode()   # report_type-aware
+     ├─ report_type = registry.get_report_type(...)
+     ├─ bibtex? → bibtex_export_response → .bib
+     └─ inaczej:
+          ├─ sumy (jeśli tabela)
+          ├─ html = render_to_string("export-document.html", ctx, request)
+          ├─ fmt == html → html_export_response(html) → .html
+          └─ fmt == docx → docx_export_response(html)
+                            → html_to_docx() [pandoc→docker html2docx] → .docx
+```
+
+## 6. Obsługa błędów
+
+- Nieznany format / `bib` poza widokiem bibtex / >5000 rekordów →
+  `HttpResponseBadRequest` (spójne z obecnym `csv/xlsx`).
+- Anonim → redirect na login (`LoginRequiredMixin`, bez zmian).
+- `DocxConversionError` (pandoc i docker padły) → propaguje jako 500; NIE
+  tłumimy po cichu (zgodnie z regułą projektu o wyjątkach). Logowanie już
+  w `docx_export.py`.
+
+## 7. Testy (TDD)
+
+Plik: `src/bpp/tests/test_views/test_mymultiseek.py` (rozszerzenie) +
+ewentualnie nowy `test_multiseek_export_document.py`.
+
+**Buildery odpowiedzi (unit):**
+- `html_export_response`: Content-Type `text/html`, Content-Disposition
+  `attachment; filename="eksport-*.html"`, treść zawiera markup listy/tabeli.
+- `docx_export_response`: monkeypatch `html_to_docx` → sentinel bytes (wzorzec
+  z `nowe_raporty/tests/test_docx_export.py`); Content-Type docx, `.docx`
+  w Content-Disposition. Dodatkowo **jeden** realny przebieg (pandoc dostępny
+  lokalnie) sprawdzający nagłówek ZIP `PK\x03\x04`.
+- `bibtex_export_response`: Content-Type `application/x-bibtex`, `.bib`, treść
+  zawiera `@` wpisy.
+
+**Routing widoku (integration, `@pytest.mark.django_db`):**
+- każdy format (`html`, `docx`, `bib`) → 200 + poprawny Content-Type;
+- `report_type` → właściwy render: list vs table (obecność `<ol>` vs `<table>`
+  i kolumny wg wariantu tabeli);
+- widok bibtex: dropdown/endpoint `bib` → `.bib`; `html`/`docx` degradują do
+  `.bib`;
+- `bib` w widoku nie-bibtex → 400;
+- >5000 rekordów → 400 (mock count);
+- anon → redirect;
+- nieznany format → 400.
+
+**Regresja partiali:**
+- istniejące testy renderu ekranowego (`test_mymultiseek.py`) przechodzą bez
+  zmian — potwierdza, że wydzielenie partiali nie zmieniło on-screen output.
+- Test „smoke" że `report-body-table.html` renderuje właściwe kolumny dla
+  `pkt_wewn` / `pkt_wewn_cytowania` / `table_cytowania` (parametryzowany).
+
+**Uruchomienie lokalnie:** `make tests-without-playwright` + docelowo
+`uv run pytest src/bpp/tests/test_views/test_mymultiseek.py`. DOCX-test realny
+wymaga pandoca (lokalnie jest); w CI fallback docker lub monkeypatch.
+
+## 8. Pliki (create/modify)
+
+**Modify:**
+- `src/bpp/views/mymultiseek.py` — rozgałęzienie `get()`, ścieżka dokumentu,
+  liczenie `sumy`, import `render_to_string`.
+- `src/bpp/views/multiseek_export.py` — `html_export_response`,
+  `docx_export_response`, `bibtex_export_response`.
+- `src/django_bpp/templates/multiseek/common-results.html` — zamiana inline
+  markupu listy/tabeli/bibtex na `{% include %}` partiali.
+- `src/django_bpp/templates/multiseek/paginator.html` — adaptacyjny dropdown.
+
+**Create:**
+- `src/django_bpp/templates/multiseek/report-body-list.html`
+- `src/django_bpp/templates/multiseek/report-body-table.html`
+- `src/django_bpp/templates/multiseek/report-body-bibtex.html`
+- `src/django_bpp/templates/multiseek/export-document.html`
+- newsfragment towncrier (`changes/`), testy.
+
+**Bez zmian:** `src/django_bpp/urls.py` (regexp już pasuje).
+
+## 9. Świadome uproszczenia (YAGNI)
+
+- Brak logo/grafik w dokumencie (tylko tytuł tekstowy).
+- Brak `wariant=` dla HTML/DOCX.
+- Limit 5000 wspólny (rewidowalny, D6).
+- BibTeX tylko w widoku bibtex (nie generujemy `.bib` z dowolnego widoku).
+
+## 10. Ryzyka
+
+- **Wydzielenie partiali** dotyka gorącego widoku ekranowego — mitigacja:
+  istniejące testy renderu jako regression gate; refaktor czysto mechaniczny
+  (przeniesienie markupu 1:1 + parametry).
+- **DOCX na 5000 wierszach** przez pandoc/docker — koszt czasu; limit 5000
+  ogranicza, ale realny render dużej tabeli może być wolny. Akceptowalne w v1.
+- **`to_bibtex` per rekord** dla BibTeX — potencjalne N+1; ograniczone limitem
+  5000. Ewentualna optymalizacja poza zakresem v1.

--- a/src/bpp/newsfragments/multiseek-eksport-html-docx-bibtex.feature.rst
+++ b/src/bpp/newsfragments/multiseek-eksport-html-docx-bibtex.feature.rst
@@ -1,0 +1,4 @@
+Eksport wyników Multiseek do formatów dokumentu: **HTML** i **DOCX (Word)** —
+odwzorowują aktualny widok (lista opisów lub tabela punktacyjna). W widoku
+BibTeX dostępny jest eksport do pliku **.bib**. Formaty pojawiają się w
+rozwijanym menu „Eksport" obok istniejących CSV/XLSX.

--- a/src/bpp/tests/test_views/test_mymultiseek.py
+++ b/src/bpp/tests/test_views/test_mymultiseek.py
@@ -837,7 +837,6 @@ def test_report_body_table_numeruje_od_start_index_zero():
             "report_type": "table",
             "export_mode": True,
             "start_index": 0,
-            "show_footer": False,
             "sumy": {},
         },
     )
@@ -988,3 +987,60 @@ def test_dropdown_pokazuje_bib_dla_bibtex(logged_in_client, multiseek_export_rek
     assert reverse("multiseek-export", kwargs={"export_format": "bib"}) in content
     assert reverse("multiseek-export", kwargs={"export_format": "html"}) not in content
     assert reverse("multiseek-export", kwargs={"export_format": "docx"}) not in content
+
+
+@pytest.mark.django_db
+def test_multiseek_export_html_numer_list_uwagi_wyroznione(
+    logged_in_client, standard_data, denorms, autor_jan_kowalski, jednostka
+):
+    """numer_list: uwagi muszą być wizualnie wyróżnione także w eksporcie.
+    Na ekranie to <span style="color:red"> — nh3 zdejmuje style, więc w
+    eksporcie owijamy w tag emfazy (przetrwa sanityzację)."""
+    wyd = any_ciagle(
+        tytul_oryginalny=f"{EXPORT_TITLE_PREFIX} - uwagi",
+        uwagi="MOJA_UWAGA_XYZ",
+    )
+    denorms.flush()
+    Rekord.objects.get_original(wyd)
+    _set_multiseek_title_filter(logged_in_client, report_type=NUMER_LIST_REPORT_TYPE)
+
+    content = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "html"})
+    ).content.decode("utf-8")
+
+    assert "MOJA_UWAGA_XYZ" in content
+    assert re.search(r"<(b|em|strong)>\s*MOJA_UWAGA_XYZ\s*</(b|em|strong)>", content), (
+        "uwagi w eksporcie nie są wyróżnione tagiem emfazy"
+    )
+
+
+@pytest.mark.django_db
+def test_multiseek_export_html_tabela_numeracja_przez_endpoint(
+    logged_in_client, multiseek_export_pair
+):
+    """Realny endpoint (nie fake-obiekty): tabela numeruje 1., 2. od start_index=0."""
+    _set_multiseek_title_filter(logged_in_client, report_type=TABLE_REPORT_TYPE)
+
+    content = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "html"})
+    ).content.decode("utf-8")
+
+    lp = re.findall(r"(\d+)\.\s*</td>", content)
+    assert lp[:2] == ["1", "2"], f"Numeracja przez endpoint: {lp}"
+
+
+@pytest.mark.django_db
+def test_multiseek_export_html_print_removed_nie_crashuje(
+    logged_in_client, multiseek_export_rekord
+):
+    """Eksport dokumentu w trybie print-removed zwraca 200 (dzieli
+    get_queryset_for_current_mode z CSV/XLSX)."""
+    _set_multiseek_title_filter(logged_in_client, report_type=LIST_REPORT_TYPE)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "html"})
+        + "?print-removed=1"
+    )
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/html; charset=utf-8"

--- a/src/bpp/tests/test_views/test_mymultiseek.py
+++ b/src/bpp/tests/test_views/test_mymultiseek.py
@@ -3,6 +3,7 @@
 import csv
 import io
 import json
+import re
 from decimal import Decimal
 
 import pytest
@@ -697,3 +698,293 @@ def test_multiseek_export_opis_xlsx_nie_ma_n_plus_1(
         f"({n1_queries} dla 2 wierszy → {n2_queries} dla 6 wierszy) — N+1."
     )
     assert n1_queries <= 18  # sensowny górny limit, z marginesem
+
+
+# ---------------------------------------------------------------------------
+# Eksport dokumentu: HTML / DOCX / BibTeX (feat-multiseek-eksport-html-docx)
+# ---------------------------------------------------------------------------
+
+LIST_REPORT_TYPE = "0"
+NUMER_LIST_REPORT_TYPE = "4"
+TABLE_CYTOWANIA_REPORT_TYPE = "5"
+BIBTEX_REPORT_TYPE = "8"
+
+
+@pytest.mark.django_db
+def test_multiseek_export_bibtex_dla_widoku_bibtex(
+    logged_in_client, multiseek_export_rekord
+):
+    _set_multiseek_title_filter(logged_in_client, report_type=BIBTEX_REPORT_TYPE)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "bib"})
+    )
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/x-bibtex; charset=utf-8"
+    assert (
+        f'filename="eksport-{MULTISEEK_DEFAULT_REPORT_TITLE}.bib"'
+        in response["Content-Disposition"]
+    )
+    assert b"@" in response.content
+
+
+@pytest.mark.django_db
+def test_multiseek_export_bib_poza_widokiem_bibtex_to_400(
+    logged_in_client, multiseek_export_rekord
+):
+    _set_multiseek_title_filter(logged_in_client, report_type=LIST_REPORT_TYPE)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "bib"})
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_multiseek_export_bib_degraduje_html_docx_w_widoku_bibtex(
+    logged_in_client, multiseek_export_rekord
+):
+    """W widoku BibTeX zapytanie o html/docx URL-em ręcznym degraduje do .bib."""
+    _set_multiseek_title_filter(logged_in_client, report_type=BIBTEX_REPORT_TYPE)
+
+    for fmt in ("html", "docx"):
+        response = logged_in_client.get(
+            reverse("multiseek-export", kwargs={"export_format": fmt})
+        )
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/x-bibtex; charset=utf-8"
+        assert ".bib" in response["Content-Disposition"]
+
+
+@pytest.mark.django_db
+def test_multiseek_export_html_lista(logged_in_client, multiseek_export_rekord):
+    _set_multiseek_title_filter(logged_in_client, report_type=LIST_REPORT_TYPE)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "html"})
+    )
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/html; charset=utf-8"
+    assert (
+        f'filename="eksport-{MULTISEEK_DEFAULT_REPORT_TITLE}.html"'
+        in response["Content-Disposition"]
+    )
+    content = response.content.decode("utf-8")
+    assert "<ol" in content
+    assert multiseek_export_rekord.tytul_oryginalny in content
+
+
+@pytest.mark.django_db
+def test_multiseek_export_html_tabela(logged_in_client, multiseek_export_rekord):
+    _set_multiseek_title_filter(logged_in_client, report_type=TABLE_REPORT_TYPE)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "html"})
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "<table" in content
+    assert "Typ MNiSW/MEiN" in content
+
+
+@pytest.mark.django_db
+def test_multiseek_export_html_tytul_z_html_jest_escapowany(
+    logged_in_client, multiseek_export_rekord
+):
+    _set_multiseek_title_filter(logged_in_client, report_type=LIST_REPORT_TYPE)
+    # Tytuł zakodowany encjami w sesji → plain_multiseek_report_title robi
+    # html.unescape PO strip_tags → literalny '<b>ZNACZNIK'. Shell musi go
+    # zescape'ować (bez |safe), inaczej XSS.
+    _set_multiseek_report_title(logged_in_client, "&lt;b&gt;ZNACZNIK")
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "html"})
+    )
+
+    content = response.content.decode("utf-8")
+    assert "&lt;b&gt;ZNACZNIK" in content
+    assert "<b>ZNACZNIK" not in content
+
+
+def test_report_body_table_numeruje_od_start_index_zero():
+    """Regression off-by-one: eksport tabeli (start_index=0) numeruje od 1,
+    nie od 0. Partial renderowany bezpośrednio z fake-elementami (bez DB)."""
+    from types import SimpleNamespace
+
+    from django.template.loader import render_to_string
+
+    def fake(opis):
+        return SimpleNamespace(
+            opis_bibliograficzny_cache=opis,
+            impact_factor="1.00",
+            punkty_kbn="10.00",
+            liczba_cytowan=0,
+            punktacja_wewnetrzna="0.00",
+            charakter_formalny="Artykuł",
+            typ_kbn="typ",
+            js_safe_pk="1_1",
+            uwagi="",
+        )
+
+    html = render_to_string(
+        "multiseek/report-body-table.html",
+        {
+            "object_list": [fake("Pierwszy"), fake("Drugi")],
+            "report_type": "table",
+            "export_mode": True,
+            "start_index": 0,
+            "show_footer": False,
+            "sumy": {},
+        },
+    )
+    lp_numbers = re.findall(r"(\d+)\.\s*</td>", html)
+    assert lp_numbers[:2] == ["1", "2"], f"Numeracja od zera: {lp_numbers}"
+
+
+DOCX_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+
+
+def _pandoc_available():
+    try:
+        import pypandoc
+
+        pypandoc.get_pandoc_path()
+        return True
+    except Exception:  # noqa: BLE001 - brak pandoca w tym środowisku
+        return False
+
+
+@pytest.mark.django_db
+def test_multiseek_export_docx_uzywa_html_to_docx(
+    logged_in_client, multiseek_export_rekord, monkeypatch
+):
+    monkeypatch.setattr(
+        "nowe_raporty.docx_export.html_to_docx",
+        lambda html, **kw: b"DOCXSENTINEL",
+    )
+    _set_multiseek_title_filter(logged_in_client, report_type=LIST_REPORT_TYPE)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "docx"})
+    )
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == DOCX_CONTENT_TYPE
+    assert (
+        f'filename="eksport-{MULTISEEK_DEFAULT_REPORT_TITLE}.docx"'
+        in response["Content-Disposition"]
+    )
+    assert response.content == b"DOCXSENTINEL"
+
+
+@pytest.mark.skipif(not _pandoc_available(), reason="pandoc niedostępny")
+@pytest.mark.django_db
+def test_multiseek_export_docx_realny_zwraca_zip(
+    logged_in_client, multiseek_export_rekord
+):
+    _set_multiseek_title_filter(logged_in_client, report_type=LIST_REPORT_TYPE)
+
+    response = logged_in_client.get(
+        reverse("multiseek-export", kwargs={"export_format": "docx"})
+    )
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == DOCX_CONTENT_TYPE
+    # DOCX to ZIP — magic header PK\x03\x04.
+    assert response.content[:4] == b"PK\x03\x04"
+
+
+@pytest.mark.django_db
+def test_multiseek_export_html_tabela_cytowania_bez_n_plus_1(
+    logged_in_client, standard_data, denorms
+):
+    """Guard dla D9: eksport tabeli z liczbą cytowań ma STAŁĄ liczbę zapytań
+    względem liczby wierszy (liczba_cytowan w projekcji, nie deferred)."""
+    prefix = f"{EXPORT_TITLE_PREFIX} - html tab n1"
+    url = reverse("multiseek-export", kwargs={"export_format": "html"})
+
+    _make_n_plus_1_rows(prefix, 2)
+    denorms.flush()
+    _set_multiseek_title_filter(
+        logged_in_client,
+        title_prefix=prefix,
+        report_type=TABLE_CYTOWANIA_REPORT_TYPE,
+    )
+    _, n1 = _query_count_for_export(logged_in_client, url)
+
+    _make_n_plus_1_rows(prefix, 4)
+    denorms.flush()
+    _, n2 = _query_count_for_export(logged_in_client, url)
+
+    assert n2 == n1, f"N+1 w eksporcie tabeli: {n1} → {n2}"
+
+
+@pytest.mark.django_db
+def test_multiseek_export_html_numer_list_bez_n_plus_1(
+    logged_in_client, standard_data, denorms
+):
+    """Guard dla D9: numer_list renderuje uwagi — musi być w projekcji."""
+    prefix = f"{EXPORT_TITLE_PREFIX} - html numer n1"
+    url = reverse("multiseek-export", kwargs={"export_format": "html"})
+
+    _make_n_plus_1_rows(prefix, 2)
+    denorms.flush()
+    _set_multiseek_title_filter(
+        logged_in_client,
+        title_prefix=prefix,
+        report_type=NUMER_LIST_REPORT_TYPE,
+    )
+    _, n1 = _query_count_for_export(logged_in_client, url)
+
+    _make_n_plus_1_rows(prefix, 4)
+    denorms.flush()
+    _, n2 = _query_count_for_export(logged_in_client, url)
+
+    assert n2 == n1, f"N+1 w eksporcie numer_list: {n1} → {n2}"
+
+
+def test_sanitize_export_html_usuwa_script_zachowuje_strukture():
+    from bpp.views.multiseek_export import sanitize_export_html
+
+    dirty = (
+        "<ol><li>Tytuł <i>x</i><sub>2</sub>"
+        "<script>alert(1)</script></li></ol>"
+        '<table><tr><td colspan="2">a</td></tr></table>'
+    )
+    clean = sanitize_export_html(dirty)
+
+    assert "<script" not in clean
+    assert "alert(1)" not in clean
+    assert "<ol>" in clean and "<li>" in clean
+    assert "<i>" in clean and "<sub>" in clean
+    assert "<table>" in clean and 'colspan="2"' in clean
+
+
+@pytest.mark.django_db
+def test_dropdown_pokazuje_html_docx_dla_listy(
+    logged_in_client, multiseek_export_rekord
+):
+    _set_multiseek_title_filter(logged_in_client, report_type=LIST_REPORT_TYPE)
+
+    content = logged_in_client.get(reverse("live-results")).content.decode("utf-8")
+
+    assert reverse("multiseek-export", kwargs={"export_format": "html"}) in content
+    assert reverse("multiseek-export", kwargs={"export_format": "docx"}) in content
+    assert reverse("multiseek-export", kwargs={"export_format": "bib"}) not in content
+
+
+@pytest.mark.django_db
+def test_dropdown_pokazuje_bib_dla_bibtex(logged_in_client, multiseek_export_rekord):
+    _set_multiseek_title_filter(logged_in_client, report_type=BIBTEX_REPORT_TYPE)
+
+    content = logged_in_client.get(reverse("live-results")).content.decode("utf-8")
+
+    assert reverse("multiseek-export", kwargs={"export_format": "bib"}) in content
+    assert reverse("multiseek-export", kwargs={"export_format": "html"}) not in content
+    assert reverse("multiseek-export", kwargs={"export_format": "docx"}) not in content

--- a/src/bpp/views/multiseek_export.py
+++ b/src/bpp/views/multiseek_export.py
@@ -228,6 +228,101 @@ def _apply_xlsx_hyperlinks(worksheet, url_cols):
                 cell.value = f'=HYPERLINK("{cell.value}", "[link]")'
 
 
+# Allowlist dla nh3.clean treści dokumentu eksportu (D8). Unia (nie podzbiór)
+# DEFAULT_ALLOWED_TAGS z nowe_raporty.docx_export (m.in. h4/strike/font —
+# markup opisu bibliograficznego pochodzi z per-instalacyjnych, DB-konfig.
+# szablonów) i tagów strukturalnych listy/tabeli. Atrybuty: td/th → colspan.
+EXPORT_HTML_STRUCTURAL_TAGS = frozenset(
+    {
+        "table",
+        "thead",
+        "tbody",
+        "tfoot",
+        "tr",
+        "td",
+        "th",
+        "ol",
+        "ul",
+        "li",
+        "p",
+        "div",
+        "span",
+        "h1",
+        "h2",
+        "h3",
+        "br",
+        "hr",
+        "pre",
+        "code",
+    }
+)
+EXPORT_HTML_ATTRIBUTES = {"td": {"colspan"}, "th": {"colspan"}}
+
+
+def sanitize_export_html(body_html):
+    """Sanityzacja treści dokumentu eksportu przez nh3.clean.
+
+    Plik opuszcza serwis (brak CSP, file://), a body zawiera DB-sourced
+    opis_bibliograficzny_cache — czyścimy jak siostrzany nowe_raporty.as_docx.
+    """
+    import nh3
+
+    from nowe_raporty.docx_export import DEFAULT_ALLOWED_TAGS
+
+    tags = set(DEFAULT_ALLOWED_TAGS) | set(EXPORT_HTML_STRUCTURAL_TAGS)
+    return nh3.clean(body_html, tags=tags, attributes=EXPORT_HTML_ATTRIBUTES)
+
+
+def html_export_response(document_html, report_title):
+    response = HttpResponse(document_html, content_type="text/html; charset=utf-8")
+    response["Content-Disposition"] = content_disposition_header(
+        as_attachment=True,
+        filename=_export_filename("html", report_title),
+    )
+    return response
+
+
+def docx_export_response(document_html, report_title):
+    """Eksport DOCX — konwersja przez nowe_raporty.docx_export.html_to_docx.
+
+    Ścieżka pierwsza (i produkcyjna) to pandoc; przy twardej awarii fallback
+    na dockerowy html2docx. DocxConversionError propaguje (500) — nie tłumimy.
+    """
+    from nowe_raporty.docx_export import html_to_docx
+
+    content = html_to_docx(document_html)
+    response = HttpResponse(
+        content,
+        content_type=(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ),
+    )
+    response["Content-Disposition"] = content_disposition_header(
+        as_attachment=True,
+        filename=_export_filename("docx", report_title),
+    )
+    return response
+
+
+def bibtex_export_response(queryset, report_title):
+    """Eksport BibTeX (.bib) — surowy tekst, gdy report_type == 'bibtex'.
+
+    Reuse bpp.export.bibtex.export_to_bibtex (dispatch po model_name);
+    rekord.original zwraca konkretną instancję publikacji.
+    """
+    from bpp.export.bibtex import export_to_bibtex
+
+    content = export_to_bibtex(
+        rekord.original for rekord in queryset.iterator(chunk_size=1000)
+    )
+    response = HttpResponse(content, content_type="application/x-bibtex; charset=utf-8")
+    response["Content-Disposition"] = content_disposition_header(
+        as_attachment=True,
+        filename=_export_filename("bib", report_title),
+    )
+    return response
+
+
 def csv_export_response(queryset, request, report_title):
     output = io.StringIO()
     writer = csv.writer(output)

--- a/src/bpp/views/mymultiseek.py
+++ b/src/bpp/views/mymultiseek.py
@@ -6,6 +6,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.db.models import Count, Sum
 from django.http import HttpResponseBadRequest, JsonResponse
+from django.template.loader import render_to_string
 from django.views.decorators.cache import never_cache
 from django.views.generic import View
 from multiseek.logic import get_registry
@@ -25,8 +26,12 @@ from bpp.views.multiseek_export import (
     MULTISEEK_EXPORT_OPIS_FIELDS,
     MULTISEEK_EXPORT_XLSX_HEADERS,  # noqa: F401 - re-eksport, uzywane w testach
     XLSX_WORKSHEET_TITLE_MAX_LENGTH,  # noqa: F401 - re-eksport, uzywane w testach
+    bibtex_export_response,
     csv_export_response,
+    docx_export_response,
+    html_export_response,
     plain_multiseek_report_title,
+    sanitize_export_html,
     xlsx_export_response,
 )
 from bpp.views.zapytanie import WprowadzanieDanychOrSuperuserMixin
@@ -50,6 +55,25 @@ EXTRA_TYPES = [
     PKT_WEWN_BEZ + "_cytowania",
     TABLE + "_cytowania",
 ]
+
+# report_type renderowane jako tabela (reszta: lista/numer_list/None).
+TABLE_REPORT_TYPES = frozenset(EXTRA_TYPES)
+
+# Projekcje eksportu DOKUMENTU dostrojone do partiali renderu (nie do CSV/XLSX).
+# Bazowe get_queryset() gubi liczba_cytowan/uwagi → N+1 na całym querysecie.
+MULTISEEK_RENDER_LIST_FIELDS = ("id", "opis_bibliograficzny_cache", "uwagi")
+MULTISEEK_RENDER_TABLE_FIELDS = (
+    "id",
+    "opis_bibliograficzny_cache",
+    "impact_factor",
+    "punkty_kbn",
+    "liczba_cytowan",
+    "punktacja_wewnetrzna",
+    "charakter_formalny",
+    "typ_kbn",
+    "charakter_formalny__nazwa",
+    "typ_kbn__nazwa",
+)
 
 
 class MyMultiseekResults(MultiseekResults):
@@ -194,16 +218,14 @@ def _multiseek_report_title(request):
 class MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults):
     http_method_names = ["get"]
 
-    def get(self, request, export_format, *args, **kwargs):
-        if export_format not in {"csv", "xlsx"}:
-            return HttpResponseBadRequest("Nieznany format eksportu.")
+    # Eksport DANYCH: stałe kolumny, niezależne od report_type.
+    DATA_FORMATS = {"csv", "xlsx"}
+    # Eksport DOKUMENTU: odwzorowuje aktualny report_type (lista/tabela/bibtex).
+    DOCUMENT_FORMATS = {"html", "docx", "bib"}
 
-        wariant = request.GET.get("wariant", "dane")
-        if wariant not in {"dane", "opis"}:
-            wariant = "dane"
-        # opis to format czytelny (raportowy) — CSV opisu nie robimy
-        if export_format == "csv":
-            wariant = "dane"
+    def get(self, request, export_format, *args, **kwargs):
+        if export_format not in self.DATA_FORMATS | self.DOCUMENT_FORMATS:
+            return HttpResponseBadRequest("Nieznany format eksportu.")
 
         queryset = self.get_queryset_for_current_mode()
         count = queryset.count()
@@ -214,6 +236,18 @@ class MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults):
             )
 
         report_title = _multiseek_report_title(request)
+        if export_format in self.DATA_FORMATS:
+            return self._export_data(request, export_format, queryset, report_title)
+        return self._export_document(request, export_format, queryset, report_title)
+
+    def _export_data(self, request, export_format, queryset, report_title):
+        wariant = request.GET.get("wariant", "dane")
+        if wariant not in {"dane", "opis"}:
+            wariant = "dane"
+        # opis to format czytelny (raportowy) — CSV opisu nie robimy
+        if export_format == "csv":
+            wariant = "dane"
+
         if wariant == "opis":
             queryset = (
                 queryset.select_related(None)
@@ -230,6 +264,58 @@ class MyMultiseekExport(LoginRequiredMixin, MyMultiseekResults):
         if export_format == "csv":
             return csv_export_response(queryset, request, report_title)
         return xlsx_export_response(queryset, request, report_title, "dane")
+
+    def _export_document(self, request, export_format, queryset, report_title):
+        registry = get_registry(self.registry)
+        report_type = registry.get_report_type(
+            self.get_multiseek_data(), request=request
+        )
+
+        if report_type == "bibtex":
+            # W widoku BibTeX html/docx degradują do .bib (D3).
+            return bibtex_export_response(queryset, report_title)
+        if export_format == "bib":
+            return HttpResponseBadRequest("BibTeX dostępny tylko w widoku BibTeX.")
+
+        if report_type in TABLE_REPORT_TYPES:
+            queryset = queryset.select_related("charakter_formalny", "typ_kbn").only(
+                *MULTISEEK_RENDER_TABLE_FIELDS
+            )
+            sumy = queryset.aggregate(
+                Sum("impact_factor"),
+                Sum("liczba_cytowan"),
+                Sum("punkty_kbn"),
+                Sum("punktacja_wewnetrzna"),
+            )
+            partial = "multiseek/report-body-table.html"
+        else:
+            queryset = queryset.only(*MULTISEEK_RENDER_LIST_FIELDS)
+            sumy = None
+            partial = "multiseek/report-body-list.html"
+
+        body_html = render_to_string(
+            partial,
+            {
+                "object_list": queryset,
+                "report_type": report_type,
+                "sumy": sumy,
+                "export_mode": True,
+                "start_index": 0,
+            },
+            request=request,
+        )
+        document_html = render_to_string(
+            "multiseek/export-document.html",
+            {
+                "body_html": sanitize_export_html(body_html),
+                "report_title": report_title,
+            },
+            request=request,
+        )
+
+        if export_format == "docx":
+            return docx_export_response(document_html, report_title)
+        return html_export_response(document_html, report_title)
 
 
 def _normalize_session_removed(request):

--- a/src/django_bpp/templates/multiseek/common-results.html
+++ b/src/django_bpp/templates/multiseek/common-results.html
@@ -7,7 +7,7 @@
 {% include "multiseek/print-logo.html" %}
 {% include "multiseek/title.html" %}
 <div class="multiseek-report-container">
-    {%  if paginator_count > 25000 %}
+    {% if paginator_count > 25000 %}
         <div style="padding-left: 4em; padding-right: 4em;">
         <p>Wynik obecnego zapytania do bazy dałby w rezultacie {{ paginator_count }} rekordów. Jest to dość duża ilość
             i szczerze mówiąc pobieranie ich wszystkich przez tą stronę WWW będzie dla Ciebie dość karkołomne. Stąd też
@@ -17,7 +17,7 @@
             Prosimy, postaraj się ograniczyć zapytanie do bazy danych w taki sposób, aby dawało w rezultacie maksymalnie
                 do 25 tysięcy rekordów - wówczas zostaną one wyświetlone w wybranym przez Ciebie formacie w tym miejscu.</p>
         <p>Jeżeli potrzebujesz pobrać wszystkie rekordy z systemu BPP, skorzystaj z dostępu przez API. Obsługiwane
-            API to <a target="_blank" class="external-arrow-box" href="/api/v1/">JSON-REST</a> oraz <a target="_blank" class="external-arrow-box" href="/bpp/oai/?verb=ListSets">protokół OAI-PMH</a>.
+            API to <a target="_blank" class="external-arrow-box" href="/api/v1/">JSON-REST</a> oraz <a target="_blank" class="external-arrow-box" href="/bpp/oai/?verb=ListSets">protokół OAI-PMH</a>.</p>
         </div>
     {% else %}
 
@@ -101,153 +101,11 @@
     {% endif %}
 
     {% if report_type == "bibtex" %}
-        <div class="multiseek-bibtex-container">
-            {% if object_list %}
-                <div class="bibtex-actions bibtex-actions-top">
-                    <button data-action="copy-bibtex" type="button">
-                        📋 Skopiuj wszystko do schowka
-                    </button>
-                    <span id="bibtex-copy-feedback" class="copy-feedback" style="display: none;">
-                        ✓ Skopiowane!
-                    </span>
-                </div>
-            {% endif %}
-            <pre>{% for element in object_list %}{{ element.original.to_bibtex }}{% if not forloop.last %}
-
-{% endif %}{% endfor %}</pre>
-        </div>
+        {% include "multiseek/report-body-bibtex.html" %}
     {% elif report_type == "list" or report_type == "numer_list" or report_type == None %}
-        <div class="multiseek-list-report">
-            <ol style="counter-reset: list-counter {{ page_obj.start_index|add:-1 }}">
-                {% for element in object_list %}
-
-                <li class="multiseek-row" id="multiseek-row-{{ element.js_safe_pk }}">
-                    <span class="multiseek-element">
-                        <a href="{% url "bpp:browse_praca" element.id.0 element.id.1 %}"
-                           target="_top">
-                            {{ element.opis_bibliograficzny_cache|safe }}
-
-                        </a>
-
-                        {% if report_type == "numer_list" %}
-                            <span style="color: red;">
-                    {{ element.uwagi }}
-                    </span>
-                        {% endif %}
-
-                    </span>
-                {% if not print_removed %}
-                    <span class="multiseek-remove-from-results">
-                        <a data-remove-result="{{ element.js_safe_pk }}" style="font-size: 8pt;">
-                            ❌
-                        </a>
-                    </span>
-                {% endif %}
-                </li>
-                {% empty %}
-                    <li style="text-align: center; color: #6c757d; padding: 20px;">{% trans "No elements" %}</li>
-                {% endfor %}
-            </ol>
-        </div>
+        {% include "multiseek/report-body-list.html" with export_mode=False start_index=page_obj.start_index|add:-1 %}
     {% else %}
-        <div class="multiseek-table-report">
-            <table>
-            <tr>
-                <th>Lp.</th>
-                <th>Tytuł, autorzy, źródło</th>
-                <th>IF</th>
-
-                {% if report_type == "table_cytowania" or report_type == "pkt_wewn_cytowania" or report_type == "pkt_wewn_bez_cytowania" %}
-                    <th>Liczba cytowań</th>
-                {% endif %}
-
-                <th>PK</th>
-
-                {% if report_type == "pkt_wewn" or report_type == "pkt_wewn_cytowania" %}
-                    <th>pkt. wewn.</th>
-                {% endif %}
-
-                {% if report_type != "pkt_wewn" and report_type != "pkt_wewn_bez" and report_type != "pkt_wewn_cytowania" and report_type != "pkt_wewn_bez_cytowania" %}
-                    <th>Charakter</th>
-                {% endif %}
-
-                <th>Typ MNiSW/MEiN</th>
-            </tr>
-            {% for element in object_list %}
-                <tr>
-                    <td valign="top">
-                        {{ page_obj.start_index|add:forloop.counter|add:-1 }}.
-                    </td>
-                    <td class="multiseek-row"
-                          id="multiseek-row-{{ element.js_safe_pk }}">
-                    <span class="multiseek-element">
-                    <a href="{% url "bpp:browse_praca" element.id.0 element.id.1 %}"
-                       target="_top">
-                        {{ element.opis_bibliograficzny_cache|safe }}
-
-                    </a>
-                    </span>
-                        {% if not print_removed %}
-                    <span class="multiseek-remove-from-results">
-                        <a data-remove-result="{{ element.js_safe_pk }}" style="font-size: 8pt;">
-                            ❌
-                        </a>
-                    </span>
-                        {% endif %}
-                    </td>
-                    <td>{{ element.impact_factor }}</td>
-                    {% if report_type == "table_cytowania" or report_type == "pkt_wewn_cytowania" or report_type == "pkt_wewn_bez_cytowania" %}
-                        <td>{{ element.liczba_cytowan }}</td>
-                    {% endif %}
-
-                    <td>{{ element.punkty_kbn }}</td>
-
-                    {% if report_type == "pkt_wewn" or report_type == "pkt_wewn_cytowania" %}
-                        <td>{{ element.punktacja_wewnetrzna }}</td>
-                    {% endif %}
-
-                {% if report_type != "pkt_wewn" and report_type != "pkt_wewn_bez" and report_type != "pkt_wewn_cytowania" and report_type != "pkt_wewn_bez_cytowania" %}
-                    <td>{{ element.charakter_formalny }}</td>
-                {% endif %}
-                    <td>{{ element.typ_kbn }}</td>
-                </tr>
-            {% empty %}
-                <tr>
-                    <td colspan="10" style="text-align: center;">{% trans "No elements" %}
-                    </td>
-                </tr>
-            {% endfor %}
-
-            {% if page_obj.number == page_obj.paginator.num_pages %}
-                <tfoot>
-                <tr>
-                    <td colspan="2">
-                        Suma:
-                    </td>
-                    <td>
-                        {{ sumy.impact_factor__sum|default_if_none:"0.00" }}
-                    </td>
-                    {% if report_type == "table_cytowania" or report_type == "pkt_wewn_cytowania" or report_type == "pkt_wewn_bez_cytowania" %}
-                        <td>
-                            {{ sumy.liczba_cytowan__sum|default_if_none:"0.00" }}
-                        </td>
-                    {% endif %}
-                    <td>
-                        {{ sumy.punkty_kbn__sum|default_if_none:"0.00" }}
-                    </td>
-                    {% if report_type == "pkt_wewn" or report_type == "pkt_wewn_cytowania" %}
-                        <td>
-                            {{ sumy.punktacja_wewnetrzna__sum|default_if_none:"0.00" }}
-                        </td>
-                    {% endif %}
-                    <td>&nbsp;</td>
-                    <td>&nbsp;</td>
-                </tr>
-                </tfoot>
-            {% endif %}
-
-            </table>
-        </div>
+        {% include "multiseek/report-body-table.html" with export_mode=False start_index=page_obj.start_index|add:-1 %}
     {% endif %}
 
 </div>

--- a/src/django_bpp/templates/multiseek/export-document.html
+++ b/src/django_bpp/templates/multiseek/export-document.html
@@ -1,0 +1,25 @@
+<!doctype html>
+{# Zaufana skorupa dokumentu eksportu HTML/DOCX. body_html jest już #}
+{# zsanityzowany (nh3.clean) po stronie widoku — dlatego |safe jest tu OK. #}
+{# report_title BEZ |safe (autoescaping): plain_multiseek_report_title robi #}
+{# html.unescape po strip_tags, więc może zawierać literalny '<'. #}
+{# CSS wyłącznie selektory elementowe — nh3.clean zdejmuje class/style #}
+{# z wstrzykniętego body. #}
+<html lang="pl">
+<head>
+<meta charset="utf-8">
+<title>{{ report_title }}</title>
+<style>
+body { font-family: sans-serif; font-size: 12px; }
+h1 { font-size: 18px; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #444; padding: 4px; vertical-align: top; text-align: left; }
+ol { padding-left: 1.5em; }
+li { margin-bottom: 0.4em; }
+</style>
+</head>
+<body>
+<h1>{{ report_title }}</h1>
+{{ body_html|safe }}
+</body>
+</html>

--- a/src/django_bpp/templates/multiseek/paginator.html
+++ b/src/django_bpp/templates/multiseek/paginator.html
@@ -47,6 +47,9 @@
     {% if request.user.is_authenticated and paginator_count > 0 and paginator_count <= multiseek_export_max_rows %}
         {% url "multiseek-export" "csv" as multiseek_export_csv_url %}
         {% url "multiseek-export" "xlsx" as multiseek_export_xlsx_url %}
+        {% url "multiseek-export" "html" as multiseek_export_html_url %}
+        {% url "multiseek-export" "docx" as multiseek_export_docx_url %}
+        {% url "multiseek-export" "bib" as multiseek_export_bib_url %}
         {# <ul class="menu"> może zawierać wyłącznie <li> — dropdown-pane #}
         {# jest tu świadomie poza <ul> (siostra), zgodnie ze wzorcem z #}
         {# multiseek/index.html (przycisk .dropdown wyzwala pane po id). #}
@@ -68,6 +71,26 @@
                         <i class="fi-download"></i> XLS: opis bibliograficzny
                     </a>
                 </li>
+                {# Eksport DOKUMENTU (odwzorowuje aktualny report_type). #}
+                {# BibTeX-view: .bib zamiast HTML/DOCX (D3). #}
+                {% if report_type == "bibtex" %}
+                <li>
+                    <a href="{{ multiseek_export_bib_url }}{% if print_removed %}?print-removed=1{% endif %}">
+                        <i class="fi-download"></i> BibTeX (.bib)
+                    </a>
+                </li>
+                {% else %}
+                <li>
+                    <a href="{{ multiseek_export_html_url }}{% if print_removed %}?print-removed=1{% endif %}">
+                        <i class="fi-download"></i> HTML
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ multiseek_export_docx_url }}{% if print_removed %}?print-removed=1{% endif %}">
+                        <i class="fi-download"></i> DOCX (Word)
+                    </a>
+                </li>
+                {% endif %}
             </ul>
         </div>
     {% endif %}

--- a/src/django_bpp/templates/multiseek/report-body-bibtex.html
+++ b/src/django_bpp/templates/multiseek/report-body-bibtex.html
@@ -1,0 +1,18 @@
+{# Render BibTeX na ekranie (<pre> + przycisk kopiowania). Eksport BibTeX #}
+{# NIE używa tego partiala — idzie surowym plikiem .bib przez #}
+{# bibtex_export_response (bpp.export.bibtex.export_to_bibtex). #}
+<div class="multiseek-bibtex-container">
+    {% if object_list %}
+        <div class="bibtex-actions bibtex-actions-top">
+            <button data-action="copy-bibtex" type="button">
+                📋 Skopiuj wszystko do schowka
+            </button>
+            <span id="bibtex-copy-feedback" class="copy-feedback" style="display: none;">
+                ✓ Skopiowane!
+            </span>
+        </div>
+    {% endif %}
+    <pre>{% for element in object_list %}{{ element.original.to_bibtex }}{% if not forloop.last %}
+
+{% endif %}{% endfor %}</pre>
+</div>

--- a/src/django_bpp/templates/multiseek/report-body-list.html
+++ b/src/django_bpp/templates/multiseek/report-body-list.html
@@ -1,0 +1,41 @@
+{% load i18n %}
+{# Numerowana lista opisów. Współdzielony przez render ekranowy #}
+{# (common-results.html, export_mode=False) i eksport dokumentu #}
+{# (export-document.html, export_mode=True). #}
+{# Parametry: export_mode (chowa chrome + link), start_index (0-based). #}
+<div class="multiseek-list-report">
+    <ol style="counter-reset: list-counter {{ start_index }}">
+        {% for element in object_list %}
+
+        <li class="multiseek-row" id="multiseek-row-{{ element.js_safe_pk }}">
+            <span class="multiseek-element">
+                {% if export_mode %}
+                    {{ element.opis_bibliograficzny_cache|safe }}
+                {% else %}
+                    <a href="{% url "bpp:browse_praca" element.id.0 element.id.1 %}"
+                       target="_top">
+                        {{ element.opis_bibliograficzny_cache|safe }}
+
+                    </a>
+                {% endif %}
+
+                {% if report_type == "numer_list" %}
+                    <span style="color: red;">
+            {{ element.uwagi }}
+            </span>
+                {% endif %}
+
+            </span>
+        {% if not export_mode and not print_removed %}
+            <span class="multiseek-remove-from-results">
+                <a data-remove-result="{{ element.js_safe_pk }}" style="font-size: 8pt;">
+                    ❌
+                </a>
+            </span>
+        {% endif %}
+        </li>
+        {% empty %}
+            <li style="text-align: center; color: #6c757d; padding: 20px;">{% trans "No elements" %}</li>
+        {% endfor %}
+    </ol>
+</div>

--- a/src/django_bpp/templates/multiseek/report-body-list.html
+++ b/src/django_bpp/templates/multiseek/report-body-list.html
@@ -20,9 +20,15 @@
                 {% endif %}
 
                 {% if report_type == "numer_list" %}
+                    {% if export_mode %}
+                        {# nh3 zdejmuje style — emfaza (b) przetrwa sanityzację, #}
+                        {# żeby uwagi były wyróżnione też w HTML/DOCX. #}
+                        <b>{{ element.uwagi }}</b>
+                    {% else %}
                     <span style="color: red;">
             {{ element.uwagi }}
             </span>
+                    {% endif %}
                 {% endif %}
 
             </span>

--- a/src/django_bpp/templates/multiseek/report-body-table.html
+++ b/src/django_bpp/templates/multiseek/report-body-table.html
@@ -1,0 +1,107 @@
+{% load i18n %}
+{# Tabela punktacyjna (kolumny wg report_type) + stopka Suma:. #}
+{# Współdzielony przez render ekranowy (export_mode=False) i eksport #}
+{# (export_mode=True). Parametry: export_mode, start_index (0-based). #}
+{# Stopka: eksport zawsze (export_mode), ekran tylko na ostatniej stronie. #}
+<div class="multiseek-table-report">
+    <table>
+    <tr>
+        <th>Lp.</th>
+        <th>Tytuł, autorzy, źródło</th>
+        <th>IF</th>
+
+        {% if report_type == "table_cytowania" or report_type == "pkt_wewn_cytowania" or report_type == "pkt_wewn_bez_cytowania" %}
+            <th>Liczba cytowań</th>
+        {% endif %}
+
+        <th>PK</th>
+
+        {% if report_type == "pkt_wewn" or report_type == "pkt_wewn_cytowania" %}
+            <th>pkt. wewn.</th>
+        {% endif %}
+
+        {% if report_type != "pkt_wewn" and report_type != "pkt_wewn_bez" and report_type != "pkt_wewn_cytowania" and report_type != "pkt_wewn_bez_cytowania" %}
+            <th>Charakter</th>
+        {% endif %}
+
+        <th>Typ MNiSW/MEiN</th>
+    </tr>
+    {% for element in object_list %}
+        <tr>
+            <td valign="top">
+                {{ start_index|add:forloop.counter }}.
+            </td>
+            <td class="multiseek-row"
+                  id="multiseek-row-{{ element.js_safe_pk }}">
+            <span class="multiseek-element">
+            {% if export_mode %}
+                {{ element.opis_bibliograficzny_cache|safe }}
+            {% else %}
+            <a href="{% url "bpp:browse_praca" element.id.0 element.id.1 %}"
+               target="_top">
+                {{ element.opis_bibliograficzny_cache|safe }}
+
+            </a>
+            {% endif %}
+            </span>
+                {% if not export_mode and not print_removed %}
+            <span class="multiseek-remove-from-results">
+                <a data-remove-result="{{ element.js_safe_pk }}" style="font-size: 8pt;">
+                    ❌
+                </a>
+            </span>
+                {% endif %}
+            </td>
+            <td>{{ element.impact_factor }}</td>
+            {% if report_type == "table_cytowania" or report_type == "pkt_wewn_cytowania" or report_type == "pkt_wewn_bez_cytowania" %}
+                <td>{{ element.liczba_cytowan }}</td>
+            {% endif %}
+
+            <td>{{ element.punkty_kbn }}</td>
+
+            {% if report_type == "pkt_wewn" or report_type == "pkt_wewn_cytowania" %}
+                <td>{{ element.punktacja_wewnetrzna }}</td>
+            {% endif %}
+
+        {% if report_type != "pkt_wewn" and report_type != "pkt_wewn_bez" and report_type != "pkt_wewn_cytowania" and report_type != "pkt_wewn_bez_cytowania" %}
+            <td>{{ element.charakter_formalny }}</td>
+        {% endif %}
+            <td>{{ element.typ_kbn }}</td>
+        </tr>
+    {% empty %}
+        <tr>
+            <td colspan="10" style="text-align: center;">{% trans "No elements" %}
+            </td>
+        </tr>
+    {% endfor %}
+
+    {% if export_mode or page_obj.number == page_obj.paginator.num_pages %}
+        <tfoot>
+        <tr>
+            <td colspan="2">
+                Suma:
+            </td>
+            <td>
+                {{ sumy.impact_factor__sum|default_if_none:"0.00" }}
+            </td>
+            {% if report_type == "table_cytowania" or report_type == "pkt_wewn_cytowania" or report_type == "pkt_wewn_bez_cytowania" %}
+                <td>
+                    {{ sumy.liczba_cytowan__sum|default_if_none:"0.00" }}
+                </td>
+            {% endif %}
+            <td>
+                {{ sumy.punkty_kbn__sum|default_if_none:"0.00" }}
+            </td>
+            {% if report_type == "pkt_wewn" or report_type == "pkt_wewn_cytowania" %}
+                <td>
+                    {{ sumy.punktacja_wewnetrzna__sum|default_if_none:"0.00" }}
+                </td>
+            {% endif %}
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+        </tr>
+        </tfoot>
+    {% endif %}
+
+    </table>
+</div>


### PR DESCRIPTION
## Cel

Rozszerza dropdown eksportu wyników Multiseek o trzy **formaty dokumentu**, odwzorowujące to, co user widzi na ekranie (aktualny `report_type`), obok istniejących eksportów danych (CSV / XLS:dane / XLS:opis):

- **HTML** — samodzielny plik z listą opisów lub tabelą punktacyjną,
- **DOCX (Word)** — ten sam render skonwertowany do Worda,
- **BibTeX (`.bib`)** — w widoku BibTeX, zamiast HTML/DOCX.

## Jak

- **Dwie rodziny eksportu.** Dane (CSV/XLSX, stałe kolumny) vs dokument (HTML/DOCX/BibTeX, wg `report_type`). Widok `MyMultiseekExport.get` rozgałęzia się na starcie.
- **Wydzielenie partiali.** Markup listy/tabeli/bibtex wyjęty z `common-results.html` do współdzielonych `report-body-{list,table,bibtex}.html`. Render ekranowy i eksport dzielą **jedno** źródło markupu (zero rozjazdu kolumn). Parametr `export_mode` chowa chrome (przyciski „usuń", linki), `start_index` (0-based) ujednolica numerację.
- **Dokument.** `export-document.html` to zaufana skorupa; body renderowany z partiala i **sanityzowany `nh3.clean`** (unia `DEFAULT_ALLOWED_TAGS` z `nowe_raporty.docx_export` + tagi strukturalne). `report_title` bez `|safe` (autoescape).
- **DOCX.** Reuse `nowe_raporty.docx_export.html_to_docx` — pandoc jako ścieżka pierwsza, dockerowy `html2docx` jako fallback na twardej awarii (na instalacjach bez działającego pandoca).
- **BibTeX.** Reuse `bpp.export.bibtex.export_to_bibtex` na `rekord.original`.
- **Bez N+1.** Eksport dokumentu ma własne projekcje `.only()` dostrojone do renderu (`liczba_cytowan`, `uwagi`) — bazowa projekcja `get_queryset()` je gubi, co na całym querysecie (do 5000) dałoby N+1. Guard testowy (query-count stały względem liczby wierszy).
- **Dropdown adaptacyjny.** BibTeX-view → „BibTeX (.bib)"; inne widoki → „HTML" + „DOCX (Word)".

## Testy

TDD, red→green dla każdego formatu. Nowe testy w `test_mymultiseek.py`:
- routing HTML/DOCX/BibTeX (200 + Content-Type + Content-Disposition),
- render wg `report_type` (lista vs tabela), numeracja tabeli od 1 (regression off-by-one),
- tytuł z `<` escapowany, sanityzacja `nh3` (script usunięty, struktura zachowana),
- DOCX: monkeypatch `html_to_docx` + realny przebieg pandoca (nagłówek ZIP),
- N+1 guard dla `table_cytowania` i `numer_list`,
- dropdown adaptacyjny (html/docx dla listy, .bib dla bibtex).

Regresja renderu ekranowego: `test_multiseek/`, `test_mymultiseek_query_count.py`, `test_mymultiseek_count_cache.py` — bez zmian, zielone. Lokalnie: 147 + 54 passed.

## Spec

Design + dwie rundy review Fable (poprawki: N+1, numeracja, pandoc/docker, sanityzacja, reuse `export_to_bibtex`, `show_footer` jako warunek w partialu) w `docs/superpowers/specs/2026-07-10-multiseek-eksport-html-docx-design.md`.

## Uwagi

- Wspólny limit **5000** rekordów (jak CSV/XLSX) — rewidowalny.
- Przy okazji naprawa dwóch pre-existing lint-defektów djLint w `common-results.html` (podwójna spacja w tagu, niezamknięty `<p>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)