### PR TITLE
security: html2docx jako sidecar HTTP (usunięcie docker.sock z appservera)

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -48,6 +48,10 @@ DJANGO_BPP_REDIS_DB_SESSION="4"
 DJANGO_BPP_REDIS_DB_CACHE="5"
 DJANGO_BPP_REDIS_DB_LOCKS="6"
 
+# Usługa html2docx (sidecar HTTP) — fallback konwersji DOCX gdy pandoc padnie.
+# Współdzielone przez appserver i workery (celery task oświadczeń też robi DOCX).
+DJANGO_BPP_HTML2DOCX_URL="http://html2docx:3030/convert"
+
 # DJANGO_BPP_RAVEN_CONFIG_URL=""
 # SENTRYSDK_CONFIG_URL=""
 # SENTRYSDK_TRACES_SAMPLE_RATE=0.02

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,8 +76,7 @@ services:
     environment:
       - ENABLE_AUTORELOAD_ON_CODE_CHANGE=${ENABLE_AUTORELOAD_ON_CODE_CHANGE:-1}
       - DJANGO_BPP_CSRF_EXTRA_ORIGINS=https://bpp.localnet:10443,https://localhost:10443
-      # Fallback konwersji DOCX (html2docx) przez usługę HTTP zamiast docker.sock.
-      - DJANGO_BPP_HTML2DOCX_URL=http://html2docx:3030/convert
+      # DJANGO_BPP_HTML2DOCX_URL jest w .env.docker (współdzielone z workerami).
     entrypoint: ["/entrypoint-appserver.sh"]
     depends_on:
       redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,8 @@ services:
     environment:
       - ENABLE_AUTORELOAD_ON_CODE_CHANGE=${ENABLE_AUTORELOAD_ON_CODE_CHANGE:-1}
       - DJANGO_BPP_CSRF_EXTRA_ORIGINS=https://bpp.localnet:10443,https://localhost:10443
+      # Fallback konwersji DOCX (html2docx) przez usługę HTTP zamiast docker.sock.
+      - DJANGO_BPP_HTML2DOCX_URL=http://html2docx:3030/convert
     entrypoint: ["/entrypoint-appserver.sh"]
     depends_on:
       redis:
@@ -94,6 +96,17 @@ services:
       - media:/mediaroot
     ports:
       - ${DJANGO_BPP_PORT_APP:-8000}:8000
+
+  # Usługa konwersji HTML->DOCX (fallback gdy pandoc zawiedzie). Sidecar HTTP
+  # zamiast docker.sock — appserver POST-uje HTML, dostaje docx. Obraz budowany
+  # w osobnym repo: https://github.com/mpasternak/html2docx
+  html2docx:
+    image: iplweb/html2docx:latest
+    restart: always
+    # Port 3030 (default obrazu); nadpisywalny env HTML2DOCX_PORT.
+    # W dev odsłaniamy port dla debugowania; w produkcji NIE publikować.
+    ports:
+      - ${DJANGO_BPP_HTML2DOCX_PORT:-3030}:3030
 
 
   # ── Workers ────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,8 +102,10 @@ services:
   html2docx:
     image: iplweb/html2docx:latest
     restart: always
-    # Port 3030 (default obrazu); nadpisywalny env HTML2DOCX_PORT.
-    # W dev odsłaniamy port dla debugowania; w produkcji NIE publikować.
+    # Port WEWNĄTRZ kontenera zostaje 3030 (prawa strona mappingu) — do niego
+    # celuje DJANGO_BPP_HTML2DOCX_URL w .env.docker. DJANGO_BPP_HTML2DOCX_PORT
+    # zmienia tylko port na HOŚCIE (lewa strona). W dev odsłaniamy port dla
+    # debugowania; w produkcji NIE publikować.
     ports:
       - ${DJANGO_BPP_HTML2DOCX_PORT:-3030}:3030
 

--- a/docker/appserver/Dockerfile
+++ b/docker/appserver/Dockerfile
@@ -1,6 +1,4 @@
-# Multi-stage build: get Docker CLI from official image
 ARG BPP_BASE_TAG=latest
-FROM docker:cli AS docker-cli
 
 FROM iplweb/bpp_base:${BPP_BASE_TAG}
 
@@ -10,7 +8,8 @@ COPY --chmod=755 docker/appserver/entrypoint-appserver.sh /
 COPY --chmod=644 docker/appserver/uvicorn_log_config.json /
 COPY --chmod=644 docker/appserver/gunicorn_conf.py /gunicorn_appserver_conf.py
 
-# Copy Docker CLI from official image (fast - ~5s vs ~70s apt install)
-COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+# Docker CLI celowo NIE jest instalowany: konwersja DOCX (html2docx) idzie
+# teraz przez usługę HTTP (DJANGO_BPP_HTML2DOCX_URL), a nie przez docker.sock.
+# Dzięki temu appserver nie ma dostępu do demona Dockera hosta.
 
 ENTRYPOINT ["/bin/bash", "-c", "/entrypoint-appserver.sh"]

--- a/docs/deweloper/html2docx.md
+++ b/docs/deweloper/html2docx.md
@@ -54,4 +54,6 @@ DJANGO_BPP_HTML2DOCX_URL=http://html2docx:3030/convert
 
 Wiring produkcyjnego compose (serwis + env + brak published portu) robi
 `bpp-deploy`. W dev `docker-compose.yml` serwis `html2docx` jest dodany, a
-appserver dostaje `DJANGO_BPP_HTML2DOCX_URL` wskazujący na niego.
+`DJANGO_BPP_HTML2DOCX_URL` siedzi w `.env.docker` (współdzielone przez
+appserver i workery — celery task oświadczeń również generuje DOCX, więc
+worker też musi widzieć usługę).

--- a/docs/deweloper/html2docx.md
+++ b/docs/deweloper/html2docx.md
@@ -1,0 +1,57 @@
+# html2docx — usługa konwersji HTML → DOCX (sidecar HTTP)
+
+BPP eksportuje niektóre raporty do DOCX. Podstawowym konwerterem jest
+`pypandoc` (in-process). Gdy pandoc zawiedzie — np. robi **core dump na
+hostach VMWare ESX** — używany jest fallback: usługa **html2docx**.
+
+Historycznie fallback uruchamiał kontener przez `docker run` (co wymagało
+montowania `/var/run/docker.sock` do appservera — pełna kontrola nad demonem
+Dockera hosta). Od teraz html2docx działa jako **długożyjąca usługa HTTP**
+(sidecar), a appserver tylko POST-uje do niej HTML. Appserver nie ma już ani
+socketa, ani Docker CLI.
+
+## Obraz i tryby
+
+Obraz `iplweb/html2docx` (źródło: https://github.com/mpasternak/html2docx,
+apka .NET 8 oparta o HtmlToOpenXml) obsługuje **dwa tryby**, wybierane liczbą
+argumentów:
+
+- **bez argumentów → serwer HTTP** (domyślny tryb kontenera),
+- **z argumentem `-`/ścieżką pliku → filtr CLI** stdin→stdout (kompatybilność
+  wstecz, standalone).
+
+## Kontrakt HTTP
+
+- `POST /convert`
+  - request: ciało = surowy HTML, `Content-Type: text/html; charset=utf-8`,
+  - response 200: bajty `.docx`
+    (`Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document`),
+  - błąd konwersji: `500` + tekst błędu.
+  - limit ciała żądania: 100 MB.
+- `GET /health` → `200` (healthcheck).
+
+## Port
+
+Domyślnie **3030**, nadpisywalny zmienną środowiskową `HTML2DOCX_PORT`
+(port 8080 bywa zajęty na stackach dockera). Serwer binduje
+`http://0.0.0.0:${HTML2DOCX_PORT:-3030}`.
+
+## Konfiguracja po stronie BPP
+
+Adres usługi podaje zmienna środowiskowa `DJANGO_BPP_HTML2DOCX_URL`
+(setting `HTML2DOCX_URL`), np.:
+
+```
+DJANGO_BPP_HTML2DOCX_URL=http://html2docx:3030/convert
+```
+
+- **Brak/pusta wartość** → fallback wyłączony: `nowe_raporty.docx_export`
+  loguje ostrzeżenie i podnosi `DocxConversionError` (degradacja **miękka**,
+  bez twardego crasha — dokładnie jak dawniej przy braku Dockera).
+- Timeouty klienta: connect 5 s, read 30 s.
+
+## Deployment
+
+Wiring produkcyjnego compose (serwis + env + brak published portu) robi
+`bpp-deploy`. W dev `docker-compose.yml` serwis `html2docx` jest dodany, a
+appserver dostaje `DJANGO_BPP_HTML2DOCX_URL` wskazujący na niego.

