### PR TITLE
fix(import_pracownikow): utwardź test integracji jednostek na ambient uczelnię (xdist flake)

### DIFF
--- a/src/bpp/newsfragments/+flake-integrate-jednostki-uczelnia.bugfix.rst
+++ b/src/bpp/newsfragments/+flake-integrate-jednostki-uczelnia.bugfix.rst
@@ -1,0 +1,7 @@
+Usunięto niestabilność testów integracji jednostek importu pracowników przy
+uruchamianiu współbieżnym (pytest-xdist, sharding CI): sąsiedni test mógł
+zostawić w bazie zacommitowaną drugą uczelnię (ambient-data), przez co
+``Uczelnia.objects.get_single_uczelnia_or_none()`` degradował do ``None`` i
+tryb „brak" nie tworzył jednostki. Testy utwardzono, gwarantując dokładnie
+jedną uczelnię (zielone w izolacji, wcześniej czerwone w niektórych układach
+shardów).

--- a/src/import_pracownikow/tests/test_pipeline/test_integrate_jednostki.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_integrate_jednostki.py
@@ -21,6 +21,23 @@ BRAK = ImportPracownikowJednostka.TRYB_BRAK
 ZGADYWANIE = ImportPracownikowJednostka.TRYB_ZGADYWANIE
 
 
+@pytest.fixture
+def uczelnia(uczelnia):
+    """Utwardza precondycję „dokładnie jedna uczelnia" (ambient-data/xdist).
+
+    ``_rozstrzygnij_jednostki`` woła ``get_single_uczelnia_or_none()``, które
+    zwraca ``None`` gdy w bazie jest 0 LUB >1 uczelnia — wtedy tryb BRAK NIE
+    tworzy jednostki (``dec.utworzona`` zostaje ``None``). Baseline ma 0 uczelni,
+    więc solo fixture daje dokładnie 1 i testy przechodzą. Pod xdist/pytest-split
+    sąsiedni test może jednak zostawić zacommitowaną DRUGĄ uczelnię (ambient-data)
+    → ``get_single_uczelnia_or_none()`` degraduje do ``None`` i te testy flakują
+    (zielone w izolacji, czerwone w niektórych układach shardów). Kasujemy
+    ambient-nadmiar, aby fixture'owa uczelnia była jedyna (rollback testu i tak
+    przywraca stan)."""
+    Uczelnia.objects.exclude(pk=uczelnia.pk).delete()
+    return uczelnia
+
+
 def _imp():
     return baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
 


### PR DESCRIPTION
## Problem

`test_tworzy_jednostke_brak_i_podlacza_wszystkie_wiersze`
(`src/import_pracownikow/tests/test_pipeline/test_integrate_jednostki.py`)
flakuje na CI (dev, pytest-split + `-n auto`):

```
assert dec.utworzona is not None
E   assert None is not None
```

Zielono w izolacji, czerwono w niektórych układach shardów → klasyczny
ambient-data flake.

## Root cause

`_rozstrzygnij_jednostki` (`pipeline/integrate.py`) rozstrzyga uczelnię raz,
przez `Uczelnia.objects.get_single_uczelnia_or_none()`. Ta metoda z definicji
zwraca `None`, gdy w bazie jest **0 LUB >1** uczelnia. Dla decyzji
tryb=BRAK + AKCEPTUJ jednostka jest tworzona **tylko** gdy uczelnia is not
None; przy `None` kod loguje „brak jednoznacznej uczelni" i zwraca
`(None, False)` → `dec.utworzona` zostaje `None` → asercja pada.

`baseline.sql` ma **pustą** tabelę `bpp_uczelnia`, więc fixture `uczelnia`
(`get_or_create(skrot="TE")`) w izolacji daje dokładnie 1 uczelnię i test
przechodzi. Pod współbieżnym runnerem sąsiedni test zostawia w bazie
zacommitowaną **drugą** uczelnię (ambient-data) → `count == 2` →
`get_single_uczelnia_or_none()` = `None`.

Zweryfikowane empirycznie: wstrzyknięcie drugiej `baker.make(Uczelnia)` przed
`integruj(...)` odtwarza dokładnie ten sam objaw (`utworzona is None`, brak
utworzonej jednostki).

## Fix

Lokalny override fixture `uczelnia` w tym module testowym kasuje
ambient-nadmiar (`Uczelnia.objects.exclude(pk=...).delete()`), gwarantując, że
fixture'owa uczelnia jest **jedyna** — precondycja, której faktycznie wymaga
`get_single_uczelnia_or_none()`. Delete jest częścią transakcji testu (rollback
i tak przywraca stan), brak reverse-FK `PROTECT` na `Uczelnia`, więc cascade
jest bezpieczny. Test `..._bez_jednoznacznej_uczelni_degraduje_bez_crasha` NIE
używa fixture (celowo tworzy 2 uczelnie) → pozostaje nietknięty.

Wzór zgodny z istniejącą utwardzeniem ambient-data w tej rodzinie testów
(`test_integrate_idempotencja.py`, `_funkcja_asystent`).

## Walidacja

- `pytest ...::test_tworzy_jednostke_brak_i_podlacza_wszystkie_wiersze -n0`
  → passed
- cały plik `test_integrate_jednostki.py -n0` → **9 passed**
- probe z wstrzykniętą ambient drugą uczelnią: przed fixem `utworzona is
  None` (repro), po fixie override kasuje nadmiar → `count == 1`, jednostka
  utworzona
- `ruff format` / `ruff check` na zmienionym pliku → czysto; pre-commit →
  passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)