### PR TITLE
fix(api): child-endpointy respektują nie_eksportuj_przez_api

### DIFF
--- a/src/api_v1/tests/test_child_endpoints_nie_eksportuj.py
+++ b/src/api_v1/tests/test_child_endpoints_nie_eksportuj.py
@@ -1,0 +1,92 @@
+"""Podrzędne (child) endpointy API muszą respektować flagę
+``nie_eksportuj_przez_api`` rekordu nadrzędnego.
+
+Główne viewsety publikacji filtrują ``.exclude(nie_eksportuj_przez_api=True)``,
+ale endpointy podrzędne (streszczenia, autorstwa, identyfikatory zewnętrznych
+baz) jechały na globalnym ``.objects.all()``. Pozwalało to anonimowemu
+użytkownikowi enumerować PK child-rekordów i wyciągać dane rekordu chronionego
+(treść streszczenia, obsadę autorską, identyfikatory zewnętrzne).
+"""
+
+import pytest
+from django.urls import reverse
+
+from bpp.models import Wydawnictwo_Ciagle_Zewnetrzna_Baza_Danych
+
+
+def _assert_respektuje_flage(api_client, parent, child_pk, basename):
+    """Sprawdza, że child jest widoczny gdy parent eksportowalny i znika
+    (lista + detal 404) gdy parent ma ``nie_eksportuj_przez_api=True``."""
+    list_url = reverse(f"api_v1:{basename}-list")
+    detail_url = reverse(f"api_v1:{basename}-detail", args=(child_pk,))
+
+    # Regresja: rekord nadrzędny eksportowalny -> child normalnie widoczny.
+    parent.nie_eksportuj_przez_api = False
+    parent.save()
+    assert api_client.get(list_url).json()["count"] == 1
+    assert api_client.get(detail_url).status_code == 200
+
+    # Luka: rekord nadrzędny wyłączony z eksportu -> child niewidoczny.
+    parent.nie_eksportuj_przez_api = True
+    parent.save()
+    assert api_client.get(list_url).json()["count"] == 0
+    assert api_client.get(detail_url).status_code == 404
+
+
+@pytest.mark.django_db
+def test_child_streszczenie_zwarte(api_client, wydawnictwo_zwarte, jezyki):
+    s = wydawnictwo_zwarte.streszczenia.create(
+        jezyk_streszczenia=jezyki["pol."], streszczenie=b"Tajne streszczenie"
+    )
+    _assert_respektuje_flage(
+        api_client, wydawnictwo_zwarte, s.pk, "wydawnictwo_zwarte_streszczenie"
+    )
+
+
+@pytest.mark.django_db
+def test_child_autor_zwarty(
+    api_client, wydawnictwo_zwarte, autor_jan_kowalski, jednostka
+):
+    wa = wydawnictwo_zwarte.dodaj_autora(autor_jan_kowalski, jednostka)
+    _assert_respektuje_flage(
+        api_client, wydawnictwo_zwarte, wa.pk, "wydawnictwo_zwarte_autor"
+    )
+
+
+@pytest.mark.django_db
+def test_child_streszczenie_ciagle(api_client, wydawnictwo_ciagle, jezyki):
+    s = wydawnictwo_ciagle.streszczenia.create(
+        jezyk_streszczenia=jezyki["pol."], streszczenie=b"Tajne streszczenie"
+    )
+    _assert_respektuje_flage(
+        api_client, wydawnictwo_ciagle, s.pk, "wydawnictwo_ciagle_streszczenie"
+    )
+
+
+@pytest.mark.django_db
+def test_child_autor_ciagly(
+    api_client, wydawnictwo_ciagle, autor_jan_kowalski, jednostka
+):
+    wa = wydawnictwo_ciagle.dodaj_autora(autor_jan_kowalski, jednostka)
+    _assert_respektuje_flage(
+        api_client, wydawnictwo_ciagle, wa.pk, "wydawnictwo_ciagle_autor"
+    )
+
+
+@pytest.mark.django_db
+def test_child_zewnetrzna_baza_ciagle(api_client, wydawnictwo_ciagle, baza_wos):
+    z = Wydawnictwo_Ciagle_Zewnetrzna_Baza_Danych.objects.create(
+        rekord=wydawnictwo_ciagle, baza=baza_wos
+    )
+    _assert_respektuje_flage(
+        api_client,
+        wydawnictwo_ciagle,
+        z.pk,
+        "wydawnictwo_ciagle_zewnetrzna_baza_danych",
+    )
+
+
+@pytest.mark.django_db
+def test_child_autor_patent(api_client, patent, autor_jan_kowalski, jednostka):
+    pa = patent.dodaj_autora(autor_jan_kowalski, jednostka)
+    _assert_respektuje_flage(api_client, patent, pa.pk, "patent_autor")

