### PR TITLE
fix(api): nie ujawniaj PII autorów anonimom (pokazuj / poprzednie nazwiska)

### DIFF
--- a/src/api_v1/serializers/autor.py
+++ b/src/api_v1/serializers/autor.py
@@ -61,6 +61,31 @@ class AutorSerializer(
         many=True, read_only=True, view_name="api_v1:autor_jednostka-detail"
     )
 
+    # Pola PII maskowane dla użytkowników niezalogowanych.
+    email = serializers.SerializerMethodField()
+    urodzony = serializers.SerializerMethodField()
+    poprzednie_nazwiska = serializers.SerializerMethodField()
+
+    def _is_authenticated(self):
+        request = self.context.get("request")
+        return bool(request and request.user.is_authenticated)
+
+    def get_email(self, obj):
+        # E-mail to PII — ujawniany wyłącznie zalogowanym.
+        return obj.email if self._is_authenticated() else ""
+
+    def get_urodzony(self, obj):
+        # Pełna data urodzenia to PII (dzień i miesiąc umożliwiają kradzież
+        # tożsamości). Anonimowi otrzymują None — najbezpieczniejszy wariant.
+        return obj.urodzony if self._is_authenticated() else None
+
+    def get_poprzednie_nazwiska(self, obj):
+        # Zalogowani widzą zawsze; anonim tylko gdy autor na to zezwolił
+        # (pokazuj_poprzednie_nazwiska=True) — zgodnie z zachowaniem frontendu.
+        if self._is_authenticated() or obj.pokazuj_poprzednie_nazwiska:
+            return obj.poprzednie_nazwiska
+        return ""
+
     class Meta:
         model = Autor
         fields = [

--- a/src/api_v1/tests/test_autor_pii_anon.py
+++ b/src/api_v1/tests/test_autor_pii_anon.py
@@ -1,0 +1,162 @@
+"""Testy regresyjne luki bezpieczeństwa: publiczne API autorów nie może
+ujawniać danych osobowych (PII) ani autorów oznaczonych jako ukryci
+(``pokazuj=False``) użytkownikom niezalogowanym.
+"""
+
+from datetime import date
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+from rest_framework.test import APIClient
+
+from bpp.models import Autor
+
+
+def _staff_client():
+    u = baker.make("bpp.BppUser", is_staff=True, is_superuser=True)
+    c = APIClient()
+    c.force_authenticate(user=u)
+    return c
+
+
+@pytest.mark.django_db
+def test_anon_lista_nie_zawiera_ukrytego_autora():
+    """Autor z ``pokazuj=False`` nie może pojawić się na publicznej liście."""
+    baker.make(Autor, nazwisko="Widoczny", imiona="Wiktor", pokazuj=True)
+    baker.make(Autor, nazwisko="Ukryty", imiona="Urban", pokazuj=False)
+
+    res = APIClient().get(reverse("api_v1:autor-list"))
+    nazwiska = {row["nazwisko"] for row in res.json()["results"]}
+    assert "Widoczny" in nazwiska
+    assert "Ukryty" not in nazwiska
+
+
+@pytest.mark.django_db
+def test_anon_detal_ukrytego_autora_404():
+    """Detal autora z ``pokazuj=False`` jest niedostępny anonimowo (404)."""
+    autor = baker.make(Autor, nazwisko="Ukryty", imiona="Urban", pokazuj=False)
+
+    res = APIClient().get(reverse("api_v1:autor-detail", args=(autor.pk,)))
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+def test_zalogowany_widzi_ukrytego_autora():
+    """Regresja w drugą stronę: zalogowany widzi ukrytego autora."""
+    autor = baker.make(Autor, nazwisko="Ukryty", imiona="Urban", pokazuj=False)
+
+    res = _staff_client().get(reverse("api_v1:autor-detail", args=(autor.pk,)))
+    assert res.status_code == 200
+
+
+@pytest.mark.django_db
+def test_anon_nie_widzi_emaila():
+    """E-mail autora to PII — nie może wyciec do anonima."""
+    autor = baker.make(
+        Autor,
+        nazwisko="Kowalski",
+        imiona="Jan",
+        pokazuj=True,
+        email="jan.kowalski@example.com",
+    )
+
+    res = APIClient().get(reverse("api_v1:autor-detail", args=(autor.pk,)))
+    data = res.json()
+    assert "jan.kowalski@example.com" not in str(data)
+    assert not data.get("email")
+
+
+@pytest.mark.django_db
+def test_zalogowany_widzi_email():
+    """Zalogowany nadal widzi e-mail autora."""
+    autor = baker.make(
+        Autor, nazwisko="Kowalski", imiona="Jan", email="jan.kowalski@example.com"
+    )
+
+    res = _staff_client().get(reverse("api_v1:autor-detail", args=(autor.pk,)))
+    assert res.json()["email"] == "jan.kowalski@example.com"
+
+
+@pytest.mark.django_db
+def test_anon_nie_widzi_pelnej_daty_urodzenia():
+    """Pełna data urodzenia to PII — anonim nie może jej otrzymać."""
+    autor = baker.make(
+        Autor,
+        nazwisko="Kowalski",
+        imiona="Jan",
+        pokazuj=True,
+        urodzony=date(1970, 3, 15),
+    )
+
+    res = APIClient().get(reverse("api_v1:autor-detail", args=(autor.pk,)))
+    data = res.json()
+    assert "1970-03-15" not in str(data)
+    assert data.get("urodzony") in (None, "")
+
+
+@pytest.mark.django_db
+def test_zalogowany_widzi_pelna_date_urodzenia():
+    """Zalogowany nadal widzi pełną datę urodzenia."""
+    autor = baker.make(
+        Autor, nazwisko="Kowalski", imiona="Jan", urodzony=date(1970, 3, 15)
+    )
+
+    res = _staff_client().get(reverse("api_v1:autor-detail", args=(autor.pk,)))
+    assert res.json()["urodzony"] == "1970-03-15"
+
+
+@pytest.mark.django_db
+def test_anon_nie_widzi_poprzednich_nazwisk_gdy_ukryte():
+    """Gdy ``pokazuj_poprzednie_nazwiska=False``, anonim nie dostaje pola."""
+    autor = baker.make(
+        Autor,
+        nazwisko="Nowak",
+        imiona="Anna",
+        pokazuj=True,
+        poprzednie_nazwiska="Kowalska",
+        pokazuj_poprzednie_nazwiska=False,
+    )
+
+    res = APIClient().get(reverse("api_v1:autor-detail", args=(autor.pk,)))
+    data = res.json()
+    assert "Kowalska" not in str(data)
+    assert not data.get("poprzednie_nazwiska")
+
+
+@pytest.mark.django_db
+def test_anon_widzi_poprzednie_nazwiska_gdy_wlaczone():
+    """Gdy ``pokazuj_poprzednie_nazwiska=True``, anonim widzi je normalnie."""
+    autor = baker.make(
+        Autor,
+        nazwisko="Nowak",
+        imiona="Anna",
+        pokazuj=True,
+        poprzednie_nazwiska="Kowalska",
+        pokazuj_poprzednie_nazwiska=True,
+    )
+
+    res = APIClient().get(reverse("api_v1:autor-detail", args=(autor.pk,)))
+    assert res.json()["poprzednie_nazwiska"] == "Kowalska"
+
+
+@pytest.mark.django_db
+def test_zalogowany_widzi_poprzednie_nazwiska_mimo_flagi():
+    """Zalogowany widzi poprzednie nazwiska nawet gdy flaga wyłączona."""
+    autor = baker.make(
+        Autor,
+        nazwisko="Nowak",
+        imiona="Anna",
+        poprzednie_nazwiska="Kowalska",
+        pokazuj_poprzednie_nazwiska=False,
+    )
+
+    res = _staff_client().get(reverse("api_v1:autor-detail", args=(autor.pk,)))
+    assert res.json()["poprzednie_nazwiska"] == "Kowalska"
+
+
+@pytest.mark.django_db
+def test_anon_filtrowanie_po_nazwisku_dziala(autor_jan_kowalski):
+    """Fix nie może zepsuć istniejącego filtrowania po nazwisku."""
+    res = APIClient().get(reverse("api_v1:autor-list") + "?nazwisko=kowal")
+    assert res.json()["count"] == 1

--- a/src/api_v1/viewsets/autor.py
+++ b/src/api_v1/viewsets/autor.py
@@ -28,6 +28,15 @@ class AutorViewSet(viewsets.ReadOnlyModelViewSet):
     # throttling kosztownego endpointu wyszukiwania (globalny wyłączony).
     throttle_classes = [SearchAnonThrottle, SearchUserThrottle]
 
+    def get_queryset(self):
+        # Anonim nie może zobaczyć autorów oznaczonych jako ukryci
+        # (pokazuj=False) — ani na liście, ani (dzięki temu) w detalu (404).
+        # Zalogowany widzi wszystkich.
+        qs = super().get_queryset()
+        if self.request.user.is_authenticated:
+            return qs
+        return qs.filter(pokazuj=True)
+
 
 class Funkcja_AutoraViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Funkcja_Autora.objects.all()

--- a/src/bpp/newsfragments/api-autor-pii-anon.bugfix.rst
+++ b/src/bpp/newsfragments/api-autor-pii-anon.bugfix.rst
@@ -1,0 +1,3 @@
+Publiczne API autorów (``/api/v1/autor/``) nie ujawnia już danych osobowych
+(e-mail, pełna data urodzenia, poprzednie nazwiska) ani autorów oznaczonych
+jako ukryci (``pokazuj=False``) użytkownikom niezalogowanym.


### PR DESCRIPTION
## Luka

Publiczny endpoint `/api/v1/autor/` (`AutorViewSet`, `ReadOnlyModelViewSet`)
nie definiował `permission_classes`, więc dziedziczył globalny default
`DjangoModelPermissionsOrAnonReadOnly` — **anonim czytał wszystko**.
`AutorSerializer` eksponował m.in.:

- `email` — dane kontaktowe (PII),
- `urodzony` — **pełną datę urodzenia** (PII, wektor kradzieży tożsamości),
- `poprzednie_nazwiska` — ujawniane mimo flagi `pokazuj_poprzednie_nazwiska=False`,

a viewset ignorował flagę `pokazuj` — autorzy oznaczeni jako ukryci
(`pokazuj=False`) byli w pełni widoczni publicznie (lista + detal).

## Fix (obrona wielowarstwowa)

1. **`AutorViewSet.get_queryset()`** — dla niezalogowanego zawęża wynik do
   `pokazuj=True`. Ukryci autorzy znikają z listy i dają **404** w detalu.
   Zalogowany widzi wszystkich. Filtr `nazwisko__icontains` działa jak dotąd
   (filterset nakłada się na zawężony queryset).

2. **`AutorSerializer`** — `SerializerMethodField` maskujące PII dla anonima
   (sprawdzają `request.user.is_authenticated`):
   - `email` → `""`,
   - `urodzony` → `None` (pełna data ukryta),
   - `poprzednie_nazwiska` → `""` gdy `pokazuj_poprzednie_nazwiska=False`
     (gdy `True` — pokazywane; zalogowani widzą zawsze, zgodnie z semantyką
     pola w modelu).

### Decyzja o `urodzony`

Wybrano **całkowite ukrycie** pełnej daty dla anonima (`None`) zamiast
redukcji do samego roku. Powód: to najbezpieczniejszy wariant (spec prosił
o „najbezpieczniejsze zachowanie"), a jednocześnie unika niespójności typu
w polu (data ISO dla zalogowanego vs liczba/rok dla anonima), która mogłaby
zaskoczyć konsumentów API. Rok-only został rozważony jako łagodniejszy
kompromis (wartość dyz­ambiguacyjna, spotykana w metadanych naukowych), ale
odrzucony na rzecz maksymalnej ochrony PII. Jeśli zależy nam na roku
publicznie — można to dołożyć osobnym, jawnie nazwanym polem (`rok_urodzenia`).

## Testy

Nowy plik `src/api_v1/tests/test_autor_pii_anon.py` (11 testów), m.in.:

- anon: ukryty autor nie na liście / detal 404; zalogowany go widzi,
- anon: `email`, pełna data `urodzony`, `poprzednie_nazwiska` (gdy flaga off)
  nieujawnione; zalogowany widzi wszystko,
- anon: `poprzednie_nazwiska` widoczne gdy flaga on,
- regresja: filtrowanie po nazwisku nadal działa.

RED→GREEN potwierdzone lokalnie (5 testów PII/widoczności failowało przed
fixem z właściwych powodów). Cała suita `src/api_v1/tests/` — 136 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)