### PR TITLE
fix(security): wymagaj uprawnień redaktorskich dla operacji mutujących

### DIFF
--- a/docs/superpowers/specs/2026-07-12-authz-editor-endpoints-design.md
+++ b/docs/superpowers/specs/2026-07-12-authz-editor-endpoints-design.md
@@ -1,0 +1,105 @@
+# Centralna bramka autoryzacji dla mutujących endpointów redaktorskich
+
+Data: 2026-07-12
+Gałąź: `fix/authz-editor-endpoints` (baza: `dev`)
+
+## Problem
+
+W kilku modułach `login_required` / `LoginRequiredMixin` jest traktowane jak
+uprawnienie redaktorskie. Zwykłe zalogowane konto (bez `is_staff`, bez grup,
+bez uprawnień modelowych) może wywołać operacje modyfikujące dane globalne:
+
+1. **Klonowanie publikacji/autorów** przez `/admin/.../toz/<pk>/` — mutacja
+   już na GET; trasy wymagają tylko zalogowania
+   (`src/django_bpp/urls.py`, `src/bpp/views/admin.py`).
+2. **Nadpisywanie punktacji źródeł** (MNiSW, IF, SNIP, kwartyle, punktacja
+   wewnętrzna) — `src/bpp/views/api/__init__.py` (`UploadPunktacjaZrodlaView`).
+3. **Masowe przepinanie publikacji między źródłami, tworzenie/usuwanie źródeł,
+   dodawanie do kolejki PBN** — `src/przemapuj_zrodla_pbn/views.py`.
+4. **Usunięcie wszystkich `MetrykaAutora` + globalne przeliczenie** —
+   `src/ewaluacja_optymalizacja/views/unpinning_analysis.py`.
+5. **Toggle przypięcia rekordu po globalnym PK** —
+   `src/ewaluacja_optymalizacja/views/evaluation_browser/views.py`
+   (`browser_toggle_pin`).
+6. **Przypinanie/odpinanie/zmiana dyscyplin** —
+   `src/ewaluacja_optymalizuj_publikacje/views.py`.
+
+Istniejący test dowodzi realności luki: zwykły użytkownik `baker.make` loguje
+się i skutecznie usuwa źródło
+(`src/przemapuj_zrodla_pbn/tests/test_views_actions.py`).
+
+Właściwa kontrola już istnieje w projekcie, ale nie jest tu użyta:
+`ma_pelne_uprawnienia_ewaluacji` = superuser **lub** grupa
+`GR_WPROWADZANIE_DANYCH` (`src/ewaluacja_metryki/views/mixins.py`).
+
+## Rozwiązanie
+
+Dwie ortogonalne warstwy defektu; ten PR zamyka pierwszą (P0) oraz towarzyszący
+jej problem „mutacja na GET". Scoping wielotenantowy (IDOR po globalnym PK) jest
+świadomie **odroczony** do osobnego PR z fiksturami multi-uczelnia.
+
+### 1. Wspólny prymityw autoryzacji — `src/bpp/permissions.py` (nowy plik)
+
+Jedno źródło prawdy, domyślnie odmawiające dostępu, w trzech formach:
+
+- `moze_wprowadzac_dane(user) -> bool` — superuser lub członek grupy
+  `GR_WPROWADZANIE_DANYCH`.
+- `WprowadzanieDanychRequiredMixin(LoginRequiredMixin)` — dla CBV.
+  Anonim → 302 na login; zalogowany-bez-uprawnień → **403** (`PermissionDenied`).
+- `wprowadzanie_danych_wymagane(view_func)` — dekorator dla FBV, ta sama
+  semantyka.
+
+`ewaluacja_metryki.views.mixins.ma_pelne_uprawnienia_ewaluacji` zostaje
+przepięte, żeby delegowało do `moze_wprowadzac_dane` (bez zmiany zachowania —
+zwijamy duplikat logiki do jednego helpera).
+
+**Semantyka statusów (celowo):** anonim → login redirect (zachowuje kontrakt
+istniejącego `test_usun_zrodlo_view_requires_login`); zalogowany-bez-uprawnień
+→ 403 (czego wymaga review).
+
+### 2. Zmiany w call-site'ach
+
+| Moduł | Zmiana |
+|-------|--------|
+| `bpp/views/api/__init__.py` | 4 widoki: `LoginRequiredMixin` → `WprowadzanieDanychRequiredMixin` |
+| `przemapuj_zrodla_pbn/views.py` | 3 FBV (`lista_skasowanych_zrodel`, `przemapuj_zrodlo`, `usun_zrodlo`): `@login_required` → `@wprowadzanie_danych_wymagane` |
+| `ewaluacja_optymalizacja/.../unpinning_analysis.py` | `analyze_unpinning_opportunities`: dekorator |
+| `ewaluacja_optymalizacja/.../evaluation_browser/views.py` | `browser_toggle_pin`: dekorator (zachowaj `@require_POST`) |
+| `ewaluacja_optymalizuj_publikacje/views.py` | 2 CBV: mixin |
+
+### 3. `toz`: GET → POST + CSRF
+
+- `bpp/views/admin.py`: `TozView(RedirectView)` → `View` z metodą `post()`,
+  która klonuje i zwraca `HttpResponseRedirect`, z mixinem
+  `WprowadzanieDanychRequiredMixin`. Brak `get()` → GET zwraca 405
+  (koniec mutacji-na-nawigacji).
+- `src/django_bpp/urls.py`: usunąć owijkę `login_required(...)` (mixin
+  przejmuje auth); nazwy URL bez zmian.
+- 3 × `change_form.html` (ciagle/zwarte/patent): `location.href = "../../toz/"
+  + pub_id` → dynamiczny `<form method="post">` z `csrfmiddlewaretoken`
+  (czytany z ukrytego inputa formularza admina), `appendTo('body').submit()`.
+  UX bez zmian: ten sam przycisk, to samo `confirm()`, natywny redirect.
+
+### 4. Testy (TDD — najpierw czerwone)
+
+- **Nowe** `src/bpp/tests/test_permissions.py`: helper + mixin + dekorator
+  (anon→login, zwykły→403, grupa→pass, superuser→pass).
+- **Nowe** testy 403 per-trasa: dla każdej mutującej trasy zwykły user → 403;
+  członek grupy/superuser → nie-403. Plus `GET /toz/<pk>/` → 405.
+- **Aktualizacja** `przemapuj_zrodla_pbn/tests/test_views_actions.py`: 4 testy
+  logujące zwykłego usera dostają wspólnego usera-redaktora (happy path);
+  stary test „zwykły user usuwa źródło" rozbity — happy path z grupą + nowy
+  test zwykły user → 403.
+- **Newsfragment** `src/bpp/newsfragments/<slug>.bugfix.rst` (PL).
+
+### Weryfikacja
+
+- `make tests-without-playwright` dla dotkniętych apek.
+- Manualnie: przycisk „Toż" w adminie przez `run-site` (POST-klon działa).
+
+## Poza zakresem (świadomie)
+
+- Scoping bieżącej uczelni przy pobraniu po globalnym PK (IDOR wielotenantowy) —
+  osobny PR z fiksturami multi-uczelnia.
+- Zmiana grupy/roli redaktorskiej (per-model Django perms) — odrzucone na rzecz
+  jednej centralnej bramki (superuser ∨ `GR_WPROWADZANIE_DANYCH`).

--- a/src/bpp/newsfragments/security-authz-redaktorskie-endpointy.bugfix.rst
+++ b/src/bpp/newsfragments/security-authz-redaktorskie-endpointy.bugfix.rst
@@ -1,0 +1,7 @@
+Naprawiono lukę autoryzacji: operacje redaktorskie — klonowanie rekordów
+(„Toż"), nadpisywanie punktacji źródeł, przemapowywanie i usuwanie źródeł,
+dodawanie do kolejki PBN oraz cały moduł analizy/optymalizacji ewaluacji
+(w tym masowe odpinanie prac i kasowanie metryk) — wymagają teraz uprawnień
+„wprowadzanie danych" (lub superusera), a nie samego zalogowania. Dodatkowo
+klonowanie „Toż" wykonuje się wyłącznie przez POST z tokenem CSRF (wcześniej
+mutowało dane już na GET).

