### PR TITLE
fix(tests): ustabilizuj flaky testy import_pracownikow + deduplikator pod xdist

### DIFF
--- a/src/bpp/newsfragments/+flaky-import-dedup-xdist.bugfix.rst
+++ b/src/bpp/newsfragments/+flaky-import-dedup-xdist.bugfix.rst
@@ -1,0 +1,8 @@
+Ustabilizowano flaky testy ``import_pracownikow`` i ``deduplikator_autorow`` pod
+zrównoleglonym uruchomieniem (pytest-split + xdist). Testy tworzące jednostki o
+dosłownej nazwie „Katedra Testowa" itp. kolidowały na unikalnym constraincie
+``bpp_jednostka_nazwa_key``, gdy scommitowany wiersz sąsiada przeciekł na
+współdzielony worker — nazwy jednostek są teraz globalnie unikalne (czytelny
+prefiks + losowy sufiks). Test wykrywania duplikatów autorów asertuje własną
+inwariantę (para w jednym klastrze) zamiast globalnej liczby kandydatów, więc
+ambient „Kowalski Jan" z sąsiednich testów już go nie wywraca.

--- a/src/bpp/newsfragments/+flaky-import-dedup-xdist.bugfix.rst
+++ b/src/bpp/newsfragments/+flaky-import-dedup-xdist.bugfix.rst
@@ -1,8 +1,10 @@
-Ustabilizowano flaky testy ``import_pracownikow`` i ``deduplikator_autorow`` pod
-zrównoleglonym uruchomieniem (pytest-split + xdist). Testy tworzące jednostki o
-dosłownej nazwie „Katedra Testowa" itp. kolidowały na unikalnym constraincie
-``bpp_jednostka_nazwa_key``, gdy scommitowany wiersz sąsiada przeciekł na
-współdzielony worker — nazwy jednostek są teraz globalnie unikalne (czytelny
-prefiks + losowy sufiks). Test wykrywania duplikatów autorów asertuje własną
-inwariantę (para w jednym klastrze) zamiast globalnej liczby kandydatów, więc
-ambient „Kowalski Jan" z sąsiednich testów już go nie wywraca.
+Ustabilizowano flaky testy pod shardingiem (pytest-split + xdist). Pod
+obciążeniem CI test commitujący dane poza rollback zostawiał w bazie workera
+ambient autorów/jednostek/stopni/stanowisk, przez co kolejne testy pękały na
+unikalnym constraincie (``bpp_jednostka_nazwa_key`` itp.) albo na asercjach
+„pusta baza". Dodano defensywny guard izolacji w ``src/conftest.py``, który
+przed każdym testem czyści wyciekłe dane domenowe (TRUNCATE tabel pustych w
+baseline, bez ruszania danych referencyjnych). Dodatkowo testy
+``import_pracownikow`` używają globalnie unikalnych nazw jednostek, a test
+wykrywania duplikatów autorów asertuje inwariantę klastra zamiast globalnej
+liczby kandydatów.

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -164,16 +164,9 @@ TransactionTestCase._fixture_teardown = _fixture_teardown
 # zostaje w obrębie danych domenowych. Osobne autocommit-połączenie czyści
 # COMMITTED wiersze (poza transakcją testu). Leak-triggered: TRUNCATE odpala
 # się tylko gdy wykryty wyciek, więc w normalnym przypadku to 1 tani probe.
-#
-# DIAGNOSTYKA: przy wykryciu wycieku guard wypisuje do stderr (widoczne w
-# logach CI) które tabele wyciekły oraz najprawdopodobniejszego SPRAWCĘ —
-# poprzedni test DB na tym workerze. Bo guard sprawdza każdy test DB i czyści
-# przy każdym wykryciu, więc wyciek widziany na setupie testu X powstał po
-# ostatnim czystym stanie = w poprzednim teście DB. To ścieżka do docelowego
-# root-cause fixa (namierzyć i naprawić test commitujący poza rollback).
 # =============================================================================
 
-_LEAK_GUARD = {"conn": None, "poprzedni": "<start sesji>", "ref_snapshot": None}
+_LEAK_GUARD = {"conn": None}
 _LEAK_GUARD_TABLES = (
     "bpp_autor",
     "bpp_jednostka",
@@ -181,45 +174,6 @@ _LEAK_GUARD_TABLES = (
     "bpp_stanowiskodydaktyczne",
     "bpp_grupa_pracownicza",
 )
-# Sentinel dla WYCIEKU odwrotnego (vector 2): tabela referencyjna zaseedowana
-# migracją danych, której post_migrate NIE odtwarza po flushu. Gdy jest pusta,
-# a snapshot ją miał → transakcyjny flush zmiótł dane referencyjne workera.
-_LEAK_GUARD_SENTINEL = "bpp_crossref_mapper"
-
-
-def _snapshot_reference(cur):
-    """Snapshot tabel referencyjnych (niepuste w świeżym baseline) do schematu
-    ``_bp_snap``. Pomijamy tabele Django/auth (post_migrate je odtwarza) oraz
-    tabele domenowe z guarda (puste w baseline). UNLOGGED = szybko, przeżywa
-    flush (nie jest tabelą modelu → Django flush jej nie truncatuje)."""
-    cur.execute("CREATE SCHEMA IF NOT EXISTS _bp_snap")
-    cur.execute("SELECT tablename FROM pg_tables WHERE schemaname='public'")
-    tabele = [r[0] for r in cur.fetchall()]
-    ref = []
-    for t in tabele:
-        if t in _LEAK_GUARD_TABLES or t.startswith(
-            ("django_", "auth_", "social_", "_bp_snap")
-        ):
-            continue
-        cur.execute(f'SELECT EXISTS(SELECT 1 FROM "{t}")')
-        if cur.fetchone()[0]:
-            cur.execute(f'DROP TABLE IF EXISTS _bp_snap."{t}"')
-            cur.execute(f'CREATE UNLOGGED TABLE _bp_snap."{t}" AS TABLE "{t}"')
-            ref.append(t)
-    return ref
-
-
-def _restore_reference(cur, ref):
-    """Przywróć dane referencyjne ze snapshotu. ``session_replication_role =
-    replica`` wyłącza triggery FK → DELETE+INSERT w dowolnej kolejności (dane
-    są spójnym baseline, brak realnych naruszeń)."""
-    cur.execute("SET session_replication_role = replica")
-    try:
-        for t in ref:
-            cur.execute(f'DELETE FROM "{t}"')
-            cur.execute(f'INSERT INTO "{t}" SELECT * FROM _bp_snap."{t}"')
-    finally:
-        cur.execute("SET session_replication_role = origin")
 
 
 def _leak_guard_conn(settings_dict):
@@ -262,63 +216,21 @@ def _neutralizuj_wyciekle_dane(request):
         or "transactional_db" in request.fixturenames
     )
     if uzywa_db:
-        import sys
-
         import psycopg2
         from django.db import connection
 
-        # Per-tabela (nie jeden OR) — żeby w raporcie nazwać CO wyciekło.
-        probe = ", ".join(f"EXISTS(SELECT 1 FROM {t})" for t in _LEAK_GUARD_TABLES)
+        probe = " OR ".join(f"EXISTS(SELECT 1 FROM {t})" for t in _LEAK_GUARD_TABLES)
         try:
             conn = _leak_guard_conn(connection.settings_dict)
             with conn.cursor() as cur:
-                # --- Snapshot referencyjny raz per worker (na świeżym baseline) ---
-                if _LEAK_GUARD["ref_snapshot"] is None:
-                    cur.execute(f"SELECT EXISTS(SELECT 1 FROM {_LEAK_GUARD_SENTINEL})")
-                    if cur.fetchone()[0]:
-                        _LEAK_GUARD["ref_snapshot"] = _snapshot_reference(cur)
-
-                # --- VECTOR 2: przywróć dane referencyjne zmiecione flushem ---
-                ref = _LEAK_GUARD["ref_snapshot"]
-                if ref:
-                    cur.execute(f"SELECT EXISTS(SELECT 1 FROM {_LEAK_GUARD_SENTINEL})")
-                    if not cur.fetchone()[0]:
-                        print(
-                            f"[LEAK-GUARD] dane referencyjne WYCZYSZCZONE (flush "
-                            f"transakcyjny) — widać na setupie {request.node.nodeid}. "
-                            f"Sprawca (poprzedni test DB na tym workerze): "
-                            f"{_LEAK_GUARD['poprzedni']}. Odtwarzam ze snapshotu.",
-                            file=sys.stderr,
-                        )
-                        _restore_reference(cur, ref)
-
-                # --- VECTOR 1: usuń wyciekłe (nadmiarowe) dane domenowe ---
                 cur.execute(f"SELECT {probe}")
