### PR TITLE
fix(ewaluacja): przywróć flush_via_queue w reset_discipline_pins_task (#3 follow-up)

### DIFF
--- a/src/ewaluacja_optymalizacja/tasks/reset_pins.py
+++ b/src/ewaluacja_optymalizacja/tasks/reset_pins.py
@@ -183,6 +183,15 @@ def reset_discipline_pins_task(
             f"Reset pins in {model.__name__} for discipline '{dyscyplina.nazwa}'"
         )
 
+    # Wyzwól denormalizację jak stary widok — .delay() (async, bez blokady),
+    # żeby DirtyInstance opadło, zanim ruszy optymalizacja. _wait_for_denorm
+    # sam flusha NIE triggeruje (świadomie, przez ryzyko deadlocka przy
+    # synchronicznym flushu), więc trigger musi być tutaj.
+    from denorm.tasks import flush_via_queue
+
+    flush_via_queue.delay()
+    logger.info("Triggered denorm flush via queue (reset dyscypliny)")
+
     _wait_for_denorm(
         self,
         progress_start=40,

--- a/src/ewaluacja_optymalizacja/tests/test_discipline_pins.py
+++ b/src/ewaluacja_optymalizacja/tests/test_discipline_pins.py
@@ -261,10 +261,16 @@ def test_reset_discipline_pins_task_creates_snapshot_and_resets(uczelnia, admin_
 
     snapshot_count_before = SnapshotOdpiec.objects.count()
 
-    with patch("ewaluacja_optymalizacja.tasks.reset_pins._wait_for_denorm"):
+    with (
+        patch("ewaluacja_optymalizacja.tasks.reset_pins._wait_for_denorm"),
+        patch("denorm.tasks.flush_via_queue") as mock_flush,
+    ):
         result = reset_discipline_pins_task.apply(
             args=(uczelnia.pk, dyscyplina.pk, admin_user.pk)
         ).result
+
+    # Denormalizacja jest wyzwalana jawnie (jak w starym widoku).
+    mock_flush.delay.assert_called_once()
 
     assert SnapshotOdpiec.objects.count() == snapshot_count_before + 1
     snapshot = SnapshotOdpiec.objects.latest("created_on")


### PR DESCRIPTION
Follow-up do PR #536: commit `83b113ecf` (jawny `flush_via_queue.delay()` w `reset_discipline_pins_task`) nie wszedł do merge'a #536 — zmergowano na wcześniejszym commicie (`9e106c730`), a fix był wypchnięty później i pozostał poza merge.

Bez tego zadanie resetu dyscypliny nie wyzwala denormalizacji (`_wait_for_denorm` sam flusha nie triggeruje), więc `DirtyInstance` może nie opaść przed optymalizacją. Ten PR domyka tę lukę — trigger async (`.delay`), test sprawdza wywołanie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)