### PR TITLE
fix(pbn_export_queue): usuń flake w testach sortowania listy kolejki PBN

### DIFF
--- a/src/bpp/newsfragments/+flake-pbn-export-queue-sort.bugfix.rst
+++ b/src/bpp/newsfragments/+flake-pbn-export-queue-sort.bugfix.rst
@@ -1,0 +1,8 @@
+Naprawiono niestabilne (zależne od ziarna RNG, pod pytest-xdist)
+testy sortowania listy kolejki eksportu PBN
+(``test_pbnexportqueuelistview_sort_by_pk`` /
+``...sort_by_reverse_pk``). Drugi rekord tworzony był przez bare
+``baker.make(Wydawnictwo_Ciagle)``, które losowało pole ``rok`` (często
+ujemne), przez co wypadał z domyślnego filtra roku widoku
+(``rok_od=2022``) i asercja robiła ``IndexError``. Testy nadają teraz
+``rok=current_rok()`` i zawężają asercję do własnych wierszy.

--- a/src/pbn_export_queue/tests/test_views_list.py
+++ b/src/pbn_export_queue/tests/test_views_list.py
@@ -9,6 +9,7 @@ from model_bakery import baker
 
 from bpp.const import GR_WPROWADZANIE_DANYCH
 from bpp.models import Wydawnictwo_Ciagle
+from fixtures.conftest_models import current_rok
 from pbn_export_queue.models import PBN_Export_Queue
 from pbn_export_queue.views import PBNExportQueuePermissionMixin
 
@@ -211,22 +212,28 @@ def test_pbnexportqueuelistview_search_by_komunikat(
 @pytest.mark.serial
 def test_pbnexportqueuelistview_sort_by_pk(client, admin_user, wydawnictwo_ciagle):
     """Test sorting by pk"""
-    baker.make(
+    # Oba rekordy dostają `rok=current_rok()`, żeby przeszły domyślny filtr
+    # widoku (`rok_od=2022`). Bez tego bare `baker.make(Wydawnictwo_Ciagle)`
+    # losuje `rok` (nierzadko ujemny — model_bakery ignoruje MinValueValidator),
+    # rekord wypadał z listy i asercja robiła IndexError (flake zależny od seedu).
+    item_a = baker.make(
         PBN_Export_Queue, rekord_do_wysylki=wydawnictwo_ciagle, zamowil=admin_user
     )
-    baker.make(
+    item_b = baker.make(
         PBN_Export_Queue,
-        rekord_do_wysylki=baker.make(Wydawnictwo_Ciagle),
+        rekord_do_wysylki=baker.make(Wydawnictwo_Ciagle, rok=current_rok()),
         zamowil=admin_user,
     )
+    own_pks = [item_a.pk, item_b.pk]
 
     client.force_login(admin_user)
     url = reverse("pbn_export_queue:export-queue-list")
     response = client.get(url + "?sort=pk")
 
     assert response.status_code == 200
-    items = list(response.context["export_queue_items"])
-    assert items[0].pk <= items[1].pk
+    # Zawężamy do własnych wierszy — odporność na ewentualne dane z innych testów.
+    items = [i.pk for i in response.context["export_queue_items"] if i.pk in own_pks]
+    assert items == sorted(own_pks)
 
 
 @pytest.mark.django_db
@@ -234,22 +241,26 @@ def test_pbnexportqueuelistview_sort_by_reverse_pk(
     client, admin_user, wydawnictwo_ciagle
 ):
     """Test sorting by reverse pk"""
-    baker.make(
+    # Patrz komentarz w test_pbnexportqueuelistview_sort_by_pk — `rok=current_rok()`
+    # gwarantuje, że oba rekordy przejdą domyślny filtr `rok_od=2022`.
+    item_a = baker.make(
         PBN_Export_Queue, rekord_do_wysylki=wydawnictwo_ciagle, zamowil=admin_user
     )
-    baker.make(
+    item_b = baker.make(
         PBN_Export_Queue,
-        rekord_do_wysylki=baker.make(Wydawnictwo_Ciagle),
+        rekord_do_wysylki=baker.make(Wydawnictwo_Ciagle, rok=current_rok()),
         zamowil=admin_user,
     )
+    own_pks = [item_a.pk, item_b.pk]
 
     client.force_login(admin_user)
     url = reverse("pbn_export_queue:export-queue-list")
     response = client.get(url + "?sort=-pk")
 
     assert response.status_code == 200
-    items = list(response.context["export_queue_items"])
-    assert items[0].pk >= items[1].pk
+    # Zawężamy do własnych wierszy — odporność na ewentualne dane z innych testów.
+    items = [i.pk for i in response.context["export_queue_items"] if i.pk in own_pks]
+    assert items == sorted(own_pks, reverse=True)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

`test_pbnexportqueuelistview_sort_by_pk` oraz `test_pbnexportqueuelistview_sort_by_reverse_pk` padały niedeterministycznie na CI (dev, sharding pytest-split, `-n auto`) z `IndexError: list index out of range` na asercji `items[0].pk <= items[1].pk` / `>=`. W izolacji zwykle przechodziły.

## Root cause

Drugi rekord w obu testach tworzony był przez bare `baker.make(Wydawnictwo_Ciagle)`, które **losowało pole `rok`**. `rok` to `IntegerField` z `MinValueValidator(0)`, którego model_bakery **nie respektuje** — generuje wartości z pełnego zakresu int, nierzadko ujemne (zreprodukowane: ~40% losowań `< 2022`, np. `-60190721`).

Widok `BasePBNExportQueueListView` ma **domyślny filtr roku `rok_od=2022`** (`_filter_by_year_range`). Gdy wylosowany `rok < 2022`, drugi rekord wypadał z listy → queryset zwracał **1 element zamiast 2** → `items[1]` robił `IndexError`.

Flake był zależny od ziarna RNG (`pytest-randomly` losuje seed per-run; kolejność pod xdist zmienia, który seed trafia w te testy) — stąd „przechodzi w izolacji, pada pod xdist". Pierwszy rekord nie miał tego problemu, bo używa fixture `wydawnictwo_ciagle`, który ustawia `rok=current_rok()` (2026, przechodzi filtr).

## Fix (po stronie testów)

- Oba rekordy dostają teraz `rok=current_rok()` (tak jak robi to fixture `wydawnictwo_ciagle`) → deterministycznie przechodzą domyślny filtr `rok_od=2022`.
- Asercja zawężona do własnych `pk`-ów (`if i.pk in own_pks`) i porównuje pełną listę z `sorted(...)` — odporna na ewentualne dane z innych testów oraz jednoznacznie sprawdza kolejność sortowania.
- Dodano newsfragment.

Sens testu (weryfikacja `?sort=pk` / `?sort=-pk`) zachowany.

## Walidacja

- `uv run pytest src/pbn_export_queue/tests/test_views_list.py -n0` → **18 passed**
- `uv run pytest src/pbn_export_queue/tests/test_views_list.py -n2` → **18 passed**
- `ruff format` / `ruff check` → czysto; pre-commit → wszystkie hooki Passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)