--- a/docs/superpowers/plans/2026-07-12-html2docx-http-sidecar.md
+++ b/docs/superpowers/plans/2026-07-12-html2docx-http-sidecar.md
@@ -1,0 +1,609 @@
+# html2docx HTTP sidecar — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Zamienić docker.sock-owy fallback html2docx (`docker run` per request) na długożyjącą usługę HTTP, tak że appserver traci Docker CLI i wołania dockera, a konwerter .NET staje się izolowanym sidecarem z wąskim API.
+
+**Architecture:** Dwa deliverables przez dwa repo. (A) `mpasternak/html2docx` (.NET 8): apka konsolowa zyskuje tryb serwera ASP.NET (`POST /convert`, `GET /health`) obok istniejącego trybu CLI stdin→stdout. (B) `iplweb/bpp`: fallback w `docx_export.py` woła usługę przez `requests.post` pod konfigurowalnym URL-em (`DJANGO_BPP_HTML2DOCX_URL`, default `None` → miękka degradacja), a obraz appservera traci Docker CLI. Wiring produkcyjnego compose robi user osobno (poza planem).
+
+**Tech Stack:** .NET 8 / ASP.NET minimal API, HtmlToOpenXml.dll 3.2.7, DocumentFormat.OpenXml 3.1.0; Python 3.10+/Django, `requests`, pytest + monkeypatch; Docker.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-html2docx-http-sidecar-design.md`
+
+## Global Constraints
+
+- **Port konwertera:** default **3030**, nadpisywalny env `HTML2DOCX_PORT`. Bind `http://0.0.0.0:${HTML2DOCX_PORT:-3030}`.
+- **Kontrakt HTTP:** `POST /convert` — request body = surowy HTML (`text/html; charset=utf-8`), response 200 = bajty `.docx` (`Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document`); błąd konwersji → 4xx/5xx + tekst. `GET /health` → 200. `MaxRequestBodySize = 104857600` (100 MB).
+- **Config po stronie bpp:** `HTML2DOCX_URL = env("DJANGO_BPP_HTML2DOCX_URL", default=None)`. Nigdy hardcodowany. `None`/pusty → fallback pominięty (warning + `DocxConversionError`), zero twardego crasha.
+- **Timeouty klienta:** `requests.post(..., timeout=(5, 30))` (connect 5 s, read 30 s).
+- **Tryb CLI w apce .NET zostaje** (arg `-`/plik → stdin→stdout, bez zmian zachowania).
+- **Python:** ZAWSZE `uv run` przed pythonem/pytest. Max linia 88 znaków (ruff).
+- **Bez `except: pass`** — każdy except loguje/re-raise/zwraca sensowny błąd.
+- **Newsfragment** dla zmiany bugfix w `src/bpp/newsfragments/`.
+- **Repo .NET:** klon jako katalog-rodzeństwo `~/Programowanie/html2docx` (nie w /tmp, nie w drzewie bpp).
+
+---
+
+## Faza A — usługa HTTP w `mpasternak/html2docx` (.NET)
+
+> Repo bez frameworka testów jednostkowych (`test/` to fixture'y manualne).
+> Weryfikacja = build obrazu + `curl`/stdin (integration-style). To świadomy
+> wybór dopasowany do repo, nie pominięcie testów.
+
+### Task A1: Klon repo + gałąź + baseline weryfikacji CLI
+
+**Files:**
+- Clone: `~/Programowanie/html2docx` (z `mpasternak/html2docx`)
+
+**Interfaces:**
+- Produces: lokalny klon na gałęzi `feat/http-server`, potwierdzony działający tryb CLI (baseline przed zmianami).
+
+- [ ] **Step 1: Klon i gałąź**
+
+```bash
+cd ~/Programowanie
+git clone git@github.com:mpasternak/html2docx.git
+cd html2docx
+git checkout -b feat/http-server
+```
+
+- [ ] **Step 2: Baseline — zbuduj obecny obraz i potwierdź tryb CLI**
+
+```bash
+cd ~/Programowanie/html2docx
+docker build -t html2docx:baseline .
+printf '<b>Ala</b> ma kota' | docker run --rm -i html2docx:baseline - > /tmp/baseline.docx
+file /tmp/baseline.docx
+```
+Expected: `/tmp/baseline.docx: Microsoft Word 2007+` (tryb CLI działa przed zmianami).
+
+- [ ] **Step 3: Commit (checkpoint gałęzi, bez zmian kodu)**
+
+Brak zmian do commita — gałąź założona. Przejdź do A2.
+
+---
+
+### Task A2: Wydziel rdzeń konwersji do wspólnej funkcji
+
+**Files:**
+- Modify: `~/Programowanie/html2docx/src/Program.cs`
+
+**Interfaces:**
+- Produces: `static byte[] ConvertHtmlToDocxBytes(string html)` — synchroniczny wrapper wołający istniejący rdzeń (`HtmlConverter` / `ParseBody` / `Save`) i zwracający bajty `.docx`. Używany i przez CLI, i przez serwer (A3).
+
+- [ ] **Step 1: Dodaj funkcję `ConvertHtmlToDocxBytes` i przełącz na nią ścieżkę CLI**
+
+W `src/Program.cs` wydziel dotychczasowy blok konwersji (od `using var memoryStream = new MemoryStream();` do zapisu) do funkcji na końcu pliku:
+
+```csharp
+static byte[] ConvertHtmlToDocxBytes(string html)
+{
+    using var memoryStream = new MemoryStream();
+    using (var doc = WordprocessingDocument.Create(
+        memoryStream, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+    {
+        var main = doc.AddMainDocumentPart();
+        main.Document = new DocumentFormat.OpenXml.Wordprocessing.Document(
+            new DocumentFormat.OpenXml.Wordprocessing.Body());
+        var converter = new HtmlConverter(main);
+        converter.ParseBody(html).GetAwaiter().GetResult();
+        main.Document.Save();
+    }
+    return memoryStream.ToArray();
+}
+```
+
+W ścieżce CLI (po ustaleniu `html`/`outputFile`) zastąp inline-konwersję wywołaniem:
+
+```csharp
+byte[] docx = ConvertHtmlToDocxBytes(html);
+if (outputFile == null)
+{
+    using var stdout = Console.OpenStandardOutput();
+    stdout.Write(docx, 0, docx.Length);
+}
+else
+{
+    File.WriteAllBytes(outputFile, docx);
+}
+```
+
+Zachowaj istniejące bloki `catch (IOException …)` i `catch (Exception …)` z komunikatami + `Environment.Exit(1)`.
+
+- [ ] **Step 2: Zbuduj i potwierdź, że CLI dalej działa (bez regresji)**
+
+```bash
+cd ~/Programowanie/html2docx
+docker build -t html2docx:a2 .
+printf '<b>Ala</b> ma kota' | docker run --rm -i html2docx:a2 - > /tmp/a2.docx
+file /tmp/a2.docx
+```
+Expected: `Microsoft Word 2007+` (refaktor rdzenia nie zmienił zachowania CLI).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/Programowanie/html2docx
+git add src/Program.cs
+git commit -m "refactor: wydziel ConvertHtmlToDocxBytes wspolny dla CLI i serwera"
+```
+
+---
+
+### Task A3: Tryb serwera ASP.NET (`POST /convert`, `GET /health`)
+
+**Files:**
+- Modify: `~/Programowanie/html2docx/src/HtmlToDocx.csproj`
+- Modify: `~/Programowanie/html2docx/src/Program.cs`
+- Modify: `~/Programowanie/html2docx/Dockerfile`
+
+**Interfaces:**
+- Consumes: `ConvertHtmlToDocxBytes(string html)` z A2.
+- Produces: obraz, który **bez argów** serwuje HTTP na `0.0.0.0:${HTML2DOCX_PORT:-3030}` z `POST /convert` i `GET /health`; **z argiem `-`/plik** działa jak CLI.
+
+- [ ] **Step 1: Przełącz SDK na Web**
+
+W `src/HtmlToDocx.csproj` zmień:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Web">
+```
+(reszta `PropertyGroup`/`ItemGroup` bez zmian; `OutputType>Exe` zostaje).
+
+- [ ] **Step 2: Dodaj rozgałęzienie CLI/serwer na początku `Program.cs`**
+
+Na samej górze `Program.cs`, PRZED dotychczasową logiką parsowania argów, wstaw: gdy są argi (CLI) — leci stara ścieżka; gdy brak argów — serwer. Najprościej owinąć: jeśli `args.Length == 0` uruchom serwer i `return`, w przeciwnym razie kontynuuj dotychczasowy kod CLI.
+
+```csharp
+if (args.Length == 0)
+{
+    var port = Environment.GetEnvironmentVariable("HTML2DOCX_PORT");
+    if (string.IsNullOrWhiteSpace(port)) port = "3030";
+
+    var builder = WebApplication.CreateBuilder(args);
+    builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
+    builder.WebHost.ConfigureKestrel(o => o.Limits.MaxRequestBodySize = 104857600);
+    var app = builder.Build();
+
+    app.MapGet("/health", () => Results.Ok("ok"));
+
+    app.MapPost("/convert", async (HttpRequest request) =>
+    {
+        using var reader = new StreamReader(request.Body);
+        var html = await reader.ReadToEndAsync();
+        try
+        {
+            var docx = ConvertHtmlToDocxBytes(html);
+            return Results.File(
+                docx,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        }
+        catch (Exception ex)
+        {
+            return Results.Problem(detail: ex.Message, statusCode: 500);
+        }
+    });
+
+    app.Run();
+    return;
+}
+```
+
+> Uwaga: `WebApplication`/`Results` wymagają `Microsoft.NET.Sdk.Web` (Step 1). Nowy default (brak argów = serwer) zastępuje stary „brak argów = czytaj stdin"; tryb stdin nadal dostępny przez arg `-`.
+
+- [ ] **Step 3: Dockerfile — port 3030**
+
+W `~/Programowanie/html2docx/Dockerfile` dodaj przed `ENTRYPOINT` (entrypoint `dotnet HtmlToDocx.dll` zostaje):
+
+```dockerfile
+ENV HTML2DOCX_PORT=3030
+EXPOSE 3030
+```
+(Odziedziczone `ASPNETCORE_HTTP_PORTS=8080` zignorowane — bind steruje `UseUrls`.)
+
+- [ ] **Step 4: Zbuduj obraz**
+
+```bash
+cd ~/Programowanie/html2docx
+docker build -t html2docx:a3 .
+```
+Expected: build OK.
+
+- [ ] **Step 5: Zweryfikuj tryb serwera — /health i /convert**
+
+```bash
+CID=$(docker run -d -p 13030:3030 html2docx:a3)
+sleep 4
+curl -s -o /dev/null -w "health=%{http_code}\n" http://localhost:13030/health
+printf '<table><tr><td><b>Ala</b></td></tr></table>' \
+  | curl -s -X POST --data-binary @- \
+    -H 'Content-Type: text/html; charset=utf-8' \
+    http://localhost:13030/convert -o /tmp/a3.docx
+file /tmp/a3.docx
+docker rm -f "$CID"
+```
+Expected: `health=200` oraz `/tmp/a3.docx: Microsoft Word 2007+`.
+
+- [ ] **Step 6: Zweryfikuj, że tryb CLI dalej działa (regresja)**
+
+```bash
+printf '<b>Ala</b> ma kota' | docker run --rm -i html2docx:a3 - > /tmp/a3-cli.docx
+file /tmp/a3-cli.docx
+```
+Expected: `Microsoft Word 2007+`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/Programowanie/html2docx
+git add src/HtmlToDocx.csproj src/Program.cs Dockerfile
+git commit -m "feat: tryb serwera HTTP (POST /convert, GET /health) na porcie 3030"
+```
+
+- [ ] **Step 8: Handoff publikacji**
+
+Poinformuj usera: gałąź `feat/http-server` gotowa; obraz `iplweb/html2docx:<nowy-tag>` musi zostać **opublikowany** (workflow `.github/workflows/docker.yml` w repo html2docx), zanim deployment przełączy bpp na `DJANGO_BPP_HTML2DOCX_URL`. Push/merge/tag — decyzja usera.
+
+---
+
+## Faza B — klient w `iplweb/bpp`
+
+> Wszystkie ścieżki względem korzenia repo bpp. Python zawsze przez `uv run`.
+
+### Task B1: Setting `HTML2DOCX_URL` z env
+
+**Files:**
+- Modify: `src/django_bpp/settings/base.py`
+
+**Interfaces:**
+- Produces: `settings.HTML2DOCX_URL` (str albo `None`), czytany z `DJANGO_BPP_HTML2DOCX_URL`.
+
+- [ ] **Step 1: Dodaj setting**
+
+W `src/django_bpp/settings/base.py` (obok innych `env(...)`, np. przy `SITE_ID`) dodaj:
+
+```python
+# URL usługi html2docx (sidecar HTTP) używanej jako fallback DOCX,
+# gdy pandoc zawiedzie. None => fallback wyłączony (miękka degradacja).
+HTML2DOCX_URL = env("DJANGO_BPP_HTML2DOCX_URL", default=None)
+```
+
+- [ ] **Step 2: Sanity check importu settings**
+
+Run: `DJANGO_BPP_SKIP_DOTENV=1 uv run python -c "from django.conf import settings; import django; django.setup(); print(repr(settings.HTML2DOCX_URL))"`
+Expected: `None` (brak env → default None; brak wyjątku).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/django_bpp/settings/base.py
+git commit -m "feat(docx): setting HTML2DOCX_URL z env (default None)"
+```
+
+---
+
+### Task B2: Klient HTTP fallbacku + miękki fail (TDD)
+
+**Files:**
+- Modify: `src/nowe_raporty/docx_export.py`
+- Test: `src/nowe_raporty/tests/test_docx_export.py`
+
+**Interfaces:**
+- Consumes: `settings.HTML2DOCX_URL` (B1).
+- Produces: `_convert_using_html2docx_service(html: str, output_path: str) -> None` — POST-uje HTML do usługi, zapisuje docx do `output_path`; przy braku URL/błędzie rzuca (propaguje do `DocxConversionError`). Zastępuje `_convert_using_docker_image` (usuwana). Oba miejsca wołające (`as_docx`, `html_to_docx`) używają nowej funkcji.
+
+- [ ] **Step 1: Napisz failujące testy nowej funkcji**
+
+W `src/nowe_raporty/tests/test_docx_export.py` dodaj (importy: `import requests`, `from django.test import override_settings`):
+
+```python
+def test_html2docx_service_success(monkeypatch, tmp_path):
+    from nowe_raporty import docx_export
+
+    output_path = tmp_path / "out.docx"
+
+    class FakeResp:
+        status_code = 200
+        content = b"docx-bytes"
+
+        def raise_for_status(self):
+            pass
+
+    captured = {}
+
+    def fake_post(url, data, headers, timeout):
+        captured["url"] = url
+        captured["data"] = data
+        return FakeResp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    with override_settings(HTML2DOCX_URL="http://html2docx:3030/convert"):
+        docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))
+
+    assert output_path.read_bytes() == b"docx-bytes"
+    assert captured["url"] == "http://html2docx:3030/convert"
+    assert captured["data"] == "<b>x</b>".encode("utf-8")
+
+
+def test_html2docx_service_soft_fail_when_url_none(tmp_path, caplog):
+    from nowe_raporty import docx_export
+
+    output_path = tmp_path / "out.docx"
+    with override_settings(HTML2DOCX_URL=None):
+        with pytest.raises(RuntimeError):
+            docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))
+    assert "html2docx" in caplog.text.lower()
+
+
+def test_html2docx_service_raises_on_error_status(monkeypatch, tmp_path):
+    from nowe_raporty import docx_export
+
+    output_path = tmp_path / "out.docx"
+
+    class FakeResp:
+        status_code = 500
+
+        def raise_for_status(self):
+            raise requests.HTTPError("500")
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: FakeResp())
+    with override_settings(HTML2DOCX_URL="http://html2docx:3030/convert"):
+        with pytest.raises(requests.HTTPError):
+            docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))
+```
+
+- [ ] **Step 2: Uruchom — testy mają failować (brak funkcji)**
+
+Run: `uv run pytest src/nowe_raporty/tests/test_docx_export.py -k html2docx_service -x`
+Expected: FAIL — `AttributeError: module 'nowe_raporty.docx_export' has no attribute '_convert_using_html2docx_service'`.
+
+- [ ] **Step 3: Zaimplementuj funkcję i usuń dockerową**
+
+W `src/nowe_raporty/docx_export.py`: usuń `import subprocess`, dodaj `import requests` i `from django.conf import settings` (jeśli brak). Usuń stałe `_DOCKER_IMAGE`/`_DOCKER_COMMAND` oraz całą `_convert_using_docker_image`. Dodaj:
+
+```python
+def _convert_using_html2docx_service(html: str, output_path: str) -> None:
+    url = getattr(settings, "HTML2DOCX_URL", None)
+    if not url:
+        LOGGER.warning(
+            "html2docx fallback niedostępny: HTML2DOCX_URL nieustawiony"
+        )
+        raise RuntimeError("HTML2DOCX_URL not configured")
+
+    response = requests.post(
+        url,
+        data=html.encode("utf-8"),
+        headers={"Content-Type": "text/html; charset=utf-8"},
+        timeout=(5, 30),
+    )
+    response.raise_for_status()
+
+    with open(output_path, "wb") as output_file:
+        output_file.write(response.content)
+
+    output_file_path = Path(output_path)
+    if not output_file_path.exists() or output_file_path.stat().st_size == 0:
+        raise RuntimeError("html2docx service produced no output")
+```
+
+- [ ] **Step 4: Przełącz oba miejsca wołające na nową funkcję**
+
+W `as_docx` (ok. linii 82) i `html_to_docx` (ok. linii 231) zmień wywołanie:
+
+```python
+_convert_using_html2docx_service(cleaned_html, output_file.name)
+```
+oraz analogicznie w `html_to_docx`:
+```python
+_convert_using_html2docx_service(html, output_path)
+```
+Komunikaty `DocxConversionError` („DOCX conversion failed using both pandoc and html2docx") zostają bez zmian.
+
+- [ ] **Step 5: Uruchom nowe testy — mają przejść**
+
+Run: `uv run pytest src/nowe_raporty/tests/test_docx_export.py -k html2docx_service -v`
+Expected: 3 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nowe_raporty/docx_export.py src/nowe_raporty/tests/test_docx_export.py
+git commit -m "feat(docx): fallback html2docx przez HTTP zamiast docker run (miekki fail)"
+```
+
+---
+
+### Task B3: Napraw istniejące testy pod nowy fallback
+
+**Files:**
+- Modify: `src/nowe_raporty/tests/test_docx_export.py`
+
+**Interfaces:**
+- Consumes: `_convert_using_html2docx_service` (B2).
+
+- [ ] **Step 1: Uruchom cały plik — zobacz co pękło po usunięciu dockera**
+
+Run: `uv run pytest src/nowe_raporty/tests/test_docx_export.py -v`
+Expected: FAIL w testach odnoszących się do `_convert_using_docker_image` / `subprocess` / integration `docker run` (`test_as_docx_falls_back_to_docker`, `test_as_docx_raises_when_both_converters_fail`, `test_convert_using_docker_image_*`, integration).
+
+- [ ] **Step 2: Przepnij testy fallbacku na nową funkcję**
+
+W `test_as_docx_falls_back_to_docker` i `test_as_docx_raises_when_both_converters_fail` zmień:
+```python
+monkeypatch.setattr(docx_export, "_convert_using_docker_image", docker_fallback)
+```
+na:
+```python
+monkeypatch.setattr(docx_export, "_convert_using_html2docx_service", docker_fallback)
+```
+(nazwy lokalnych helperów `docker_fallback` możesz zostawić lub przemianować na `service_fallback` — bez znaczenia funkcjonalnego).
+
+- [ ] **Step 3: Usuń martwe testy dockerowe**
+
+Usuń testy operujące bezpośrednio na `subprocess`/`_convert_using_docker_image`
+(`test_convert_using_docker_image_success`, `test_convert_using_docker_image_with_stderr`,
+`test_convert_using_docker_image_*`, custom-image test na `HTML2DOCX_DOCKER_IMAGE`)
+oraz integration-test wołający realny `docker run iplweb/html2docx`. Zastępuje je
+`test_html2docx_service_*` z B2. Usuń nieużywany `import subprocess`.
+
+- [ ] **Step 4: Uruchom cały plik — zielono**
+
+Run: `uv run pytest src/nowe_raporty/tests/test_docx_export.py -v`
+Expected: wszystkie PASS, brak referencji do dockera.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nowe_raporty/tests/test_docx_export.py
+git commit -m "test(docx): przepnij testy fallbacku z docker na usluge HTTP"
+```
+
+---
+
+### Task B4: Zdejmij Docker CLI z obrazu appservera
+
+**Files:**
+- Modify: `docker/appserver/Dockerfile`
+
+**Interfaces:**
+- (brak — zmiana obrazu)
+
+- [ ] **Step 1: Usuń stage docker-cli i COPY**
+
+W `docker/appserver/Dockerfile` usuń:
+```dockerfile
+ARG BPP_BASE_TAG=latest
+FROM docker:cli AS docker-cli
+```
+(zostaw samą linię `ARG BPP_BASE_TAG=latest` — jest potrzebna dla `FROM iplweb/bpp_base:${BPP_BASE_TAG}`) oraz usuń:
+```dockerfile
+# Copy Docker CLI from official image (fast - ~5s vs ~70s apt install)
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+```
+Wynik: brak `FROM docker:cli`, brak `COPY --from=docker-cli`. `ARG BPP_BASE_TAG=latest` pozostaje nad `FROM iplweb/bpp_base`.
+
+- [ ] **Step 2: Zweryfikuj składnię Dockerfile (bez pełnego builda)**
+
+Run: `docker build --check -f docker/appserver/Dockerfile .`
+Expected: brak błędów składni (`--check` nie buduje, tylko waliduje). Jeśli `--check` niedostępny w wersji Dockera — pomiń, walidacja nastąpi w CI build test-runnera.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/appserver/Dockerfile
+git commit -m "refactor(docker): usun Docker CLI z obrazu appservera (niepotrzebny po HTTP fallbacku)"
+```
+
+---
+
+### Task B5: Dev compose (opcjonalnie) + newsfragment + docs
+
+**Files:**
+- Modify: `docker-compose.yml` (dev)
+- Create: `src/bpp/newsfragments/<slug>.bugfix.rst`
+- Modify: `docs/deweloper/` (krótka notka o kontrakcie)
+
+**Interfaces:**
+- (brak)
+
+- [ ] **Step 1: Dodaj serwis html2docx do dev compose**
+
+W `docker-compose.yml` dodaj serwis (obok innych) i env na `appserver`:
+
+```yaml
+  html2docx:
+    image: iplweb/html2docx:latest
+    restart: unless-stopped
+    # brak published portu — tylko sieć wewnętrzna compose
+```
+oraz w bloku `appserver` (environment):
+```yaml
+      DJANGO_BPP_HTML2DOCX_URL: "http://html2docx:3030/convert"
+```
+
+- [ ] **Step 2: Zweryfikuj poprawność YAML**
+
+Run: `uv run python -c "import yaml,sys; yaml.safe_load(open('docker-compose.yml')); print('yaml ok')"`
+Expected: `yaml ok`.
+
+- [ ] **Step 3: Newsfragment**
+
+Utwórz `src/bpp/newsfragments/html2docx-http.bugfix.rst`:
+
+```rst
+Fallback konwersji DOCX (html2docx) działa teraz przez usługę HTTP zamiast
+uruchamiania kontenera przez ``docker.sock``. Appserver nie potrzebuje już
+dostępu do demona Dockera hosta ani Docker CLI w obrazie. Adres usługi podaje
+zmienna środowiskowa ``DJANGO_BPP_HTML2DOCX_URL`` (brak = fallback wyłączony).
+```
+
+- [ ] **Step 4: Notka w docs o kontrakcie**
+
+Dopisz krótką sekcję (np. w `docs/deweloper/polecenia.md` lub nowy plik `docs/deweloper/html2docx.md`) opisującą: usługę `iplweb/html2docx` w trybie serwera, port 3030 (`HTML2DOCX_PORT`), `POST /convert` (body=HTML, resp=docx), `GET /health`, oraz konfigurację `DJANGO_BPP_HTML2DOCX_URL` po stronie bpp.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker-compose.yml src/bpp/newsfragments/html2docx-http.bugfix.rst docs/
+git commit -m "docs+dev: serwis html2docx w dev compose, newsfragment, notka o kontrakcie"
+```
+
+---
+
+### Task B6: Weryfikacja end-to-end (bpp ↔ realna usługa)
+
+**Files:**
+- (brak zmian — weryfikacja)
+
+**Interfaces:**
+- Consumes: obraz `html2docx:a3` (Faza A) + `_convert_using_html2docx_service` (B2).
+
+- [ ] **Step 1: Uruchom usługę i wywołaj fallback z Pythona**
+
+```bash
+CID=$(docker run -d -p 13030:3030 html2docx:a3)
+sleep 4
+DJANGO_BPP_SKIP_DOTENV=1 DJANGO_BPP_HTML2DOCX_URL=http://localhost:13030/convert \
+  uv run python -c "
+import django; django.setup()
+from nowe_raporty import docx_export
+import tempfile, pathlib
+p = tempfile.NamedTemporaryFile(suffix='.docx', delete=False).name
+docx_export._convert_using_html2docx_service('<table><tr><td><b>Ala</b></td></tr></table>', p)
+print('bytes', pathlib.Path(p).stat().st_size)
+"
+docker rm -f "$CID"
+```
+Expected: `bytes` > 0 (realny docx wygenerowany przez usługę przez ścieżkę Pythona).
+
+- [ ] **Step 2: Pełna suita modułu**
+
+Run: `uv run pytest src/nowe_raporty/tests/test_docx_export.py -v`
+Expected: wszystkie PASS.
+
+- [ ] **Step 3: ruff**
+
+Run: `ruff check src/nowe_raporty/docx_export.py src/nowe_raporty/tests/test_docx_export.py src/django_bpp/settings/base.py`
+Expected: brak naruszeń (m.in. brak nieużywanego `subprocess`).
+
+---
+
+## Kolejność i handoff
+
+1. **Faza A** (repo html2docx) — dostarcz usługę, zbuduj/zweryfikuj obraz.
+2. **Faza B** (repo bpp) — klient + testy + odchudzenie obrazu appservera.
+3. **B6** — weryfikacja end-to-end bpp ↔ realna usługa.
+4. **Handoff do usera:** publikacja obrazu `iplweb/html2docx:<tag>` **przed** przepięciem deploya; wiring `docker-compose.application.yml` (serwis + env + zdjęcie socketa) robi user sam (poza planem).
+
+## Self-review (spec coverage)
+
+- Kontrakt HTTP (POST /convert, GET /health, 100 MB, port 3030 + env) → A3, Global Constraints. ✓
+- Tryb CLI zostaje → A2/A3 Step 6. ✓
+- Config `HTML2DOCX_URL` z env default None → B1. ✓
+- Miękki fail → B2 Step 1/3 (test + impl). ✓
+- Timeouty 5/30 → B2 Step 3. ✓
+- Oba call-sites przełączone → B2 Step 4. ✓
+- Docker CLI usunięty z appservera → B4. ✓
+- Testy przepięte, docker-testy usunięte → B3. ✓
+- Newsfragment + docs → B5. ✓
+- Deploy poza zakresem, handoff → Kolejność i handoff. ✓

--- a/docs/superpowers/specs/2026-07-12-html2docx-http-sidecar-design.md
+++ b/docs/superpowers/specs/2026-07-12-html2docx-http-sidecar-design.md
@@ -1,0 +1,172 @@
+# html2docx jako sidecar HTTP — usunięcie docker.sock z appservera
+
+**Data:** 2026-07-12
+**Status:** design zatwierdzony, do spisania planu
+**Repozytoria:** `mpasternak/html2docx` (.NET), `iplweb/bpp`, `iplweb/bpp-deploy`
+
+## Problem
+
+Produkcyjny appserver ma zamontowany `/var/run/docker.sock`
+(`bpp-deploy/docker-compose.application.yml:95`, `:ro`) i zawiera Docker CLI
+(`docker/appserver/Dockerfile`). Wykorzystuje to do konwersji HTML→DOCX:
+`src/nowe_raporty/docx_export.py` odpala `docker run --rm -i iplweb/html2docx -`
+jako **fallback**, gdy `pypandoc` zawiedzie.
+
+Sufiks `:ro` nie czyni API Dockera read-only — proces nadal może tworzyć
+kontenery, montować katalogi hosta i wykonywać procesy. Każde przyszłe RCE
+w appserverze (jedynej z tych usług, która parsuje niezaufany input z sieci)
+oznacza natychmiastowe przejęcie hosta i wszystkich kontenerów. Fallback
+odpalany rzadko — a socket wisi 24/7.
+
+### Dlaczego fallback musi zostać
+
+Obraz `iplweb/html2docx` istnieje, bo **pandoc robi core dump na hostach
+VMWare ESX** (opis repo `mpasternak/html2docx`). To realna produkcyjna siatka
+bezpieczeństwa pod crashującym primary converterem, nie kaprys — nie wolno go
+po prostu usunąć.
+
+### Fakty ustalone empirycznie (2026-07-12)
+
+- `iplweb/html2docx` to **.NET 8** (nie Mono): `dotnet HtmlToDocx.dll`,
+  `DOTNET_VERSION=8.0.20`. Framework-dependent; sama apka ~11 KB, runtime
+  .NET ~106 MB. Obraz ~90 MB (arm64).
+- To **console-filter**: stdin(HTML) → stdout(DOCX), jeden strzał, exit.
+  **Nie serwuje HTTP** (mimo odziedziczonego `ASPNETCORE_HTTP_PORTS=8080`
+  i runtime'u ASP.NET — apka ich nie używa). Zweryfikowane: uruchomienie
+  bez arg produkuje DOCX i kończy proces.
+- Rdzeń konwersji (`src/Program.cs`): `new HtmlConverter(main);
+  await converter.ParseBody(html); main.Document.Save();` → MemoryStream →
+  stdout. Biblioteka: **HtmlToOpenXml.dll 3.2.7** + DocumentFormat.OpenXml 3.1.0.
+- Input do konwertera jest już **nh3-sanitizowany** (`docx_export.py:58`) —
+  ten sam HTML, który pandoc przetwarza in-process. „Izolacja" kontenera nigdy
+  nie była tu środkiem bezpieczeństwa; wynika z heterogeniczności runtime'ów
+  (.NET vs Python).
+- `requests>=2.34.2` jest zależnością bpp (klient HTTP gotowy).
+- Fallback wołany z dwóch miejsc: `as_docx()` i `html_to_docx()`, oba przez
+  wspólne `_convert_using_docker_image` w `docx_export.py`.
+
+## Rozważone i odrzucone warianty
+
+- **A — html2docx jako biblioteka pip in-process.** Niemożliwe: to binarka
+  .NET, nie pakiet Python.
+- **C — bake runtime .NET w obraz appservera + lokalny subprocess.** Działa
+  (zweryfikowane: `dotnet /app/HtmlToDocx.dll -` daje poprawny docx), ale
+  dokłada ~106 MB runtime .NET do bazowego obrazu appservera — **jawnie
+  odrzucone przez usera** („absolutnie nie chcę dokładać niczego do
+  podstawowego obrazu").
+- **D — docker-socket-proxy.** Proxy przepuszczające `containers/create` i tak
+  pozwala mountować hosta → nie zamyka dziury.
+
+## Wybrany wariant: B — sidecar HTTP
+
+html2docx staje się długożyjącym serwisem HTTP w osobnym kontenerze; appserver
+woła go POST-em po sieci wewnętrznej. Appserver traci socket **i** Docker CLI.
+Konwerter zyskuje realną izolację: osobny kontener, wąskie API, tylko sieć
+wewnętrzna, nie-root.
+
+### Kontrakt HTTP (zatwierdzony)
+
+- `POST /convert`
+  - **Request:** ciało = surowy HTML, `Content-Type: text/html; charset=utf-8`.
+  - **Response 200:** bajty `.docx`,
+    `Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document`.
+  - **Błąd konwersji:** HTTP 4xx/5xx + tekst błędu w ciele (odpowiednik
+    dzisiejszego stderr).
+  - Limit ciała żądania podniesiony w Kestrelu (raporty bywają duże;
+    docelowo ~100 MB) — dokładna wartość do ustalenia w planie.
+- `GET /health` → `200` (healthcheck compose/autoheal).
+
+Odwzorowuje 1:1 dzisiejszy filtr stdin→stdout — minimum kodu po obu stronach,
+brak parsowania multipart, brak narzutu base64.
+
+## Zmiany po stronie .NET — `mpasternak/html2docx`
+
+1. **`src/HtmlToDocx.csproj`**: `<Project Sdk="Microsoft.NET.Sdk">` →
+   `Microsoft.NET.Sdk.Web`. Runtime ASP.NET jest już w obrazie bazowym.
+2. **`src/Program.cs`** — rozgałęzienie na starcie:
+   - **brak argów → tryb serwera** (nowy default): `WebApplication`
+     nasłuchujący na `0.0.0.0:8080`, endpointy `POST /convert` i `GET /health`.
+     Endpoint reużywa istniejący rdzeń konwersji (HtmlConverter/ParseBody/Save)
+     — wydzielony do wspólnej funkcji `ConvertHtmlToDocxBytes(string html)`.
+   - **arg `-`/nazwa pliku → tryb CLI** (bez zmian): stary filtr stdin→stdout
+     zachowany dla kompatybilności i standalone-żności. Ta sama funkcja rdzenia.
+   - Obsługa błędów: w trybie serwera wyjątek konwersji → odpowiedź 4xx/5xx
+     z komunikatem; w trybie CLI → dotychczasowe `Console.Error` + `Exit(1)`.
+   - Limit ciała żądania Kestrela (`MaxRequestBodySize`) podniesiony.
+3. **`Dockerfile`**: entrypoint zostaje `dotnet HtmlToDocx.dll` (teraz domyślnie
+   serwuje), `EXPOSE 8080`, user nie-root (uid 1654) bez zmian. Bez socketa.
+   Rozważyć `HEALTHCHECK` w obrazie (lub zdać się na healthcheck compose).
+
+## Zmiany po stronie BPP — `iplweb/bpp`
+
+1. **`src/nowe_raporty/docx_export.py`**:
+   - `_convert_using_docker_image` → `_convert_using_html2docx_service(html,
+     output_path)`:
+     `requests.post(settings.HTML2DOCX_URL, data=html.encode("utf-8"),
+     headers={"Content-Type": "text/html; charset=utf-8"}, timeout=(5, 30))`.
+     `200` → `response.content` (docx) do pliku; non-200/timeout/ConnectionError
+     → `raise` (propaguje do `DocxConversionError` — logika fallbacku bez zmian).
+   - Settingsy: `HTML2DOCX_URL` (default `http://html2docx:8080/convert`)
+     zastępuje `HTML2DOCX_DOCKER_IMAGE` / `HTML2DOCX_DOCKER_COMMAND`. Znika
+     import i wołanie dockera.
+   - Timeouty: connect ~5 s, read ~30 s — do potwierdzenia w planie.
+2. **`docker/appserver/Dockerfile`**: usunąć stage `FROM docker:cli AS
+   docker-cli` i `COPY --from=docker-cli … /usr/local/bin/docker` — appserver
+   traci Docker CLI (chudszy obraz, mniejsza powierzchnia).
+3. **`docker-compose.yml` (dev)**: dodać serwis `html2docx`
+   (`image: iplweb/html2docx:...`, sieć wewnętrzna, bez published portu) oraz
+   env `HTML2DOCX_URL` na appserverze — żeby fallback dało się przetestować
+   lokalnie.
+4. **`src/nowe_raporty/tests/test_docx_export.py`**: mock `requests.post`
+   zamiast `subprocess.run`; przypadki 200 / non-200 / timeout / ConnectionError.
+   Rozważyć integration-test z realnym serwisem przez testcontainers (osobny
+   punkt w planie — dziś istnieje integration-test wołający realny
+   `docker run`, do zastąpienia).
+5. **Newsfragment** (`src/bpp/newsfragments/*.bugfix.rst`) — po polsku, o
+   usunięciu docker.sock z appservera / przejściu na sidecar HTTP.
+6. **Docs**: notka o kontrakcie HTTP obrazu html2docx (np. w
+   `docs/deweloper/`), żeby kontrakt był udokumentowany.
+
+## Zmiany deploymentu — `iplweb/bpp-deploy`
+
+1. **`docker-compose.application.yml`**:
+   - usunąć `- /var/run/docker.sock:/var/run/docker.sock:ro` z appservera
+     (linia 95);
+   - dodać serwis `html2docx`: `image: iplweb/html2docx:${DOCKER_VERSION:-latest}`,
+     sieć wewnętrzna, **bez published portu**, `restart: always`, healthcheck
+     `GET /health`, label `autoheal=true` (autoheal już działa w stacku);
+   - na appserverze env `HTML2DOCX_URL=http://html2docx:8080/convert`;
+   - `depends_on` html2docx — **miękkie** (bez `condition: service_healthy`
+     twardo blokującego start appservera), bo to ścieżka awaryjna; decyzja do
+     potwierdzenia w planie.
+   - ofelia / autoheal / monitoring **zostają** z socketem — to demony infry
+     bez wejścia z sieci, poza zakresem zastrzeżenia reviewera.
+
+## Efekt bezpieczeństwa
+
+- Appserver: **zero `docker.sock`, zero Docker CLI**. RCE w appserverze nie ma
+  już czym sięgnąć do demona Dockera hosta.
+- Konwerter: osobny kontener, **wąskie API HTTP** (`/convert`, `/health`),
+  tylko sieć wewnętrzna (bez published portu), nie-root, parsuje wyłącznie
+  nh3-sanitizowany HTML.
+- Fallback nadal dostępny (wymóg ESX/core-dump spełniony); nowa zależność =
+  zdrowie kontenera html2docx, mitygowane `restart: always` + healthcheck +
+  autoheal.
+
+## Ryzyka i punkty do rozstrzygnięcia w planie
+
+- **Reliability fallbacku:** B dokłada zależność od drugiego kontenera będącego
+  up. Mitygacja: `restart: always` + healthcheck + autoheal. Zaakceptowane
+  świadomie (user wybrał B ponad C mimo tego).
+- **Dev/test bez serwisu:** gdy html2docx nie biegnie (np. czysty `pytest`),
+  fallback rzuci `DocxConversionError` — tak jak dziś rzucał, gdy brak dockera.
+  Testy jednostkowe mockują `requests.post`, więc nie wymagają serwisu.
+- **Wersjonowanie obrazu:** `DOCKER_VERSION` html2docx niezależny od bpp —
+  ustalić politykę pinowania (tag vs digest) w bpp-deploy.
+- **Rozmiar żądania:** dobrać `MaxRequestBodySize` (Kestrel) i ewentualny limit
+  po stronie nginx/appserver dla realnych raportów.
+- **Kolejność wdrożenia:** obraz html2docx z trybem serwera musi być
+  opublikowany **zanim** deploy przełączy appserver na `HTML2DOCX_URL` i usunie
+  socket — inaczej fallback jest chwilowo martwy. Sekwencja w planie.
+- **CI integration-test:** zastąpić dzisiejszy `docker run`-owy test wariantem
+  z testcontainers stawiającym serwis, albo oznaczyć jako opt-in.

--- a/docs/superpowers/specs/2026-07-12-html2docx-http-sidecar-design.md
+++ b/docs/superpowers/specs/2026-07-12-html2docx-http-sidecar-design.md
@@ -2,7 +2,9 @@
 
 **Data:** 2026-07-12
 **Status:** design zatwierdzony, do spisania planu
-**Repozytoria:** `mpasternak/html2docx` (.NET), `iplweb/bpp`, `iplweb/bpp-deploy`
+**Zakres:** `mpasternak/html2docx` (.NET — usługa HTTP) + `iplweb/bpp` (klient).
+`iplweb/bpp-deploy` — **downstream, robi user sam**, tu tylko udokumentowany
+kontrakt.
 
 ## Problem
 
@@ -60,9 +62,10 @@ po prostu usunąć.
 ## Wybrany wariant: B — sidecar HTTP
 
 html2docx staje się długożyjącym serwisem HTTP w osobnym kontenerze; appserver
-woła go POST-em po sieci wewnętrznej. Appserver traci socket **i** Docker CLI.
-Konwerter zyskuje realną izolację: osobny kontener, wąskie API, tylko sieć
-wewnętrzna, nie-root.
+woła go POST-em po sieci wewnętrznej. W zakresie tego speca appserver traci
+**Docker CLI** i przestaje wołać dockera; sam mount `docker.sock` zdejmuje
+downstream deployment. Konwerter zyskuje realną izolację: osobny kontener,
+wąskie API, tylko sieć wewnętrzna, nie-root.
 
 ### Kontrakt HTTP (zatwierdzony)
 
@@ -72,8 +75,8 @@ wewnętrzna, nie-root.
     `Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document`.
   - **Błąd konwersji:** HTTP 4xx/5xx + tekst błędu w ciele (odpowiednik
     dzisiejszego stderr).
-  - Limit ciała żądania podniesiony w Kestrelu (raporty bywają duże;
-    docelowo ~100 MB) — dokładna wartość do ustalenia w planie.
+  - Limit ciała żądania Kestrela `MaxRequestBodySize = 100 MB` (104857600 B) —
+    raporty bywają duże.
 - `GET /health` → `200` (healthcheck compose/autoheal).
 
 Odwzorowuje 1:1 dzisiejszy filtr stdin→stdout — minimum kodu po obu stronach,
@@ -106,67 +109,79 @@ brak parsowania multipart, brak narzutu base64.
      headers={"Content-Type": "text/html; charset=utf-8"}, timeout=(5, 30))`.
      `200` → `response.content` (docx) do pliku; non-200/timeout/ConnectionError
      → `raise` (propaguje do `DocxConversionError` — logika fallbacku bez zmian).
-   - Settingsy: `HTML2DOCX_URL` (default `http://html2docx:8080/convert`)
-     zastępuje `HTML2DOCX_DOCKER_IMAGE` / `HTML2DOCX_DOCKER_COMMAND`. Znika
+   - **Endpoint z konfiguracji, nigdy hardcodowany.** Setting `HTML2DOCX_URL`
+     czytany z env (np. `DJANGO_BPP_HTML2DOCX_URL`), **default `None`**.
+     Zastępuje `HTML2DOCX_DOCKER_IMAGE` / `HTML2DOCX_DOCKER_COMMAND`. Znika
      import i wołanie dockera.
-   - Timeouty: connect ~5 s, read ~30 s — do potwierdzenia w planie.
+   - **Miękki fail:** gdy `HTML2DOCX_URL` jest `None`/pusty → fallback HTTP
+     jest pominięty, logujemy `warning` („html2docx nie skonfigurowany") i
+     rzucamy `DocxConversionError` — dokładnie tak, jak dziś, gdy dockera nie
+     ma. Gdy ustawiony, ale serwis nieosiągalny → to samo (błąd propaguje do
+     500). Appserver nigdy nie wywala się twardo.
+   - Timeouty klienta: connect 5 s, read 30 s.
+   - Host/port docelowego serwisu = wyłącznie sprawa konfiguracji (env), poza
+     kodem — patrz sekcja Deployment.
 2. **`docker/appserver/Dockerfile`**: usunąć stage `FROM docker:cli AS
    docker-cli` i `COPY --from=docker-cli … /usr/local/bin/docker` — appserver
    traci Docker CLI (chudszy obraz, mniejsza powierzchnia).
-3. **`docker-compose.yml` (dev)**: dodać serwis `html2docx`
+3. **`docker-compose.yml` (dev)** — opcjonalnie: dodać serwis `html2docx`
    (`image: iplweb/html2docx:...`, sieć wewnętrzna, bez published portu) oraz
-   env `HTML2DOCX_URL` na appserverze — żeby fallback dało się przetestować
-   lokalnie.
+   ustawić `DJANGO_BPP_HTML2DOCX_URL` na appserverze — żeby fallback dało się
+   przetestować lokalnie. Bez tego (default `None`) dev jedzie na samym
+   pandocu, co jest OK.
 4. **`src/nowe_raporty/tests/test_docx_export.py`**: mock `requests.post`
-   zamiast `subprocess.run`; przypadki 200 / non-200 / timeout / ConnectionError.
-   Rozważyć integration-test z realnym serwisem przez testcontainers (osobny
-   punkt w planie — dziś istnieje integration-test wołający realny
-   `docker run`, do zastąpienia).
+   zamiast `subprocess.run`; przypadki 200 / non-200 / timeout /
+   ConnectionError / `HTML2DOCX_URL is None` (miękki fallback). Rozważyć
+   integration-test z realnym serwisem przez testcontainers (osobny punkt
+   w planie — dziś istnieje integration-test wołający realny `docker run`,
+   do zastąpienia).
 5. **Newsfragment** (`src/bpp/newsfragments/*.bugfix.rst`) — po polsku, o
-   usunięciu docker.sock z appservera / przejściu na sidecar HTTP.
+   przejściu fallbacku html2docx z `docker run` na usługę HTTP (+ usunięcie
+   Docker CLI z obrazu appservera).
 6. **Docs**: notka o kontrakcie HTTP obrazu html2docx (np. w
    `docs/deweloper/`), żeby kontrakt był udokumentowany.
 
-## Zmiany deploymentu — `iplweb/bpp-deploy`
+## Deployment — `iplweb/bpp-deploy` (robi user sam, poza zakresem)
 
-1. **`docker-compose.application.yml`**:
-   - usunąć `- /var/run/docker.sock:/var/run/docker.sock:ro` z appservera
-     (linia 95);
-   - dodać serwis `html2docx`: `image: iplweb/html2docx:${DOCKER_VERSION:-latest}`,
-     sieć wewnętrzna, **bez published portu**, `restart: always`, healthcheck
-     `GET /health`, label `autoheal=true` (autoheal już działa w stacku);
-   - na appserverze env `HTML2DOCX_URL=http://html2docx:8080/convert`;
-   - `depends_on` html2docx — **miękkie** (bez `condition: service_healthy`
-     twardo blokującego start appservera), bo to ścieżka awaryjna; decyzja do
-     potwierdzenia w planie.
-   - ofelia / autoheal / monitoring **zostają** z socketem — to demony infry
-     bez wejścia z sieci, poza zakresem zastrzeżenia reviewera.
+Cały wiring produkcyjnego compose robi **user we własnym zakresie** — **nie
+jest** deliverable tego speca ani planu. Spec tylko **dokumentuje kontrakt**,
+który deployment musi spełnić po wdrożeniu obrazu z trybem serwera i klienta
+w bpp:
+
+- serwis `html2docx` (`image: iplweb/html2docx:<tag>`, sieć wewnętrzna, **bez
+  published portu**, restart + healthcheck wg uznania), pin **po tagu**;
+- na appserverze env `DJANGO_BPP_HTML2DOCX_URL=http://<host>:<port>/convert`;
+- zdjęcie mountu `docker.sock` z appservera.
+
+`depends_on`, healthcheck, restart policy, sieć — decyzje deploymentu, nie
+tego planu.
 
 ## Efekt bezpieczeństwa
 
-- Appserver: **zero `docker.sock`, zero Docker CLI**. RCE w appserverze nie ma
-  już czym sięgnąć do demona Dockera hosta.
+- Appserver: **zero Docker CLI** w obrazie (zmiana w bpp) i kod nie woła już
+  dockera; **zero `docker.sock`** po zdjęciu mountu przez bpp-deploy. RCE
+  w appserverze nie ma już czym sięgnąć do demona Dockera hosta.
 - Konwerter: osobny kontener, **wąskie API HTTP** (`/convert`, `/health`),
   tylko sieć wewnętrzna (bez published portu), nie-root, parsuje wyłącznie
   nh3-sanitizowany HTML.
 - Fallback nadal dostępny (wymóg ESX/core-dump spełniony); nowa zależność =
-  zdrowie kontenera html2docx, mitygowane `restart: always` + healthcheck +
-  autoheal.
+  zdrowie kontenera html2docx, mitygowane po stronie deploymentu (restart +
+  healthcheck + autoheal), a po stronie bpp degradacją miękką.
 
 ## Ryzyka i punkty do rozstrzygnięcia w planie
 
 - **Reliability fallbacku:** B dokłada zależność od drugiego kontenera będącego
-  up. Mitygacja: `restart: always` + healthcheck + autoheal. Zaakceptowane
-  świadomie (user wybrał B ponad C mimo tego).
-- **Dev/test bez serwisu:** gdy html2docx nie biegnie (np. czysty `pytest`),
-  fallback rzuci `DocxConversionError` — tak jak dziś rzucał, gdy brak dockera.
-  Testy jednostkowe mockują `requests.post`, więc nie wymagają serwisu.
-- **Wersjonowanie obrazu:** `DOCKER_VERSION` html2docx niezależny od bpp —
-  ustalić politykę pinowania (tag vs digest) w bpp-deploy.
-- **Rozmiar żądania:** dobrać `MaxRequestBodySize` (Kestrel) i ewentualny limit
-  po stronie nginx/appserver dla realnych raportów.
-- **Kolejność wdrożenia:** obraz html2docx z trybem serwera musi być
-  opublikowany **zanim** deploy przełączy appserver na `HTML2DOCX_URL` i usunie
-  socket — inaczej fallback jest chwilowo martwy. Sekwencja w planie.
+  up. Mitygacja **po stronie deploymentu** (restart + healthcheck + autoheal).
+  Zaakceptowane świadomie (user wybrał B ponad C mimo tego). Po stronie bpp
+  degradacja jest miękka (patrz niżej), więc niedostępny serwis = brak eksportu
+  DOCX, nie crash.
+- **Dev/test bez serwisu:** gdy `HTML2DOCX_URL` jest `None` lub html2docx nie
+  biegnie (np. czysty `pytest`), fallback rzuci `DocxConversionError` — tak jak
+  dziś rzucał, gdy brak dockera. Testy jednostkowe mockują `requests.post`,
+  więc nie wymagają serwisu.
+- **Kolejność deliverables:** obraz html2docx z trybem serwera musi być
+  opublikowany i dostępny **zanim** user przełączy deployment na
+  `DJANGO_BPP_HTML2DOCX_URL` i zdejmie socket. Plan dostarcza (a) usługę .NET
+  i (b) klienta bpp; sam moment przepięcia deploya to handoff do usera.
 - **CI integration-test:** zastąpić dzisiejszy `docker run`-owy test wariantem
   z testcontainers stawiającym serwis, albo oznaczyć jako opt-in.

--- a/docs/superpowers/specs/2026-07-12-html2docx-http-sidecar-design.md
+++ b/docs/superpowers/specs/2026-07-12-html2docx-http-sidecar-design.md
@@ -78,6 +78,8 @@ wąskie API, tylko sieć wewnętrzna, nie-root.
   - Limit ciała żądania Kestrela `MaxRequestBodySize = 100 MB` (104857600 B) —
     raporty bywają duże.
 - `GET /health` → `200` (healthcheck compose/autoheal).
+- **Port:** domyślnie **3030** (8080 bywa zajęty na stacku), nadpisywalny env
+  `HTML2DOCX_PORT`. Serwer binduje `http://0.0.0.0:${HTML2DOCX_PORT:-3030}`.
 
 Odwzorowuje 1:1 dzisiejszy filtr stdin→stdout — minimum kodu po obu stronach,
 brak parsowania multipart, brak narzutu base64.
@@ -88,17 +90,20 @@ brak parsowania multipart, brak narzutu base64.
    `Microsoft.NET.Sdk.Web`. Runtime ASP.NET jest już w obrazie bazowym.
 2. **`src/Program.cs`** — rozgałęzienie na starcie:
    - **brak argów → tryb serwera** (nowy default): `WebApplication`
-     nasłuchujący na `0.0.0.0:8080`, endpointy `POST /convert` i `GET /health`.
-     Endpoint reużywa istniejący rdzeń konwersji (HtmlConverter/ParseBody/Save)
-     — wydzielony do wspólnej funkcji `ConvertHtmlToDocxBytes(string html)`.
+     nasłuchujący na `0.0.0.0:${HTML2DOCX_PORT:-3030}`, endpointy `POST /convert`
+     i `GET /health`. Endpoint reużywa istniejący rdzeń konwersji
+     (HtmlConverter/ParseBody/Save) — wydzielony do wspólnej funkcji
+     `ConvertHtmlToDocxBytes(string html)`.
    - **arg `-`/nazwa pliku → tryb CLI** (bez zmian): stary filtr stdin→stdout
      zachowany dla kompatybilności i standalone-żności. Ta sama funkcja rdzenia.
    - Obsługa błędów: w trybie serwera wyjątek konwersji → odpowiedź 4xx/5xx
      z komunikatem; w trybie CLI → dotychczasowe `Console.Error` + `Exit(1)`.
    - Limit ciała żądania Kestrela (`MaxRequestBodySize`) podniesiony.
 3. **`Dockerfile`**: entrypoint zostaje `dotnet HtmlToDocx.dll` (teraz domyślnie
-   serwuje), `EXPOSE 8080`, user nie-root (uid 1654) bez zmian. Bez socketa.
-   Rozważyć `HEALTHCHECK` w obrazie (lub zdać się na healthcheck compose).
+   serwuje), `ENV HTML2DOCX_PORT=3030` + `EXPOSE 3030`, user nie-root (uid 1654)
+   bez zmian. Bez socketa. Rozważyć `HEALTHCHECK` w obrazie (lub zdać się na
+   healthcheck compose). Odziedziczone `ASPNETCORE_HTTP_PORTS=8080` nie ma
+   znaczenia — bind steruje jawny `UseUrls` z `HTML2DOCX_PORT`.
 
 ## Zmiany po stronie BPP — `iplweb/bpp`
 
@@ -150,7 +155,8 @@ w bpp:
 
 - serwis `html2docx` (`image: iplweb/html2docx:<tag>`, sieć wewnętrzna, **bez
   published portu**, restart + healthcheck wg uznania), pin **po tagu**;
-- na appserverze env `DJANGO_BPP_HTML2DOCX_URL=http://<host>:<port>/convert`;
+  domyślny port **3030** (env `HTML2DOCX_PORT` jeśli trzeba inny);
+- na appserverze env `DJANGO_BPP_HTML2DOCX_URL=http://html2docx:3030/convert`;
 - zdjęcie mountu `docker.sock` z appservera.
 
 `depends_on`, healthcheck, restart policy, sieć — decyzje deploymentu, nie

--- a/src/bpp/newsfragments/+html2docx-http.bugfix.rst
+++ b/src/bpp/newsfragments/+html2docx-http.bugfix.rst
@@ -1,0 +1,6 @@
+Fallback konwersji DOCX (html2docx) działa teraz przez usługę HTTP zamiast
+uruchamiania kontenera przez ``docker.sock``. Appserver nie potrzebuje już
+dostępu do demona Dockera hosta ani Docker CLI w obrazie — usuwa to ryzyko,
+w którym błąd w aplikacji dawałby kontrolę nad całym hostem. Adres usługi
+podaje zmienna środowiskowa ``DJANGO_BPP_HTML2DOCX_URL`` (brak = fallback
+wyłączony, degradacja miękka).

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -216,6 +216,12 @@ SITE_ID = env("DJANGO_BPP_SITE_ID", default=1, cast=int)
 USE_I18N = True
 USE_TZ = True
 
+# URL usługi html2docx (sidecar HTTP) używanej jako fallback konwersji DOCX,
+# gdy pandoc zawiedzie (np. core dump na VMWare ESX). None => fallback
+# wyłączony, degradacja miękka (DocxConversionError). Patrz
+# nowe_raporty.docx_export._convert_using_html2docx_service.
+HTML2DOCX_URL = env("DJANGO_BPP_HTML2DOCX_URL", default=None)
+
 # Django 5.0 transitional; stanie się domyślne w 6.0. Wycisza
 # RemovedInDjango60Warning z forms.URLField dla URL-i bez schematu.
 FORMS_URLFIELD_ASSUME_HTTPS = True

--- a/src/nowe_raporty/docx_export.py
+++ b/src/nowe_raporty/docx_export.py
@@ -77,6 +77,7 @@ def as_docx(  # noqa: PLR0913
             _convert_using_html2docx_service(cleaned_html, output_file.name)
         except Exception as service_exc:  # noqa: BLE001
             output_file.close()
+            Path(output_file.name).unlink(missing_ok=True)
             raise DocxConversionError(
                 "DOCX conversion failed using both pandoc and html2docx"
             ) from service_exc
@@ -106,13 +107,18 @@ def _convert_using_html2docx_service(html: str, output_path: str) -> None:
     )
     response.raise_for_status()
 
-    with open(output_path, "wb") as output_file:
-        output_file.write(response.content)
-
-    # Validate output
-    output_file_path = Path(output_path)
-    if not output_file_path.exists() or output_file_path.stat().st_size == 0:
+    content = response.content
+    # Walidujemy zawartość PRZED zapisem: pusty body => brak wyniku; a status
+    # 200 z nie-DOCX (np. strona błędu proxy) rozpoznajemy po magii ZIP —
+    # .docx to archiwum ZIP zaczynające się od "PK\x03\x04". Bez tego user
+    # dostałby uszkodzony plik podany jako poprawny.
+    if not content:
         raise RuntimeError("html2docx service produced no output")
+    if not content.startswith(b"PK\x03\x04"):
+        raise RuntimeError("html2docx service returned non-DOCX content")
+
+    with open(output_path, "wb") as output_file:
+        output_file.write(content)
 
 
 def _replace_pagebreak_in_paragraph(paragraph, marker: str) -> bool:

--- a/src/nowe_raporty/docx_export.py
+++ b/src/nowe_raporty/docx_export.py
@@ -1,11 +1,11 @@
 import logging
-import subprocess
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import nh3
 import pypandoc
+import requests
 from django.conf import settings
 from flexible_reports.adapters import django_tables2 as flexible_tables
 
@@ -33,11 +33,6 @@ DEFAULT_ALLOWED_TAGS: Iterable[str] = (
 )
 
 DEFAULT_ALLOWED_ATTRIBUTES: Mapping[str, Iterable[str]] = {"td": ("colspan",)}
-
-_DOCKER_IMAGE = getattr(settings, "HTML2DOCX_DOCKER_IMAGE", "iplweb/html2docx:latest")
-_DOCKER_COMMAND: Iterable[str] = getattr(
-    settings, "HTML2DOCX_DOCKER_COMMAND", ("docker",)
-)
 
 PAGEBREAK_MARKER = "---PAGEBREAK---"
 
@@ -79,64 +74,45 @@ def as_docx(  # noqa: PLR0913
             "Pandoc conversion failed, retrying with html2docx", exc_info=exc
         )
         try:
-            _convert_using_docker_image(cleaned_html, output_file.name)
-        except Exception as docker_exc:  # noqa: BLE001
+            _convert_using_html2docx_service(cleaned_html, output_file.name)
+        except Exception as service_exc:  # noqa: BLE001
             output_file.close()
             raise DocxConversionError(
                 "DOCX conversion failed using both pandoc and html2docx"
-            ) from docker_exc
+            ) from service_exc
 
         output_file.seek(0)
         return output_file
 
 
-def _convert_using_docker_image(html: str, output_path: str) -> None:
-    # Use docker to run html2docx container with stdin/stdout piping
-    cmd = list(_DOCKER_COMMAND) + [
-        "run",
-        "--rm",
-        "-i",
-        _DOCKER_IMAGE,
-        "-",  # Read from stdin
-    ]
+def _convert_using_html2docx_service(html: str, output_path: str) -> None:
+    """Konwertuj HTML do DOCX przez usługę HTTP html2docx (sidecar).
 
-    try:
-        process = subprocess.run(  # noqa: S603
-            cmd,
-            input=html.encode("utf-8"),
-            check=True,
-            capture_output=True,
-            text=False,  # Binary mode for DOCX output
-        )
+    Adres usługi bierze się z ``settings.HTML2DOCX_URL``. Gdy nieustawiony,
+    fallback jest niedostępny — logujemy ostrzeżenie i podnosimy wyjątek,
+    który wyżej zamienia się w ``DocxConversionError`` (degradacja miękka,
+    dokładnie jak dawniej przy braku Dockera).
+    """
+    url = getattr(settings, "HTML2DOCX_URL", None)
+    if not url:
+        LOGGER.warning("html2docx fallback niedostępny: HTML2DOCX_URL nieustawiony")
+        raise RuntimeError("HTML2DOCX_URL not configured")
 
-        # Write the captured stdout to the output file
-        with open(output_path, "wb") as output_file:
-            output_file.write(process.stdout)
+    response = requests.post(
+        url,
+        data=html.encode("utf-8"),
+        headers={"Content-Type": "text/html; charset=utf-8"},
+        timeout=(5, 30),
+    )
+    response.raise_for_status()
 
-        if process.stderr:
-            LOGGER.debug(
-                "html2docx docker stderr: %s",
-                process.stderr.decode("utf-8", errors="replace"),
-            )
-
-    except subprocess.CalledProcessError as exc:
-        LOGGER.error(
-            "html2docx docker conversion failed: %s",
-            (
-                exc.stderr.decode("utf-8", errors="replace")
-                if exc.stderr
-                else "No error output"
-            ),
-        )
-        raise
-    except FileNotFoundError:
-        LOGGER.error("docker executable not found")
-        raise
+    with open(output_path, "wb") as output_file:
+        output_file.write(response.content)
 
     # Validate output
     output_file_path = Path(output_path)
     if not output_file_path.exists() or output_file_path.stat().st_size == 0:
-        raise RuntimeError("html2docx docker produced no output")
+        raise RuntimeError("html2docx service produced no output")
 
 
 def _replace_pagebreak_in_paragraph(paragraph, marker: str) -> bool:
@@ -203,7 +179,8 @@ def _replace_pagebreak_markers(docx_path: str, marker: str = PAGEBREAK_MARKER) -
 def html_to_docx(html: str, process_pagebreaks: bool = True) -> bytes:
     """Convert HTML string to DOCX bytes.
 
-    Uses pypandoc as primary converter with Docker html2docx as fallback.
+    Uses pypandoc as primary converter with the html2docx HTTP service
+    as fallback.
     Optionally processes page break markers (---PAGEBREAK---) and replaces
     them with actual Word page breaks.
 
@@ -215,7 +192,7 @@ def html_to_docx(html: str, process_pagebreaks: bool = True) -> bytes:
         DOCX file content as bytes
 
     Raises:
-        DocxConversionError: If both pypandoc and docker conversion fail
+        DocxConversionError: If both pypandoc and the html2docx service fail
     """
     output_file = NamedTemporaryFile(delete=False, suffix=".docx")
     output_path = output_file.name
@@ -228,12 +205,12 @@ def html_to_docx(html: str, process_pagebreaks: bool = True) -> bytes:
             "Pandoc conversion failed, retrying with html2docx", exc_info=exc
         )
         try:
-            _convert_using_docker_image(html, output_path)
-        except Exception as docker_exc:  # noqa: BLE001
+            _convert_using_html2docx_service(html, output_path)
+        except Exception as service_exc:  # noqa: BLE001
             Path(output_path).unlink(missing_ok=True)
             raise DocxConversionError(
                 "DOCX conversion failed using both pandoc and html2docx"
-            ) from docker_exc
+            ) from service_exc
 
     # Post-process to replace pagebreak markers with real page breaks
     if process_pagebreaks and PAGEBREAK_MARKER in html:

