### PR TITLE
fix(import_pracownikow): puste wiersze XLSX, widoczne błędy (konsola/rollbar/admin), odrzucanie plików wielo-arkuszowych

### DIFF
--- a/src/bpp/newsfragments/import-pracownikow-jeden-arkusz.bugfix.rst
+++ b/src/bpp/newsfragments/import-pracownikow-jeden-arkusz.bugfix.rst
@@ -1,0 +1,5 @@
+Import pracowników i jednostek: pliki wieloarkuszowe (kilka arkuszy z danymi
+w jednym skoroszycie, np. dwie uczelnie) są teraz odrzucane z czytelnym
+komunikatem zamiast wywalać się w trakcie przetwarzania. Obowiązuje zasada
+„jeden arkusz = jeden import" — plik należy podzielić na osobne pliki
+(po jednym arkuszu) i zaimportować każdy osobno.

--- a/src/bpp/newsfragments/import-pracownikow-obsluga-bledow.bugfix.rst
+++ b/src/bpp/newsfragments/import-pracownikow-obsluga-bledow.bugfix.rst
@@ -1,0 +1,5 @@
+Import pracowników i jednostek: pusty wiersz w pliku XLSX (np. na końcu
+arkusza) nie przerywa już całego importu — puste wiersze są pomijane tak
+samo jak w plikach CSV. Błędy przetwarzania trafiają teraz na konsolę oraz
+do Rollbara, a same operacje importu (wraz z pełnym tracebackiem błędu) i ich
+wyniki są widoczne w panelu administracyjnym.

--- a/src/import_common/sources.py
+++ b/src/import_common/sources.py
@@ -36,6 +36,11 @@ class TabularSource(Protocol):
 
     def data(self) -> Iterator[dict]: ...
 
+    def liczba_arkuszy_z_danymi(self) -> int:
+        """Liczba arkuszy z danymi (CSV = zawsze 1). Importy „jeden arkusz =
+        jeden import" odrzucają plik, gdy > 1."""
+        ...
+
 
 class XLSXSource:
     """Adapter na istniejący ``XLSImportFile`` (openpyxl)."""
@@ -53,6 +58,9 @@ class XLSXSource:
 
     def data(self) -> Iterator[dict]:
         return self._xif.data()
+
+    def liczba_arkuszy_z_danymi(self) -> int:
+        return self._xif.liczba_arkuszy_z_danymi()
 
 
 def wykryj_format(path) -> str:
@@ -140,6 +148,11 @@ class CSVSource:
     @staticmethod
     def _pusty(row) -> bool:
         return not any((c or "").strip() for c in row)
+
+    def liczba_arkuszy_z_danymi(self) -> int:
+        # CSV to zawsze jeden „arkusz" — nigdy nie wyzwala reguły „jeden
+        # arkusz = jeden import".
+        return 1
 
     def count(self) -> int:
         _colnames, no = self._naglowek

--- a/src/import_common/tests/test_sources.py
+++ b/src/import_common/tests/test_sources.py
@@ -106,7 +106,7 @@ def test_csvsource_pomija_puste_linie(tmp_path):
 def test_csvsource_poszarpany_wiersz_zachowuje_loc_keys(tmp_path):
     # wiersz danych KRÓTSZY niż nagłówek (csv.reader nie padduje) — klucze
     # lokalizacyjne muszą i tak powstać na właściwych pozycjach
-    tresc = f"{_CSV_NAGLOWEK}\n" "1;Kowalski;Jan\n"  # brak 3 ostatnich kolumn
+    tresc = f"{_CSV_NAGLOWEK}\n1;Kowalski;Jan\n"  # brak 3 ostatnich kolumn
     path = _zapisz(tmp_path, tresc, encoding="utf-8")
     wiersz = list(CSVSource(path).data())[0]
     assert wiersz["__xls_loc_sheet__"] == 0
@@ -132,6 +132,93 @@ def test_csvsource_srednik_wygrywa_z_przecinkiem_dziesietnym(tmp_path):
     assert wiersz["nazwisko"] == "Kowalski"
 
 