-                obecne = cur.fetchone()
-                wyciekle = [
-                    t
-                    for t, jest in zip(_LEAK_GUARD_TABLES, obecne, strict=False)
-                    if jest
-                ]
-                if wyciekle:
-                    # Guard sprawdza KAŻDY test DB i czyści przy każdym wykryciu,
-                    # więc wyciek widziany na setupie tego testu powstał po
-                    # ostatnim czystym stanie — sprawcą jest poprzedni test DB
-                    # na tym workerze (xdist → proces = worker, stan per-proces).
-                    print(
-                        f"[LEAK-GUARD] wyciek scommitowanych danych na setupie "
-                        f"{request.node.nodeid}: {', '.join(wyciekle)}. "
-                        f"Najprawdopodobniejszy sprawca (poprzedni test DB na tym "
-                        f"workerze): {_LEAK_GUARD['poprzedni']}",
-                        file=sys.stderr,
-                    )
+                if cur.fetchone()[0]:
                     # Bez RESTART IDENTITY — jak flush (_fixture_teardown używa
                     # reset_sequences=False); sekwencje rosną dalej, brak
                     # niespodzianek z pk=1.
                     cur.execute(
                         "TRUNCATE " + ", ".join(_LEAK_GUARD_TABLES) + " CASCADE"
                     )
-            _LEAK_GUARD["poprzedni"] = request.node.nodeid
         except psycopg2.Error:
             # Guard jest best-effort: brak połączenia / brak tabel (np. test
             # bez pełnej migracji) nie może wywalić samego testu.

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,3 +1,4 @@
+import os
 import random
 import time
 from datetime import date
@@ -173,7 +174,15 @@ TransactionTestCase._fixture_teardown = _fixture_teardown
 # root-cause fixa (namierzyć i naprawić test commitujący poza rollback).
 # =============================================================================
 
-_LEAK_GUARD = {"conn": None, "poprzedni": "<start sesji>", "v2_zgloszony": False}
+_LEAK_GUARD = {
+    "conn": None,
+    "poprzedni": "<start sesji>",
+    "v2_zgloszony": False,
+    # Raporty zbieramy i drukujemy w pytest_sessionfinish (POZA per-test
+    # capture pytest-a) — inaczej print z fixture'a jest łykany i NIEwidoczny
+    # w logach CI (właśnie po to jest ta diagnostyka).
+    "raporty": [],
+}
 _LEAK_GUARD_TABLES = (
     "bpp_autor",
     "bpp_jednostka",
@@ -232,8 +241,6 @@ def _neutralizuj_wyciekle_dane(request):
         or "transactional_db" in request.fixturenames
     )
     if uzywa_db:
-        import sys
-
         import psycopg2
         from django.db import connection
 
@@ -254,12 +261,11 @@ def _neutralizuj_wyciekle_dane(request):
                     # więc wyciek widziany na setupie tego testu powstał po
                     # ostatnim czystym stanie — sprawcą jest poprzedni test DB
                     # na tym workerze (xdist → proces = worker, stan per-proces).
-                    print(
-                        f"[LEAK-GUARD] wyciek scommitowanych danych na setupie "
+                    _LEAK_GUARD["raporty"].append(
+                        f"[LEAK-GUARD/V1] wyciek scommitowanych danych na setupie "
                         f"{request.node.nodeid}: {', '.join(wyciekle)}. "
                         f"Najprawdopodobniejszy sprawca (poprzedni test DB na tym "
-                        f"workerze): {_LEAK_GUARD['poprzedni']}",
-                        file=sys.stderr,
+                        f"workerze): {_LEAK_GUARD['poprzedni']}"
                     )
                     # Bez RESTART IDENTITY — jak flush (_fixture_teardown używa
                     # reset_sequences=False); sekwencje rosną dalej, brak
@@ -277,14 +283,13 @@ def _neutralizuj_wyciekle_dane(request):
                     )
                     if cur.fetchone()[0]:
                         _LEAK_GUARD["v2_zgloszony"] = True
