### PR TITLE
feat(oauth_mcp): warstwa OAuth 2.1 dla serwera MCP (Faza 3, strona BPP)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-mcp-oauth-authorization.md
+++ b/docs/superpowers/plans/2026-07-11-mcp-oauth-authorization.md
@@ -1,0 +1,1357 @@
+# OAuth 2.1 dla serwera MCP — Implementation Plan (strona BPP)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dodać do BPP warstwę OAuth 2.1 Authorization Server
+(`django-oauth-toolkit`) + token-aware, read-only DRF, tak by serwer MCP
+`bpp-mcp` mógł działać z uprawnieniami zalogowanego użytkownika BPP.
+
+**Architecture:** BPP zostaje Authorization Serverem: `/o/authorize|token|
+revoke` z DOT (`base_urlpatterns`), własny endpoint DCR (`/o/register/`) i własny
+RFC 8414 metadata (`/.well-known/oauth-authorization-server`), bo DOT tego nie
+shipuje. API `/api/v1/` przyjmuje `Bearer` przez `StrictOAuth2Authentication`
+(rzuca 401 na nieważny token, nie degraduje do anona) i jest twardo read-only
+przez middleware na prefiksie (nieobchodzone per-view). Endpoint `whoami`
+pozwala `bpp-mcp` zrobić preflight tożsamości mapowany na HTTP 401.
+
+**Tech Stack:** Django, DRF, `django-oauth-toolkit` (pinned), pytest +
+model_bakery, testcontainers (PG+Redis).
+
+**Spec:** `docs/superpowers/specs/2026-07-11-mcp-oauth-authorization-design.md`
+(po review Fable #1 i #2). Odwołania „(§X)" wskazują sekcje speca.
+
+## Global Constraints
+
+- Max line length **88** (ruff). `uv run` przed KAŻDĄ komendą Python. Pytest
+  only (no unittest.TestCase), `model_bakery.baker.make`, `@pytest.mark.django_db`.
+- **NIE modyfikować istniejących migracji.** Nowe migracje `oauth2_provider` OK.
+- **Baseline odświeżyć RAZ, przy scalaniu** (`make baseline-update`), NIE w
+  trakcie ani w równoległych branchach.
+- Django template comments per-line `{# … #}`. Admin=emoji, frontend=fi-icon.
+- Read-only MVP: **żadnego scope `write`**, żadnych narzędzi zapisu.
+- Issuer OAuth = **root hosta** (`https://host`, BEZ `/o`); URL-e budować przez
+  `request.build_absolute_uri()` (nie sklejać ręcznie — `SECURE_PROXY_SSL_HEADER`).
+- Wszystkie literały UI przez `{% trans %}` / `gettext` (LocaleMiddleware aktywne).
+
+---
+
+## File Structure
+
+- `pyproject.toml` — dep `django-oauth-toolkit` (pinned).
+- `src/django_bpp/settings/base.py` — `INSTALLED_APPS`, `OAUTH2_PROVIDER`,
+  `REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"]`, `MIDDLEWARE`.
+- `src/oauth_mcp/` — **nowa apka** (izolacja warstwy OAuth-MCP):
+  - `authentication.py` — `StrictOAuth2Authentication`.
+  - `middleware.py` — `ApiReadOnlyForBearerMiddleware`.
+  - `views_metadata.py` — RFC 8414 metadata view.
+  - `views_dcr.py` — RFC 7591 Dynamic Client Registration view.
+  - `views_whoami.py` — `whoami` DRF view.
+  - `signals.py` — revoke-on-password-change / is_active.
+  - `urls.py` — well-known + `/o/register/` + montaż `base_urlpatterns`.
+  - `apps.py`, `__init__.py`.
+  - `templates/oauth2_provider/authorize.html` — ekran zgody (override DOT).
+  - `tests/` — per-komponent.
+- `src/django_bpp/urls.py` — include `oauth_mcp.urls`; fix Microsoft `next`.
+
+> Dlaczego osobna apka `oauth_mcp`, nie `api_v1`: warstwa AS + auth + middleware
+> to jedna odpowiedzialność (autoryzacja MCP), zmienia się razem, i trzyma
+> `api_v1` czystym. Zgodne z „files that change together live together".
+
+---
+
+### Task 1: Instalacja i pin django-oauth-toolkit + apka `oauth_mcp`
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `src/oauth_mcp/__init__.py`, `src/oauth_mcp/apps.py`
+- Modify: `src/django_bpp/settings/base.py` (INSTALLED_APPS)
+- Test: `src/oauth_mcp/tests/test_install.py`
+
+**Interfaces:**
+- Produces: apka `oauth_mcp` w INSTALLED_APPS; `oauth2_provider` migrowalny.
+
+- [ ] **Step 1: Dodaj zależność (pinned)**
+
+```bash
+uv add "django-oauth-toolkit>=3.0,<4.0"
+```
+
+Zapisz w `pyproject.toml` dokładną wybraną wersję (np. `==3.0.1`) — patrz Step 6
+weryfikacja.
+
+- [ ] **Step 2: Utwórz apkę**
+
+`src/oauth_mcp/__init__.py`: pusty.
+`src/oauth_mcp/apps.py`:
+
+```python
+from django.apps import AppConfig
+
+
+class OauthMcpConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "oauth_mcp"
+
+    def ready(self):
+        from oauth_mcp import signals  # noqa: F401  (rejestruje receivery)
+```
+
+- [ ] **Step 3: INSTALLED_APPS**
+
+W `src/django_bpp/settings/base.py` dodaj (po `rest_framework`):
+`"oauth2_provider",` oraz `"oauth_mcp",`.
+
+- [ ] **Step 4: Test — apki załadowane, modele DOT migrowalne**
+
+`src/oauth_mcp/tests/test_install.py`:
+
+```python
+import pytest
+from django.apps import apps
+
+
+def test_apki_zaladowane():
+    assert apps.is_installed("oauth2_provider")
+    assert apps.is_installed("oauth_mcp")
+
+
+@pytest.mark.django_db
+def test_modele_dot_dostepne():
+    from oauth2_provider.models import get_access_token_model
+
+    AccessToken = get_access_token_model()
+    assert AccessToken.objects.count() == 0
+```
+
+- [ ] **Step 5: Uruchom migracje + test**
+
+```bash
+uv run python src/manage.py makemigrations --check --dry-run
+uv run pytest src/oauth_mcp/tests/test_install.py -v
+```
+
+Expected: PASS (migracje `oauth2_provider` istnieją w pakiecie; nasz kod nie
+tworzy modeli).
+
+- [ ] **Step 6: Weryfikacja założeń wersji (BLOKUJE resztę planu)**
+
+```bash
+uv run python -c "import oauth2_provider, oauth2_provider.urls as u; \
+print(oauth2_provider.VERSION); \
+print('base_urlpatterns' in dir(u)); \
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication; \
+print('OAuth2Authentication OK'); \
+from oauth2_provider.models import get_access_token_model; print('token model OK')"
+```
+
+Expected: wersja wypisana, `base_urlpatterns` = True, importy OK. Jeśli
+`base_urlpatterns` nie istnieje w tej wersji — zanotuj rzeczywistą nazwę i
+dostosuj Task 2. **Potwierdź w komentarzu commita, że DOT NIE ma `/o/register/`
+(DCR) ani czystego RFC 8414 — dlatego Task 6 i 7 piszą je od zera.**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyproject.toml uv.lock src/oauth_mcp src/django_bpp/settings/base.py
+git commit -m "feat(oauth_mcp): zainstaluj django-oauth-toolkit + apka oauth_mcp"
+```
+
+---
+
+### Task 2: Montaż AS (`/o/`) + konfiguracja OAUTH2_PROVIDER
+
+**Files:**
+- Create: `src/oauth_mcp/urls.py`
+- Modify: `src/django_bpp/settings/base.py` (OAUTH2_PROVIDER)
+- Modify: `src/django_bpp/urls.py` (include)
+- Test: `src/oauth_mcp/tests/test_authorize.py`
+
+**Interfaces:**
+- Produces: `/o/authorize/`, `/o/token/`, `/o/revoke_token/` (z DOT
+  `base_urlpatterns`); ustawienia PKCE/scopes/refresh.
+- Consumes: apka z Task 1.
+
+- [ ] **Step 1: OAUTH2_PROVIDER w base.py**
+
+```python
+OAUTH2_PROVIDER = {
+    "PKCE_REQUIRED": True,
+    "DEFAULT_SCOPES": ["read"],
+    "SCOPES": {"read": "Odczyt danych BPP w Twoim imieniu"},
+    "ROTATE_REFRESH_TOKEN": True,
+    "ACCESS_TOKEN_EXPIRE_SECONDS": 60 * 30,          # 30 min
+    "REFRESH_TOKEN_EXPIRE_SECONDS": 60 * 60 * 24 * 7,  # 7 dni (NIE None!)
+    "ALLOWED_GRANT_TYPES": ["authorization-code", "refresh-token"],
+}
+```
+
+- [ ] **Step 2: urls.py apki — montaż base_urlpatterns**
+
+`src/oauth_mcp/urls.py`:
+
+```python
+from django.urls import include, path
+from oauth2_provider import urls as oauth2_urls
+
+app_name = "oauth_mcp"
+
+# UWAGA: montujemy TYLKO base_urlpatterns (authorize/token/introspect/revoke),
+# NIE management-views (/o/applications/ CRUD dostępne każdemu zalogowanemu).
+urlpatterns = [
+    path("o/", include((oauth2_urls.base_urlpatterns, "oauth2_provider"))),
+]
+```
+
+- [ ] **Step 3: include w głównym urls.py**
+
+W `src/django_bpp/urls.py` dodaj do `urlpatterns`:
+`path("", include("oauth_mcp.urls")),`
+
+- [ ] **Step 4: Test — authorize wymaga logowania, token wymaga PKCE**
+
+`src/oauth_mcp/tests/test_authorize.py`:
+
+```python
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+from oauth2_provider.models import get_application_model
+
+
+@pytest.mark.django_db
+def test_authorize_niezalogowany_redirect_na_login(client):
+    resp = client.get("/o/authorize/", {"response_type": "code"})
+    assert resp.status_code == 302
+    assert "/accounts/login/" in resp["Location"]
+
+
+@pytest.mark.django_db
+def test_pkce_wymagane(client, django_user_model):
+    Application = get_application_model()
+    user = baker.make(django_user_model)
+    app = Application.objects.create(
+        user=user,
+        client_type=Application.CLIENT_PUBLIC,
+        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        redirect_uris="https://claude.ai/callback",
+        name="test",
+    )
+    client.force_login(user)
+    # authorize BEZ code_challenge → odrzucone (PKCE_REQUIRED)
+    resp = client.get(
+        "/o/authorize/",
+        {
+            "response_type": "code",
+            "client_id": app.client_id,
+            "redirect_uri": "https://claude.ai/callback",
+        },
+    )
+    assert resp.status_code == 400
+```
+
+- [ ] **Step 5: Uruchom**
+
+```bash
+uv run pytest src/oauth_mcp/tests/test_authorize.py -v
+```
+
+Expected: PASS. Jeśli PKCE-brak daje redirect z błędem zamiast 400 — dostosuj
+asercję do rzeczywistego zachowania wersji (sprawdź `resp.status_code` /
+`Location`), zachowując intencję „bez PKCE nie przejdzie".
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/oauth_mcp/urls.py src/django_bpp/urls.py src/django_bpp/settings/base.py src/oauth_mcp/tests/test_authorize.py
+git commit -m "feat(oauth_mcp): montaż AS /o/ (base_urlpatterns) + PKCE/scopes/refresh"
+```
+
+---
+
+### Task 3: `StrictOAuth2Authentication` (401 na nieważny bearer, is_active)
+
+**Files:**
+- Create: `src/oauth_mcp/authentication.py`
+- Modify: `src/django_bpp/settings/base.py` (DEFAULT_AUTHENTICATION_CLASSES)
+- Test: `src/oauth_mcp/tests/test_authentication.py`
+
+**Interfaces:**
+- Produces: `oauth_mcp.authentication.StrictOAuth2Authentication`.
+- Consumes: `/o/` z Task 2 (do wystawienia tokenów w testach).
+
+- [ ] **Step 1: Implementacja**
+
+`src/oauth_mcp/authentication.py`:
+
+```python
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication
+from rest_framework.exceptions import AuthenticationFailed
+
+
+class StrictOAuth2Authentication(OAuth2Authentication):
+    """OAuth2 auth, która NIE degraduje po cichu do anonima.
+
+    Standardowe ``OAuth2Authentication`` przy nieważnym bearerze zwraca
+    ``None`` → DRF spada na Session/Basic → ``AnonymousUser`` → endpoint
+    ``AnonReadOnly`` oddaje 200 publiczne. Chcemy twardego 401, gdy klient
+    JAWNIE przysłał ``Authorization: Bearer`` (spec §5.4a / B-1). Dodatkowo
+    odrzucamy nieaktywnych użytkowników (spec §5.7 / W-D).
+    """
+
+    def authenticate(self, request):
+        result = super().authenticate(request)
+        header = request.META.get("HTTP_AUTHORIZATION", "")
+        bearer_obecny = header.lower().startswith("bearer ")
+        if result is None:
+            if bearer_obecny:
+                raise AuthenticationFailed("Nieprawidłowy lub wygasły token.")
+            return None
+        user, token = result
+        if not user or not user.is_active:
+            raise AuthenticationFailed("Konto nieaktywne.")
+        return user, token
+```
+
+- [ ] **Step 2: Wpisz pełną listę auth classes w base.py**
+
+W `REST_FRAMEWORK` dodaj klucz (dziś go NIE ma — wypisz jawnie, OAuth2
+pierwsze):
+
+```python
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "oauth_mcp.authentication.StrictOAuth2Authentication",
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.BasicAuthentication",
+    ],
+```
+
+> To niczego nie zmienia dla obecnych klientów (DRF domyślnie ma
+> `[Session, Basic]`; CSRF przy sesji obowiązuje już dziś).
+
+- [ ] **Step 3: Fixture wystawiający token (reużywalny)**
+
+`src/oauth_mcp/tests/conftest.py`:
+
+```python
+import pytest
+from model_bakery import baker
+from oauth2_provider.models import get_access_token_model, get_application_model
+
+
+@pytest.fixture
+def access_token(db, django_user_model):
+    def _make(scope="read", is_active=True):
+        AccessToken = get_access_token_model()
+        Application = get_application_model()
+        user = baker.make(django_user_model, is_active=is_active)
+        app = Application.objects.create(
+            user=user,
+            client_type=Application.CLIENT_PUBLIC,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://claude.ai/callback",
+            name="test-mcp",
+        )
+        from django.utils import timezone
+        from datetime import timedelta
+
+        tok = AccessToken.objects.create(
+            user=user,
+            application=app,
+            token="tok-" + str(user.pk),
+            expires=timezone.now() + timedelta(hours=1),
+            scope=scope,
+        )
+        return user, tok
+
+    return _make
+```
+
+- [ ] **Step 4: Testy**
+
+`src/oauth_mcp/tests/test_authentication.py`:
+
+```python
+import pytest
+
+
+@pytest.mark.django_db
+def test_wazny_token_ustawia_usera(access_token, client):
+    user, tok = access_token()
+    resp = client.get(
+        "/api/v1/whoami/", HTTP_AUTHORIZATION=f"Bearer {tok.token}"
+    )
+    # whoami powstaje w Task 5; tu sprawdzamy tylko że NIE ma 500/anon-degrade.
+    assert resp.status_code in (200, 404)
+
+
+@pytest.mark.django_db
+def test_niewazny_bearer_daje_401_nie_anon(access_token, client):
+    # dowolny anonimowy read-only endpoint api_v1 z GŁUPIM bearerem → 401
+    resp = client.get(
+        "/api/v1/wydawnictwo_ciagle/",
+        HTTP_AUTHORIZATION="Bearer nieistniejacy-token",
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+def test_brak_bearera_dalej_anonimowo(client):
+    resp = client.get("/api/v1/wydawnictwo_ciagle/")
+    assert resp.status_code == 200  # AnonReadOnly bez zmian
+```
+
+- [ ] **Step 5: Uruchom**
+
+```bash
+uv run pytest src/oauth_mcp/tests/test_authentication.py -v
+```
+
+Expected: `test_niewazny_bearer_daje_401_nie_anon` i
+`test_brak_bearera_dalej_anonimowo` PASS. (`test_wazny_token...` przejdzie w
+pełni po Task 5 — dopuszczamy 404 tymczasowo.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/oauth_mcp/authentication.py src/django_bpp/settings/base.py src/oauth_mcp/tests/
+git commit -m "feat(oauth_mcp): StrictOAuth2Authentication — 401 na nieważny bearer + is_active"
+```
+
+---
+
+### Task 4: Middleware read-only na `/api/v1/`
+
+**Files:**
+- Create: `src/oauth_mcp/middleware.py`
+- Modify: `src/django_bpp/settings/base.py` (MIDDLEWARE)
+- Test: `src/oauth_mcp/tests/test_readonly_middleware.py`
+
+**Interfaces:**
+- Produces: `oauth_mcp.middleware.ApiReadOnlyForBearerMiddleware`.
+- Consumes: `StrictOAuth2Authentication` (Task 3), fixture `access_token`.
+
+> Dlaczego middleware, nie permission class: per-view `permission_classes`
+> zastępują globalne (spec §5.4b / B-2 — `RaportSlotowUczelniaViewSet` to write
+> z per-view auth). Middleware na prefiksie jest nieobchodzone.
+
+- [ ] **Step 1: Implementacja**
+
+`src/oauth_mcp/middleware.py`:
+
+```python
+from django.http import JsonResponse
+
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+
+
+class ApiReadOnlyForBearerMiddleware:
+    """Blokuje mutacje `/api/v1/` wykonane tokenem OAuth (MVP read-only).
+
+    Auth DRF biegnie w widoku (po middleware), więc tu wykrywamy bearer po
+    nagłówku i sami weryfikujemy token, zamiast polegać na `request.auth`
+    (jeszcze nieustawionym). To warstwa nieobchodzona przez per-view
+    `permission_classes` (spec §5.4b / B-2).
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if (
+            request.path.startswith("/api/v1/")
+            and request.method not in SAFE_METHODS
+            and self._ma_wazny_bearer(request)
+        ):
+            return JsonResponse(
+                {"detail": "Zapis przez token MCP jest wyłączony (read-only)."},
+                status=403,
+            )
+        return self.get_response(request)
+
+    @staticmethod
+    def _ma_wazny_bearer(request):
+        header = request.META.get("HTTP_AUTHORIZATION", "")
+        if not header.lower().startswith("bearer "):
+            return False
+        raw = header.split(" ", 1)[1].strip()
+        from oauth2_provider.models import get_access_token_model
+
+        AccessToken = get_access_token_model()
+        tok = AccessToken.objects.filter(token=raw).first()
+        return bool(tok and tok.is_valid())
+```
+
+- [ ] **Step 2: Dodaj do MIDDLEWARE**
+
+W `src/django_bpp/settings/base.py` dopisz na końcu listy `MIDDLEWARE`:
+`"oauth_mcp.middleware.ApiReadOnlyForBearerMiddleware",`
+
+- [ ] **Step 3: Testy**
+
+`src/oauth_mcp/tests/test_readonly_middleware.py`:
+
+```python
+import pytest
+
+
+@pytest.mark.django_db
+def test_post_z_bearerem_blokowany_403(access_token, client):
+    user, tok = access_token()
+    resp = client.post(
+        "/api/v1/raport_slotow_uczelnia/",
+        data={},
+        HTTP_AUTHORIZATION=f"Bearer {tok.token}",
+        content_type="application/json",
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_get_z_bearerem_przechodzi_przez_middleware(access_token, client):
+    user, tok = access_token()
+    resp = client.get(
+        "/api/v1/wydawnictwo_ciagle/",
+        HTTP_AUTHORIZATION=f"Bearer {tok.token}",
+    )
+    # middleware nie blokuje GET; sam endpoint może dać 200
+    assert resp.status_code != 403
+
+
+@pytest.mark.django_db
+def test_post_bez_bearera_nietkniety(client):
+    # bez tokenu middleware nie ingeruje (obsłuży to normalny auth/perm)
+    resp = client.post(
+        "/api/v1/raport_slotow_uczelnia/", data={}, content_type="application/json"
+    )
+    assert resp.status_code != 403 or resp.status_code == 403
+    # intencja: middleware NIE jest źródłem 403 tutaj (brak bearera)
+```
+
+> Uwaga do `test_post_bez_bearera_nietkniety`: doprecyzuj asercję po zobaczeniu
+> realnego kodu odpowiedzi (endpoint i tak wymaga `IsAuthenticated`+grupa →
+> najpewniej 401/403 z DRF, nie z naszego middleware). Kluczowe: nasz middleware
+> NIE zwraca 403 gdy brak bearera.
+
+- [ ] **Step 4: Uruchom**
+
+```bash
+uv run pytest src/oauth_mcp/tests/test_readonly_middleware.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/oauth_mcp/middleware.py src/django_bpp/settings/base.py src/oauth_mcp/tests/test_readonly_middleware.py
+git commit -m "feat(oauth_mcp): middleware read-only /api/v1/ dla tokenów MCP"
+```
+
+---
+
+### Task 5: Endpoint `GET /api/v1/whoami/`
+
+**Files:**
+- Create: `src/oauth_mcp/views_whoami.py`
+- Modify: `src/api_v1/urls.py` (rejestracja ścieżki)
+- Test: `src/oauth_mcp/tests/test_whoami.py`
+
+**Interfaces:**
+- Produces: `GET /api/v1/whoami/` → 200 `{id, username, is_staff, is_superuser}`
+  dla ważnego tokenu; 401 dla braku/nieważnego (dzięki Task 3).
+- Consumes: `StrictOAuth2Authentication` (Task 3).
+
+- [ ] **Step 1: Widok**
+
+`src/oauth_mcp/views_whoami.py`:
+
+```python
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from oauth_mcp.authentication import StrictOAuth2Authentication
+
+
+class WhoAmIView(APIView):
+    """Preflight tożsamości dla bpp-mcp (spec §5.4d).
+
+    Ważny token → 200 z tożsamością; brak/nieważny → 401 (transportowy,
+    mapowalny przez klienta MCP na re-auth). Świadomie NIE dopuszczamy
+    anonimowego 200.
+    """
+
+    authentication_classes = [StrictOAuth2Authentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        u = request.user
+        return Response(
+            {
+                "id": u.pk,
+                "username": u.get_username(),
+                "is_staff": u.is_staff,
+                "is_superuser": u.is_superuser,
+            }
+        )
+```
+
+- [ ] **Step 2: Rejestracja ścieżki**
+
+W `src/api_v1/urls.py` dodaj (obok innych `path`, przed routerem lub po):
+
+```python
+from oauth_mcp.views_whoami import WhoAmIView
+# ...
+urlpatterns = [
+    path("whoami/", WhoAmIView.as_view(), name="whoami"),
+    # ... reszta / router
+]
+```
+
+> Sprawdź w `src/api_v1/urls.py`, jak łączone są `urlpatterns` z `router.urls`
+> — dołóż `path` do listy łączonej z `router.urls` (nie nadpisz routera).
+
+- [ ] **Step 3: Testy**
+
+`src/oauth_mcp/tests/test_whoami.py`:
+
+```python
+import pytest
+
+
+@pytest.mark.django_db
+def test_whoami_wazny_token(access_token, client):
+    user, tok = access_token()
+    resp = client.get("/api/v1/whoami/", HTTP_AUTHORIZATION=f"Bearer {tok.token}")
+    assert resp.status_code == 200
+    assert resp.json()["username"] == user.get_username()
+
+
+@pytest.mark.django_db
+def test_whoami_bez_tokenu_401(client):
+    resp = client.get("/api/v1/whoami/")
+    assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+def test_whoami_niewazny_token_401(client):
+    resp = client.get("/api/v1/whoami/", HTTP_AUTHORIZATION="Bearer zly")
+    assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+def test_whoami_nieaktywny_user_401(access_token, client):
+    user, tok = access_token(is_active=False)
+    resp = client.get("/api/v1/whoami/", HTTP_AUTHORIZATION=f"Bearer {tok.token}")
+    assert resp.status_code == 401
+```
+
+- [ ] **Step 4: Uruchom**
+
+```bash
+uv run pytest src/oauth_mcp/tests/test_whoami.py -v
+```
+
+Expected: wszystkie PASS. (Domyka też `test_wazny_token_ustawia_usera` z Task 3.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/oauth_mcp/views_whoami.py src/api_v1/urls.py src/oauth_mcp/tests/test_whoami.py
+git commit -m "feat(oauth_mcp): endpoint /api/v1/whoami/ (preflight tożsamości MCP)"
+```
+
+---
+
+### Task 6: RFC 8414 metadata (`/.well-known/oauth-authorization-server`)
+
+**Files:**
+- Create: `src/oauth_mcp/views_metadata.py`
+- Modify: `src/oauth_mcp/urls.py`
+- Test: `src/oauth_mcp/tests/test_metadata.py`
+
+**Interfaces:**
+- Produces: `GET /.well-known/oauth-authorization-server` → JSON z issuer=host
+  i endpointami; dołożone do `urlpatterns`.
+
+- [ ] **Step 1: Widok**
+
+`src/oauth_mcp/views_metadata.py`:
+
+```python
+from django.http import JsonResponse
+
+
+def oauth_authorization_server_metadata(request):
+    """RFC 8414 — DOT nie shipuje czystego wariantu, piszemy sami (spec §5.6).
+
+    Issuer = ROOT hosta (bez /o); URL-e przez build_absolute_uri (poprawny
+    scheme z SECURE_PROXY_SSL_HEADER, host per-request — wielo-domenowość).
+    """
+    issuer = request.build_absolute_uri("/").rstrip("/")
+    return JsonResponse(
+        {
+            "issuer": issuer,
+            "authorization_endpoint": request.build_absolute_uri("/o/authorize/"),
+            "token_endpoint": request.build_absolute_uri("/o/token/"),
+            "revocation_endpoint": request.build_absolute_uri("/o/revoke_token/"),
+            "registration_endpoint": request.build_absolute_uri("/o/register/"),
+            "scopes_supported": ["read"],
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_methods_supported": ["none"],
+        }
+    )
+```
+
+- [ ] **Step 2: URL**
+
+W `src/oauth_mcp/urls.py` dodaj do `urlpatterns`:
+
+```python
+from oauth_mcp.views_metadata import oauth_authorization_server_metadata
+# ...
+    path(
+        ".well-known/oauth-authorization-server",
+        oauth_authorization_server_metadata,
+        name="oauth-as-metadata",
+    ),
+```
+
+- [ ] **Step 3: Testy**
+
+`src/oauth_mcp/tests/test_metadata.py`:
+
+```python
+import pytest
+
+
+@pytest.mark.django_db
+def test_metadata_ksztalt(client):
+    resp = client.get("/.well-known/oauth-authorization-server")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["issuer"].startswith("http")
+    assert not data["issuer"].endswith("/o")  # issuer = ROOT
+    assert data["authorization_endpoint"].endswith("/o/authorize/")
+    assert data["registration_endpoint"].endswith("/o/register/")
+    assert data["code_challenge_methods_supported"] == ["S256"]
+    assert data["scopes_supported"] == ["read"]
+
+
+@pytest.mark.django_db
+def test_metadata_issuer_z_hosta(client):
+    resp = client.get(
+        "/.well-known/oauth-authorization-server", HTTP_HOST="inna.uczelnia.pl"
+    )
+    assert "inna.uczelnia.pl" in resp.json()["issuer"]
+```
+
+- [ ] **Step 4: Uruchom**
+
+```bash
+uv run pytest src/oauth_mcp/tests/test_metadata.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/oauth_mcp/views_metadata.py src/oauth_mcp/urls.py src/oauth_mcp/tests/test_metadata.py
+git commit -m "feat(oauth_mcp): RFC 8414 metadata /.well-known/oauth-authorization-server"
+```
+
+---
+
+### Task 7: DCR (`POST /o/register/`, RFC 7591, własny)
+
+**Files:**
+- Create: `src/oauth_mcp/views_dcr.py`
+- Modify: `src/oauth_mcp/urls.py`
+- Test: `src/oauth_mcp/tests/test_dcr.py`
+
+**Interfaces:**
+- Produces: `POST /o/register/` → 201 `{client_id, ...}` dla dozwolonego
+  `redirect_uri`; 400 dla niedozwolonego/nie-HTTPS. `csrf_exempt`, ręczny
+  rate-limit.
+
+> DOT NIE ma DCR (spec §5.6/§12.1) — piszemy widok od zera.
+
+- [ ] **Step 1: Widok**
+
+`src/oauth_mcp/views_dcr.py`:
+
+```python
+import json
+import re
+
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from oauth2_provider.models import get_application_model
+
+# Allowlista wzorców redirect_uri (spec §5.6): callbacki Claude + lokalne.
+_ALLOWED_REDIRECT_PATTERNS = [
+    re.compile(r"^https://claude\.ai/[^\s]*$"),
+    re.compile(r"^https://[a-z0-9.-]+\.claude\.ai/[^\s]*$"),
+    re.compile(r"^https://claude\.com/[^\s]*$"),
+    re.compile(r"^http://localhost(:\d+)?/[^\s]*$"),
+    re.compile(r"^http://127\.0\.0\.1(:\d+)?/[^\s]*$"),
+]
+
+
+def _dozwolony(uri: str) -> bool:
+    return any(p.match(uri) for p in _ALLOWED_REDIRECT_PATTERNS)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class DynamicClientRegistrationView(View):
+    """RFC 7591 — rejestracja publicznego klienta MCP (public + PKCE).
+
+    Otwarta rejestracja z twardymi limitami (spec §5.6/§8/W7): allowlista
+    redirect_uri, bez auto-approve dla nieznanych wzorców. Rate-limit: patrz
+    Step 2 (ręczny — to nie DRF view).
+    """
+
+    def post(self, request):
+        try:
+            payload = json.loads(request.body or "{}")
+        except json.JSONDecodeError:
+            return JsonResponse({"error": "invalid_client_metadata"}, status=400)
+
+        redirect_uris = payload.get("redirect_uris") or []
+        if not redirect_uris or not all(_dozwolony(u) for u in redirect_uris):
+            return JsonResponse(
+                {"error": "invalid_redirect_uri"}, status=400
+            )
+
+        Application = get_application_model()
+        app = Application.objects.create(
+            name=(payload.get("client_name") or "mcp-client")[:255],
+            client_type=Application.CLIENT_PUBLIC,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris=" ".join(redirect_uris),
+        )
+        return JsonResponse(
+            {
+                "client_id": app.client_id,
+                "redirect_uris": redirect_uris,
+                "token_endpoint_auth_method": "none",
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+            },
+            status=201,
+        )
+```
+
+- [ ] **Step 2: Rate-limit (ręczny, prosty licznik w cache)**
+
+Dodaj na początku `post()` (przed parsowaniem):
+
+```python
+        from django.core.cache import cache
+
+        ip = request.META.get("REMOTE_ADDR", "?")
+        key = f"dcr-rate:{ip}"
+        licznik = cache.get(key, 0)
+        if licznik >= 20:  # 20 rejestracji / okno
+            return JsonResponse({"error": "rate_limited"}, status=429)
+        cache.set(key, licznik + 1, timeout=3600)  # okno 1h
+```
+
+- [ ] **Step 3: URL**
+
+W `src/oauth_mcp/urls.py` dodaj:
+
+```python
+from oauth_mcp.views_dcr import DynamicClientRegistrationView
+# ...
+    path("o/register/", DynamicClientRegistrationView.as_view(), name="dcr"),
+```
+
+- [ ] **Step 4: Testy**
+
+`src/oauth_mcp/tests/test_dcr.py`:
+
+```python
+import json
+import pytest
+
+
+@pytest.mark.django_db
+def test_dcr_dozwolony_redirect_201(client):
+    resp = client.post(
+        "/o/register/",
+        data=json.dumps(
+            {"client_name": "Claude", "redirect_uris": ["https://claude.ai/cb"]}
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    assert resp.json()["client_id"]
+    assert resp.json()["token_endpoint_auth_method"] == "none"
+
+
+@pytest.mark.django_db
+def test_dcr_niedozwolony_redirect_400(client):
+    resp = client.post(
+        "/o/register/",
+        data=json.dumps({"redirect_uris": ["https://evil.example/cb"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_dcr_nie_https_400(client):
+    resp = client.post(
+        "/o/register/",
+        data=json.dumps({"redirect_uris": ["http://evil.example/cb"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_dcr_bez_csrf_dziala(client):
+    # brak tokenu CSRF nie blokuje (csrf_exempt)
+    resp = client.post(
+        "/o/register/",
+        data=json.dumps({"redirect_uris": ["http://localhost:8765/cb"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+```
+
+- [ ] **Step 5: Uruchom**
+
+```bash
+uv run pytest src/oauth_mcp/tests/test_dcr.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/oauth_mcp/views_dcr.py src/oauth_mcp/urls.py src/oauth_mcp/tests/test_dcr.py
+git commit -m "feat(oauth_mcp): DCR /o/register/ (RFC 7591, allowlista redirect_uri, rate-limit)"
+```
+
+---
+
+### Task 8: Ekran zgody (`authorize.html`, read-only, `{% trans %}`)
+
+**Files:**
+- Create: `src/oauth_mcp/templates/oauth2_provider/authorize.html`
+- Test: `src/oauth_mcp/tests/test_consent.py`
+
+**Interfaces:**
+- Produces: nadpisany szablon zgody DOT z komunikatem read-only.
+
+- [ ] **Step 1: Szablon**
+
+`src/oauth_mcp/templates/oauth2_provider/authorize.html` (override DOT — apka
+`oauth_mcp` przed `oauth2_provider` w INSTALLED_APPS zapewnia pierwszeństwo;
+jeśli nie — patrz Step 3). Styl Foundation + `fi-icon`, literały `{% trans %}`:
+
+```django
+{% extends "base.html" %}
+{% load i18n %}
+{% block content %}
+<div class="row">
+  <div class="column">
+    <h3><span class="fi-key"></span> {% trans "Autoryzacja aplikacji" %}</h3>
+    {% if not error %}
+    <p>
+      {% blocktrans with name=application.name %}Aplikacja <strong>{{ name }}</strong>
+      prosi o <strong>ODCZYT</strong> danych BPP w Twoim imieniu.{% endblocktrans %}
+    </p>
+    <p>{% trans "Zakres:" %} <code>{{ scope }}</code></p>
+    <form method="post" action="{% url 'oauth2_provider:authorize' %}">
+      {% csrf_token %}
+      {% for field in form %}{{ field }}{% endfor %}
+      <button type="submit" class="button alert" name="allow" value="">
+        {% trans "Odmów" %}
+      </button>
+      <button type="submit" class="button success" name="allow" value="Authorize">
+        {% trans "Zezwól na odczyt" %}
+      </button>
+    </form>
+    {% else %}
+    <p class="alert callout">{{ error.error }}: {{ error.description }}</p>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 2: Test renderu**
+
+`src/oauth_mcp/tests/test_consent.py`:
+
+```python
+import pytest
+from model_bakery import baker
+from oauth2_provider.models import get_application_model
+
+
+@pytest.mark.django_db
+def test_ekran_zgody_pokazuje_readonly(client, django_user_model):
+    Application = get_application_model()
+    user = baker.make(django_user_model)
+    app = Application.objects.create(
+        user=user,
+        client_type=Application.CLIENT_PUBLIC,
+        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        redirect_uris="https://claude.ai/cb",
+        name="Claude",
+    )
+    client.force_login(user)
+    resp = client.get(
+        "/o/authorize/",
+        {
+            "response_type": "code",
+            "client_id": app.client_id,
+            "redirect_uri": "https://claude.ai/cb",
+            "code_challenge": "x" * 43,
+            "code_challenge_method": "S256",
+            "scope": "read",
+        },
+    )
+    assert resp.status_code == 200
+    assert b"ODCZYT" in resp.content
+    assert b"Claude" in resp.content
+```
+
+- [ ] **Step 3: Uruchom (i ewentualna korekta pierwszeństwa szablonu)**
+
+```bash
+uv run pytest src/oauth_mcp/tests/test_consent.py -v
+```
+
+Jeśli render bierze szablon DOT zamiast naszego: upewnij się, że `oauth_mcp`
+jest w INSTALLED_APPS **przed** `oauth2_provider` (APP_DIRS szuka po kolejności),
+albo dodaj `DIRS` z `src/oauth_mcp/templates`. Sprawdź, że `base.html` istnieje
+i dostarcza blok `content`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/oauth_mcp/templates src/oauth_mcp/tests/test_consent.py
+git commit -m "feat(oauth_mcp): ekran zgody read-only (authorize.html, i18n)"
+```
+
+---
+
+### Task 9: Revoke-on-password-change + is_active (signal)
+
+**Files:**
+- Create: `src/oauth_mcp/signals.py`
+- Test: `src/oauth_mcp/tests/test_revoke_signals.py`
+
+**Interfaces:**
+- Produces: receiver kasujący tokeny usera po zmianie hasła.
+- Consumes: `apps.ready()` z Task 1 (import `signals`).
+
+- [ ] **Step 1: Implementacja**
+
+`src/oauth_mcp/signals.py`:
+
+```python
+from django.contrib.auth import get_user_model
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+
+@receiver(pre_save, sender=get_user_model())
+def revoke_tokens_on_password_change(sender, instance, **kwargs):
+    """Zmiana hasła / dezaktywacja → skasuj tokeny OAuth usera (spec §5.7/W-D)."""
+    if not instance.pk:
+        return
+    try:
+        stary = sender.objects.get(pk=instance.pk)
+    except sender.DoesNotExist:
+        return
+
+    haslo_zmienione = stary.password != instance.password
+    dezaktywowany = stary.is_active and not instance.is_active
+    if haslo_zmienione or dezaktywowany:
+        from oauth2_provider.models import (
+            get_access_token_model,
+            get_refresh_token_model,
+        )
+
+        get_access_token_model().objects.filter(user=instance).delete()
+        get_refresh_token_model().objects.filter(user=instance).delete()
+```
+
+- [ ] **Step 2: Testy**
+
+`src/oauth_mcp/tests/test_revoke_signals.py`:
+
+```python
+import pytest
+from oauth2_provider.models import get_access_token_model
+
+
+@pytest.mark.django_db
+def test_zmiana_hasla_kasuje_tokeny(access_token):
+    user, tok = access_token()
+    AccessToken = get_access_token_model()
+    assert AccessToken.objects.filter(user=user).exists()
+    user.set_password("nowe-haslo-123")
+    user.save()
+    assert not AccessToken.objects.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_dezaktywacja_kasuje_tokeny(access_token):
+    user, tok = access_token()
+    AccessToken = get_access_token_model()
+    user.is_active = False
+    user.save()
+    assert not AccessToken.objects.filter(user=user).exists()
+```
+
+- [ ] **Step 3: Uruchom**
+
+```bash
+uv run pytest src/oauth_mcp/tests/test_revoke_signals.py -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/oauth_mcp/signals.py src/oauth_mcp/tests/test_revoke_signals.py
+git commit -m "feat(oauth_mcp): revoke tokenów przy zmianie hasła / dezaktywacji"
+```
+
+---
+
+### Task 10: Naprawa propagacji `next` przy logowaniu Microsoft
+
+**Files:**
+- Modify: `src/django_bpp/urls.py` (wariant `microsoft_auth`, ~472)
+- Test: `src/oauth_mcp/tests/test_microsoft_next.py`
+
+**Interfaces:**
+- Produces: `?next=` przeżywa redirect na Microsoft (spec §4/W5).
+
+- [ ] **Step 1: Dodaj `query_string=True`**
+
+W `src/django_bpp/urls.py`, w bloku `elif apps.is_installed("microsoft_auth")`,
+zmień:
+
+```python
+        url(
+            r"^accounts/login/$",
+            RedirectView.as_view(
+                pattern_name="microsoft_auth:to-auth-redirect",
+                query_string=True,
+            ),
+            name="login_form",
+        ),
+```
+
+- [ ] **Step 2: Test (warunkowy — tylko gdy microsoft_auth aktywne)**
+
+`src/oauth_mcp/tests/test_microsoft_next.py`:
+
+```python
+import pytest
+from django.apps import apps
+
+
+@pytest.mark.skipif(
+    not apps.is_installed("microsoft_auth"),
+    reason="wariant Microsoft nieaktywny w tej konfiguracji",
+)
+@pytest.mark.django_db
+def test_login_zachowuje_next(client):
+    resp = client.get("/accounts/login/?next=/o/authorize/%3Ffoo%3Dbar")
+    assert resp.status_code == 302
+    assert "next=" in resp["Location"]
+```
+
+> Jeśli `microsoft_auth` nie jest instalowane w środowisku testów, test się
+> skipnie — to OK; naprawa i tak jest w kodzie. ORCID: weryfikacja manualna
+> (spec §4), poza tym planem.
+
+- [ ] **Step 3: Uruchom**
+
+```bash
+uv run pytest src/oauth_mcp/tests/test_microsoft_next.py -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/django_bpp/urls.py src/oauth_mcp/tests/test_microsoft_next.py
+git commit -m "fix(auth): zachowaj ?next= przy logowaniu Microsoft (query_string=True)"
+```
+
+---
+
+### Task 11: Pełny test tańca Auth Code + PKCE + refresh (integracja)
+
+**Files:**
+- Test: `src/oauth_mcp/tests/test_flow_integration.py`
+
+**Interfaces:**
+- Consumes: całość Task 1–8.
+
+- [ ] **Step 1: Test end-to-end (bez przeglądarki)**
+
+`src/oauth_mcp/tests/test_flow_integration.py`:
+
+```python
+import base64
+import hashlib
+import pytest
+from model_bakery import baker
+from oauth2_provider.models import get_application_model
+
+
+def _pkce():
+    verifier = "a" * 64
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .decode()
+        .rstrip("=")
+    )
+    return verifier, challenge
+
+
+@pytest.mark.django_db
+def test_pelny_taniec_pkce_i_token(client, django_user_model):
+    Application = get_application_model()
+    user = baker.make(django_user_model, is_active=True)
+    app = Application.objects.create(
+        user=user,
+        client_type=Application.CLIENT_PUBLIC,
+        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        redirect_uris="https://claude.ai/cb",
+        name="Claude",
+    )
+    client.force_login(user)
+    verifier, challenge = _pkce()
+    resp = client.post(
+        "/o/authorize/",
+        {
+            "response_type": "code",
+            "client_id": app.client_id,
+            "redirect_uri": "https://claude.ai/cb",
+            "scope": "read",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "allow": "Authorize",
+        },
+    )
+    assert resp.status_code == 302
+    code = resp["Location"].split("code=")[1].split("&")[0]
+
+    token_resp = client.post(
+        "/o/token/",
+        {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "https://claude.ai/cb",
+            "client_id": app.client_id,
+            "code_verifier": verifier,
+        },
+    )
+    assert token_resp.status_code == 200
+    body = token_resp.json()
+    assert body["token_type"].lower() == "bearer"
+    assert body["scope"] == "read"
+
+    # token działa na whoami
+    who = client.get(
+        "/api/v1/whoami/", HTTP_AUTHORIZATION=f"Bearer {body['access_token']}"
+    )
+    assert who.status_code == 200
+    assert who.json()["id"] == user.pk
+```
+
+- [ ] **Step 2: Uruchom**
+
+```bash
+uv run pytest src/oauth_mcp/tests/test_flow_integration.py -v
+```
+
+Expected: PASS. Jeśli format redirectu/kodu różni się w wersji DOT — dostosuj
+parsowanie `code`, zachowując intencję.
+
+- [ ] **Step 3: Uruchom całość apki + ruff**
+
+```bash
+uv run pytest src/oauth_mcp/ -v
+ruff format src/oauth_mcp; ruff check src/oauth_mcp
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/oauth_mcp/tests/test_flow_integration.py
+git commit -m "test(oauth_mcp): pełny taniec Auth Code + PKCE + whoami"
+```
+
+---
+
+### Task 12: Newsfragment + checklist scalenia
+
+**Files:**
+- Create: `newsfragments/<numer>.feature` (jeśli repo używa towncrier — sprawdź
+  `newsfragments/` / `pyproject.toml`)
+- Modify: ten plan (odhacz checklist)
+
+- [ ] **Step 1: Newsfragment**
+
+Sprawdź konwencję: `ls newsfragments/ 2>/dev/null | head`. Jeśli istnieje —
+utwórz `newsfragments/<id>.feature`:
+
+```text
+Warstwa OAuth 2.1 (Authorization Server) dla serwera MCP: BPP wystawia
+/o/authorize|token|register, RFC 8414 metadata i endpoint /api/v1/whoami/;
+API przyjmuje token Bearer z uprawnieniami użytkownika (read-only).
+```
+
+- [ ] **Step 2: Checklist scalenia (NIE wykonywać w trakcie — przy merge do dev):**
+  - [ ] `make baseline-update` (RAZ, po scaleniu — migracje `oauth2_provider`).
+  - [ ] Jeśli scalane razem z Fazą 0 (`/szukaj/`): dołożyć test regresu
+        „anonimowy `/szukaj/` działa" (tu nie ma tego endpointu).
+  - [ ] Konfiguracja nginx `auth_request` (jeśli w deploymencie): wyłączyć
+        `/o/*`, `/.well-known/*`, `/api/v1/*` spod bramki sesyjnej (spec §5.7/D6).
+  - [ ] Weryfikacja manualna `next` dla ORCID (spec §4).
+  - [ ] Rozważyć cron `cleartokens` (higiena DOT, spec §8/D3).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add newsfragments/ docs/superpowers/plans/2026-07-11-mcp-oauth-authorization.md
+git commit -m "docs(oauth_mcp): newsfragment + checklist scalenia"
+```
+
+---
+
+## Poza tym planem (świadomie)
+
+- Introspekcja z confidential clientem (§5.4c) — wariant alternatywny do
+  `whoami`; dokładamy tylko gdy potrzebne.
+- `authorized_tokens` (cherry-pick management view, §5.2) — nice-to-have,
+  osobny task gdy pojawi się potrzeba UI „moje autoryzacje".
+- Cała strona `bpp-mcp` (§6) — osobny pakiet, osobna sesja, na gotowym BPP.
+- RFC 8707 / audience binding — poza zakresem (DOT nie wspiera, §8/§11).
+
+## Self-Review (wykonane przy pisaniu planu)
+
+- **Spec coverage:** §5.1→T1, §5.2→T2, §5.3→T2, §5.4a→T3, §5.4b→T4, §5.4d→T5,
+  §5.6 metadata→T6, §5.6 DCR→T7, §5.5→T8, §5.7 revoke→T9, §4 Microsoft→T10,
+  przepływ §7→T11, §10 testy→rozproszone, checklist scalenia→T12. §5.4c
+  (introspekcja) i §5.2 authorized_tokens świadomie odłożone (patrz wyżej).
+- **Placeholdery:** brak „TBD"; każdy krok ma realny kod/komendę.
+- **Type consistency:** `StrictOAuth2Authentication` (T3) używane w T5/T11;
+  `access_token` fixture (T3 conftest) w T4/T5/T9; `get_access_token_model()`
+  spójnie; issuer-root spójny T6↔spec.

--- a/docs/superpowers/plans/2026-07-11-mcp-oauth-authorization.md
+++ b/docs/superpowers/plans/2026-07-11-mcp-oauth-authorization.md
@@ -66,7 +66,9 @@ model_bakery, testcontainers (PG+Redis).
 
 **Files:**
 - Modify: `pyproject.toml`
-- Create: `src/oauth_mcp/__init__.py`, `src/oauth_mcp/apps.py`
+- Create: `src/oauth_mcp/__init__.py`, `src/oauth_mcp/apps.py`,
+  `src/oauth_mcp/signals.py` (stub — wypełnia Task 9),
+  `src/oauth_mcp/tests/__init__.py`
 - Modify: `src/django_bpp/settings/base.py` (INSTALLED_APPS)
 - Test: `src/oauth_mcp/tests/test_install.py`
 
@@ -99,10 +101,22 @@ class OauthMcpConfig(AppConfig):
         from oauth_mcp import signals  # noqa: F401  (rejestruje receivery)
 ```
 
-- [ ] **Step 3: INSTALLED_APPS**
+**Utwórz też STUB `src/oauth_mcp/signals.py`** (inaczej `ready()` wywali
+ImportError już przy Step 5 — B1):
 
-W `src/django_bpp/settings/base.py` dodaj (po `rest_framework`):
-`"oauth2_provider",` oraz `"oauth_mcp",`.
+```python
+"""Receivery rewokacji tokenów — implementacja w Task 9."""
+```
+
+`src/oauth_mcp/tests/__init__.py`: pusty (unikamy kolizji nazw modułów pytest).
+
+- [ ] **Step 3: INSTALLED_APPS (kolejność ma znaczenie)**
+
+W `src/django_bpp/settings/base.py` dodaj (po `rest_framework`) **w tej
+kolejności — `oauth_mcp` PRZED `oauth2_provider`**, bo app_directories loader
+bierze szablon z pierwszej apki i tak `oauth_mcp` nadpisze `authorize.html`
+(Task 8, W5):
+`"oauth_mcp",` a następnie `"oauth2_provider",`.
 
 - [ ] **Step 4: Test — apki załadowane, modele DOT migrowalne**
 
@@ -184,9 +198,12 @@ OAUTH2_PROVIDER = {
     "ROTATE_REFRESH_TOKEN": True,
     "ACCESS_TOKEN_EXPIRE_SECONDS": 60 * 30,          # 30 min
     "REFRESH_TOKEN_EXPIRE_SECONDS": 60 * 60 * 24 * 7,  # 7 dni (NIE None!)
-    "ALLOWED_GRANT_TYPES": ["authorization-code", "refresh-token"],
 }
 ```
+
+> NIE dodawaj `ALLOWED_GRANT_TYPES` — taki klucz nie istnieje w DOT
+> (`OAUTH2_PROVIDER`) i zostałby po cichu zignorowany (W4). Granty kontroluje
+> DCR (tworzy tylko public+authorization-code) i atrybut `Application`.
 
 - [ ] **Step 2: urls.py apki — montaż base_urlpatterns**
 
@@ -196,7 +213,10 @@ OAUTH2_PROVIDER = {
 from django.urls import include, path
 from oauth2_provider import urls as oauth2_urls
 
-app_name = "oauth_mcp"
+# BEZ `app_name` na tym module! Deklaracja `app_name="oauth_mcp"` zagnieżdżałaby
+# namespace DOT (`oauth_mcp:oauth2_provider:authorize`) i psuła
+# `{% url 'oauth2_provider:authorize' %}` w szablonie zgody → NoReverseMatch
+# (B2). Zostawiamy `oauth2_provider:*` na top-levelu, jak w dokumentacji DOT.
 
 # UWAGA: montujemy TYLKO base_urlpatterns (authorize/token/introspect/revoke),
 # NIE management-views (/o/applications/ CRUD dostępne każdemu zalogowanemu).
@@ -249,7 +269,10 @@ def test_pkce_wymagane(client, django_user_model):
             "redirect_uri": "https://claude.ai/callback",
         },
     )
-    assert resp.status_code == 400
+    # DOT przy PKCE_REQUIRED i braku code_challenge zwraca redirectowalny błąd:
+    # 302 z ?error=... na redirect_uri (nie 400) — D3.
+    assert resp.status_code == 302
+    assert "error=" in resp["Location"]
 ```
 
 - [ ] **Step 5: Uruchom**
@@ -258,9 +281,7 @@ def test_pkce_wymagane(client, django_user_model):
 uv run pytest src/oauth_mcp/tests/test_authorize.py -v
 ```
 
-Expected: PASS. Jeśli PKCE-brak daje redirect z błędem zamiast 400 — dostosuj
-asercję do rzeczywistego zachowania wersji (sprawdź `resp.status_code` /
-`Location`), zachowując intencję „bez PKCE nie przejdzie".
+Expected: PASS („bez PKCE nie przejdzie" = redirect z `error=`).
 
 - [ ] **Step 6: Commit**
 
@@ -486,8 +507,10 @@ class ApiReadOnlyForBearerMiddleware:
 
 - [ ] **Step 2: Dodaj do MIDDLEWARE**
 
-W `src/django_bpp/settings/base.py` dopisz na końcu listy `MIDDLEWARE`:
-`"oauth_mcp.middleware.ApiReadOnlyForBearerMiddleware",`
+W `src/django_bpp/settings/base.py` wstaw
+`"oauth_mcp.middleware.ApiReadOnlyForBearerMiddleware",` **przed**
+`"axes.middleware.AxesMiddleware"` (base.py ~331–333 dokumentuje invariant, że
+AxesMiddleware musi zostać OSTATNIE — nie łam go, D1).
 
 - [ ] **Step 3: Testy**
 
@@ -522,18 +545,13 @@ def test_get_z_bearerem_przechodzi_przez_middleware(access_token, client):
 
 @pytest.mark.django_db
 def test_post_bez_bearera_nietkniety(client):
-    # bez tokenu middleware nie ingeruje (obsłuży to normalny auth/perm)
+    # bez tokenu middleware nie ingeruje; endpoint (per-view [Basic] +
+    # IsAuthenticated) sam odrzuca anonima → 401 z DRF, NIE 403 z middleware.
     resp = client.post(
         "/api/v1/raport_slotow_uczelnia/", data={}, content_type="application/json"
     )
-    assert resp.status_code != 403 or resp.status_code == 403
-    # intencja: middleware NIE jest źródłem 403 tutaj (brak bearera)
+    assert resp.status_code == 401
 ```
-
-> Uwaga do `test_post_bez_bearera_nietkniety`: doprecyzuj asercję po zobaczeniu
-> realnego kodu odpowiedzi (endpoint i tak wymaga `IsAuthenticated`+grupa →
-> najpewniej 401/403 z DRF, nie z naszego middleware). Kluczowe: nasz middleware
-> NIE zwraca 403 gdy brak bearera.
 
 - [ ] **Step 4: Uruchom**
 
@@ -599,19 +617,20 @@ class WhoAmIView(APIView):
 
 - [ ] **Step 2: Rejestracja ścieżki**
 
-W `src/api_v1/urls.py` dodaj (obok innych `path`, przed routerem lub po):
+`src/api_v1/urls.py` importuje dziś tylko `re_path as url` — **dopisz import
+`path`**. Realny kształt pliku to `urlpatterns = [url(r"^", include(router.urls))]`,
+więc dołóż `path` PRZED wpięciem routera (kolejność ma znaczenie — `whoami/`
+musi złapać przed catch-all routera):
 
 ```python
+from django.urls import path                     # DOPISZ (jest tylko re_path)
 from oauth_mcp.views_whoami import WhoAmIView
 # ...
 urlpatterns = [
     path("whoami/", WhoAmIView.as_view(), name="whoami"),
-    # ... reszta / router
+    url(r"^", include(router.urls)),             # istniejący wpis routera
 ]
 ```
-
-> Sprawdź w `src/api_v1/urls.py`, jak łączone są `urlpatterns` z `router.urls`
-> — dołóż `path` do listy łączonej z `router.urls` (nie nadpisz routera).
 
 - [ ] **Step 3: Testy**
 
@@ -744,10 +763,12 @@ def test_metadata_ksztalt(client):
 
 @pytest.mark.django_db
 def test_metadata_issuer_z_hosta(client):
+    # Host MUSI być w ALLOWED_HOSTS (testy dziedziczą zamkniętą listę) — inaczej
+    # DisallowedHost, nie 200 (B3). `test.unexistenttld` jest w ALLOWED_HOSTS.
     resp = client.get(
-        "/.well-known/oauth-authorization-server", HTTP_HOST="inna.uczelnia.pl"
+        "/.well-known/oauth-authorization-server", HTTP_HOST="test.unexistenttld"
     )
-    assert "inna.uczelnia.pl" in resp.json()["issuer"]
+    assert "test.unexistenttld" in resp.json()["issuer"]
 ```
 
 - [ ] **Step 4: Uruchom**
@@ -862,6 +883,11 @@ Dodaj na początku `post()` (przed parsowaniem):
         cache.set(key, licznik + 1, timeout=3600)  # okno 1h
 ```
 
+> D5: za nginx-em `REMOTE_ADDR` to IP proxy → limit staje się globalny per
+> instancja (20/h dla wszystkich). Zaakceptować (i tak bariera na zalew), albo
+> czytać `X-Forwarded-For` zza zaufanego proxy. Świadoma decyzja — dla MVP
+> globalny limit jest OK.
+
 - [ ] **Step 3: URL**
 
 W `src/oauth_mcp/urls.py` dodaj:
@@ -916,9 +942,13 @@ def test_dcr_nie_https_400(client):
 
 
 @pytest.mark.django_db
-def test_dcr_bez_csrf_dziala(client):
-    # brak tokenu CSRF nie blokuje (csrf_exempt)
-    resp = client.post(
+def test_dcr_bez_csrf_dziala():
+    # Domyślny test client ma enforce_csrf_checks=False → nie dowiódłby niczego.
+    # Wymuszamy CSRF, by realnie przetestować csrf_exempt (W3).
+    from django.test import Client
+
+    csrf_client = Client(enforce_csrf_checks=True)
+    resp = csrf_client.post(
         "/o/register/",
         data=json.dumps({"redirect_uris": ["http://localhost:8765/cb"]}),
         content_type="application/json",
@@ -968,7 +998,10 @@ jeśli nie — patrz Step 3). Styl Foundation + `fi-icon`, literały `{% trans %
       {% blocktrans with name=application.name %}Aplikacja <strong>{{ name }}</strong>
       prosi o <strong>ODCZYT</strong> danych BPP w Twoim imieniu.{% endblocktrans %}
     </p>
-    <p>{% trans "Zakres:" %} <code>{{ scope }}</code></p>
+    <p>{% trans "Zakres:" %}</p>
+    <ul>
+      {% for opis in scopes_descriptions %}<li>{{ opis }}</li>{% endfor %}
+    </ul>
     <form method="post" action="{% url 'oauth2_provider:authorize' %}">
       {% csrf_token %}
       {% for field in form %}{{ field }}{% endfor %}
@@ -999,6 +1032,8 @@ from oauth2_provider.models import get_application_model
 
 @pytest.mark.django_db
 def test_ekran_zgody_pokazuje_readonly(client, django_user_model):
+    # base.html + context-processory BPP wolą mieć Uczelnia (D7).
+    baker.make("bpp.Uczelnia")
     Application = get_application_model()
     user = baker.make(django_user_model)
     app = Application.objects.create(
@@ -1066,9 +1101,15 @@ from django.dispatch import receiver
 
 
 @receiver(pre_save, sender=get_user_model())
-def revoke_tokens_on_password_change(sender, instance, **kwargs):
+def revoke_tokens_on_password_change(sender, instance, update_fields=None, **kwargs):
     """Zmiana hasła / dezaktywacja → skasuj tokeny OAuth usera (spec §5.7/W-D)."""
     if not instance.pk:
+        return
+    # Tani short-circuit (D6): np. `update last_login` przy każdym logowaniu
+    # przekazuje update_fields={"last_login"} → nie ruszamy DB.
+    if update_fields is not None and not (
+        {"password", "is_active"} & set(update_fields)
+    ):
         return
     try:
         stary = sender.objects.get(pk=instance.pk)
@@ -1273,6 +1314,44 @@ def test_pelny_taniec_pkce_i_token(client, django_user_model):
     )
     assert who.status_code == 200
     assert who.json()["id"] == user.pk
+
+    # rotacja refresh (spec §10/§13/W2)
+    refresh = body["refresh_token"]
+    r1 = client.post(
+        "/o/token/",
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh,
+            "client_id": app.client_id,
+        },
+    )
+    assert r1.status_code == 200
+    assert r1.json()["refresh_token"] != refresh  # ROTATE_REFRESH_TOKEN
+    # stary refresh już nieważny
+    r2 = client.post(
+        "/o/token/",
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh,
+            "client_id": app.client_id,
+        },
+    )
+    assert r2.status_code == 400
+
+
+@pytest.mark.django_db
+def test_revoke_uniewaznia_token(access_token, client):
+    """Revoke → kolejny request/whoami → 401 (spec §10/§13/W2)."""
+    user, tok = access_token()
+    resp = client.post(
+        "/o/revoke_token/",
+        {"token": tok.token, "client_id": tok.application.client_id},
+    )
+    assert resp.status_code == 200
+    who = client.get(
+        "/api/v1/whoami/", HTTP_AUTHORIZATION=f"Bearer {tok.token}"
+    )
+    assert who.status_code == 401
 ```
 
 - [ ] **Step 2: Uruchom**
@@ -1325,7 +1404,12 @@ API przyjmuje token Bearer z uprawnieniami użytkownika (read-only).
   - [ ] Konfiguracja nginx `auth_request` (jeśli w deploymencie): wyłączyć
         `/o/*`, `/.well-known/*`, `/api/v1/*` spod bramki sesyjnej (spec §5.7/D6).
   - [ ] Weryfikacja manualna `next` dla ORCID (spec §4).
-  - [ ] Rozważyć cron `cleartokens` (higiena DOT, spec §8/D3).
+  - [ ] Rozważyć cron `cleartokens` (higiena DOT, spec §8/D3) ORAZ sprzątanie
+        klientów DCR bez tokenów (spec §5.6).
+  - [ ] Smoke na ŚWIEŻEJ bazie: `FirstRunWizardMiddleware` przekierowuje
+        `/o/*` i `/.well-known/*` do kreatora, dopóki brak `Uczelnia` — testy
+        tego nie łapią (`settings/test.py` usuwa ten middleware). Zweryfikuj na
+        bazie z `Uczelnia`.
 
 - [ ] **Step 3: Commit**
 
@@ -1338,8 +1422,16 @@ git commit -m "docs(oauth_mcp): newsfragment + checklist scalenia"
 
 ## Poza tym planem (świadomie)
 
+- **Dostęp bearer (odczyt) do `raport_slotow_*`** — te viewsety mają per-view
+  `authentication_classes=[Basic]`, więc token MCP jest tam dziś ignorowany
+  (odczyt niedostępny). Dołożenie `StrictOAuth2Authentication` do ich per-view
+  list to osobny task, gdy pojawi się realna potrzeba (write i tak blokuje
+  middleware z Task 4). Główny motywator (DjangoQL) tego nie wymaga — dlatego
+  odraczamy (W1). NIE twierdzimy w tym planie, że raporty slotów działają przez
+  token.
 - Introspekcja z confidential clientem (§5.4c) — wariant alternatywny do
-  `whoami`; dokładamy tylko gdy potrzebne.
+  `whoami`; dokładamy tylko gdy potrzebne. `/o/introspect/` jest zamontowany
+  (base_urlpatterns), ale bez scope `introspection` pozostaje martwy — OK.
 - `authorized_tokens` (cherry-pick management view, §5.2) — nice-to-have,
   osobny task gdy pojawi się potrzeba UI „moje autoryzacje".
 - Cała strona `bpp-mcp` (§6) — osobny pakiet, osobna sesja, na gotowym BPP.

--- a/docs/superpowers/specs/2026-07-11-mcp-oauth-authorization-design.md
+++ b/docs/superpowers/specs/2026-07-11-mcp-oauth-authorization-design.md
@@ -1,0 +1,345 @@
+# Autoryzacja OAuth 2.1 dla serwera MCP — delegacja tożsamości BPP
+
+**Data:** 2026-07-11
+**Gałąź:** `feat-mcp-oauth` (od `dev`)
+**Status:** design (po rewizji review Fable #1 i #2)
+**Powiązany spec:** `2026-07-10-api-szukaj-skill-mcp-design.md` (Fazy 0–2 —
+API `/szukaj/`, skill `bpp-skills`, serwer `bpp-mcp`). Ten dokument dokłada
+**Fazę 3 — autoryzację** i jest wobec tamtego samodzielny (tamten spec żyje
+na gałęzi `feat-api-szukaj-skill-mcp`, nie na `dev`).
+
+---
+
+## 1. Cel i motywacja
+
+Serwer MCP `bpp-mcp` (Faza 2) woła dziś API BPP **anonimowo** — widzi tylko
+dane publiczne. Chcemy, żeby MCP mógł działać **z uprawnieniami konkretnego,
+zalogowanego użytkownika BPP**, tak jakby ten użytkownik siedział przy
+przeglądarce.
+
+**Konkretny motywator (sprostowany po weryfikacji kodu):** wyszukiwanie DjangoQL
+(„zapytanie": `src/bpp/views/zapytanie.py`) ma dostać w przyszłości endpoint API
+i MCP ma umieć je odpalić **jako zalogowany użytkownik**. UWAGA: te widoki są
+chronione `WprowadzanieDanychOrSuperuserMixin` (`zapytanie.py:287`,
+`raise_exception=True`, `user_can_use_query_editor`) = **superuser LUB staff +
+grupa „wprowadzanie danych"**. Realnymi beneficjentami tej funkcji są więc
+**konta uprzywilejowane**. Ogólniejszy cel pozostaje: MCP widzi to, co dany
+użytkownik (dane nie-publiczne, raporty slotów wg `GR_RAPORTY_WYSWIETLANIE`).
+
+**Konsekwencja dla modelu zagrożeń (§8):** tokeny odblokowujące DjangoQL należą
+do staff/superuserów → **krótki TTL, rotacja refresh, revoke, odrzucanie
+`is_active=False` — obowiązkowe.**
+
+**Wymagania jakościowe:**
+- **Wszystkie metody logowania BPP** bez dodatkowej logiki auth (§4 — ale
+  propagacja `next` per-backend wymaga weryfikacji/naprawy).
+- Użytkownik **świadomie autoryzuje** serwer MCP (ekran zgody).
+- **Read-only egzekwowane serwerowo** (§5.4), w warstwie nieobchodzonej per-view.
+
+## 2. Kontekst — rzeczywistość ustalona z kodu
+
+- **Wszystkie backendy auth zbiegają się w sesji Django** (`base.py`
+  ~1171–1342). Fundament designu (§4).
+- **DRF nie ma klucza `DEFAULT_AUTHENTICATION_CLASSES`** (`base.py:966`) — leci
+  na defaultach DRF (Session + Basic). `DEFAULT_PERMISSION_CLASSES` =
+  `DjangoModelPermissionsOrAnonReadOnly`. **Throttling globalnie wyłączony.**
+- **`api_v1` MA write i per-view override'y** (kluczowe dla §5.4):
+  - `RaportSlotowUczelniaViewSet` (`viewsets/raport_slotow_uczelnia.py:49`) to
+    **`ModelViewSet` (write!)** z per-view `authentication_classes=[Basic]` +
+    `permission_classes=[IsAuthenticated, IsGrupaRaportyWyswietlanie]`.
+  - `recent_author_publications` / `recent_unit_publications` — per-view
+    `permission_classes=[AllowAny]`.
+  - **Wniosek:** globalna zmiana DRF **nie obowiązuje uniwersalnie** — per-view
+    listy zastępują defaulty. Read-only guard MUSI żyć poza DRF-owym per-view.
+- **`/api/v1/szukaj/` jest anonimowe** (FTS, Faza 0) — nie jest celem. **Nie
+  istnieje na `feat-mcp-oauth`** (żyje na niescalonej `feat-api-szukaj-skill-mcp`)
+  → wpływ na testy regresu (§10).
+- **`django-oauth-toolkit` NIE zainstalowany** — dokładamy, **pinned**.
+- **`bpp-mcp` to osobny pakiet** — §3.
+- **`LOGIN_URL` default `/accounts/login/` istnieje** (nie wymaga zmiany), ale
+  wariant Microsoft odbija `RedirectView(...)` **bez `query_string=True`**
+  (`urls.py` ~472) → gubi `?next=` (§4). Wariant OIDC używa
+  `InstitutionalLoginView._redirect_preserving_next` — Microsoft przez OIDC
+  zachowuje `next` (dotyczy tylko wariantu „gołego" `microsoft_auth`).
+- **`password_policies`** — request bearer na etapie middleware to
+  `AnonymousUser` (DRF auth PO middleware, `middleware.py:12`) → pomijany.
+- **`SECURE_PROXY_SSL_HEADER`** ustawiony (`base.py:588`, `production.py:123`) →
+  metadata budować przez `request.build_absolute_uri()` (poprawny scheme).
+- **Wielo-domenowość w jednym procesie** (`SiteResolutionMiddleware`) → issuer
+  z `request` (§5.6). `/.well-known/` nie blokowane przez
+  `MaliciousRequestBlockingMiddleware`.
+
+## 3. Decyzje architektoniczne i podział własności
+
+Cztery filary (NIE kwestionujemy kierunku):
+1. **Pełny OAuth 2.1 z delegacją tożsamości.**
+2. **Warstwa OAuth w BPP** — `django-oauth-toolkit` + token-aware DRF.
+3. **Końcówka MCP osobno** — `bpp-mcp` (Resource Server).
+4. **MVP: read-only**, egzekwowane serwerowo.
+
+| Zakres | Repo | Kto | Kiedy |
+|---|---|---|---|
+| §5 OAuth AS + token-aware API | **BPP** (`feat-mcp-oauth`) | ta sesja | **najpierw** |
+| §6 MCP resource server | **bpp-mcp** (osobny pakiet) | osobna sesja | **potem** |
+
+Producent przed konsumentem. Ta sesja dostarcza tylko §5; §6 to kontrakt.
+
+## 4. Idea nośna — „wszystkie metody logowania" (założenie z checklistą)
+
+`authorize` DOT jest `@login_required` → niezalogowany trafia na `LOGIN_URL` =
+strona logowania BPP z wszystkimi backendami. **Zysk nie jest darmowy
+bezwarunkowo** — taniec zależy od tego, że `?next=/o/authorize/...` przeżyje
+przekierowanie do IdP i powrót:
+- **Hasło/lokalny** (`HTMXAwareLoginView`): `next` natywnie. ✅
+- **OIDC/Keycloak/Microsoft-przez-OIDC** (`_redirect_preserving_next`,
+  mozilla-django-oidc): OK, potwierdzić. ⚠️
+- **Microsoft „goły"** (`RedirectView` bez `query_string=True`): **gubi `next`**
+  → naprawić `query_string=True` + sprawdzić odtworzenie `next` po callbacku ze
+  `state`. ❌→naprawa (zakres §5).
+- **ORCID**: propagacja `next` — **niezweryfikowana**. ⚠️
+
+§4 to **założenie z listą weryfikacji**; naprawa „gołego" Microsoftu w zakresie
+tej sesji, reszta — testy manualne per-tenant.
+
+## 5. Strona BPP — warstwa OAuth (zakres tej sesji)
+
+### 5.1 Instalacja i modele
+- `django-oauth-toolkit` (**wersja przypięta** — §12.1), `oauth2_provider` w
+  `INSTALLED_APPS`, migracje nowej apki. Baseline `make baseline-update`
+  **RAZ, po scaleniu**.
+
+### 5.2 URL-e AS — cherry-pick, nie całe `urls`
+Zamontować **`oauth2_provider.urls.base_urlpatterns`** pod `/o/` (NIE pełne
+`urls` — wycina management-views `/o/applications/` CRUD dostępne każdemu
+zalogowanemu, obejście DCR). Endpointy: `/o/authorize/`, `/o/token/`,
+`/o/introspect/` (jeśli wariant z introspekcją — §5.4c), `/o/revoke_token/`.
+
+`/o/authorized_tokens/` (user widzi/odwołuje swoje zgody) jest w DOT w
+**`management_urlpatterns`, NIE w `base_urlpatterns`** — więc **cherry-pick
+jawnie** `AuthorizedTokensListView`/`AuthorizedTokenDeleteView` + ostyluj ich
+szablony (extendują `oauth2_provider/base.html`, nie frontend BPP), albo pomiń.
+`/o/applications/` — jeśli w ogóle, superuser-only.
+
+### 5.3 Konfiguracja `OAUTH2_PROVIDER`
+- **PKCE wymagane** (`PKCE_REQUIRED = True`); brak implicit grant.
+- **`DEFAULT_SCOPES = ["read"]`** (obowiązkowo — DOT domyślnie `["__all__"]`,
+  co dałoby klientowi bez `scope` wszystkie scopes, w tym `introspection`).
+- Scope `read` (jedyny wydawany userom). Scope **`introspection` definiować
+  TYLKO w wariancie z introspekcją** (§5.4c) i wtedy ograniczyć go do
+  confidential clienta (custom `SCOPES_BACKEND_CLASS` / per-app allowlista —
+  DOT nie ma per-app allowlisty scopes out-of-the-box). `write` — nie definiujemy.
+- Grant user-facing: **`authorization-code` + `refresh_token`** z
+  **`ROTATE_REFRESH_TOKEN = True`** i **`REFRESH_TOKEN_EXPIRE_SECONDS`
+  ustawionym** (default `None` = łańcuch refresh żyje wiecznie — W-D). Krótki
+  `ACCESS_TOKEN_EXPIRE_SECONDS`.
+
+### 5.4 Token-aware API + egzekwowanie read-only (dwie warstwy)
+
+**(a) Własna, „ścisła" klasa auth — `StrictOAuth2Authentication`:**
+Standardowe `OAuth2Authentication` przy **nieważnym** bearerze zwraca `None` →
+DRF spada na Session/Basic → `AnonymousUser` → `AnonReadOnly` oddaje **200
+publiczne** (cicha degradacja, brak 401, brak re-auth — B-1). Dlatego subklasa,
+która:
+- gdy nagłówek `Authorization: Bearer` **jest obecny, a token nieważny/wygasły/
+  zrewokowany** → **`raise AuthenticationFailed`** (żadnego fallthrough na anona),
+- odrzuca token, gdy `token.user.is_active is False` (W-D).
+
+Wpisać jawnie pełną listę `DEFAULT_AUTHENTICATION_CLASSES`:
+`[StrictOAuth2Authentication, SessionAuthentication, BasicAuthentication]`.
+(To **niczego nie zmienia** dla obecnych klientów — DRF i tak domyślnie ma
+`[Session, Basic]`, CSRF przy sesji obowiązuje już dziś, `/api/v1/api-auth/`
+browsable-login działa dalej, POST-y raport_slotów mają per-view `[Basic]`.)
+
+**(b) Read-only w warstwie nieobchodzonej per-view — middleware `/api/v1/`:**
+Ponieważ per-view `authentication_classes`/`permission_classes` **zastępują**
+defaulty (B-2: `RaportSlotowUczelniaViewSet` to write z per-view `[Basic]`),
+globalna klasa permission NIE wystarczy. Dokładamy **middleware na prefiksie
+`/api/v1/`**: jeśli request niesie bearer (`isinstance(request.auth,
+get_access_token_model())` — model swappable, D-c) **i metoda nie-SAFE**
+(POST/PUT/PATCH/DELETE) → **403**. To zamyka write dla tokenów niezależnie od
+per-view. Dla raport_slotów: gdy plan dołoży tam OAuth2 do per-view listy,
+middleware i tak zablokuje mutację tokenem.
+
+**(c) Introspekcja — opcjonalna, wymaga client-auth (B1):**
+`IntrospectTokenView` DOT wymaga scope `introspection` + uwierzytelnienia
+klienta. Warianty:
+- **Domyślny (rekomendowany): BEZ introspekcji.** `bpp-mcp` nie robi
+  introspekcji; preflight tożsamości robi przez **endpoint `whoami`** (§5.4d).
+- **Z introspekcją:** per-instancja ręcznie prowizjonowany **confidential
+  `Application`** (grant `client-credentials`, scope `introspection`),
+  credentials do konfiguracji `bpp-mcp` jako `BPP_MCP_CLIENT_ID/SECRET`.
+
+**(d) Endpoint `whoami` — konieczny dla poprawnego re-auth MCP (W-C):**
+Bez introspekcji `bpp-mcp` nie rozpozna **nieważnego** tokenu przed wywołaniem
+narzędzia, a 401 z API złapany w środku tool-calla wraca do klienta jako **błąd
+JSON-RPC**, który **NIE triggeruje re-autoryzacji** (klienci MCP re-auth robią
+na **HTTP 401 transportu**). Dlatego BPP dostarcza tani endpoint
+**`GET /api/v1/whoami/`** autoryzowany bearerem (przez `StrictOAuth2Authentication`
++ `IsAuthenticated`): ważny token → 200 `{username, id, ...}`; brak/nieważny →
+**HTTP 401**. `bpp-mcp` woła go jako preflight i mapuje 401 na transportowy 401
+przed dispatchem JSON-RPC. **Ten endpoint jest w zakresie tej sesji.**
+
+### 5.5 Ekran zgody
+Szablon `authorize.html` (Foundation, `fi-icon`, nie emoji), **literały przez
+`{% trans %}`** (LocaleMiddleware aktywne, D-e): „Aplikacja <nazwa> prosi o
+ODCZYT danych BPP w Twoim imieniu" + scope. Czytelnie read-only.
+
+### 5.6 Glue do napisania (DOT tego nie shipuje — §12.1)
+- **Metadata (RFC 8414):** issuer = **`{host}` (root, BEZ `/o`)**, dokument pod
+  `/.well-known/oauth-authorization-server`; endpointy w środku `/o/...`. Budować
+  URL-e przez **`request.build_absolute_uri()`** (poprawny scheme z
+  `SECURE_PROXY_SSL_HEADER`, host per-request — wielo-domenowość, W2/D-d). DOT ma
+  OIDC `openid-configuration`; czysty RFC 8414 zwykle dopisujemy sami.
+- **DCR (RFC 7591):** `/o/register/` — **DOT NIE ma tego endpointu (również 3.x)
+  → piszemy widok od zera** (JSON RFC 7591 → public `Application`+PKCE,
+  `token_endpoint_auth_method:"none"`, `grant_types` z `refresh_token`).
+  `csrf_exempt` (globalny `CsrfViewMiddleware`!). **Ręczny rate-limit** (to nie
+  DRF view, throttling DRF nie działa). Polityka: **otwarty DCR + twarde
+  limity** — allowlista wzorców `redirect_uri` (HTTPS + znane callbacki Claude,
+  `http://localhost:*` / `http://127.0.0.1:*`), rate-limit `/o/register/`,
+  sprzątanie klientów bez tokenów (celery/cron), **bez auto-approve** dla
+  nieznanych wzorców. „initial access token" jest **martwy** dla Claude'a
+  (rejestruje się bez poświadczeń) — NIE stosujemy.
+- **`LOGIN_URL`** default OK; naprawa Microsoft `query_string=True` (§4).
+
+### 5.7 Interakcje z istniejącymi mechanizmami
+- **`axes`** — logowanie w `authorize` tą samą stroną → brute-force dziedziczony.
+- **`password_policies`** — bearer-request na middleware to `AnonymousUser` →
+  pomijany. User z wygasłym hasłem w `/o/authorize/` zostanie odesłany na zmianę
+  hasła — sprawdzić powrót na `authorize` (`next`, D2).
+- **Rewokacja przy zmianie hasła / dezaktywacji (W-D):** DOT nie sprawdza
+  `is_active` (kryte w §5.4a) i nie rewokuje tokenów przy zmianie hasła — dołożyć
+  **signal** (password-change / `is_active=False`) → revoke tokenów usera.
+- **`loginas`** (`/login/user/<id>/`) — admin w impersonacji mógłby wydać token
+  „w imieniu"; rozważyć blokadę consent przy aktywnym loginas (D4).
+- **`auth_server.py`** — nie dotykamy. W deploymentach z nginx `auth_request`:
+  `/o/*`, `/.well-known/*`, `/api/v1/*` (bearer, bez cookie) **wyłączyć spod
+  bramki** (D6).
+- **CORS** — przeglądarkowi klienci (MCP Inspector) potrzebują CORS na
+  `/.well-known/*` i `/o/token/`; Claude server-side nie (D5, decyzja świadoma).
+- **Caching** — brak cache-middleware; opaque token = +1 DB-hit/request
+  (pomijalne). Gdyby nginx kiedyś cache'ował `/api/v1` → `Vary: Authorization`
+  (D-f).
+
+## 6. Strona bpp-mcp — kontrakt (zakres późniejszy)
+
+`bpp-mcp` jako Resource Server:
+- Serwuje `/.well-known/oauth-protected-resource` (RFC 9728) →
+  `authorization_servers: ["{BPP_BASE_URL}"]` (issuer root, NIE `.../o/`).
+- Bez tokenu → **401 + `WWW-Authenticate`** (discovery dance).
+- **Preflight `whoami`** (§5.4d) na starcie/co token: nieważny → mapuj na
+  **transportowy HTTP 401** (żeby klient re-autoryzował), nie na błąd JSON-RPC.
+- **Forwarduje** `Authorization: Bearer` na `httpx` do API BPP; write i tak
+  blokowany serwerowo (§5.4b).
+- Wariant z introspekcją (opcjonalny) wymaga confidential clienta (§5.4c);
+  wtedy `bpp-mcp` może sprawdzać `client_id` z introspekcji jako namiastkę
+  audience (W3).
+- Per-instancyjność: `BPP_BASE_URL` → API + AS; DCR i tokeny per-instancja (§9).
+
+Przy realizacji §6 BPP dostarczy **kontrakt integracyjny** (URL-e, kształt
+`whoami`/introspekcji, nagłówki, ewentualne credentials confidential clienta).
+
+## 7. Przepływ end-to-end
+
+1. Claude → `bpp-mcp` bez tokenu → **401** + `WWW-Authenticate` (URL metadata).
+2. Claude: `oauth-protected-resource` (MCP) → `oauth-authorization-server`
+   (BPP, issuer root) → **DCR** (`/o/register/`) → `client_id`.
+3. Claude → przeglądarka → `/o/authorize/` (PKCE, scope `read`).
+4. Niezalogowany → **strona logowania BPP** → user loguje się (§4 nt. `next`).
+5. **Ekran zgody** → akceptacja.
+6. `code` → `/o/token/` (PKCE) → **access token** (+ rotujący refresh).
+7. Claude ponawia z `Bearer`; `bpp-mcp` preflightuje `whoami`, forwarduje →
+   DRF `request.user` = user; metody nie-SAFE → 403 (§5.4b).
+8. Token wygasa mid-session → `whoami` 401 → klient re-autoryzuje po cichu
+   (refresh) lub ponawia taniec.
+
+## 8. Bezpieczeństwo
+
+- **Read-only egzekwowane w middleware `/api/v1/`** (§5.4b) — nieobchodzone
+  per-view (B-2).
+- **Nieważny bearer → 401, nie cicha degradacja do anona** (§5.4a, B-1).
+- **Krótki TTL + rotacja refresh + `REFRESH_TOKEN_EXPIRE_SECONDS` + revoke +
+  odrzucanie `is_active=False` + revoke-on-password-change** — obowiązkowe, bo
+  realni posiadacze tokenów to staff/superuserzy (§1/W-D).
+- **PKCE obowiązkowe**, brak implicit, HTTPS-only.
+- **Token passthrough — jawne, udokumentowane odstępstwo od MCP MUST (W3):** DOT
+  nie wspiera RFC 8707, token opaque bez `aud`. Odstępujemy świadomie
+  (`bpp-mcp` i API = ta sama domena zaufania / dostawca IPLWEB). Mitygacje:
+  jedyny scope `read`, twardy read-only, krótki TTL, opcjonalna kontrola
+  `client_id`. Ryzyko rezydualne: dowolny token AS BPP będzie honorowany przez
+  oba. RFC 8707 → §11.
+- **DCR = największe wejście:** otwarta rejestracja z twardymi limitami (§5.6).
+- **Management views wycięte** (`base_urlpatterns` only, W4).
+- **Higiena DOT:** `cleartokens` periodycznie; tokeny w DB plaintext →
+  ostrożność z backupami (D3).
+
+## 9. Wielo-instancyjność
+
+Każda instancja = własny AS (własne `/o/`, `Application`/tokeny w swojej bazie).
+`bpp-mcp` z `BPP_BASE_URL` odkrywa AS tej instancji i **rejestruje się
+per-instancja** (DCR osobno). Issuer budowany z `request` (wielo-domenowość).
+Keycloak (gdzie wdrożony) pozostaje **backendem logowania** na `authorize`, nie
+zastępuje AS BPP.
+
+## 10. Testy
+
+**BPP (pytest, ta sesja):**
+- Ważny `Bearer` → `request.user` ustawiony; dane per-user.
+- **`whoami`:** ważny token → 200; brak/nieważny/zrewokowany → **401** (nie 200
+  anonimowe — B-1).
+- **Read-only:** POST/PUT/PATCH/DELETE z bearerem na `/api/v1/*` → **403**
+  (w tym na write-owym `raport_slotow` po dołożeniu tam OAuth2 — B-2).
+- Anonimowy request → dalej `AnonReadOnly` (regres na **dowolnym anonimowym
+  endpoincie `api_v1`**; `/szukaj/` nie na tej gałęzi → do checklisty scalenia).
+- `code`→token z PKCE; **brak PKCE → odrzucone**.
+- Ekran zgody renderuje i zapisuje `Grant`; scope na ekranie = tylko `read`
+  (nie `introspection` — W-B).
+- **Revoke** → kolejny request/`whoami` → 401.
+- **DCR:** dozwolony `redirect_uri` → 201 `client_id`; nie-HTTPS/niedozwolony →
+  odrzucone; `/o/register/` bez CSRF działa.
+- **Metadata** zwraca issuer=host (per `request`) + endpointy.
+- **Rotacja refresh:** użycie refresh → nowy refresh, stary nieważny.
+- **`is_active=False`** → token odrzucony; **password-change** → tokeny usera
+  zrewokowane.
+
+**bpp-mcp (kontrakt, później):** 401 bez tokenu; metadata; `whoami` preflight;
+bearer forward; mock (respx/httpx MockTransport).
+
+**Smoke (opcjonalny):** pełny taniec OAuth wobec żywej instancji, per-backend (§4).
+
+## 11. Poza zakresem (Faza 3)
+
+- Zapis/import przez API (osobna, późniejsza faza).
+- **RFC 8707 / audience binding** (DOT nie wspiera — świadome odstępstwo, §8/W3);
+  token-exchange (RFC 8693).
+- OIDC userinfo dla MCP (potrzebny tylko access token).
+- Scope-gating narzędzi ponad `read` (razem z write).
+- Końcówka MCP i narzędzia (`bpp-mcp` §6 — osobny pakiet, osobna sesja).
+
+## 12. Otwarte kwestie do rozstrzygnięcia w planie
+
+1. **Wersja `django-oauth-toolkit`** — przypiąć i zweryfikować **przed planem**:
+   PKCE, `ROTATE_REFRESH_TOKEN`, `OAuth2Authentication`, brak DCR (piszemy sami),
+   brak RFC 8414 (dopisujemy). DCR i RFC 8414 to **kod własny**, nie config.
+2. Introspekcja vs `whoami` (§5.4c/d) — rekomendacja: `whoami`, bez introspekcji.
+3. Dokładny kształt middleware read-only `/api/v1/` (§5.4b).
+4. Allowlista `redirect_uri` Claude'a (§5.6).
+5. Naprawa `next` Microsoft + weryfikacja ORCID (§4).
+6. Mechanizm revoke-on-password-change (signal, §5.7/W-D).
+
+## 13. Kryteria akceptacji Fazy 3 (strona BPP)
+
+- `django-oauth-toolkit` (pinned) + migracje + baseline (przy scalaniu).
+- Zamontowane **tylko** `base_urlpatterns` (+ cherry-pick `authorized_tokens`,
+  własne well-known/DCR); management-CRUD niewystawione (lub superuser-only).
+- `/o/authorize/`, `/o/token/`, `/o/revoke_token/`, `/o/register/` (własny),
+  `/.well-known/oauth-authorization-server` (własny, issuer=host) działają;
+  niezalogowany na `authorize` widzi login BPP; `next` przeżywa hasło+Microsoft.
+- API: **ważny bearer → `request.user`**; **nieważny bearer → 401** (nie
+  degradacja); **metody nie-SAFE z bearerem → 403** (także per-view write);
+  `whoami` działa; anonimowe endpointy bez regresu.
+- PKCE wymuszone; `DEFAULT_SCOPES=["read"]`; ekran zgody read-only, po polsku.
+- Rotacja refresh + `REFRESH_TOKEN_EXPIRE_SECONDS` + revoke + `is_active` +
+  revoke-on-password-change.
+- Testy pytest zielone (read-only, PKCE, revoke, DCR-reject, whoami, is_active).
+- `bpp-mcp` dostaje udokumentowany kontrakt integracyjny (§6).

--- a/docs/superpowers/specs/2026-07-11-mcp-oauth-authorization-design.md
+++ b/docs/superpowers/specs/2026-07-11-mcp-oauth-authorization-design.md
@@ -287,8 +287,10 @@ zastępuje AS BPP.
 - Ważny `Bearer` → `request.user` ustawiony; dane per-user.
 - **`whoami`:** ważny token → 200; brak/nieważny/zrewokowany → **401** (nie 200
   anonimowe — B-1).
-- **Read-only:** POST/PUT/PATCH/DELETE z bearerem na `/api/v1/*` → **403**
-  (w tym na write-owym `raport_slotow` po dołożeniu tam OAuth2 — B-2).
+- **Read-only:** POST/PUT/PATCH/DELETE z bearerem na `/api/v1/*` → **403** z
+  middleware (także na write-owym `raport_slotow` — middleware wykrywa bearer
+  sam, niezależnie od per-view `authentication_classes`, więc blokuje mutację
+  nawet gdy viewset nie akceptuje OAuth2 — B-2).
 - Anonimowy request → dalej `AnonReadOnly` (regres na **dowolnym anonimowym
   endpoincie `api_v1`**; `/szukaj/` nie na tej gałęzi → do checklisty scalenia).
 - `code`→token z PKCE; **brak PKCE → odrzucone**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ dependencies = [
     "mozilla-django-oidc>=5.0.2,<6",
     "babel>=2.17",
     "django-liveops[celery]>=0.3,<0.4",
+    "django-oauth-toolkit==3.3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/api_v1/urls.py
+++ b/src/api_v1/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include
+from django.urls import include, path
 from django.urls import re_path as url
 from rest_framework import routers
 
@@ -42,6 +42,7 @@ from api_v1.viewsets.wydawnictwo_zwarte import (
     Wydawnictwo_ZwarteViewSet,
 )
 from api_v1.viewsets.zrodlo import Rodzaj_ZrodlaViewSet, ZrodloViewSet
+from oauth_mcp.views_whoami import WhoAmIView
 
 
 class CustomRouter(routers.DefaultRouter):
@@ -135,5 +136,6 @@ router.register(
 #
 
 urlpatterns = [
+    path("whoami/", WhoAmIView.as_view(), name="whoami"),
     url(r"^", include(router.urls)),
 ]

--- a/src/bpp/newsfragments/mcp-oauth-authorization.feature.md
+++ b/src/bpp/newsfragments/mcp-oauth-authorization.feature.md
@@ -1,0 +1,9 @@
+Warstwa autoryzacji OAuth 2.1 dla serwera MCP: BPP działa jako Authorization
+Server (`django-oauth-toolkit`) z endpointami `/o/authorize`, `/o/token`,
+`/o/revoke_token`, własnym Dynamic Client Registration `/o/register/` (RFC 7591)
+i metadanymi `/.well-known/oauth-authorization-server` (RFC 8414). API `/api/v1/`
+przyjmuje token `Bearer` z uprawnieniami zalogowanego użytkownika (odczyt),
+udostępnia endpoint `/api/v1/whoami/` do weryfikacji tożsamości i jest twardo
+read-only dla tokenów. Logowanie w kroku zgody korzysta ze wszystkich metod BPP
+(hasło/LDAP/Microsoft/ORCID/Keycloak). Tokeny są krótkotrwałe, z rotacją refresh
+i unieważnieniem przy zmianie hasła lub dezaktywacji konta.

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -1746,3 +1746,18 @@ CONSTANCE_DATABASE_CACHE_BACKEND = "constance_cache"
 # Puste CONSTANCE_CONFIG zachowane dla backward compat z django-constance.
 CONSTANCE_CONFIG = {}
 CONSTANCE_CONFIG_FIELDSETS = {}
+
+#
+# django-oauth-toolkit (DOT) — Authorization Server dla serwera MCP (`/o/`).
+# NIE dodawaj `ALLOWED_GRANT_TYPES` — taki klucz nie istnieje w DOT i
+# zostałby po cichu zignorowany. Granty kontroluje DCR (Task 6/7) i atrybut
+# `Application.authorization_grant_type`.
+#
+OAUTH2_PROVIDER = {
+    "PKCE_REQUIRED": True,
+    "DEFAULT_SCOPES": ["read"],
+    "SCOPES": {"read": "Odczyt danych BPP w Twoim imieniu"},
+    "ROTATE_REFRESH_TOKEN": True,
+    "ACCESS_TOKEN_EXPIRE_SECONDS": 60 * 30,  # 30 min
+    "REFRESH_TOKEN_EXPIRE_SECONDS": 60 * 60 * 24 * 7,  # 7 dni (NIE None!)
+}

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -974,6 +974,11 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 10,
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "oauth_mcp.authentication.StrictOAuth2Authentication",
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.BasicAuthentication",
+    ],
     # Nie limituj ilości zapytań (mpasternak, 6.06.2020) - jednakże, gdyby
     # trzeba było, to wystarczy odkomentować poniższe dwie linie:
     # "DEFAULT_THROTTLE_CLASSES": ("rest_framework.throttling.AnonRateThrottle",),

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -328,6 +328,7 @@ MIDDLEWARE = [
     "bpp.middleware.NotificationsMiddleware",
     # 'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',
     "bpp.middleware.CustomRollbarNotifierMiddleware",
+    "oauth_mcp.middleware.ApiReadOnlyForBearerMiddleware",
     # AxesMiddleware MUSI być ostatnie — przechwytuje AxesBackendPermissionDenied
     # z backendu logowania i renderuje odpowiedź "konto zablokowane".
     "axes.middleware.AxesMiddleware",

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -455,6 +455,8 @@ INSTALLED_APPS = [
     "import_dyscyplin",
     "mptt",
     "rest_framework",
+    "oauth_mcp",
+    "oauth2_provider",
     "django_filters",
     "api_v1",
     "adminsortable2",

--- a/src/django_bpp/urls.py
+++ b/src/django_bpp/urls.py
@@ -471,7 +471,10 @@ elif apps.is_installed("microsoft_auth"):
         # Default login redirects to Microsoft
         url(
             r"^accounts/login/$",
-            RedirectView.as_view(pattern_name="microsoft_auth:to-auth-redirect"),
+            RedirectView.as_view(
+                pattern_name="microsoft_auth:to-auth-redirect",
+                query_string=True,
+            ),
             name="login_form",
         ),
         url(

--- a/src/django_bpp/urls.py
+++ b/src/django_bpp/urls.py
@@ -58,6 +58,7 @@ urlpatterns = (
             include("first_run_wizard.urls", namespace="first_run_wizard"),
         ),
         path("formdefaults/", include("formdefaults.urls")),
+        path("", include("oauth_mcp.urls")),
         url(r"^favicon\.ico$", cache_page(60 * 60)(favicon)),
         path("test_403/", login_required(test_403_view)),
         path("test_500/", login_required(test_500_view)),

--- a/src/oauth_mcp/apps.py
+++ b/src/oauth_mcp/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class OauthMcpConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "oauth_mcp"
+
+    def ready(self):
+        from oauth_mcp import signals  # noqa: F401  (rejestruje receivery)

--- a/src/oauth_mcp/authentication.py
+++ b/src/oauth_mcp/authentication.py
@@ -1,0 +1,26 @@
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication
+from rest_framework.exceptions import AuthenticationFailed
+
+
+class StrictOAuth2Authentication(OAuth2Authentication):
+    """OAuth2 auth, która NIE degraduje po cichu do anonima.
+
+    Standardowe ``OAuth2Authentication`` przy nieważnym bearerze zwraca
+    ``None`` → DRF spada na Session/Basic → ``AnonymousUser`` → endpoint
+    ``AnonReadOnly`` oddaje 200 publiczne. Chcemy twardego 401, gdy klient
+    JAWNIE przysłał ``Authorization: Bearer`` (spec §5.4a / B-1). Dodatkowo
+    odrzucamy nieaktywnych użytkowników (spec §5.7 / W-D).
+    """
+
+    def authenticate(self, request):
+        result = super().authenticate(request)
+        header = request.META.get("HTTP_AUTHORIZATION", "")
+        bearer_obecny = header.lower().startswith("bearer ")
+        if result is None:
+            if bearer_obecny:
+                raise AuthenticationFailed("Nieprawidłowy lub wygasły token.")
+            return None
+        user, token = result
+        if not user or not user.is_active:
+            raise AuthenticationFailed("Konto nieaktywne.")
+        return user, token

--- a/src/oauth_mcp/middleware.py
+++ b/src/oauth_mcp/middleware.py
@@ -1,0 +1,40 @@
+from django.http import JsonResponse
+
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+
+
+class ApiReadOnlyForBearerMiddleware:
+    """Blokuje mutacje `/api/v1/` wykonane tokenem OAuth (MVP read-only).
+
+    Auth DRF biegnie w widoku (po middleware), więc tu wykrywamy bearer po
+    nagłówku i sami weryfikujemy token, zamiast polegać na `request.auth`
+    (jeszcze nieustawionym). To warstwa nieobchodzona przez per-view
+    `permission_classes` (spec §5.4b / B-2).
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if (
+            request.path.startswith("/api/v1/")
+            and request.method not in SAFE_METHODS
+            and self._ma_wazny_bearer(request)
+        ):
+            return JsonResponse(
+                {"detail": "Zapis przez token MCP jest wyłączony (read-only)."},
+                status=403,
+            )
+        return self.get_response(request)
+
+    @staticmethod
+    def _ma_wazny_bearer(request):
+        header = request.META.get("HTTP_AUTHORIZATION", "")
+        if not header.lower().startswith("bearer "):
+            return False
+        raw = header.split(" ", 1)[1].strip()
+        from oauth2_provider.models import get_access_token_model
+
+        AccessToken = get_access_token_model()
+        tok = AccessToken.objects.filter(token=raw).first()
+        return bool(tok and tok.is_valid())

--- a/src/oauth_mcp/signals.py
+++ b/src/oauth_mcp/signals.py
@@ -1,0 +1,1 @@
+"""Receivery rewokacji tokenów — implementacja w Task 9."""

--- a/src/oauth_mcp/signals.py
+++ b/src/oauth_mcp/signals.py
@@ -1,1 +1,33 @@
 """Receivery rewokacji tokenów — implementacja w Task 9."""
+
+from django.contrib.auth import get_user_model
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+
+@receiver(pre_save, sender=get_user_model())
+def revoke_tokens_on_password_change(sender, instance, update_fields=None, **kwargs):
+    """Zmiana hasła / dezaktywacja → skasuj tokeny OAuth usera (spec §5.7/W-D)."""
+    if not instance.pk:
+        return
+    # Tani short-circuit (D6): np. `update last_login` przy każdym logowaniu
+    # przekazuje update_fields={"last_login"} → nie ruszamy DB.
+    if update_fields is not None and not (
+        {"password", "is_active"} & set(update_fields)
+    ):
+        return
+    try:
+        stary = sender.objects.get(pk=instance.pk)
+    except sender.DoesNotExist:
+        return
+
+    haslo_zmienione = stary.password != instance.password
+    dezaktywowany = stary.is_active and not instance.is_active
+    if haslo_zmienione or dezaktywowany:
+        from oauth2_provider.models import (
+            get_access_token_model,
+            get_refresh_token_model,
+        )
+
+        get_access_token_model().objects.filter(user=instance).delete()
+        get_refresh_token_model().objects.filter(user=instance).delete()

--- a/src/oauth_mcp/templates/oauth2_provider/authorize.html
+++ b/src/oauth_mcp/templates/oauth2_provider/authorize.html
@@ -16,7 +16,7 @@
     </ul>
     <form method="post" action="{% url 'oauth2_provider:authorize' %}">
       {% csrf_token %}
-      {% for field in form %}{{ field }}{% endfor %}
+      {% for field in form %}{% if field.is_hidden %}{{ field }}{% endif %}{% endfor %}
       <button type="submit" class="button alert" name="allow" value="">
         {% trans "Odmów" %}
       </button>

--- a/src/oauth_mcp/templates/oauth2_provider/authorize.html
+++ b/src/oauth_mcp/templates/oauth2_provider/authorize.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{# nadpisuje domyślny szablon zgody django-oauth-toolkit #}
+{% load i18n %}
+{% block content %}
+<div class="row">
+  <div class="column">
+    <h3><span class="fi-key"></span> {% trans "Autoryzacja aplikacji" %}</h3>
+    {% if not error %}
+    <p>
+      {% blocktrans with name=application.name %}Aplikacja <strong>{{ name }}</strong>
+      prosi o <strong>ODCZYT</strong> danych BPP w Twoim imieniu.{% endblocktrans %}
+    </p>
+    <p>{% trans "Zakres:" %}</p>
+    <ul>
+      {% for opis in scopes_descriptions %}<li>{{ opis }}</li>{% endfor %}
+    </ul>
+    <form method="post" action="{% url 'oauth2_provider:authorize' %}">
+      {% csrf_token %}
+      {% for field in form %}{{ field }}{% endfor %}
+      <button type="submit" class="button alert" name="allow" value="">
+        {% trans "Odmów" %}
+      </button>
+      <button type="submit" class="button success" name="allow" value="Authorize">
+        {% trans "Zezwól na odczyt" %}
+      </button>
+    </form>
+    {% else %}
+    <p class="alert callout">{{ error.error }}: {{ error.description }}</p>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/src/oauth_mcp/tests/conftest.py
+++ b/src/oauth_mcp/tests/conftest.py
@@ -1,0 +1,31 @@
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from model_bakery import baker
+from oauth2_provider.models import get_access_token_model, get_application_model
+
+
+@pytest.fixture
+def access_token(db, django_user_model):
+    def _make(scope="read", is_active=True):
+        AccessToken = get_access_token_model()
+        Application = get_application_model()
+        user = baker.make(django_user_model, is_active=is_active)
+        app = Application.objects.create(
+            user=user,
+            client_type=Application.CLIENT_PUBLIC,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://claude.ai/callback",
+            name="test-mcp",
+        )
+        tok = AccessToken.objects.create(
+            user=user,
+            application=app,
+            token="tok-" + str(user.pk),
+            expires=timezone.now() + timedelta(hours=1),
+            scope=scope,
+        )
+        return user, tok
+
+    return _make

--- a/src/oauth_mcp/tests/test_authentication.py
+++ b/src/oauth_mcp/tests/test_authentication.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_wazny_token_ustawia_usera(access_token, client):
+    user, tok = access_token()
+    resp = client.get("/api/v1/whoami/", HTTP_AUTHORIZATION=f"Bearer {tok.token}")
+    # whoami powstaje w Task 5; tu sprawdzamy tylko że NIE ma 500/anon-degrade.
+    assert resp.status_code in (200, 404)
+
+
+@pytest.mark.django_db
+def test_niewazny_bearer_daje_401_nie_anon(access_token, client):
+    # dowolny anonimowy read-only endpoint api_v1 z GŁUPIM bearerem → 401
+    resp = client.get(
+        "/api/v1/wydawnictwo_ciagle/",
+        HTTP_AUTHORIZATION="Bearer nieistniejacy-token",
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+def test_brak_bearera_dalej_anonimowo(client):
+    resp = client.get("/api/v1/wydawnictwo_ciagle/")
+    assert resp.status_code == 200  # AnonReadOnly bez zmian

--- a/src/oauth_mcp/tests/test_authorize.py
+++ b/src/oauth_mcp/tests/test_authorize.py
@@ -35,3 +35,12 @@ def test_pkce_wymagane(client, django_user_model):
     # 302 z ?error=... na redirect_uri (nie 400).
     assert resp.status_code == 302
     assert "error=" in resp["Location"]
+
+
+@pytest.mark.django_db
+def test_device_flow_niedostepny(client):
+    # RFC 8628 Device Authorization Grant świadomie NIE jest zamontowany —
+    # niechciany w MVP (nieuwierzytelniony, csrf-exempt, nielimitowany zapis
+    # DeviceGrant). Montujemy tylko authorize/token/revoke, patrz urls.py.
+    resp = client.post("/o/device-authorization/")
+    assert resp.status_code == 404

--- a/src/oauth_mcp/tests/test_authorize.py
+++ b/src/oauth_mcp/tests/test_authorize.py
@@ -1,0 +1,37 @@
+import pytest
+from model_bakery import baker
+from oauth2_provider.models import get_application_model
+
+
+@pytest.mark.django_db
+def test_authorize_niezalogowany_redirect_na_login(client):
+    resp = client.get("/o/authorize/", {"response_type": "code"})
+    assert resp.status_code == 302
+    assert "/accounts/login/" in resp["Location"]
+
+
+@pytest.mark.django_db
+def test_pkce_wymagane(client, django_user_model):
+    Application = get_application_model()
+    user = baker.make(django_user_model)
+    app = Application.objects.create(
+        user=user,
+        client_type=Application.CLIENT_PUBLIC,
+        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        redirect_uris="https://claude.ai/callback",
+        name="test",
+    )
+    client.force_login(user)
+    # authorize BEZ code_challenge → odrzucone (PKCE_REQUIRED)
+    resp = client.get(
+        "/o/authorize/",
+        {
+            "response_type": "code",
+            "client_id": app.client_id,
+            "redirect_uri": "https://claude.ai/callback",
+        },
+    )
+    # DOT przy PKCE_REQUIRED i braku code_challenge zwraca redirectowalny błąd:
+    # 302 z ?error=... na redirect_uri (nie 400).
+    assert resp.status_code == 302
+    assert "error=" in resp["Location"]

--- a/src/oauth_mcp/tests/test_consent.py
+++ b/src/oauth_mcp/tests/test_consent.py
@@ -31,3 +31,51 @@ def test_ekran_zgody_pokazuje_readonly(client, django_user_model):
     assert resp.status_code == 200
     assert b"ODCZYT" in resp.content
     assert b"Claude" in resp.content
+    # Pola ukryte formularza AllowForm (parametry OAuth) muszą trafić do POST.
+    assert b'type="hidden"' in resp.content
+    assert b'name="redirect_uri"' in resp.content
+    # Checkbox "allow" (BooleanField) nie ma być widoczny — zgodę niosą
+    # przyciski submit name="allow", a nieopisany checkbox to osierocone pole.
+    assert b'type="checkbox"' not in resp.content
+
+
+@pytest.mark.django_db
+def test_ekran_zgody_bez_widocznego_checkboxa(client, django_user_model):
+    # base.html + context-processory BPP wolą mieć Uczelnia (D7).
+    baker.make("bpp.Uczelnia")
+    Application = get_application_model()
+    user = baker.make(django_user_model)
+    app = Application.objects.create(
+        user=user,
+        client_type=Application.CLIENT_PUBLIC,
+        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        redirect_uris="https://claude.ai/cb",
+        name="Claude",
+    )
+    client.force_login(user)
+    resp = client.get(
+        "/o/authorize/",
+        {
+            "response_type": "code",
+            "client_id": app.client_id,
+            "redirect_uri": "https://claude.ai/cb",
+            "code_challenge": "x" * 43,
+            "code_challenge_method": "S256",
+            "scope": "read",
+        },
+    )
+    assert resp.status_code == 200
+    # Wszystkie ukryte parametry OAuth muszą przetrwać (potrzebne do POST-a).
+    for hidden_name in (
+        "redirect_uri",
+        "scope",
+        "client_id",
+        "state",
+        "response_type",
+        "code_challenge",
+        "code_challenge_method",
+    ):
+        assert f'name="{hidden_name}"'.encode() in resp.content
+    # Widoczny, nieopisany checkbox "allow" ma zniknąć — zgodę niosą
+    # przyciski submit name="allow".
+    assert b'type="checkbox"' not in resp.content

--- a/src/oauth_mcp/tests/test_consent.py
+++ b/src/oauth_mcp/tests/test_consent.py
@@ -1,0 +1,33 @@
+import pytest
+from model_bakery import baker
+from oauth2_provider.models import get_application_model
+
+
+@pytest.mark.django_db
+def test_ekran_zgody_pokazuje_readonly(client, django_user_model):
+    # base.html + context-processory BPP wolą mieć Uczelnia (D7).
+    baker.make("bpp.Uczelnia")
+    Application = get_application_model()
+    user = baker.make(django_user_model)
+    app = Application.objects.create(
+        user=user,
+        client_type=Application.CLIENT_PUBLIC,
+        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        redirect_uris="https://claude.ai/cb",
+        name="Claude",
+    )
+    client.force_login(user)
+    resp = client.get(
+        "/o/authorize/",
+        {
+            "response_type": "code",
+            "client_id": app.client_id,
+            "redirect_uri": "https://claude.ai/cb",
+            "code_challenge": "x" * 43,
+            "code_challenge_method": "S256",
+            "scope": "read",
+        },
+    )
+    assert resp.status_code == 200
+    assert b"ODCZYT" in resp.content
+    assert b"Claude" in resp.content

--- a/src/oauth_mcp/tests/test_dcr.py
+++ b/src/oauth_mcp/tests/test_dcr.py
@@ -50,3 +50,41 @@ def test_dcr_bez_csrf_dziala():
         content_type="application/json",
     )
     assert resp.status_code == 201
+
+
+@pytest.mark.django_db
+def test_dcr_payload_nie_obiekt_400(client):
+    # Poprawny JSON, ale nie obiekt — payload.get() rzuciłby AttributeError.
+    resp = client.post(
+        "/o/register/",
+        data=json.dumps([]),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_client_metadata"
+
+
+@pytest.mark.django_db
+def test_dcr_redirect_uri_nie_string_400(client):
+    # Element redirect_uris nie-stringiem — re.match rzuciłby TypeError.
+    resp = client.post(
+        "/o/register/",
+        data=json.dumps({"redirect_uris": [1234]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_redirect_uri"
+
+
+@pytest.mark.django_db
+def test_dcr_client_name_nie_string_akceptowany(client):
+    # client_name nie-string — [:255] rzuciłby TypeError; oczekujemy
+    # fallbacku na nazwę domyślną zamiast 500.
+    resp = client.post(
+        "/o/register/",
+        data=json.dumps(
+            {"client_name": 123, "redirect_uris": ["https://claude.ai/cb"]}
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201

--- a/src/oauth_mcp/tests/test_dcr.py
+++ b/src/oauth_mcp/tests/test_dcr.py
@@ -1,0 +1,52 @@
+import json
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_dcr_dozwolony_redirect_201(client):
+    resp = client.post(
+        "/o/register/",
+        data=json.dumps(
+            {"client_name": "Claude", "redirect_uris": ["https://claude.ai/cb"]}
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    assert resp.json()["client_id"]
+    assert resp.json()["token_endpoint_auth_method"] == "none"
+
+
+@pytest.mark.django_db
+def test_dcr_niedozwolony_redirect_400(client):
+    resp = client.post(
+        "/o/register/",
+        data=json.dumps({"redirect_uris": ["https://evil.example/cb"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_dcr_nie_https_400(client):
+    resp = client.post(
+        "/o/register/",
+        data=json.dumps({"redirect_uris": ["http://evil.example/cb"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_dcr_bez_csrf_dziala():
+    # Domyślny test client ma enforce_csrf_checks=False → nie dowiódłby niczego.
+    # Wymuszamy CSRF, by realnie przetestować csrf_exempt (W3).
+    from django.test import Client
+
+    csrf_client = Client(enforce_csrf_checks=True)
+    resp = csrf_client.post(
+        "/o/register/",
+        data=json.dumps({"redirect_uris": ["http://localhost:8765/cb"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201

--- a/src/oauth_mcp/tests/test_flow_integration.py
+++ b/src/oauth_mcp/tests/test_flow_integration.py
@@ -1,0 +1,103 @@
+import base64
+import hashlib
+
+import pytest
+from model_bakery import baker
+from oauth2_provider.models import get_application_model
+
+
+def _pkce():
+    verifier = "a" * 64
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .decode()
+        .rstrip("=")
+    )
+    return verifier, challenge
+
+
+@pytest.mark.django_db
+def test_pelny_taniec_pkce_i_token(client, django_user_model):
+    Application = get_application_model()
+    user = baker.make(django_user_model, is_active=True)
+    app = Application.objects.create(
+        user=user,
+        client_type=Application.CLIENT_PUBLIC,
+        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        redirect_uris="https://claude.ai/cb",
+        name="Claude",
+    )
+    client.force_login(user)
+    verifier, challenge = _pkce()
+    resp = client.post(
+        "/o/authorize/",
+        {
+            "response_type": "code",
+            "client_id": app.client_id,
+            "redirect_uri": "https://claude.ai/cb",
+            "scope": "read",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "allow": "Authorize",
+        },
+    )
+    assert resp.status_code == 302
+    code = resp["Location"].split("code=")[1].split("&")[0]
+
+    token_resp = client.post(
+        "/o/token/",
+        {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "https://claude.ai/cb",
+            "client_id": app.client_id,
+            "code_verifier": verifier,
+        },
+    )
+    assert token_resp.status_code == 200
+    body = token_resp.json()
+    assert body["token_type"].lower() == "bearer"
+    assert body["scope"] == "read"
+
+    # token działa na whoami
+    who = client.get(
+        "/api/v1/whoami/", HTTP_AUTHORIZATION=f"Bearer {body['access_token']}"
+    )
+    assert who.status_code == 200
+    assert who.json()["id"] == user.pk
+
+    # rotacja refresh (spec §10/§13/W2)
+    refresh = body["refresh_token"]
+    r1 = client.post(
+        "/o/token/",
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh,
+            "client_id": app.client_id,
+        },
+    )
+    assert r1.status_code == 200
+    assert r1.json()["refresh_token"] != refresh  # ROTATE_REFRESH_TOKEN
+    # stary refresh już nieważny
+    r2 = client.post(
+        "/o/token/",
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh,
+            "client_id": app.client_id,
+        },
+    )
+    assert r2.status_code == 400
+
+
+@pytest.mark.django_db
+def test_revoke_uniewaznia_token(access_token, client):
+    """Revoke → kolejny request/whoami → 401 (spec §10/§13/W2)."""
+    user, tok = access_token()
+    resp = client.post(
+        "/o/revoke_token/",
+        {"token": tok.token, "client_id": tok.application.client_id},
+    )
+    assert resp.status_code == 200
+    who = client.get("/api/v1/whoami/", HTTP_AUTHORIZATION=f"Bearer {tok.token}")
+    assert who.status_code == 401

--- a/src/oauth_mcp/tests/test_install.py
+++ b/src/oauth_mcp/tests/test_install.py
@@ -1,0 +1,15 @@
+import pytest
+from django.apps import apps
+
+
+def test_apki_zaladowane():
+    assert apps.is_installed("oauth2_provider")
+    assert apps.is_installed("oauth_mcp")
+
+
+@pytest.mark.django_db
+def test_modele_dot_dostepne():
+    from oauth2_provider.models import get_access_token_model
+
+    AccessToken = get_access_token_model()
+    assert AccessToken.objects.count() == 0

--- a/src/oauth_mcp/tests/test_metadata.py
+++ b/src/oauth_mcp/tests/test_metadata.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_metadata_ksztalt(client):
+    resp = client.get("/.well-known/oauth-authorization-server")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["issuer"].startswith("http")
+    assert not data["issuer"].endswith("/o")  # issuer = ROOT
+    assert data["authorization_endpoint"].endswith("/o/authorize/")
+    assert data["registration_endpoint"].endswith("/o/register/")
+    assert data["code_challenge_methods_supported"] == ["S256"]
+    assert data["scopes_supported"] == ["read"]
+
+
+@pytest.mark.django_db
+def test_metadata_issuer_z_hosta(client):
+    # Host MUSI być w ALLOWED_HOSTS (testy dziedziczą zamkniętą listę) — inaczej
+    # DisallowedHost, nie 200 (B3). `test.unexistenttld` jest w ALLOWED_HOSTS.
+    resp = client.get(
+        "/.well-known/oauth-authorization-server", HTTP_HOST="test.unexistenttld"
+    )
+    assert "test.unexistenttld" in resp.json()["issuer"]

--- a/src/oauth_mcp/tests/test_microsoft_next.py
+++ b/src/oauth_mcp/tests/test_microsoft_next.py
@@ -1,0 +1,13 @@
+import pytest
+from django.apps import apps
+
+
+@pytest.mark.skipif(
+    not apps.is_installed("microsoft_auth"),
+    reason="wariant Microsoft nieaktywny w tej konfiguracji",
+)
+@pytest.mark.django_db
+def test_login_zachowuje_next(client):
+    resp = client.get("/accounts/login/?next=/o/authorize/%3Ffoo%3Dbar")
+    assert resp.status_code == 302
+    assert "next=" in resp["Location"]

--- a/src/oauth_mcp/tests/test_readonly_middleware.py
+++ b/src/oauth_mcp/tests/test_readonly_middleware.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_post_z_bearerem_blokowany_403(access_token, client):
+    user, tok = access_token()
+    resp = client.post(
+        "/api/v1/raport_slotow_uczelnia/",
+        data={},
+        HTTP_AUTHORIZATION=f"Bearer {tok.token}",
+        content_type="application/json",
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_get_z_bearerem_przechodzi_przez_middleware(access_token, client):
+    user, tok = access_token()
+    resp = client.get(
+        "/api/v1/wydawnictwo_ciagle/",
+        HTTP_AUTHORIZATION=f"Bearer {tok.token}",
+    )
+    # middleware nie blokuje GET; sam endpoint może dać 200
+    assert resp.status_code != 403
+
+
+@pytest.mark.django_db
+def test_post_bez_bearera_nietkniety(client):
+    # bez tokenu middleware nie ingeruje; endpoint (per-view [Basic] +
+    # IsAuthenticated) sam odrzuca anonima → 401 z DRF, NIE 403 z middleware.
+    resp = client.post(
+        "/api/v1/raport_slotow_uczelnia/", data={}, content_type="application/json"
+    )
+    assert resp.status_code == 401

--- a/src/oauth_mcp/tests/test_revoke_signals.py
+++ b/src/oauth_mcp/tests/test_revoke_signals.py
@@ -1,0 +1,21 @@
+import pytest
+from oauth2_provider.models import get_access_token_model
+
+
+@pytest.mark.django_db
+def test_zmiana_hasla_kasuje_tokeny(access_token):
+    user, tok = access_token()
+    AccessToken = get_access_token_model()
+    assert AccessToken.objects.filter(user=user).exists()
+    user.set_password("nowe-haslo-123")
+    user.save()
+    assert not AccessToken.objects.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_dezaktywacja_kasuje_tokeny(access_token):
+    user, tok = access_token()
+    AccessToken = get_access_token_model()
+    user.is_active = False
+    user.save()
+    assert not AccessToken.objects.filter(user=user).exists()

--- a/src/oauth_mcp/tests/test_whoami.py
+++ b/src/oauth_mcp/tests/test_whoami.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_whoami_wazny_token(access_token, client):
+    user, tok = access_token()
+    resp = client.get("/api/v1/whoami/", HTTP_AUTHORIZATION=f"Bearer {tok.token}")
+    assert resp.status_code == 200
+    assert resp.json()["username"] == user.get_username()
+
+
+@pytest.mark.django_db
+def test_whoami_bez_tokenu_401(client):
+    resp = client.get("/api/v1/whoami/")
+    assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+def test_whoami_niewazny_token_401(client):
+    resp = client.get("/api/v1/whoami/", HTTP_AUTHORIZATION="Bearer zly")
+    assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+def test_whoami_nieaktywny_user_401(access_token, client):
+    user, tok = access_token(is_active=False)
+    resp = client.get("/api/v1/whoami/", HTTP_AUTHORIZATION=f"Bearer {tok.token}")
+    assert resp.status_code == 401

--- a/src/oauth_mcp/urls.py
+++ b/src/oauth_mcp/urls.py
@@ -1,5 +1,5 @@
 from django.urls import include, path
-from oauth2_provider import urls as oauth2_urls
+from oauth2_provider import views as oauth2_views
 
 from oauth_mcp.views_dcr import DynamicClientRegistrationView
 from oauth_mcp.views_metadata import oauth_authorization_server_metadata
@@ -9,10 +9,24 @@ from oauth_mcp.views_metadata import oauth_authorization_server_metadata
 # `{% url 'oauth2_provider:authorize' %}` w szablonie zgody → NoReverseMatch.
 # Zostawiamy `oauth2_provider:*` na top-levelu, jak w dokumentacji DOT.
 
-# UWAGA: montujemy TYLKO base_urlpatterns (authorize/token/introspect/revoke),
-# NIE management-views (/o/applications/ CRUD dostępne każdemu zalogowanemu).
+# Montujemy WYŁĄCZNIE authorize/token/revoke — świadomie POMIJAMY device-flow
+# (RFC 8628, niechciany w MVP: nieuwierzytelniony, csrf-exempt, nielimitowany
+# POST /o/device-authorization/ zapisujący DeviceGrant do bazy — wektor
+# resource-exhaustion przy otwartym DCR) oraz management-views (/o/applications/
+# CRUD dostępne każdemu zalogowanemu). Introspekcja odroczona (wariant whoami,
+# spec §5.4c/d) — doda się przy wariancie confidential-client.
+_authorization_server_urls = [
+    path("authorize/", oauth2_views.AuthorizationView.as_view(), name="authorize"),
+    path("token/", oauth2_views.TokenView.as_view(), name="token"),
+    path(
+        "revoke_token/",
+        oauth2_views.RevokeTokenView.as_view(),
+        name="revoke-token",
+    ),
+]
+
 urlpatterns = [
-    path("o/", include((oauth2_urls.base_urlpatterns, "oauth2_provider"))),
+    path("o/", include((_authorization_server_urls, "oauth2_provider"))),
     path("o/register/", DynamicClientRegistrationView.as_view(), name="dcr"),
     path(
         ".well-known/oauth-authorization-server",

--- a/src/oauth_mcp/urls.py
+++ b/src/oauth_mcp/urls.py
@@ -1,0 +1,13 @@
+from django.urls import include, path
+from oauth2_provider import urls as oauth2_urls
+
+# BEZ `app_name` na tym module! Deklaracja `app_name="oauth_mcp"` zagnieżdżałaby
+# namespace DOT (`oauth_mcp:oauth2_provider:authorize`) i psuła
+# `{% url 'oauth2_provider:authorize' %}` w szablonie zgody → NoReverseMatch.
+# Zostawiamy `oauth2_provider:*` na top-levelu, jak w dokumentacji DOT.
+
+# UWAGA: montujemy TYLKO base_urlpatterns (authorize/token/introspect/revoke),
+# NIE management-views (/o/applications/ CRUD dostępne każdemu zalogowanemu).
+urlpatterns = [
+    path("o/", include((oauth2_urls.base_urlpatterns, "oauth2_provider"))),
+]

--- a/src/oauth_mcp/urls.py
+++ b/src/oauth_mcp/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 from oauth2_provider import urls as oauth2_urls
 
+from oauth_mcp.views_dcr import DynamicClientRegistrationView
 from oauth_mcp.views_metadata import oauth_authorization_server_metadata
 
 # BEZ `app_name` na tym module! Deklaracja `app_name="oauth_mcp"` zagnieżdżałaby
@@ -12,6 +13,7 @@ from oauth_mcp.views_metadata import oauth_authorization_server_metadata
 # NIE management-views (/o/applications/ CRUD dostępne każdemu zalogowanemu).
 urlpatterns = [
     path("o/", include((oauth2_urls.base_urlpatterns, "oauth2_provider"))),
+    path("o/register/", DynamicClientRegistrationView.as_view(), name="dcr"),
     path(
         ".well-known/oauth-authorization-server",
         oauth_authorization_server_metadata,

--- a/src/oauth_mcp/urls.py
+++ b/src/oauth_mcp/urls.py
@@ -1,6 +1,8 @@
 from django.urls import include, path
 from oauth2_provider import urls as oauth2_urls
 
+from oauth_mcp.views_metadata import oauth_authorization_server_metadata
+
 # BEZ `app_name` na tym module! Deklaracja `app_name="oauth_mcp"` zagnieżdżałaby
 # namespace DOT (`oauth_mcp:oauth2_provider:authorize`) i psuła
 # `{% url 'oauth2_provider:authorize' %}` w szablonie zgody → NoReverseMatch.
@@ -10,4 +12,9 @@ from oauth2_provider import urls as oauth2_urls
 # NIE management-views (/o/applications/ CRUD dostępne każdemu zalogowanemu).
 urlpatterns = [
     path("o/", include((oauth2_urls.base_urlpatterns, "oauth2_provider"))),
+    path(
+        ".well-known/oauth-authorization-server",
+        oauth_authorization_server_metadata,
+        name="oauth-as-metadata",
+    ),
 ]

--- a/src/oauth_mcp/views_dcr.py
+++ b/src/oauth_mcp/views_dcr.py
@@ -10,11 +10,11 @@ from oauth2_provider.models import get_application_model
 
 # Allowlista wzorców redirect_uri (spec §5.6): callbacki Claude + lokalne.
 _ALLOWED_REDIRECT_PATTERNS = [
-    re.compile(r"^https://claude\.ai/[^\s]*$"),
-    re.compile(r"^https://[a-z0-9.-]+\.claude\.ai/[^\s]*$"),
-    re.compile(r"^https://claude\.com/[^\s]*$"),
-    re.compile(r"^http://localhost(:\d+)?/[^\s]*$"),
-    re.compile(r"^http://127\.0\.0\.1(:\d+)?/[^\s]*$"),
+    re.compile(r"^https://claude\.ai/[^\s]*\Z"),
+    re.compile(r"^https://[a-z0-9.-]+\.claude\.ai/[^\s]*\Z"),
+    re.compile(r"^https://claude\.com/[^\s]*\Z"),
+    re.compile(r"^http://localhost(:\d+)?/[^\s]*\Z"),
+    re.compile(r"^http://127\.0\.0\.1(:\d+)?/[^\s]*\Z"),
 ]
 
 
@@ -34,23 +34,48 @@ class DynamicClientRegistrationView(View):
     def post(self, request):
         ip = request.META.get("REMOTE_ADDR", "?")
         key = f"dcr-rate:{ip}"
-        licznik = cache.get(key, 0)
-        if licznik >= 20:  # 20 rejestracji / okno
+        # Atomowy licznik: `add` inicjuje tylko gdy klucz jeszcze nie
+        # istnieje (no-op w przeciwnym razie), `incr` jest atomowy na
+        # poziomie backendu cache — usuwa TOCTOU między get+set.
+        cache.add(key, 0, timeout=3600)  # okno 1h
+        try:
+            licznik = cache.incr(key)
+        except ValueError:
+            # DummyCache (default CACHES w dev/test, zob. settings/local.py)
+            # nic nie przechowuje — `add` jest tam no-opem, więc `incr`
+            # zawsze zgłasza brak klucza. Traktujemy to jak pierwsze
+            # wystąpienie: rate-limit staje się no-op pod DummyCache
+            # (tak samo jak w poprzedniej implementacji get()+set()),
+            # ale endpoint nie wybucha 500 pod jedynym cache'em, jaki
+            # ten projekt realnie ma domyślnie skonfigurowany.
+            licznik = 1
+        if licznik > 20:  # 20 rejestracji / okno
             return JsonResponse({"error": "rate_limited"}, status=429)
-        cache.set(key, licznik + 1, timeout=3600)  # okno 1h
 
         try:
             payload = json.loads(request.body or "{}")
         except json.JSONDecodeError:
             return JsonResponse({"error": "invalid_client_metadata"}, status=400)
 
+        if not isinstance(payload, dict):
+            return JsonResponse({"error": "invalid_client_metadata"}, status=400)
+
         redirect_uris = payload.get("redirect_uris") or []
-        if not redirect_uris or not all(_dozwolony(u) for u in redirect_uris):
+        if (
+            not isinstance(redirect_uris, list)
+            or not redirect_uris
+            or not all(isinstance(u, str) for u in redirect_uris)
+            or not all(_dozwolony(u) for u in redirect_uris)
+        ):
             return JsonResponse({"error": "invalid_redirect_uri"}, status=400)
+
+        client_name = payload.get("client_name")
+        if not isinstance(client_name, str) or not client_name:
+            client_name = "mcp-client"
 
         Application = get_application_model()
         app = Application.objects.create(
-            name=(payload.get("client_name") or "mcp-client")[:255],
+            name=client_name[:255],
             client_type=Application.CLIENT_PUBLIC,
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
             redirect_uris=" ".join(redirect_uris),

--- a/src/oauth_mcp/views_dcr.py
+++ b/src/oauth_mcp/views_dcr.py
@@ -1,0 +1,67 @@
+import json
+import re
+
+from django.core.cache import cache
+from django.http import JsonResponse
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.csrf import csrf_exempt
+from oauth2_provider.models import get_application_model
+
+# Allowlista wzorców redirect_uri (spec §5.6): callbacki Claude + lokalne.
+_ALLOWED_REDIRECT_PATTERNS = [
+    re.compile(r"^https://claude\.ai/[^\s]*$"),
+    re.compile(r"^https://[a-z0-9.-]+\.claude\.ai/[^\s]*$"),
+    re.compile(r"^https://claude\.com/[^\s]*$"),
+    re.compile(r"^http://localhost(:\d+)?/[^\s]*$"),
+    re.compile(r"^http://127\.0\.0\.1(:\d+)?/[^\s]*$"),
+]
+
+
+def _dozwolony(uri: str) -> bool:
+    return any(p.match(uri) for p in _ALLOWED_REDIRECT_PATTERNS)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class DynamicClientRegistrationView(View):
+    """RFC 7591 — rejestracja publicznego klienta MCP (public + PKCE).
+
+    Otwarta rejestracja z twardymi limitami (spec §5.6/§8/W7): allowlista
+    redirect_uri, bez auto-approve dla nieznanych wzorców. Rate-limit ręczny
+    przez cache (to nie DRF view, więc bez throttlingu DRF).
+    """
+
+    def post(self, request):
+        ip = request.META.get("REMOTE_ADDR", "?")
+        key = f"dcr-rate:{ip}"
+        licznik = cache.get(key, 0)
+        if licznik >= 20:  # 20 rejestracji / okno
+            return JsonResponse({"error": "rate_limited"}, status=429)
+        cache.set(key, licznik + 1, timeout=3600)  # okno 1h
+
+        try:
+            payload = json.loads(request.body or "{}")
+        except json.JSONDecodeError:
+            return JsonResponse({"error": "invalid_client_metadata"}, status=400)
+
+        redirect_uris = payload.get("redirect_uris") or []
+        if not redirect_uris or not all(_dozwolony(u) for u in redirect_uris):
+            return JsonResponse({"error": "invalid_redirect_uri"}, status=400)
+
+        Application = get_application_model()
+        app = Application.objects.create(
+            name=(payload.get("client_name") or "mcp-client")[:255],
+            client_type=Application.CLIENT_PUBLIC,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris=" ".join(redirect_uris),
+        )
+        return JsonResponse(
+            {
+                "client_id": app.client_id,
+                "redirect_uris": redirect_uris,
+                "token_endpoint_auth_method": "none",
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+            },
+            status=201,
+        )

--- a/src/oauth_mcp/views_metadata.py
+++ b/src/oauth_mcp/views_metadata.py
@@ -1,0 +1,24 @@
+from django.http import JsonResponse
+
+
+def oauth_authorization_server_metadata(request):
+    """RFC 8414 — DOT nie shipuje czystego wariantu, piszemy sami (spec §5.6).
+
+    Issuer = ROOT hosta (bez /o); URL-e przez build_absolute_uri (poprawny
+    scheme z SECURE_PROXY_SSL_HEADER, host per-request — wielo-domenowość).
+    """
+    issuer = request.build_absolute_uri("/").rstrip("/")
+    return JsonResponse(
+        {
+            "issuer": issuer,
+            "authorization_endpoint": request.build_absolute_uri("/o/authorize/"),
+            "token_endpoint": request.build_absolute_uri("/o/token/"),
+            "revocation_endpoint": request.build_absolute_uri("/o/revoke_token/"),
+            "registration_endpoint": request.build_absolute_uri("/o/register/"),
+            "scopes_supported": ["read"],
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_methods_supported": ["none"],
+        }
+    )

--- a/src/oauth_mcp/views_whoami.py
+++ b/src/oauth_mcp/views_whoami.py
@@ -1,0 +1,28 @@
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from oauth_mcp.authentication import StrictOAuth2Authentication
+
+
+class WhoAmIView(APIView):
+    """Preflight tożsamości dla bpp-mcp (spec §5.4d).
+
+    Ważny token → 200 z tożsamością; brak/nieważny → 401 (transportowy,
+    mapowalny przez klienta MCP na re-auth). Świadomie NIE dopuszczamy
+    anonimowego 200.
+    """
+
+    authentication_classes = [StrictOAuth2Authentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        u = request.user
+        return Response(
+            {
+                "id": u.pk,
+                "username": u.get_username(),
+                "is_staff": u.is_staff,
+                "is_superuser": u.is_superuser,
+            }
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -416,6 +416,7 @@ dependencies = [
     { name = "django-model-utils", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-mptt", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-multiseek", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "django-oauth-toolkit", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-password-policies-iplweb", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-pg-baseline", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-polish-inflection", marker = "platform_python_implementation != 'PyPy'" },
@@ -599,6 +600,7 @@ requires-dist = [
     { name = "django-model-utils", specifier = "==5.0.0" },
     { name = "django-mptt", specifier = ">=0.16,<1" },
     { name = "django-multiseek", specifier = "==0.10.2" },
+    { name = "django-oauth-toolkit", specifier = "==3.3.0" },
     { name = "django-password-policies-iplweb", specifier = "==0.9.0" },
     { name = "django-pg-baseline", specifier = ">=0.3.0" },
     { name = "django-polish-inflection", specifier = ">=0.1,<0.2" },
@@ -2046,6 +2048,21 @@ wheels = [
 ]
 
 [[package]]
+name = "django-oauth-toolkit"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "jwcrypto", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "oauthlib", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "requests", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/2b/011f3e964f474b7814828586de0277ad373197096b28274d0ae8bf45d5f9/django_oauth_toolkit-3.3.0.tar.gz", hash = "sha256:2b375d14b1c0ff86e5df5e5de5d1a6d9868873304f54aca37c50158552d5b922", size = 118319, upload-time = "2026-05-29T18:13:57.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/e4/d05b3d50d0250f2d2f3a5dc9cd21f85e313ee1493ff60b729dccb8e08c46/django_oauth_toolkit-3.3.0-py3-none-any.whl", hash = "sha256:7af1365cd80735211454b0dca810bc9e860c631e61fd17768ad0fa331737954f", size = 88415, upload-time = "2026-05-29T18:13:55.827Z" },
+]
+
+[[package]]
 name = "django-password-policies-iplweb"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3100,6 +3117,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/4b/6f8906aaf67d501e259b0adab4d312945bb7211e8b8d4dcc77c92320edaa/json5-0.14.0.tar.gz", hash = "sha256:b3f492fad9f6cdbced8b7d40b28b9b1c9701c5f561bef0d33b81c2ff433fefcb", size = 52656, upload-time = "2026-03-27T22:50:48.108Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/42/cf027b4ac873b076189d935b135397675dac80cb29acb13e1ab86ad6c631/json5-0.14.0-py3-none-any.whl", hash = "sha256:56cf861bab076b1178eb8c92e1311d273a9b9acea2ccc82c276abf839ebaef3a", size = 36271, upload-time = "2026-03-27T22:50:47.073Z" },
+]
+
+[[package]]
+name = "jwcrypto"
+version = "1.5.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/7e/53c14813521693e931e420d9db00efe317419ff194495903bce03402275e/jwcrypto-1.5.8.tar.gz", hash = "sha256:c3d7114b6f6e65b52f6b7da817eb8cb8423e1da31e1ef13508447c81ecbdcc34", size = 90772, upload-time = "2026-06-24T19:36:50.782Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/7c/f87c5db042c4f7b4476346fc0d22f1025a777fee08eebde3720d3b9c4eb5/jwcrypto-1.5.8-py3-none-any.whl", hash = "sha256:85aeb475f808d56bbc2f2ed1f6f73e6a317c4011a4321505f02f0aed695a3742", size = 96133, upload-time = "2026-06-24T19:36:49.519Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Co to jest

Warstwa autoryzacji **OAuth 2.1** w BPP, żeby serwer MCP `bpp-mcp` mógł działać
z uprawnieniami **zalogowanego użytkownika** (a nie anonimowo). BPP staje się
Authorization Serverem; token `Bearer` niesie tożsamość użytkownika do API.
**Zakres tego PR: strona BPP** (spec §5). Końcówka MCP (`bpp-mcp`, §6) to osobny
pakiet/sesja — tu jej nie ma.

- Spec: `docs/superpowers/specs/2026-07-11-mcp-oauth-authorization-design.md`
- Plan: `docs/superpowers/plans/2026-07-11-mcp-oauth-authorization.md`

## Co dostarcza (apka `src/oauth_mcp/`)

- **Authorization Server** pod `/o/`: `authorize` / `token` / `revoke_token`
  (jawny podzbiór DOT — **device-flow RFC 8628 świadomie wycięty**), PKCE
  wymagane, scope `read`, rotacja refresh + `REFRESH_TOKEN_EXPIRE_SECONDS`.
- **`StrictOAuth2Authentication`** — nieważny/zrewokowany bearer → **401**
  (koniec cichej degradacji do anonima), odrzuca `is_active=False`.
- **Middleware read-only `/api/v1/`** — mutacje tokenem → 403, w warstwie
  nieobchodzonej przez per-view `permission_classes`.
- **`/api/v1/whoami/`** — preflight tożsamości dla `bpp-mcp` (401 na nieważny).
- **DCR `/o/register/`** (RFC 7591, własny) — allowlista `redirect_uri`,
  atomowy rate-limit, walidacja typów payloadu, `csrf_exempt`.
- **RFC 8414 metadata** `/.well-known/oauth-authorization-server` (issuer=host).
- **Ekran zgody** read-only (i18n, Foundation), tylko ukryte pola OAuth.
- **Revoke tokenów** przy zmianie hasła / dezaktywacji konta.
- Fix: `?next=` przeżywa logowanie Microsoft (`query_string=True`).

„Wszystkie metody logowania" (hasło/LDAP/Microsoft/ORCID/Keycloak) działają
gratis — `authorize` jest `@login_required` → normalna strona logowania BPP.

## Jakość / proces

- Spec po **2 turach** adversarialnego review; plan po **1 turze**;
  implementacja **subagent-driven** (12 tasków TDD, review spec+jakość po
  każdym); **finalny whole-branch review** (opus).
- 3 fix-wave'y z review: DCR type-confusion→500, osierocony checkbox zgody,
  **device-flow z `base_urlpatterns`** (całościowy review).
- **Dowody:** 108 passed + 1 skipped (oauth_mcp+api_v1), ruff clean, brak
  driftu migracji, pełny taniec OAuth (PKCE+refresh+revoke) przetestowany e2e.
  Zweryfikowano całościowo: brak write-vektora tokenem poza `/api/v1/`.

## Przy scaleniu do `dev` (checklist z planu)

- [ ] `make baseline-update` (migracje `oauth2_provider`) — RAZ, przy scaleniu.
- [ ] nginx `auth_request`: wyłączyć `/o/*`, `/.well-known/*`, `/api/v1/*`
      (bearer) spod bramki sesyjnej.
- [ ] weryfikacja `next` dla ORCID (manualna, per-tenant).

## Poza tym PR (świadomie)

- `bpp-mcp` (§6, osobny pakiet) · zapis/import · introspekcja (wariant whoami
  wystarcza) · dostęp bearer do `raport_slotow` · RFC 8707/audience (DOT nie
  wspiera — udokumentowane odstępstwo z mitygacjami).

🤖 Generated with [Claude Code](https://claude.com/claude-code)