+def _zapisz_xlsx(tmp_path, wiersze, nazwa="dane.xlsx"):
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    for w in wiersze:
+        ws.append(w)
+    p = tmp_path / nazwa
+    wb.save(str(p))
+    return str(p)
+
+
+def test_xlsxsource_pomija_puste_wiersze(tmp_path):
+    # openpyxl `sheet.max_row` obejmuje puste wiersze końcowe (Excel śledzi
+    # „użyty zakres"), więc bez filtra pustych trafiają do pipeline'u i wywalają
+    # walidację wymaganych pól (nazwisko/imię) — cały import pada na jednym
+    # pustym wierszu na końcu arkusza. XLSX MUSI pomijać puste wiersze tak samo
+    # jak CSVSource (symetria kontraktu). Regresja: operacja bd90660e.
+    path = _zapisz_xlsx(
+        tmp_path,
+        [
+            ["Nazwisko", "Imię", "Stanowisko"],  # nagłówek (row 1)
+            ["Kowalski", "Jan", "Adiunkt"],  # dane (row 2)
+            [None, None, None],  # pusty wiersz w środku (row 3)
+            ["Nowak", "Ewa", "Profesor"],  # dane (row 4)
+            [None, None, None],  # pusty wiersz końcowy (row 5)
+            ["", "", ""],  # pusty wiersz — puste stringi (row 6)
+        ],
+    )
+    src = XLSXSource(path)
+    assert src.count() == 2
+    wiersze = list(src.data())
+    assert len(wiersze) == 2
+    assert wiersze[0]["nazwisko"] == "Kowalski"
+    assert wiersze[1]["nazwisko"] == "Nowak"
+    # klucze lokalizacyjne wskazują REALNY wiersz w arkuszu (0-based) — pominięcie
+    # pustego wiersza nie przesuwa numeracji kolejnych.
+    assert wiersze[1]["__xls_loc_row__"] == 3
+
+
+def test_xlsxsource_liczba_arkuszy_z_danymi_dwa(tmp_path):
+    # Dwa arkusze, każdy z rozpoznanym nagłówkiem → 2 arkusze z danymi (baza
+    # reguły „jeden arkusz = jeden import"). Odzwierciedla plik UAFM_x_MWSL.
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    ws0 = wb.active
+    ws0.title = "UAFM"
+    ws0.append(["Nazwisko", "Imię", "Stanowisko"])
+    ws0.append(["Kowalski", "Jan", "Adiunkt"])
+    ws1 = wb.create_sheet("MWSL")
+    ws1.append(["Nazwisko", "Imię", "Stanowisko"])
+    ws1.append(["Nowak", "Ewa", "Profesor"])
+    p = tmp_path / "dwa.xlsx"
+    wb.save(str(p))
+    assert XLSXSource(str(p)).liczba_arkuszy_z_danymi() == 2
+
+
+def test_xlsxsource_liczba_arkuszy_z_danymi_jeden(tmp_path):
+    path = _zapisz_xlsx(
+        tmp_path,
+        [["Nazwisko", "Imię", "Stanowisko"], ["Kowalski", "Jan", "Adiunkt"]],
+    )
+    assert XLSXSource(path).liczba_arkuszy_z_danymi() == 1
+
+
+def test_xlsxsource_pusty_drugi_arkusz_nie_liczy(tmp_path):
+    # Drugi arkusz bez rozpoznanego nagłówka (pusty / śmieciowy) NIE liczy się
+    # jako arkusz z danymi — reguła „jeden arkusz = jeden import" go ignoruje,
+    # więc plik z jednym arkuszem danych + pustym Sheet2 przechodzi.
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    ws0 = wb.active
+    ws0.append(["Nazwisko", "Imię", "Stanowisko"])
+    ws0.append(["Kowalski", "Jan", "Adiunkt"])
+    wb.create_sheet("Pusty")  # bez nagłówka
+    p = tmp_path / "jeden_plus_pusty.xlsx"
+    wb.save(str(p))
+    assert XLSXSource(str(p)).liczba_arkuszy_z_danymi() == 1
+
+
+def test_csvsource_liczba_arkuszy_z_danymi_jeden(tmp_path):
+    path = _zapisz(tmp_path, f"{_CSV_NAGLOWEK}\n1;Kowalski;Jan;;Asystent;Katedra\n")
+    assert CSVSource(path).liczba_arkuszy_z_danymi() == 1
+
+
 def test_otworz_zrodlo_xlsx(default_xlsx):
     assert isinstance(otworz_zrodlo(default_xlsx), XLSXSource)
 
@@ -145,7 +232,7 @@ def test_otworz_zrodlo_csv(tmp_path):
 def test_csvsource_crlf_realny_excel(tmp_path):
     # realny Excel zapisuje końce linii jako CRLF (\r\n) — csv.reader ścina
     # \r, więc ostatnia kolumna NIE może wyciec z doklejonym \r
-    tresc = f"{_CSV_NAGLOWEK}\r\n" "1;Kowalski;Jan;;Asystent;Katedra Chorób\r\n"
+    tresc = f"{_CSV_NAGLOWEK}\r\n1;Kowalski;Jan;;Asystent;Katedra Chorób\r\n"
     path = _zapisz(tmp_path, tresc, encoding="utf-8")
     src = CSVSource(path)
     assert src.count() == 1
