### PR TITLE
security(ci): przypnij skanery CVE do wersji + checksum (supply-chain)

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -215,14 +215,56 @@ jobs:
 
       - name: Zainstaluj skanery CVE
         if: ${{ !inputs.skip_scan }}
+        env:
+          # Skanery CVE PRZYPIĘTE do konkretnych wersji + weryfikowane po SHA256.
+          # Wcześniej ten krok pobierał ruchomy `latest` (osv-scanner) i wykony-
+          # wał `curl | sh` z gałęzi `main` (grype, trivy) — czyli URUCHAMIAŁ
+          # NIEPRZYPIĘTY kod z Internetu w jobie z `packages: write` (push obrazu
+          # do GHCR) i `contents: write` (push gałęzi release/*). Klasyczny wektor
+          # supply-chain: ktokolwiek z write-em na tych repo/gałęziach (albo ich
+          # przejęcie) wstrzykuje kod, który leci z sekretami tego joba.
+          #
+          # BUMP: podnieś wersję i wklej SHA256 z pliku *checksums* danego release
+          #   (osv:   osv-scanner_SHA256SUMS → osv-scanner_linux_amd64)
+          #   (grype: grype_<ver>_checksums.txt → grype_<ver>_linux_amd64.tar.gz)
+          #   (trivy: trivy_<ver>_checksums.txt → trivy_<ver>_Linux-64bit.tar.gz)
+          # NIE zgaduj sumy — pobierz realną z assetów release-u, inaczej gate CVE
+          # padnie na `sha256sum -c` i zablokuje całe wydanie.
+          OSV_SCANNER_VERSION: "2.4.0"
+          OSV_SCANNER_SHA256: "15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0"
+          GRYPE_VERSION: "0.115.0"
+          GRYPE_SHA256: "3fad92940650e514c0aa2dad83526942a055e210cec09a8a59d9c024adc2b90e"
+          TRIVY_VERSION: "0.72.0"
+          TRIVY_SHA256: "bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea"
         run: |
-          curl -sSL -o /usr/local/bin/osv-scanner \
-            https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64
-          chmod +x /usr/local/bin/osv-scanner
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh \
-            | sh -s -- -b /usr/local/bin
-          curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-            | sh -s -- -b /usr/local/bin
+          set -euo pipefail
+          TMP="$(mktemp -d)"
+          trap 'rm -rf "$TMP"' EXIT
+
+          # --- osv-scanner: przypięty binarny release + weryfikacja SHA256 ---
+          curl -sSL -o "${TMP}/osv-scanner" \
+            "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          echo "${OSV_SCANNER_SHA256}  ${TMP}/osv-scanner" | sha256sum -c -
+          install -m 0755 "${TMP}/osv-scanner" /usr/local/bin/osv-scanner
+
+          # --- grype: przypięty tarball + weryfikacja SHA256 (BEZ curl|sh) ---
+          curl -sSL -o "${TMP}/grype.tar.gz" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
+          echo "${GRYPE_SHA256}  ${TMP}/grype.tar.gz" | sha256sum -c -
+          tar -xzf "${TMP}/grype.tar.gz" -C "${TMP}" grype
+          install -m 0755 "${TMP}/grype" /usr/local/bin/grype
+
+          # --- trivy: przypięty tarball + weryfikacja SHA256 (BEZ curl|sh) ---
+          curl -sSL -o "${TMP}/trivy.tar.gz" \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          echo "${TRIVY_SHA256}  ${TMP}/trivy.tar.gz" | sha256sum -c -
+          tar -xzf "${TMP}/trivy.tar.gz" -C "${TMP}" trivy
+          install -m 0755 "${TMP}/trivy" /usr/local/bin/trivy
+
+          # Smoke-check: binarki są na PATH (scan-deps.sh woła je przez command -v).
+          osv-scanner --version
+          grype version
+          trivy --version
 
       - name: Skan CVE (bramka)
         if: ${{ !inputs.skip_scan }}

--- a/src/bpp/newsfragments/ci-pin-cve-scanners.bugfix.rst
+++ b/src/bpp/newsfragments/ci-pin-cve-scanners.bugfix.rst
@@ -1,0 +1,4 @@
+Skanery CVE w pipeline wydań (osv-scanner, grype, trivy) są przypięte do
+konkretnych wersji i weryfikowane po sumie kontrolnej SHA256 — koniec z
+pobieraniem nieprzypiętego kodu z gałęzi ``main`` i ruchomego ``latest``
+(zamknięty wektor supply-chain w jobie z uprawnieniami do zapisu).