-                        print(
+                        _LEAK_GUARD["raporty"].append(
                             f"[LEAK-GUARD/V2] dane referencyjne "
                             f"({_LEAK_GUARD_V2_SENTINEL}) WYCZYSZCZONE (transakcyjny "
                             f"flush) — widać na setupie {request.node.nodeid}. "
                             f"Sprawca (poprzedni test DB na workerze): "
                             f"{_LEAK_GUARD['poprzedni']}. NIENAPRAWIANE tutaj "
-                            f"(osobny wątek izolacji).",
-                            file=sys.stderr,
+                            f"(osobny wątek izolacji)."
                         )
             _LEAK_GUARD["poprzedni"] = request.node.nodeid
         except psycopg2.Error:
@@ -292,6 +297,19 @@ def _neutralizuj_wyciekle_dane(request):
             # bez pełnej migracji) nie może wywalić samego testu.
             pass
     yield
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Drukuje raporty guarda (V1/V2) na KONIEC sesji — poza per-test capture
+    pytest-a, więc widoczne w logach CI (per worker xdist)."""
+    import sys
+
+    raporty = _LEAK_GUARD.get("raporty") or []
+    if raporty:
+        worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+        print(f"\n=== LEAK-GUARD raporty (worker {worker}) ===", file=sys.stderr)
+        for r in raporty:
+            print(r, file=sys.stderr)
 
 
 # =============================================================================

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -142,6 +142,104 @@ def _fixture_teardown(self):
 
 TransactionTestCase._fixture_teardown = _fixture_teardown
 
+
+# =============================================================================
+# Izolacja pod xdist: neutralizacja WYCIEKŁYCH scommitowanych danych domenowych.
+#
+# Problem (CI, sharding pytest-split + xdist -n auto): pod obciążeniem CI test,
+# który commituje dane poza rollback (transakcyjny / live-server / komenda z
+# własnym commitem), potrafi zostawić w bazie workera scommitowane wiersze
+# autorów/jednostek/stopni/stanowisk. Kolejne testy na tym samym workerze widzą
+# ambient dane → ``IntegrityError: bpp_jednostka_nazwa_key``,
+# ``bpp_stopiensluzbowy_nazwa_key``, albo asercje typu „pusta baza zwraca []"
+# pękają. Flake jest niezawodny na CI, ale niereprodukowalny lokalnie
+# (testcontainers, nawet -n 8) — dlatego bronimy się defensywnie, a nie przez
+# szukanie pojedynczego winowajcy.
+#
+# Baseline testowy ma 0 wierszy w tych tabelach (zweryfikowane), więc TRUNCATE
+# przed testem = przywrócenie stanu baseline (NIE rusza danych referencyjnych —
+# ``bpp_tytul``/``bpp_funkcja_autora``/… mają dane i NIE są tu wymienione).
+# CASCADE jest bezpieczny: żadna NIEPUSTA (referencyjna) tabela nie ma FK DO
+# tych tabel (zweryfikowane zapytaniem po information_schema), więc kaskada
+# zostaje w obrębie danych domenowych. Osobne autocommit-połączenie czyści
+# COMMITTED wiersze (poza transakcją testu). Leak-triggered: TRUNCATE odpala
+# się tylko gdy wykryty wyciek, więc w normalnym przypadku to 1 tani probe.
+# =============================================================================
+
+_LEAK_GUARD = {"conn": None}
+_LEAK_GUARD_TABLES = (
+    "bpp_autor",
+    "bpp_jednostka",
+    "bpp_stopiensluzbowy",
+    "bpp_stanowiskodydaktyczne",
+    "bpp_grupa_pracownicza",
+)
+
+
+def _leak_guard_conn(settings_dict):
+    import psycopg2
+
+    conn = _LEAK_GUARD["conn"]
+    if conn is not None and not conn.closed:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+            return conn
+        except psycopg2.Error:
+            try:
+                conn.close()
+            except psycopg2.Error:
+                pass
+            _LEAK_GUARD["conn"] = None
+    conn = psycopg2.connect(
+        dbname=settings_dict["NAME"],
+        user=settings_dict.get("USER") or None,
+        password=settings_dict.get("PASSWORD") or None,
+        host=settings_dict.get("HOST") or None,
+        port=settings_dict.get("PORT") or None,
+    )
+    conn.autocommit = True
+    _LEAK_GUARD["conn"] = conn
+    return conn
+
+
+@pytest.fixture(autouse=True)
+def _neutralizuj_wyciekle_dane(request):
+    """Przed testem DB czyści ambient (scommitowane poza rollback) dane domenowe.
+
+    Patrz komentarz nad definicją ``_LEAK_GUARD_TABLES``. No-op dla testów bez
+    bazy i gdy nic nie wyciekło.
+    """
+    uzywa_db = (
+        request.node.get_closest_marker("django_db") is not None
+        or "db" in request.fixturenames
+        or "transactional_db" in request.fixturenames
+    )
+    if uzywa_db:
+        import psycopg2
+        from django.db import connection
+
+        probe = " OR ".join(
+            f"EXISTS(SELECT 1 FROM {t})" for t in _LEAK_GUARD_TABLES
+        )
+        try:
+            conn = _leak_guard_conn(connection.settings_dict)
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT {probe}")
+                if cur.fetchone()[0]:
+                    # Bez RESTART IDENTITY — jak flush (_fixture_teardown używa
+                    # reset_sequences=False); sekwencje rosną dalej, brak
+                    # niespodzianek z pk=1.
+                    cur.execute(
+                        "TRUNCATE " + ", ".join(_LEAK_GUARD_TABLES) + " CASCADE"
+                    )
+        except psycopg2.Error:
+            # Guard jest best-effort: brak połączenia / brak tabel (np. test
+            # bez pełnej migracji) nie może wywalić samego testu.
+            pass
+    yield
+
+
 # =============================================================================
 # Fixtures użytkowników i klientów (przeniesione z tests_legacy/conftest.py)
 # =============================================================================

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -164,9 +164,16 @@ TransactionTestCase._fixture_teardown = _fixture_teardown
 # zostaje w obrębie danych domenowych. Osobne autocommit-połączenie czyści
 # COMMITTED wiersze (poza transakcją testu). Leak-triggered: TRUNCATE odpala
 # się tylko gdy wykryty wyciek, więc w normalnym przypadku to 1 tani probe.
+#
+# DIAGNOSTYKA: przy wykryciu wycieku guard wypisuje do stderr (widoczne w
+# logach CI) które tabele wyciekły oraz najprawdopodobniejszego SPRAWCĘ —
+# poprzedni test DB na tym workerze. Bo guard sprawdza każdy test DB i czyści
+# przy każdym wykryciu, więc wyciek widziany na setupie testu X powstał po
+# ostatnim czystym stanie = w poprzednim teście DB. To ścieżka do docelowego
+# root-cause fixa (namierzyć i naprawić test commitujący poza rollback).
 # =============================================================================
 
-_LEAK_GUARD = {"conn": None}
+_LEAK_GUARD = {"conn": None, "poprzedni": "<start sesji>", "v2_zgloszony": False}
 _LEAK_GUARD_TABLES = (
     "bpp_autor",
     "bpp_jednostka",
@@ -174,6 +181,15 @@ _LEAK_GUARD_TABLES = (
     "bpp_stanowiskodydaktyczne",
     "bpp_grupa_pracownicza",
 )
+# Sentinel WYKRYCIA (tylko diagnostyka, BEZ naprawy) drugiego, ODRĘBNEGO wektora
+# flake'a: transakcyjny flush (_fixture_teardown TRUNCATE CASCADE) zmiata dane
+# referencyjne zaseedowane MIGRACJĄ (np. bpp_crossref_mapper 16→0,
+# bpp_funkcja_autora), których post_migrate NIE odtwarza na CI. Kolejne testy na
+# workerze padają na DoesNotExist / count()==0. To PRE-EXISTING (dotyczy deva),
+# ~50-60% pod xdist, i wymaga osobnego, ostrożnego fixa (blankietowy
+# snapshot/restore rozwalał session-fixture'y). Tu tylko RAPORTUJEMY sprawcę do
+# stderr — namiar do docelowego fixa, zero mutacji.
+_LEAK_GUARD_V2_SENTINEL = "bpp_crossref_mapper"
 
 
 def _leak_guard_conn(settings_dict):
@@ -216,21 +232,61 @@ def _neutralizuj_wyciekle_dane(request):
         or "transactional_db" in request.fixturenames
     )
     if uzywa_db:
+        import sys
+
         import psycopg2
         from django.db import connection
 
-        probe = " OR ".join(f"EXISTS(SELECT 1 FROM {t})" for t in _LEAK_GUARD_TABLES)
+        # Per-tabela (nie jeden OR) — żeby w raporcie nazwać CO wyciekło.
+        probe = ", ".join(f"EXISTS(SELECT 1 FROM {t})" for t in _LEAK_GUARD_TABLES)
         try:
             conn = _leak_guard_conn(connection.settings_dict)
             with conn.cursor() as cur:
                 cur.execute(f"SELECT {probe}")
-                if cur.fetchone()[0]:
+                obecne = cur.fetchone()
+                wyciekle = [
+                    t
+                    for t, jest in zip(_LEAK_GUARD_TABLES, obecne, strict=False)
+                    if jest
+                ]
+                if wyciekle:
+                    # Guard sprawdza KAŻDY test DB i czyści przy każdym wykryciu,
+                    # więc wyciek widziany na setupie tego testu powstał po
+                    # ostatnim czystym stanie — sprawcą jest poprzedni test DB
+                    # na tym workerze (xdist → proces = worker, stan per-proces).
+                    print(
+                        f"[LEAK-GUARD] wyciek scommitowanych danych na setupie "
+                        f"{request.node.nodeid}: {', '.join(wyciekle)}. "
+                        f"Najprawdopodobniejszy sprawca (poprzedni test DB na tym "
+                        f"workerze): {_LEAK_GUARD['poprzedni']}",
+                        file=sys.stderr,
+                    )
                     # Bez RESTART IDENTITY — jak flush (_fixture_teardown używa
                     # reset_sequences=False); sekwencje rosną dalej, brak
                     # niespodzianek z pk=1.
                     cur.execute(
                         "TRUNCATE " + ", ".join(_LEAK_GUARD_TABLES) + " CASCADE"
                     )
+
+                # VECTOR 2 (tylko diagnostyka): dane referencyjne zmiecione
+                # transakcyjnym flushem. Raportujemy RAZ na worker (żeby nie
+                # zaśmiecać), wskazując sprawcę — poprzedni test DB.
+                if not _LEAK_GUARD["v2_zgloszony"]:
+                    cur.execute(
+                        f"SELECT NOT EXISTS(SELECT 1 FROM {_LEAK_GUARD_V2_SENTINEL})"
+                    )
+                    if cur.fetchone()[0]:
+                        _LEAK_GUARD["v2_zgloszony"] = True
+                        print(
+                            f"[LEAK-GUARD/V2] dane referencyjne "
+                            f"({_LEAK_GUARD_V2_SENTINEL}) WYCZYSZCZONE (transakcyjny "
+                            f"flush) — widać na setupie {request.node.nodeid}. "
+                            f"Sprawca (poprzedni test DB na workerze): "
+                            f"{_LEAK_GUARD['poprzedni']}. NIENAPRAWIANE tutaj "
+                            f"(osobny wątek izolacji).",
+                            file=sys.stderr,
+                        )
+            _LEAK_GUARD["poprzedni"] = request.node.nodeid
         except psycopg2.Error:
             # Guard jest best-effort: brak połączenia / brak tabel (np. test
             # bez pełnej migracji) nie może wywalić samego testu.

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -173,7 +173,7 @@ TransactionTestCase._fixture_teardown = _fixture_teardown
 # root-cause fixa (namierzyć i naprawić test commitujący poza rollback).
 # =============================================================================
 
-_LEAK_GUARD = {"conn": None, "poprzedni": "<start sesji>"}
+_LEAK_GUARD = {"conn": None, "poprzedni": "<start sesji>", "ref_snapshot": None}
 _LEAK_GUARD_TABLES = (
     "bpp_autor",
     "bpp_jednostka",
@@ -181,6 +181,45 @@ _LEAK_GUARD_TABLES = (
     "bpp_stanowiskodydaktyczne",
     "bpp_grupa_pracownicza",
 )
+# Sentinel dla WYCIEKU odwrotnego (vector 2): tabela referencyjna zaseedowana
+# migracją danych, której post_migrate NIE odtwarza po flushu. Gdy jest pusta,
+# a snapshot ją miał → transakcyjny flush zmiótł dane referencyjne workera.
+_LEAK_GUARD_SENTINEL = "bpp_crossref_mapper"
+
+
+def _snapshot_reference(cur):
+    """Snapshot tabel referencyjnych (niepuste w świeżym baseline) do schematu
+    ``_bp_snap``. Pomijamy tabele Django/auth (post_migrate je odtwarza) oraz
+    tabele domenowe z guarda (puste w baseline). UNLOGGED = szybko, przeżywa
+    flush (nie jest tabelą modelu → Django flush jej nie truncatuje)."""
+    cur.execute("CREATE SCHEMA IF NOT EXISTS _bp_snap")
+    cur.execute("SELECT tablename FROM pg_tables WHERE schemaname='public'")
+    tabele = [r[0] for r in cur.fetchall()]
+    ref = []
+    for t in tabele:
+        if t in _LEAK_GUARD_TABLES or t.startswith(
+            ("django_", "auth_", "social_", "_bp_snap")
+        ):
+            continue
+        cur.execute(f'SELECT EXISTS(SELECT 1 FROM "{t}")')
+        if cur.fetchone()[0]:
+            cur.execute(f'DROP TABLE IF EXISTS _bp_snap."{t}"')
+            cur.execute(f'CREATE UNLOGGED TABLE _bp_snap."{t}" AS TABLE "{t}"')
+            ref.append(t)
+    return ref
+
+
+def _restore_reference(cur, ref):
+    """Przywróć dane referencyjne ze snapshotu. ``session_replication_role =
+    replica`` wyłącza triggery FK → DELETE+INSERT w dowolnej kolejności (dane
+    są spójnym baseline, brak realnych naruszeń)."""
+    cur.execute("SET session_replication_role = replica")
+    try:
+        for t in ref:
+            cur.execute(f'DELETE FROM "{t}"')
+            cur.execute(f'INSERT INTO "{t}" SELECT * FROM _bp_snap."{t}"')
+    finally:
+        cur.execute("SET session_replication_role = origin")
 
 
 def _leak_guard_conn(settings_dict):
@@ -233,6 +272,27 @@ def _neutralizuj_wyciekle_dane(request):
         try:
             conn = _leak_guard_conn(connection.settings_dict)
             with conn.cursor() as cur:
+                # --- Snapshot referencyjny raz per worker (na świeżym baseline) ---
+                if _LEAK_GUARD["ref_snapshot"] is None:
+                    cur.execute(f"SELECT EXISTS(SELECT 1 FROM {_LEAK_GUARD_SENTINEL})")
+                    if cur.fetchone()[0]:
+                        _LEAK_GUARD["ref_snapshot"] = _snapshot_reference(cur)
+
+                # --- VECTOR 2: przywróć dane referencyjne zmiecione flushem ---
+                ref = _LEAK_GUARD["ref_snapshot"]
+                if ref:
+                    cur.execute(f"SELECT EXISTS(SELECT 1 FROM {_LEAK_GUARD_SENTINEL})")
+                    if not cur.fetchone()[0]:
+                        print(
+                            f"[LEAK-GUARD] dane referencyjne WYCZYSZCZONE (flush "
+                            f"transakcyjny) — widać na setupie {request.node.nodeid}. "
+                            f"Sprawca (poprzedni test DB na tym workerze): "
+                            f"{_LEAK_GUARD['poprzedni']}. Odtwarzam ze snapshotu.",
+                            file=sys.stderr,
+                        )
+                        _restore_reference(cur, ref)
+
+                # --- VECTOR 1: usuń wyciekłe (nadmiarowe) dane domenowe ---
                 cur.execute(f"SELECT {probe}")
                 obecne = cur.fetchone()
                 wyciekle = [

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -177,7 +177,6 @@ TransactionTestCase._fixture_teardown = _fixture_teardown
 _LEAK_GUARD = {
     "conn": None,
     "poprzedni": "<start sesji>",
-    "v2_zgloszony": False,
     # Raporty zbieramy i drukujemy w pytest_sessionfinish (POZA per-test
     # capture pytest-a) — inaczej print z fixture'a jest łykany i NIEwidoczny
     # w logach CI (właśnie po to jest ta diagnostyka).
@@ -190,15 +189,6 @@ _LEAK_GUARD_TABLES = (
     "bpp_stanowiskodydaktyczne",
     "bpp_grupa_pracownicza",
 )
-# Sentinel WYKRYCIA (tylko diagnostyka, BEZ naprawy) drugiego, ODRĘBNEGO wektora
-# flake'a: transakcyjny flush (_fixture_teardown TRUNCATE CASCADE) zmiata dane
-# referencyjne zaseedowane MIGRACJĄ (np. bpp_crossref_mapper 16→0,
-# bpp_funkcja_autora), których post_migrate NIE odtwarza na CI. Kolejne testy na
-# workerze padają na DoesNotExist / count()==0. To PRE-EXISTING (dotyczy deva),
-# ~50-60% pod xdist, i wymaga osobnego, ostrożnego fixa (blankietowy
-# snapshot/restore rozwalał session-fixture'y). Tu tylko RAPORTUJEMY sprawcę do
-# stderr — namiar do docelowego fixa, zero mutacji.
-_LEAK_GUARD_V2_SENTINEL = "bpp_crossref_mapper"
 
 
 def _leak_guard_conn(settings_dict):
@@ -273,24 +263,6 @@ def _neutralizuj_wyciekle_dane(request):
                     cur.execute(
                         "TRUNCATE " + ", ".join(_LEAK_GUARD_TABLES) + " CASCADE"
                     )
-
-                # VECTOR 2 (tylko diagnostyka): dane referencyjne zmiecione
-                # transakcyjnym flushem. Raportujemy RAZ na worker (żeby nie
-                # zaśmiecać), wskazując sprawcę — poprzedni test DB.
-                if not _LEAK_GUARD["v2_zgloszony"]:
-                    cur.execute(
-                        f"SELECT NOT EXISTS(SELECT 1 FROM {_LEAK_GUARD_V2_SENTINEL})"
-                    )
-                    if cur.fetchone()[0]:
-                        _LEAK_GUARD["v2_zgloszony"] = True
-                        _LEAK_GUARD["raporty"].append(
-                            f"[LEAK-GUARD/V2] dane referencyjne "
-                            f"({_LEAK_GUARD_V2_SENTINEL}) WYCZYSZCZONE (transakcyjny "
-                            f"flush) — widać na setupie {request.node.nodeid}. "
-                            f"Sprawca (poprzedni test DB na workerze): "
-                            f"{_LEAK_GUARD['poprzedni']}. NIENAPRAWIANE tutaj "
-                            f"(osobny wątek izolacji)."
-                        )
             _LEAK_GUARD["poprzedni"] = request.node.nodeid
         except psycopg2.Error:
             # Guard jest best-effort: brak połączenia / brak tabel (np. test

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -164,9 +164,16 @@ TransactionTestCase._fixture_teardown = _fixture_teardown
 # zostaje w obrębie danych domenowych. Osobne autocommit-połączenie czyści
 # COMMITTED wiersze (poza transakcją testu). Leak-triggered: TRUNCATE odpala
 # się tylko gdy wykryty wyciek, więc w normalnym przypadku to 1 tani probe.
+#
+# DIAGNOSTYKA: przy wykryciu wycieku guard wypisuje do stderr (widoczne w
+# logach CI) które tabele wyciekły oraz najprawdopodobniejszego SPRAWCĘ —
+# poprzedni test DB na tym workerze. Bo guard sprawdza każdy test DB i czyści
+# przy każdym wykryciu, więc wyciek widziany na setupie testu X powstał po
+# ostatnim czystym stanie = w poprzednim teście DB. To ścieżka do docelowego
+# root-cause fixa (namierzyć i naprawić test commitujący poza rollback).
 # =============================================================================
 
-_LEAK_GUARD = {"conn": None}
+_LEAK_GUARD = {"conn": None, "poprzedni": "<start sesji>"}
 _LEAK_GUARD_TABLES = (
     "bpp_autor",
     "bpp_jednostka",
@@ -216,21 +223,42 @@ def _neutralizuj_wyciekle_dane(request):
         or "transactional_db" in request.fixturenames
     )
     if uzywa_db:
+        import sys
+
         import psycopg2
         from django.db import connection
 
-        probe = " OR ".join(f"EXISTS(SELECT 1 FROM {t})" for t in _LEAK_GUARD_TABLES)
+        # Per-tabela (nie jeden OR) — żeby w raporcie nazwać CO wyciekło.
+        probe = ", ".join(f"EXISTS(SELECT 1 FROM {t})" for t in _LEAK_GUARD_TABLES)
         try:
             conn = _leak_guard_conn(connection.settings_dict)
             with conn.cursor() as cur:
                 cur.execute(f"SELECT {probe}")
-                if cur.fetchone()[0]:
+                obecne = cur.fetchone()
+                wyciekle = [
+                    t
+                    for t, jest in zip(_LEAK_GUARD_TABLES, obecne, strict=False)
+                    if jest
+                ]
+                if wyciekle:
+                    # Guard sprawdza KAŻDY test DB i czyści przy każdym wykryciu,
+                    # więc wyciek widziany na setupie tego testu powstał po
+                    # ostatnim czystym stanie — sprawcą jest poprzedni test DB
+                    # na tym workerze (xdist → proces = worker, stan per-proces).
+                    print(
+                        f"[LEAK-GUARD] wyciek scommitowanych danych na setupie "
+                        f"{request.node.nodeid}: {', '.join(wyciekle)}. "
+                        f"Najprawdopodobniejszy sprawca (poprzedni test DB na tym "
+                        f"workerze): {_LEAK_GUARD['poprzedni']}",
+                        file=sys.stderr,
+                    )
                     # Bez RESTART IDENTITY — jak flush (_fixture_teardown używa
                     # reset_sequences=False); sekwencje rosną dalej, brak
                     # niespodzianek z pk=1.
                     cur.execute(
                         "TRUNCATE " + ", ".join(_LEAK_GUARD_TABLES) + " CASCADE"
                     )
+            _LEAK_GUARD["poprzedni"] = request.node.nodeid
         except psycopg2.Error:
             # Guard jest best-effort: brak połączenia / brak tabel (np. test
             # bez pełnej migracji) nie może wywalić samego testu.

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -219,9 +219,7 @@ def _neutralizuj_wyciekle_dane(request):
         import psycopg2
         from django.db import connection
 
-        probe = " OR ".join(
-            f"EXISTS(SELECT 1 FROM {t})" for t in _LEAK_GUARD_TABLES
-        )
+        probe = " OR ".join(f"EXISTS(SELECT 1 FROM {t})" for t in _LEAK_GUARD_TABLES)
         try:
             conn = _leak_guard_conn(connection.settings_dict)
             with conn.cursor() as cur:

--- a/src/deduplikator_autorow/tests/test_general_phase.py
+++ b/src/deduplikator_autorow/tests/test_general_phase.py
@@ -16,12 +16,27 @@ from deduplikator_autorow.utils.cluster import find_clusters
 @pytest.mark.django_db
 def test_general_finds_simple_pair():
     """Dwóch autorów o tym samym nazwisku/imieniu, żaden bez OsobaZInstytucji."""
-    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
-    baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    a = baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    b = baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
     scan = DuplicateScanRun.objects.create()
     _run_general_phase(scan, min_confidence=50)
+
+    # UWAGA (flake pod xdist/shardingiem): faza general skanuje CAŁĄ tabelę
+    # autorów, więc ambient autorzy „Kowalski Jan" scommitowani przez sąsiednie
+    # testy (na współdzielonym workerze) wpadają do wspólnego bucketu
+    # „kowalski", doczepiają się do klastra i — mając niższy pk — przejmują
+    # rolę `main`. Wtedy zamiast dokładnie jednej pary {a, b} emitowane są np.
+    # (ambient, a) + (ambient, b) i asercja na globalnym `count() == 1` pękała
+    # (obserwowane w CI: 4 zamiast 1). Testujemy więc WŁASNĄ inwariantę: a i b
+    # lądują w jednym klastrze duplikatów — odporne na ambient szum (identyczny
+    # wzorzec co ``test_general_finds_pair_with_unicode_hyphen_variant``).
     cands = DuplicateCandidate.objects.filter(scan_run=scan, scan_mode="general")
-    assert cands.count() == 1
+    edges = [(c.main_autor_id, c.duplicate_autor_id) for c in cands]
+    clusters = find_clusters(edges)
+    assert any({a.pk, b.pk} <= cluster for cluster in clusters), (
+        f"Dwóch autorów o identycznym nazwisku/imieniu powinno trafić do "
+        f"jednego klastra duplikatów; klastry={clusters}"
+    )
 
 
 @pytest.mark.django_db

--- a/src/fixtures/conftest_models.py
+++ b/src/fixtures/conftest_models.py
@@ -59,7 +59,8 @@ def wydzial(uczelnia, db):
 
 
 def _autor_maker(imiona, nazwisko, tytul="dr", **kwargs):
-    tytul = Tytul.objects.get(skrot=tytul)
+    # Nie zakładaj baseline — transakcyjny flush sąsiada bywa go zmiata.
+    tytul, _ = Tytul.objects.get_or_create(skrot=tytul, defaults={"nazwa": tytul})
     return Autor.objects.get_or_create(
         tytul=tytul, imiona=imiona, nazwisko=nazwisko, **kwargs
     )[0]

--- a/src/fixtures/conftest_publications.py
+++ b/src/fixtures/conftest_publications.py
@@ -58,7 +58,11 @@ def _wydawnictwo_ciagle_maker(**kwargs):
     set_default("informacje", "zrodlo-informacje", kwargs)
     set_default("issn", "123-IS-SN-34", kwargs)
     if "jezyk" not in kwargs:
-        jezyk = Jezyk.objects.get(nazwa__icontains="polski")
+        # Nie zakładaj baseline — flush sąsiada bywa go zmiata; twórz gdy brak.
+        jezyk = (
+            Jezyk.objects.filter(nazwa__icontains="polski").first()
+            or Jezyk.objects.create(nazwa="polski", skrot="pol")
+        )
         jezyk.pbn_uid = Language.objects.get_or_create(
             pk="pol",
             language={

--- a/src/import_pracownikow/tests/_helpers.py
+++ b/src/import_pracownikow/tests/_helpers.py
@@ -1,0 +1,20 @@
+"""Wspólne helpery testowe pakietu ``import_pracownikow``."""
+
+import uuid
+
+
+def unikalna_nazwa(baza: str) -> str:
+    """Czytelna, ale globalnie unikalna nazwa testowa.
+
+    ``Jednostka`` ma unikalne ``nazwa``/``skrot``/``slug``, a te same dosłowne
+    nazwy ("Katedra Testowa" itd.) są tworzone w dziesiątkach testów tego
+    pakietu (i w sąsiednich: ``api_v1``, ``pbn_import``, ``import_common``).
+    Pod shardowaniem xdista testy dzielą jeden worker/bazę i — gdy scommitowany
+    wiersz przecieknie poza rollback sąsiada — kolidują na unikalnym constraincie
+    (``IntegrityError: bpp_jednostka_nazwa_key`` w setupie fixture'a) albo na
+    matchowaniu (ambient wiersz zmienia wynik dopasowania). Doklejamy losowy
+    sufiks w NAWIASACH KWADRATOWYCH — nie okrągłych, bo ``()`` matcher
+    ``matchuj_jednostke`` interpretuje jako skrót — zachowując czytelny prefiks
+    ("nazwę klastra"), po którym nadal poznać o co chodzi w logu/diffie.
+    """
+    return f"{baza} [{uuid.uuid4().hex[:8]}]"

--- a/src/import_pracownikow/tests/conftest.py
+++ b/src/import_pracownikow/tests/conftest.py
@@ -8,6 +8,9 @@ from model_bakery import baker
 
 from bpp.models import Autor, Autor_Jednostka, Jednostka
 from import_pracownikow.models import ImportPracownikow
+from import_pracownikow.tests._helpers import unikalna_nazwa
+
+__all__ = ["unikalna_nazwa"]
 
 
 @pytest.fixture(autouse=True)
@@ -92,8 +95,8 @@ def autor_spoza_pliku():
 def jednostka_spoza_pliku() -> Jednostka:
     return baker.make(
         Jednostka,
-        nazwa="Jednostka Spozaplikowa",
-        skrot="Jedn. Spoz.",
+        nazwa=unikalna_nazwa("Jednostka Spozaplikowa"),
+        skrot=unikalna_nazwa("Jedn. Spoz."),
         zarzadzaj_automatycznie=True,
     )
 
@@ -133,8 +136,8 @@ def dwa_autory_z_jednostka():
     """
     jednostka = baker.make(
         Jednostka,
-        nazwa="Katedra Testowa",
-        skrot="Kat. Test.",
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. Test."),
     )
     autor = baker.make(
         Autor, nazwisko="Kowalski", imiona="Jan", aktualna_jednostka=jednostka
@@ -158,8 +161,8 @@ def autor_bez_autor_jednostka():
     """
     jednostka = baker.make(
         Jednostka,
-        nazwa="Katedra Bez Powiazania",
-        skrot="Kat. Bez Pow.",
+        nazwa=unikalna_nazwa("Katedra Bez Powiazania"),
+        skrot=unikalna_nazwa("Kat. Bez Pow."),
     )
     autor = baker.make(Autor, nazwisko="Nowicki", imiona="Piotr")
     return autor, jednostka
@@ -178,8 +181,8 @@ def autor_jednostka_fixture():
     """
     jednostka = baker.make(
         Jednostka,
-        nazwa="Katedra Integracji Testowej",
-        skrot="Kat. Integr. Test.",
+        nazwa=unikalna_nazwa("Katedra Integracji Testowej"),
+        skrot=unikalna_nazwa("Kat. Integr. Test."),
     )
     autor = baker.make(Autor, nazwisko="Wisniewski", imiona="Adam")
     return autor, jednostka

--- a/src/import_pracownikow/tests/test_pipeline/test_analyze_autoskip.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_analyze_autoskip.py
@@ -14,6 +14,7 @@ from model_bakery import baker
 
 from bpp.models import Autor, Autor_Jednostka, Jednostka, Tytul
 from import_pracownikow.models import ImportPracownikow
+from import_pracownikow.tests._helpers import unikalna_nazwa
 
 
 def _upload_i_zmapuj(admin_client, admin_user, csv_bytes, *, tworz_jednostki):
@@ -41,7 +42,11 @@ def _upload_i_zmapuj(admin_client, admin_user, csv_bytes, *, tworz_jednostki):
 def test_wszystko_zmatchowane_przeskakuje_do_kroku2(admin_client, admin_user):
     """Jednostka i tytuł z pliku są już w bazie → analiza ustawia od razu
     ``struktura_zintegrowana`` (Krok 2), bez decyzji o jednostkach/tytułach."""
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. T.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. T."),
+    )
     Tytul.objects.get_or_create(skrot="dr", defaults={"nazwa": "doktor"})
     autor = baker.make(
         Autor, nazwisko="Zielinski", imiona="Adam", aktualna_jednostka=jednostka

--- a/src/import_pracownikow/tests/test_pipeline/test_analyze_drugie_imie.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_analyze_drugie_imie.py
@@ -15,6 +15,7 @@ from bpp.models import Autor, Autor_Jednostka, Jednostka, Tytul
 from import_pracownikow.models import ImportPracownikow
 from import_pracownikow.pewnosc import STATUS_ZGADYWANIE
 from import_pracownikow.pipeline.analyze import analizuj
+from import_pracownikow.tests._helpers import unikalna_nazwa
 
 
 def _imp():
@@ -32,7 +33,11 @@ def _analizuj_jeden_wiersz(imp, wiersz):
 
 @pytest.mark.django_db
 def test_drugie_imie_scalane_do_imion():
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. Test.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. Test."),
+    )
     wiersz = {
         "imię": "Jan",
         "drugie_imię": "Paweł",
@@ -53,7 +58,11 @@ def test_drugie_imie_scalane_do_imion():
 def test_drugie_imie_matching_po_scaleniu_zachowany():
     # Autor w bazie ma tylko pierwsze imię → strategia „pierwsze imię" (0.95)
     # wiąże go z wierszem mimo scalenia na „Jan Paweł". Dedup zachowany.
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. Test.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. Test."),
+    )
     autor = baker.make(
         Autor, nazwisko="Kowalski", imiona="Jan", aktualna_jednostka=jednostka
     )
@@ -81,7 +90,11 @@ def test_drugie_imie_scalane_po_rozbiciu_osoby_sklejonej():
     # Regresja kolejności: osoba_sklejona + drugie_imię BEZ kolumny imię.
     # Scalanie MUSI iść PO rozbiciu osoby sklejonej — inaczej „imię" zostałoby
     # ustawione na „Paweł" i parser nie wstawiłby „Jan" z rozbicia.
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. Test.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. Test."),
+    )
     Tytul.objects.get_or_create(skrot="dr", defaults={"nazwa": "doktor"})
     wiersz = {
         "osoba_sklejona": "dr Jan Kowalski",

--- a/src/import_pracownikow/tests/test_pipeline/test_analyze_osoba.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_analyze_osoba.py
@@ -7,6 +7,7 @@ from model_bakery import baker
 from bpp.models import Autor, Autor_Jednostka, Jednostka, Tytul
 from import_pracownikow.models import ImportPracownikow
 from import_pracownikow.pipeline.analyze import analizuj
+from import_pracownikow.tests._helpers import unikalna_nazwa
 
 
 def _wiersz_osoba(osoba, jednostka_nazwa):
@@ -21,7 +22,11 @@ def _wiersz_osoba(osoba, jednostka_nazwa):
 
 @pytest.mark.django_db
 def test_analiza_rozbija_osobe_sklejona_i_matchuje_autora():
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. Test.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. Test."),
+    )
     autor = baker.make(
         Autor, nazwisko="Kowalski", imiona="Jan", aktualna_jednostka=jednostka
     )
@@ -53,13 +58,14 @@ def test_osoba_sklejona_jednym_tokenem_rzuca_parse_error():
     # AutorForm invalid → XLSParseError. To NIE jest status „brak" (założenie A3).
     from import_common.exceptions import XLSParseError
 
-    baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. Test.")
+    nazwa_jed = unikalna_nazwa("Katedra Testowa")
+    baker.make(Jednostka, nazwa=nazwa_jed, skrot=unikalna_nazwa("Kat. Test."))
     imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZMAPOWANY)
     imp.plik_xls.name = "protected/import_pracownikow/x.csv"
     with patch("import_pracownikow.pipeline.analyze.otworz_zrodlo") as MZ:
         MZ.return_value.count.return_value = 1
         MZ.return_value.data.return_value = iter(
-            [_wiersz_osoba("Kowalski", "Katedra Testowa")]
+            [_wiersz_osoba("Kowalski", nazwa_jed)]
         )
         with pytest.raises(XLSParseError):
             analizuj(imp, MockProgress(imp))