@@ -159,7 +246,7 @@ def test_csvsource_cr_only_konce_linii(tmp_path):
     # `newline=""` w StringIO `csv.reader` rzuca `_csv.Error: new-line character
     # seen in unquoted field` i wywala CAŁĄ analizę surowym tracebackiem. Musi
     # sparsować się poprawnie (a nie-CSV śmieć degradować do domenowego wyjątku).
-    tresc = f"{_CSV_NAGLOWEK}\r" "1;Kowalski;Jan;;Asystent;Katedra Chorób\r"
+    tresc = f"{_CSV_NAGLOWEK}\r1;Kowalski;Jan;;Asystent;Katedra Chorób\r"
     path = _zapisz(tmp_path, tresc, encoding="utf-8")
     src = CSVSource(path)
     assert src.count() == 1
@@ -173,7 +260,7 @@ def test_csvsource_stray_cr_w_polu(tmp_path):
     # — z `newline=""` csv.reader traktuje \r jako koniec rekordu (rozbija wiersz)
     # ZAMIAST rzucać `_csv.Error`. Kluczowe: analiza NIE wywala się surowym
     # tracebackiem; degradacja (rozbity rekord) jest akceptowalna wobec crasha.
-    tresc = f"{_CSV_NAGLOWEK}\n" "1;Kowal\rski;Jan;;Asystent;Katedra\n"
+    tresc = f"{_CSV_NAGLOWEK}\n1;Kowal\rski;Jan;;Asystent;Katedra\n"
     path = _zapisz(tmp_path, tresc, encoding="utf-8")
     src = CSVSource(path)
     # nie rzuca `_csv.Error` (przed fixem: crash całej analizy)

--- a/src/import_common/util.py
+++ b/src/import_common/util.py
@@ -175,19 +175,44 @@ class XLSImportFile:
             _cache[sheet] = res
         return _cache
 
+    @staticmethod
+    def _pusty(values) -> bool:
+        """Wiersz pusty = wszystkie komórki danych ``None`` albo białe znaki.
+        openpyxl ``sheet.max_row`` obejmuje puste wiersze końcowe (Excel śledzi
+        „użyty zakres" — stąd rozjazd `max_row` z realną liczbą danych), więc
+        bez tego filtra puste wiersze trafiają do pipeline'u i wywalają
+        walidację wymaganych pól (nazwisko/imię) — cały import pada na jednym
+        pustym wierszu na końcu arkusza. Zwierciadło ``CSVSource._pusty``."""
+        return not any((str(v).strip() if v is not None else "") for v in values)
+
     def count(self) -> int:
         """
-        Zwraca całkowitą liczbę wierszy do analizy
+        Zwraca całkowitą liczbę NIEPUSTYCH wierszy do analizy — spójne z
+        ``data()`` (puste wiersze pomijamy po obu stronach, inaczej pasek
+        postępu nigdy nie dobija do 100%).
         """
         total = 0
-        for _n_sheet, sheet in enumerate(self.xl_workbook.worksheets):
+        for sheet in self.xl_workbook.worksheets:
             res = self.sheet_row_cache.get(sheet)
             if res is None:
                 continue
             labels, no = res
-            total += sheet.max_row - no
+            for n_row, row in enumerate(sheet.rows):
+                if n_row < no:
+                    continue
+                if self._pusty(cell.value for cell in row[: len(labels)]):
+                    continue
+                total += 1
 
         return total