--- a/src/nowe_raporty/tests/test_docx_export.py
+++ b/src/nowe_raporty/tests/test_docx_export.py
@@ -1,12 +1,14 @@
-import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
+import requests
+from django.test import override_settings
 
 from nowe_raporty import docx_export
 
 HTML_CONTENT = "<h1>Test</h1>"
+
+SERVICE_URL = "http://html2docx:3030/convert"
 
 
 @pytest.fixture(autouse=True)
@@ -31,23 +33,25 @@ def test_as_docx_uses_pandoc(monkeypatch):
         Path(temp_file.name).unlink(missing_ok=True)
 
 
-def test_as_docx_falls_back_to_docker(monkeypatch):
+def test_as_docx_falls_back_to_service(monkeypatch):
     monkeypatch.setattr(
         docx_export.pypandoc,
         "convert_text",
         lambda *args, **kwargs: (_ for _ in ()).throw(OSError("pandoc missing")),
     )
 
-    def docker_fallback(html, output_path):
+    def service_fallback(html, output_path):
         assert html == HTML_CONTENT
-        Path(output_path).write_bytes(b"docker-doc")
+        Path(output_path).write_bytes(b"service-doc")
 
-    monkeypatch.setattr(docx_export, "_convert_using_docker_image", docker_fallback)
+    monkeypatch.setattr(
+        docx_export, "_convert_using_html2docx_service", service_fallback
+    )
 
     temp_file = docx_export.as_docx(object(), {})
 
     try:
