### PR TITLE
fix(import_pracownikow): izolacja flake'a Playwright + spec dedup→rekord główny

### DIFF
--- a/docs/superpowers/specs/2026-07-12-import-pracownikow-dedup-i-widoki-design.md
+++ b/docs/superpowers/specs/2026-07-12-import-pracownikow-dedup-i-widoki-design.md
@@ -1,0 +1,230 @@
+# Import pracowników — dopasowanie do rekordu głównego (dedup) + wzbogacenie widoków
+
+- **Data:** 2026-07-12
+- **Branch:** `feat/import-pracownikow-dedup-ui`
+- **Autor specyfikacji:** brainstorming z użytkownikiem (mpasternak)
+
+## Cel
+
+Batch usprawnień w przepływie `import_pracownikow`: (1) jedna zmiana logiki
+dopasowania autora (dopasowanie zdublowanych autorów do **rekordu głównego**
+przez logikę deduplikatora) oraz (2) dziewięć zmian UI na trzech podstronach
+(`/rezultaty/`, `/odpiecia/`, `/audyt/`) — wzbogacenie o ORCID, linki, wskaźnik
+PBN-instytucjonalny, spójny wygląd tabel, aktywne wyszukiwanie i akcję zbiorczą.
+
+## Zakres (10 pozycji)
+
+| # | Podstrona / obszar | Pozycja |
+|---|---|---|
+| 1 | `/odpiecia/` | Przycisk zbiorczy „zaznacz do odpięcia" dla wierszy z bieżącego filtra tabeli (+ odznacz) |
+| 2 | `/odpiecia/` | Kolumny ORCID + link do autora BPP (BEZ kolumny „linia XLSX") |
+| 3 | `/odpiecia/` | Wspólny wygląd tabeli z `/rezultaty/` |
+| 4 | `/rezultaty/` | Kolumna ORCID |
+| 5 | `/rezultaty/` | Wskaźnik: autor pochodzi z API instytucjonalnego PBN (`OsobaZInstytucji`) |
+| 6 | `/rezultaty/` | Przekolorowanie plakietek statusów (patrz „Schemat plakietek") |
+| 7 | logika | Zdublowany autor → dopasowanie do rekordu głównego (deduplikator, **opcja B**), tylko `import_pracownikow` |
+| 8 | `/audyt/` | Pełne nazwy jednostek na plakietkach |
+| 9 | `/audyt/` | Dane autora: ORCID, link do strony autora BPP, link do adminu |
+| 10 | `/audyt/` | Aktywne wyszukiwanie + stronicowanie (DataTables) |
+
+## Punkty integracji (stan istniejący)
+
+- **Dopasowanie autora:** `import_pracownikow/pipeline/analyze.py::_dopasuj_autora_i_status`
+  — ścieżka ID (`matchuj_autora`), a poza ID: `znajdz_kandydatow_autora`
+  (`import_common/core/autor.py`) → `oblicz_status_pewnosci` →
+  `wybierz_autora_z_kandydatow` (`import_pracownikow/pewnosc.py`).
+- **Status/plakietki:** `import_pracownikow/pewnosc.py` (`STATUS_*`,
+  `STATUS_DISPLAY`, `oblicz_status_pewnosci`, `wybierz_autora_z_kandydatow`),
+  render przez `ImportPracownikowRow.confidence_badge` (`models.py:564`).
+- **Deduplikator:** `deduplikator_autorow/utils/analysis.py`
+  (`analiza_duplikatow(osoba_z_instytucji)`, `_ustal_glownego_autora`),
+  `finders.py::_osoba_z_instytucji_autora(autor)` (`autor.pbn_uid.osobazinstytucji`),
+  próg wyświetlania `MIN_PEWNOSC_DO_WYSWIETLENIA = 50` (pewność 0–100).
+- **„Autorzy zaimportowani z jednostki":** `pbn_api.models.OsobaZInstytucji`
+  (`.personId` → `Scientist` → `.rekord_w_bpp` = główny autor BPP).
+- **Widoki:** `OdpieciaView`, `ImportPracownikowResultsView`, `LogZmianView`
+  (`views.py`); szablony `odpiecia.html`, `importpracownikowrow_list.html`,
+  `audyt.html` + partiale `_wiersz_preview_kom.html`, `_odpiecie_row*.html`.
+- **URL autora:** `bpp:browse_autor` (pk), admin `admin:bpp_autor_change`.
+- **SCSS:** `import_pracownikow` nie ma własnego SCSS; wspólny
+  `src/bpp/static/scss/common.scss` jest `@import`-owany przez każdy theme
+  `app-*.scss` → tam trafia nowy kolor plakietki.
+
+---
+
+## Pozycja 7 — dopasowanie do rekordu głównego (opcja B)
+
+### Zasada
+
+Gdy dopasowanie po nazwisku daje **≥2 kandydatów na najwyższym tierze pewności**
+(dziś zawsze `STATUS_WIELU` → wybór ręczny), spróbuj rozstrzygnąć automatycznie
+przez logikę deduplikatora, ale **tylko gdy sygnał jest jednoznaczny**. Ryzyko:
+`STATUS_WIELU` powstaje też dla dwóch **różnych** osób o tym samym nazwisku —
+auto-wybór w tym przypadku byłby korupcją danych. Dlatego bramka jest
+konserwatywna.
+
+### Algorytm `_rozstrzygnij_do_rekordu_glownego(kandydaci)`
+
+Wywoływany w `_dopasuj_autora_i_status` **tylko** gdy wyliczony `status ==
+STATUS_WIELU`.
+
+1. **Top-tier:** `top = [k for k in kandydaci if k.pewnosc == kandydaci[0].pewnosc]`.
+2. **PBN-backed:** dla każdego `k` w `top` ustal `OsobaZInstytucji`
+   (`k.autor.pbn_uid.osobazinstytucji`, wzorzec `_osoba_z_instytucji_autora`,
+   z obsługą `RelatedObjectDoesNotExist` i braku `pbn_uid`).
+3. Jeśli **dokładnie jeden** kandydat z `top` jest PBN-backed → `osoba` = jego
+   `OsobaZInstytucji`, `glowny = _ustal_glownego_autora(osoba)`.
+   W przeciwnym razie (0 lub ≥2 PBN-backed, albo `glowny is None`) → **zwróć
+   `(None, STATUS_WIELU)`** (wybór ręczny).
+4. `analiza = analiza_duplikatow(osoba)`; zbuduj mapę
+   `{a["autor"].pk: a["pewnosc"] for a in analiza["analiza"]}` (pewność 0–100).
+5. **Bramka potwierdzenia:** każdy kandydat z `top` **inny niż `glowny`** musi
+   być w mapie z `pewnosc >= PROG_AUTO_DEDUP`. Jeśli tak (wszystkie pozostałe to
+   potwierdzone duplikaty rekordu głównego) → **zwróć `(glowny, STATUS_DEDUP)`**.
+   Jeśli którykolwiek pozostały kandydat nie jest potwierdzonym duplikatem →
+   **zwróć `(None, STATUS_WIELU)`** (bezpieczeństwo > automatyzacja).
+6. `glowny` może NIE być wśród `top` (name-match go nie znalazł, np. inne
+   nazwisko) — to poprawne: sedno pozycji to dopasowanie do rekordu głównego,
+   nie do żadnego z name-kandydatów. Bramka z pkt. 5 dalej działa (wszystkie
+   `top` to wtedy duplikaty).
+
+### Parametr do zatwierdzenia
+
+- `PROG_AUTO_DEDUP` — próg pewności deduplikatora do **automatycznego** scalenia.
+  Musi być **wyższy** niż próg wyświetlania (`50`). Proponowany **domyślny: 80**
+  (0–100). Wartość wydzielona jako nazwana stała w `import_pracownikow`
+  (nie w deduplikatorze), do rewizji w planie/PR.
+
+### Wydajność
+
+- `analiza_duplikatow` (+ `szukaj_kopii` + zgadywanie płci + 8 ocen) uruchamiane
+  wyłącznie dla wierszy `STATUS_WIELU` z **dokładnie jednym** PBN-backed
+  kandydatem — mniejszość wierszy.
+- **Memoizacja per `osoba.pk`** w obrębie jednego przebiegu analizy (ta sama
+  osoba instytucjonalna bywa kandydatem dla wielu wierszy o tym samym nazwisku).
+
+### Transparentność / audyt
+
+- Nowy status `STATUS_DEDUP = "dedup"` (autom. dopasowanie do rekordu głównego).
+- Przy rozstrzygnięciu zapis do `log_zmian`/diff wiersza: „auto-dopasowano do
+  rekordu głównego #<pk> (deduplikator, pewność N%)".
+- `STATUS_DEDUP` traktowany jak status **rozstrzygnięty**:
+  - dołączyć do `confidence__in=[STATUS_TWARDY, STATUS_RECZNY]` w
+    `ImportPracownikowResultsView.get_queryset` (`_prio` → na dół listy),
+  - dodać do `CONFIDENCE_CHOICES` + `STATUS_DISPLAY`,
+  - migracja stanu Django dla `choices` pola `confidence` (no-op DB;
+    **nowa** migracja `002x`, nie modyfikacja istniejących).
+
+### Zależność między pozycjami
+
+Pozycja 5 (wskaźnik PBN-instytucjonalny) i pozycja 7 dzielą to samo zapytanie
+`autor.pbn_uid.osobazinstytucji` — wspólny helper
+`autor_ma_osobe_z_instytucji(autor)` w `import_common` lub `import_pracownikow`,
+z prefetch/adnotacją w widokach, by uniknąć N+1.
+
+---
+
+## Schemat plakietek statusów (pozycja 6 + 7)
+
+Zmiana w `import_pracownikow/pewnosc.py::STATUS_DISPLAY`. Kolory Foundation
+dostępne (skompilowane): `success`, `warning`, `primary`, `secondary`, `alert`.
+`info`/`debug` **nie istnieją** w zbudowanym CSS.
+
+| status | kolor (było → jest) | ikona | etykieta |
+|---|---|---|---|
+| twardy | success (bez zmian) | fi-check | twardy match |
+| **dedup** (nowy) | **primary** (zwolniony przez wielu→alert) | fi-torsos | rekord główny |
+| zgadywanie | warning (bez zmian) | fi-flag | zgadywanie |
+| **wielu** | primary → **alert** | fi-page-multiple | wielu kandydatów |
+| brak | secondary (bez zmian) | fi-minus-circle | brak dopasowania |
+| **reczny** | success → **kolor custom** | fi-pencil | wybór użytkownika |
+
+- **reczny** dostaje **własny kolor** (custom): nowa reguła
+  `.label.import-reczny { background-color: <fiolet, np. #7b3fa0>; color: #fefefe; }`
+  w `src/bpp/static/scss/common.scss` (po komponencie label Foundation), potem
+  `grunt build`. `confidence_badge` zwraca wtedy klasę `import-reczny` zamiast
+  klasy Foundation dla statusu ręcznego (render: `class="label {{ klasa }}"`).
+- Wszystkie sześć stanów pozostaje rozróżnialnych parą (kolor, ikona).
+
+---
+
+## Zmiany UI
+
+### `/rezultaty/` (poz. 4, 5)
+
+- Kolumna „Autor" (`_wiersz_preview_kom.html`): pod linkiem do autora dołożyć
+  ORCID (link `https://orcid.org/<orcid>` gdy niepusty) oraz — gdy autor ma
+  `OsobaZInstytucji` — małą plakietkę „PBN" (np. `label secondary` + tooltip
+  „z API instytucjonalnego PBN").
+- `ImportPracownikowResultsView`: prefetch/adnotacja „ma OsobaZInstytucji" po
+  `autor.pbn_uid` (bez N+1). `orcid`/`tytul` już na `Autor`.
+
+### `/odpiecia/` (poz. 1, 2, 3)
+
+- **Kolumny** (`_odpiecie_row_kom.html`): „Autor" jako **link** do
+  `bpp:browse_autor` + ORCID (jak w rezultaty); nowa kolumna „ORCID" lub ORCID
+  inline pod nazwiskiem — spójnie z rezultaty. **Bez** kolumny „linia XLSX".
+- `OdpieciaView.get_queryset` już `select_related` autora/tytuł/jednostkę;
+  dołożyć `autor_jednostka__autor__pbn_uid` jeśli pokazujemy wskaźnik PBN
+  (opcjonalnie, spójnie z rezultaty).
+- **Przycisk zbiorczy (poz. 1):** przycisk „Zaznacz do odpięcia zaznaczone w
+  tabeli" + „Odznacz wszystkie z bieżącego wyboru". Działanie **po stronie
+  klienta**: JS czyta wiersze przechodzące bieżący filtr DataTables
+  (`dt.rows({search:'applied'})`), zbiera ich `odp.pk`, wysyła **POST** do
+  nowego endpointu zbiorczego.
+  - Nowy widok `ZaznaczOdpieciaView` (wzorzec `ZaznaczWszystkiePrzepieciaView`):
+    owner/superuser-scope + bramka `edytowalny_podglad`; przyjmuje listę
+    `odp_pk[]` + flagę `zaznacz` (true/false); `update(zaznaczone=...)`
+    filtrowane po `parent` i `pk__in`; zwraca JSON lub redirect z komunikatem.
+  - Nowy URL `<uuid:pk>/odpiecia/zaznacz/`.
+  - Puste wyszukiwanie → filtr obejmuje wszystkie wiersze (naturalne „zaznacz
+    wszystkie").
+- **Wspólny wygląd (poz. 3):** ten sam init DataTables i te same kolumny/
+  klasy co `/rezultaty/`.
+
+### `/audyt/` (poz. 8, 9, 10)
+
+- **Poz. 8:** plakietka jednostki → `jednostka.nazwa` (pełna) zamiast
+  `jednostka.skrot`; `skrot` do `title=` (tooltip).
+- **Poz. 9:** w sekcji „Zmiany per wiersz" dane autora: ORCID (link),
+  link do `bpp:browse_autor`, link do `admin:bpp_autor_change`.
+- **Poz. 10:** sekcję „Zmiany per wiersz" przebudować na **tabelę DataTables**
+  (kolumny: Autor / Jednostka / Zmiany) z aktywnym wyszukiwaniem i
+  **stronicowaniem** (tu paging **włączony** — widok read-only po integracji,
+  brak per-wierszowego HTMX do zachowania). Usunąć serwerowe `is_paginated`
+  (Django Paginator) z `LogZmianView` / szablonu — DataTables przejmuje paging
+  i search po stronie klienta. Kolumna „Zmiany" = `<ul>` z `log_zmian_lista`.
+  - `LogZmianView`: ładować wszystkie wiersze ze zmianami (bez serwerowej
+    paginacji); prefetch autora + `pbn_uid` + jednostki (bez N+1).
+
+---
+
+## Testy
+
+- **Poz. 7 (priorytet):**
+  - Dwa różne rekordy tego samego autora (główny z `OsobaZInstytucji`+ORCID+tytuł,
+    duplikat bez) o identycznej pewności nazwiskowej → `STATUS_DEDUP`, autor =
+    główny.
+  - Dwie **różne** osoby o tym samym nazwisku (obie bez lub obie z PBN, brak
+    potwierdzenia duplikatu) → pozostaje `STATUS_WIELU` (brak auto-wyboru).
+  - Duplikat poniżej `PROG_AUTO_DEDUP` → `STATUS_WIELU`.
+  - Główny spoza top-tier (name-match nie znalazł głównego) → auto-wybór
+    głównego, gdy wszystkie top-tier to potwierdzone duplikaty.
+  - Memoizacja: `analiza_duplikatow` liczone raz per `osoba` w przebiegu.
+- **UI:** render kolumn ORCID/linków (rezultaty, odpiecia, audyt); klasa
+  plakietki per status (rozszerzyć `test_confidence_badge_*`); endpoint zbiorczy
+  odpięć (owner-scope, bramka podglądu, filtrowanie `pk__in`, toggle
+  zaznacz/odznacz); pełna nazwa jednostki w audycie.
+- Konwencje: pytest (bez klas), `@pytest.mark.django_db`, `model_bakery.baker`.
+
+## Poza zakresem / ryzyka
+
+- Brak zmian w `import_common` widocznych dla innych importerów (poz. 7 lokalna).
+- Brak pełnego UI scalania duplikatów — używamy tylko *odczytu* analizy
+  deduplikatora do wyboru rekordu głównego (bez `scal_autora`).
+- `PROG_AUTO_DEDUP` = decyzja jakościowa; domyślnie konserwatywnie (80),
+  do rewizji.
+- DataTables w audycie ładuje wszystkie wiersze do DOM — dla bardzo dużych
+  importów rozważyć limit; obecnie spójne z pozostałymi tabelami przepływu.
+- Newsfragment (`src/bpp/newsfragments/`, `.feature.rst`) po implementacji.
+- Baseline: nowa migracja `choices` — odświeżyć baseline dopiero przy scalaniu.

--- a/docs/superpowers/specs/2026-07-12-import-pracownikow-dedup-i-widoki-design.md
+++ b/docs/superpowers/specs/2026-07-12-import-pracownikow-dedup-i-widoki-design.md
@@ -22,7 +22,7 @@ PBN-instytucjonalny, spójny wygląd tabel, aktywne wyszukiwanie i akcję zbiorc
 | 4 | `/rezultaty/` | Kolumna ORCID |
 | 5 | `/rezultaty/` | Wskaźnik: autor pochodzi z API instytucjonalnego PBN (`OsobaZInstytucji`) |
 | 6 | `/rezultaty/` | Przekolorowanie plakietek statusów (patrz „Schemat plakietek") |
-| 7 | logika | Zdublowany autor → dopasowanie do rekordu głównego (deduplikator, **opcja B**), tylko `import_pracownikow` |
+| 7 | logika | Zdublowany autor → operacje zatrudnienia (przypisanie do jednostki, zmiana miejsca pracy, przepięcia) kierowane na rekord **oryginalny/główny** (ORCID + tytuł + PBN instytucjonalny), **BEZ scalania rekordów**, tylko `import_pracownikow` |
 | 8 | `/audyt/` | Pełne nazwy jednostek na plakietkach |
 | 9 | `/audyt/` | Dane autora: ORCID, link do strony autora BPP, link do adminu |
 | 10 | `/audyt/` | Aktywne wyszukiwanie + stronicowanie (DataTables) |
@@ -52,62 +52,86 @@ PBN-instytucjonalny, spójny wygląd tabel, aktywne wyszukiwanie i akcję zbiorc
 
 ---
 
-## Pozycja 7 — dopasowanie do rekordu głównego (opcja B)
+## Pozycja 7 — operacje zatrudnienia kierowane na rekord ORYGINALNY
 
-### Zasada
+### Zasada (DOPRECYZOWANE przez użytkownika)
 
-Gdy dopasowanie po nazwisku daje **≥2 kandydatów na najwyższym tierze pewności**
-(dziś zawsze `STATUS_WIELU` → wybór ręczny), spróbuj rozstrzygnąć automatycznie
-przez logikę deduplikatora, ale **tylko gdy sygnał jest jednoznaczny**. Ryzyko:
-`STATUS_WIELU` powstaje też dla dwóch **różnych** osób o tym samym nazwisku —
-auto-wybór w tym przypadku byłby korupcją danych. Dlatego bramka jest
-konserwatywna.
+**NIE scalamy rekordów autorów podczas importu.** Zmiana dotyczy wyłącznie tego,
+do **którego rekordu autora** import podpina operacje zatrudnienia
+(`Autor_Jednostka`: przypisanie do jednostki, zmiana miejsca pracy, przepięcia
+dorobku). Gdy dopasowanie po nazwisku trafia na **rekord-duplikat**, import ma
+podpiąć zatrudnienie do **rekordu oryginalnego/głównego** — tego z ORCID,
+tytułem i odpowiednikiem w API instytucjonalnym PBN (`OsobaZInstytucji`). Żaden
+rekord nie jest usuwany ani łączony (`scal_autora` **nie** jest wołane).
 
-### Algorytm `_rozstrzygnij_do_rekordu_glownego(kandydaci)`
+### Mechanizm — persystowany `DuplicateCandidate` (nie live analiza)
 
-Wywoływany w `_dopasuj_autora_i_status` **tylko** gdy wyliczony `status ==
-STATUS_WIELU`.
+Deduplikator zapisuje wyniki skanu w `deduplikator_autorow.models.DuplicateCandidate`:
+`duplicate_autor` (duplikat) → `main_autor` (oryginał, z `OsobaZInstytucji`/
+`pbn_uid`), z `confidence_percent` (0.0–1.0), `confidence_score` (surowy) i
+`status` (`pending`/`merged`/`not_duplicate`). To gotowa, przeglądalna przez
+operatora, **odwrotna** mapa duplikat→oryginał — dużo tańsza niż uruchamianie
+`analiza_duplikatow` per wiersz. („Opcja B" = logika deduplikatora; używamy jej
+**zmaterializowanej** formy zamiast liczyć na żywo.)
 
-1. **Top-tier:** `top = [k for k in kandydaci if k.pewnosc == kandydaci[0].pewnosc]`.
-2. **PBN-backed:** dla każdego `k` w `top` ustal `OsobaZInstytucji`
-   (`k.autor.pbn_uid.osobazinstytucji`, wzorzec `_osoba_z_instytucji_autora`,
-   z obsługą `RelatedObjectDoesNotExist` i braku `pbn_uid`).
-3. Jeśli **dokładnie jeden** kandydat z `top` jest PBN-backed → `osoba` = jego
-   `OsobaZInstytucji`, `glowny = _ustal_glownego_autora(osoba)`.
-   W przeciwnym razie (0 lub ≥2 PBN-backed, albo `glowny is None`) → **zwróć
-   `(None, STATUS_WIELU)`** (wybór ręczny).
-4. `analiza = analiza_duplikatow(osoba)`; zbuduj mapę
-   `{a["autor"].pk: a["pewnosc"] for a in analiza["analiza"]}` (pewność 0–100).
-5. **Bramka potwierdzenia:** każdy kandydat z `top` **inny niż `glowny`** musi
-   być w mapie z `pewnosc >= PROG_AUTO_DEDUP`. Jeśli tak (wszystkie pozostałe to
-   potwierdzone duplikaty rekordu głównego) → **zwróć `(glowny, STATUS_DEDUP)`**.
-   Jeśli którykolwiek pozostały kandydat nie jest potwierdzonym duplikatem →
-   **zwróć `(None, STATUS_WIELU)`** (bezpieczeństwo > automatyzacja).
-6. `glowny` może NIE być wśród `top` (name-match go nie znalazł, np. inne
-   nazwisko) — to poprawne: sedno pozycji to dopasowanie do rekordu głównego,
-   nie do żadnego z name-kandydatów. Bramka z pkt. 5 dalej działa (wszystkie
-   `top` to wtedy duplikaty).
+### Helper `kanoniczny_autor(autor) -> Autor`
+
+Czysty helper (w `import_pracownikow`, np. `dedup.py`):
+
+1. Jeśli istnieje `NotADuplicate` dla `autor` → zwróć `autor` (operator
+   zawetował — nie przekierowuj).
+2. Znajdź najlepszy `DuplicateCandidate` gdzie `duplicate_autor == autor`,
+   `status != NOT_DUPLICATE`, `confidence_percent >= PROG_KANONICZNY`,
+   sort po `-confidence_percent` (bierz `main_autor` najpewniejszego).
+   - Uszanuj też `main_osoba_z_instytucji`/`main_autor` jako „oryginał"
+     (ma pochodzić z PBN instytucjonalnego — to gwarantuje konstrukcja skanu).
+3. Jeśli znaleziono → zwróć `main_autor`; inaczej zwróć `autor` (no-op).
+
+Idempotentny: dla rekordu, który sam jest `main_autor` (nie występuje jako
+`duplicate_autor`), zwraca wejściowy autor.
+
+### Punkt wpięcia
+
+W `_dopasuj_autora_i_status` (`analyze.py`), **po** ustaleniu `(autor, status,
+kandydaci)` i **tylko** gdy `autor is not None` (twardy/zgadywanie/ID):
+
+```
+autor_kanoniczny = kanoniczny_autor(autor)
+if autor_kanoniczny != autor:
+    # przekierowanie zatrudnienia na oryginał; zapamiętaj do audytu/badge
+    status = STATUS_DEDUP
+    autor = autor_kanoniczny
+```
+
+- Dla `STATUS_WIELU`/`STATUS_BRAK` (brak auto-autora) nie przekierowujemy —
+  wybór należy do operatora. Po ręcznym wyborze (`DopasujAutoraView`/
+  `WybierzKandydataView`) można opcjonalnie zaproponować oryginał, ale to
+  **poza zakresem** tej iteracji (patrz Ryzyka).
+- Dla dopasowania po `pbn_uid` (ID-path) rekord i tak jest zwykle oryginałem
+  (duplikaty nie mają `pbn_uid`) → helper jest no-opem. Poprawne.
 
 ### Parametr do zatwierdzenia
 
-- `PROG_AUTO_DEDUP` — próg pewności deduplikatora do **automatycznego** scalenia.
-  Musi być **wyższy** niż próg wyświetlania (`50`). Proponowany **domyślny: 80**
-  (0–100). Wartość wydzielona jako nazwana stała w `import_pracownikow`
-  (nie w deduplikatorze), do rewizji w planie/PR.
+- `PROG_KANONICZNY` — minimalny `confidence_percent` z `DuplicateCandidate`, przy
+  którym ufamy relacji duplikat→oryginał na tyle, by przekierować zatrudnienie.
+  Musi być **wyższy** niż próg wyświetlania deduplikatora
+  (`MIN_PEWNOSC_DO_WYSWIETLENIA = 50` na skali 0–100 ≈ `0.5`). Proponowany
+  **domyślny: 0.80**. Stała w `import_pracownikow`, do rewizji w PR.
 
-### Wydajność
+### Zależność od skanu (WAŻNE)
 
-- `analiza_duplikatow` (+ `szukaj_kopii` + zgadywanie płci + 8 ocen) uruchamiane
-  wyłącznie dla wierszy `STATUS_WIELU` z **dokładnie jednym** PBN-backed
-  kandydatem — mniejszość wierszy.
-- **Memoizacja per `osoba.pk`** w obrębie jednego przebiegu analizy (ta sama
-  osoba instytucjonalna bywa kandydatem dla wielu wierszy o tym samym nazwisku).
+Przekierowanie działa **tylko dla par duplikat→oryginał obecnych w
+`DuplicateCandidate`**, tj. gdy skan deduplikatora został uruchomiony i pokrył
+danego autora. Brak wpisu → brak przekierowania (bezpieczny no-op, import działa
+jak dziś). Live `analiza_duplikatow` jako fallback dla nieprzeskanowanych
+autorów — **poza zakresem** (droższe per-wiersz; do rozważenia osobno).
 
 ### Transparentność / audyt
 
-- Nowy status `STATUS_DEDUP = "dedup"` (autom. dopasowanie do rekordu głównego).
-- Przy rozstrzygnięciu zapis do `log_zmian`/diff wiersza: „auto-dopasowano do
-  rekordu głównego #<pk> (deduplikator, pewność N%)".
+- Nowy status `STATUS_DEDUP = "dedup"` — etykieta „rekord główny"
+  (NIE „scalono"): wiersz dopasowano do rekordu oryginalnego.
+- Zapis do `log_zmian`/diff wiersza: „zatrudnienie przypisane do rekordu
+  głównego #<main_pk> (zamiast duplikatu #<dup_pk>, deduplikator, pewność N%)".
 - `STATUS_DEDUP` traktowany jak status **rozstrzygnięty**:
   - dołączyć do `confidence__in=[STATUS_TWARDY, STATUS_RECZNY]` w
     `ImportPracownikowResultsView.get_queryset` (`_prio` → na dół listy),
@@ -117,10 +141,9 @@ STATUS_WIELU`.
 
 ### Zależność między pozycjami
 
-Pozycja 5 (wskaźnik PBN-instytucjonalny) i pozycja 7 dzielą to samo zapytanie
-`autor.pbn_uid.osobazinstytucji` — wspólny helper
-`autor_ma_osobe_z_instytucji(autor)` w `import_common` lub `import_pracownikow`,
-z prefetch/adnotacją w widokach, by uniknąć N+1.
+Pozycja 5 (wskaźnik PBN-instytucjonalny) dzieli sygnał „autor ma
+`OsobaZInstytucji`" (`autor.pbn_uid.osobazinstytucji`) — wspólny helper
+`autor_ma_osobe_z_instytucji(autor)` z prefetch/adnotacją w widokach (bez N+1).
 
 ---
 
@@ -202,15 +225,20 @@ dostępne (skompilowane): `success`, `warning`, `primary`, `secondary`, `alert`.
 ## Testy
 
 - **Poz. 7 (priorytet):**
-  - Dwa różne rekordy tego samego autora (główny z `OsobaZInstytucji`+ORCID+tytuł,
-    duplikat bez) o identycznej pewności nazwiskowej → `STATUS_DEDUP`, autor =
-    główny.
-  - Dwie **różne** osoby o tym samym nazwisku (obie bez lub obie z PBN, brak
-    potwierdzenia duplikatu) → pozostaje `STATUS_WIELU` (brak auto-wyboru).
-  - Duplikat poniżej `PROG_AUTO_DEDUP` → `STATUS_WIELU`.
-  - Główny spoza top-tier (name-match nie znalazł głównego) → auto-wybór
-    głównego, gdy wszystkie top-tier to potwierdzone duplikaty.
-  - Memoizacja: `analiza_duplikatow` liczone raz per `osoba` w przebiegu.
+  - Name-match trafia na duplikat; istnieje `DuplicateCandidate`
+    duplikat→oryginał z `confidence_percent >= PROG_KANONICZNY` i
+    `status != not_duplicate` → `row.autor == main_autor`, `STATUS_DEDUP`;
+    `Autor_Jednostka` powstaje dla **oryginału**, duplikat nietknięty.
+  - `DuplicateCandidate` poniżej `PROG_KANONICZNY` → brak przekierowania
+    (autor = trafiony rekord, status bez zmian).
+  - `NotADuplicate` dla trafionego autora → brak przekierowania (weto operatora).
+  - Brak jakiegokolwiek `DuplicateCandidate` dla autora → no-op (autor bez zmian).
+  - Dopasowanie po `pbn_uid` do oryginału → `kanoniczny_autor` no-op
+    (oryginał nie występuje jako `duplicate_autor`).
+  - Idempotencja: `kanoniczny_autor(main_autor) == main_autor`.
+  - `STATUS_WIELU`/`STATUS_BRAK` (brak auto-autora) → przekierowanie się nie
+    odpala.
+  - Audyt: log zawiera `main_pk` i `dup_pk`.
 - **UI:** render kolumn ORCID/linków (rezultaty, odpiecia, audyt); klasa
   plakietki per status (rozszerzyć `test_confidence_badge_*`); endpoint zbiorczy
   odpięć (owner-scope, bramka podglądu, filtrowanie `pk__in`, toggle
@@ -220,9 +248,14 @@ dostępne (skompilowane): `success`, `warning`, `primary`, `secondary`, `alert`.
 ## Poza zakresem / ryzyka
 
 - Brak zmian w `import_common` widocznych dla innych importerów (poz. 7 lokalna).
-- Brak pełnego UI scalania duplikatów — używamy tylko *odczytu* analizy
-  deduplikatora do wyboru rekordu głównego (bez `scal_autora`).
-- `PROG_AUTO_DEDUP` = decyzja jakościowa; domyślnie konserwatywnie (80),
+- **Nie scalamy rekordów** — tylko *odczyt* `DuplicateCandidate` do wyboru
+  rekordu, do którego trafia zatrudnienie (`scal_autora` NIE jest wołane).
+- **Zależność od skanu:** przekierowanie działa tylko dla par obecnych w
+  `DuplicateCandidate` (deduplikator musiał przeskanować autora). Brak wpisu →
+  no-op. Live `analiza_duplikatow` jako fallback — poza zakresem.
+- **Ręczny wybór** operatora (`STATUS_WIELU`) nie jest auto-przekierowywany —
+  poza zakresem tej iteracji.
+- `PROG_KANONICZNY` = decyzja jakościowa; domyślnie konserwatywnie (0.80),
   do rewizji.
 - DataTables w audycie ładuje wszystkie wiersze do DOM — dla bardzo dużych
   importów rozważyć limit; obecnie spójne z pozostałymi tabelami przepływu.

--- a/src/bpp/newsfragments/+testy-playwright-wyciek-petli-zdarzen.bugfix.rst
+++ b/src/bpp/newsfragments/+testy-playwright-wyciek-petli-zdarzen.bugfix.rst
@@ -1,0 +1,10 @@
+Poprawiona stabilność testów ``import_pracownikow`` przy uruchamianiu
+współbieżnym (pytest-xdist, sharding CI): testy Playwright (sync-API na
+greenletach) potrafiły zostawić w wątku workera ustawiony ``asyncio``
+running-loop marker, przez co kolejny test analizy importu na tym samym
+workerze wywalał ``async_to_sync`` (eager-runner liveops →
+``WebProgress`` → ``channel_layer.group_send``) na „You cannot use
+AsyncToSync in the same thread as an async event loop". Wyjątek był
+połykany przez runner, a stan importu utykał na ``zmapowany`` — flake
+zależny od kolejności shardowania. Fixture izoluje teraz test od
+wyciekłej pętli (zeruje marker na czas testu i przywraca go po nim).

--- a/src/import_pracownikow/tests/conftest.py
+++ b/src/import_pracownikow/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import pytest
@@ -7,6 +8,36 @@ from model_bakery import baker
 
 from bpp.models import Autor, Autor_Jednostka, Jednostka
 from import_pracownikow.models import ImportPracownikow
+
+
+@pytest.fixture(autouse=True)
+def _bez_wycieklej_petli_zdarzen():
+    """Izoluje test od wyciekłej „bieżącej pętli zdarzeń" w wątku workera.
+
+    Testy Playwright (sync-API na greenletach) potrafią zostawić w wątku
+    ustawiony ``asyncio`` running-loop marker, który już się nie czyści. Gdy
+    taki test wypadnie na tym samym workerze xdist PRZED testem
+    ``import_pracownikow``, każde wywołanie ``asgiref.sync.async_to_sync``
+    w analizie (eager-runner liveops → ``WebProgress._push`` →
+    ``channel_layer.group_send``) wywala się na „You cannot use AsyncToSync in
+    the same thread as an async event loop"; wyjątek jest połknięty przez
+    runner, a stan importu utyka na ``zmapowany`` zamiast przejść dalej. Efekt:
+    flake zależny od kolejności shardowania (zielono w izolacji, czerwono po
+    teście Playwright na tym samym workerze).
+
+    Zerujemy marker NA CZAS testu (nasze testy są synchroniczne — nie potrzebują
+    działającej pętli), a po teście PRZYWRACAMY go w niezmienionej postaci, żeby
+    ewentualny kolejny test Playwright na tym workerze zastał swój współdzielony
+    stan pętli nietknięty. Prywatne ``asyncio.events._{get,set}_running_loop``
+    to jedyny sposób na ten marker — dopuszczalne w kodzie wyłącznie testowym.
+    """
+    zapisany = asyncio.events._get_running_loop()
+    if zapisany is not None:
+        asyncio.events._set_running_loop(None)
+    try:
+        yield
+    finally:
+        asyncio.events._set_running_loop(zapisany)
 
 
 def xls_path_factory(suffix=""):


### PR DESCRIPTION
## Co jest w tym PR

Trzy commity ponad `dev`:

### 🐛 `f502c535e` — fix flake'a testów (odblokowuje CI)
Testy Playwright (`pytest-playwright`, sync-API na greenletach) zostawiały
w wątku workera xdist ustawiony `asyncio` running-loop marker, który się nie
czyścił. Gdy taki test wypadł **przed** testem analizy `import_pracownikow` na
tym samym workerze, eager-runner liveops publikujący postęp przez
`WebProgress._push` → `async_to_sync(channel_layer.group_send)` wywalał się na
`RuntimeError: You cannot use AsyncToSync in the same thread as an async event
loop`. Runner połykał wyjątek, a stan importu utykał na `zmapowany` zamiast
przejść dalej → **flake zależny od kolejności shardowania** (zielony w izolacji,
czerwony na CI; padał m.in. `test_przepnij_wszystkie_pre_zaznacza_flage`).

Fix: autouse fixture `save→clear→restore` markera pętli wokół każdego
(synchronicznego) testu `import_pracownikow` — test leci z czystym markerem,
po nim marker jest przywracany, więc sąsiednie testy Playwright na workerze nie
są psute.

**Walidacja:**
- `-n2` (nasila leak): bez fixu FAIL → z fixem GREEN 3/3.
- `-n4` (**dokładny config CI**): **562 passed, 0 failed — 3/3 iteracje**.

### 📄 `5bf30efcc` + `bc66ae2ce` — dokumentacja (spec dedup→rekord główny)
Spec deduplikacji autorów kierującej zatrudnienie na rekord główny/oryginał
(bez scalania) + wzbogacenie widoków.

## Uwagi
- Niezacommitowana WIP (implementacja dedup-ui) **nie** wchodzi do tego PR.
- Osobny, pre-istniejący flake `test_integrate_jednostki` (`get_single_uczelnia_or_none()`
  → None) wychodzi **tylko** pod sztucznie gęstym `-n2`, pod `-n4` (CI) nie
  występuje — poza zakresem tego PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)