+
+    def liczba_arkuszy_z_danymi(self) -> int:
+        """Liczba arkuszy z rozpoznanym nagłówkiem (= arkuszy z danymi).
+        Importy wymuszające „jeden arkusz = jeden import" (np. import
+        pracowników) używają tego do odrzucenia plików wieloarkuszowych: dwa
+        arkusze w jednym skoroszycie to zwykle dwa rozłączne zbiory (np. dwie
+        uczelnie), których nie wolno po cichu skleić w jeden import."""
+        return len(self.sheet_row_cache)
 
     def data(self) -> Generator[dict, None, None]:
         """
@@ -214,6 +239,8 @@ class XLSImportFile:
                 if n_row < res[1]:
                     continue
                 data = [x.value for x in row[: len(colnames) - 2]]
+                if self._pusty(data):
+                    continue
                 data.append(n_sheet)
                 data.append(n_row)
 

--- a/src/import_pracownikow/admin.py
+++ b/src/import_pracownikow/admin.py
@@ -1,1 +1,71 @@
-# Register your models here.
+"""Admin operacji „Import pracowników i jednostek".
+
+liveops dostarcza gotowy, read-only ``LiveOperationAdmin`` (stan, traceback,
+wynik, etapy). Do tej pory nikt nie zarejestrował konkretnego modelu, więc
+w adminie nie było ANI JEDNEJ operacji importu — diagnoza błędu (np. operacji
+``bd90660e``) wymagała ręcznego zaglądania do bazy. Rejestrujemy operację
+oraz jej wiersze (podgląd rezultatów per wiersz)."""
+
+from django.contrib import admin
+from django.utils.html import format_html
+from liveops.admin import LiveOperationAdmin
+
+from import_pracownikow.models import ImportPracownikow, ImportPracownikowRow
+
+
+@admin.register(ImportPracownikow)
+class ImportPracownikowAdmin(LiveOperationAdmin):
+    """Read-only widok operacji importu — stan pipeline'u + traceback błędu."""
+
+    list_display = (
+        "short_id",
+        "owner",
+        "stan",
+        "state",
+        "created_on",
+        "finished_on",
+        "finished_successfully",
+        "blad_skrocony",
+    )
+    list_filter = ("finished_successfully", "cancelled", "stan")
+    search_fields = ("id", "owner__username", "traceback")
+
+    @admin.display(description="Błąd (skrót)")
+    def blad_skrocony(self, obj):
+        """Ostatnia linia tracebacku — czytelne „co poszło nie tak" wprost na
+        liście, bez wchodzenia w szczegóły."""
+        czytelny = obj.readable_exception()
+        if not czytelny:
+            return "—"
+        return format_html("<span style='color:#a00'>{}</span>", czytelny)
+
+
+@admin.register(ImportPracownikowRow)
+class ImportPracownikowRowAdmin(admin.ModelAdmin):
+    """Podgląd wierszy (rezultatów) importu — kogo/jak dopasowano: autora,
+    jednostkę i tytuł. Read-only: wiersze produkuje pipeline analizy."""
+
+    list_display = (
+        "id",
+        "parent",
+        "autor",
+        "confidence",
+        "jednostka",
+        "jednostka_status",
+        "tytul",
+        "zmiany_potrzebne",
+    )
+    list_filter = ("confidence", "jednostka_status", "zmiany_potrzebne")
+    search_fields = (
+        "parent__id",
+        "autor__nazwisko",
+        "autor__imiona",
+        "jednostka__nazwa",
+    )
+    raw_id_fields = ("parent", "autor", "jednostka", "autor_jednostka", "tytul")
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False

--- a/src/import_pracownikow/mapping.py
+++ b/src/import_pracownikow/mapping.py
@@ -110,6 +110,31 @@ TRY_NAMES = sorted(set(_SYNONIMY.keys()))
 MIN_POINTS = 2
 
 
+def sprawdz_pojedynczy_arkusz(zrodlo):
+    """Wymusza regułę „jeden arkusz = jeden import".
+
+    Plik z więcej niż jednym arkuszem z danymi (np. dwie uczelnie w jednym
+    skoroszycie — jak ``Pracownicy_..._UAFM_x_MWSL.xlsx``) jest ODRZUCANY:
+    auto-sklejenie mieszałoby rozłączne zbiory, a auto-podział na osobne
+    importy zakładałby, że arkusze są porównywalne (nie są — inne kolumny,
+    inna uczelnia). Świadomie NIE obsługujemy plików wieloarkuszowych —
+    użytkownik dzieli plik i importuje każdy arkusz osobno.
+
+    Podnosi ``BadNoOfSheetsException`` z czytelnym komunikatem (ekran
+    mapowania go łapie i pokazuje; w tle wyjątek trafia na konsolę/rollbar/
+    admin). CSV to zawsze jeden arkusz — nigdy nie wyzwala tej reguły.
+    """
+    from import_common.exceptions import BadNoOfSheetsException
+
+    n = zrodlo.liczba_arkuszy_z_danymi()
+    if n > 1:
+        raise BadNoOfSheetsException(
+            f"Plik zawiera więcej niż jeden arkusz z danymi (znaleziono: {n}). "
+            f"Jeden import obsługuje tylko jeden arkusz — podziel plik na osobne "
+            f"pliki (po jednym arkuszu) i zaimportuj każdy osobno."
+        )
+
+
 # Fallback podłańcuchowy: gdy DOKŁADNY synonim nie trafił, sprawdzamy czy
 # nagłówek ZAWIERA któryś fragment (kolejność = priorytet). Dla długich,
 # opisowych nagłówków typu „stopien_tytul_aktualny_na_dzien_..." (IHIT).

--- a/src/import_pracownikow/models.py
+++ b/src/import_pracownikow/models.py
@@ -199,6 +199,25 @@ class ImportPracownikow(LiveOperation):
         return None
 
     def run(self, p):