-        assert Path(temp_file.name).read_bytes() == b"docker-doc"
+        assert Path(temp_file.name).read_bytes() == b"service-doc"
     finally:
         temp_file.close()
         Path(temp_file.name).unlink(missing_ok=True)
@@ -60,258 +64,87 @@ def test_as_docx_raises_when_both_converters_fail(monkeypatch):
         lambda *args, **kwargs: (_ for _ in ()).throw(OSError("pandoc missing")),
     )
 
-    def docker_fallback(html, output_path):  # noqa: ARG001
-        raise RuntimeError("docker failed")
+    def service_fallback(html, output_path):  # noqa: ARG001
+        raise RuntimeError("service failed")
 
-    monkeypatch.setattr(docx_export, "_convert_using_docker_image", docker_fallback)
+    monkeypatch.setattr(
+        docx_export, "_convert_using_html2docx_service", service_fallback
+    )
 
     with pytest.raises(docx_export.DocxConversionError):
         docx_export.as_docx(object(), {})
 
 
-def test_convert_using_docker_image_success(monkeypatch, tmp_path):
-    """Test successful HTML to DOCX conversion using Docker."""
-    html_input = "<h1>Test Document</h1>"
-    output_path = tmp_path / "output.docx"
-    expected_docx_content = b"fake-docx-content"
+def test_html2docx_service_success(monkeypatch, tmp_path):
+    """Fallback POST-uje HTML i zapisuje zwrócone bajty docx."""
+    output_path = tmp_path / "out.docx"
 