--- a/src/bpp/permissions.py
+++ b/src/bpp/permissions.py
@@ -1,0 +1,89 @@
+"""Centralna bramka autoryzacji dla operacji redaktorskich (wprowadzanie
+danych).
+
+Problem, który to zamyka: w wielu widokach ``login_required`` /
+``LoginRequiredMixin`` było traktowane jak uprawnienie redaktorskie. Samo
+zalogowanie to jednak *uwierzytelnienie*, nie *autoryzacja* — zwykłe konto
+(bez ``is_staff``, bez grup) mogło wywoływać operacje mutujące dane globalne.
+
+Jedno źródło prawdy, domyślnie odmawiające dostępu, w trzech formach:
+
+- :func:`moze_wprowadzac_dane` — predykat (superuser LUB grupa
+  ``GR_WPROWADZANIE_DANYCH``),
+- :class:`WprowadzanieDanychRequiredMixin` — dla widoków klasowych,
+- :func:`wprowadzanie_danych_wymagane` — dekorator dla widoków funkcyjnych.
+
+Semantyka statusów (celowo, spójnie w mixinie i dekoratorze):
+
+- anonim → 302 na stronę logowania (kontrakt ``LoginRequiredMixin``),
+- zalogowany-bez-uprawnień → 403 (``PermissionDenied``),
+- uprawniony → normalna odpowiedź widoku.
+"""
+
+from functools import wraps
+
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
+from django.urls import URLPattern, URLResolver
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+
+_KOMUNIKAT = "Brak uprawnień do wprowadzania danych."
+
+
+def moze_wprowadzac_dane(user) -> bool:
+    """Czy ``user`` ma pełne uprawnienia redaktorskie: superuser lub członek
+    grupy ``GR_WPROWADZANIE_DANYCH``. Anonim / zwykły użytkownik → ``False``."""
+    return bool(
+        user.is_authenticated
+        and (
+            user.is_superuser
+            or user.groups.filter(name=GR_WPROWADZANIE_DANYCH).exists()
+        )
+    )
+
+
+class WprowadzanieDanychRequiredMixin(LoginRequiredMixin):
+    """Mixin dla CBV: anonim → login redirect; zalogowany-bez-uprawnień → 403.
+
+    Kolejność ma znaczenie: dla anonima delegujemy do ``LoginRequiredMixin``
+    (przekierowanie na login), a dopiero dla zalogowanych, ale bez uprawnień,
+    podnosimy ``PermissionDenied`` (403).
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated and not moze_wprowadzac_dane(request.user):
+            raise PermissionDenied(_KOMUNIKAT)
+        return super().dispatch(request, *args, **kwargs)
+
+
+def wprowadzanie_danych_wymagane(view_func):
+    """Dekorator dla FBV z tą samą semantyką co
+    :class:`WprowadzanieDanychRequiredMixin`."""
+
+    @wraps(view_func)
+    @login_required
+    def _wrapped(request, *args, **kwargs):
+        if not moze_wprowadzac_dane(request.user):
+            raise PermissionDenied(_KOMUNIKAT)
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped
+
+
+def wymagaj_wprowadzania_danych_dla_urlpatterns(urlpatterns):
+    """Owija (rekurencyjnie, in-place) każdy wzorzec URL dekoratorem
+    :func:`wprowadzanie_danych_wymagane`.
+
+    Służy do bramkowania *całej* aplikacji redaktorskiej na poziomie URLconf —
+    dzięki temu każdy nowy widok jest chroniony domyślnie, bez pamiętania o
+    dekoratorze na pojedynczej funkcji. Zwraca tę samą listę (dla wygody
+    ``urlpatterns = wymagaj_...([...])``).
+    """
+    for wzorzec in urlpatterns:
+        if isinstance(wzorzec, URLResolver):
+            wymagaj_wprowadzania_danych_dla_urlpatterns(wzorzec.url_patterns)
+        elif isinstance(wzorzec, URLPattern) and wzorzec.callback is not None:
+            wzorzec.callback = wprowadzanie_danych_wymagane(wzorzec.callback)
+    return urlpatterns

--- a/src/bpp/tests/test_authz_views.py
+++ b/src/bpp/tests/test_authz_views.py
@@ -1,0 +1,87 @@
+"""Regresja bezpieczeństwa dla widoków w aplikacji ``bpp``:
+
+- ``toz`` (klonowanie rekordów) — mutacja tylko przez POST + CSRF, dostęp tylko
+  dla redaktorów; GET już nie mutuje (405),
+- widoki API punktacji/habilitacji/jednostki — dostęp tylko dla redaktorów.
+
+Wcześniej trasy były chronione tylko zalogowaniem (``login_required`` /
+``LoginRequiredMixin``), co pozwalało zwykłemu koncie m.in. nadpisywać
+punktację źródeł i klonować rekordy.
+"""
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.models.wydawnictwo_ciagle import Wydawnictwo_Ciagle
+
+
+@pytest.fixture
+def zwykly_user(db):
+    return baker.make("bpp.BppUser", is_staff=False, is_superuser=False)
+
+
+# --- toz (klonowanie) ----------------------------------------------------
+
+TOZ_URL = "admin_bpp_wydawnictwo_ciagle_toz"
+
+
+@pytest.mark.django_db
+def test_toz_post_klonuje_dla_redaktora(admin_client):
+    """Kontrola pozytywna: POST redaktora klonuje rekord (UX bez zmian)."""
+    c1 = baker.make(Wydawnictwo_Ciagle)
+    url = reverse(TOZ_URL, args=[c1.pk])
+    response = admin_client.post(url)
+    assert response.status_code == 302
+    assert Wydawnictwo_Ciagle.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_toz_get_nie_mutuje_405(admin_client):
+    """GET już NIE klonuje (dawniej mutacja na GET) — 405, zero kopii."""
+    c1 = baker.make(Wydawnictwo_Ciagle)
+    url = reverse(TOZ_URL, args=[c1.pk])
+    response = admin_client.get(url)
+    assert response.status_code == 405
+    assert Wydawnictwo_Ciagle.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_toz_zwykly_user_403(client, zwykly_user):
+    c1 = baker.make(Wydawnictwo_Ciagle)
+    url = reverse(TOZ_URL, args=[c1.pk])
+    client.force_login(zwykly_user)
+    assert client.post(url).status_code == 403
+    assert Wydawnictwo_Ciagle.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_toz_anonim_przekierowuje(client):
+    c1 = baker.make(Wydawnictwo_Ciagle)
+    url = reverse(TOZ_URL, args=[c1.pk])
+    assert client.post(url).status_code == 302
+
+
+# --- API punktacji / habilitacji / jednostki -----------------------------
+
+API_ROUTES = [
+    ("bpp:api_rok_habilitacji", {}),
+    ("bpp:api_punktacja_zrodla", {"zrodlo_id": 1, "rok": 2020}),
+    ("bpp:api_upload_punktacja_zrodla", {"zrodlo_id": 1, "rok": 2020}),
+    ("bpp:api_ostatnia_jednostka_i_dyscyplina", {}),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("name,kwargs", API_ROUTES)
+def test_api_zwykly_user_403(client, zwykly_user, name, kwargs):
+    client.force_login(zwykly_user)
+    url = reverse(name, kwargs=kwargs)
+    assert client.post(url).status_code == 403
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("name,kwargs", API_ROUTES)
+def test_api_anonim_przekierowuje(client, name, kwargs):
+    url = reverse(name, kwargs=kwargs)
+    assert client.post(url).status_code == 302

--- a/src/bpp/tests/test_permissions.py
+++ b/src/bpp/tests/test_permissions.py
@@ -1,0 +1,162 @@
+"""Testy centralnej bramki autoryzacji dla operacji redaktorskich
+(`bpp.permissions`).
+
+Kontrakt:
+- `moze_wprowadzac_dane(user)` — superuser LUB członek grupy
+  ``GR_WPROWADZANIE_DANYCH``; anonim / zwykły użytkownik → False.
+- `WprowadzanieDanychRequiredMixin` i `wprowadzanie_danych_wymagane`:
+  anonim → 302 (login), zalogowany-bez-uprawnień → 403 (PermissionDenied),
+  uprawniony → normalna odpowiedź widoku.
+"""
+
+import pytest
+from django.contrib.auth.models import AnonymousUser, Group
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse
+from django.views import View
+from model_bakery import baker
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+from bpp.permissions import (
+    WprowadzanieDanychRequiredMixin,
+    moze_wprowadzac_dane,
+    wprowadzanie_danych_wymagane,
+    wymagaj_wprowadzania_danych_dla_urlpatterns,
+)
+
+
+@pytest.fixture
+def wprowadzanie_danych_group(db):
+    group, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    return group
+
+
+@pytest.fixture
+def zwykly_user(db):
+    """Zalogowany, ale bez żadnych uprawnień redaktorskich."""
+    return baker.make("bpp.BppUser", is_staff=False, is_superuser=False)
+
+
+@pytest.fixture
+def user_z_grupa(db, wprowadzanie_danych_group):
+    user = baker.make("bpp.BppUser", is_staff=True, is_superuser=False)
+    user.groups.add(wprowadzanie_danych_group)
+    return user
+
+
+@pytest.fixture
+def superuser(db):
+    return baker.make("bpp.BppUser", is_staff=True, is_superuser=True)
+
+
+# --- moze_wprowadzac_dane ------------------------------------------------
+
+
+def test_moze_wprowadzac_dane_anonim_odmawia():
+    assert moze_wprowadzac_dane(AnonymousUser()) is False
+
+
+def test_moze_wprowadzac_dane_zwykly_user_odmawia(zwykly_user):
+    assert moze_wprowadzac_dane(zwykly_user) is False
+
+
+def test_moze_wprowadzac_dane_grupa_przepuszcza(user_z_grupa):
+    assert moze_wprowadzac_dane(user_z_grupa) is True
+
+
+def test_moze_wprowadzac_dane_superuser_przepuszcza(superuser):
+    assert moze_wprowadzac_dane(superuser) is True
+
+
+# --- dekorator FBV -------------------------------------------------------
+
+
+def _widok_fbv(request):
+    return HttpResponse("ok")
+
+
+def test_dekorator_anonim_przekierowuje_na_login(rf):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+    response = wprowadzanie_danych_wymagane(_widok_fbv)(request)
+    assert response.status_code == 302
+
+
+def test_dekorator_zwykly_user_403(rf, zwykly_user):
+    request = rf.get("/")
+    request.user = zwykly_user
+    with pytest.raises(PermissionDenied):
+        wprowadzanie_danych_wymagane(_widok_fbv)(request)
+
+
+def test_dekorator_grupa_przepuszcza(rf, user_z_grupa):
+    request = rf.get("/")
+    request.user = user_z_grupa
+    response = wprowadzanie_danych_wymagane(_widok_fbv)(request)
+    assert response.status_code == 200
+
+
+def test_dekorator_superuser_przepuszcza(rf, superuser):
+    request = rf.get("/")
+    request.user = superuser
+    response = wprowadzanie_danych_wymagane(_widok_fbv)(request)
+    assert response.status_code == 200
+
+
+# --- mixin CBV -----------------------------------------------------------
+
+
+class _WidokCBV(WprowadzanieDanychRequiredMixin, View):
+    def get(self, request, *args, **kwargs):
+        return HttpResponse("ok")
+
+
+def test_mixin_anonim_przekierowuje_na_login(rf):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+    response = _WidokCBV.as_view()(request)
+    assert response.status_code == 302
+
+
+def test_mixin_zwykly_user_403(rf, zwykly_user):
+    request = rf.get("/")
+    request.user = zwykly_user
+    with pytest.raises(PermissionDenied):
+        _WidokCBV.as_view()(request)
+
+
+def test_mixin_grupa_przepuszcza(rf, user_z_grupa):
+    request = rf.get("/")
+    request.user = user_z_grupa
+    response = _WidokCBV.as_view()(request)
+    assert response.status_code == 200
+
+
+def test_mixin_superuser_przepuszcza(rf, superuser):
+    request = rf.get("/")
+    request.user = superuser
+    response = _WidokCBV.as_view()(request)
+    assert response.status_code == 200
+
+
+# --- owijanie całego URLconf-a (bramkowanie aplikacji) -------------------
+
+
+def test_wrapper_owija_kazdy_wzorzec(rf, zwykly_user, superuser):
+    """`wymagaj_wprowadzania_danych_dla_urlpatterns` bramkuje każdy widok
+    listy URL — zwykły user → 403, uprawniony → normalna odpowiedź."""
+    from django.urls import path
+
+    patterns = wymagaj_wprowadzania_danych_dla_urlpatterns(
+        [path("x/", _widok_fbv, name="x")]
+    )
+    callback = patterns[0].callback
+
+    request = rf.get("/x/")
+    request.user = zwykly_user
+    with pytest.raises(PermissionDenied):
+        callback(request)
+
+    request = rf.get("/x/")
+    request.user = superuser
+    assert callback(request).status_code == 200

--- a/src/bpp/tests/test_playwright/test_admin/test_toz_tamze.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_toz_tamze.py
@@ -122,10 +122,11 @@ def test_admin_wydawnictwo_zwarte_toz(live_server, admin_page: Page):
 
     admin_page.on("dialog", handle_dialog)
 
-    # #toz: dialog confirm → location.href="../../toz/<pk>" → widok tworzy
-    # kopię (commit) i przekierowuje na change-form kopii. Blokujemy do
-    # zakończenia tej nawigacji, żeby GET/toz + insert + redirect + finalny
-    # GET zdążyły się dokończyć ZANIM czytamy bazę i ZANIM teardown truncuje.
+    # #toz: dialog confirm → POST na ../../toz/<pk>/ (ukryty formularz + CSRF)
+    # → widok tworzy kopię (commit) i przekierowuje na change-form kopii.
+    # Blokujemy do zakończenia tej nawigacji, żeby POST/toz + insert + redirect
+    # + finalny GET zdążyły się dokończyć ZANIM czytamy bazę i ZANIM teardown
+    # truncuje.
     with admin_page.expect_navigation(wait_until="domcontentloaded"):
         admin_page.click("#toz")
 
@@ -171,10 +172,11 @@ def test_admin_wydawnictwo_ciagle_toz(live_server, admin_page: Page):
 
     admin_page.on("dialog", handle_dialog)
 
-    # #toz: dialog confirm → location.href="../../toz/<pk>" → widok tworzy
-    # kopię (commit) i przekierowuje na change-form kopii. Blokujemy do
-    # zakończenia tej nawigacji, żeby GET/toz + insert + redirect + finalny
-    # GET zdążyły się dokończyć ZANIM czytamy bazę i ZANIM teardown truncuje.
+    # #toz: dialog confirm → POST na ../../toz/<pk>/ (ukryty formularz + CSRF)
+    # → widok tworzy kopię (commit) i przekierowuje na change-form kopii.
+    # Blokujemy do zakończenia tej nawigacji, żeby POST/toz + insert + redirect
+    # + finalny GET zdążyły się dokończyć ZANIM czytamy bazę i ZANIM teardown
+    # truncuje.
     with admin_page.expect_navigation(wait_until="domcontentloaded"):
         admin_page.click("#toz")
 
@@ -211,10 +213,11 @@ def test_admin_patent_toz(live_server, admin_page: Page):
 
     admin_page.on("dialog", handle_dialog)
 
-    # #toz: dialog confirm → location.href="../../toz/<pk>" → widok tworzy
-    # kopię (commit) i przekierowuje na change-form kopii. Blokujemy do
-    # zakończenia tej nawigacji, żeby GET/toz + insert + redirect + finalny
-    # GET zdążyły się dokończyć ZANIM czytamy bazę i ZANIM teardown truncuje.
+    # #toz: dialog confirm → POST na ../../toz/<pk>/ (ukryty formularz + CSRF)
+    # → widok tworzy kopię (commit) i przekierowuje na change-form kopii.
+    # Blokujemy do zakończenia tej nawigacji, żeby POST/toz + insert + redirect
+    # + finalny GET zdążyły się dokończyć ZANIM czytamy bazę i ZANIM teardown
+    # truncuje.
     with admin_page.expect_navigation(wait_until="domcontentloaded"):
         admin_page.click("#toz")
 

--- a/src/bpp/views/admin.py
+++ b/src/bpp/views/admin.py
@@ -6,15 +6,26 @@ except ImportError:
     from django.urls import reverse
 
 from django.db import transaction
+from django.http import HttpResponseRedirect
 from django.http.response import Http404
-from django.views.generic import RedirectView
+from django.views import View
 
 from bpp.models.patent import Patent, Patent_Autor
 from bpp.models.wydawnictwo_ciagle import Wydawnictwo_Ciagle, Wydawnictwo_Ciagle_Autor
 from bpp.models.wydawnictwo_zwarte import Wydawnictwo_Zwarte, Wydawnictwo_Zwarte_Autor
+from bpp.permissions import WprowadzanieDanychRequiredMixin
 
 
-class TozView(RedirectView):
+class TozView(WprowadzanieDanychRequiredMixin, View):
+    """Tworzy kopię ("Toż") rekordu wraz z przypisaniami autorów.
+
+    Mutacja wykonywana WYŁĄCZNIE przez POST + CSRF. Wcześniej klonowanie
+    działało na GET (``RedirectView``), co łamało kontrakt „GET jest
+    bezpieczny": rekord dało się sklonować samą nawigacją/linkiem/prefetchem
+    i bez ochrony CSRF. Dostęp ograniczony do redaktorów (grupa „wprowadzanie
+    danych" lub superuser) — patrz ``WprowadzanieDanychRequiredMixin``.
+    """
+
     @transaction.atomic
     def get_redirect_url(self, pk):
         try:
@@ -40,6 +51,9 @@ class TozView(RedirectView):
             wca_copy.save()
 
         return reverse(f"admin:bpp_{self.klass_name}_change", args=(w_copy.pk,))
+
+    def post(self, request, pk):
+        return HttpResponseRedirect(self.get_redirect_url(pk))
 
 
 class WydawnictwoCiagleTozView(TozView):

--- a/src/bpp/views/api/__init__.py
+++ b/src/bpp/views/api/__init__.py
@@ -1,6 +1,5 @@
 from decimal import Decimal, InvalidOperation
 
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import models, transaction
 from django.http import JsonResponse
 from django.http.response import HttpResponseNotFound
@@ -10,6 +9,7 @@ from bpp.models import Autor, Autor_Dyscyplina, Uczelnia, Zrodlo
 from bpp.models.abstract import POLA_PUNKTACJI
 from bpp.models.praca_habilitacyjna import Praca_Habilitacyjna
 from bpp.models.zrodlo import Punktacja_Zrodla
+from bpp.permissions import WprowadzanieDanychRequiredMixin
 
 # Pola punktacji będące liczbami dziesiętnymi (DecimalField). Bibliotekarze
 # w Polsce naturalnie wpisują je z przecinkiem dziesiętnym ("3,2"), a
@@ -23,7 +23,7 @@ POLA_DZIESIETNE = frozenset(
 )
 
 
-class RokHabilitacjiView(LoginRequiredMixin, View):
+class RokHabilitacjiView(WprowadzanieDanychRequiredMixin, View):
     def post(self, request, *args, **kw):
         try:
             autor = Autor.objects.get(pk=int(request.POST.get("autor_pk")))
@@ -38,7 +38,7 @@ class RokHabilitacjiView(LoginRequiredMixin, View):
         return JsonResponse({"rok": habilitacja.rok})
 
 
-class PunktacjaZrodlaView(LoginRequiredMixin, View):
+class PunktacjaZrodlaView(WprowadzanieDanychRequiredMixin, View):
     def post(self, request, zrodlo_id, rok, *args, **kw):
         try:
             z = Zrodlo.objects.get(pk=zrodlo_id)
@@ -55,7 +55,7 @@ class PunktacjaZrodlaView(LoginRequiredMixin, View):
         return JsonResponse(d)
 
 
-class UploadPunktacjaZrodlaView(LoginRequiredMixin, View):
+class UploadPunktacjaZrodlaView(WprowadzanieDanychRequiredMixin, View):
     def ok(self):
         return JsonResponse({"result": "ok"})
 
@@ -154,7 +154,7 @@ def ostatnia_dyscyplina(request, a, rok):
             return ad.dyscyplina_naukowa or ad.subdyscyplina_naukowa
 
 
-class OstatniaJednostkaIDyscyplinaView(LoginRequiredMixin, View):
+class OstatniaJednostkaIDyscyplinaView(WprowadzanieDanychRequiredMixin, View):
     """Zwraca jako JSON ostatnią jednostkę danego autora oraz ewentualnie jego
     dyscyplinę naukową, w sytuacji gdy jest ona jedna i określona na dany rok.
     """

--- a/src/django_bpp/templates/admin/bpp/patent/change_form.html
+++ b/src/django_bpp/templates/admin/bpp/patent/change_form.html
@@ -43,20 +43,23 @@
                 $("#toz").click(function () {
                     if (confirm('Utworzysz kopię tego rekordu. Czy kontynuować?')) {
                         // Klonowanie to mutacja — POST + token CSRF (dawniej
-                        // GET-nawigacja). Budujemy i submitujemy ukryty formularz:
-                        // przeglądarka nawiguje jak przy location.href, a serwer
-                        // zwraca redirect na świeżą kopię. Ten sam UX, zero klików.
-                        var $tozForm = $("<form/>")
-                            .attr("method", "post")
-                            // Ukośnik na końcu jest wymagany: wzorzec URL to
-                            // toz/<pk>/ , a APPEND_SLASH nie przekieruje POST-a
-                            // (zgubiłby ciało) — bez ukośnika byłoby 404.
-                            .attr("action", "../../toz/" + pub_id + "/");
-                        $tozForm.append($("<input/>")
-                            .attr("type", "hidden")
-                            .attr("name", "csrfmiddlewaretoken")
-                            .val($("input[name=csrfmiddlewaretoken]").val()));
-                        $tozForm.appendTo("body").submit();
+                        // GET-nawigacja). Formularz budujemy natywnym DOM (nie
+                        // jQuery-z-HTML-stringa), a submit nawiguje jak
+                        // location.href; serwer zwraca redirect na świeżą kopię.
+                        // Ten sam UX, zero dodatkowych kliknięć.
+                        // Ukośnik na końcu wymagany: wzorzec to toz/<pk>/, a
+                        // APPEND_SLASH nie przekieruje POST-a (zgubiłby ciało).
+                        var tozForm = document.createElement("form");
+                        tozForm.method = "post";
+                        tozForm.action = "../../toz/" + pub_id + "/";
+                        var tozCsrf = document.createElement("input");
+                        tozCsrf.type = "hidden";
+                        tozCsrf.name = "csrfmiddlewaretoken";
+                        tozCsrf.value = document.querySelector(
+                            "input[name=csrfmiddlewaretoken]").value;
+                        tozForm.appendChild(tozCsrf);
+                        document.body.appendChild(tozForm);
+                        tozForm.submit();
                     }
                 });
             }

--- a/src/django_bpp/templates/admin/bpp/patent/change_form.html
+++ b/src/django_bpp/templates/admin/bpp/patent/change_form.html
@@ -42,7 +42,21 @@
 
                 $("#toz").click(function () {
                     if (confirm('Utworzysz kopię tego rekordu. Czy kontynuować?')) {
-                        location.href = "../../toz/" + pub_id;
+                        // Klonowanie to mutacja — POST + token CSRF (dawniej
+                        // GET-nawigacja). Budujemy i submitujemy ukryty formularz:
+                        // przeglądarka nawiguje jak przy location.href, a serwer
+                        // zwraca redirect na świeżą kopię. Ten sam UX, zero klików.
+                        var $tozForm = $("<form/>")
+                            .attr("method", "post")
+                            // Ukośnik na końcu jest wymagany: wzorzec URL to
+                            // toz/<pk>/ , a APPEND_SLASH nie przekieruje POST-a
+                            // (zgubiłby ciało) — bez ukośnika byłoby 404.
+                            .attr("action", "../../toz/" + pub_id + "/");
+                        $tozForm.append($("<input/>")
+                            .attr("type", "hidden")
+                            .attr("name", "csrfmiddlewaretoken")
+                            .val($("input[name=csrfmiddlewaretoken]").val()));
+                        $tozForm.appendTo("body").submit();
                     }
                 });
             }

--- a/src/django_bpp/templates/admin/bpp/patent/change_form.html
+++ b/src/django_bpp/templates/admin/bpp/patent/change_form.html
@@ -51,7 +51,10 @@
                         // APPEND_SLASH nie przekieruje POST-a (zgubiłby ciało).
                         var tozForm = document.createElement("form");
                         tozForm.method = "post";
-                        tozForm.action = "../../toz/" + pub_id + "/";
+                        // pub_id to PK (liczba). parseInt sanitizuje wartość
+                        // czytaną z DOM (.val()), żeby nie przenosiła meta-znaków
+                        // do URL-a — usuwa CodeQL js/xss-through-dom u źródła.
+                        tozForm.action = "../../toz/" + parseInt(pub_id, 10) + "/";
                         var tozCsrf = document.createElement("input");
                         tozCsrf.type = "hidden";
                         tozCsrf.name = "csrfmiddlewaretoken";

--- a/src/django_bpp/templates/admin/bpp/wydawnictwo_ciagle/change_form.html
+++ b/src/django_bpp/templates/admin/bpp/wydawnictwo_ciagle/change_form.html
@@ -109,7 +109,21 @@
                     if (confirm('Utworzysz kopię tego rekordu. Czy kontynuować?')) {
                         window.onbeforeunload = function (e) {
                         };
-                        location.href = "../../toz/" + pub_id;
+                        // Klonowanie to mutacja — POST + token CSRF (dawniej
+                        // GET-nawigacja). Budujemy i submitujemy ukryty formularz:
+                        // przeglądarka nawiguje jak przy location.href, a serwer
+                        // zwraca redirect na świeżą kopię. Ten sam UX, zero klików.
+                        var $tozForm = $("<form/>")
+                            .attr("method", "post")
+                            // Ukośnik na końcu jest wymagany: wzorzec URL to
+                            // toz/<pk>/ , a APPEND_SLASH nie przekieruje POST-a
+                            // (zgubiłby ciało) — bez ukośnika byłoby 404.
+                            .attr("action", "../../toz/" + pub_id + "/");
+                        $tozForm.append($("<input/>")
+                            .attr("type", "hidden")
+                            .attr("name", "csrfmiddlewaretoken")
+                            .val($("input[name=csrfmiddlewaretoken]").val()));
+                        $tozForm.appendTo("body").submit();
                     }
                 });
             }

--- a/src/django_bpp/templates/admin/bpp/wydawnictwo_ciagle/change_form.html
+++ b/src/django_bpp/templates/admin/bpp/wydawnictwo_ciagle/change_form.html
@@ -118,7 +118,10 @@
                         // APPEND_SLASH nie przekieruje POST-a (zgubiłby ciało).
                         var tozForm = document.createElement("form");
                         tozForm.method = "post";
-                        tozForm.action = "../../toz/" + pub_id + "/";
+                        // pub_id to PK (liczba). parseInt sanitizuje wartość
+                        // czytaną z DOM (.val()), żeby nie przenosiła meta-znaków
+                        // do URL-a — usuwa CodeQL js/xss-through-dom u źródła.
+                        tozForm.action = "../../toz/" + parseInt(pub_id, 10) + "/";
                         var tozCsrf = document.createElement("input");
                         tozCsrf.type = "hidden";
                         tozCsrf.name = "csrfmiddlewaretoken";

--- a/src/django_bpp/templates/admin/bpp/wydawnictwo_ciagle/change_form.html
+++ b/src/django_bpp/templates/admin/bpp/wydawnictwo_ciagle/change_form.html
@@ -110,20 +110,23 @@
                         window.onbeforeunload = function (e) {
                         };
                         // Klonowanie to mutacja — POST + token CSRF (dawniej
-                        // GET-nawigacja). Budujemy i submitujemy ukryty formularz:
-                        // przeglądarka nawiguje jak przy location.href, a serwer
-                        // zwraca redirect na świeżą kopię. Ten sam UX, zero klików.
-                        var $tozForm = $("<form/>")
-                            .attr("method", "post")
-                            // Ukośnik na końcu jest wymagany: wzorzec URL to
-                            // toz/<pk>/ , a APPEND_SLASH nie przekieruje POST-a
-                            // (zgubiłby ciało) — bez ukośnika byłoby 404.
-                            .attr("action", "../../toz/" + pub_id + "/");
-                        $tozForm.append($("<input/>")
-                            .attr("type", "hidden")
-                            .attr("name", "csrfmiddlewaretoken")
-                            .val($("input[name=csrfmiddlewaretoken]").val()));
-                        $tozForm.appendTo("body").submit();
+                        // GET-nawigacja). Formularz budujemy natywnym DOM (nie
+                        // jQuery-z-HTML-stringa), a submit nawiguje jak
+                        // location.href; serwer zwraca redirect na świeżą kopię.
+                        // Ten sam UX, zero dodatkowych kliknięć.
+                        // Ukośnik na końcu wymagany: wzorzec to toz/<pk>/, a
+                        // APPEND_SLASH nie przekieruje POST-a (zgubiłby ciało).
+                        var tozForm = document.createElement("form");
+                        tozForm.method = "post";
+                        tozForm.action = "../../toz/" + pub_id + "/";
+                        var tozCsrf = document.createElement("input");
+                        tozCsrf.type = "hidden";
+                        tozCsrf.name = "csrfmiddlewaretoken";
+                        tozCsrf.value = document.querySelector(
+                            "input[name=csrfmiddlewaretoken]").value;
+                        tozForm.appendChild(tozCsrf);
+                        document.body.appendChild(tozForm);
+                        tozForm.submit();
                     }
                 });
             }

--- a/src/django_bpp/templates/admin/bpp/wydawnictwo_zwarte/change_form.html
+++ b/src/django_bpp/templates/admin/bpp/wydawnictwo_zwarte/change_form.html
@@ -112,20 +112,23 @@
                         window.onbeforeunload = function (e) {
                         };
                         // Klonowanie to mutacja — POST + token CSRF (dawniej
-                        // GET-nawigacja). Budujemy i submitujemy ukryty formularz:
-                        // przeglądarka nawiguje jak przy location.href, a serwer
-                        // zwraca redirect na świeżą kopię. Ten sam UX, zero klików.
-                        var $tozForm = $("<form/>")
-                            .attr("method", "post")
-                            // Ukośnik na końcu jest wymagany: wzorzec URL to
-                            // toz/<pk>/ , a APPEND_SLASH nie przekieruje POST-a
-                            // (zgubiłby ciało) — bez ukośnika byłoby 404.
-                            .attr("action", "../../toz/" + pub_id + "/");
-                        $tozForm.append($("<input/>")
-                            .attr("type", "hidden")
-                            .attr("name", "csrfmiddlewaretoken")
-                            .val($("input[name=csrfmiddlewaretoken]").val()));
-                        $tozForm.appendTo("body").submit();
+                        // GET-nawigacja). Formularz budujemy natywnym DOM (nie
+                        // jQuery-z-HTML-stringa), a submit nawiguje jak
+                        // location.href; serwer zwraca redirect na świeżą kopię.
+                        // Ten sam UX, zero dodatkowych kliknięć.
+                        // Ukośnik na końcu wymagany: wzorzec to toz/<pk>/, a
+                        // APPEND_SLASH nie przekieruje POST-a (zgubiłby ciało).
+                        var tozForm = document.createElement("form");
+                        tozForm.method = "post";
+                        tozForm.action = "../../toz/" + pub_id + "/";
+                        var tozCsrf = document.createElement("input");
+                        tozCsrf.type = "hidden";
+                        tozCsrf.name = "csrfmiddlewaretoken";
+                        tozCsrf.value = document.querySelector(
+                            "input[name=csrfmiddlewaretoken]").value;
+                        tozForm.appendChild(tozCsrf);
+                        document.body.appendChild(tozForm);
+                        tozForm.submit();
                     }
                 });
             }

--- a/src/django_bpp/templates/admin/bpp/wydawnictwo_zwarte/change_form.html
+++ b/src/django_bpp/templates/admin/bpp/wydawnictwo_zwarte/change_form.html
@@ -111,7 +111,21 @@
                     if (confirm('Utworzysz kopię tego rekordu. Czy kontynuować?')) {
                         window.onbeforeunload = function (e) {
                         };
-                        location.href = "../../toz/" + pub_id;
+                        // Klonowanie to mutacja — POST + token CSRF (dawniej
+                        // GET-nawigacja). Budujemy i submitujemy ukryty formularz:
+                        // przeglądarka nawiguje jak przy location.href, a serwer
+                        // zwraca redirect na świeżą kopię. Ten sam UX, zero klików.
+                        var $tozForm = $("<form/>")
+                            .attr("method", "post")
+                            // Ukośnik na końcu jest wymagany: wzorzec URL to
+                            // toz/<pk>/ , a APPEND_SLASH nie przekieruje POST-a
+                            // (zgubiłby ciało) — bez ukośnika byłoby 404.
+                            .attr("action", "../../toz/" + pub_id + "/");
+                        $tozForm.append($("<input/>")
+                            .attr("type", "hidden")
+                            .attr("name", "csrfmiddlewaretoken")
+                            .val($("input[name=csrfmiddlewaretoken]").val()));
+                        $tozForm.appendTo("body").submit();
                     }
                 });
             }

--- a/src/django_bpp/templates/admin/bpp/wydawnictwo_zwarte/change_form.html
+++ b/src/django_bpp/templates/admin/bpp/wydawnictwo_zwarte/change_form.html
@@ -120,7 +120,10 @@
                         // APPEND_SLASH nie przekieruje POST-a (zgubiłby ciało).
                         var tozForm = document.createElement("form");
                         tozForm.method = "post";
-                        tozForm.action = "../../toz/" + pub_id + "/";
+                        // pub_id to PK (liczba). parseInt sanitizuje wartość
+                        // czytaną z DOM (.val()), żeby nie przenosiła meta-znaków
+                        // do URL-a — usuwa CodeQL js/xss-through-dom u źródła.
+                        tozForm.action = "../../toz/" + parseInt(pub_id, 10) + "/";
                         var tozCsrf = document.createElement("input");
                         tozCsrf.type = "hidden";
                         tozCsrf.name = "csrfmiddlewaretoken";

--- a/src/django_bpp/urls.py
+++ b/src/django_bpp/urls.py
@@ -65,18 +65,20 @@ urlpatterns = (
         path("test_exception/", login_required(test_exception_view)),
         path("tinymce/", include("tinymce.urls")),
         url(
+            # Auth (redaktor + POST/CSRF) egzekwuje WprowadzanieDanychRequiredMixin
+            # w samym TozView — bez owijki login_required (dawniej GET-mutacja).
             r"^admin/bpp/wydawnictwo_ciagle/toz/(?P<pk>[\d]+)/$",
-            login_required(WydawnictwoCiagleTozView.as_view()),
+            WydawnictwoCiagleTozView.as_view(),
             name="admin_bpp_wydawnictwo_ciagle_toz",
         ),
         url(
             r"^admin/bpp/wydawnictwo_zwarte/toz/(?P<pk>[\d]+)/$",
-            login_required(WydawnictwoZwarteTozView.as_view()),
+            WydawnictwoZwarteTozView.as_view(),
             name="admin_bpp_wydawnictwo_zwarte_toz",
         ),
         url(
             r"^admin/bpp/patent/toz/(?P<pk>[\d]+)/$",
-            login_required(PatentTozView.as_view()),
+            PatentTozView.as_view(),
             name="admin_bpp_patent_toz",
         ),
         # url(r'^admin/', include(admin.site.urls)),

--- a/src/ewaluacja_metryki/views/mixins.py
+++ b/src/ewaluacja_metryki/views/mixins.py
@@ -3,13 +3,16 @@ from django.contrib.auth.mixins import (
     UserPassesTestMixin,
 )
 
-from bpp.const import GR_WPROWADZANIE_DANYCH
+from bpp.permissions import moze_wprowadzac_dane
 
 
 def ma_pelne_uprawnienia_ewaluacji(user):
     """Sprawdza czy użytkownik ma pełne uprawnienia do ewaluacji
-    (superuser lub grupa wprowadzania danych)."""
-    return user.is_superuser or user.groups.filter(name=GR_WPROWADZANIE_DANYCH).exists()
+    (superuser lub grupa wprowadzania danych).
+
+    Deleguje do centralnej bramki ``bpp.permissions.moze_wprowadzac_dane``
+    — jedno źródło prawdy dla „pełnych uprawnień redaktorskich"."""
+    return moze_wprowadzac_dane(user)
 
 
 def ma_uprawnienia_ewaluacji(user):

--- a/src/ewaluacja_optymalizacja/tests/test_authz.py
+++ b/src/ewaluacja_optymalizacja/tests/test_authz.py
@@ -1,0 +1,40 @@
+"""Regresja bezpieczeństwa: CAŁA aplikacja ``ewaluacja_optymalizacja`` to
+narzędzie redaktorskie — każdy widok wymaga uprawnień „wprowadzanie danych".
+
+Bramka jest nałożona na poziomie URLconf
+(``wymagaj_wprowadzania_danych_dla_urlpatterns``), więc test sprawdza
+reprezentatywny zestaw tras (w tym mutujące: analiza odpinania, toggle-pin).
+Wcześniej widoki miały tylko ``@login_required``.
+"""
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+
+ROUTES = [
+    ("ewaluacja_optymalizacja:index", {}),
+    ("ewaluacja_optymalizacja:analyze-unpinning", {}),
+    ("ewaluacja_optymalizacja:unpinning-list", {}),
+    ("ewaluacja_optymalizacja:browser-toggle-pin", {"model_type": "ciagle", "pk": 1}),
+]
+
+
+@pytest.fixture
+def zwykly_user(db):
+    return baker.make("bpp.BppUser", is_staff=False, is_superuser=False)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("name,kwargs", ROUTES)
+def test_zwykly_user_dostaje_403(client, zwykly_user, name, kwargs):
+    client.force_login(zwykly_user)
+    url = reverse(name, kwargs=kwargs)
+    assert client.get(url).status_code == 403
+    assert client.post(url).status_code == 403
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("name,kwargs", ROUTES)
+def test_anonim_przekierowuje_na_login(client, name, kwargs):
+    url = reverse(name, kwargs=kwargs)
+    assert client.get(url).status_code == 302

--- a/src/ewaluacja_optymalizacja/urls.py
+++ b/src/ewaluacja_optymalizacja/urls.py
@@ -1,5 +1,7 @@
 from django.urls import path
 
+from bpp.permissions import wymagaj_wprowadzania_danych_dla_urlpatterns
+
 from . import views
 
 app_name = "ewaluacja_optymalizacja"
@@ -216,3 +218,11 @@ urlpatterns = [
         name="browser-recalc-status",
     ),
 ]
