### PR TITLE
feat(import-pracownikow): domyślne podstawowe miejsce pracy + data rozpoczęcia

### DIFF
--- a/src/import_pracownikow/models.py
+++ b/src/import_pracownikow/models.py
@@ -520,9 +520,16 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
     def _check_autor_jednostka_needs_update(self, dane):
         """Sprawdza czy powiązanie autor-jednostka wymaga aktualizacji."""
         aj = self.autor_jednostka
+        if aj is None:
+            # Wiersz z odroczoną jednostką (jednostka=None) nie ma AJ do
+            # zaktualizowania — nie ma też czego ustawić jako podstawowe miejsce
+            # pracy. Guard przed dostępem do atrybutów None (checki niżej łapią
+            # None dopiero przez short-circuit dane.get(...), a #4 primary nie).
+            return False
         checks = [
-            dane.get("data_zatrudnienia") is not None
-            and aj.rozpoczal_prace != dane["data_zatrudnienia"],
+            # #4: rozpoczęcie stemplujemy TYLKO gdy puste (data z pliku / importu)
+            # — integracja potrzebna, gdy plik niesie datę, a AJ jej nie ma.
+            dane.get("data_zatrudnienia") is not None and aj.rozpoczal_prace is None,
             dane.get("data_końca_zatrudnienia") is not None
             and aj.zakonczyl_prace != dane["data_końca_zatrudnienia"],
             self.funkcja_autora is not None and aj.funkcja != self.funkcja_autora,
@@ -531,6 +538,11 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
             self.wymiar_etatu is not None and aj.wymiar_etatu != self.wymiar_etatu,
             self.podstawowe_miejsce_pracy is not None
             and self.podstawowe_miejsce_pracy != aj.podstawowe_miejsce_pracy,
+            # #4: domyślnie import ustawia jednostkę autora jako podstawowe miejsce
+            # pracy — integracja potrzebna, gdy AJ jeszcze nim nie jest, a plik nie
+            # mówi jawnie „Podstawowe miejsce pracy"=NIE.
+            self.podstawowe_miejsce_pracy is not False
+            and not aj.podstawowe_miejsce_pracy,
         ]
         return any(checks)
 
@@ -575,13 +587,15 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
         aj = self.autor_jednostka
         dane = self.dane_bardziej_znormalizowane
 
-        if (
-            dane.get("data_zatrudnienia") is not None
-            and aj.rozpoczal_prace != dane["data_zatrudnienia"]
-        ):
-            aj.rozpoczal_prace = dane["data_zatrudnienia"]
+        # #4: rozpoczęcie pracy stemplujemy TYLKO gdy puste (nie nadpisujemy
+        # istniejącej daty). Priorytet: data zatrudnienia z pliku; w razie braku
+        # — data importu (dziś). Dawniej data z pliku nadpisywała istniejącą
+        # wartość — teraz jej nie ruszamy (decyzja usera, #4).
+        if aj.rozpoczal_prace is None:
+            nowa_data = dane.get("data_zatrudnienia") or timezone.localdate()
+            aj.rozpoczal_prace = nowa_data
             self.log_zmian["autor_jednostka"].append(
-                f"data zatrudnienia na {dane['data_zatrudnienia']}"
+                f"data rozpoczęcia pracy na {nowa_data}"
             )
 
         if (
@@ -614,20 +628,20 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
                 f"wymiar_etatu na {self.wymiar_etatu}"
             )
 
-        if (
-            self.podstawowe_miejsce_pracy is not None
-            and self.podstawowe_miejsce_pracy != aj.podstawowe_miejsce_pracy
-        ):
-            if not self.podstawowe_miejsce_pracy:
+        # #4: domyślnie KAŻDY zaimportowany wiersz ustawia swoją jednostkę jako
+        # podstawowe miejsce pracy autora — ustaw_podstawowe_miejsce_pracy()
+        # (+ trigger) zdejmuje flagę z pozostałych AJ tego autora. Kolumna
+        # „Podstawowe miejsce pracy"=NIE w pliku (self.podstawowe_miejsce_pracy is
+        # False) wyłącza to dla danego wiersza; brak kolumny (None) = domyślnie TAK.
+        if self.podstawowe_miejsce_pracy is False:
+            if aj.podstawowe_miejsce_pracy is not False:
                 aj.podstawowe_miejsce_pracy = False
                 self.log_zmian["autor_jednostka"].append(
                     "podstawowe_miejsce_pracy -> nie"
                 )