-    # Mock subprocess.run to simulate successful docker execution
-    mock_result = MagicMock()
-    mock_result.stdout = expected_docx_content
-    mock_result.stderr = b""
+    class FakeResp:
+        content = b"docx-bytes"
 
-    def mock_subprocess_run(cmd, input, check, capture_output, text):  # noqa: ARG001
-        assert cmd[0] == "docker"
-        assert cmd[1:] == [
-            "run",
-            "--rm",
-            "-i",
-            "iplweb/html2docx:latest",
-            "-",
-        ]
-        assert input == html_input.encode("utf-8")
-        assert check is True
-        assert capture_output is True
-        assert text is False
-        return mock_result
+        def raise_for_status(self):
+            pass
 
-    monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
+    captured = {}
 
-    docx_export._convert_using_docker_image(html_input, str(output_path))
+    def fake_post(url, data, headers, timeout):
+        captured["url"] = url
+        captured["data"] = data
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return FakeResp()
 
-    assert output_path.exists()
-    assert output_path.read_bytes() == expected_docx_content
+    monkeypatch.setattr(requests, "post", fake_post)
+    with override_settings(HTML2DOCX_URL=SERVICE_URL):
+        docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))
 
+    assert output_path.read_bytes() == b"docx-bytes"
+    assert captured["url"] == SERVICE_URL
+    assert captured["data"] == b"<b>x</b>"
+    assert captured["timeout"] == (5, 30)
 