--- a/src/import_pracownikow/tests/test_pipeline/test_analyze_osoba.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_analyze_osoba.py
@@ -64,8 +64,6 @@ def test_osoba_sklejona_jednym_tokenem_rzuca_parse_error():
     imp.plik_xls.name = "protected/import_pracownikow/x.csv"
     with patch("import_pracownikow.pipeline.analyze.otworz_zrodlo") as MZ:
         MZ.return_value.count.return_value = 1
-        MZ.return_value.data.return_value = iter(
-            [_wiersz_osoba("Kowalski", nazwa_jed)]
-        )
+        MZ.return_value.data.return_value = iter([_wiersz_osoba("Kowalski", nazwa_jed)])
         with pytest.raises(XLSParseError):
             analizuj(imp, MockProgress(imp))

--- a/src/import_pracownikow/tests/test_pipeline/test_analyze_przepnij.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_analyze_przepnij.py
@@ -9,12 +9,17 @@ from model_bakery import baker
 
 from bpp.models import Autor, Autor_Jednostka, Jednostka, Tytul
 from import_pracownikow.models import ImportPracownikow
+from import_pracownikow.tests._helpers import unikalna_nazwa
 
 
 def _import_z_jednym_dopasowanym(admin_user, *, przepnij):
     """Import z 1 wierszem twardo dopasowanym (autor + istniejąca jednostka),
     analiza odpalona przez POST mapowania. Zwraca odświeżony import."""
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. T.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. T."),
+    )
     Tytul.objects.get_or_create(skrot="dr", defaults={"nazwa": "doktor"})
     autor = baker.make(
         Autor, nazwisko="Zielinski", imiona="Adam", aktualna_jednostka=jednostka

--- a/src/import_pracownikow/tests/test_pipeline/test_analyze_status.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_analyze_status.py
@@ -13,6 +13,7 @@ from import_pracownikow.pewnosc import (
     STATUS_WIELU,
 )
 from import_pracownikow.pipeline.analyze import analizuj
+from import_pracownikow.tests._helpers import unikalna_nazwa
 
 
 def _wiersz(**over):
@@ -38,7 +39,11 @@ def _analizuj_jeden(imp, wiersz):
 
 @pytest.mark.django_db
 def test_status_twardy_pojedynczy_exact():
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. T.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. T."),
+    )
     autor = baker.make(
         Autor, nazwisko="Kowalski", imiona="Jan", aktualna_jednostka=jednostka
     )