+
+# Cała aplikacja to narzędzie redaktorskie (analiza/optymalizacja ewaluacji) —
+# bramkujemy KAŻDY widok wymaganiem uprawnień „wprowadzanie danych" na poziomie
+# URLconf. Dzięki temu nowe widoki są chronione domyślnie, bez pamiętania o
+# dekoratorze. Wcześniej widoki miały tylko @login_required (samo zalogowanie),
+# co pozwalało zwykłemu koncie m.in. na masowe odpinanie prac czy kasowanie
+# metryk.
+wymagaj_wprowadzania_danych_dla_urlpatterns(urlpatterns)

--- a/src/ewaluacja_optymalizuj_publikacje/tests/test_authz.py
+++ b/src/ewaluacja_optymalizuj_publikacje/tests/test_authz.py
@@ -1,0 +1,33 @@
+"""Regresja bezpieczeństwa: widoki optymalizacji publikacji
+(przypinanie/odpinanie/zmiana dyscyplin) wymagają uprawnień redaktorskich.
+Wcześniej używały ``LoginRequiredMixin`` (samo zalogowanie).
+"""
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+
+
+@pytest.fixture
+def zwykly_user(db):
+    return baker.make("bpp.BppUser", is_staff=False, is_superuser=False)
+
+
+@pytest.mark.django_db
+def test_zwykly_user_dostaje_403(client, zwykly_user):
+    client.force_login(zwykly_user)
+    url = reverse("ewaluacja_optymalizuj_publikacje:index")
+    assert client.get(url).status_code == 403
+
+
+@pytest.mark.django_db
+def test_anonim_przekierowuje_na_login(client):
+    url = reverse("ewaluacja_optymalizuj_publikacje:index")
+    assert client.get(url).status_code == 302
+
+
+@pytest.mark.django_db
+def test_redaktor_ma_dostep(admin_client):
+    """Kontrola pozytywna: redaktor (superuser) przechodzi bramkę."""
+    url = reverse("ewaluacja_optymalizuj_publikacje:index")
+    assert admin_client.get(url).status_code != 403