--- a/src/api_v1/viewsets/common.py
+++ b/src/api_v1/viewsets/common.py
@@ -1,6 +1,5 @@
-from rest_framework.pagination import PageNumberPagination
-
 from django.utils.functional import cached_property
+from rest_framework.pagination import PageNumberPagination
 
 from bpp.models import Uczelnia
 
@@ -20,6 +19,28 @@ class UkryjStatusyKorektyMixin:
             queryset = queryset.exclude(status_korekty_id__in=self.ukryte_statusy)
 
         return queryset
+
+
+class UkryjNieEksportowaneMixin:
+    """Ukrywa child-rekordy, których rekord nadrzędny ma ustawioną flagę
+    ``nie_eksportuj_przez_api``.
+
+    Główne viewsety publikacji filtrują to na poziomie rekordu, ale endpointy
+    podrzędne (streszczenia, autorstwa, identyfikatory zewnętrznych baz) jadą
+    na globalnym querysecie modelu-dziecka — bez tego mixina anonimowy
+    użytkownik mógłby enumerować ich PK i wyciągać dane rekordu chronionego.
+
+    ``parent_lookup`` to nazwa relacji prowadzącej do rekordu nadrzędnego
+    (domyślnie ``rekord``); nadpisz na podklasie, jeśli child używa innej.
+    """
+
+    parent_lookup = "rekord"
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        return queryset.exclude(
+            **{f"{self.parent_lookup}__nie_eksportuj_przez_api": True}
+        )
 
 
 class StreszczeniaPagination(PageNumberPagination):

--- a/src/api_v1/viewsets/patent.py
+++ b/src/api_v1/viewsets/patent.py
@@ -2,7 +2,7 @@ import django_filters
 from rest_framework import viewsets
 
 from api_v1.serializers.patent import Patent_AutorSerializer, PatentSerializer
-from api_v1.viewsets.common import UkryjStatusyKorektyMixin
+from api_v1.viewsets.common import UkryjNieEksportowaneMixin, UkryjStatusyKorektyMixin
 from bpp.models import Patent, Patent_Autor
 
 
@@ -12,7 +12,7 @@ class Patent_AutorFilterSet(django_filters.rest_framework.FilterSet):
         model = Patent_Autor
 
 
-class Patent_AutorViewSet(viewsets.ReadOnlyModelViewSet):
+class Patent_AutorViewSet(UkryjNieEksportowaneMixin, viewsets.ReadOnlyModelViewSet):
     queryset = Patent_Autor.objects.all()
     serializer_class = Patent_AutorSerializer
     filterset_class = Patent_AutorFilterSet

--- a/src/api_v1/viewsets/wydawnictwo_ciagle.py
+++ b/src/api_v1/viewsets/wydawnictwo_ciagle.py
@@ -7,7 +7,11 @@ from api_v1.serializers.wydawnictwo_ciagle import (
     Wydawnictwo_Ciagle_Zewnetrzna_Baza_DanychSerializer,
     Wydawnictwo_CiagleSerializer,
 )