+        # liveops.runner._handle_error zapisuje traceback WYŁĄCZNIE do bazy (pole
+        # `traceback`) — bez śladu na konsoli workera i bez zgłoszenia do
+        # rollbara. Owijamy właściwy przebieg, żeby błąd był WIDOCZNY: surowy
+        # traceback na stderr (konsola celery/run-site) + rollbar (konwencja
+        # bg-tasków w projekcie), po czym re-raise — liveops i tak zapisze
+        # traceback do bazy i pokaże błąd w UI/adminie.
+        try:
+            self._wykonaj(p)
+        except Exception:
+            import sys
+            import traceback as _traceback
+
+            import rollbar
+
+            _traceback.print_exc()
+            rollbar.report_exc_info(sys.exc_info())
+            raise
+
+    def _wykonaj(self, p):
         if self.stan == self.STAN_ZMAPOWANY:
             from import_pracownikow.pipeline.analyze import analizuj
 
@@ -274,6 +293,23 @@ class ImportPracownikow(LiveOperation):
         self.log_seq = 0
         return list(self._POLA_LIVEOPS_RESET)
 
+    def waliduj_liczbe_arkuszy(self):
+        """Egzekwuje „jeden arkusz = jeden import": otwiera plik i podnosi
+        ``BadNoOfSheetsException``, gdy ma > 1 arkusz z danymi. Dla widoków
+        ruszających analizę z pominięciem ekranu mapowania (RestartAnalizaView) —
+        ``naglowki_i_probka`` robi tę samą kontrolę na ścieżce mapowania."""
+        from import_common.sources import otworz_zrodlo
+        from import_pracownikow.mapping import (
+            MIN_POINTS,
+            TRY_NAMES,
+            sprawdz_pojedynczy_arkusz,
+        )
+
+        zrodlo = otworz_zrodlo(
+            self.plik_xls.path, try_names=TRY_NAMES, min_points=MIN_POINTS
+        )
+        sprawdz_pojedynczy_arkusz(zrodlo)
+
     def naglowki_i_probka(self, limit=10):
         """Synchronicznie (bez liveops) czyta znormalizowane nagłówki i do
         ``limit`` wierszy próbki — na ekran mapowania. Nagłówki = klucze
@@ -282,11 +318,19 @@ class ImportPracownikow(LiveOperation):
         rzucić ``HeaderNotFoundException`` (plik bez rozpoznawalnego
         nagłówka) — widok (T8) łapie to i pokazuje komunikat, nie 500."""
         from import_common.sources import otworz_zrodlo
-        from import_pracownikow.mapping import MIN_POINTS, TRY_NAMES
+        from import_pracownikow.mapping import (
+            MIN_POINTS,
+            TRY_NAMES,
+            sprawdz_pojedynczy_arkusz,
+        )
 
         zrodlo = otworz_zrodlo(
             self.plik_xls.path, try_names=TRY_NAMES, min_points=MIN_POINTS
         )
+        # „Jeden arkusz = jeden import" — plik wieloarkuszowy odrzucamy zanim
+        # użytkownik zacznie mapować (mieszałby dwa rozłączne zbiory). Widok
+        # łapie BadNoOfSheetsException i pokazuje komunikat.
+        sprawdz_pojedynczy_arkusz(zrodlo)
         probka = []
         naglowki = []
         for i, wiersz in enumerate(zrodlo.data()):