--- a/src/ewaluacja_optymalizuj_publikacje/views.py
+++ b/src/ewaluacja_optymalizuj_publikacje/views.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import View
@@ -11,6 +10,7 @@ from bpp.models import (
     Rekord,
 )
 from bpp.models.sloty.core import CannotAdapt, IPunktacjaCacher, ISlot
+from bpp.permissions import WprowadzanieDanychRequiredMixin
 from ewaluacja_metryki.models import MetrykaAutora
 from ewaluacja_metryki.utils import przelicz_metryki_dla_publikacji
 
@@ -18,7 +18,7 @@ from .forms import OptymalizacjaForm
 from .models import OptymalizacjaPublikacji
 
 
-class OptymalizujPublikacjeView(LoginRequiredMixin, View):
+class OptymalizujPublikacjeView(WprowadzanieDanychRequiredMixin, View):
     """Main view for optimizing a single publication"""
 
     template_name = "ewaluacja_optymalizuj_publikacje/optymalizuj_fixed.html"
@@ -473,7 +473,7 @@ class OptymalizujPublikacjeView(LoginRequiredMixin, View):
         ]
 
 
-class HistoriaOptymalizacjiView(LoginRequiredMixin, View):
+class HistoriaOptymalizacjiView(WprowadzanieDanychRequiredMixin, View):
     """View optimization history"""
 
     template_name = "ewaluacja_optymalizuj_publikacje/historia.html"