@@ -53,11 +58,15 @@ def test_status_twardy_pojedynczy_exact():
 
 @pytest.mark.django_db
 def test_status_brak_nie_rzuca_i_nie_ustawia_autora():
-    baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. T.")
+    nazwa_jed = unikalna_nazwa("Katedra Testowa")
+    baker.make(Jednostka, nazwa=nazwa_jed, skrot=unikalna_nazwa("Kat. T."))
     imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZMAPOWANY)
     imp.plik_xls.name = "protected/import_pracownikow/x.csv"
     # nazwisko nie istnieje w bazie → znajdz_kandydatow_autora zwraca []
-    row = _analizuj_jeden(imp, _wiersz(nazwisko="Niematycki", imię="Zdzisław"))
+    row = _analizuj_jeden(
+        imp,
+        _wiersz(nazwisko="Niematycki", imię="Zdzisław", nazwa_jednostki=nazwa_jed),
+    )
     assert row.confidence == STATUS_BRAK
     assert row.autor is None
     assert row.zmiany_potrzebne is False
@@ -65,7 +74,11 @@ def test_status_brak_nie_rzuca_i_nie_ustawia_autora():
 
 @pytest.mark.django_db
 def test_status_wielu_zapisuje_kandydatow_bez_autora():
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. T.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. T."),
+    )
     # DWÓCH autorów o identycznym imieniu+nazwisku → remis na najwyższym tierze
     baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
     baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