-def test_convert_using_docker_image_with_stderr(monkeypatch, tmp_path, caplog):
-    """Test Docker conversion with stderr output (warnings/debug info)."""
-    import logging
 
-    # Set log level to DEBUG to capture debug messages
-    caplog.set_level(logging.DEBUG)
+def test_html2docx_service_soft_fail_when_url_none(monkeypatch, tmp_path, caplog):
+    """Brak HTML2DOCX_URL => warning + wyjątek, bez próby HTTP (miękki fail)."""
+    output_path = tmp_path / "out.docx"
 
-    html_input = "<h1>Test</h1>"
-    output_path = tmp_path / "output.docx"
-    expected_docx_content = b"docx-data"
+    def fail_post(*args, **kwargs):  # noqa: ARG001
+        raise AssertionError("nie powinno wołać requests.post gdy URL=None")
 
-    mock_result = MagicMock()
-    mock_result.stdout = expected_docx_content
-    mock_result.stderr = b"some warning message"
+    monkeypatch.setattr(requests, "post", fail_post)
 
-    monkeypatch.setattr(
-        subprocess,
-        "run",
-        lambda *args, **kwargs: mock_result,  # noqa: ARG005
-    )
+    with override_settings(HTML2DOCX_URL=None):
+        with pytest.raises(RuntimeError):
+            docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))
 