--- a/src/przemapuj_zrodla_pbn/tests/conftest.py
+++ b/src/przemapuj_zrodla_pbn/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from django.contrib.auth.models import Group
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
+
+
+@pytest.fixture
+def redaktor(django_user_model):
+    """Użytkownik z uprawnieniami redaktorskimi (grupa „wprowadzanie danych").
+
+    Widoki tej aplikacji mutują dane globalne (usuwanie/przemapowanie źródeł),
+    więc wymagają uprawnień redaktorskich — samo zalogowanie nie wystarcza.
+    """
+    user = django_user_model.objects.create(username="redaktor-przemapuj")
+    grupa, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+    user.groups.add(grupa)
+    return user

--- a/src/przemapuj_zrodla_pbn/tests/test_authz.py
+++ b/src/przemapuj_zrodla_pbn/tests/test_authz.py
@@ -1,0 +1,48 @@
+"""Regresja bezpieczeństwa: widoki przemapowania/usuwania źródeł mutują dane
+globalne, więc wymagają uprawnień redaktorskich (grupa „wprowadzanie danych"
+lub superuser). Zwykłe zalogowane konto NIE może ich wywołać.
+
+Wcześniej trasy były chronione tylko ``@login_required`` — zwykły użytkownik
+skutecznie usuwał źródło (patrz historia ``test_views_actions.py``).
+"""
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+
+ROUTES = [
+    ("przemapuj_zrodla_pbn:lista_skasowanych_zrodel", {}),
+    ("przemapuj_zrodla_pbn:przemapuj_zrodlo", {"zrodlo_id": 1}),
+    ("przemapuj_zrodla_pbn:usun_zrodlo", {"zrodlo_id": 1}),
+]
+
+
+@pytest.fixture
+def zwykly_user(db):
+    return baker.make("bpp.BppUser", is_staff=False, is_superuser=False)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("name,kwargs", ROUTES)
+def test_zwykly_user_dostaje_403(client, zwykly_user, name, kwargs):
+    client.force_login(zwykly_user)
+    url = reverse(name, kwargs=kwargs)
+    assert client.get(url).status_code == 403
+    assert client.post(url).status_code == 403
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("name,kwargs", ROUTES)
+def test_anonim_przekierowuje_na_login(client, name, kwargs):
+    url = reverse(name, kwargs=kwargs)
+    response = client.get(url)
+    assert response.status_code == 302
+    assert "/accounts/login/" in response.url
+
+
+@pytest.mark.django_db
+def test_redaktor_ma_dostep(client, redaktor):
+    """Kontrola pozytywna: redaktor przechodzi bramkę (widok listy → 200)."""
+    url = reverse("przemapuj_zrodla_pbn:lista_skasowanych_zrodel")
+    client.force_login(redaktor)
+    assert client.get(url).status_code == 200