### PR DESCRIPTION
## Wektor (potwierdzony)

`.github/workflows/release-candidate.yml`, job `prepare` (`contents: write` +
`packages: write`), krok **„Zainstaluj skanery CVE"** pobierał i URUCHAMIAŁ
nieprzypięty kod z Internetu — w tym samym jobie, który pushuje obraz test-runner
do GHCR i pushuje gałąź `release/*`:

- `osv-scanner` z ruchomego `releases/latest/...` **bez** weryfikacji sumy,
- `grype`: `curl -sSfL .../anchore/grype/main/install.sh | sh` — kod z gałęzi `main`,
- `trivy`: `curl -sSfL .../aquasecurity/trivy/main/contrib/install.sh | sh` — jw.

Przejęcie któregokolwiek źródła (lub złośliwy commit do `main` / podmiana
`latest`) = wykonanie dowolnego kodu z sekretami wydania (`GITHUB_TOKEN` z
`packages:write` + `contents:write`, `DOCKER_PAT`). Reszta `uses:` w tym
workflow jest już SHA-pinnowana — ten krok był wyjątkiem.

## Fix — pinowanie wersji + weryfikacja SHA256

Każdy skaner przypięty do konkretnej wersji (env na górze kroku, łatwy bump)
i weryfikowany po SHA256 pobranym z pliku *checksums* danego release. grype i
trivy pobierane jako tarball + weryfikacja zamiast `curl | sh` — **zero**
nieprzypiętego kodu z `main`. `set -euo pipefail` + `sha256sum -c` → każda
niezgodność sumy twardo wywala krok, zanim binarka zostanie zainstalowana.

| skaner | wersja | SHA256 (artefakt) | źródło sumy |
|--------|--------|-------------------|-------------|
| osv-scanner | v2.4.0 | `15314940…e8ed8a0` (`osv-scanner_linux_amd64`) | `osv-scanner_SHA256SUMS` z release v2.4.0 |
| grype | v0.115.0 | `3fad9294…dc2b90e` (`grype_0.115.0_linux_amd64.tar.gz`) | `grype_0.115.0_checksums.txt` z release v0.115.0 |
| trivy | v0.72.0 | `bbb64b96…62b9b2ea` (`trivy_0.72.0_Linux-64bit.tar.gz`) | `trivy_0.72.0_checksums.txt` z release v0.72.0 |

Wszystkie trzy sumy zweryfikowane end-to-end: pobrany artefakt → `shasum -a 256`
zgadza się z wartością w pliku checksums release-u (nie zgadywane).

## Decyzja: binarki + checksum, nie GitHub Actions

`bin/scan-deps.sh` (wołany w następnym kroku „Skan CVE (bramka)") wymaga
binarek na PATH przez `command -v osv-scanner|grype|trivy` i sam generuje SBOM
+ odpala wszystkie trzy skanery. Akcje `anchore/scan-action` /
`aquasecurity/trivy-action` skanują we własnym zakresie, ale **nie** kładą
binarek na PATH dla późniejszego skryptu — pogodzenie ich ze `scan-deps.sh`
byłoby przebudową skryptu. Wybrano mniej inwazyjny wariant (binarki +
weryfikacja checksum), który w pełni eliminuje główny wektor (nieprzypięty
kod) bez ruszania `bin/`.

## Follow-up (nie w tym PR): separacja uprawnień joba

Skan mógłby biec w osobnym jobie z `permissions: contents: read` (bez write).
Nie zrobiono tu, bo bump RC + skan + build + push gałęzi współdzielą drzewo
robocze `prepare` (commit RC żyje tylko w tym jobie), a separacja wymaga
re-checkoutu / przeniesienia stanu przez barierę — realna przebudowa. Priorytet
tego PR to pinowanie, które i tak neutralizuje właściwe zagrożenie (złośliwa
binarka blokowana checksumem niezależnie od uprawnień joba). Separacja = osobny
follow-up.

## Weryfikacja

- `python -c "yaml.safe_load(...)"` → OK
- `zizmor --config zizmor.yml release-candidate.yml` → No findings (3 suppressed = pre-existing)
- `actionlint` niedostępny lokalnie — pominięty
- Workflow nie uruchamiany (per polecenie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)