-    docx_export._convert_using_docker_image(html_input, str(output_path))
+    assert "html2docx" in caplog.text.lower()
 
-    assert output_path.exists()
-    assert output_path.read_bytes() == expected_docx_content
-    assert "html2docx docker stderr: some warning message" in caplog.text
 
+def test_html2docx_service_raises_on_error_status(monkeypatch, tmp_path):
+    """Non-2xx z usługi => wyjątek propaguje (wyżej -> DocxConversionError)."""
+    output_path = tmp_path / "out.docx"
 
-def test_convert_using_docker_image_called_process_error(monkeypatch, tmp_path, caplog):
-    """Test handling of Docker command failure (non-zero exit code)."""
-    html_input = "<h1>Test</h1>"
-    output_path = tmp_path / "output.docx"
+    class FakeResp:
+        def raise_for_status(self):
+            raise requests.HTTPError("500")
 
-    error = subprocess.CalledProcessError(
-        returncode=1, cmd=["docker"], stderr=b"docker error message"
-    )
+    monkeypatch.setattr(requests, "post", lambda *a, **k: FakeResp())
+    with override_settings(HTML2DOCX_URL=SERVICE_URL):
+        with pytest.raises(requests.HTTPError):
+            docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))
 
-    def mock_subprocess_run(*args, **kwargs):  # noqa: ARG001
-        raise error
 
-    monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
+def test_html2docx_service_empty_output_raises(monkeypatch, tmp_path):
+    """Pusty docx z usługi => RuntimeError (walidacja rozmiaru)."""
+    output_path = tmp_path / "out.docx"
 
-    with pytest.raises(subprocess.CalledProcessError):
-        docx_export._convert_using_docker_image(html_input, str(output_path))
+    class FakeResp:
+        content = b""
 
-    assert "html2docx docker conversion failed: docker error message" in caplog.text
+        def raise_for_status(self):
+            pass
 