--- a/src/przemapuj_zrodla_pbn/tests/test_enqueue_uczelnia.py
+++ b/src/przemapuj_zrodla_pbn/tests/test_enqueue_uczelnia.py
@@ -11,9 +11,11 @@ przekazuje uczelnię (a nie tylko że manager kolejki ją wspiera).
 """
 
 import pytest
+from django.contrib.auth.models import Group
 from django.urls import reverse
 from model_bakery import baker
 
+from bpp.const import GR_WPROWADZANIE_DANYCH
 from pbn_export_queue.models import PBN_Export_Queue
 
 
@@ -24,6 +26,7 @@ def test_przemapuj_zrodlo_enqueue_sets_uczelnia_from_request(
     settings.ALLOWED_HOSTS = ["*"]
 
     user = baker.make("bpp.BppUser")
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     journal_deleted = baker.make(

--- a/src/przemapuj_zrodla_pbn/tests/test_przemapuj_zrodlo_characterization.py
+++ b/src/przemapuj_zrodla_pbn/tests/test_przemapuj_zrodlo_characterization.py
@@ -7,9 +7,11 @@ PRZED refaktoryzacją.
 """
 
 import pytest
+from django.contrib.auth.models import Group
 from django.urls import reverse
 from model_bakery import baker
 
+from bpp.const import GR_WPROWADZANIE_DANYCH
 from bpp.models import Wydawnictwo_Ciagle, Zrodlo
 from przemapuj_zrodla_pbn.models import PrzeMapowanieZrodla
 
