### PR TITLE
feat(zglos_publikacje): ALTCHA proof-of-work CAPTCHA (opt-in) + hint logowania + read-only e-mail

### DIFF
--- a/docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md
+++ b/docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md
@@ -1,0 +1,228 @@
+# Feature: ALTCHA (proof-of-work) na anonimowym formularzu zgłoszeń
+
+Data: 2026-07-12
+Gałąź: `feat/zglos-captcha-altcha`
+Kontynuacja hardeningu formularza zgłaszania publikacji (po naprawie #2 —
+limity uploadu). Adresuje **tempo** anonimowych zgłoszeń (spam/DoS), którego
+limity plików nie ruszały.
+
+## Cel i decyzje (uzgodnione z właścicielem)
+
+- **Mechanizm:** ALTCHA — proof-of-work, **self-hosted, in-process** (bez
+  osobnej usługi/kontenera). GDPR-clean, WCAG 2.2 AA, zero danych do trzeciej
+  strony.
+- **Bramka:** tylko dla **anonimowych** (`not request.user.is_authenticated`).
+  Zalogowany pracownik uczelni nie jest wektorem spamu → bez tarcia.
+- **Umiejscowienie:** **pierwszy krok** kreatora (`RodzajPublikacjiForm`,
+  step "0") — odrzuca bota, zanim dojdzie do uploadu plików (krok 2).
+- **Docker:** żadnej nowej usługi. `ALTCHA_HMAC_KEY` to sekret env
+  **auto-generowany w bpp-deploy** (`_ensure_secret`, jak inne sekrety) i
+  wpięty do wszystkich serwisów Django — dzięki temu default ON nie psuje
+  upgrade'ów (każda instalacja dostaje klucz automatycznie).
+- **Model klucza = jak `SECRET_KEY`** (świadoma decyzja właściciela): sentinel
+  default w `base.py`, placeholder w `.env.docker`, dummy inline na buildzie,
+  **bez** hard import-time `raise` (który psuł build). Zamiast fail-fast —
+  nie-fatalny **system-check WARNING**, gdy captcha ON a klucz to placeholder.
+
+## Architektura ALTCHA (dlaczego bez usługi)
+
+PoW liczy **przeglądarka** (web component ~17 kB gzip). Serwer tylko:
+1. **generuje challenge** — HMAC-podpisany sekretem (`django-altcha`, in-proc),
+2. **weryfikuje rozwiązanie** — in-proc, + ochrona przed replay przez Django
+   cache (BPP ma Redis).
+
+Biblioteki:
+- **`django-altcha`** (PyPI, aboutcode-org, 1.0.0) — `AltchaField` + widget +
+  `AltchaChallengeView`. Ustawienie `ALTCHA_HMAC_KEY`. **Sam bundluje web
+  component** (`static/altcha/altcha.min.js`) → self-host bez CDN, bez npm/Grunt
+  (patrz C). Zero osobnej paczki frontendowej.
+
+## Rozwiązanie
+
+### A. Zależności + konfiguracja
+
+- `pyproject.toml`: dodać `django-altcha`; `INSTALLED_APPS += ["django_altcha"]`.
+  **To wystarcza do self-hostu widgetu** — django-altcha 1.0.0 bundluje
+  `django_altcha/static/altcha/altcha.min.js`, a `ALTCHA_JS_URL` domyślnie
+  rozwiązuje się przez `static()`. `collectstatic` (kontrakt Docker build-stage)
+  łapie app-static normalnie. **Żadnego npm/Grunt/`Media` override** (patrz C).
+- `ALTCHA_HMAC_KEY` (sekret HMAC-signing challenge) — **odwzorowanie wzorca
+  `SECRET_KEY`** (`base.py:26,107,850`: sentinel default + `env(...)`; brak
+  hard-raise w `production.py`):
+  - **`base.py`:** `ALTCHA_HMAC_KEY_UNSET = "Please set the ALTCHA_HMAC_KEY..."`
+    (sentinel), `ALTCHA_HMAC_KEY = env("ALTCHA_HMAC_KEY", default=...UNSET)`.
+    **Bez** import-time `raise` — to on psuł build (patrz niżej).
+  - **`.env.docker` (dev compose):** placeholder (jak
+    `DJANGO_BPP_SECRET_KEY="ZMIEN..."`). Captcha w dev compose jest dev-only.
+  - **Build (`testserver` collectstatic):** `ALTCHA_HMAC_KEY=
+    build-time-only-not-used` **inline w RUN-ie** — dokładnie jak istniejący
+    `DJANGO_BPP_SECRET_KEY=build-time-only-not-used`. Inline env RUN-a NIE
+    persystuje w obrazie → nic forgeable nie ląduje w publicznym obrazie.
+  - **`local.py` (dev/run-site):** **efemeryczny** `secrets.token_hex(32)` przy
+    load-zie settings (widget faktycznie działa, nic forgeable w repo).
+  - **`test.py`:** stały test-key (captcha domyślnie wyłączona — niżej; klucz
+    użyty przez testy captchy, które włączają ją przez `@override_settings`).
+  - **Produkcja:** realny klucz **auto-generowany w bpp-deploy** (sekcja E).
+
+  **Dlaczego bez hard-guardu:** import-time `raise ImproperlyConfigured` w
+  `production.py` rozbijał trzy niezależne konsumpcje production-settings —
+  build `testserver` (`collectstatic` pod `DJANGO_SETTINGS_MODULE=production`),
+  dev `docker compose up` (obraz z wbakowanym production + commitowany
+  `.env.docker`) oraz worker/beatserver. Repo nie stosuje takiego raise nawet
+  dla `SECRET_KEY`. Zamiast tego — miękki warning (niżej) + auto-gen w prod.
+
+- **System-check WARNING (nie-fatal):** `django.core.checks` rejestrowany w
+  `AppConfig.ready()` app `zglos_publikacje`: gdy `ZGLOS_CAPTCHA_ENABLED` a
+  `ALTCHA_HMAC_KEY` == sentinel/placeholder → `checks.Warning` (nie `Error`).
+  Level Warning **nie wywala** `collectstatic`/`manage.py` (w odróżnieniu od
+  `raise`), więc build i dev są bezpieczne; operator dostaje sygnał
+  „captcha ON, a klucz to placeholder" na `manage.py check`/starcie komend.
+  (Świadomie best-effort: checki nie biegną pod czystym gunicorn/daphne —
+  realną gwarancję klucza w prod daje auto-gen bpp-deploy, nie ten check.)
+- `ZGLOS_CAPTCHA_ENABLED` (bool): `base.py` default `True`; **`test.py`
+  = `False`** (cała dotychczasowa suita `zglos_publikacje` + Playwright,
+  wspólne `--ds=django_bpp.settings.test`, przechodzą bez zmian — pole ALTCHA
+  w ogóle nie powstaje). W dev (`local.py`) **włączona** — świadomie, do
+  oglądania w `run-site`. **`get_form_kwargs` czyta ten flag w call-time**
+  (nie stała modułowa), inaczej `@override_settings` w nowych testach nie
+  zadziała.
+- **Replay-protection (cache):** `ALTCHA_CACHE_ALIAS` domyślnie `"default"`.
+  `production.py` → Redis (działa). **Uwaga: dev/test `default` = DummyCache →
+  `is_challenge_used()` zawsze `False` (replay-check to no-op).** Nowe testy
+  replay MUSZĄ override'ować cache na locmem, inaczej testują nic.
+
+### B. Bramka anon-only + pole warunkowe (unik ponownej weryfikacji)
+
+Dlaczego flaga (SPROSTOWANIE po review): `render_done` rewaliduje WSZYSTKIE
+kroki. Pole ALTCHA na kroku 0 rewalidowane ze starymi danymi (brak świeżego
+PoW; do tego replay-protection ubiłby ponowne użycie) byłoby niepoprawne —
+ale to **NIE** daje 500: formtools robi `render_revalidation_failure` →
+**HTTP 200, powrót na krok 0** z błędem „Challenge already used"
+(`AltchaField.validate` rzuca zwykły `ValidationError`, nie wyjątek jak
+`FileNotFoundError` przy `pliki`). Flaga jest więc potrzebna z powodu **UX**
+(inaczej user po wypełnieniu 5 kroków wraca na krok 0 i re-solve), nie 500.
+Wzorzec jak `pliki_juz_zapisane`:
+
+- `Zgloszenie_PublikacjiWizard.get_form_kwargs("0")` przekazuje
+  `captcha_wymagany: bool` = `settings.ZGLOS_CAPTCHA_ENABLED` (czytane
+  **call-time**) AND `not request.user.is_authenticated` AND
+  NOT `request.session.get("zglos_captcha_ok")`.
+- `RodzajPublikacjiForm.__init__(captcha_wymagany=False)`: dodaje `AltchaField`
+  **tylko** gdy `captcha_wymagany`. Inaczej pole nieobecne. (Forma dostaje sam
+  bool — nie potrzebuje całego `request`.)
+- Po ważnym POST kroku 0 z zweryfikowanym ALTCHA (`AltchaField.validate`) →
+  wizard ustawia `request.session["zglos_captcha_ok"] = True` w
+  **`process_step` dla kroku "0"** (istniejący override obsługuje dziś tylko
+  "2" — dodać branch "0"). `process_step` wykonuje się PRZED `set_step_data`
+  i przed czyszczeniem cache warunków, więc flaga jest na miejscu, zanim
+  cokolwiek rewaliduje krok 0.
+- Rewalidacja w `render_done`: flaga ustawiona → `captcha_wymagany=False` →
+  pole nieobecne → brak ponownej weryfikacji, `done()` dochodzi do skutku.
+- **Flagę czyścić na POCZĄTKU `done()`** (nie na końcu) — konsekwentnie wobec
+  wczesnych `raise` w `done()`; koszt = 1 PoW na 1 utworzone zgłoszenie.
+
+**Znane, zaakceptowane ograniczenie flagi:** jedno rozwiązanie PoW odblokowuje
+w tej samej sesji wielokrotny upload tmp (pętla krok 0→2→2…), bo tworzenie
+rekordu jest dopiero w `done()`. PoW i tak tego nie broni (bot bierze świeżą
+sesję + tani PoW/sesję) — upload-DoS pozostaje tematem **rate-limitu**, nie
+CAPTCHY (sprzątanie tmp pokrywa naprawa #2 + cron co 6h).
+
+### C. Frontend (self-host widgetu — django-altcha robi to sam)
+
+SPROSTOWANIE po review: **żadnego npm/Grunt/`Media` override.** django-altcha
+1.0.0 bundluje `django_altcha/static/altcha/altcha.min.js`, a `ALTCHA_JS_URL`
+domyślnie rozwiązuje się przez `static()`. Dokładanie paczki npm tworzyłoby
+DRUGĄ kopię widgetu i ryzyko version-skew (bundlowany JS musi pasować do
+formatu payloadu pythonowej libki). Wystarczy:
+
+- `INSTALLED_APPS += ["django_altcha"]` (sekcja A) + `collectstatic` (kontrakt
+  Docker build-stage łapie app-static normalnie — patrz CLAUDE.md „Static files
+  contract"). Zero dodatkowej roboty frontendowej.
+- `AltchaField` z opcją **`challengeurl`** (nie `challengejson`) wskazującą na
+  `AltchaChallengeView` django-altcha, zamontowany w `zglos_publikacje/urls.py`.
+  URL przez **`reverse_lazy`** (pole definiowane przy imporcie modułu `forms`).
+  Dzięki `challengeurl` działa `refetchonexpire` — challenge nie wygasa przy
+  dłuższym wypełnianiu kroku 0.
+- Ustawić `auto="onsubmit"` (lub `"onload"`) na widgecie, żeby po spaleniu
+  challenge (np. user rozwiązał PoW, ale forma padła na innym polu kroku 0 —
+  `mark_challenge_used` odpala się w `validate` niezależnie od reszty)
+  re-solve był bezobsługowy.
+- Szablon kroku 0 (`step_rodzaj.html`): pole renderuje `<altcha-widget>` tylko
+  gdy jest obecne (anon). Ikony public-frontend = Foundation (nie dotyczy
+  widgetu).
+- CSP: BPP obecnie nie ustawia żadnego CSP — motywacja self-hostu jest
+  prospektywna (prywatność + brak CDN). Gdyby CSP kiedyś wszedł, altcha wymaga
+  `worker-src blob:` (web worker z blob URL).
+
+### D. Testy
+
+Istniejące testy wizardu (POST kroku 0 bez ALTCHA) **nie mogą się wywalić** →
+w środowisku testowym `ZGLOS_CAPTCHA_ENABLED=False` domyślnie (żeby cała
+dotychczasowa suita `zglos_publikacje` przechodziła bez zmian).
+
+Nowe testy (`test_zglos_captcha.py`), z `@override_settings(
+ZGLOS_CAPTCHA_ENABLED=True, ALTCHA_HMAC_KEY=<test>)` + mock weryfikacji
+django-altcha. **Replay-testy MUSZĄ dodatkowo override'ować cache na locmem**
+(`CACHES={"default": LocMemCache}`), bo test.py dziedziczy DummyCache →
+`is_challenge_used()` inaczej zawsze `False` (test niczego nie dowodzi):
+1. Anonim na kroku 0 → forma MA `AltchaField` (renderuje `<altcha-widget>`).
+2. Zalogowany na kroku 0 → forma NIE ma pola (bramka anon-only).
+3. Anonim, brak/nieprawidłowe rozwiązanie → krok 0 nieważny, brak awansu.
+4. Anonim, poprawne rozwiązanie (mock verify OK) → awans na krok 1 +
+   `session["zglos_captcha_ok"] == True`.
+5. **Rewalidacja/late (przeformułowane):** po przejściu kroku 0 (flaga w sesji),
+   pełne dojście do `render_done` → **`done()` dochodzi do skutku (zgłoszenie
+   powstaje), a wizard NIE cofa na krok 0**. (Uwaga: bez flagi objaw to nie
+   500, lecz `render_revalidation_failure` → 200 + powrót na krok 0; asercja
+   „brak 500" byłaby zbyt słaba i przeszłaby nawet bez flagi — dlatego test na
+   „done() się wykonał / brak cofnięcia".)
+6. Replay: to samo rozwiązanie użyte dwa razy (z locmem cache) → drugie
+   odrzucone jako „already used".
+7. `ZGLOS_CAPTCHA_ENABLED=False` → forma bez pola nawet dla anonima
+   (dowód, że dotychczasowa suita nie jest ruszona).
+8. System-check WARNING: `@override_settings(ZGLOS_CAPTCHA_ENABLED=True,
+   ALTCHA_HMAC_KEY=<sentinel/placeholder>)` → `run_checks`/wywołanie funkcji
+   check zwraca `checks.Warning` (poziom Warning, NIE Error — build nietknięty).
+   Odwrotnie: realny klucz + ON → brak warninga; OFF + placeholder → brak
+   warninga. (Bez importu `production.py` w procesie testu — check operuje na
+   aktywnych `settings`, więc żadnej mutacji współdzielonych dictów base.)
+
+### E. Wdrożenie (osobny PR w bpp-deploy)
+
+- **Auto-generacja klucza:** w `scripts/ensure-config-files.sh`, obok innych
+  `_ensure_secret`:
+  ```sh
+  _ensure_secret ALTCHA_HMAC_KEY "$(openssl rand -hex 32)"   # 64-hex
+  ```
+  `_ensure_secret` jest **idempotentny** (dodaje do `.env` tylko gdy brak, nie
+  nadpisuje) i odpala się na **każdym `make up`** → wszystkie instalacje
+  (świeże i po upgrade) dostają stabilny klucz bez ręcznego kroku. To eliminuje
+  breaking-upgrade przy default ON.
+- **Wpięcie env** `ALTCHA_HMAC_KEY` do **appservera, workerserver i
+  beatserver** w compose (guard/warning i sama weryfikacja odpalają się w
+  każdym imporcie/procesie Django; wszystkie trzy jadą na production settings).
+- Ten PR bpp-deploy jest niezależny od PR-a bpp (captcha działa dopiero z oboma;
+  do czasu — `ZGLOS_CAPTCHA_ENABLED` można trzymać OFF).
+
+## Świadome ograniczenia
+
+- PoW nie blokuje pojedynczego zdeterminowanego bota z zapleczem obliczeniowym
+  — podnosi **koszt** masowego wysyłania. To celowo dobrany trade-off
+  (prywatność + self-host) vs managed challenge (Turnstile/hCaptcha).
+- Tempo dalej ograniczalne dodatkowo rate-limitem na endpoint (osobny temat).
+- **Flow edycji (`edycja_zgloszenia/<uuid:kod_do_edycji>`)** używa tego samego
+  wizardu → anonimowy autor poprawiający zwrócone zgłoszenie z linku e-mail
+  też dostanie PoW na kroku 0. **Świadomie akceptujemy** — to nadal anonimowy
+  zapis, a edycje są rzadkie; jeden PoW na wejście w edycję jest do przyjęcia.
+- **Sentinel/placeholder klucz = forgeable captcha (cicho).** Instalacja
+  omijająca auto-gen bpp-deploy i nie ustawiająca klucza uruchomi captchę na
+  sentinelu → HMAC znany → obejście PoW. **Identyczny profil ryzyka jak
+  `SECRET_KEY`** (repo też nie fail-fastuje). Mitygacja: auto-gen pokrywa realne
+  wdrożenia; system-check WARNING sygnalizuje placeholder. Świadomy trade-off
+  prostoty (brak build-time trapów) vs twardego fail-fast.
+
+## Poza zakresem
+
+- Rate-limiting/throttling endpointu (osobno).
+- CAPTCHA na innych formularzach (tylko zgłoszenia).
+- Zmiana domyślnej publiczności formularza.

--- a/docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md
+++ b/docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md
@@ -58,8 +58,12 @@ Biblioteki:
     build-time-only-not-used` **inline w RUN-ie** — dokładnie jak istniejący
     `DJANGO_BPP_SECRET_KEY=build-time-only-not-used`. Inline env RUN-a NIE
     persystuje w obrazie → nic forgeable nie ląduje w publicznym obrazie.
-  - **`local.py` (dev/run-site):** **efemeryczny** `secrets.token_hex(32)` przy
-    load-zie settings (widget faktycznie działa, nic forgeable w repo).
+  - **`local.py` (dev/run-site):** efemeryczny klucz **tylko gdy env nieustawiony**
+    — `os.environ.setdefault("ALTCHA_HMAC_KEY", secrets.token_hex(32))` PRZED
+    importem `base` (dokładnie wzorzec `DJANGO_BPP_SECRET_KEY` w `local.py`).
+    Dzięki temu precedencja jest jednoznaczna (fix codex): `run-site` bez env →
+    losowy klucz (widget działa, nic forgeable w repo); dev `docker compose up`
+    ładuje `.env.docker` → `setdefault` NIE nadpisuje placeholdera.
   - **`test.py`:** stały test-key (captcha domyślnie wyłączona — niżej; klucz
     użyty przez testy captchy, które włączają ją przez `@override_settings`).
   - **Produkcja:** realny klucz **auto-generowany w bpp-deploy** (sekcja E).
@@ -74,11 +78,14 @@ Biblioteki:
 - **System-check WARNING (nie-fatal):** `django.core.checks` rejestrowany w
   `AppConfig.ready()` app `zglos_publikacje`: gdy `ZGLOS_CAPTCHA_ENABLED` a
   `ALTCHA_HMAC_KEY` == sentinel/placeholder → `checks.Warning` (nie `Error`).
-  Level Warning **nie wywala** `collectstatic`/`manage.py` (w odróżnieniu od
-  `raise`), więc build i dev są bezpieczne; operator dostaje sygnał
-  „captcha ON, a klucz to placeholder" na `manage.py check`/starcie komend.
-  (Świadomie best-effort: checki nie biegną pod czystym gunicorn/daphne —
-  realną gwarancję klucza w prod daje auto-gen bpp-deploy, nie ten check.)
+  Widoczność (doprecyzowanie po codex): `collectstatic` uruchamia **tylko**
+  checki z tagiem `staticfiles`, więc nasz zwykły check **nie odpali się na
+  buildzie** — to dobrze, build pozostaje wykonywalny niezależnie od poziomu
+  (Warning i tak nie wywala). Ostrzeżenie pojawia się przy `manage.py check`
+  i `migrate` (entrypoint robi `migrate`), NIE „na dowolnym starcie komend"
+  ani pod czystym gunicorn/daphne. **Realną gwarancję klucza w prod daje
+  auto-gen bpp-deploy, nie ten check** — check to best-effort sygnał dla
+  operatora, nie mechanizm bezpieczeństwa.
 - `ZGLOS_CAPTCHA_ENABLED` (bool): `base.py` default `True`; **`test.py`
   = `False`** (cała dotychczasowa suita `zglos_publikacje` + Playwright,
   wspólne `--ds=django_bpp.settings.test`, przechodzą bez zmian — pole ALTCHA
@@ -103,29 +110,37 @@ ale to **NIE** daje 500: formtools robi `render_revalidation_failure` →
 (inaczej user po wypełnieniu 5 kroków wraca na krok 0 i re-solve), nie 500.
 Wzorzec jak `pliki_juz_zapisane`:
 
+- **Marker trzymamy w `self.storage.extra_data`, NIE w `request.session`**
+  (KRYTYCZNE po review codex). Sesja ma zasięg wielu przebiegów wizardu:
+  GET na URL wizardu resetuje TYLKO storage wizardu (`views.py` `get()`),
+  nie sesję — więc flaga sesyjna po jednym PoW odblokowałaby wiele zgłoszeń
+  pętlą „rozwiąż PoW → GET-restart → nowe zgłoszenie bez PoW". `extra_data`
+  resetuje się RAZEM z wizardem (jak `pliki_list`), więc restart wymusza nowy
+  PoW. Klucz: `PLIKI…`-analogiczny `ZGLOS_CAPTCHA_OK_KEY = "captcha_ok"`.
 - `Zgloszenie_PublikacjiWizard.get_form_kwargs("0")` przekazuje
   `captcha_wymagany: bool` = `settings.ZGLOS_CAPTCHA_ENABLED` (czytane
   **call-time**) AND `not request.user.is_authenticated` AND
-  NOT `request.session.get("zglos_captcha_ok")`.
+  NOT `self.storage.extra_data.get(ZGLOS_CAPTCHA_OK_KEY)`.
 - `RodzajPublikacjiForm.__init__(captcha_wymagany=False)`: dodaje `AltchaField`
   **tylko** gdy `captcha_wymagany`. Inaczej pole nieobecne. (Forma dostaje sam
   bool — nie potrzebuje całego `request`.)
 - Po ważnym POST kroku 0 z zweryfikowanym ALTCHA (`AltchaField.validate`) →
-  wizard ustawia `request.session["zglos_captcha_ok"] = True` w
+  wizard ustawia `extra_data[ZGLOS_CAPTCHA_OK_KEY] = True` w
   **`process_step` dla kroku "0"** (istniejący override obsługuje dziś tylko
   "2" — dodać branch "0"). `process_step` wykonuje się PRZED `set_step_data`
-  i przed czyszczeniem cache warunków, więc flaga jest na miejscu, zanim
+  i przed czyszczeniem cache warunków, więc marker jest na miejscu, zanim
   cokolwiek rewaliduje krok 0.
-- Rewalidacja w `render_done`: flaga ustawiona → `captcha_wymagany=False` →
+- Rewalidacja w `render_done`: marker ustawiony → `captcha_wymagany=False` →
   pole nieobecne → brak ponownej weryfikacji, `done()` dochodzi do skutku.
-- **Flagę czyścić na POCZĄTKU `done()`** (nie na końcu) — konsekwentnie wobec
-  wczesnych `raise` w `done()`; koszt = 1 PoW na 1 utworzone zgłoszenie.
+- Nie trzeba osobno czyścić markera w `done()` — `render_done` po udanym
+  `done()` i tak robi `storage.reset()` (zeruje `extra_data`). GET-restart
+  również. Czyli: 1 PoW = 1 przebieg wizardu (a przebieg → co najwyżej 1
+  zgłoszenie w `done()`).
 
-**Znane, zaakceptowane ograniczenie flagi:** jedno rozwiązanie PoW odblokowuje
-w tej samej sesji wielokrotny upload tmp (pętla krok 0→2→2…), bo tworzenie
-rekordu jest dopiero w `done()`. PoW i tak tego nie broni (bot bierze świeżą
-sesję + tani PoW/sesję) — upload-DoS pozostaje tematem **rate-limitu**, nie
-CAPTCHY (sprzątanie tmp pokrywa naprawa #2 + cron co 6h).
+**Znane, zaakceptowane ograniczenie:** w RAMACH jednego przebiegu PoW nie broni
+wielokrotnego uploadu tmp (pętla krok 0→2→2…) — ale to i tak nie tworzy
+rekordów (dopiero `done()`), a upload-DoS to temat **rate-limitu**, nie CAPTCHY
+(sprzątanie tmp pokrywa naprawa #2 + cron co 6h).
 
 ### C. Frontend (self-host widgetu — django-altcha robi to sam)
 
@@ -143,10 +158,14 @@ formatu payloadu pythonowej libki). Wystarczy:
   URL przez **`reverse_lazy`** (pole definiowane przy imporcie modułu `forms`).
   Dzięki `challengeurl` działa `refetchonexpire` — challenge nie wygasa przy
   dłuższym wypełnianiu kroku 0.
-- Ustawić `auto="onsubmit"` (lub `"onload"`) na widgecie, żeby po spaleniu
-  challenge (np. user rozwiązał PoW, ale forma padła na innym polu kroku 0 —
-  `mark_challenge_used` odpala się w `validate` niezależnie od reszty)
-  re-solve był bezobsługowy.
+- **`auto="onload"`** (NIE `onsubmit` — ustalenie po review codex): kafelki
+  kroku 0 wołają `form.submit()` **bezpośrednio** (`step_rodzaj.html`), co
+  **omija zdarzenie `submit`**, na którym widget przechwyciłby formularz przy
+  `onsubmit` → PoW nigdy by się nie policzył. `onload` liczy PoW przy
+  załadowaniu strony (gotowy zanim user kliknie kafelek). To też pokrywa
+  re-solve po spaleniu challenge (`mark_challenge_used` odpala się w `validate`
+  niezależnie od reszty pól). Alternatywa `form.requestSubmit()` w JS +
+  `onsubmit` — odrzucona (więcej zmian + wymaga browser-testu).
 - Szablon kroku 0 (`step_rodzaj.html`): pole renderuje `<altcha-widget>` tylko
   gdy jest obecne (anon). Ikony public-frontend = Foundation (nie dotyczy
   widgetu).
@@ -169,15 +188,23 @@ django-altcha. **Replay-testy MUSZĄ dodatkowo override'ować cache na locmem**
 2. Zalogowany na kroku 0 → forma NIE ma pola (bramka anon-only).
 3. Anonim, brak/nieprawidłowe rozwiązanie → krok 0 nieważny, brak awansu.
 4. Anonim, poprawne rozwiązanie (mock verify OK) → awans na krok 1 +
-   `session["zglos_captcha_ok"] == True`.
-5. **Rewalidacja/late (przeformułowane):** po przejściu kroku 0 (flaga w sesji),
-   pełne dojście do `render_done` → **`done()` dochodzi do skutku (zgłoszenie
-   powstaje), a wizard NIE cofa na krok 0**. (Uwaga: bez flagi objaw to nie
-   500, lecz `render_revalidation_failure` → 200 + powrót na krok 0; asercja
-   „brak 500" byłaby zbyt słaba i przeszłaby nawet bez flagi — dlatego test na
-   „done() się wykonał / brak cofnięcia".)
-6. Replay: to samo rozwiązanie użyte dwa razy (z locmem cache) → drugie
-   odrzucone jako „already used".
+   `storage.extra_data[ZGLOS_CAPTCHA_OK_KEY] == True`.
+4b. **GET-restart (regresja HIGH 1):** rozwiąż krok 0 (marker w extra_data) →
+   GET na URL wizardu (storage.reset) → krok 0 znów MA `AltchaField` (marker
+   wyzerowany razem z wizardem). Dowodzi, że jeden PoW NIE odblokowuje kolejnego
+   przebiegu w tej samej sesji.
+5. **Rewalidacja/late — NIE-tautologicznie (fix codex):** mock `verify_solution`
+   podpięty tak, by **liczyć wywołania**. Pełny przebieg do `done()` →
+   **weryfikator wołany DOKŁADNIE RAZ** (tylko POST kroku 0; przy rewalidacji
+   w `render_done` pole nieobecne dzięki markerowi → brak drugiego wywołania),
+   `done()` dochodzi do skutku. (Sama asercja „done() się wykonał" byłaby
+   tautologiczna — z DummyCache i mockiem-zawsze-OK przeszłaby też bez markera;
+   dlatego liczymy wywołania weryfikatora.)
+6. Replay — na **poziomie pola/cache**, nie wizardu (fix codex): w tej samej
+   sesji po pierwszym PoW pole znika (marker), więc replay trzeba testować
+   **dwiema niezależnymi instancjami `AltchaField`/klientami** dzielącymi
+   **LocMemCache** (`@override_settings(CACHES=locmem)` — inaczej DummyCache =
+   no-op): to samo rozwiązanie → drugie odrzucone jako „already used".
 7. `ZGLOS_CAPTCHA_ENABLED=False` → forma bez pola nawet dla anonima
    (dowód, że dotychczasowa suita nie jest ruszona).
 8. System-check WARNING: `@override_settings(ZGLOS_CAPTCHA_ENABLED=True,
@@ -201,8 +228,18 @@ django-altcha. **Replay-testy MUSZĄ dodatkowo override'ować cache na locmem**
 - **Wpięcie env** `ALTCHA_HMAC_KEY` do **appservera, workerserver i
   beatserver** w compose (guard/warning i sama weryfikacja odpalają się w
   każdym imporcie/procesie Django; wszystkie trzy jadą na production settings).
-- Ten PR bpp-deploy jest niezależny od PR-a bpp (captcha działa dopiero z oboma;
-  do czasu — `ZGLOS_CAPTCHA_ENABLED` można trzymać OFF).
+- **Twarda kolejność (fix codex — NIE „niezależne PR-y"):** przy default ON
+  kod BPP nie może trafić na prod PRZED auto-genem, bo publiczny formularz
+  ruszyłby na sentinelu → captcha forgeable (tylko warning). W normalnym flow
+  bpp-deploy jest to zapewnione: `make up` uruchamia `ensure-config-files`
+  (generuje klucz do `.env`) **PRZED** `docker compose up` z nowym obrazem —
+  więc klucz istnieje, zanim kontener z default-ON wstanie. Warunek: zmiana
+  bpp-deploy (auto-gen + wpięcie env) musi być **wdrożona razem z / przed**
+  obrazem BPP (standardowo: `git pull` bpp-deploy → `make up`). Nie deployować
+  nowego obrazu BPP pod starym bpp-deploy.
+- **Alternatywa zerowego ryzyka (do decyzji właściciela):** default **OFF** w
+  BPP, a `ZGLOS_CAPTCHA_ENABLED=1` włączane osobno po potwierdzeniu dystrybucji
+  klucza. Eliminuje zależność kolejności kosztem ręcznego włączenia.
 
 ## Świadome ograniczenia
 

--- a/docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md
+++ b/docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md
@@ -218,6 +218,13 @@ django-altcha. **Replay-testy MUSZĄ dodatkowo override'ować cache na locmem**
    Odwrotnie: realny klucz + ON → brak warninga; OFF + placeholder → brak
    warninga. (Bez importu `production.py` w procesie testu — check operuje na
    aktywnych `settings`, więc żadnej mutacji współdzielonych dictów base.)
+9. **F1 hint:** anonim + captcha ON → krok 0 zawiera link „zaloguj się"
+   (marker w HTML); zalogowany → brak widgetu I brak hintu.
+10. **F2 email read-only:** zalogowany z e-mailem → pole `email` kroku 2 ma
+   `disabled == True` i `initial` == e-mail konta; **POST z podmienionym
+   e-mailem → zapisany e-mail konta, nie z POST** (dowód serwerowego wymuszenia).
+   Anonim oraz zalogowany bez e-maila (`PUSTY_ADRES_EMAIL`) → pole edytowalne
+   (`disabled` falsy), POST-owany e-mail respektowany.
 
 ### E. Wdrożenie (osobny PR w bpp-deploy)
 
@@ -240,6 +247,34 @@ django-altcha. **Replay-testy MUSZĄ dodatkowo override'ować cache na locmem**
   (`ZGLOS_CAPTCHA_ENABLED=1` w env), bez ryzyka forgeable-okna. Zalecenie:
   włączać dopiero po potwierdzeniu (`make up` na bpp-deploy z tą zmianą +
   obecność `ALTCHA_HMAC_KEY` w `.env`).
+
+### F. Dodatkowe wymagania (zalogowany użytkownik)
+
+**F1. Hint „zaloguj się, aby pominąć weryfikację".** Gdy na kroku 0 renderuje
+się widget ALTCHA (a więc TYLKO dla anonima — bramka z sekcji B), obok niego
+komunikat z linkiem do logowania: „Jesteś niezalogowany — **zaloguj się**, aby
+pominąć tę weryfikację." Link na stronę logowania z `?next=` wracającym na URL
+kreatora. W `step_rodzaj.html` warunkowo: widoczny wyłącznie gdy pole
+`AltchaField` jest obecne w formularzu (ten sam warunek co widget). Dla
+zalogowanego — brak zarówno widgetu, jak i hintu.
+
+**F2. Pole e-mail read-only dla zalogowanego z e-mailem.** Gdy użytkownik jest
+zalogowany **i** ma realny e-mail (`request.user.email != PUSTY_ADRES_EMAIL`,
+jak w istniejącym `get_form_initial` kroku 2, `views.py:326-328`), pole `email`
+na kroku 2 (`Zgloszenie_Publikacji_DaneForm`) ma być **niezmienialne**:
+
+- Implementacja przez **`self.fields["email"].disabled = True`** (NIE tylko
+  `widget.attrs["readonly"]`). `disabled=True` sprawia, że Django **ignoruje
+  wartość z POST i bierze `initial`** (e-mail konta) → „nie pozwól zmienić"
+  wymuszone **serwerowo**, nie tylko wizualnie (sam `readonly` jest obchodzony
+  POST-em). `initial` = e-mail konta (już ustawiany w `get_form_initial`).
+- Wizard `get_form_kwargs("2")` przekazuje `email_zablokowany: bool` (lub sam
+  e-mail konta), liczony call-time z `request.user`. Forma w `__init__`
+  ustawia `disabled` + `initial` gdy `email_zablokowany`.
+- Anonim / zalogowany bez e-maila → pole **edytowalne** (bez zmian).
+- Uwaga na rewalidację w `render_done`: `get_form_kwargs("2")` czyta
+  `request.user` (stabilne w przebiegu), więc `disabled` jest spójne przy
+  rekonstrukcji kroku 2; disabled → wartość z `initial`, nie z magazynu POST.
 
 ## Świadome ograniczenia
 

--- a/docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md
+++ b/docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md
@@ -15,10 +15,14 @@ limity plików nie ruszały.
   Zalogowany pracownik uczelni nie jest wektorem spamu → bez tarcia.
 - **Umiejscowienie:** **pierwszy krok** kreatora (`RodzajPublikacjiForm`,
   step "0") — odrzuca bota, zanim dojdzie do uploadu plików (krok 2).
+- **Captcha domyślnie WYŁĄCZONA** (`ZGLOS_CAPTCHA_ENABLED=False`, decyzja
+  właściciela) — opt-in per instalacja. Nie psuje żadnego upgrade'u i eliminuje
+  zależność kolejności wdrożenia. Włączenie: `ZGLOS_CAPTCHA_ENABLED=1` po
+  potwierdzeniu, że klucz jest (auto-gen bpp-deploy go dostarcza).
 - **Docker:** żadnej nowej usługi. `ALTCHA_HMAC_KEY` to sekret env
   **auto-generowany w bpp-deploy** (`_ensure_secret`, jak inne sekrety) i
-  wpięty do wszystkich serwisów Django — dzięki temu default ON nie psuje
-  upgrade'ów (każda instalacja dostaje klucz automatycznie).
+  wpięty do wszystkich serwisów Django — więc gdy operator włączy captchę,
+  klucz już czeka.
 - **Model klucza = jak `SECRET_KEY`** (świadoma decyzja właściciela): sentinel
   default w `base.py`, placeholder w `.env.docker`, dummy inline na buildzie,
   **bez** hard import-time `raise` (który psuł build). Zamiast fail-fast —
@@ -86,13 +90,14 @@ Biblioteki:
   ani pod czystym gunicorn/daphne. **Realną gwarancję klucza w prod daje
   auto-gen bpp-deploy, nie ten check** — check to best-effort sygnał dla
   operatora, nie mechanizm bezpieczeństwa.
-- `ZGLOS_CAPTCHA_ENABLED` (bool): `base.py` default `True`; **`test.py`
-  = `False`** (cała dotychczasowa suita `zglos_publikacje` + Playwright,
+- `ZGLOS_CAPTCHA_ENABLED` (bool): `base.py` **default `False`**
+  (`env.bool("ZGLOS_CAPTCHA_ENABLED", default=False)`) — opt-in. `test.py`
+  dziedziczy `False` (cała dotychczasowa suita `zglos_publikacje` + Playwright,
   wspólne `--ds=django_bpp.settings.test`, przechodzą bez zmian — pole ALTCHA
-  w ogóle nie powstaje). W dev (`local.py`) **włączona** — świadomie, do
-  oglądania w `run-site`. **`get_form_kwargs` czyta ten flag w call-time**
-  (nie stała modułowa), inaczej `@override_settings` w nowych testach nie
-  zadziała.
+  w ogóle nie powstaje). W dev (`local.py`) **włączona** (`= True`) — świadomie,
+  do oglądania widgetu w `run-site`. **`get_form_kwargs` czyta ten flag w
+  call-time** (nie stała modułowa), inaczej `@override_settings` w nowych
+  testach nie zadziała.
 - **Replay-protection (cache):** `ALTCHA_CACHE_ALIAS` domyślnie `"default"`.
   `production.py` → Redis (działa). **Uwaga: dev/test `default` = DummyCache →
   `is_challenge_used()` zawsze `False` (replay-check to no-op).** Nowe testy
@@ -223,23 +228,18 @@ django-altcha. **Replay-testy MUSZĄ dodatkowo override'ować cache na locmem**
   ```
   `_ensure_secret` jest **idempotentny** (dodaje do `.env` tylko gdy brak, nie
   nadpisuje) i odpala się na **każdym `make up`** → wszystkie instalacje
-  (świeże i po upgrade) dostają stabilny klucz bez ręcznego kroku. To eliminuje
-  breaking-upgrade przy default ON.
+  (świeże i po upgrade) dostają stabilny klucz bez ręcznego kroku — więc gdy
+  operator włączy captchę (`ZGLOS_CAPTCHA_ENABLED=1`), klucz już czeka.
 - **Wpięcie env** `ALTCHA_HMAC_KEY` do **appservera, workerserver i
   beatserver** w compose (guard/warning i sama weryfikacja odpalają się w
   każdym imporcie/procesie Django; wszystkie trzy jadą na production settings).
-- **Twarda kolejność (fix codex — NIE „niezależne PR-y"):** przy default ON
-  kod BPP nie może trafić na prod PRZED auto-genem, bo publiczny formularz
-  ruszyłby na sentinelu → captcha forgeable (tylko warning). W normalnym flow
-  bpp-deploy jest to zapewnione: `make up` uruchamia `ensure-config-files`
-  (generuje klucz do `.env`) **PRZED** `docker compose up` z nowym obrazem —
-  więc klucz istnieje, zanim kontener z default-ON wstanie. Warunek: zmiana
-  bpp-deploy (auto-gen + wpięcie env) musi być **wdrożona razem z / przed**
-  obrazem BPP (standardowo: `git pull` bpp-deploy → `make up`). Nie deployować
-  nowego obrazu BPP pod starym bpp-deploy.
-- **Alternatywa zerowego ryzyka (do decyzji właściciela):** default **OFF** w
-  BPP, a `ZGLOS_CAPTCHA_ENABLED=1` włączane osobno po potwierdzeniu dystrybucji
-  klucza. Eliminuje zależność kolejności kosztem ręcznego włączenia.
+- **Kolejność wdrożenia nie jest problemem — captcha jest default OFF.** Kod
+  BPP może trafić na prod niezależnie: przy `ZGLOS_CAPTCHA_ENABLED=False` pole
+  ALTCHA nie powstaje, sentinel-klucz nikogo nie dotyczy. Auto-gen bpp-deploy
+  przygotowuje klucz z wyprzedzeniem, więc **włączenie to jeden krok operatora**
+  (`ZGLOS_CAPTCHA_ENABLED=1` w env), bez ryzyka forgeable-okna. Zalecenie:
+  włączać dopiero po potwierdzeniu (`make up` na bpp-deploy z tą zmianą +
+  obecność `ALTCHA_HMAC_KEY` w `.env`).
 
 ## Świadome ograniczenia
 

--- a/docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md
+++ b/docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md
@@ -57,7 +57,9 @@ Biblioteki:
     (sentinel), `ALTCHA_HMAC_KEY = env("ALTCHA_HMAC_KEY", default=...UNSET)`.
     **Bez** import-time `raise` — to on psuł build (patrz niżej).
   - **`.env.docker` (dev compose):** placeholder (jak
-    `DJANGO_BPP_SECRET_KEY="ZMIEN..."`). Captcha w dev compose jest dev-only.
+    `DJANGO_BPP_SECRET_KEY="ZMIEN..."`). Przy default OFF captcha w dev compose
+    i tak jest **wyłączona** — placeholder to tylko wartość dla spójności
+    (`env(...)` musi coś zwrócić), nie działający klucz.
   - **Build (`testserver` collectstatic):** `ALTCHA_HMAC_KEY=
     build-time-only-not-used` **inline w RUN-ie** — dokładnie jak istniejący
     `DJANGO_BPP_SECRET_KEY=build-time-only-not-used`. Inline env RUN-a NIE
@@ -91,13 +93,15 @@ Biblioteki:
   auto-gen bpp-deploy, nie ten check** — check to best-effort sygnał dla
   operatora, nie mechanizm bezpieczeństwa.
 - `ZGLOS_CAPTCHA_ENABLED` (bool): `base.py` **default `False`**
-  (`env.bool("ZGLOS_CAPTCHA_ENABLED", default=False)`) — opt-in. `test.py`
-  dziedziczy `False` (cała dotychczasowa suita `zglos_publikacje` + Playwright,
-  wspólne `--ds=django_bpp.settings.test`, przechodzą bez zmian — pole ALTCHA
-  w ogóle nie powstaje). W dev (`local.py`) **włączona** (`= True`) — świadomie,
-  do oglądania widgetu w `run-site`. **`get_form_kwargs` czyta ten flag w
-  call-time** (nie stała modułowa), inaczej `@override_settings` w nowych
-  testach nie zadziała.
+  (`env.bool("ZGLOS_CAPTCHA_ENABLED", default=False)`) — opt-in. W dev
+  (`local.py`) **włączona** (`= True`) — do oglądania widgetu w `run-site`.
+  **KRYTYCZNE:** `test.py` robi `from .local import *`, więc dziedziczyłby
+  `True` z `local.py` → cała suita dostałaby captchę ON. Dlatego `test.py`
+  **jawnie** `ZGLOS_CAPTCHA_ENABLED = False` (dokładnie jak `AXES_ENABLED =
+  False`, `test.py`) — tak, żeby dotychczasowa suita `zglos_publikacje` +
+  Playwright (`--ds=django_bpp.settings.test`) przechodziły bez zmian (pole
+  ALTCHA nie powstaje). **`get_form_kwargs` czyta ten flag call-time** (nie
+  stała modułowa), inaczej `@override_settings` w nowych testach nie zadziała.
 - **Replay-protection (cache):** `ALTCHA_CACHE_ALIAS` domyślnie `"default"`.
   `production.py` → Redis (działa). **Uwaga: dev/test `default` = DummyCache →
   `is_challenge_used()` zawsze `False` (replay-check to no-op).** Nowe testy
@@ -162,7 +166,10 @@ formatu payloadu pythonowej libki). Wystarczy:
   `AltchaChallengeView` django-altcha, zamontowany w `zglos_publikacje/urls.py`.
   URL przez **`reverse_lazy`** (pole definiowane przy imporcie modułu `forms`).
   Dzięki `challengeurl` działa `refetchonexpire` — challenge nie wygasa przy
-  dłuższym wypełnianiu kroku 0.
+  dłuższym wypełnianiu kroku 0. Endpoint montujemy **bezwarunkowo** — przy
+  captcha OFF pole nigdy nie powstaje, więc nikt go nie woła; sam podpisany
+  challenge jest bezstanowy i nieszkodliwy. (Świadomie akceptujemy żywy endpoint
+  przy OFF, zamiast warunkować mount.)
 - **`auto="onload"`** (NIE `onsubmit` — ustalenie po review codex): kafelki
   kroku 0 wołają `form.submit()` **bezpośrednio** (`step_rodzaj.html`), co
   **omija zdarzenie `submit`**, na którym widget przechwyciłby formularz przy
@@ -171,6 +178,10 @@ formatu payloadu pythonowej libki). Wystarczy:
   re-solve po spaleniu challenge (`mark_challenge_used` odpala się w `validate`
   niezależnie od reszty pól). Alternatywa `form.requestSubmit()` w JS +
   `onsubmit` — odrzucona (więcej zmian + wymaga browser-testu).
+  **Rezydualny race (świadomy, łagodna degradacja):** klik w kafelek ZANIM PoW
+  się doliczy (wolne urządzenie, pierwsza ~1 s) → pusty payload → błąd „token
+  missing" → re-render kroku 0 z nowym challenge, drugi klik działa. Nie 500,
+  ale nie jest bezwarunkowo „gotowe zanim user kliknie".
 - Szablon kroku 0 (`step_rodzaj.html`): pole renderuje `<altcha-widget>` tylko
   gdy jest obecne (anon). Ikony public-frontend = Foundation (nie dotyczy
   widgetu).
@@ -181,8 +192,17 @@ formatu payloadu pythonowej libki). Wystarczy:
 ### D. Testy
 
 Istniejące testy wizardu (POST kroku 0 bez ALTCHA) **nie mogą się wywalić** →
-w środowisku testowym `ZGLOS_CAPTCHA_ENABLED=False` domyślnie (żeby cała
-dotychczasowa suita `zglos_publikacje` przechodziła bez zmian).
+`test.py` ma **jawnie** `ZGLOS_CAPTCHA_ENABLED = False` (patrz A — bo dziedziczy
+`True` z `local.py`), więc cała dotychczasowa suita `zglos_publikacje` przechodzi
+bez zmian.
+
+**Gotcha mockowania (testy 3–5):** po zamockowanym `verify_solution` django-altcha
+**bezwarunkowo** odpala `replay_attack_protection`, które robi `base64decode +
+json` na payloadzie i wymaga klucza `"challenge"`. Śmieciowy payload wywali
+`ValidationError` MIMO mock-OK. Fake payload w testach musi być
+`base64(json({"challenge": ...}))` **albo** trzeba zamockować też
+`replay_attack_protection` (ew. użyć własnego `ALTCHA_VERIFICATION_ENABLED`
+django-altcha — jego wewnętrzny kill-switch, NIE mylić z `ZGLOS_CAPTCHA_ENABLED`).
 
 Nowe testy (`test_zglos_captcha.py`), z `@override_settings(
 ZGLOS_CAPTCHA_ENABLED=True, ALTCHA_HMAC_KEY=<test>)` + mock weryfikacji

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ dependencies = [
     "babel>=2.17",
     "django-liveops[celery]>=0.3,<0.4",
     "django-oauth-toolkit==3.3.0",
+    "django-altcha>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/bpp/newsfragments/zglos-captcha-altcha.feature.rst
+++ b/src/bpp/newsfragments/zglos-captcha-altcha.feature.rst
@@ -1,0 +1,8 @@
+Formularz zgłaszania publikacji może teraz wymagać od niezalogowanych
+użytkowników weryfikacji proof-of-work ALTCHA (self-hosted, bez usług
+zewnętrznych, zgodny z RODO) — jako ochrona przed automatycznym spamem.
+Funkcja jest domyślnie **wyłączona** (opt-in: ``ZGLOS_CAPTCHA_ENABLED``);
+klucz ``ALTCHA_HMAC_KEY`` jest generowany automatycznie po stronie wdrożenia.
+Obok weryfikacji pojawia się informacja, że zalogowanie się ją pomija.
+Dodatkowo: zalogowany użytkownik z ustawionym adresem e-mail ma to pole
+zablokowane do edycji (wypełniane adresem z konta).

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -24,6 +24,7 @@ SCRIPT_PATH = os.path.abspath(os.path.dirname(__file__))
 SITE_ROOT = os.path.abspath(os.path.join(SCRIPT_PATH, "..", ".."))
 
 SECRET_KEY_UNSET = "Please set the DJANGO_BPP_SECRET_KEY variable."
+ALTCHA_HMAC_KEY_UNSET = "Please set the ALTCHA_HMAC_KEY variable."
 
 
 # Ponieważ konieczna jest konfiguracja django-ldap-auth i potrzebne będą kolejne zmienne
@@ -105,6 +106,8 @@ env = environ.Env(
     DJANGO_BPP_DB_DISABLE_SSL=(bool, False),
     DJANGO_BPP_TEST_TEMPLATE=(str, ""),
     DJANGO_BPP_SECRET_KEY=(str, SECRET_KEY_UNSET),
+    ALTCHA_HMAC_KEY=(str, ALTCHA_HMAC_KEY_UNSET),
+    ZGLOS_CAPTCHA_ENABLED=(bool, False),
     DJANGO_BPP_MEDIA_ROOT=(str, os.path.join(os.getenv("HOME", "C:/"), "bpp-media")),
     #
     # Konfiguracja wymuszania zmiany haseł
@@ -848,6 +851,14 @@ if _test_template:
     DATABASES["default"]["TEST"] = test_settings
 
 SECRET_KEY = env("DJANGO_BPP_SECRET_KEY")
+
+# ALTCHA — proof-of-work CAPTCHA na anonimowym formularzu zgłoszeń publikacji.
+# Model klucza jak SECRET_KEY: sentinel default, realny klucz z env (auto-gen
+# w bpp-deploy). Captcha domyślnie WYŁĄCZONA (opt-in). Brak hard-raise — miękki
+# system-check WARNING (zglos_publikacje/checks.py) sygnalizuje placeholder.
+ALTCHA_HMAC_KEY = env("ALTCHA_HMAC_KEY")
+ZGLOS_CAPTCHA_ENABLED = env("ZGLOS_CAPTCHA_ENABLED")
+INSTALLED_APPS += ["django_altcha"]
 
 # Klucz Fernet do szyfrowania sekretów integracji (DSpace itd.).
 # Wygeneruj: python -c "from cryptography.fernet import Fernet;

--- a/src/django_bpp/settings/local.py
+++ b/src/django_bpp/settings/local.py
@@ -6,6 +6,7 @@
 # import *`` i dokłada modyfikacje specyficzne dla pytest.
 
 import os
+import secrets
 
 
 def setenv_default(varname, default_value):
@@ -15,6 +16,10 @@ def setenv_default(varname, default_value):
 
 setenv_default("DJANGO_SETTINGS_MODULE", "django_bpp.settings.local")
 setenv_default("DJANGO_BPP_SECRET_KEY", "0xdeadbeef 2")
+# ALTCHA: efemeryczny klucz per-proces TYLKO gdy env nieustawiony (jak wyżej).
+# run-site bez env → losowy klucz (widget działa, nic forgeable w repo); dev
+# docker compose ładuje .env.docker → setenv_default NIE nadpisze placeholdera.
+setenv_default("ALTCHA_HMAC_KEY", secrets.token_hex(32))
 # Staly dev-owy klucz Fernet dla EncryptedTextField (credentiale DSpace itd.).
 # Bez niego zapis pola EncryptedTextField wywala ImproperlyConfigured
 # (src/bpp/fields.py). Stala wartosc (nie generowana co restart), zeby
@@ -132,3 +137,7 @@ except ImportError:
     # produkcyjnym dla testow rece). Pomijamy bez bledu — autologin
     # i tak by sie nie wlaczyl bez DJANGO_DEV_HELPERS_ENABLED=1.
     pass
+
+# ALTCHA captcha WŁĄCZONA w dev (base ma default OFF) — do ogladania widgetu
+# w run-site. test.py nadpisuje z powrotem na False (patrz test.py).
+ZGLOS_CAPTCHA_ENABLED = True

--- a/src/django_bpp/settings/test.py
+++ b/src/django_bpp/settings/test.py
@@ -103,3 +103,12 @@ CACHEOPS_ENABLED = False
 # punktowo przez @override_settings(AXES_ENABLED=True) i logują się POST-em do
 # widoku logowania (który request przekazuje).
 AXES_ENABLED = False
+
+# ALTCHA captcha WYŁĄCZONA w testach. KRYTYCZNE: test.py robi `from .local
+# import *`, a local.py ma ZGLOS_CAPTCHA_ENABLED = True — bez tego jawnego
+# False cała suita dostałaby captchę ON (pole ALTCHA na kroku 0 kreatora
+# zgłoszeń). Testy captchy włączają ją punktowo przez @override_settings.
+ZGLOS_CAPTCHA_ENABLED = False
+# Stały test-key (nie efemeryczny z local.py) — dla testów captchy, które
+# włączają ZGLOS_CAPTCHA_ENABLED przez @override_settings.
+ALTCHA_HMAC_KEY = "test-altcha-hmac-key-deterministic-0123456789abcdef"

--- a/src/zglos_publikacje/apps.py
+++ b/src/zglos_publikacje/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class ZglosPublikacjeConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "zglos_publikacje"
+
+    def ready(self):
+        # Rejestruje system-check ALTCHA (captcha ON + klucz-placeholder).
+        from . import checks  # noqa: F401

--- a/src/zglos_publikacje/checks.py
+++ b/src/zglos_publikacje/checks.py
@@ -1,0 +1,39 @@
+"""System-check ostrzegający, że CAPTCHA jest włączona z kluczem-placeholderem.
+
+Świadomie **nie-fatalny** (Warning, nie Error) — nie wywala `collectstatic`
+ani buildu (mirror wzorca `SECRET_KEY`, który też nie fail-fastuje). Realną
+gwarancję realnego klucza w produkcji daje auto-gen w bpp-deploy; ten check to
+best-effort sygnał dla operatora (widoczny przy `manage.py check`/`migrate`).
+"""
+
+from django.conf import settings
+from django.core import checks
+
+W001_ID = "zglos_publikacje.W001"
+
+
+def _klucz_wyglada_na_placeholder(klucz: str) -> bool:
+    if not klucz:
+        return True
+    if klucz == getattr(settings, "ALTCHA_HMAC_KEY_UNSET", None):
+        return True
+    # .env.docker placeholder ("ZMIEN...") oraz build-time dummy.
+    return "ZMIEN" in klucz or "build-time" in klucz
+
+
+@checks.register()
+def captcha_key_placeholder_check(app_configs, **kwargs):
+    if not getattr(settings, "ZGLOS_CAPTCHA_ENABLED", False):
+        return []
+    if _klucz_wyglada_na_placeholder(getattr(settings, "ALTCHA_HMAC_KEY", "")):
+        return [
+            checks.Warning(
+                "ZGLOS_CAPTCHA_ENABLED jest włączone, ale ALTCHA_HMAC_KEY "
+                "wygląda na placeholder — CAPTCHA będzie możliwa do podrobienia "
+                "(HMAC znany). Ustaw realny klucz (auto-gen w bpp-deploy).",
+                hint="Wygeneruj: openssl rand -hex 32; wstrzyknij jako env "
+                "ALTCHA_HMAC_KEY do serwisów Django.",
+                id=W001_ID,
+            )
+        ]
+    return []

--- a/src/zglos_publikacje/forms.py
+++ b/src/zglos_publikacje/forms.py
@@ -8,6 +8,8 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.forms import inlineformset_factory
 from django.forms.widgets import HiddenInput
+from django.urls import reverse_lazy
+from django_altcha import AltchaField
 
 from bpp.models import Autor, Dyscyplina_Naukowa, Jednostka, Uczelnia
 from zglos_publikacje.models import (
@@ -149,6 +151,23 @@ class RodzajPublikacjiForm(forms.Form):
         ],
         widget=forms.RadioSelect,
     )
+
+    def __init__(self, *args, captcha_wymagany=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Bramka anon-only (sekcja B): pole ALTCHA powstaje TYLKO gdy wizard
+        # tak zażąda (captcha ON + anonim + brak markera). Dla zalogowanych
+        # i przy captcha OFF pola nie ma → dotychczasowa suita bez zmian.
+        if captcha_wymagany:
+            # `auto="onload"` (nie onsubmit): kafelki kroku 0 wołają
+            # form.submit() bezpośrednio, omijając zdarzenie `submit`, na
+            # którym widget przechwyciłby formularz → PoW liczony przy
+            # załadowaniu strony. `challengeurl` (nie challengejson) daje
+            # refetchonexpire dla dłuższego wypełniania.
+            self.fields["captcha"] = AltchaField(
+                label="Weryfikacja",
+                challengeurl=reverse_lazy("zglos_publikacje:altcha-challenge"),
+                auto="onload",
+            )
 
 
 class FormaDostepuForm(forms.Form):
@@ -315,7 +334,13 @@ class Zgloszenie_Publikacji_DaneForm(forms.ModelForm):
         )
 
     def __init__(
-        self, *args, rodzaj=None, forma_dostepu=None, pliki_juz_zapisane=False, **kw
+        self,
+        *args,
+        rodzaj=None,
+        forma_dostepu=None,
+        pliki_juz_zapisane=False,
+        email_zablokowany=False,
+        **kw,
     ):
         self.rodzaj = rodzaj
         self.forma_dostepu = forma_dostepu
@@ -352,6 +377,14 @@ class Zgloszenie_Publikacji_DaneForm(forms.ModelForm):
         self._usun_pola_wg_formy_dostepu(forma_dostepu)
         self._usun_pola_wg_rodzaju(rodzaj)
         self._dostosuj_strona_www(rodzaj, forma_dostepu)
+
+        # F2: zalogowany z realnym e-mailem → pole `email` niezmienialne.
+        # `disabled=True` (NIE tylko readonly w widgecie) sprawia, że Django
+        # ignoruje wartość z POST i bierze `initial` (e-mail konta, ustawiany
+        # w get_form_initial kroku 2) → wymuszenie serwerowe, nie tylko wizualne.
+        if email_zablokowany and "email" in self.fields:
+            self.fields["email"].disabled = True
+
         self._zbuduj_layout()
 
     def clean(self):

--- a/src/zglos_publikacje/templates/zglos_publikacje/step_rodzaj.html
+++ b/src/zglos_publikacje/templates/zglos_publikacje/step_rodzaj.html
@@ -24,6 +24,21 @@
         {% endfor %}
     </div>
 
+    {# Widget ALTCHA + hint „zaloguj się" — obecne TYLKO gdy pole captcha #}
+    {# istnieje w formularzu, tj. dla anonima przy captcha ON (bramka w #}
+    {# forms/views). Dla zalogowanego pola nie ma → nic się nie renderuje. #}
+    {% if form.captcha %}
+        <div class="zglos-captcha">
+            {{ form.captcha }}
+            <p class="zglos-captcha-hint">
+                <span class="fi-lock" aria-hidden="true"></span>
+                Jesteś niezalogowany —
+                <a href="{% url "login_form" %}?next={{ request.get_full_path|urlencode }}">zaloguj się</a>,
+                aby pominąć tę weryfikację.
+            </p>
+        </div>
+    {% endif %}
+
     <script>
         (function() {
             var tiles = document.querySelectorAll('.tile-card');

--- a/src/zglos_publikacje/tests/test_playwright/test_zglos_publikacje.py
+++ b/src/zglos_publikacje/tests/test_playwright/test_zglos_publikacje.py
@@ -51,7 +51,11 @@ def _przejdz_kroki_0_1_2(
     # Krok 2: dane
     page.fill("[name='2-tytul_oryginalny']", "test")
     page.fill("[name='2-rok']", str(rok))
-    page.fill("[name='2-email']", "moj@email.pl")
+    # Pole e-mail jest `disabled` i pre-wypełnione kontem dla zalogowanego
+    # użytkownika z e-mailem (F2) — wypełniamy je tylko gdy edytowalne
+    # (anonim / zalogowany bez e-maila).
+    if page.is_editable("[name='2-email']"):
+        page.fill("[name='2-email']", "moj@email.pl")
     if strona_www:
         page.fill("[name='2-strona_www']", strona_www)
 

--- a/src/zglos_publikacje/tests/test_zglos_captcha.py
+++ b/src/zglos_publikacje/tests/test_zglos_captcha.py
@@ -1,0 +1,375 @@
+"""Testy integracji ALTCHA (proof-of-work CAPTCHA) + e-mail read-only.
+
+Pokrywa sekcje B/C/D/F specyfikacji
+``2026-07-12-zglos-captcha-altcha-design.md``:
+
+- bramka anon-only na kroku 0 kreatora (pole ``captcha`` powstaje tylko dla
+  anonima przy ``ZGLOS_CAPTCHA_ENABLED=True``),
+- marker ``captcha_ok`` w ``storage.extra_data`` (1 PoW = 1 przebieg wizardu:
+  awans + brak re-solve przy rewalidacji w ``render_done``, reset na GET),
+- replay-protection na poziomie pola/cache (``LocMemCache`` — bo ``test.py`` ma
+  ``DummyCache`` = no-op),
+- system-check ``zglos_publikacje.W001`` (placeholder klucza + captcha ON),
+- hint „zaloguj się" (F1) oraz serwerowe wymuszenie e-maila konta (F2).
+
+Gotcha mockowania (spec D): po zamockowanym ``verify_solution`` django-altcha
+i tak odpala ``replay_attack_protection`` → ``base64decode+json`` na payloadzie,
+wymaga klucza ``"challenge"``. Dlatego fałszywy payload to
+``base64(json({"challenge": ...}))`` — patrz ``_fake_payload``.
+"""
+
+import base64
+import json
+from unittest import mock
+
+import pytest
+from django.conf import settings as dj_settings
+from django.core.exceptions import ValidationError
+from django.test import override_settings
+from django.urls import reverse
+from django_altcha import AltchaField
+from model_bakery import baker
+
+from bpp.models import BppUser
+from zglos_publikacje.checks import W001_ID, captcha_key_placeholder_check
+from zglos_publikacje.forms import Zgloszenie_Publikacji_DaneForm
+from zglos_publikacje.models import Zgloszenie_Publikacji
+
+# Cel patcha weryfikatora: `import altcha` w django_altcha/__init__.py sprawia,
+# że `django_altcha.altcha` JEST modułem `altcha`; patchujemy jego atrybut
+# `verify_solution`, a django-altcha woła go przez lookup call-time.
+VERIFY_TARGET = "django_altcha.altcha.verify_solution"
+
+LOCMEM_CACHE = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+
+
+def _url():
+    return reverse("zglos_publikacje:nowe_zgloszenie")
+
+
+def _fake_payload(challenge="chal-domyslny"):
+    """Payload ALTCHA akceptowalny przez `replay_attack_protection`.
+
+    Sama weryfikacja PoW jest mockowana, ale django-altcha bezwarunkowo
+    dekoduje payload (base64→json) i czyta klucz ``challenge`` — musi więc
+    być poprawnym base64(JSON) z tym kluczem.
+    """
+    raw = json.dumps({"challenge": challenge}).encode()
+    return base64.b64encode(raw).decode()
+
+
+def _verify_ok():
+    """Kontekst-manager mockujący weryfikator na (True, None) + licznik."""
+    return mock.patch(VERIFY_TARGET, return_value=(True, None))
+
+
+# ---------------------------------------------------------------------------
+# Test 1: anonim, krok 0 → forma MA pole `captcha` (renderuje <altcha-widget>).
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+@override_settings(ZGLOS_CAPTCHA_ENABLED=True)
+def test_anonim_krok0_ma_pole_captcha(webtest_app, uczelnia):
+    page = webtest_app.get(_url())
+    assert b"<altcha-widget" in page.content
+    assert "0-captcha" in page.forms[0].fields
+
+
+# ---------------------------------------------------------------------------
+# Test 2: zalogowany, krok 0 → forma NIE ma pola `captcha` (bramka anon-only).
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+@override_settings(ZGLOS_CAPTCHA_ENABLED=True)
+def test_zalogowany_krok0_bez_pola_captcha(webtest_app, uczelnia):
+    user = baker.make(BppUser)
+    webtest_app.set_user(user)
+    page = webtest_app.get(_url())
+    assert b"<altcha-widget" not in page.content
+    # Zalogowany → forms[0] to nav-form wylogowania; wizard-form po id.
+    assert "0-captcha" not in page.forms["form-container"].fields
+
+
+# ---------------------------------------------------------------------------
+# Test 3a: anonim, brak payloadu → krok 0 nieważny, brak awansu.
+#   Re-render kroku 0 wciąż zawiera <altcha-widget> = marker extra_data
+#   NIE został ustawiony (inaczej pole by zniknęło).
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+@override_settings(ZGLOS_CAPTCHA_ENABLED=True)
+def test_anonim_brak_payloadu_krok0_niewazny(webtest_app, uczelnia):
+    page = webtest_app.get(_url())
+    form = page.forms[0]
+    form["0-rodzaj"] = "ARTYKUL"
+    # `0-captcha` pozostaje puste → AltchaField.required wywala walidację.
+    resp = form.submit()
+    assert resp.status_code == 200
+    assert b"1-forma_dostepu" not in resp.content  # brak awansu na krok 1
+    # Marker nieustawiony → pole captcha nadal obecne przy re-renderze.
+    assert b"<altcha-widget" in resp.content
+
+
+# ---------------------------------------------------------------------------
+# Test 3b: anonim, ZŁE rozwiązanie (mock verify → (False, ...)) → krok 0
+#   nieważny mimo obecnego payloadu.
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+@override_settings(ZGLOS_CAPTCHA_ENABLED=True)
+def test_anonim_zle_rozwiazanie_krok0_niewazny(webtest_app, uczelnia):
+    page = webtest_app.get(_url())
+    form = page.forms[0]
+    form["0-rodzaj"] = "ARTYKUL"
+    form["0-captcha"] = _fake_payload("zle")
+    with mock.patch(VERIFY_TARGET, return_value=(False, "bad")) as m:
+        resp = form.submit()
+    assert m.call_count == 1  # weryfikator został wywołany
+    assert resp.status_code == 200
+    assert b"1-forma_dostepu" not in resp.content
+    assert b"<altcha-widget" in resp.content
+
+
+# ---------------------------------------------------------------------------
+# Test 4: anonim, POPRAWNE rozwiązanie → awans na krok 1; marker `captcha_ok`
+#   dowiedziony behawioralnie — cofnięcie na krok 0 (wizard_goto_step) w tej
+#   samej sesji NIE pokazuje już widgetu (captcha_wymagany=False, bo marker set).
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+@override_settings(ZGLOS_CAPTCHA_ENABLED=True)
+def test_anonim_poprawne_rozwiazanie_awans_i_marker(webtest_app, uczelnia):
+    page = webtest_app.get(_url())
+    form = page.forms[0]
+    form["0-rodzaj"] = "ARTYKUL"
+    form["0-captcha"] = _fake_payload("ok-4")
+    with _verify_ok():
+        page1 = form.submit()
+    # Awans na krok 1.
+    assert b"1-forma_dostepu" in page1.content
+    assert b"<altcha-widget" not in page1.content
+
+    # Cofnij na krok 0 — marker set → pole captcha znika (dowód extra_data OK).
+    fields = list(page1.forms[0].submit_fields())
+    fields.append(("wizard_goto_step", "0"))
+    back = webtest_app.post(_url(), params=fields)
+    assert back.status_code == 200
+    assert b"<altcha-widget" not in back.content
+
+
+# ---------------------------------------------------------------------------
+# Test 4b: GET-restart (regresja HIGH 1). Rozwiąż krok 0, potem GET na URL
+#   wizardu (storage.reset zeruje marker) → krok 0 znów MA pole captcha.
+#   Dowodzi: jeden PoW NIE odblokowuje kolejnego przebiegu w tej samej sesji.
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+@override_settings(ZGLOS_CAPTCHA_ENABLED=True)
+def test_get_restart_przywraca_pole_captcha(webtest_app, uczelnia):
+    page = webtest_app.get(_url())
+    form = page.forms[0]
+    form["0-rodzaj"] = "ARTYKUL"
+    form["0-captcha"] = _fake_payload("ok-4b")
+    with _verify_ok():
+        page1 = form.submit()
+    assert b"1-forma_dostepu" in page1.content  # marker set, jesteśmy na kroku 1
+
+    # GET restartuje kreator (storage.reset) → marker wyzerowany.
+    restart = webtest_app.get(_url())
+    assert b"<altcha-widget" in restart.content
+    assert "0-captcha" in restart.forms[0].fields
+
+
+# ---------------------------------------------------------------------------
+# Test 5: pełny przebieg do done() → weryfikator wołany DOKŁADNIE RAZ.
+#   Non-tautologiczny dowód markera: bez niego rewalidacja wszystkich kroków w
+#   render_done wywołałaby verify_solution po raz drugi. Ścieżka POZOSTALE +
+#   OTWARTY omija krok 4 (opłaty; wymagaj_oplatach_inne=False) i pole plików.
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+@override_settings(ZGLOS_CAPTCHA_ENABLED=True)
+def test_pelny_przebieg_weryfikator_wolany_raz(
+    webtest_app,
+    uczelnia,
+    typy_odpowiedzialnosci,
+    autor_jan_kowalski,
+    aktualna_jednostka,
+):
+    with _verify_ok() as m:
+        page = webtest_app.get(_url())
+        form = page.forms[0]
+        form["0-rodzaj"] = "POZOSTALE"
+        form["0-captcha"] = _fake_payload("ok-5")
+        page1 = form.submit()  # → krok 1
+
+        page1.forms[0]["1-forma_dostepu"] = "OTWARTY"
+        page2 = page1.forms[0].submit()  # → krok 2
+
+        f2 = page2.forms[0]
+        f2["2-tytul_oryginalny"] = "Testowa publikacja"
+        f2["2-rok"] = "2020"
+        if "2-email" in f2.fields:
+            f2["2-email"] = "zglaszajacy@test.pl"
+        if "2-strona_www" in f2.fields:
+            f2["2-strona_www"] = "https://example.com/"
+        if "2-zgoda_na_publikacje_pelnego_tekstu" in f2.fields:
+            f2["2-zgoda_na_publikacje_pelnego_tekstu"] = "True"
+        page3 = f2.submit()  # → krok 3
+
+        f3 = page3.forms[0]
+        f3["3-0-autor"].force_value(autor_jan_kowalski.pk)
+        f3["3-0-jednostka"].force_value(aktualna_jednostka.pk)
+        resp = f3.submit()  # → done()
+
+    assert resp.status_code == 200
+    assert Zgloszenie_Publikacji.objects.count() == 1
+    # Marker działa: rewalidacja kroku 0 w render_done rekonstruuje formę BEZ
+    # pola captcha, więc weryfikator NIE jest wołany po raz drugi.
+    assert m.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 6: replay-protection na poziomie pola + LocMemCache. To samo rozwiązanie
+#   w dwóch niezależnych AltchaField → drugie odrzucone jako „already used".
+# ---------------------------------------------------------------------------
+@override_settings(CACHES=LOCMEM_CACHE)
+def test_replay_odrzucony_na_locmem_cache():
+    from django.core.cache import caches
+
+    caches["default"].clear()  # LocMem współdzieli store per-nazwa między testami
+    payload = _fake_payload("replay-6")
+
+    with _verify_ok():
+        AltchaField().clean(payload)  # 1. użycie — mark_challenge_used
+        with pytest.raises(ValidationError):
+            AltchaField().clean(payload)  # 2. użycie — replay → ValidationError
+
+
+# ---------------------------------------------------------------------------
+# Test 7: ZGLOS_CAPTCHA_ENABLED=False (default test.py) → anonim krok 0 NIE ma
+#   pola captcha (dowód: dotychczasowa suita nie jest ruszona).
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+def test_captcha_off_anonim_bez_pola(webtest_app, uczelnia):
+    assert dj_settings.ZGLOS_CAPTCHA_ENABLED is False
+    page = webtest_app.get(_url())
+    assert b"<altcha-widget" not in page.content
+    assert "0-captcha" not in page.forms[0].fields
+
+
+# ---------------------------------------------------------------------------
+# Test 8: system-check zglos_publikacje.W001.
+#   ON + placeholder → 1 Warning; ON + realny klucz → []; OFF + placeholder → [].
+# ---------------------------------------------------------------------------
+def test_system_check_placeholder():
+    sentinel = dj_settings.ALTCHA_HMAC_KEY_UNSET
+
+    # ON + placeholder → dokładnie jeden Warning W001.
+    with override_settings(ZGLOS_CAPTCHA_ENABLED=True, ALTCHA_HMAC_KEY=sentinel):
+        warnings = captcha_key_placeholder_check(None)
+        assert len(warnings) == 1
+        assert warnings[0].id == W001_ID
+
+    # ON + realny klucz → brak ostrzeżenia.
+    with override_settings(
+        ZGLOS_CAPTCHA_ENABLED=True, ALTCHA_HMAC_KEY="prawdziwy-losowy-klucz-hex"
+    ):
+        assert captcha_key_placeholder_check(None) == []
+
+    # OFF + placeholder → brak ostrzeżenia (check no-op gdy captcha wyłączona).
+    with override_settings(ZGLOS_CAPTCHA_ENABLED=False, ALTCHA_HMAC_KEY=sentinel):
+        assert captcha_key_placeholder_check(None) == []
+
+
+# ---------------------------------------------------------------------------
+# Test 9: F1 hint „zaloguj się".
+#   anonim + ON → HTML kroku 0 ma hint + widget; zalogowany → brak obu.
+# ---------------------------------------------------------------------------
+HINT_MARKER = "aby pominąć tę weryfikację".encode()
+
+
+@pytest.mark.django_db
+@override_settings(ZGLOS_CAPTCHA_ENABLED=True)
+def test_hint_zaloguj_sie_anonim(webtest_app, uczelnia):
+    page = webtest_app.get(_url())
+    assert b"<altcha-widget" in page.content
+    assert HINT_MARKER in page.content
+    # Link prowadzi na stronę logowania.
+    assert reverse("login_form").encode() in page.content
+
+
+@pytest.mark.django_db
+@override_settings(ZGLOS_CAPTCHA_ENABLED=True)
+def test_hint_zaloguj_sie_brak_dla_zalogowanego(webtest_app, uczelnia):
+    user = baker.make(BppUser)
+    webtest_app.set_user(user)
+    page = webtest_app.get(_url())
+    assert b"<altcha-widget" not in page.content
+    assert HINT_MARKER not in page.content
+
+
+# ---------------------------------------------------------------------------
+# Test 10: F2 e-mail read-only.
+# ---------------------------------------------------------------------------
+def _dane_form(email_zablokowany, uczelnia, initial=None):
+    return Zgloszenie_Publikacji_DaneForm(
+        rodzaj="POZOSTALE",
+        forma_dostepu="OTWARTY",
+        email_zablokowany=email_zablokowany,
+        uczelnia=uczelnia,
+        initial=initial or {},
+    )
+
+
+@pytest.mark.django_db
+def test_email_disabled_gdy_zablokowany(uczelnia):
+    form = _dane_form(True, uczelnia, initial={"email": "konto@real.pl"})
+    assert form.fields["email"].disabled is True
+
+
+@pytest.mark.django_db
+def test_email_edytowalny_gdy_niezablokowany(uczelnia):
+    # Anonim / zalogowany bez e-maila → pole edytowalne.
+    form = _dane_form(False, uczelnia)
+    assert not form.fields["email"].disabled
+
+
+@pytest.mark.django_db
+def test_email_wymuszony_serwerowo_dla_zalogowanego(
+    webtest_app,
+    uczelnia,
+    typy_odpowiedzialnosci,
+    autor_jan_kowalski,
+    aktualna_jednostka,
+):
+    """POST z podmienionym e-mailem → zapisany e-mail KONTA (disabled → initial).
+
+    `disabled=True` sprawia, że Django ignoruje wartość z POST i bierze
+    `initial` (e-mail konta), więc atak „podmień 2-email" nie przechodzi.
+    """
+    user = baker.make(BppUser, email="konto@real.pl")
+    webtest_app.set_user(user)
+
+    # Zalogowany → w nawigacji jest form wylogowania; wizard-form po id.
+    page = webtest_app.get(_url())  # zalogowany → brak captcha
+    page.forms["form-container"]["0-rodzaj"] = "POZOSTALE"
+    page1 = page.forms["form-container"].submit()  # → krok 1
+
+    page1.forms["form-container"]["1-forma_dostepu"] = "OTWARTY"
+    page2 = page1.forms["form-container"].submit()  # → krok 2
+
+    f2 = page2.forms["form-container"]
+    f2["2-tytul_oryginalny"] = "Testowa publikacja"
+    f2["2-rok"] = "2020"
+    if "2-strona_www" in f2.fields:
+        f2["2-strona_www"] = "https://example.com/"
+    if "2-zgoda_na_publikacje_pelnego_tekstu" in f2.fields:
+        f2["2-zgoda_na_publikacje_pelnego_tekstu"] = "True"
+    # Pole `2-email` jest disabled → webtest nie wyśle go z formularza.
+    # Wstrzykujemy podmieniony e-mail ręcznie, symulując złośliwy POST.
+    fields = list(f2.submit_fields())
+    fields.append(("2-email", "atak@evil.pl"))
+    page3 = webtest_app.post(_url(), params=fields)  # → krok 3
+
+    f3 = page3.forms["form-container"]
+    f3["3-0-autor"].force_value(autor_jan_kowalski.pk)
+    f3["3-0-jednostka"].force_value(aktualna_jednostka.pk)
+    f3.submit()  # → done()
+
+    zp = Zgloszenie_Publikacji.objects.order_by("-pk").first()
+    assert zp is not None
+    assert zp.email == "konto@real.pl"  # NIE atak@evil.pl

--- a/src/zglos_publikacje/urls.py
+++ b/src/zglos_publikacje/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django_altcha import AltchaChallengeView
 
 from . import views
 from .autocomplete import (
@@ -18,6 +19,13 @@ urlpatterns = [
         name="edycja_zgloszenia",
     ),
     path("sukces/", views.Sukces.as_view()),
+    # Endpoint wyzwania ALTCHA (self-host); montowany bezwarunkowo — przy
+    # captcha OFF pole nie powstaje, więc nikt go nie woła (patrz spec C).
+    path(
+        "altcha-challenge/",
+        AltchaChallengeView.as_view(),
+        name="altcha-challenge",
+    ),
     # Autocomplete
     path(
         "public-wydawca-autocomplete/",

--- a/src/zglos_publikacje/views.py
+++ b/src/zglos_publikacje/views.py
@@ -210,6 +210,13 @@ MODEL_FORMA_DOSTEPU_TO_FORM = {
 }
 
 
+# Marker w storage.extra_data: krok 0 z poprawnym ALTCHA już przeszedł, więc
+# przy rewalidacji w render_done pole captcha nie powstaje (unik re-solve /
+# replay-block). Trzymany w extra_data (NIE w sesji) — render_done po done()
+# i GET-restart robią storage.reset() → 1 PoW = 1 przebieg wizardu (sekcja B).
+ZGLOS_CAPTCHA_OK_KEY = "captcha_ok"
+
+
 class Zgloszenie_PublikacjiWizard(UczelniaSettingRequiredMixin, SessionWizardView):
     uczelnia_attr = "pokazuj_formularz_zglaszania_publikacji"
 
@@ -263,11 +270,27 @@ class Zgloszenie_PublikacjiWizard(UczelniaSettingRequiredMixin, SessionWizardVie
 
     def get_form_kwargs(self, step=None):
         kwargs = super().get_form_kwargs(step)
+        if step == "0":
+            # Bramka anon-only (sekcja B). Flag czytany CALL-TIME
+            # (settings.ZGLOS_CAPTCHA_ENABLED), by @override_settings w testach
+            # działał. Marker w extra_data → po zaliczonym PoW pole znika, więc
+            # rewalidacja w render_done nie wymusza re-solve.
+            kwargs["captcha_wymagany"] = (
+                settings.ZGLOS_CAPTCHA_ENABLED
+                and not self.request.user.is_authenticated
+                and not self.storage.extra_data.get(ZGLOS_CAPTCHA_OK_KEY)
+            )
         if step == "2":
             step0 = self.get_cleaned_data_for_step("0") or {}
             step1 = self.get_cleaned_data_for_step("1") or {}
             kwargs["rodzaj"] = step0.get("rodzaj")
             kwargs["forma_dostepu"] = step1.get("forma_dostepu")
+            # F2: pole `email` niezmienialne dla zalogowanego z realnym e-mailem
+            # (liczone call-time z request.user — stabilne w przebiegu wizardu).
+            kwargs["email_zablokowany"] = (
+                self.request.user.is_authenticated
+                and self.request.user.email != PUSTY_ADRES_EMAIL
+            )
             # Multi-hosted: forma musi dostać uczelnię z requestu, inaczej
             # spada do Uczelnia.objects.get() (crash przy >1 uczelni).
             kwargs["uczelnia"] = Uczelnia.objects.get_for_request(self.request)
@@ -345,6 +368,13 @@ class Zgloszenie_PublikacjiWizard(UczelniaSettingRequiredMixin, SessionWizardVie
         return super().get_form_initial(step)
 
     def process_step(self, form):
+        if self.steps.current == "0":
+            # Krok 0 przeszedł walidację (process_step woła się PO is_valid),
+            # więc ALTCHA — jeśli pole było obecne — jest zweryfikowane. Marker
+            # w extra_data zdejmuje pole przy rewalidacji w render_done.
+            extra = self.storage.extra_data
+            extra[ZGLOS_CAPTCHA_OK_KEY] = True
+            self.storage.extra_data = extra
         if self.steps.current == "2":
             self.request.session[const.SESSION_KEY] = form.cleaned_data.get("rok")
         return super().process_step(form)

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,15 @@ wheels = [
 ]
 
 [[package]]
+name = "altcha"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/0e/ec05af090d38d74e9a6ea55ce606549a4b13c3d62e340387f772ffc634e4/altcha-1.0.0.tar.gz", hash = "sha256:33056826a60efdc3d9651d5a13d72d7c8ee1c7f4456b9c9db65838f47fac9082", size = 11244, upload-time = "2025-12-14T05:30:31.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/19/978dac535829b3e9175427d4d91a34b0ec6e120375a38fabd9840acf32ca/altcha-1.0.0-py3-none-any.whl", hash = "sha256:78cc0fd3ba907d069252e4ea47e0dd981d4d9bd41f360333cc76ca2ce2d2a46c", size = 9161, upload-time = "2025-12-14T05:30:29.815Z" },
+]
+
+[[package]]
 name = "amqp"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -376,6 +385,7 @@ dependencies = [
     { name = "django", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-admin-sortable2", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-admin-tools", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "django-altcha", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-autocomplete-light", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-autoslug", marker = "platform_python_implementation != 'PyPy'" },
     { name = "django-axes", marker = "platform_python_implementation != 'PyPy'" },
@@ -558,6 +568,7 @@ requires-dist = [
     { name = "django", specifier = ">=5.2.15,<5.3" },
     { name = "django-admin-sortable2", specifier = ">=2.3.1,<3" },
     { name = "django-admin-tools", specifier = "==0.9.3" },
+    { name = "django-altcha", specifier = ">=1.0.0" },
     { name = "django-auth-ldap", marker = "extra == 'ldap'", specifier = ">=5.3.0" },
     { name = "django-autocomplete-light", specifier = "==5.0.0" },
     { name = "django-autoslug", specifier = "==1.9.9" },
@@ -1466,6 +1477,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/97/3c429698dca7e90d4ca141494d6dda59156a600fb7712426cdebe66bef88/django-admin-tools-0.9.3.tar.gz", hash = "sha256:5aee0735907f0807c88b793f6b14eccff586e652d41e77f02c691f624f965672", size = 468063, upload-time = "2023-08-10T12:40:33.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/ac/53ba422cf4da78ecd1444ba98a751e2649d76d66d6301bd574e59537b697/django_admin_tools-0.9.3-py2.py3-none-any.whl", hash = "sha256:f4bef88a5c5f4b97a760c09b822fc6f0e9f12c91a755860b1c011d01345282d3", size = 294775, upload-time = "2023-08-10T12:40:36.273Z" },
+]
+
+[[package]]
+name = "django-altcha"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altcha", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "django", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/7d/c77f7a0b6aac8d08d27c0e7de98217c37413bdc641c496c228076875a645/django_altcha-1.0.0.tar.gz", hash = "sha256:06a4f437b086a0c296b53e02dbd7f783ce07972150b8238dbae6da8cfb284efa", size = 61790, upload-time = "2026-04-21T10:40:57.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/4205a5e66e198a18ad5c8fc07e83084f8285eca7f7f0fd50052de8a84f63/django_altcha-1.0.0-py3-none-any.whl", hash = "sha256:023a90675df2a5fab8203a79edc322207dd0b7a9e6edac731b9063bd8bad4b83", size = 51285, upload-time = "2026-04-21T10:40:55.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Kontekst

Kontynuacja hardeningu anonimowego formularza zgłaszania publikacji (po naprawie limitów uploadu #551). Adresuje **tempo** anonimowych zgłoszeń (spam/DoS) przez proof-of-work ALTCHA — self-hosted, in-process, RODO/WCAG, bez usług zewnętrznych ani CDN.

Spec (7 iteracji review: 2× fable + codex + fable): `docs/superpowers/specs/2026-07-12-zglos-captcha-altcha-design.md`.

## Co robi

**CAPTCHA (B/C):** warunkowe pole `AltchaField` (`auto="onload"`, `challengeurl`) na kroku 0 kreatora — **tylko dla anonima** (`ZGLOS_CAPTCHA_ENABLED ∧ not is_authenticated ∧ brak markera`). Marker w `storage.extra_data` (nie sesji — GET-restart wymusza nowy PoW; 1 PoW = 1 przebieg). `render_done` nie weryfikuje ponownie (pole nieobecne przy markerze). `AltchaChallengeView` zamontowany, widget self-hostowany przez django-altcha.

**F1 — hint:** obok widgetu (tylko anon) komunikat „zaloguj się, aby pominąć weryfikację" z linkiem `login_form?next=`.

**F2 — read-only e-mail:** zalogowany z e-mailem → pole `email` kroku 2 `disabled=True` — **serwerowe wymuszenie** (Django ignoruje POST, bierze `initial` = e-mail konta; sam `readonly` byłby obchodzony POST-em).

**Klucz jak `SECRET_KEY`:** sentinel default, `ALTCHA_HMAC_KEY` z env, **bez** hard-raise (nie psuje buildu). Nie-fatalny **system-check WARNING** przy captcha-ON-z-placeholderem. Efemeryczny klucz w dev (run-site), stały w testach.

## Domyślnie WYŁĄCZONA (opt-in)

`ZGLOS_CAPTCHA_ENABLED=False` w `base.py` → zero wpływu na istniejące instalacje, brak zależności kolejności wdrożenia. Włączenie = 1 krok operatora. `local.py` = ON (podgląd w run-site); `test.py` **jawnie** OFF (bo dziedziczy ON z local).

## Testy

**111 passed** w `src/zglos_publikacje/` (raw). 15 nowych w `test_zglos_captcha.py` (mapują 10 pkt spec D): pole obecne/nieobecne wg anon/ON, marker+GET-restart, **weryfikator wołany dokładnie raz** (non-tautologiczny dowód markera), replay na LocMemCache, system-check, F1 hint, F2 e-mail (w tym POST-podmiana ignorowana serwerowo). Dostosowany helper Playwright (e-mail disabled dla zalogowanego). **Bez zmian modeli → bez migracji.**

## Powiązane / wdrożenie (osobno)

- Auto-gen `ALTCHA_HMAC_KEY` (`_ensure_secret`) + wpięcie env do serwisów Django — **osobny PR bpp-deploy** (do zrobienia przy włączaniu).

## Świadome ograniczenia

- PoW podnosi **koszt** masowego wysyłania, nie blokuje pojedynczego bota z zapleczem obliczeniowym (trade-off prywatność+self-host vs managed challenge).
- Endpoint challenge żywy także przy OFF (bezstanowy, nieszkodliwy — pole nie powstaje, nikt nie woła).

🤖 Generated with [Claude Code](https://claude.com/claude-code)