### PR TITLE
fix(deduplikator_autorow): ustabilizuj flaky test wariantu myślnika Unicode

### DIFF
--- a/src/bpp/newsfragments/+flake-deduplikator-unicode.bugfix.rst
+++ b/src/bpp/newsfragments/+flake-deduplikator-unicode.bugfix.rst
@@ -1,0 +1,8 @@
+Ustabilizowano test fazy general deduplikatora autorów
+(``test_general_finds_pair_with_unicode_hyphen_variant``), który flakował
+pod ``pytest-xdist``/shardingiem. Faza general skanuje całą tabelę autorów,
+więc ambient rekordy scommitowane przez sąsiednie testy (o pospolitych
+nazwiskach jak „Nowak"/„Kowalski") doczepiały się do klastra i przejmowały
+rolę rekordu głównego, psując asercję na dokładnej liczbie i tożsamości pary.
+Test sprawdza teraz wyłącznie własną inwariantę: po normalizacji myślnika
+Unicode obaj autorzy trafiają do tego samego klastra duplikatów.

--- a/src/deduplikator_autorow/tests/test_general_phase.py
+++ b/src/deduplikator_autorow/tests/test_general_phase.py
@@ -10,6 +10,7 @@ from deduplikator_autorow.models import (
     NotADuplicate,
 )
 from deduplikator_autorow.tasks import _run_general_phase
+from deduplikator_autorow.utils.cluster import find_clusters
 
 
 @pytest.mark.django_db
@@ -32,10 +33,23 @@ def test_general_finds_pair_with_unicode_hyphen_variant():
     scan = DuplicateScanRun.objects.create()
     _run_general_phase(scan, min_confidence=50)
 
+    # UWAGA (flake pod xdist/shardingiem): faza general skanuje CAŁĄ tabelę
+    # autorów, więc ambient autorzy scommitowani przez sąsiednie testy
+    # (transactional / live-server) o pospolitych polskich nazwiskach
+    # ("Nowak", "Kowalski") wpadają do wspólnych bucketów "kowalski"/"nowak",
+    # doczepiają się do klastra i — mając niższy pk — przejmują rolę `main`.
+    # Wtedy zamiast bezpośredniej pary {a, b} emitowane są (ambient, a) +
+    # (ambient, b), przez co asercja na dokładnej liczbie/tożsamości pary
+    # pękała. Testujemy więc WYŁĄCZNIE własną inwariantę: dzięki normalizacji
+    # myślnika Unicode a i b lądują w tym samym klastrze duplikatów (bez
+    # normalizacji trafiłyby do rozłącznych bucketów i różnych klastrów).
     cands = DuplicateCandidate.objects.filter(scan_run=scan, scan_mode="general")
-    assert cands.count() == 1
-    cand = cands.get()
-    assert {cand.main_autor_id, cand.duplicate_autor_id} == {a.pk, b.pk}
+    edges = [(c.main_autor_id, c.duplicate_autor_id) for c in cands]
+    clusters = find_clusters(edges)
+    assert any({a.pk, b.pk} <= cluster for cluster in clusters), (
+        f"Autorzy różniący się tylko wariantem myślnika Unicode powinni "
+        f"trafić do jednego klastra duplikatów; klastry={clusters}"
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

`test_general_finds_pair_with_unicode_hyphen_variant` flakował na CI
(dev, pytest-split sharding + `-n auto`), a przechodził w izolacji
(`-n0`) — czyli flake ambient-data pod współbieżnym xdist, nie twarda
regresja.

## Root cause (zreprodukowany)

Faza `general` deduplikatora (`_run_general_phase`) skanuje **całą**
tabelę `Autor` — buduje meta/buckety dla wszystkich autorów w bazie i
paruje ich w obrębie bucketów nazwisk. Test zakładał czystą tabelę.

Pod xdist/shardingiem ambient autorzy scommitowani przez sąsiednie
testy (transactional / live-server) o pospolitych polskich nazwiskach
(„Nowak", „Kowalski") wpadają do wspólnych bucketów `kowalski`/`nowak`
(nazwisko złożone „Kowalski-Nowak" jest splitowane na człony). Taki
ambient autor:

1. paruje się (score ≥ 50) z obydwoma autorami testu (zawieranie
   nazwiska + wspólne imię),
2. `find_clusters` scala `{ambient, a, b}` w jeden klaster,
3. `pick_main_pk` wybiera ambient jako `main` (najniższy pk, brak
   innych sygnałów),
4. zamiast bezpośredniej pary `{a, b}` emitowane są `(ambient, a)` +
   `(ambient, b)`.

Wtedy `cands.count() == 1` daje 2, a asercja tożsamości pary
`{main, dup} == {a, b}` nie znajduje bezpośredniej krawędzi.

Repro (ambient „Nowak Dorota", pk niższy od a/b): `COUNT=2`,
`EDGES=[(ambient,a),(ambient,b)]`, stare asercje `False`, nowa
`True`.

## Fix (po stronie testu — zachowany sens)

Test sprawdza teraz **wyłącznie własną inwariantę**: po normalizacji
myślnika Unicode (`U+2011` → `-`) obaj autorzy trafiają do **tego
samego klastra** duplikatów. Asercja buduje graf kandydatów i przez
`find_clusters` sprawdza, że `{a.pk, b.pk}` są w jednym komponencie —
odporne na doczepiony ambient. Bez normalizacji autorzy wylądowaliby
w rozłącznych bucketach i osobnych klastrach, więc asercja nadal
wychwyci regresję normalizacji (także w obecności ambient danych).

## Walidacja

- `uv run pytest src/deduplikator_autorow/tests/test_general_phase.py -n0`
  → **9 passed**.
- Reprodukcja z wstrzykniętym ambient autorem: stare asercje pękają,
  nowa (connectivity) przechodzi.
- `ruff format` + `ruff check` + `pre-commit` — czysto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)