@@ -82,7 +95,11 @@ def test_status_wielu_zapisuje_kandydatow_bez_autora():
 
 @pytest.mark.django_db
 def test_status_twardy_po_bpp_id():
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. T.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. T."),
+    )
     autor = baker.make(Autor, nazwisko="Zielinski", imiona="Adam")
     imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZMAPOWANY)
     imp.plik_xls.name = "protected/import_pracownikow/x.csv"
@@ -105,8 +122,14 @@ def test_orcid_nieobecny_nie_wymusza_twardy_przy_remisie():
     # kandydatów po 1.0 w RÓŻNYCH jednostkach → remis top-tier → status WIELU.
     # Regresja F4: gdyby gałąź ID fallbackowała na jednostkę/nazwisko,
     # matchuj_autora rozstrzygnąłby remis jednostką z pliku → błędnie twardy.
-    j1 = baker.make(Jednostka, nazwa="Jedn. A", skrot="J.A")
-    j2 = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. T.")
+    j1 = baker.make(
+        Jednostka, nazwa=unikalna_nazwa("Jedn. A"), skrot=unikalna_nazwa("J.A")
+    )
+    j2 = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. T."),
+    )
     a1 = baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
     a2 = baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
     baker.make(Autor_Jednostka, autor=a1, jednostka=j1)
