### PR TITLE
fix(import-pracownikow): QA – przejście po analizie, kontrast przycisków, kafelek jednostek

### DIFF
--- a/src/import_pracownikow/models.py
+++ b/src/import_pracownikow/models.py
@@ -7,6 +7,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import DataError, models, transaction
 from django.db.models import Count, JSONField, Q
 from django.db.models.expressions import RawSQL
+from django.urls import reverse
 from django.utils import timezone
 from liveops.models import LiveOperation
 
@@ -142,6 +143,23 @@ class ImportPracownikow(LiveOperation):
             self.STAN_PRZEANALIZOWANY,
             self.STAN_STRUKTURA_ZINTEGROWANA,
         )
+
+    def get_success_url(self):
+        """URL, na który ``liveops.js`` przenosi po zakończonym runie
+        (FINISHED_OK). ``progress.py`` woła to w ``transaction.on_commit``, więc
+        ``self.stan`` jest już finalny (analyze/integrate ustawiają go na tej
+        samej instancji ``self``).
+
+        Auto-przejście TYLKO po analizie (dry-run) → hub „szczegóły importu"
+        (Krok 1). Po integracji zwracamy ``None`` — zostajemy na panelu wyniku
+        liveops z podsumowaniem (zintegrowano/utworzono/pominięto). Zastępuje
+        martwy inline-``<script>`` z ``import_pracownikow_result.html``, który
+        nigdy się nie wykonywał: liveops wstrzykuje wynik przez
+        ``DOMParser``+``replaceWith``, a tak wstawiony ``<script>`` przeglądarka
+        oznacza „already started"."""
+        if self.stan == self.STAN_PRZEANALIZOWANY:
+            return reverse("import_pracownikow:przeglad", kwargs={"pk": self.pk})
+        return None
 
     def run(self, p):
         if self.stan == self.STAN_ZMAPOWANY:

