### PR TITLE
feat(zglos_publikacje): retencja plików tmp przez Celery beat (zamiast Ofelii)

### DIFF
--- a/src/bpp/newsfragments/zglos-tmp-celerybeat.feature.rst
+++ b/src/bpp/newsfragments/zglos-tmp-celerybeat.feature.rst
@@ -1,0 +1,6 @@
+Retencja porzuconych plików tymczasowych kreatora zgłaszania publikacji jest
+teraz uruchamiana automatycznie jako cykliczne zadanie Celery beat (co 6 h),
+obok pozostałych zadań czyszczących. Rdzeń czyszczenia jest współdzielony z
+management-commandą ``wyczysc_zglos_tmp`` (do ręcznych/ops uruchomień). Dzięki
+temu retencja jedzie razem z kodem aplikacji — nie wymaga osobnej konfiguracji
+crona po stronie wdrożenia.

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -779,6 +779,15 @@ CELERYBEAT_SCHEDULE = {
         "task": "oswiadczenia.tasks.remove_old_oswiadczenia_export_files",
         "schedule": timedelta(days=1),
     },
+    # Retencja porzuconych plików tmp kreatora zgłoszeń publikacji (anonimowy
+    # formularz — porzucone uploady zostałyby na wolumenie media bez ograniczeń;
+    # anty-DoS na dysk, bpp #551). Kasuje sieroty >24h z osobnego katalogu tmp,
+    # nie ruszając finalnych załączników. Worker montuje media (jak sąsiednie
+    # cleanup-*), więc kasowanie działa.
+    "wyczysc-zglos-tmp-pliki": {
+        "task": "zglos_publikacje.tasks.wyczysc_zglos_tmp_pliki",
+        "schedule": timedelta(hours=6),
+    },
     "rebuild-pbn-author-match-cache": {
         "task": "importer_autorow_pbn.tasks.auto_rebuild_match_cache_task",
         "schedule": crontab(hour=3, minute=30),  # Daily at 3:30 AM

--- a/src/zglos_publikacje/cleanup.py
+++ b/src/zglos_publikacje/cleanup.py
@@ -1,0 +1,85 @@
+"""Rdzeń czyszczenia porzuconych plików tymczasowych kreatora zgłoszeń.
+
+Wspólny dla management-commandy `wyczysc_zglos_tmp` (ręczne/ops runy) oraz
+celery-taska `zglos_publikacje.tasks.wyczysc_zglos_tmp_pliki` (cykliczny beat).
+Kasuje pliki starsze niż `older_than_hours` WYŁĄCZNIE z katalogu tmp
+(`zglos_tmp_dir()`), tego samego punktu prawdy co wizard.
+
+Bezpieczeństwo wobec nakazu klienta „nigdy nie kasuj plików realnych zgłoszeń"
+opiera się na KONSTRUKCJI: trwałe pliki ukończonych zgłoszeń lądują w OSOBNYM
+katalogu (`protected/zglos_publikacje/`), którego tu nie dotykamy. Dodatkowo
+strażnik równości basename odmawia działania, gdy rozwiązany katalog celu nie
+jest dokładnie skonfigurowanym katalogiem tmp.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import time
+
+from zglos_publikacje.storage import ZGLOS_TMP_DIRNAME, zglos_tmp_dir
+
+
+class ZglosTmpGuardError(Exception):
+    """Strażnik ścieżki: katalog celu nie jest skonfigurowanym katalogiem tmp."""
+
+
+def wyczysc_tmp_pliki(older_than_hours: int = 24, dry_run: bool = False) -> dict:
+    """Skasuj porzucone pliki tmp starsze niż `older_than_hours`.
+
+    Zwraca dict `{skasowane, skasowane_bajty, pominiete, katalog_nieobecny}`.
+    Rzuca `ValueError` dla ujemnego progu, `ZglosTmpGuardError` gdy strażnik
+    ścieżki odmawia (katalog o innym basename niż tmp).
+    """
+    if older_than_hours < 0:
+        # Ujemny próg → prog w przyszłości → skasowałby WSZYSTKO, łącznie
+        # z plikami in-flight żywych sesji. Odmawiamy (błąd wywołującego).
+        raise ValueError("older_than_hours musi być >= 0.")
+
+    # realpath — neutralizuje symlink i trailing slash zanim porównamy basename.
+    tmp = pathlib.Path(zglos_tmp_dir()).resolve()
+
+    wynik = {
+        "skasowane": 0,
+        "skasowane_bajty": 0,
+        "pominiete": 0,
+        "katalog_nieobecny": False,
+    }
+
+    if not tmp.exists():
+        # Świeża instalacja, zero uploadów — nie ma czego czyścić. NIE wołamy
+        # iterdir() (rzuciłby FileNotFoundError).
+        wynik["katalog_nieobecny"] = True
+        return wynik
+
+    # STRAŻNIK: równość basename (nie endswith). Zabezpieczenie przed
+    # skasowaniem złego katalogu, gdyby punkt prawdy został podmieniony.
+    if tmp.name != ZGLOS_TMP_DIRNAME:
+        raise ZglosTmpGuardError(
+            f"Katalog docelowy '{tmp}' nie jest katalogiem tmp "
+            f"'{ZGLOS_TMP_DIRNAME}' — odmawiam działania."
+        )
+
+    prog = time.time() - older_than_hours * 3600
+
+    for e in tmp.iterdir():
+        # lstat — nie podążaj za linkiem; kasuj tylko zwykłe pliki, nigdy
+        # symlinki (mogłyby wskazywać na plik trwały) ani katalogi.
+        if not e.is_file() or e.is_symlink():
+            wynik["pominiete"] += 1
+            continue
+        try:
+            st = e.lstat()
+            if st.st_mtime < prog:
+                if not dry_run:
+                    e.unlink()
+                wynik["skasowane"] += 1
+                wynik["skasowane_bajty"] += st.st_size
+            else:
+                wynik["pominiete"] += 1
+        except FileNotFoundError:
+            # Żywa sesja kreatora skasowała swój plik równolegle (między
+            # iterdir a lstat/unlink) — nie nasz problem, nie wywalaj przebiegu.
+            wynik["pominiete"] += 1
+
+    return wynik

--- a/src/zglos_publikacje/management/commands/wyczysc_zglos_tmp.py
+++ b/src/zglos_publikacje/management/commands/wyczysc_zglos_tmp.py
@@ -1,24 +1,17 @@
 """Czyszczenie porzuconych plików tymczasowych kreatora zgłoszeń.
 
-Kasuje pliki starsze niż `--older-than-hours` (default 24) WYŁĄCZNIE
-z katalogu tmp (`MEDIA_ROOT/protected/zglos_publikacje_tmp/`), tego samego
-punktu prawdy co wizard (`storage.zglos_tmp_dir`).
-
-Bezpieczeństwo wobec nakazu klienta „nigdy nie kasuj plików realnych
-zgłoszeń" opiera się na KONSTRUKCJI: trwałe pliki ukończonych zgłoszeń
-lądują w OSOBNYM katalogu (`protected/zglos_publikacje/`), którego ta
-komenda nie dotyka. Dodatkowo strażnik ścieżki odmawia działania, gdy
-rozwiązany katalog celu nie jest dokładnie skonfigurowanym katalogiem tmp.
+Cienki wrapper CLI na `zglos_publikacje.cleanup.wyczysc_tmp_pliki` (ten sam
+rdzeń woła cykliczny celery task `zglos_publikacje.tasks`). Kasuje pliki
+starsze niż `--older-than-hours` (default 24) WYŁĄCZNIE z katalogu tmp
+(`MEDIA_ROOT/protected/zglos_publikacje_tmp/`). Trwałe pliki ukończonych
+zgłoszeń są w osobnym katalogu i pozostają nietknięte.
 """
 
 from __future__ import annotations
 
-import pathlib
-import time
-
 from django.core.management.base import BaseCommand, CommandError
 
-from zglos_publikacje.storage import ZGLOS_TMP_DIRNAME, zglos_tmp_dir
+from zglos_publikacje.cleanup import ZglosTmpGuardError, wyczysc_tmp_pliki
 
 
 class Command(BaseCommand):
@@ -45,59 +38,22 @@ class Command(BaseCommand):
         older_than_hours = options["older_than_hours"]
         dry_run = options["dry_run"]
 
-        if older_than_hours < 0:
-            # Ujemny próg → prog w przyszłości → skasowałby WSZYSTKO, łącznie
-            # z plikami in-flight żywych sesji. Odmawiamy (błąd operatora).
-            raise CommandError("--older-than-hours musi być >= 0.")
-
-        # realpath — neutralizuje symlink i trailing slash zanim porównamy
-        # basename ze strażnikiem.
-        tmp = pathlib.Path(zglos_tmp_dir()).resolve()
-
-        if not tmp.exists():
-            # Świeża instalacja, zero uploadów — nie ma czego czyścić.
-            # NIE wołamy iterdir() (rzuciłby FileNotFoundError).
-            self.stdout.write(f"Katalog tmp nie istnieje ({tmp}) — nic do czyszczenia.")
-            return
-
-        # STRAŻNIK: równość basename (nie endswith). Zabezpieczenie przed
-        # skasowaniem złego katalogu, gdyby punkt prawdy został podmieniony.
-        if tmp.name != ZGLOS_TMP_DIRNAME:
-            raise CommandError(
-                "Strażnik ścieżki: katalog docelowy "
-                f"'{tmp}' nie jest katalogiem tmp "
-                f"'{ZGLOS_TMP_DIRNAME}' — odmawiam działania."
+        try:
+            wynik = wyczysc_tmp_pliki(
+                older_than_hours=older_than_hours, dry_run=dry_run
             )
+        except ValueError as e:
+            raise CommandError(str(e)) from e
+        except ZglosTmpGuardError as e:
+            raise CommandError(f"Strażnik ścieżki: {e}") from e
 
-        prog = time.time() - older_than_hours * 3600
-
-        skasowane = 0
-        skasowane_bajty = 0
-        pominiete = 0
-
-        for e in tmp.iterdir():
-            # lstat — nie podążaj za linkiem; kasuj tylko zwykłe pliki, nigdy
-            # symlinki (mogłyby wskazywać na plik trwały) ani katalogi.
-            if not e.is_file() or e.is_symlink():
-                pominiete += 1
-                continue
-            try:
-                st = e.lstat()
-                if st.st_mtime < prog:
-                    if not dry_run:
-                        e.unlink()
-                    skasowane += 1
-                    skasowane_bajty += st.st_size
-                else:
-                    pominiete += 1
-            except FileNotFoundError:
-                # Żywa sesja kreatora skasowała swój plik równolegle (między
-                # iterdir a lstat/unlink) — nie nasz problem, nie wywalaj crona.
-                pominiete += 1
+        if wynik["katalog_nieobecny"]:
+            self.stdout.write("Katalog tmp nie istnieje — nic do czyszczenia.")
+            return
 
         etykieta = "do skasowania" if dry_run else "skasowano"
         naglowek = "[DRY-RUN] " if dry_run else ""
         self.stdout.write(
-            f"{naglowek}{etykieta}: {skasowane} plików "
-            f"({skasowane_bajty} bajtów); pominięto: {pominiete}."
+            f"{naglowek}{etykieta}: {wynik['skasowane']} plików "
+            f"({wynik['skasowane_bajty']} bajtów); pominięto: {wynik['pominiete']}."
         )

--- a/src/zglos_publikacje/tasks.py
+++ b/src/zglos_publikacje/tasks.py
@@ -1,0 +1,30 @@
+"""Celery taski aplikacji zgłoszeń publikacji."""
+
+from celery import shared_task
+from celery.utils.log import get_task_logger
+
+from zglos_publikacje.cleanup import wyczysc_tmp_pliki
+
+logger = get_task_logger(__name__)
+
+
+@shared_task
+def wyczysc_zglos_tmp_pliki(older_than_hours: int = 24) -> dict:
+    """Cykliczna retencja porzuconych plików tmp kreatora zgłoszeń.
+
+    Rejestrowany w `CELERYBEAT_SCHEDULE`. Rdzeń wspólny z management-commandą
+    `wyczysc_zglos_tmp`. Worker montuje wolumen media (jak przy
+    `remove_old_integrator_files` / `remove_old_oswiadczenia_export_files`),
+    więc kasowanie plików pod `MEDIA_ROOT` działa.
+    """
+    wynik = wyczysc_tmp_pliki(older_than_hours=older_than_hours)
+    if wynik["katalog_nieobecny"]:
+        logger.info("wyczysc_zglos_tmp_pliki: katalog tmp nie istnieje — pomijam.")
+    else:
+        logger.info(
+            "wyczysc_zglos_tmp_pliki: skasowano %s plików (%s bajtów), pominięto %s.",
+            wynik["skasowane"],
+            wynik["skasowane_bajty"],
+            wynik["pominiete"],
+        )
+    return wynik

--- a/src/zglos_publikacje/tests/test_tasks_wyczysc_zglos.py
+++ b/src/zglos_publikacje/tests/test_tasks_wyczysc_zglos.py
@@ -1,0 +1,52 @@
+"""Testy celery-taska retencji plików tmp + rejestracji w CELERYBEAT_SCHEDULE."""
+
+import os
+import time
+
+from django.conf import settings
+from django.test import override_settings
+
+from zglos_publikacje.storage import zglos_tmp_dir
+from zglos_publikacje.tasks import wyczysc_zglos_tmp_pliki
+
+GODZINA = 3600
+NAZWA_TASKA = "zglos_publikacje.tasks.wyczysc_zglos_tmp_pliki"
+
+
+def _ustaw_mtime(sciezka, przed_iloma_godzinami):
+    t = time.time() - przed_iloma_godzinami * GODZINA
+    os.utime(sciezka, (t, t))
+
+
+def test_task_kasuje_stare_zostawia_swieze(tmp_path):
+    """Task (rdzeń wspólny z komendą) kasuje sieroty >24h, świeże zostawia."""
+    with override_settings(MEDIA_ROOT=str(tmp_path)):
+        tmp = zglos_tmp_dir()
+        os.makedirs(tmp)
+        stary = os.path.join(tmp, "stary.pdf")
+        swiezy = os.path.join(tmp, "swiezy.pdf")
+        for p, mtime_h in ((stary, 25), (swiezy, 1)):
+            with open(p, "wb") as f:
+                f.write(b"x" * 10)
+            _ustaw_mtime(p, mtime_h)
+
+        wynik = wyczysc_zglos_tmp_pliki()
+
+        assert wynik["skasowane"] == 1
+        assert not os.path.exists(stary)
+        assert os.path.exists(swiezy)
+
+
+def test_task_nieistniejacy_katalog_bez_wyjatku(tmp_path):
+    """Świeża instalacja (brak katalogu tmp) → task nie rzuca, sygnalizuje brak."""
+    with override_settings(MEDIA_ROOT=str(tmp_path)):
+        assert not os.path.exists(zglos_tmp_dir())
+        wynik = wyczysc_zglos_tmp_pliki()
+        assert wynik["katalog_nieobecny"] is True
+        assert wynik["skasowane"] == 0
+
+
+def test_task_zarejestrowany_w_celerybeat():
+    """Task retencji jest wpięty w harmonogram beat (obok rodzeństwa cleanup-*)."""
+    nazwy = {wpis["task"] for wpis in settings.CELERYBEAT_SCHEDULE.values()}
+    assert NAZWA_TASKA in nazwy

--- a/src/zglos_publikacje/tests/test_wyczysc_zglos_tmp.py
+++ b/src/zglos_publikacje/tests/test_wyczysc_zglos_tmp.py
@@ -18,7 +18,8 @@ from django.test import override_settings
 from zglos_publikacje.storage import zglos_tmp_dir
 
 GODZINA = 3600
-COMMAND_MODULE = "zglos_publikacje.management.commands.wyczysc_zglos_tmp"
+# Logika (w tym wołanie zglos_tmp_dir) siedzi w rdzeniu cleanup, nie w komendzie.
+CLEANUP_MODULE = "zglos_publikacje.cleanup"
 
 
 def _ustaw_mtime(sciezka, przed_iloma_godzinami):
@@ -122,7 +123,7 @@ def test_straznik_odmawia_na_zlym_katalogu(tmp_path, monkeypatch):
             f.write(b"b" * 20)
         _ustaw_mtime(plik, 100)  # bardzo stary — i tak nie wolno go tknąć
 
-        monkeypatch.setattr(f"{COMMAND_MODULE}.zglos_tmp_dir", lambda: zly)
+        monkeypatch.setattr(f"{CLEANUP_MODULE}.zglos_tmp_dir", lambda: zly)
 
         with pytest.raises(CommandError):
             call_command("wyczysc_zglos_tmp")


### PR DESCRIPTION
## Kontekst

Po naprawie #551 (`wyczysc_zglos_tmp` — retencja porzuconych plików tmp kreatora zgłoszeń) trzeba było wpiąć czyszczenie w harmonogram. Pierwotnie poszło do Ofelii (bpp-deploy), ale **właściwe miejsce to Celery beat w kodzie bpp**.

**Dlaczego beat, nie Ofelia:** w bpp `CELERYBEAT_SCHEDULE` już trzyma bezpośrednie rodzeństwo — `cleanup-integrator2-files`, `cleanup-oswiadczenia-export-files`: lekkie, cykliczne kasowanie plików. Ofelia (bpp-deploy) trzyma **ciężkie one-shoty** (denorm_rebuild, rebuild_*, pbn_integrator — izolowane od puli workerów) + infra (backup, LE, log-rotate, restart). `wyczysc_zglos_tmp` to lekki cyklik → beat. Zaleta: retencja jedzie z kodem, każde wdrożenie ją dostaje bez konfiguracji crona.

Worker montuje wolumen media (`media:/mediaroot`, jak przy istniejących `cleanup-*` taskach kasujących pliki pod MEDIA_ROOT) — więc task ma dostęp do plików.

## Zmiany

- **`zglos_publikacje/cleanup.py`** (nowy) — rdzeń `wyczysc_tmp_pliki(older_than_hours, dry_run)`, współdzielony. Strażnik ścieżki (równość basename), pomijanie symlinków, `lstat`, obsługa wyścigu (`FileNotFoundError`), odmowa dla ujemnego progu — bez zmian względem #551, tylko wyciągnięte z komendy.
- **`zglos_publikacje/tasks.py`** (nowy) — `@shared_task wyczysc_zglos_tmp_pliki` (autodiscover).
- **`CELERYBEAT_SCHEDULE`** — wpis `wyczysc-zglos-tmp-pliki`, **co 6 h** (obok rodzeństwa cleanup).
- **Komenda `wyczysc_zglos_tmp`** — cienki wrapper CLI na ten sam rdzeń (zostaje do ręcznych/ops runów + testów).

## Testy

**11 passed** (`test_wyczysc_zglos_tmp.py` 8 — komenda bez zmian zachowania; `test_tasks_wyczysc_zglos.py` 3 — task kasuje/zostawia, brak katalogu bez wyjątku, rejestracja w `CELERYBEAT_SCHEDULE`). Bez zmian modeli → bez migracji.

## Powiązane

- bpp-deploy PR #18 — sprowadzony do **nginx-only** (cron Ofelii wycięty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)