@@ -29,6 +31,7 @@ def _make_journal(**kwargs):
 @pytest.mark.django_db
 def test_view_odrzuca_zrodlo_ktore_nie_jest_deleted(client, django_user_model):
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     journal_active = _make_journal(status="ACTIVE", title="Aktywne")
@@ -46,6 +49,7 @@ def test_view_odrzuca_zrodlo_ktore_nie_jest_deleted(client, django_user_model):
 @pytest.mark.django_db
 def test_confirm_przemapowanie_na_istniejace_zrodlo(client, django_user_model):
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     journal_deleted = _make_journal(status="DELETED", title="Stara", issn="1234-5678")
@@ -95,6 +99,7 @@ def test_confirm_przemapowanie_na_istniejace_zrodlo(client, django_user_model):
 @pytest.mark.django_db
 def test_confirm_przemapowanie_na_journal_tworzy_nowe_zrodlo(client, django_user_model):
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     # Rodzaj "czasopismo" jest wymagany przez ścieżkę journal.
@@ -148,6 +153,7 @@ def test_confirm_cel_skasowany_jest_poza_sugestiami_wiec_formularz_niewalidny(
     # i widok renderuje stronę (200) bez przemapowania. Strażnik DELETED w
     # widoku jest wewnętrznym zabezpieczeniem nieosiągalnym tą ścieżką.
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     journal_deleted = _make_journal(status="DELETED", title="Stara", issn="9999-0000")
@@ -192,6 +198,7 @@ def test_confirm_cel_skasowany_jest_poza_sugestiami_wiec_formularz_niewalidny(
 @pytest.mark.django_db
 def test_confirm_z_niewalidnym_formularzem_renderuje_strone(client, django_user_model):
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     journal_deleted = _make_journal(status="DELETED", title="Stara", issn="")
@@ -211,6 +218,7 @@ def test_confirm_z_niewalidnym_formularzem_renderuje_strone(client, django_user_
 @pytest.mark.django_db
 def test_preview_journal_renderuje_podglad(client, django_user_model):
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     journal_deleted = _make_journal(status="DELETED", title="Stara P", issn="1111-2222")

--- a/src/przemapuj_zrodla_pbn/tests/test_views_actions.py
+++ b/src/przemapuj_zrodla_pbn/tests/test_views_actions.py
@@ -27,10 +27,9 @@ def test_usun_zrodlo_view_requires_login(client):
 
 
 @pytest.mark.django_db
-def test_usun_zrodlo_view_get_shows_confirmation_page(client, django_user_model):
+def test_usun_zrodlo_view_get_shows_confirmation_page(client, redaktor):
     """Test czy widok GET usuwania pokazuje stronę potwierdzenia"""
-    user = baker.make(django_user_model)
-    client.force_login(user)
+    client.force_login(redaktor)
 
     journal_deleted = baker.make(
         "pbn_api.Journal",
@@ -54,12 +53,11 @@ def test_usun_zrodlo_view_get_shows_confirmation_page(client, django_user_model)
 
 
 @pytest.mark.django_db
-def test_usun_zrodlo_view_rejects_non_deleted_source(client, django_user_model):
+def test_usun_zrodlo_view_rejects_non_deleted_source(client, redaktor):
     """Test czy widok odrzuca próbę usunięcia źródła które nie jest DELETED w PBN"""
     from bpp.models import Zrodlo
 
-    user = baker.make(django_user_model)
-    client.force_login(user)
+    client.force_login(redaktor)
 
     journal_active = baker.make(
         "pbn_api.Journal",
@@ -81,12 +79,11 @@ def test_usun_zrodlo_view_rejects_non_deleted_source(client, django_user_model):
 
 
 @pytest.mark.django_db
-def test_usun_zrodlo_view_rejects_source_with_records(client, django_user_model):
+def test_usun_zrodlo_view_rejects_source_with_records(client, redaktor):
     """Test czy widok odrzuca próbę usunięcia źródła które ma rekordy"""
     from bpp.models import Zrodlo
 
-    user = baker.make(django_user_model)
-    client.force_login(user)
+    client.force_login(redaktor)
 
     journal_deleted = baker.make(
         "pbn_api.Journal",
@@ -113,12 +110,11 @@ def test_usun_zrodlo_view_rejects_source_with_records(client, django_user_model)
 
 
 @pytest.mark.django_db
-def test_usun_zrodlo_view_post_deletes_source_successfully(client, django_user_model):
+def test_usun_zrodlo_view_post_deletes_source_successfully(client, redaktor):
     """Test czy widok POST usuwa źródło bez rekordów i zapisuje log"""
     from przemapuj_zrodla_pbn.models import PrzeMapowanieZrodla
 
-    user = baker.make(django_user_model)
-    client.force_login(user)
+    client.force_login(redaktor)
 
     journal_deleted = baker.make(
         "pbn_api.Journal",
@@ -154,4 +150,4 @@ def test_usun_zrodlo_view_post_deletes_source_successfully(client, django_user_m
     assert log.zrodlo_skasowane_pbn_uid == journal_deleted
     assert log.zrodlo_nowe is None
     assert log.liczba_rekordow == 0
-    assert log.utworzono_przez == user
+    assert log.utworzono_przez == redaktor

--- a/src/przemapuj_zrodla_pbn/tests/test_views_detail.py
+++ b/src/przemapuj_zrodla_pbn/tests/test_views_detail.py
@@ -7,9 +7,11 @@ Ten moduł zawiera testy dla:
 """
 
 import pytest
+from django.contrib.auth.models import Group
 from django.urls import reverse
 from model_bakery import baker
 
+from bpp.const import GR_WPROWADZANIE_DANYCH
 from przemapuj_zrodla_pbn.views import znajdz_podobne_zrodla
 
 
@@ -35,6 +37,7 @@ def test_przemapuj_zrodlo_view_requires_login(client):
 def test_przemapuj_zrodlo_view_get(client, django_user_model):
     """Test czy widok GET przemapowania działa poprawnie"""
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     journal_deleted = baker.make(
@@ -128,6 +131,7 @@ def test_znajdz_podobne_zrodla_function_categorizes_correctly():
 def test_przemapuj_zrodlo_view_post_preview(client, django_user_model):
     """Test czy widok POST z parametrem preview działa"""
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     # Użyj podobnej nazwy i tego samego ISSN aby źródło było znalezione przez algorytm
@@ -174,6 +178,7 @@ def test_przemapuj_zrodlo_view_shows_pbn_links_for_zrodla_bpp(
 ):
     """Test czy widok pokazuje linki 'zobacz w PBN' dla źródeł BPP z pbn_uid"""
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     # Źródło skasowane
@@ -232,6 +237,7 @@ def test_przemapuj_zrodlo_view_shows_pbn_links_for_journale_pbn(
 ):
     """Test czy widok poprawnie wyświetla stronę z sugestiami dla journali z PBN"""
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     # Źródło skasowane

--- a/src/przemapuj_zrodla_pbn/tests/test_views_list.py
+++ b/src/przemapuj_zrodla_pbn/tests/test_views_list.py
@@ -6,8 +6,11 @@ Ten moduł zawiera testy dla:
 """
 
 import pytest
+from django.contrib.auth.models import Group
 from django.urls import reverse
 from model_bakery import baker
+
+from bpp.const import GR_WPROWADZANIE_DANYCH
 
 
 @pytest.mark.django_db
@@ -25,6 +28,7 @@ def test_lista_skasowanych_zrodel_view_requires_login(client):
 def test_lista_skasowanych_zrodel_view_shows_deleted_sources(client, django_user_model):
     """Test czy widok pokazuje źródła ze statusem DELETED"""
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     # Utwórz źródło ze statusem DELETED
@@ -63,6 +67,7 @@ def test_lista_skasowanych_zrodel_shows_usun_button_for_zero_records(
 ):
     """Test czy lista pokazuje przycisk 'Usuń' dla źródeł bez rekordów"""
     user = baker.make(django_user_model)
+    user.groups.add(Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)[0])
     client.force_login(user)
 
     # Źródło bez rekordów

--- a/src/przemapuj_zrodla_pbn/views.py
+++ b/src/przemapuj_zrodla_pbn/views.py
@@ -3,13 +3,13 @@ import sys
 
 import rollbar
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.contrib.postgres.search import TrigramSimilarity
 from django.db import models, transaction
 from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404, redirect, render
 
 from bpp.models import Rekord, Rodzaj_Zrodla, Uczelnia, Wydawnictwo_Ciagle, Zrodlo
+from bpp.permissions import wprowadzanie_danych_wymagane
 from bpp.util import zaloguj_polkniety_wyjatek
 from pbn_api.const import ACTIVE, DELETED
 from pbn_api.models import Journal
@@ -401,7 +401,7 @@ def znajdz_podobne_zrodla(journal_skasowane, max_results=10):
     return results
 
 
-@login_required
+@wprowadzanie_danych_wymagane
 def lista_skasowanych_zrodel(request):
     """Widok listy wszystkich źródeł skasowanych w PBN."""
 
@@ -617,7 +617,7 @@ def _obsluz_preview(request, zrodlo, form, liczba_rekordow, sugerowane):
     return render(request, "przemapuj_zrodla_pbn/przemapuj_zrodlo.html", context)
 
 
-@login_required
+@wprowadzanie_danych_wymagane
 def przemapuj_zrodlo(request, zrodlo_id):
     """Główny widok do przemapowania źródła."""
     zrodlo = get_object_or_404(Zrodlo, pk=zrodlo_id)
@@ -674,7 +674,7 @@ def przemapuj_zrodlo(request, zrodlo_id):
     return render(request, "przemapuj_zrodla_pbn/przemapuj_zrodlo.html", context)
 
 
-@login_required
+@wprowadzanie_danych_wymagane
 def usun_zrodlo(request, zrodlo_id):
     """Usuwa źródło skasowane w PBN, które nie ma żadnych rekordów."""
     zrodlo = get_object_or_404(Zrodlo, pk=zrodlo_id)


### PR DESCRIPTION
## Problem

W wielu miejscach `login_required` / `LoginRequiredMixin` było traktowane jak uprawnienie redaktorskie. Zwykłe zalogowane konto (bez `is_staff`, grup, uprawnień modelowych) mogło wywoływać operacje mutujące dane globalne:

- **Klonowanie rekordów** przez `/admin/.../toz/<pk>/` — mutacja już na GET.
- **Nadpisywanie punktacji źródeł** (MNiSW, IF, SNIP, kwartyle, punktacja wewnętrzna).
- **Przemapowywanie/tworzenie/usuwanie źródeł** + dodawanie do kolejki PBN.
- **Kasowanie wszystkich `MetrykaAutora`** + globalne przeliczenie.
- **Masowe odpinanie prac, reset przypięć, toggle-pin** po globalnym PK.

Istniejący test wręcz potwierdzał lukę: zwykły user `baker.make` skutecznie usuwał źródło.

## Rozwiązanie

Centralna, domyślnie-odmawiająca bramka `bpp.permissions` = **superuser lub grupa „wprowadzanie danych"**, w czterech formach:

| forma | zastosowanie |
|-------|--------------|
| `moze_wprowadzac_dane(user)` | predykat (jedno źródło prawdy) |
| `WprowadzanieDanychRequiredMixin` | widoki klasowe (api, Toż, optymalizuj_publikacje) |
| `wprowadzanie_danych_wymagane` | widoki funkcyjne (przemapuj_zrodla_pbn) |
| `wymagaj_wprowadzania_danych_dla_urlpatterns` | **cała** aplikacja `ewaluacja_optymalizacja` na poziomie URLconf → nowe widoki chronione domyślnie |

Semantyka: anonim → 302 na login; zalogowany-bez-uprawnień → **403**.

**Zakres `ewaluacja_optymalizacja`:** review wskazało 2 linie, ale cała aplikacja (~30 widoków, m.in. `reset_all_pins`, `unpin_all_sensible`, `trigger_denorm_flush`) była chroniona tylko zalogowaniem — bramkujemy ją w całości.

**`ewaluacja_metryki` bez zmian dostępu:** `ma_pelne_uprawnienia_ewaluacji` deleguje do centralnego helpera; dostęp autora do własnej metryki (`ma_uprawnienia_ewaluacji`, `EwaluacjaRequiredMixin`) zachowany.

### Toż: GET → POST + CSRF

`TozView` (dawniej `RedirectView` mutujący na GET) → `View` z `post()`, mutacja wyłącznie przez POST + token CSRF. JS w 3 `change_form.html` buduje ukryty formularz POST z tokenem i submituje — **ten sam UX, zero dodatkowych kliknięć**. (Test Playwright wyłapał brakujący trailing slash: `APPEND_SLASH` nie przekierowuje POST-a — naprawione.)

## Poza zakresem (świadomie)

Scoping bieżącej uczelni przy pobraniu po globalnym PK (IDOR wielotenantowy) — osobny, skupiony PR z fiksturami multi-uczelnia.

## Testy

- Jednostkowe bramki (predykat/mixin/dekorator/owijka).
- Regresja **403 per-trasa** dla każdej mutującej trasy — udowodnione jako *load-bearing* (bez bramki 6 asercji staje się czerwonych).
- **Playwright Toż** (ciagle/zwarte/patent) — POST + CSRF + redirect end-to-end.
- Zaktualizowane istniejące testy happy-path (użytkownik z grupą redaktorską).

Spec: `docs/superpowers/specs/2026-07-12-authz-editor-endpoints-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)