-
-def test_convert_using_docker_image_called_process_error_no_stderr(
-    monkeypatch, tmp_path, caplog
-):
-    """Test handling of Docker failure without stderr output."""
-    html_input = "<h1>Test</h1>"
-    output_path = tmp_path / "output.docx"
-
-    error = subprocess.CalledProcessError(returncode=1, cmd=["docker"], stderr=None)
-
-    def mock_subprocess_run(*args, **kwargs):  # noqa: ARG001
-        raise error
-
-    monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-
-    with pytest.raises(subprocess.CalledProcessError):
-        docx_export._convert_using_docker_image(html_input, str(output_path))
-
-    assert "No error output" in caplog.text
-
-
-def test_convert_using_docker_image_file_not_found_error(monkeypatch, tmp_path, caplog):
-    """Test handling of Docker executable not found."""
-    html_input = "<h1>Test</h1>"
-    output_path = tmp_path / "output.docx"
-
-    def mock_subprocess_run(*args, **kwargs):  # noqa: ARG001
-        raise FileNotFoundError("docker not found")
-
-    monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-
-    with pytest.raises(FileNotFoundError):
-        docx_export._convert_using_docker_image(html_input, str(output_path))
-
-    assert "docker executable not found" in caplog.text
-
-
-def test_convert_using_docker_image_empty_output(monkeypatch, tmp_path):
-    """Test validation when Docker produces empty output."""
-    html_input = "<h1>Test</h1>"
-    output_path = tmp_path / "output.docx"
-
-    mock_result = MagicMock()
-    mock_result.stdout = b""
-    mock_result.stderr = b""
-
-    monkeypatch.setattr(
-        subprocess,
-        "run",
-        lambda *args, **kwargs: mock_result,  # noqa: ARG005
-    )
-
-    with pytest.raises(RuntimeError, match="html2docx docker produced no output"):
-        docx_export._convert_using_docker_image(html_input, str(output_path))
-
-
-def test_convert_using_docker_image_custom_docker_command(monkeypatch, tmp_path):
-    """Test using custom Docker command from settings."""
-    html_input = "<h1>Test</h1>"
-    output_path = tmp_path / "output.docx"
-    expected_docx_content = b"docx-output"
-
-    # Mock custom docker command
-    monkeypatch.setattr(docx_export, "_DOCKER_COMMAND", ("podman",))
-
-    mock_result = MagicMock()
-    mock_result.stdout = expected_docx_content
-    mock_result.stderr = b""
-
-    def mock_subprocess_run(cmd, *args, **kwargs):  # noqa: ARG001
-        assert cmd[0] == "podman"
-        assert "run" in cmd
-        return mock_result
-
-    monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-
-    docx_export._convert_using_docker_image(html_input, str(output_path))
-
-    assert output_path.exists()
-    assert output_path.read_bytes() == expected_docx_content
-
-
-def test_convert_using_docker_image_custom_docker_image(monkeypatch, tmp_path):
-    """Test using custom Docker image from settings."""
-    html_input = "<h1>Test</h1>"
-    output_path = tmp_path / "output.docx"
-    expected_docx_content = b"docx-data"
-
-    # Mock custom docker image
-    custom_image = "custom/html2docx:v2"
-    monkeypatch.setattr(docx_export, "_DOCKER_IMAGE", custom_image)
-
-    mock_result = MagicMock()
-    mock_result.stdout = expected_docx_content
-    mock_result.stderr = b""
-
-    def mock_subprocess_run(cmd, *args, **kwargs):  # noqa: ARG001
-        assert custom_image in cmd
-        return mock_result
-
-    monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-
-    docx_export._convert_using_docker_image(html_input, str(output_path))
-
-    assert output_path.exists()
-
-
-def _docker_available():
-    """Sprawdza dostępność Docker daemona LENIWIE (przy uruchomieniu testu).
-
-    Nie wołaj tego w `@pytest.mark.skipif(...)` — argumenty dekoratora liczą
-    się w momencie *importu* modułu (czyli przy każdej kolekcji pytest, także
-    `pytest -k cos_innego`), więc `docker info` startowałby na każdym przebiegu
-    i niepotrzebnie wiązał całą sesję z demonem Dockera. Wywołane wewnątrz
-    ciała testu odpala się tylko wtedy, gdy ten test naprawdę jest zbierany
-    do uruchomienia.
-    """
-    try:
-        return (
-            subprocess.run(
-                ["docker", "info"], capture_output=True, check=False
-            ).returncode
-            == 0
-        )
-    except FileNotFoundError:
-        return False
-
-
-@pytest.mark.slow
-def test_convert_using_docker_image_integration(tmp_path):
-    """Integration test: actual Docker conversion with real html2docx container.
-
-    This test requires:
-    - Docker to be installed and running
-    - Network access to pull the html2docx image (if not already present)
-
-    NOTE: This test currently expects the function to fail because the
-    iplweb/html2docx:latest image doesn't properly handle the "- -"
-    arguments (stdin + stdout). The image works with just "-" for stdin,
-    outputting to stdout by default. This appears to be a bug in the
-    current implementation.
-    """
-    html_input = """
-    <!DOCTYPE html>
-    <html>
-    <head><title>Integration Test</title></head>
-    <body>
-        <h1>Test Document</h1>
-        <p>This is a <b>bold</b> and <i>italic</i> text.</p>
-        <table>
-            <tr><th>Header 1</th><th>Header 2</th></tr>
-            <tr><td>Cell 1</td><td>Cell 2</td></tr>
-        </table>
-    </body>
-    </html>
-    """
-
-    if not _docker_available():
-        pytest.skip("Docker is not available")
-
-    output_path = tmp_path / "integration_test.docx"
-
-    # The current implementation uses "- -" which doesn't work with the image
-    # This test documents the actual behavior
-    docx_export._convert_using_docker_image(html_input, str(output_path))
+    monkeypatch.setattr(requests, "post", lambda *a, **k: FakeResp())
+    with override_settings(HTML2DOCX_URL=SERVICE_URL):
+        with pytest.raises(RuntimeError, match="no output"):
+            docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))

--- a/src/nowe_raporty/tests/test_docx_export.py
+++ b/src/nowe_raporty/tests/test_docx_export.py
@@ -80,7 +80,7 @@ def test_html2docx_service_success(monkeypatch, tmp_path):
     output_path = tmp_path / "out.docx"
 
     class FakeResp:
-        content = b"docx-bytes"
+        content = b"PK\x03\x04docx"  # magia ZIP = poprawny .docx
 
         def raise_for_status(self):
             pass
@@ -98,7 +98,7 @@ def test_html2docx_service_success(monkeypatch, tmp_path):
     with override_settings(HTML2DOCX_URL=SERVICE_URL):
         docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))
 
-    assert output_path.read_bytes() == b"docx-bytes"
+    assert output_path.read_bytes() == b"PK\x03\x04docx"
     assert captured["url"] == SERVICE_URL
     assert captured["data"] == b"<b>x</b>"
     assert captured["timeout"] == (5, 30)
@@ -147,4 +147,42 @@ def test_html2docx_service_empty_output_raises(monkeypatch, tmp_path):
     monkeypatch.setattr(requests, "post", lambda *a, **k: FakeResp())
     with override_settings(HTML2DOCX_URL=SERVICE_URL):
         with pytest.raises(RuntimeError, match="no output"):
+            docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))
+
+
+def test_html2docx_service_rejects_non_docx(monkeypatch, tmp_path):
+    """Status 200 z treścią nie-DOCX (np. strona błędu proxy) => RuntimeError.
+
+    Chroni przed podaniem userowi uszkodzonego .docx, gdy usługa/proxy zwróci
+    200 z HTML-em zamiast archiwum ZIP.
+    """
+    output_path = tmp_path / "out.docx"
+
+    class FakeResp:
+        content = b"<html><body>Bad Gateway</body></html>"
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: FakeResp())
+    with override_settings(HTML2DOCX_URL=SERVICE_URL):
+        with pytest.raises(RuntimeError, match="non-DOCX"):
+            docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))
+    assert not output_path.exists()
+
+
+def test_html2docx_service_propagates_connection_error(monkeypatch, tmp_path):
+    """Usługa nieosiągalna (ConnectionError) => wyjątek propaguje.
+
+    Kluczowy scenariusz produkcyjny: kontener html2docx padł. Wyżej zamienia
+    się w DocxConversionError (miękki fail, HTTP 500 — bez crasha).
+    """
+    output_path = tmp_path / "out.docx"
+
+    def fake_post(*args, **kwargs):  # noqa: ARG001
+        raise requests.ConnectionError("connection refused")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    with override_settings(HTML2DOCX_URL=SERVICE_URL):
+        with pytest.raises(requests.ConnectionError):
             docx_export._convert_using_html2docx_service("<b>x</b>", str(output_path))


### PR DESCRIPTION
## Cel

Poprawka **bezpieczeństwa**. Produkcyjny appserver miał zamontowany
`/var/run/docker.sock`, bo fallback konwersji DOCX (`nowe_raporty/docx_export.py`)
uruchamiał `docker run iplweb/html2docx` gdy pandoc zawiedzie. Sufiks `:ro` nie
czyni API Dockera read-only — proces mógł tworzyć kontenery, montować katalogi
hosta i wykonywać procesy. Skutek: **każde przyszłe RCE w appserverze = przejęcie
hosta i wszystkich kontenerów**. Fallback odpalany rzadko — a socket wisiał 24/7.

Ten PR zastępuje docker-run-fallback wywołaniem **HTTP do długożyjącej usługi
html2docx** (osobny kontener .NET). Appserver traci Docker CLI, a po stronie
deploya znika potrzeba `docker.sock`.

> **Fallback musi zostać**: obraz html2docx istnieje, bo pandoc robi *core dump
> na hostach VMWare ESX*. To realna siatka bezpieczeństwa pod crashującym
> primary converterem — nie usuwamy go, tylko zmieniamy sposób dostępu.

## Co się zmienia (bpp)

- **`src/nowe_raporty/docx_export.py`** — `_convert_using_docker_image` →
  `_convert_using_html2docx_service`: `requests.post` HTML → usługa, zapis
  zwróconych bajtów docx. Usunięte: `import subprocess`, stałe `_DOCKER_*`.
- **`src/django_bpp/settings/base.py`** — setting `HTML2DOCX_URL` z env
  `DJANGO_BPP_HTML2DOCX_URL` (**default `None`**).
- **`docker/appserver/Dockerfile`** — usunięty stage `FROM docker:cli` i Docker
  CLI (mniejszy obraz, mniejsza powierzchnia ataku).
- **`docker-compose.yml` + `.env.docker`** (dev) — serwis `html2docx` + URL
  współdzielony przez appserver i workery (celery task oświadczeń też robi DOCX).
- Testy, newsfragment, `docs/deweloper/html2docx.md`.

## Miękka degradacja (świadomy wybór)

Łańcuch: `pandoc (in-process) → html2docx HTTP → DocxConversionError (500)`.
Gdy `HTML2DOCX_URL` nieustawiony / usługa nieosiągalna / timeout / non-200 /
odpowiedź nie-DOCX → warning + `DocxConversionError` (HTTP 500, **bez crasha**).
**Nie ma powrotu do dockera** — to celowe: docker fallback wymagałby z powrotem
`docker.sock` + Docker CLI, czyli cofnąłby całą tę poprawkę.

## Kontrakt usługi html2docx

`POST /convert` (body = HTML `text/html; charset=utf-8`, resp = bajty `.docx`),
`GET /health`. Port domyślnie **3030** (env `HTML2DOCX_PORT`). Walidacja
odpowiedzi po magii ZIP `PK\x03\x04` (200 z nie-DOCX → błąd, nie uszkodzony plik).

## Testy

- 9/9 unit (sukces / `URL=None` miękki fail / non-2xx / pusty output / nie-DOCX /
  `ConnectionError`).
- E2E: ścieżka Pythona bpp ↔ realna usługa → poprawny docx (`PK\x03\x04`).
- ruff check + format czyste. Code review (subagent) — brak blockerów; uwagi
  (wyciek pliku tmp, walidacja DOCX) zaadresowane.

## Zakres / handoff

- **Obraz `iplweb/html2docx` z trybem serwera HTTP — opublikowany** (repo obrazu
  poprawione). ✔
- **Wiring produkcyjnego `bpp-deploy`** (serwis + env `DJANGO_BPP_HTML2DOCX_URL`
  + zdjęcie `docker.sock` z appservera) jest **poza tym PR** — robi go deployment
  osobno. Kontrakt: `docs/deweloper/html2docx.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