-            else:
-                aj.ustaw_podstawowe_miejsce_pracy()
-                self.log_zmian["autor_jednostka"].append(
-                    "podstawowe_miejsce_pracy -> tak"
-                )
+        elif not aj.podstawowe_miejsce_pracy:
+            aj.ustaw_podstawowe_miejsce_pracy()
+            self.log_zmian["autor_jednostka"].append("podstawowe_miejsce_pracy -> tak")
 
         # Autor_Jednostka.clean() waliduje rozpoczal < zakonczyl, ale Model.save()
         # NIE woła clean() (uwaga reviewera #4). Bronimy niezmiennika tutaj — na

--- a/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
+++ b/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
@@ -17,6 +17,11 @@
     </p>
     <h1>Import danych {{ parent_object.plik_xls.name }}</h1>
 
+    {# Ostrzeżenie #4 na stronie autorów+jednostek — tylko przed zapisem osób. #}
+    {% if parent_object.edytowalny_podglad %}
+        {% include "import_pracownikow/partials/_ostrzezenie_podstawowe_miejsce.html" %}
+    {% endif %}
+
     {% if parent_object.stan == "przeanalizowany" and parent_object.jednostki_do_decyzji.exists %}
         <div class="callout primary">
             {# link do ekranu weryfikacji jednostek do utworzenia / auto-dopasowanych #}

--- a/src/import_pracownikow/templates/import_pracownikow/partials/_ostrzezenie_podstawowe_miejsce.html
+++ b/src/import_pracownikow/templates/import_pracownikow/partials/_ostrzezenie_podstawowe_miejsce.html
@@ -1,0 +1,14 @@
+{# Ostrzeżenie #4: import osób ustawia podstawowe miejsce pracy. Współdzielone #}
+{# przez hub (Krok 2, przed „Zapisz osoby do bazy") i listę autorów+jednostek. #}
+<div class="callout warning">
+    <p>
+        <span class="fi-alert"></span>
+        <strong>Uwaga — podstawowe miejsce pracy.</strong>
+        Import ustawi jednostkę wskazaną w pliku jako <strong>podstawowe
+        miejsce pracy</strong> każdego autora, a pozostałe jednostki tego autora
+        oznaczy jako <strong>NIE</strong>-podstawowe. Datę rozpoczęcia pracy
+        uzupełni (z pliku, a w razie braku — datą importu), o ile nie jest już
+        wypełniona. Kolumna „Podstawowe miejsce pracy” = <em>NIE</em> w pliku
+        wyłącza to ustawienie dla danego wiersza.
+    </p>
+</div>

--- a/src/import_pracownikow/templates/import_pracownikow/przeglad.html
+++ b/src/import_pracownikow/templates/import_pracownikow/przeglad.html
@@ -74,6 +74,9 @@
             <h2>Krok 2 — osoby</h2>
             <p>Sprawdź dopasowania autorów i powiązania w kafelkach poniżej, a gdy
                 wszystko się zgadza — zaimportuj osoby do bazy.</p>
+            {# Ostrzeżenie #4: „Zapisz osoby do bazy" zmienia bazę (m.in. podstawowe #}
+            {# miejsce pracy) — pokazujemy je tuż przed przyciskiem. #}
+            {% include "import_pracownikow/partials/_ostrzezenie_podstawowe_miejsce.html" %}
             <form method="post"
                   action="{% url "import_pracownikow:zatwierdz" parent_object.pk %}">
                 {% csrf_token %}

--- a/src/import_pracownikow/tests/test_models/test_mapowanie_model.py
+++ b/src/import_pracownikow/tests/test_models/test_mapowanie_model.py
@@ -98,7 +98,16 @@ def test_brak_stanowiska_nie_kasuje_funkcji_przy_integracji():
     funkcja = baker.make(Funkcja_Autora)
     jednostka = baker.make(Jednostka)
     autor = baker.make(Autor)
-    aj = baker.make(Autor_Jednostka, autor=autor, jednostka=jednostka, funkcja=funkcja)
+    # podstawowe_miejsce_pracy=True izoluje test od #4 (domyślnie import ustawia
+    # jednostkę autora jako podstawowe miejsce pracy); tu sprawdzamy tylko, że
+    # brak stanowiska w pliku nie kasuje istniejącej funkcji.
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        funkcja=funkcja,
+        podstawowe_miejsce_pracy=True,
+    )
     row = baker.make(
         ImportPracownikowRow,
         autor=autor,

--- a/src/import_pracownikow/tests/test_pipeline/test_integrate.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_integrate.py
@@ -177,7 +177,16 @@ def test_commit_pomija_wiersz_gdy_recheck_nieaktualny(autor_jednostka_fixture):
     # "asystent" jest w danych referencyjnych (baseline) — używamy istniejącego
     # wpisu zamiast tworzyć nowy (uniqueness na "nazwa").
     funkcja = Funkcja_Autora.objects.get(nazwa="asystent")
-    aj = baker.make(Autor_Jednostka, autor=autor, jednostka=jednostka, funkcja=funkcja)
+    # podstawowe_miejsce_pracy=True: bez tego #4 (domyślnie import ustawia
+    # jednostkę jako podstawowe miejsce pracy) trzymałby wiersz jako „wymaga
+    # integracji" i recheck NIE pominąłby go jako nieaktualnego.
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        funkcja=funkcja,
+        podstawowe_miejsce_pracy=True,
+    )
     imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
     row = ImportPracownikowRow.objects.create(
         parent=imp,

--- a/src/import_pracownikow/tests/test_pipeline/test_integrate_podstawowe_miejsce.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_integrate_podstawowe_miejsce.py
@@ -1,0 +1,150 @@
+"""Faza integracji: domyślne podstawowe miejsce pracy + stemplowanie daty (#4).
+
+Decyzja usera: import ma ustawiać jednostkę autora (z wiersza) jako PODSTAWOWE
+miejsce pracy, a pozostałe jednostki tego autora oznaczać jako NIE-podstawowe.
+Datę rozpoczęcia pracy stemplujemy TYLKO gdy pusta — priorytet: data z pliku,
+w razie braku data importu (dziś). Kolumna „Podstawowe miejsce pracy"=NIE w
+pliku wyłącza to dla danego wiersza.
+"""
+
+from datetime import date
+
+import pytest
+from django.utils import timezone
+from liveops.testing import MockProgress
+from model_bakery import baker
+
+from bpp.models import Autor_Jednostka, Jednostka
+from import_pracownikow.models import ImportPracownikow, ImportPracownikowRow
+from import_pracownikow.pipeline.integrate import integruj
+
+
+def _row(imp, autor, jednostka, aj, **kwargs):
+    dane = kwargs.pop("dane_znormalizowane", {})
+    return ImportPracownikowRow.objects.create(
+        parent=imp,
+        autor=autor,
+        jednostka=jednostka,
+        autor_jednostka=aj,
+        dane_znormalizowane=dane,
+        diff_do_utworzenia={},
+        zmiany_potrzebne=True,
+        **kwargs,
+    )
+
+
+@pytest.mark.django_db
+def test_import_ustawia_jednostke_jako_podstawowe_miejsce_pracy(
+    autor_jednostka_fixture,
+):
+    """Domyślnie (bez kolumny w pliku) import ustawia jednostkę wiersza jako
+    podstawowe miejsce pracy autora, a inną jednostkę tego autora → NIE."""
+    autor, jednostka = autor_jednostka_fixture
+    inna = baker.make(Jednostka)
+    aj_inna = baker.make(
+        Autor_Jednostka, autor=autor, jednostka=inna, podstawowe_miejsce_pracy=True
+    )
+    aj = baker.make(
+        Autor_Jednostka, autor=autor, jednostka=jednostka, podstawowe_miejsce_pracy=None
+    )
+    imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
+    _row(imp, autor, jednostka, aj, podstawowe_miejsce_pracy=None)
+
+    integruj(imp, MockProgress(imp))
+
+    aj.refresh_from_db()
+    aj_inna.refresh_from_db()
+    assert aj.podstawowe_miejsce_pracy is True
+    assert aj_inna.podstawowe_miejsce_pracy is False
+
+
+@pytest.mark.django_db
+def test_plik_nie_wylacza_podstawowego_miejsca(autor_jednostka_fixture):
+    """Kolumna „Podstawowe miejsce pracy"=NIE (row.podstawowe_miejsce_pracy is
+    False) zdejmuje flagę zamiast ustawiać."""
+    autor, jednostka = autor_jednostka_fixture
+    aj = baker.make(
+        Autor_Jednostka, autor=autor, jednostka=jednostka, podstawowe_miejsce_pracy=True
+    )
+    imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
+    _row(imp, autor, jednostka, aj, podstawowe_miejsce_pracy=False)
+
+    integruj(imp, MockProgress(imp))
+
+    aj.refresh_from_db()
+    assert aj.podstawowe_miejsce_pracy is False
+
+
+@pytest.mark.django_db
+def test_stempluje_date_importu_gdy_brak_w_pliku(autor_jednostka_fixture):
+    """Brak daty w pliku + puste rozpoczal_prace → data importu (dziś)."""
+    autor, jednostka = autor_jednostka_fixture
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=None,
+        podstawowe_miejsce_pracy=None,
+    )
+    imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
+    _row(imp, autor, jednostka, aj, dane_znormalizowane={})
+
+    integruj(imp, MockProgress(imp))
+
+    aj.refresh_from_db()
+    assert aj.rozpoczal_prace == timezone.localdate()
+
+
+@pytest.mark.django_db
+def test_stempluje_date_z_pliku_gdy_pusta(autor_jednostka_fixture):
+    """Data zatrudnienia z pliku trafia do pustego rozpoczal_prace."""
+    autor, jednostka = autor_jednostka_fixture
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=None,
+        podstawowe_miejsce_pracy=None,
+    )
+    imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
+    _row(
+        imp,
+        autor,
+        jednostka,
+        aj,
+        dane_znormalizowane={"data_zatrudnienia": "2025-03-01"},
+    )
+
+    integruj(imp, MockProgress(imp))
+
+    aj.refresh_from_db()
+    assert aj.rozpoczal_prace == date(2025, 3, 1)
+
+
+@pytest.mark.django_db
+def test_nie_nadpisuje_istniejacej_daty_rozpoczecia(autor_jednostka_fixture):
+    """Istniejące rozpoczal_prace NIE jest nadpisywane — nawet gdy plik niesie
+    inną datę (wiersz integrowany z powodu ustawiania podstawowego miejsca)."""
+    autor, jednostka = autor_jednostka_fixture
+    istnieje = date(2000, 1, 1)
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=istnieje,
+        podstawowe_miejsce_pracy=None,
+    )
+    imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
+    _row(
+        imp,
+        autor,
+        jednostka,
+        aj,
+        dane_znormalizowane={"data_zatrudnienia": "2025-03-01"},
+    )
+
+    integruj(imp, MockProgress(imp))
+
+    aj.refresh_from_db()
+    assert aj.rozpoczal_prace == istnieje  # nie ruszone
+    assert aj.podstawowe_miejsce_pracy is True  # ale primary jednak ustawione


### PR DESCRIPTION
## Co i dlaczego

Czwarta poprawka z QA importera pracowników (#1–3 poszły w #530). Import osób
ma teraz **ustawiać jednostkę wskazaną w pliku jako podstawowe miejsce pracy**
autora, a pozostałe jednostki tego autora oznaczać jako **NIE**-podstawowe.

### Zachowanie

- **Domyślnie** (brak kolumny „Podstawowe miejsce pracy" w pliku) integracja
  wywołuje `Autor_Jednostka.ustaw_podstawowe_miejsce_pracy()` — flaga schodzi
  z pozostałych AJ (metoda + trigger DB).
- **Kolumna = NIE** (`row.podstawowe_miejsce_pracy is False`) wyłącza to dla
  danego wiersza (zdejmuje flagę zamiast ustawiać).
- **Data rozpoczęcia pracy** stemplowana **tylko gdy pusta** — priorytet: data
  z pliku (`data_zatrudnienia`), w razie braku data importu (dziś).
  Istniejącej daty **nie nadpisujemy**.
- `check_if_integration_needed` rozszerzony o dwa warunki (domyślny primary +
  data-gdy-pusta), z guardem na `autor_jednostka is None`.

### Ostrzeżenie w UI (decyzja usera — notatka w kilku miejscach)

Nowy partial `_ostrzezenie_podstawowe_miejsce.html` (callout warning) pokazany:
- w hubie **Krok 2**, tuż przed przyciskiem „Zapisz osoby do bazy",
- na stronie **autorów+jednostek** (edytowalny podgląd, przed zapisem).

## Testy

- Nowy `test_integrate_podstawowe_miejsce.py` — 5 testów (domyślny primary,
  plik-wyłącza, data-importu-gdy-brak, data-z-pliku, nie-nadpisuj-daty).
- Dwa istniejące testy izolowane od nowej domyślności (AJ `podstawowe=True`
  w setupie), w tym fix realnego buga: guard `aj is None` w
  `_check_autor_jednostka_needs_update`.
- Cała apka `import_pracownikow`: **342 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)