### PR TITLE
Bump django-first-run-wizard to 0.2.0 (setup-wizard race fix + zero per-request cost)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ dependencies = [
     # niezdefiniowane (no-op AppConfig.ready).
     "django-pg-baseline>=0.3.0",
     "django-site-blog>=0.2.1",
-    "django-first-run-wizard>=0.1.1",
+    "django-first-run-wizard>=0.2.0",
     "uvicorn-worker>=0.4.0",
     "mozilla-django-oidc>=5.0.2,<6",
     "babel>=2.17",

--- a/src/bpp/newsfragments/first-run-wizard-state.bugfix.rst
+++ b/src/bpp/newsfragments/first-run-wizard-state.bugfix.rst
@@ -1,0 +1,7 @@
+Kreator pierwszego uruchomienia: dwa równoległe żądania tworzące pierwsze
+konto administratora nie mogą już utworzyć dwóch superużytkowników
+(blokada transakcyjna zamiast sprawdzenia podatnego na wyścig). Ukończony
+kreator nie wykonuje już zapytań do bazy przy każdym żądaniu — po
+zakończeniu konfiguracji middleware sam się wyłącza, a widoki ``/setup/``
+zwracają 404 (usunięcie uczelni lub użytkownika nie otwiera ponownie
+kreatora). Wymaga ``django-first-run-wizard>=0.2.0``.

--- a/src/bpp_setup_wizard/tests.py
+++ b/src/bpp_setup_wizard/tests.py
@@ -139,9 +139,11 @@ def test_uczelnia_setup_not_accessible_when_exists(admin_user, uczelnia):
 
     response = client.get(reverse("first_run_wizard:step", kwargs={"name": "uczelnia"}))
 
-    # Step is_complete()==True → WizardStepView redirects to '/'.
-    assert response.status_code == 302
-    assert response.url == "/"
+    # Admin + uczelnia both exist → every step is complete → the wizard is
+    # done. With django-first-run-wizard>=0.2.0 the middleware records
+    # completion (on construction) and the /setup/ views return 404 — setup
+    # is closed for good; deleting the uczelnia no longer re-opens it.
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/uv.lock
+++ b/uv.lock
@@ -584,7 +584,7 @@ requires-dist = [
     { name = "django-extensions", specifier = ">=3.2,<5" },
     { name = "django-favicon-plus-reloaded", specifier = ">=1.2,<2" },
     { name = "django-filter", specifier = ">=25.2,<25.3" },
-    { name = "django-first-run-wizard", specifier = ">=0.1.1" },
+    { name = "django-first-run-wizard", specifier = ">=0.2.0" },
     { name = "django-flexible-reports", specifier = ">=0.3.2" },
     { name = "django-formdefaults", specifier = ">=0.6.2" },
     { name = "django-formtools", specifier = ">=2.6.1,<3" },
@@ -1836,14 +1836,14 @@ wheels = [
 
 [[package]]
 name = "django-first-run-wizard"
-version = "0.1.1"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/43/5bae4b00929c3100f2a263e4dcae24eefcfad80efc9d1413aa7e2b3be4f4/django_first_run_wizard-0.1.1.tar.gz", hash = "sha256:2e84550eb58e10af4a3fb64e6e5735bdc9ae14f73c96ac12f7b2c616c37a0d0b", size = 19188, upload-time = "2026-05-13T20:49:11.237Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/04/7eefcc00d4c157249c482e5f28db6795ff42dd3b7ab353717dde89801300/django_first_run_wizard-0.2.0.tar.gz", hash = "sha256:9b3c52d0f0f6d9ba4c5ef6843103d321ab9f58ce233a1feff970286316530af1", size = 27234, upload-time = "2026-07-12T17:03:05.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/5c/7b03f140f2e3a236721e7bbaf8351b580562cdb9a210224a2dcd0686bf94/django_first_run_wizard-0.1.1-py3-none-any.whl", hash = "sha256:58d3b8df89b79cf86fa89f6233ed47b35ed3bbaf434abe0085f46d984346598e", size = 19348, upload-time = "2026-05-13T20:49:12.374Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/8c68db2a91a6516fccb30d1db9419f628c0031abd906b803a337457e4274/django_first_run_wizard-0.2.0-py3-none-any.whl", hash = "sha256:ef4030fb4d995b2ed486a74472e50e78b7ee2ddbe3367e3a8ee2e446678d5020", size = 26149, upload-time = "2026-07-12T17:03:07.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `django-first-run-wizard` `0.1.1 → 0.2.0` (published to PyPI). The new release backs the first-run wizard with a single-row state model, fixing two issues in bpp's setup flow.

## Why
- **Security (race):** two simultaneous POSTs to the first-superuser step could each create a superuser — the only guard was `form.clean()`'s `User.objects.exists()`, a TOCTOU check both requests can pass. 0.2.0 creates the admin inside `transaction.atomic()` under `select_for_update()` on the state row, re-checking after the lock → exactly one winner; the loser gets a form error, not an HTTP 500.
- **Performance:** the wizard middleware ran an `EXISTS` query per step on *every* request, forever. 0.2.0 records `completed_at` once setup is done and raises `MiddlewareNotUsed` at construction, so a finished install runs zero wizard queries per request.
- **Correctness:** `/setup/` returns 404 after completion; deleting the uczelnia/admin no longer re-opens the wizard.

The completion flag lives in the DB (not a cache), so a database reset re-opens the wizard — the right behavior for bpp's dev/reset workflow.

## Changes
- `pyproject.toml` + `uv.lock`: `django-first-run-wizard>=0.2.0`.
- `test_uczelnia_setup_not_accessible_when_exists`: updated to the new contract (404 instead of 302→`/`) — once admin+uczelnia exist the wizard is complete and `/setup/` is closed.
- Newsfragment added.

The new package migration `first_run_wizard.0001_initial` applies as a post-baseline delta (creates the singleton table + seeds `pk=1`). Baseline refresh deferred to merge per convention.

## Testing
`src/bpp_setup_wizard/tests.py`: **13 passed** against 0.2.0 (migration applied via testcontainers).

Package side: https://github.com/iplweb/django-first-run-wizard/pull/1 — 43 tests on SQLite + a threaded two-connection race test on real PostgreSQL (proven to fail 15/15 if the lock is removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)