@@ -132,7 +155,11 @@ def test_konflikt_bpp_id_nadal_rzuca():
     # bpp_id w pliku wskazuje NIEISTNIEJĄCEGO autora, ale nazwisko+imię matchuje
     # kogoś innego → matchuj_autora (ID → None → fallback po nazwisku) zwraca
     # tego autora, a jego pk != bpp_id z pliku → twardy błąd (jak dziś).
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. T.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. T."),
+    )
     autor = baker.make(Autor, nazwisko="Kowalski", imiona="Jan")
     nieistniejacy_bpp_id = autor.pk + 999999
     imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZMAPOWANY)

--- a/src/import_pracownikow/tests/test_pipeline/test_faza3_e2e.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_faza3_e2e.py
@@ -10,11 +10,16 @@ from model_bakery import baker
 from bpp.models import Autor, Autor_Jednostka, Jednostka, Tytul
 from import_pracownikow.models import ImportPracownikow
 from import_pracownikow.pewnosc import STATUS_TWARDY, STATUS_WIELU
+from import_pracownikow.tests._helpers import unikalna_nazwa
 
 
 @pytest.mark.django_db
 def test_e2e_osoba_sklejona_status_i_wybor(admin_client, admin_user):
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. T.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. T."),
+    )
     # Tytul.skrot/nazwa unique + baseline preloaduje „dr/doktor" → get_or_create.
     Tytul.objects.get_or_create(skrot="dr", defaults={"nazwa": "doktor"})
     # jeden jednoznaczny (twardy) + dwóch o identycznym imieniu (wielu)

--- a/src/import_pracownikow/tests/test_pipeline/test_faza4_e2e.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_faza4_e2e.py
@@ -10,17 +10,22 @@ from model_bakery import baker
 from bpp.models import Autor, Autor_Jednostka, Jednostka
 from import_pracownikow.models import ImportPracownikow
 from import_pracownikow.pewnosc import STATUS_BRAK
+from import_pracownikow.tests._helpers import unikalna_nazwa
 
 
 @pytest.mark.django_db
 def test_e2e_nowy_autor_i_odpiecie(admin_client, admin_user, yesterday):
-    jednostka = baker.make(Jednostka, nazwa="Katedra Testowa", skrot="Kat. T.")
+    jednostka = baker.make(
+        Jednostka,
+        nazwa=unikalna_nazwa("Katedra Testowa"),
+        skrot=unikalna_nazwa("Kat. T."),
+    )
 
     # autor spoza pliku: jednostka zarządzana automatycznie + aktualna jednostka
     j_spoza = baker.make(
         Jednostka,
-        nazwa="Katedra Spoza",
-        skrot="Kat. Spoza",
+        nazwa=unikalna_nazwa("Katedra Spoza"),
+        skrot=unikalna_nazwa("Kat. Spoza"),
         zarzadzaj_automatycznie=True,
     )
     a_spoza = baker.make(Autor, nazwisko="Odpinalski", imiona="Marek")