--- a/src/import_pracownikow/tests/test_error_visibility.py
+++ b/src/import_pracownikow/tests/test_error_visibility.py
@@ -1,0 +1,95 @@
+"""Widoczność błędów importu pracowników i jednostek.
+
+Regresja operacji ``bd90660e``: import padł na pustym wierszu XLS, ale
+`liveops.runner._handle_error` zapisuje traceback WYŁĄCZNIE do bazy (pole
+`traceback`) — bez śladu na konsoli workera ani w rollbarze, a admin nie miał
+żadnego widoku operacji importu. Te testy pilnują, że:
+
+1. wyjątek w ``run()`` trafia na rollbar (i konsolę) i jest re-raise'owany,
+2. model ``ImportPracownikow`` jest zarejestrowany w adminie i pokazuje traceback.
+"""
+
+import sys
+
+import pytest
+from django.urls import reverse
+from liveops.testing import MockProgress
+from model_bakery import baker
+
+from import_pracownikow.models import ImportPracownikow
+
+
+@pytest.mark.django_db
+def test_run_zglasza_wyjatek_na_rollbar_i_reraise(admin_user, monkeypatch):
+    """Wyjątek w ``run()`` MUSI trafić na rollbar (i konsolę) oraz zostać
+    re-raise'owany — inaczej liveops chowa go tylko do bazy i ani user, ani
+    monitoring nic nie widzi."""
+    zgloszenia = []
+    monkeypatch.setattr(
+        "rollbar.report_exc_info",
+        lambda *a, **k: zgloszenia.append(sys.exc_info()[1]),
+    )
+
+    def wybuchnij(*a, **k):
+        raise ValueError("boom-testowy")
+
+    # run() robi lokalny `from ...analyze import analizuj`, więc patchujemy
+    # atrybut modułu (resolved w momencie wywołania).
+    monkeypatch.setattr("import_pracownikow.pipeline.analyze.analizuj", wybuchnij)
+
+    op = baker.make(
+        ImportPracownikow, owner=admin_user, stan=ImportPracownikow.STAN_ZMAPOWANY
+    )
+    with pytest.raises(ValueError, match="boom-testowy"):
+        op.run(MockProgress(op))
+
+    assert zgloszenia, "rollbar.report_exc_info nie został wywołany"
+    assert isinstance(zgloszenia[0], ValueError)
+
+
+@pytest.mark.django_db
+def test_run_sukces_nie_dotyka_rollbara(
+    admin_user, monkeypatch, baza_importu_pracownikow, testdata_xlsx_path
+):
+    """Poprawny przebieg nie zgłasza niczego na rollbar (brak fałszywych alarmów)."""
+    zgloszenia = []
+    monkeypatch.setattr(
+        "rollbar.report_exc_info", lambda *a, **k: zgloszenia.append(True)
+    )
+    from import_pracownikow.tests.conftest import import_pracownikow_factory
+
+    op = import_pracownikow_factory(admin_user, testdata_xlsx_path)
+    op.stan = ImportPracownikow.STAN_ZMAPOWANY
+    op.run(MockProgress(op))
+
+    assert not zgloszenia
+
+
+@pytest.mark.django_db
+def test_admin_import_pracownikow_zarejestrowany(admin_client):
+    """Changelista operacji importu ładuje się (model zarejestrowany w adminie)."""
+    url = reverse("admin:import_pracownikow_importpracownikow_changelist")
+    resp = admin_client.get(url)
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_admin_wiersze_importu_zarejestrowane(admin_client):
+    """Changelista wierszy (rezultatów) importu ładuje się (drill-down)."""
+    url = reverse("admin:import_pracownikow_importpracownikowrow_changelist")
+    resp = admin_client.get(url)
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_admin_import_pokazuje_traceback(admin_client, admin_user):
+    """Widok szczegółów operacji pokazuje traceback (diagnoza bez zaglądania do bazy)."""
+    op = baker.make(
+        ImportPracownikow,
+        owner=admin_user,
+        traceback="MARKER-TRACEBACK-123",
+    )
+    url = reverse("admin:import_pracownikow_importpracownikow_change", args=[op.pk])
+    resp = admin_client.get(url)
+    assert resp.status_code == 200
+    assert b"MARKER-TRACEBACK-123" in resp.content

--- a/src/import_pracownikow/tests/test_views_liveops.py
+++ b/src/import_pracownikow/tests/test_views_liveops.py
@@ -290,12 +290,17 @@ def test_zatwierdz_bez_zakresu_domyslnie_pelny(admin_client, admin_user):
 
 
 @pytest.mark.django_db
-def test_restart_analiza_cofa_stan_i_kasuje_wiersze(admin_client, admin_user):
-    imp = baker.make(
-        ImportPracownikow,
-        owner=admin_user,
-        stan=ImportPracownikow.STAN_PRZEANALIZOWANY,
-    )
+def test_restart_analiza_cofa_stan_i_kasuje_wiersze(
+    admin_client, admin_user, testdata_xlsx_path
+):
+    # Restart otwiera plik (bramka „jeden arkusz = jeden import"), więc import
+    # potrzebuje REALNEGO, jednoarkuszowego pliku (jak w produkcji — nie da się
+    # przeanalizować importu bez pliku).
+    from import_pracownikow.tests.conftest import import_pracownikow_factory
+
+    imp = import_pracownikow_factory(admin_user, testdata_xlsx_path)
+    imp.stan = ImportPracownikow.STAN_PRZEANALIZOWANY
+    imp.save(update_fields=["stan"])
     baker.make(
         "import_pracownikow.ImportPracownikowRow", parent=imp, zmiany_potrzebne=False
     )

