### PR TITLE
chore(deps): zaktualizuj Django do 5.2.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 requires-python = ">=3.11,<3.15"
 dependencies = [
-    "Django>=5.2.15,<5.3",
+    "Django>=5.2.16,<5.3",
     "django-polish-inflection>=0.1,<0.2",
     "django-axes>=7.0,<9",
     "arrow>=1.3,<2",

--- a/src/bpp/newsfragments/django-5.2.16.bugfix.rst
+++ b/src/bpp/newsfragments/django-5.2.16.bugfix.rst
@@ -1,0 +1,1 @@
+Zaktualizowano Django do 5.2.16 (poprawki bezpieczeństwa serii 5.2 LTS).

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ requires-dist = [
     { name = "cssmin", specifier = "==0.2.0" },
     { name = "dbfread", specifier = ">=2.0.7" },
     { name = "dj-pagination", specifier = "==2.5.0" },
-    { name = "django", specifier = ">=5.2.15,<5.3" },
+    { name = "django", specifier = ">=5.2.16,<5.3" },
     { name = "django-admin-sortable2", specifier = ">=2.3.1,<3" },
     { name = "django-admin-tools", specifier = "==0.9.3" },
     { name = "django-auth-ldap", marker = "extra == 'ldap'", specifier = ">=5.3.0" },
@@ -1435,16 +1435,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.15"
+version = "5.2.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref", marker = "platform_python_implementation != 'PyPy'" },
     { name = "sqlparse", marker = "platform_python_implementation != 'PyPy'" },
     { name = "tzdata", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/e3/31722f7284c9f43333daff9aee9184678e4487adcb5506af0db8cea09ce1/django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7", size = 10873669, upload-time = "2026-06-03T13:03:35.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/b5/38140b1643c00d5c46ce69c78e6980fd285aee223100319631bedee4f5e7/django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970", size = 8311957, upload-time = "2026-06-03T13:03:31.329Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Co

Bump Django `5.2.15` → `5.2.16` (seria 5.2 LTS, poprawki bezpieczeństwa).

- `pyproject.toml`: floor pinu `Django>=5.2.15,<5.3` → `>=5.2.16,<5.3`
- `uv.lock`: re-resolve wyłącznie `django` (`uv lock --upgrade-package django`)
- newsfragment (towncrier, `bugfix`)

## Dlaczego

Utrzymanie zależności na najnowszym patch LTS. Zmiana w obrębie serii 5.2 — bez zmian API, czysto patch-level.

## Testy

`make tests` uruchomione lokalnie (wynik dopisany w komentarzu). CI: czekam na `Build test-runner image` + `Tests (sharded)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)