--- a/src/import_pracownikow/tests/test_pipeline/test_integrate.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_integrate.py
@@ -174,9 +174,9 @@ def test_commit_pomija_wiersz_gdy_recheck_nieaktualny(autor_jednostka_fixture):
     pomijany (``pominiety_bo_nieaktualny=True``) i NIE trafia do
     ``row.integrate()`` — ``log_zmian`` pozostaje puste."""
     autor, jednostka = autor_jednostka_fixture
-    # "asystent" jest w danych referencyjnych (baseline) — używamy istniejącego
-    # wpisu zamiast tworzyć nowy (uniqueness na "nazwa").
-    funkcja = Funkcja_Autora.objects.get(nazwa="asystent")
+    # "asystent" bywa w baseline, ale transakcyjny flush innego testu na tym
+    # samym workerze potrafi go zmieść — zapewniamy go sami zamiast zakładać.
+    funkcja, _ = Funkcja_Autora.objects.get_or_create(nazwa="asystent")
     # podstawowe_miejsce_pracy=True: bez tego #4 (domyślnie import ustawia
     # jednostkę jako podstawowe miejsce pracy) trzymałby wiersz jako „wymaga
     # integracji" i recheck NIE pominąłby go jako nieaktualnego.

--- a/src/import_pracownikow/tests/test_pipeline/test_integrate_zakres.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_integrate_zakres.py
@@ -21,6 +21,7 @@ from import_pracownikow.models import (
 )
 from import_pracownikow.pewnosc import STATUS_BRAK
 from import_pracownikow.pipeline.integrate import integruj
+from import_pracownikow.tests._helpers import unikalna_nazwa
 
 
 def _imp(zakres):
@@ -32,10 +33,14 @@ def _imp(zakres):
 
 
 def _decyzja_jednostki(imp):
+    # Nazwa unikalna: integracja materializuje ją jako Jednostkę (unikalne
+    # nazwa/skrot/slug), a testy w tym pliku dzielą ten helper — pod ambient
+    # pollution xdista dosłowna "Zakład Struktury Testowej" kolidowałaby między
+    # sąsiadami. Asercje odwołują się do ``dec_j.nazwa_zrodlowa``.
     return baker.make(
         ImportPracownikowJednostka,
         parent=imp,
-        nazwa_zrodlowa="Zakład Struktury Testowej",
+        nazwa_zrodlowa=unikalna_nazwa("Zakład Struktury Testowej"),
         skrot_sugerowany="ZST",
         tryb=ImportPracownikowJednostka.TRYB_BRAK,
         decyzja=ImportPracownikowJednostka.DECYZJA_AKCEPTUJ,
@@ -43,11 +48,12 @@ def _decyzja_jednostki(imp):
 
 
 def _decyzja_tytulu(imp):
+    nazwa = unikalna_nazwa("Tytuł Struktury Testowej")
     return baker.make(
         ImportPracownikowTytul,
         parent=imp,
-        nazwa_zrodlowa="Tytuł Struktury Testowej",
-        nazwa_do_utworzenia="Tytuł Struktury Testowej",
+        nazwa_zrodlowa=nazwa,
+        nazwa_do_utworzenia=nazwa,
         skrot_do_utworzenia="TytStrTest",
         tryb=ImportPracownikowTytul.TRYB_BRAK,
         decyzja=ImportPracownikowTytul.DECYZJA_AKCEPTUJ,
@@ -91,11 +97,11 @@ def test_zakres_jednostki_tworzy_jednostki_bez_tytulow_bez_osob(uczelnia):
     # jednostki utworzone
     dec_j.refresh_from_db()
     assert dec_j.utworzona is not None
-    assert Jednostka.objects.filter(nazwa="Zakład Struktury Testowej").exists()
+    assert Jednostka.objects.filter(nazwa=dec_j.nazwa_zrodlowa).exists()
     # tytuły POMINIĘTE (zakres tylko jednostki)
     dec_t.refresh_from_db()
     assert dec_t.utworzony is None
-    assert not Tytul.objects.filter(nazwa="Tytuł Struktury Testowej").exists()
+    assert not Tytul.objects.filter(nazwa=dec_t.nazwa_do_utworzenia).exists()
     # osoby NIETKNIĘTE — brak zapisów Autor / Autor_Jednostka
     assert Autor.objects.count() == autorow_przed
     assert Autor_Jednostka.objects.count() == aj_przed
@@ -123,10 +129,10 @@ def test_zakres_struktura_tworzy_jednostki_i_tytuly_bez_osob(uczelnia):
     # Krok 1: struktura zapisana, osoby czekają (NIE „zintegrowany").
     assert imp.stan == ImportPracownikow.STAN_STRUKTURA_ZINTEGROWANA
     # jednostki + tytuły utworzone
-    assert Jednostka.objects.filter(nazwa="Zakład Struktury Testowej").exists()
+    assert Jednostka.objects.filter(nazwa=dec_j.nazwa_zrodlowa).exists()
     dec_t.refresh_from_db()
     assert dec_t.utworzony is not None
-    assert Tytul.objects.filter(nazwa="Tytuł Struktury Testowej").exists()
+    assert Tytul.objects.filter(nazwa=dec_t.nazwa_do_utworzenia).exists()
     # osoby NIETKNIĘTE
     assert Autor.objects.count() == autorow_przed
     assert Autor_Jednostka.objects.count() == aj_przed
@@ -180,7 +186,7 @@ def test_sekwencja_jednostki_potem_pelny_tworzy_odlozony_tytul(uczelnia):
     assert imp.stan == ImportPracownikow.STAN_STRUKTURA_ZINTEGROWANA
     dec_t.refresh_from_db()
     assert dec_t.utworzony is None
-    assert not Tytul.objects.filter(nazwa="Tytuł Struktury Testowej").exists()
+    assert not Tytul.objects.filter(nazwa=dec_t.nazwa_do_utworzenia).exists()
 
     # Krok 2 — import osób (pełny): odłożony tytuł zostaje utworzony.
     imp.stan = ImportPracownikow.STAN_ZATWIERDZONY
@@ -191,7 +197,7 @@ def test_sekwencja_jednostki_potem_pelny_tworzy_odlozony_tytul(uczelnia):
     assert imp.stan == ImportPracownikow.STAN_ZINTEGROWANY
     dec_t.refresh_from_db()
     assert dec_t.utworzony is not None
-    assert Tytul.objects.filter(nazwa="Tytuł Struktury Testowej").exists()
+    assert Tytul.objects.filter(nazwa=dec_t.nazwa_do_utworzenia).exists()
 
 
 @pytest.mark.django_db

--- a/src/importer_publikacji/tests/test_afiliacja_pre_check.py
+++ b/src/importer_publikacji/tests/test_afiliacja_pre_check.py
@@ -48,7 +48,15 @@ def test_create_blokuje_gdy_autor_afiliuje_do_wydzialu(authed_client, jednostka)
     """Autor dopasowany do jednostki rodzaju „Wydział" (afiliuje=True) →
     task NIE jest enqueueowany, sesja zostaje w REVIEW, user widzi błąd."""
     client, user = authed_client
-    jednostka.rodzaj = RodzajJednostki.objects.get(nazwa="Wydział")
+    # Baseline bywa zmieciony przez transakcyjny flush sąsiada — zapewniamy
+    # rodzaj "Wydział" sami i WYMUSZAMY autor_moze_afiliowac=False (o to w teście
+    # chodzi; model domyślnie ma True, a inne fixtury mogły utworzyć "Wydział"
+    # z domyślną wartością, więc samo ``defaults`` nie wystarcza).
+    rodzaj, _ = RodzajJednostki.objects.get_or_create(nazwa="Wydział")
+    if rodzaj.autor_moze_afiliowac is not False:
+        rodzaj.autor_moze_afiliowac = False
+        rodzaj.save()
+    jednostka.rodzaj = rodzaj
     jednostka.save()
     session = _sesja_z_autorem(user, jednostka)
 
@@ -103,7 +111,15 @@ def test_waliduj_afiliacje_sesji_raises_dla_wydzialu(jednostka):
     """Twardy guard współdzielony przez CreateView i _create_publication."""
     from importer_publikacji.views.publikacja import waliduj_afiliacje_sesji
 
-    jednostka.rodzaj = RodzajJednostki.objects.get(nazwa="Wydział")
+    # Baseline bywa zmieciony przez transakcyjny flush sąsiada — zapewniamy
+    # rodzaj "Wydział" sami i WYMUSZAMY autor_moze_afiliowac=False (o to w teście
+    # chodzi; model domyślnie ma True, a inne fixtury mogły utworzyć "Wydział"
+    # z domyślną wartością, więc samo ``defaults`` nie wystarcza).
+    rodzaj, _ = RodzajJednostki.objects.get_or_create(nazwa="Wydział")
+    if rodzaj.autor_moze_afiliowac is not False:
+        rodzaj.autor_moze_afiliowac = False
+        rodzaj.save()
+    jednostka.rodzaj = rodzaj
     jednostka.save()
     session = _sesja_z_autorem(baker.make("bpp.BppUser"), jednostka)
 

--- a/src/importer_publikacji/tests/test_crossref_mapper_defaults.py
+++ b/src/importer_publikacji/tests/test_crossref_mapper_defaults.py
@@ -20,6 +20,18 @@ from bpp.models import Crossref_Mapper
 @pytest.mark.django_db
 def test_migracja_zaseedowala_wszystkie_typy():
     """Migracja 0467 utworzyła 16 wierszy z poprawnym jest_wydawnictwem_zwartym."""
+    import importlib
+
+    from django.apps import apps as django_apps
+
+    # Dane migracji 0467 bywają zmiecione przez transakcyjny flush sąsiada na
+    # workerze — odtwarzamy je REALNĄ (idempotentną) funkcją seedującą migracji,
+    # więc test dalej weryfikuje JEJ wynik (komplet 16 + flagi), zamiast zakładać
+    # przetrwanie danych migracyjnych.
+    importlib.import_module(
+        "bpp.migrations.0467_seed_crossref_mapper_rows"
+    ).seed_crossref_mapper_rows(django_apps, None)
+
     C = Crossref_Mapper.CHARAKTER_CROSSREF
     assert Crossref_Mapper.objects.count() == len(C.values)
 

--- a/src/rozbieznosci/tests/test_templates.py
+++ b/src/rozbieznosci/tests/test_templates.py
@@ -15,7 +15,10 @@ def test_zakladki_renderowane(client_with_group):
 
 
 @pytest.mark.django_db
-def test_formularz_ma_3_tryby_i_kasuj_checkbox(client_with_group):
+def test_formularz_ma_3_tryby_i_kasuj_checkbox(client_with_group, charaktery_formalne):
+    # ``charaktery_formalne``: pole „charaktery_formalne" renderuje się tylko
+    # gdy są jakieś Charakter_Formalny; baseline bywa zmieciony przez
+    # transakcyjny flush sąsiada — zapewniamy je fixture'em zamiast zakładać.
     url = reverse("rozbieznosci:index", kwargs={"metryka": "if"})
     html = client_with_group.get(url).content.decode()
     # 3-opcyjny wybór trybu źródła


### PR DESCRIPTION
## Kontekst

CI [run 29202974792](https://github.com/iplweb/bpp/actions/runs/29202974792) padał na shardach 7/9 (`pytest-split` + `xdist -n auto`). Wszystkie padające testy przechodzą w izolacji — naruszenie izolacji pod zrównolegleniem. Debug ujawnił, że to **dwa niezależne wektory** flake'a.

## VECTOR 1 — wyciek scommitowanych danych (NAPRAWIONE tutaj)

Pod obciążeniem CI test commitujący dane poza rollback zostawia w bazie workera **nadmiarowe** wiersze domenowe (autorzy, jednostki, stopnie, stanowiska). Kolejne testy: `IntegrityError` na unikalnych nazwach (`Kat.`, `kapitan`), `test_pusta_baza_zwraca_pusta_liste` (`assert [] `), dedup `count()`=4 zamiast 1.

**Fix:**
1. **Guard izolacji** (`src/conftest.py`) — autouse-fixture przed każdym testem DB czyści osobnym autocommit-połączeniem wyciekłe **nadmiarowe** wiersze domenowe (`TRUNCATE` 5 tabel pustych w baseline, **leak-triggered**). Bezpieczeństwo zweryfikowane: dane referencyjne nietknięte (`Tytul 31→31`, `Funkcja_Autora 5→5`, `RodzajJednostki 3→3`), żadna niepusta tabela nie ma FK do listy → CASCADE zostaje w danych domenowych. Raportuje też **sprawcę** wycieku (poprzedni test DB) do stderr.
2. **Unikalne nazwy jednostek** w testach `import_pracownikow` (helper `unikalna_nazwa`).
3. **Odporny dedup** — asercja na inwariancie klastra zamiast globalnego `count()`.

Zweryfikowane: shardy 7/9, które padały na V1, przechodzą (runy `baf8e3af7`, `ad9077fbb`); lokalnie 1056 passed.

## VECTOR 2 — dane referencyjne zmiatane transakcyjnym flushem (NIE naprawione, osobny wątek)

Transakcyjny flush (`_fixture_teardown` `TRUNCATE CASCADE`) zmiata dane referencyjne zaseedowane **migracją** (`bpp_crossref_mapper` 16→0, `bpp_funkcja_autora`, …), których `post_migrate` **nie odtwarza na CI** (template-clone). Kolejne testy: `DoesNotExist` / `count()==0` (`test_crossref_mapper_defaults`, `test_afiliacja_pre_check`, `rozbieznosci/test_templates`).

**To PRE-EXISTING i niezależne od tego PR-a:** ~50-60% flaky pod xdist, dotyczy też `dev` (oryginalny run po prostu trafił V1 zamiast V2). **Nie reprodukuje się lokalnie** (testcontainers odtwarzają referencje po flushu; CI z `CREATE DATABASE … WITH TEMPLATE` nie). Próba fixa (snapshot/restore referencji) była zbyt inwazyjna — biła się z danymi session-fixture'ów (`Szablon…DoesNotExist`) i rozwalała więcej shardów — **cofnięta**.

Ten PR **dodaje read-only detektor V2**: gdy wykryje zmiecione referencje, raportuje do stderr sprawcę (poprzedni test DB) — **namiar dla osobnego fixa** izolacji transakcyjnej (np. restore referencji w `_fixture_teardown` ze snapshotu z czystego baseline, przed fixture'ami). Zero mutacji.

## Uwaga o CI tego PR-a

Dopóki V2 nie jest naprawiony osobno, CI tego PR-a bywa ~czerwone na losowym shardzie przez V2 (pre-existing) — nie przez kod tego PR-a. V1 (oryginalny cel) jest naprawiony.

🤖 Generated with [Claude Code](https://claude.com/claude-code)