--- a/src/import_pracownikow/tests/test_wiele_arkuszy.py
+++ b/src/import_pracownikow/tests/test_wiele_arkuszy.py
@@ -1,0 +1,91 @@
+"""Reguła „jeden arkusz = jeden import".
+
+Plik wieloarkuszowy (np. ``Pracownicy_..._UAFM_x_MWSL.xlsx`` — dwie uczelnie
+w jednym skoroszycie) jest ODRZUCANY z czytelnym błędem. Świadomie NIE
+obsługujemy takich plików (ani auto-sklejenia, ani auto-podziału — arkusze to
+rozłączne, nieporównywalne zbiory). Użytkownik dzieli plik na osobne pliki
+(po jednym arkuszu) i importuje każdy osobno.
+"""
+
+import openpyxl
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from import_common.exceptions import BadNoOfSheetsException
+from import_pracownikow.models import ImportPracownikow
+
+
+def _plik_dwa_arkusze(tmp_path):
+    wb = openpyxl.Workbook()
+    ws0 = wb.active
+    ws0.title = "UAFM"
+    ws0.append(["Nazwisko", "Imię", "Stanowisko"])
+    ws0.append(["Kowalski", "Jan", "Adiunkt"])
+    ws1 = wb.create_sheet("MWSL")
+    ws1.append(["Nazwisko", "Imię", "Stanowisko"])
+    ws1.append(["Nowak", "Ewa", "Profesor"])
+    p = tmp_path / "dwa_arkusze.xlsx"
+    wb.save(str(p))
+    return p
+
+
+def _import_z_pliku(user, path):
+    imp = ImportPracownikow(owner=user)
+    with open(path, "rb") as f:
+        imp.plik_xls = SimpleUploadedFile("dwa_arkusze.xlsx", f.read())
+    imp.save()
+    return imp
+
+
+@pytest.mark.django_db
+def test_naglowki_i_probka_odrzuca_plik_wieloarkuszowy(admin_user, tmp_path):
+    imp = _import_z_pliku(admin_user, _plik_dwa_arkusze(tmp_path))
+    with pytest.raises(BadNoOfSheetsException):
+        imp.naglowki_i_probka()
+
+
+@pytest.mark.django_db
+def test_waliduj_liczbe_arkuszy_odrzuca_plik_wieloarkuszowy(admin_user, tmp_path):
+    imp = _import_z_pliku(admin_user, _plik_dwa_arkusze(tmp_path))
+    with pytest.raises(BadNoOfSheetsException):
+        imp.waliduj_liczbe_arkuszy()
+
+
+@pytest.mark.django_db
+def test_restart_analiza_view_odrzuca_plik_wieloarkuszowy(
+    admin_client, admin_user, tmp_path
+):
+    """Bezpiecznik na ścieżce restartu: RESTART istniejącego importu (np. sprzed
+    tej reguły) wchodzi w analizę z pominięciem ekranu mapowania — widok
+    restartu odrzuca plik wieloarkuszowy z czytelnym komunikatem, bez re-enqueue."""
+    imp = _import_z_pliku(admin_user, _plik_dwa_arkusze(tmp_path))
+    url = reverse("import_pracownikow:restart-analiza", kwargs={"pk": imp.pk})
+    resp = admin_client.post(url, follow=True)
+    assert resp.status_code == 200
+    assert "więcej niż jeden arkusz" in resp.content.decode("utf-8")
+
+
+@pytest.mark.django_db
+def test_mapowanie_view_odrzuca_plik_wieloarkuszowy(admin_client, admin_user, tmp_path):
+    """Ekran mapowania odrzuca plik wieloarkuszowy od razu — redirect na listę
+    z czytelnym komunikatem, zamiast crashu w tle."""
+    imp = _import_z_pliku(admin_user, _plik_dwa_arkusze(tmp_path))
+    url = reverse("import_pracownikow:mapowanie", kwargs={"pk": imp.pk})
+    resp = admin_client.get(url, follow=True)
+    assert resp.status_code == 200
+    assert "więcej niż jeden arkusz" in resp.content.decode("utf-8")
+
+
+@pytest.mark.django_db
+def test_import_jednoarkuszowy_przechodzi(
+    admin_client, admin_user, baza_importu_pracownikow, testdata_xlsx_path
+):
+    """Regresja: plik JEDNOARKUSZOWY nadal działa (reguła nie blokuje normalnych
+    importów) — ekran mapowania renderuje kolumny."""
+    from import_pracownikow.tests.conftest import import_pracownikow_factory
+
+    imp = import_pracownikow_factory(admin_user, testdata_xlsx_path)
+    url = reverse("import_pracownikow:mapowanie", kwargs={"pk": imp.pk})
+    resp = admin_client.get(url)
+    assert resp.status_code == 200

--- a/src/import_pracownikow/views.py
+++ b/src/import_pracownikow/views.py
@@ -27,7 +27,7 @@ from bpp.models import (
     Wydawnictwo_Ciagle_Autor,
     Wydawnictwo_Zwarte_Autor,
 )