-from api_v1.viewsets.common import StreszczeniaPagination, UkryjStatusyKorektyMixin
+from api_v1.viewsets.common import (
+    StreszczeniaPagination,
+    UkryjNieEksportowaneMixin,
+    UkryjStatusyKorektyMixin,
+)
 from bpp.models import (
     Wydawnictwo_Ciagle,
     Wydawnictwo_Ciagle_Autor,
@@ -22,7 +26,9 @@ class Wydawnictwo_Ciagle_AutorFilterSet(django_filters.rest_framework.FilterSet)
         model = Wydawnictwo_Ciagle_Autor
 
 
-class Wydawnictwo_Ciagle_AutorViewSet(viewsets.ReadOnlyModelViewSet):
+class Wydawnictwo_Ciagle_AutorViewSet(
+    UkryjNieEksportowaneMixin, viewsets.ReadOnlyModelViewSet
+):
     queryset = Wydawnictwo_Ciagle_Autor.objects.all()
     serializer_class = Wydawnictwo_Ciagle_AutorSerializer
     filterset_class = Wydawnictwo_Ciagle_AutorFilterSet
@@ -57,12 +63,16 @@ class Wydawnictwo_CiagleViewSet(
     filterset_class = Wydawnictwo_CiagleFilterSet
 
 
-class Wydawnictwo_Ciagle_Zewnetrzna_Baza_DanychViewSet(viewsets.ReadOnlyModelViewSet):
+class Wydawnictwo_Ciagle_Zewnetrzna_Baza_DanychViewSet(
+    UkryjNieEksportowaneMixin, viewsets.ReadOnlyModelViewSet
+):
     queryset = Wydawnictwo_Ciagle_Zewnetrzna_Baza_Danych.objects.all()
     serializer_class = Wydawnictwo_Ciagle_Zewnetrzna_Baza_DanychSerializer
 
 
-class Wydawnictwo_Ciagle_StreszczenieViewSet(viewsets.ReadOnlyModelViewSet):
+class Wydawnictwo_Ciagle_StreszczenieViewSet(
+    UkryjNieEksportowaneMixin, viewsets.ReadOnlyModelViewSet
+):
     queryset = Wydawnictwo_Ciagle_Streszczenie.objects.all()
     serializer_class = Wydawnictwo_Ciagle_StreszczenieSerializer
     pagination_class = StreszczeniaPagination

--- a/src/api_v1/viewsets/wydawnictwo_zwarte.py
+++ b/src/api_v1/viewsets/wydawnictwo_zwarte.py
@@ -6,7 +6,11 @@ from api_v1.serializers.wydawnictwo_zwarte import (
     Wydawnictwo_Zwarte_StreszczenieSerializer,
     Wydawnictwo_ZwarteSerializer,
 )
-from api_v1.viewsets.common import StreszczeniaPagination, UkryjStatusyKorektyMixin
+from api_v1.viewsets.common import (
+    StreszczeniaPagination,
+    UkryjNieEksportowaneMixin,
+    UkryjStatusyKorektyMixin,
+)
 from bpp.models import (
     Wydawnictwo_Zwarte,
     Wydawnictwo_Zwarte_Autor,
@@ -20,7 +24,9 @@ class Wydawnictwo_Zwarte_AutorFilterSet(django_filters.rest_framework.FilterSet)
         model = Wydawnictwo_Zwarte_Autor
 
 
-class Wydawnictwo_Zwarte_AutorViewSet(viewsets.ReadOnlyModelViewSet):
+class Wydawnictwo_Zwarte_AutorViewSet(
+    UkryjNieEksportowaneMixin, viewsets.ReadOnlyModelViewSet
+):
     queryset = Wydawnictwo_Zwarte_Autor.objects.all().select_related()
     serializer_class = Wydawnictwo_Zwarte_AutorSerializer
     filterset_class = Wydawnictwo_Zwarte_AutorFilterSet
@@ -49,7 +55,9 @@ class Wydawnictwo_ZwarteViewSet(
     filterset_class = Wydawnictwo_ZwarteFilterSet
 
 
-class Wydawnictwo_Zwarte_StreszczenieViewSet(viewsets.ReadOnlyModelViewSet):
+class Wydawnictwo_Zwarte_StreszczenieViewSet(
+    UkryjNieEksportowaneMixin, viewsets.ReadOnlyModelViewSet
+):
     queryset = Wydawnictwo_Zwarte_Streszczenie.objects.all()
     serializer_class = Wydawnictwo_Zwarte_StreszczenieSerializer
     pagination_class = StreszczeniaPagination

--- a/src/bpp/newsfragments/api-child-nie-eksportuj.bugfix.rst
+++ b/src/bpp/newsfragments/api-child-nie-eksportuj.bugfix.rst
@@ -1,0 +1,1 @@
+Podrzędne endpointy API (streszczenia, autorstwa, identyfikatory zewnętrznych baz danych) respektują flagę ``nie_eksportuj_przez_api`` rekordu nadrzędnego — anonimowy użytkownik nie może już enumerować ich kluczy i wyciągać danych rekordu wyłączonego z eksportu.


### PR DESCRIPTION
## Problem (luka bezpieczeństwa)

Główne viewsety publikacji (`Wydawnictwo_Zwarte`, `Wydawnictwo_Ciagle`,
`Patent`) filtrują `.exclude(nie_eksportuj_przez_api=True)`, więc rekordy
wyłączone z eksportu nie pojawiają się w API. Jednak podrzędne (child)
endpointy jechały na globalnym `.objects.all()`:

- `Wydawnictwo_Zwarte_StreszczenieViewSet`
- `Wydawnictwo_Zwarte_AutorViewSet`
- `Wydawnictwo_Ciagle_AutorViewSet`
- `Wydawnictwo_Ciagle_StreszczenieViewSet`
- `Wydawnictwo_Ciagle_Zewnetrzna_Baza_DanychViewSet`
- `Patent_AutorViewSet`

Dzięki temu anonimowy użytkownik mógł enumerować PK child-rekordów
(lista + detal) i wyciągać dane rekordu chronionego: treść streszczenia,
obsadę autorską, identyfikatory zewnętrznych baz danych.

## Fix

Nowy wspólny mixin `UkryjNieEksportowaneMixin` w
`src/api_v1/viewsets/common.py` (analogiczny do istniejącego
`UkryjStatusyKorektyMixin`) nadpisuje `get_queryset()` i przez `super()`
dokłada `.exclude(<parent_lookup>__nie_eksportuj_przez_api=True)`. Nazwa
relacji jest konfigurowalna atrybutem klasowym `parent_lookup` (domyślnie
`"rekord"` — wszystkie sześć child-modeli używa FK `rekord`). Mixin
zastosowano do wszystkich sześciu child-viewsetów; komponuje się poprawnie
z istniejącymi klasami bazowymi przez `super().get_queryset()`.

## Testy

`src/api_v1/tests/test_child_endpoints_nie_eksportuj.py` — dla każdego typu
child-endpointu asertuje, że przy `nie_eksportuj_przez_api=True` na rekordzie
nadrzędnym child znika z listy (`count == 0`) i zwraca 404 na detalu, a przy
`False` jest normalnie widoczny (regresja):

- `test_child_streszczenie_zwarte`
- `test_child_autor_zwarty`
- `test_child_streszczenie_ciagle`
- `test_child_autor_ciagly`
- `test_child_zewnetrzna_baza_ciagle`
- `test_child_autor_patent`

TDD: testy najpierw RED (`assert 1 == 0` — child widoczny mimo flagi),
po fixie GREEN (6 passed). Istniejące testy zwarte/ciagle/patent (30) bez
regresji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)