--- a/src/import_pracownikow/templates/import_pracownikow/import_pracownikow_result.html
+++ b/src/import_pracownikow/templates/import_pracownikow/import_pracownikow_result.html
@@ -9,21 +9,18 @@
 {# częściowy import nie udawał pełnego sukcesu (uwaga reviewera #3). #}
 <div class="panel callout {% if byl_dry_run %}secondary{% elif wymaga_uwagi %}warning{% else %}success{% endif %}">
     {% if byl_dry_run %}
-        {# Analiza (dry-run) gotowa. NIE pokazujemy komunikatu-podglądu — od razu #}
-        {# przechodzimy na hub szczegółów, który prowadzi przez Krok 1 (struktura) #}
-        {# → Krok 2 (osoby). Skrypt przenosi automatycznie; link to fallback dla #}
-        {# no-JS oraz gdyby OOB-swap nie wykonał skryptu. #}
+        {# Analiza (dry-run) gotowa. Auto-przejście na hub szczegółów (Krok 1 → #}
+        {# Krok 2) robi teraz liveops przez ImportPracownikow.get_success_url() #}
+        {# — inline <script> tu NIE działał (liveops wstrzykuje wynik przez #}
+        {# DOMParser+replaceWith, taki <script> jest „already started"). Panel #}
+        {# + link zostają jako fallback dla no-JS / gdyby push „finished" nie #}
+        {# dotarł. #}
         <h3><span class="fi-check"></span> Analiza zakończona</h3>
         <p>Przechodzę do szczegółów importu…</p>
         <a href="{% url 'import_pracownikow:przeglad' operation.pk %}"
-           class="button">
+           class="button primary">
             <span class="fi-list"></span> Zobacz szczegóły
         </a>
-        <script>
-            window.location.assign(
-                "{% url 'import_pracownikow:przeglad' operation.pk %}"
-            );
-        </script>
     {% elif zakres == "jednostki" or zakres == "struktura" %}
         {# Krok 1 gotowy: struktura zapisana, osoby czekają na Krok 2 (na hubie). #}
         <h3><span class="fi-check"></span> Struktura zapisana</h3>

--- a/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
+++ b/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
@@ -24,7 +24,7 @@
             {{ parent_object.jednostki_do_decyzji.count }} jednostek z pliku wymaga
             weryfikacji (do utworzenia lub auto-dopasowane).
             <a href="{% url "import_pracownikow:jednostki" pk=parent_object.pk %}"
-               class="button">Zweryfikuj jednostki</a>
+               class="button primary">Zweryfikuj jednostki</a>
         </div>
     {% endif %}
 

--- a/src/import_pracownikow/templates/import_pracownikow/przeglad.html
+++ b/src/import_pracownikow/templates/import_pracownikow/przeglad.html
@@ -32,7 +32,7 @@
                     {{ liczniki_jednostek.do_utworzenia }} do utworzenia ·
                     {{ liczniki_jednostek.do_sprawdzenia }} do sprawdzenia.
                     <a href="{% url "import_pracownikow:jednostki" parent_object.pk %}"
-                       class="button">Zweryfikuj jednostki</a>
+                       class="button primary">Zweryfikuj jednostki</a>
                 </p>
             {% endif %}
             {# Dwa warianty struktury OBOK siebie (jeden formularz, name=zakres). #}
@@ -86,8 +86,10 @@
     {% endif %}
 
     <div class="row">
-        {# Struktura (Krok 1): jednostki + tytuły. #}
-        {% if pokaz_jednostki %}
+        {# Struktura: kafelek „Jednostki" tylko POZA flow Krok 1/Krok 2 (audyt #}
+        {# zintegrowanego). W Kroku 1 przycisk „Zweryfikuj jednostki" jest już w #}
+        {# górnym callout, więc nie dublujemy go osobnym kafelkiem. #}
+        {% if pokaz_jednostki and not faza_struktury and not moze_importowac_osoby %}
             <div class="medium-6 columns">
                 <div class="callout">
                     <h3><span class="fi-marker"></span> Jednostki</h3>
@@ -96,7 +98,7 @@
                         {{ liczniki_jednostek.do_sprawdzenia }} do sprawdzenia
                     </p>
                     <a href="{% url "import_pracownikow:jednostki" parent_object.pk %}"
-                       class="button">Zweryfikuj jednostki</a>
+                       class="button primary">Zweryfikuj jednostki</a>
                 </div>
             </div>
         {% endif %}
@@ -110,7 +112,7 @@
                         {{ liczniki_tytulow.do_sprawdzenia }} do sprawdzenia
                     </p>
                     <a href="{% url "import_pracownikow:tytuly" parent_object.pk %}"
-                       class="button">Zweryfikuj tytuły</a>
+                       class="button primary">Zweryfikuj tytuły</a>
                 </div>
             </div>
         {% endif %}

--- a/src/import_pracownikow/tests/test_views_liveops.py
+++ b/src/import_pracownikow/tests/test_views_liveops.py
@@ -46,23 +46,48 @@ def test_strona_live_wstrzykuje_csrf_header_dla_htmx(admin_client, admin_user):
 
 @pytest.mark.django_db
 def test_panel_wyniku_analiza_przekierowuje_na_przeglad(admin_user):
-    """Po analizie (dry-run) panel wyniku NIE pokazuje już komunikatu-podglądu
-    ani przycisku zatwierdzenia — od razu kieruje na hub szczegółów (link +
-    skrypt ``window.location``). Renderowany BEZ requestu (jak worker przy
-    OOB-swapie)."""
+    """Po analizie (dry-run) panel wyniku NIE pokazuje komunikatu-podglądu ani
+    przycisku zatwierdzenia — kieruje na hub szczegółów. Auto-przejście robi
+    liveops przez ``get_success_url()`` (inline ``<script>`` nie działał przy
+    OOB-swapie — DOMParser+replaceWith nie odpala „already started" skryptu);
+    w panelu zostaje link-fallback. Render BEZ requestu (jak worker)."""
     from django.template.loader import render_to_string
 
-    imp = baker.make(ImportPracownikow, owner=admin_user)
+    imp = baker.make(
+        ImportPracownikow,
+        owner=admin_user,
+        stan=ImportPracownikow.STAN_PRZEANALIZOWANY,
+    )
+    przeglad = reverse("import_pracownikow:przeglad", kwargs={"pk": imp.pk})
+    # Auto-przejście: liveops czyta get_success_url() po zakończonym dry-runie.
+    assert imp.get_success_url() == przeglad
     html = render_to_string(
         "import_pracownikow/import_pracownikow_result.html",
         {"operation": imp, "byl_dry_run": True, "total": 5, "zmiany_potrzebne": 3},
     )
-    przeglad = reverse("import_pracownikow:przeglad", kwargs={"pk": imp.pk})
+    # Link-fallback (no-JS / gdyby push „finished" nie dotarł) nadal jest.
     assert przeglad in html
-    assert "window.location" in html
     # stary komunikat-podgląd i in-panel „Zapisz" zniknęły
     assert "To był" not in html
     assert "Zapisz zmiany do bazy" not in html
+
+
+@pytest.mark.django_db
+def test_get_success_url_tylko_po_analizie(admin_user):
+    """``get_success_url()`` kieruje na hub TYLKO po analizie (dry-run). Po
+    integracji (struktura/pełna) zwraca ``None`` — zostajemy na panelu wyniku
+    liveops z podsumowaniem, zamiast auto-przeskoczyć."""
+    imp = baker.make(ImportPracownikow, owner=admin_user)
+    przeglad = reverse("import_pracownikow:przeglad", kwargs={"pk": imp.pk})
+    imp.stan = ImportPracownikow.STAN_PRZEANALIZOWANY
+    assert imp.get_success_url() == przeglad
+    for stan in (
+        ImportPracownikow.STAN_STRUKTURA_ZINTEGROWANA,
+        ImportPracownikow.STAN_ZINTEGROWANY,
+        ImportPracownikow.STAN_UTWORZONY,
+    ):
+        imp.stan = stan
+        assert imp.get_success_url() is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixy z live-QA importu pracowników (na aktualnym `dev`, po PR #529).

## #1 — brak przejścia po analizie
Po dry-runie liveops miał przenosić na hub przez inline `<script>` window.location, który **się nie wykonywał** (liveops wstrzykuje wynik przez `DOMParser`+`replaceWith`, taki `<script>` jest „already started"). Zastąpione `ImportPracownikow.get_success_url()` — auto-przejście tylko po analizie; po integracji `None` → zostaje panel wyniku z podsumowaniem. Panel + link zostają jako fallback.

## #2 — kontrast przycisków
„Zweryfikuj jednostki/tytuły" → `.button.primary` (zielone tło + biały tekst). Bare `.button` dawał czarny tekst na zielonym (Foundation `color-pick-contrast` na `$primary` #28a745).

## #3 — zdublowany kafelek „Jednostki"
Kafelek pod spodem tylko poza flow Krok 1/Krok 2 (w Kroku 1 przycisk jest już w górnym callout).

Testy: `test_views_liveops` zaktualizowany (asercja mechanizmu przejścia) + nowy test gatingu stanów. 20 passed.

⏳ **#4** (domyślne podstawowe miejsce pracy + data + notki ostrzegawcze) dojdzie do tego PR-a osobnym commitem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)