-from import_common.exceptions import HeaderNotFoundException
+from import_common.exceptions import BadNoOfSheetsException, HeaderNotFoundException
 from import_pracownikow.forms import MapowanieForm, NowyImportForm
 from import_pracownikow.mapping import dopasuj_profil
 from import_pracownikow.models import (
@@ -192,6 +192,11 @@ class MapowanieView(GroupRequiredMixin, FormView):
                 "Nie rozpoznano wiersza nagłówka w pliku — sprawdź, czy plik "
                 "zawiera kolumny takie jak nazwisko / imię / jednostka.",
             )
+            return HttpResponseRedirect(reverse("import_pracownikow:index"))
+        except BadNoOfSheetsException as exc:
+            # „Jeden arkusz = jeden import" — plik wieloarkuszowy (np. dwie
+            # uczelnie w jednym skoroszycie) odrzucamy z czytelnym komunikatem.
+            messages.error(request, str(exc))
             return HttpResponseRedirect(reverse("import_pracownikow:index"))
         if not self._naglowki:
             messages.error(request, "Plik nie zawiera kolumn do zmapowania.")
@@ -1118,6 +1123,15 @@ class RestartAnalizaView(_PkOwnerRestartMixin):
 
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
+        # „Jeden arkusz = jeden import" — restart ISTNIEJĄCEGO importu wchodzi w
+        # analizę z pominięciem ekranu mapowania, więc plik wieloarkuszowy
+        # (np. import sprzed tej reguły) łapiemy tutaj, zamiast pozwolić mu
+        # wywalić analizę w tle.
+        try:
+            obj.waliduj_liczbe_arkuszy()
+        except BadNoOfSheetsException as exc:
+            messages.error(request, str(exc))
+            return HttpResponseRedirect(reverse("import_pracownikow:index"))
         obj.stan = ImportPracownikow.STAN_ZMAPOWANY
         obj.save(update_fields=["stan"])
         return super().post(request, *args, **kwargs)


### PR DESCRIPTION
## Kontekst

Operacja importu `bd90660e` wywaliła się z komunikatem „Wystąpił błąd podczas
przetwarzania" — **bez żadnego śladu** na konsoli, w Rollbarze ani w panelu
administracyjnym. Traceback (wyciągnięty z bazy) wskazał pusty wiersz na końcu
arkusza XLSX; dalsza diagnoza odsłoniła drugi problem: plik miał **dwa arkusze**
(dwie uczelnie — UAFM + MWSL) o różnej strukturze.

## Zmiany

**1. Pusty wiersz nie przerywa importu** (`import_common/util.py`)
`XLSImportFile.data()` (ścieżka XLSX) zwracał puste wiersze końcowe (openpyxl
`sheet.max_row` obejmuje „użyty zakres"), a `AutorForm` je odrzucał →
`XLSParseError` przerywał **cały** import. `CSVSource` już pomijał puste wiersze
(`_pusty`) — ścieżka XLSX nie. Teraz obie są symetryczne, `count()`/`data()`
spójne.

**2. Błędy są widoczne** (`import_pracownikow/models.py`, `admin.py`)
liveops `_handle_error` zapisywał traceback **tylko do bazy**. `run()` jest
teraz owinięty: `traceback.print_exc()` (konsola) + `rollbar.report_exc_info()`,
potem re-raise (liveops i tak zapisuje do bazy i pokazuje błąd w UI).
Zarejestrowany admin (`LiveOperationAdmin` dla operacji + widok wierszy) — stan,
pełny traceback i wyniki widoczne w panelu.

**3. „Jeden arkusz = jeden import"** (`mapping.py`, `models.py`, `views.py`, `sources.py`)
Plik z >1 arkuszem z danymi jest odrzucany z czytelnym komunikatem (świadomie
nie obsługujemy plików wieloarkuszowych — mieszałyby rozłączne zbiory).
Egzekwowane na dwóch bramkach widoku: ekran mapowania (nowe importy) oraz
restart analizy (istniejące importy sprzed reguły, które omijają mapowanie).
`BadNoOfSheetsException` — konwencja jak w `import_dyscyplin`. Puste/śmieciowe
arkusze bez nagłówka nie liczą się (brak fałszywych odrzuceń).

## Testy

716 zielonych (`import_common` + `import_pracownikow` + `import_dyscyplin`,
równolegle), w tym nowe testy jednostkowe źródeł, widoczności błędów i reguły
jednego arkusza. Zweryfikowane na realnym pliku `Pracownicy_..._UAFM_x_MWSL.xlsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
