### PR TITLE
Importer publikacji: uproszczony krok 1, układ kafli 3+2, kolory statusów + fix Safari

### DIFF
--- a/docs/superpowers/specs/2026-07-13-importer-uproszczenie-design.md
+++ b/docs/superpowers/specs/2026-07-13-importer-uproszczenie-design.md
@@ -1,0 +1,142 @@
+# Uproszczenie importera publikacji (UI + bug Safari)
+
+Data: 2026-07-13
+Branch: `feat/importer-uproszczenie-kafelki`
+Zakres: wyłącznie UI + jeden bugfix. Bez nowego providera (PubMed odłożony do
+osobnego PR-a).
+
+## Cel
+
+Strona kafelkowa `importer_publikacji/` jest dobra, ale po kliknięciu kafla
+trafiamy do współdzielonego formularza „Krok 1” z pełnym wyborem providerów
+(radia) **oraz** listą sesji importu pod spodem. Chcemy: po kliknięciu kafla —
+tylko pole na dane wybranego źródła, bez listy sesji. Plus kilka poprawek
+kosmetycznych i naprawa martwej strony w Safari.
+
+## A. Kafelek → tylko pole na dane
+
+`IndexView._get_fetch_form` jest jedynym producentem `step_fetch.html` i **zawsze**
+zna providera (`?provider=` z kafla albo deep-linku admina). `FetchView.post`
+re-renderuje `step_fetch.html` przy błędzie walidacji. Zatem `step_fetch.html`
+jest zawsze jedno-providerowy — upraszczamy go do tego wariantu:
+
+- nagłówek: ikona + nazwa wybranego źródła,
+- link **„← Wybierz inne źródło”** (przycisk normal) wracający do kafelków
+  (breadcrumb „Importer publikacji” robi to samo),
+- provider jako `<input type="hidden">` (nie `RadioSelect`),
+- render **serwerowy tylko właściwego** pola dla trybu providera:
+  - `InputMode.TEXT` (BibTeX) → `textarea` + „Importuj”,
+  - `InputMode.IDENTIFIER` (CrossRef/PBN/DSpace/WWW) → jednowierszowe pole
+    identyfikatora + „Pobierz dane”, label z `identifier_label`,
+    help-text z `input_help_text`, placeholder z `input_placeholder`,
+- **usuwamy** JS-owy toggle radio→pole (niepotrzebny — provider jest znany),
+- **usuwamy** blok listy sesji (`{% if sessions is not None %}`) oraz
+  `ctx.update(_sessions_list_context(request))` z `_get_fetch_form`.
+
+### Zmiany
+
+- `views/helpers.py`: `_fetch_context(form, request, provider_name)` zwraca
+  metadane **jednego** providera (`provider_meta`) zamiast
+  `providers_metadata_json` wszystkich. Nadal zwraca `form`.
+- `views/wizard.py`:
+  - `_get_fetch_form` — kontekst single-provider, bez `_sessions_list_context`.
+  - `FetchView.post` — przy nie-validnym formularzu przekaż `provider_name`
+    z `request.POST` do `_fetch_context`, żeby re-render był single-provider.
+- `templates/.../partials/step_fetch.html` — przepisany na wariant
+  jedno-providerowy (hidden provider + jedno pole + back-link, bez radia,
+  bez listy sesji, bez toggle-JS).
+
+Deep-linki admina (`?provider=X&identifier=Y`) nadal działają: identyfikator
+jest pre-wypełniony, operator klika „Pobierz dane”.
+
+## B. Układ kafelków 3+2
+
+`.tile-grid--providers` w `src/bpp/static/scss/_wizard_forms.scss`: zamiast
+`repeat(auto-fit, minmax(220px, 1fr))` — responsywne stałe kolumny:
+
+- small (mobile): 1 kolumna,
+- medium (≥640px): 2 kolumny,
+- large (≥1024px): 3 kolumny.
+
+5 kafelków → **3 + 2** na desktopie. Po zmianie: `grunt build`, commit
+skompilowanego CSS.
+
+## C. Przyciski nawigacyjne small/tiny → normal (tylko nawigacja)
+
+Usuwamy `tiny`/`small` z przycisków **nawigacyjnych**:
+
+- `step_landing.html` — „Importy w toku / ostatnie” (`button tiny secondary`),
+- `session_list.html` — „Powrót do importera” (`button tiny secondary`),
+- stopki kroków (`step_source.html`, `step_review.html`, `step_verify.html`,
+  `step_authors.html`) — „Powrót do listy” (`button hollow secondary small`)
+  i „Anuluj import” (`button alert hollow small`).
+
+**Bez zmian (zostają tiny/small)** — inline'owe akcje w wierszach tabel oraz
+kontrolki formularzy:
+
+- `batch_detail.html` (Importuj/Pomiń/Kontynuuj/Ponów/Przywróć per wiersz),
+- `author_row.html` (edycja/usuń autora), `_pbn_result_list.html`,
+  `step_pbn.html`, „Kontynuuj” w `session_list.html`,
+- „Reset” filtra w `session_list.html`,
+- inline'owe `button small warning`/`small hollow` w krokach.
+
+## D. Kolory statusów w liście sesji
+
+Mapowanie klas Foundation przenosimy do testowalnej property
+`ImportSession.status_badge_class` (zamiast drabiny `{% if %}` w szablonie):
+
+| Status | Wyświetlane | Klasa | Kolor |
+|---|---|---|---|
+| `completed` | Zakończono | `success` | zielony (jedyny) |
+| `import_failed` | Błąd importu | `alert` | czerwony |
+| `fetching`, `creating` | Trwa pobieranie / tworzenie | `warning` | pomarańcz |
+| `fetched`, `verified`, `source_matched`, `authors_matched`, `punktacja`, `pbn_check`, `review` | (w toku) | `secondary` | szary |
+
+`cancelled` jest już wykluczony z listy. `session_list.html` używa
+`{{ s.status_badge_class }}`.
+
+## E. Bug Safari — martwa strona po htmx → wstecz
+
+**Objaw:** po kilku interakcjach klik „Importy w toku” (nawigacja htmx),
+potem Wstecz — w Safari błąd JS, strona nieklikalna.
+
+**Hipoteza:** przy Back (bfcache / history-restore Safari) skrypt
+`session_list.html` re-inicjalizuje DataTable/select2 →
+`Cannot reinitialise DataTable` rzuca wyjątek → reszta handlera nie wykonuje
+się → uchwyty zdarzeń niepodpięte → strona martwa.
+
+**Fix (idempotentna inicjalizacja, dobra praktyka niezależnie od dokładnej
+ścieżki):**
+
+- DataTable: init tylko gdy `!$.fn.dataTable.isDataTable(table)`,
+- select2: pomijaj elementy z klasą `.select2-hidden-accessible`
+  (już zainicjalizowane),
+- całość handlera w `try/catch` z `console.error` (BEZ cichego łykania —
+  zgodnie z regułami repo: logujemy),
+- utwardzenie re-inicjalizacji dla swapów htmx (init niezależny od
+  pojedynczego `$(document).ready`, odporny na wielokrotne wywołanie).
+
+**Weryfikacja:** użytkownik potwierdza w Safari po wdrożeniu; dodatkowo
+(jeśli lokalnie zielone) test Playwright (Chromium): sessions → wstecz →
+naprzód, DataTable dokładnie raz + znana kontrolka klikalna.
+
+## Testy
+
+- **Unit:** `ImportSession.status_badge_class` — każdy status → oczekiwana klasa.
+- **Widok:** `_get_fetch_form` — kontekst ma `provider_meta`, **nie** ma
+  `sessions`; `step_fetch` renderuje hidden `provider` + tylko właściwe pole,
+  bez radia i bez tabeli sesji; deep-link prefill; `FetchView.post` invalid →
+  re-render single-provider.
+- **Regresja kolorów:** render listy sesji — `success` tylko dla `completed`,
+  `warning` dla fetching/creating, `alert` dla import_failed, `secondary` dla
+  reszty.
+- **SCSS:** `grunt build` + sprawdzenie że skompilowany CSS się zmienił.
+- **Playwright (opcjonalnie):** bug E.
+- `make tests` (lub co najmniej moduł importera + szeroki przebieg).
+
+## Dostarczane
+
+- Worktree `~/Programowanie/bpp-importer-uproszczenie`,
+  branch `feat/importer-uproszczenie-kafelki`.
+- Newsfragmenty w `src/bpp/newsfragments/` (feature + bugfix).
+- PR → `dev`.

--- a/src/bpp/newsfragments/importer-safari-lista-sesji.bugfix.rst
+++ b/src/bpp/newsfragments/importer-safari-lista-sesji.bugfix.rst
@@ -1,0 +1,4 @@
+Importer publikacji: naprawiono zawieszanie się listy „Importy w toku /
+ostatnie" w Safari po nawigacji HTMX i cofnięciu (Wstecz) — ponowna
+inicjalizacja tabeli/filtrów jest teraz idempotentna, więc strona nie staje
+się nieklikalna.

--- a/src/bpp/newsfragments/importer-uproszczenie-kafelki.feature.rst
+++ b/src/bpp/newsfragments/importer-uproszczenie-kafelki.feature.rst
@@ -1,0 +1,7 @@
+Importer publikacji: po wybraniu kafla źródła krok 1 pokazuje teraz wyłącznie
+pole na dane wybranego dostawcy (textarea dla BibTeX, jedno pole na adres/DOI
+dla pozostałych), bez powtórnego wyboru źródła i bez listy sesji pod spodem.
+Kafle źródeł układają się w 3 kolumny (3 + 2), przyciski nawigacyjne mają
+normalny rozmiar zamiast pomniejszonego, a etykiety statusów na liście sesji
+są zielone tylko dla importów zakończonych (w toku — szare/pomarańczowe,
+błędy — czerwone).

--- a/src/bpp/static/scss/_wizard_forms.scss
+++ b/src/bpp/static/scss/_wizard_forms.scss
@@ -13,12 +13,20 @@
     grid-template-columns: 1fr;
 }
 
-// Kafle dostawców danych importera: liczba źródeł rośnie w czasie
-// (BibTeX/CrossRef/PBN/DSpace/WWW...), więc auto-fit zamiast sztywnych
-// 2 kolumn lepiej wykorzystuje szerokość na większych ekranach i sam
-// się przełamuje na mobile.
+// Kafle dostawców danych importera: stały układ 3 kolumn na desktopie
+// (dla 5 źródeł daje czytelne 3 + 2), 2 kolumny na tablecie, 1 na mobile.
+// Wcześniejszy auto-fit (minmax 220px) dawał na szerokich ekranach 4 + 1,
+// co wyglądało niesymetrycznie.
 .tile-grid--providers {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: 1fr;
+
+    @media screen and (min-width: 640px) {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media screen and (min-width: 1024px) {
+        grid-template-columns: repeat(3, 1fr);
+    }
 }
 
 .wizard-wybor-info {

--- a/src/importer_publikacji/models.py
+++ b/src/importer_publikacji/models.py
@@ -254,6 +254,25 @@ class ImportSession(models.Model):
             kwargs={"session_id": self.pk},
         )
 
+    @property
+    def status_badge_class(self) -> str:
+        """Klasa koloru Foundation dla etykiety statusu na liście sesji.
+
+        Semantyka kolorów (żeby operator nie brał stanów w toku za sukces):
+        - ``success`` (zielony) — TYLKO ``COMPLETED`` („Zakończono"),
+        - ``alert`` (czerwony) — ``IMPORT_FAILED`` (błąd, wymaga akcji),
+        - ``warning`` (pomarańcz) — aktywne przetwarzanie (FETCHING/CREATING),
+        - ``secondary`` (szary) — pozostałe stany w toku (dane pobrane, ale
+          wizard niedokończony: czeka na operatora).
+        """
+        if self.status == self.Status.COMPLETED:
+            return "success"
+        if self.status == self.Status.IMPORT_FAILED:
+            return "alert"
+        if self.status in (self.Status.FETCHING, self.Status.CREATING):
+            return "warning"
+        return "secondary"
+
     # Statusy "w locie": task Celery jeszcze pracuje (albo powinien). Tylko
     # dla nich watchdog może orzec zawieszenie — stan terminalny nigdy nie
     # jest "zawieszony".

--- a/src/importer_publikacji/templates/importer_publikacji/partials/session_list.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/session_list.html
@@ -7,7 +7,7 @@
         {# — przy embedowaniu w kroku fetch (step_fetch.html) tego dublowania #}
         {# linku "powrót do importera" nie chcemy, bo tam i tak już nim jesteśmy. #}
         <p>
-            <a class="button tiny secondary"
+            <a class="button secondary"
                href="{% url 'importer_publikacji:index' %}"
                hx-get="{% url 'importer_publikacji:index' %}"
                hx-target="#importer-wizard"
@@ -116,18 +116,7 @@
                         </td>
                         <td>{{ s.provider_name }}</td>
                         <td>
-                            <span class="label
-                                {% if s.status == 'completed' %}
-                                    success
-                                {% elif s.status == 'cancelled' %}
-                                    alert
-                                {% elif s.status == 'import_failed' %}
-                                    alert
-                                {% elif s.status == 'fetching' or s.status == 'creating' %}
-                                    warning
-                                {% else %}
-                                    primary
-                                {% endif %}">
+                            <span class="label {{ s.status_badge_class }}">
                                 {{ s.get_status_display }}
                             </span>
                         </td>
@@ -166,51 +155,86 @@
 </style>
 
 <script>
-$(document).ready(function() {
-    var $form = $('#session-filter-form');
-
-    $('#session-list-container .importer-user-select2')
-        .select2({
-            placeholder: 'Wybierz...',
-            allowClear: true,
-            language: 'pl',
-            width: '150px'
-        })
-        .on('change', function() {
-            htmx.trigger($form[0], 'change');
-        });
-
-    $('#session-filter-reset').on('click', function() {
-        $form.find('input[type="text"]').val('');
-        $form.find('input[type="date"]').val('');
-        $form.find('select').each(function() {
-            var $sel = $(this);
-            if ($sel.hasClass('importer-user-select2')) {
-                $sel.val(null)
-                    .trigger('change.select2');
-            } else {
-                $sel.val('');
+// Inicjalizacja idempotentna. Przy nawigacji htmx + Wstecz (szczególnie
+// bfcache / history-restore w Safari) ten fragment potrafi się wykonać
+// ponownie na DOM-ie, gdzie DataTable/select2 są JUŻ zainicjalizowane.
+// Bez zabezpieczeń DataTable rzucał „Cannot reinitialise DataTable", co
+// przerywało przetwarzanie htmx nowej treści → uchwyty hx-* nie były
+// podpinane → strona stawała się nieklikalna. Guardy poniżej sprawiają,
+// że powtórne wywołanie jest no-opem zamiast wyjątku.
+(function() {
+    function initSessionList() {
+        try {
+            var $form = $('#session-filter-form');
+            if (!$form.length) {
+                return;
             }
-        });
-        htmx.trigger($form[0], 'change');
-    });
 
-    var table = $('#sessions-table');
-    if (table.length && $.fn.DataTable) {
-        table.DataTable({
-            paging: true,
-            pageLength: 25,
-            ordering: true,
-            order: [[0, 'desc']],
-            info: true,
-            searching: false,
-            language: {
-                url: "{% static 'bpp/js/Polish.json' %}"
-            },
-            columnDefs: [
-                {orderable: false, targets: [7]}
-            ]
-        });
+            // select2 tylko na jeszcze-nie-zainicjalizowanych polach
+            // (.select2-hidden-accessible znaczy „już podpięte").
+            $('#session-list-container .importer-user-select2')
+                .not('.select2-hidden-accessible')
+                .select2({
+                    placeholder: 'Wybierz...',
+                    allowClear: true,
+                    language: 'pl',
+                    width: '150px'
+                })
+                .on('change', function() {
+                    htmx.trigger($form[0], 'change');
+                });
+
+            // .off przed .on — żeby powtórny init nie dublował handlera.
+            $('#session-filter-reset')
+                .off('click.importerReset')
+                .on('click.importerReset', function() {
+                    $form.find('input[type="text"]').val('');
+                    $form.find('input[type="date"]').val('');
+                    $form.find('select').each(function() {
+                        var $sel = $(this);
+                        if ($sel.hasClass('importer-user-select2')) {
+                            $sel.val(null)
+                                .trigger('change.select2');
+                        } else {
+                            $sel.val('');
+                        }
+                    });
+                    htmx.trigger($form[0], 'change');
+                });
+
+            var table = $('#sessions-table');
+            if (table.length && $.fn.DataTable
+                    && !$.fn.dataTable.isDataTable(table[0])) {
+                table.DataTable({
+                    paging: true,
+                    pageLength: 25,
+                    ordering: true,
+                    order: [[0, 'desc']],
+                    info: true,
+                    searching: false,
+                    language: {
+                        url: "{% static 'bpp/js/Polish.json' %}"
+                    },
+                    columnDefs: [
+                        {orderable: false, targets: [7]}
+                    ]
+                });
+            }
+        } catch (e) {
+            // Nie połykamy po cichu — logujemy. Jeden błąd inicjalizacji
+            // (np. wyścig re-init przy Wstecz w Safari) nie może zabić
+            // reszty strony.
+            console.error(
+                '[importer] inicjalizacja listy sesji nie powiodła się:',
+                e
+            );
+        }
     }
-});
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initSessionList);
+    } else {
+        initSessionList();
+    }
+})();
 </script>

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_authors.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_authors.html
@@ -225,14 +225,14 @@
         </div>
         <div class="cell">
             <a href="{% url 'importer_publikacji:index' %}"
-               class="button hollow secondary small">
+               class="button hollow secondary">
                 <span class="fi-list"></span>
                 Powrót do listy
             </a>
         </div>
         <div class="cell">
             <button type="button"
-                    class="button alert hollow small"
+                    class="button alert hollow"
                     hx-post="{% url 'importer_publikacji:cancel' session.pk %}"
                     hx-target="#importer-wizard"
                     hx-confirm="Czy na pewno chcesz anulować import? Sesja zostanie skasowana.">

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_fetch.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_fetch.html
@@ -1,132 +1,94 @@
-{% if cancelled %}
-    <div class="callout warning" data-closable>
-        Sesja importu została anulowana.
-        <button class="close-button" data-close
-                type="button" aria-label="Zamknij">
-            <span aria-hidden="true">&times;</span>
-        </button>
-    </div>
-{% endif %}
-
 {% load bpp_formdefaults %}
 <div class="callout">
     <h4>
-        <span class="fi-magnifying-glass"></span>
+        <span class="{{ provider_meta.icon }}"></span>
         Krok 1: Podaj dane publikacji
     </h4>
+
+    <p class="importer-chosen-source">
+        Źródło danych: <strong>{{ provider_meta.choice_label }}</strong>
+        <a class="importer-change-source"
+           href="{% url 'importer_publikacji:index' %}"
+           hx-get="{% url 'importer_publikacji:index' %}"
+           hx-target="#importer-wizard"
+           hx-push-url="true">
+            <span class="fi-arrow-left"></span>
+            Wybierz inne źródło
+        </a>
+    </p>
+
     <div class="formdefaults-wrap">{% bpp_formdefaults_button form %}</div>
     <form hx-post="{% url 'importer_publikacji:fetch' %}"
           hx-target="#importer-wizard"
           hx-indicator="#fetch-spinner">
         {% csrf_token %}
+        <input type="hidden" name="provider" value="{{ provider_name }}">
 
-        <label>{{ form.provider.label }}</label>
-        <div id="provider-radios">
-            {% for radio in form.provider %}
-                <div>{{ radio }}</div>
-            {% endfor %}
-        </div>
         {% if form.provider.errors %}
             {% for error in form.provider.errors %}
-                <p class="help-text"
-                   style="color: red;">{{ error }}</p>
+                <p class="help-text" style="color: red;">{{ error }}</p>
             {% endfor %}
         {% endif %}
 
-        <div id="input-identifier" class="grid-x grid-margin-x">
-            <div class="cell medium-8">
-                {{ form.identifier.label_tag }}
-                {{ form.identifier }}
-                {% if form.identifier.errors %}
-                    {% for error in form.identifier.errors %}
-                        <p class="help-text"
-                           style="color: red;">{{ error }}</p>
-                    {% endfor %}
-                {% endif %}
+        {% if provider_meta.input_mode == "text" %}
+            {# Provider tekstowy (BibTeX): duża textarea na wklejenie danych. #}
+            <div id="input-text" class="grid-x grid-margin-x">
+                <div class="cell medium-12">
+                    <label for="{{ form.text_input.id_for_label }}">
+                        {{ form.text_input.label }}
+                    </label>
+                    {{ form.text_input }}
+                    {% if provider_meta.input_help_text %}
+                        <p class="help-text">
+                            {{ provider_meta.input_help_text }}
+                        </p>
+                    {% endif %}
+                    {% if form.text_input.errors %}
+                        {% for error in form.text_input.errors %}
+                            <p class="help-text"
+                               style="color: red;">{{ error }}</p>
+                        {% endfor %}
+                    {% endif %}
+                </div>
+                <div class="cell medium-4">
+                    <button type="submit" class="button expanded">
+                        <span class="fi-magnifying-glass"></span>
+                        Importuj
+                    </button>
+                </div>
             </div>
-            <div class="cell medium-4">
-                <label>&nbsp;</label>
-                <button type="submit"
-                        class="button expanded">
-                    <span class="fi-magnifying-glass"></span>
-                    Pobierz dane
-                </button>
+        {% else %}
+            {# Provider identyfikatorowy: jedno pole (DOI / URL / PBN UID...). #}
+            {# id="input-identifier" zachowane dla selektorów testów Playwright. #}
+            <div id="input-identifier" class="grid-x grid-margin-x">
+                <div class="cell medium-8">
+                    <label for="{{ form.identifier.id_for_label }}">
+                        {{ provider_meta.identifier_label|default:form.identifier.label }}
+                    </label>
+                    {{ form.identifier }}
+                    {% if provider_meta.input_help_text %}
+                        <p class="help-text">
+                            {{ provider_meta.input_help_text }}
+                        </p>
+                    {% endif %}
+                    {% if form.identifier.errors %}
+                        {% for error in form.identifier.errors %}
+                            <p class="help-text"
+                               style="color: red;">{{ error }}</p>
+                        {% endfor %}
+                    {% endif %}
+                </div>
+                <div class="cell medium-4">
+                    <label>&nbsp;</label>
+                    <button type="submit" class="button expanded">
+                        <span class="fi-magnifying-glass"></span>
+                        Pobierz dane
+                    </button>
+                </div>
             </div>
-        </div>
-
-        <div id="input-text" class="grid-x grid-margin-x"
-             style="display: none;">
-            <div class="cell medium-12">
-                {{ form.text_input.label_tag }}
-                {{ form.text_input }}
-                {% if form.text_input.errors %}
-                    {% for error in form.text_input.errors %}
-                        <p class="help-text"
-                           style="color: red;">{{ error }}</p>
-                    {% endfor %}
-                {% endif %}
-            </div>
-            <div class="cell medium-12">
-                <p class="help-text" id="input-help-text"></p>
-            </div>
-            <div class="cell medium-4">
-                <button type="submit"
-                        class="button expanded">
-                    <span class="fi-magnifying-glass"></span>
-                    Importuj
-                </button>
-            </div>
-        </div>
+        {% endif %}
     </form>
     <div id="fetch-spinner" class="htmx-indicator">
         <span class="fi-loop"></span> Przetwarzanie danych...
     </div>
 </div>
-
-{% if providers_metadata_json %}
-<script>
-(function() {
-    var meta = {{ providers_metadata_json|safe }};
-    var radios = document.querySelectorAll(
-        'input[name="provider"]'
-    );
-    var idBlock = document.getElementById('input-identifier');
-    var textBlock = document.getElementById('input-text');
-    var helpText = document.getElementById('input-help-text');
-
-    function toggle() {
-        var checked = document.querySelector(
-            'input[name="provider"]:checked'
-        );
-        if (!checked) return;
-        var info = meta[checked.value];
-        if (!info) return;
-        if (info.input_mode === 'text') {
-            idBlock.style.display = 'none';
-            textBlock.style.display = '';
-            helpText.textContent =
-                info.input_help_text || '';
-        } else {
-            idBlock.style.display = '';
-            textBlock.style.display = 'none';
-            helpText.textContent = '';
-            var idLabel = idBlock.querySelector('label');
-            if (idLabel && info.identifier_label) {
-                idLabel.textContent =
-                    info.identifier_label;
-            }
-        }
-    }
-
-    radios.forEach(function(r) {
-        r.addEventListener('change', toggle);
-    });
-    toggle();
-})();
-</script>
-{% endif %}
-
-{% if sessions is not None %}
-    <hr>
-    {% include "importer_publikacji/partials/session_list.html" %}
-{% endif %}

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_landing.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_landing.html
@@ -45,7 +45,7 @@
             {% endif %}
         </div>
         <div class="cell shrink">
-            <a class="button tiny secondary"
+            <a class="button secondary"
                id="import-sessions-link"
                href="{% url 'importer_publikacji:sessions' %}"
                hx-get="{% url 'importer_publikacji:sessions' %}"

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_review.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_review.html
@@ -314,14 +314,14 @@
     </form>
     <div>
         <a href="{% url 'importer_publikacji:index' %}"
-           class="button hollow secondary small">
+           class="button hollow secondary">
             <span class="fi-list"></span>
             Powrót do listy
         </a>
     </div>
     <div>
         <button type="button"
-                class="button alert hollow small"
+                class="button alert hollow"
                 hx-post="{% url 'importer_publikacji:cancel' session.pk %}"
                 hx-target="#importer-wizard"
                 hx-confirm="Czy na pewno chcesz anulować import? Sesja zostanie skasowana.">

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_source.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_source.html
@@ -145,14 +145,14 @@
             </div>
             <div class="cell">
                 <a href="{% url 'importer_publikacji:index' %}"
-                   class="button hollow secondary small">
+                   class="button hollow secondary">
                     <span class="fi-list"></span>
                     Powrót do listy
                 </a>
             </div>
             <div class="cell">
                 <button type="button"
-                        class="button alert hollow small"
+                        class="button alert hollow"
                         hx-post="{% url 'importer_publikacji:cancel' session.pk %}"
                         hx-target="#importer-wizard"
                         hx-confirm="Czy na pewno chcesz anulować import? Sesja zostanie skasowana.">

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
@@ -465,14 +465,14 @@
             </div>
             <div class="cell">
                 <a href="{% url 'importer_publikacji:index' %}"
-                   class="button hollow secondary small">
+                   class="button hollow secondary">
                     <span class="fi-list"></span>
                     Powrót do listy
                 </a>
             </div>
             <div class="cell">
                 <button type="button"
-                        class="button alert hollow small"
+                        class="button alert hollow"
                         hx-post="{% url 'importer_publikacji:cancel' session.pk %}"
                         hx-target="#importer-wizard"
                         hx-confirm="Czy na pewno chcesz anulować import? Sesja zostanie skasowana.">

--- a/src/importer_publikacji/tests/test_fetch_single_provider.py
+++ b/src/importer_publikacji/tests/test_fetch_single_provider.py
@@ -1,0 +1,136 @@
+"""Testy uproszczonego kroku 1 importera (jedno wybrane źródło) oraz kolorów
+statusów na liście sesji.
+
+Po kliknięciu kafla (albo deep-linku ``?provider=``) krok 1 pokazuje TYLKO
+pole na dane wybranego providera — bez radiowego wyboru źródła i bez tabeli
+sesji pod spodem. Kolory etykiet statusów: zielony tylko dla „Zakończono".
+"""
+
+import pytest
+from django.urls import reverse
+
+from importer_publikacji.models import ImportSession
+
+S = ImportSession.Status
+
+
+def _make_session(user, status, ident):
+    return ImportSession.objects.create(
+        created_by=user,
+        provider_name="CrossRef",
+        identifier=ident,
+        status=status,
+        raw_data={},
+        normalized_data={},
+    )
+
+
+# --- Krok 1: pojedyncze źródło -------------------------------------------
+
+
+@pytest.mark.django_db
+def test_fetch_single_provider_has_no_radio_group(importer_client):
+    """Wybór providera przez kafel → brak grupy radiowej; provider jako
+    ukryte pole."""
+    url = reverse("importer_publikacji:index") + "?provider=CrossRef"
+    content = importer_client.get(url).content.decode()
+    assert 'id="provider-radios"' not in content
+    assert '<input type="hidden" name="provider" value="CrossRef"' in content
+
+
+@pytest.mark.django_db
+def test_fetch_single_provider_has_no_sessions_table(importer_client, importer_user):
+    """Krok 1 nie dokleja listy sesji pod spodem."""
+    _make_session(importer_user, S.FETCHED, "10.1/a")
+    url = reverse("importer_publikacji:index") + "?provider=CrossRef"
+    content = importer_client.get(url).content.decode()
+    assert 'id="sessions-table"' not in content
+    assert "Sesje importu" not in content
+
+
+@pytest.mark.django_db
+def test_fetch_single_provider_has_change_source_link(importer_client):
+    """Jest link „Wybierz inne źródło" wracający do kafelków."""
+    url = reverse("importer_publikacji:index") + "?provider=CrossRef"
+    content = importer_client.get(url).content.decode()
+    assert "Wybierz inne źródło" in content
+
+
+@pytest.mark.django_db
+def test_fetch_identifier_provider_renders_single_input(importer_client):
+    """Provider identyfikatorowy (CrossRef) → jedno pole identyfikatora,
+    przycisk „Pobierz dane", brak textarea."""
+    url = reverse("importer_publikacji:index") + "?provider=CrossRef"
+    content = importer_client.get(url).content.decode()
+    assert 'name="identifier"' in content
+    assert 'id="input-identifier"' in content
+    assert "Pobierz dane" in content
+    assert 'name="text_input"' not in content
+
+
+@pytest.mark.django_db
+def test_fetch_text_provider_renders_textarea(importer_client):
+    """Provider tekstowy (BibTeX) → textarea, przycisk „Importuj", brak
+    pojedynczego pola identyfikatora."""
+    url = reverse("importer_publikacji:index") + "?provider=BibTeX"
+    content = importer_client.get(url).content.decode()
+    assert 'name="text_input"' in content
+    assert "Importuj" in content
+    assert 'name="identifier"' not in content
+
+
+@pytest.mark.django_db
+def test_fetch_post_invalid_rerenders_single_provider(importer_client):
+    """POST bez identyfikatora → błąd walidacji re-renderuje single-provider
+    (nadal bez radia i bez listy sesji)."""
+    url = reverse("importer_publikacji:fetch")
+    response = importer_client.post(
+        url,
+        {"provider": "CrossRef", "identifier": ""},
+        HTTP_HX_REQUEST="true",
+    )
+    content = response.content.decode()
+    assert 'id="provider-radios"' not in content
+    assert 'id="sessions-table"' not in content
+    assert '<input type="hidden" name="provider" value="CrossRef"' in content
+
+
+# --- Kolory statusów na liście sesji -------------------------------------
+
+
+@pytest.mark.django_db
+def test_session_list_completed_is_green(importer_client, importer_user):
+    _make_session(importer_user, S.COMPLETED, "10.1/done")
+    content = importer_client.get(
+        reverse("importer_publikacji:sessions")
+    ).content.decode()
+    assert "label success" in content
+
+
+@pytest.mark.django_db
+def test_session_list_fetched_is_not_green(importer_client, importer_user):
+    """„Pobrano dane" (FETCHED) to stan w toku → szary, NIE zielony."""
+    _make_session(importer_user, S.FETCHED, "10.1/f")
+    content = importer_client.get(
+        reverse("importer_publikacji:sessions")
+    ).content.decode()
+    assert "label secondary" in content
+    assert "label success" not in content
+
+
+@pytest.mark.django_db
+def test_session_list_fetching_is_orange(importer_client, importer_user):
+    _make_session(importer_user, S.FETCHING, "10.1/w")
+    content = importer_client.get(
+        reverse("importer_publikacji:sessions")
+    ).content.decode()
+    assert "label warning" in content
+
+
+@pytest.mark.django_db
+def test_session_list_failed_is_red(importer_client, importer_user):
+    _make_session(importer_user, S.IMPORT_FAILED, "10.1/x")
+    content = importer_client.get(
+        reverse("importer_publikacji:sessions")
+    ).content.decode()
+    assert "label alert" in content

--- a/src/importer_publikacji/tests/test_status_badge.py
+++ b/src/importer_publikacji/tests/test_status_badge.py
@@ -1,0 +1,30 @@
+"""Property ``ImportSession.status_badge_class`` — mapowanie statusu na klasę
+koloru Foundation. Zielony (``success``) TYLKO dla „Zakończono"; błąd →
+czerwony; aktywne przetwarzanie → pomarańcz; reszta (w toku) → szary."""
+
+import pytest
+
+from importer_publikacji.models import ImportSession
+
+S = ImportSession.Status
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        (S.COMPLETED, "success"),
+        (S.IMPORT_FAILED, "alert"),
+        (S.FETCHING, "warning"),
+        (S.CREATING, "warning"),
+        (S.FETCHED, "secondary"),
+        (S.VERIFIED, "secondary"),
+        (S.SOURCE_MATCHED, "secondary"),
+        (S.AUTHORS_MATCHED, "secondary"),
+        (S.PUNKTACJA, "secondary"),
+        (S.PBN_CHECK, "secondary"),
+        (S.REVIEW, "secondary"),
+    ],
+)
+def test_status_badge_class(status, expected):
+    # Property czysto obliczeniowa — instancja bez zapisu do bazy wystarcza.
+    assert ImportSession(status=status).status_badge_class == expected

--- a/src/importer_publikacji/views/helpers.py
+++ b/src/importer_publikacji/views/helpers.py
@@ -8,8 +8,6 @@ Zawiera:
 - pomocnicze nakładki HTMX (HX-Push-Url, OOB breadcrumbs).
 """
 
-import json
-
 from django.shortcuts import render
 from django.template.loader import render_to_string
 
@@ -144,16 +142,29 @@ def _get_crossref_mapper(publication_type):
     return mapper
 
 
-def _fetch_context(form=None, request=None):
-    """Kontekst dla kroku fetch (providers_metadata)."""
+def _fetch_context(form=None, request=None, provider_name=None):
+    """Kontekst kroku fetch dla POJEDYNCZEGO wybranego providera.
+
+    W kaflowym/deep-linkowym flow provider jest zawsze znany (``?provider=``
+    z kafla albo POST). Zwracamy metadane TEGO JEDNEGO providera
+    (``provider_meta``) zamiast całej mapy — szablon renderuje wyłącznie
+    właściwe pole (identyfikator albo textarea), bez radiowego wyboru źródła
+    i bez listy sesji pod spodem.
+    """
+    metadata = get_providers_metadata()
+    if provider_name is None and form is not None:
+        provider_name = form.data.get("provider") or form.initial.get("provider")
     if form is None:
         last_provider = None
         if request is not None:
             last_provider = request.session.get("importer_last_provider")
         form = FetchForm(last_provider=last_provider)
+        if provider_name is None:
+            provider_name = form.initial.get("provider")
     return {
         "form": form,
-        "providers_metadata_json": json.dumps(get_providers_metadata()),
+        "provider_name": provider_name,
+        "provider_meta": metadata.get(provider_name),
     }
 
 

--- a/src/importer_publikacji/views/wizard.py
+++ b/src/importer_publikacji/views/wizard.py
@@ -33,7 +33,7 @@ from ..models import (
     MultipleWorksImportEntry,
 )
 from ..permissions import ImporterPermissionMixin
-from ..providers import InputMode, get_provider
+from ..providers import InputMode, get_provider, get_providers_metadata
 from ..tasks import create_publication_task, fetch_session_task
 from .authors import (
     _create_single_author,
@@ -102,13 +102,17 @@ class IndexView(ImporterPermissionMixin, View):
         return self._get_landing(request)
 
     def _get_fetch_form(self, request):
-        initial = {"provider": request.GET["provider"]}
+        provider_name = request.GET["provider"]
+        # Nieznany provider (stary/zepsuty deep-link) → wróć do kafelków,
+        # zamiast renderować pusty nagłówek jednego źródła.
+        if provider_name not in get_providers_metadata():
+            return self._get_landing(request)
+        initial = {"provider": provider_name}
         if request.GET.get("identifier"):
             initial["identifier"] = request.GET["identifier"]
         form = FetchForm(initial=initial)
 
-        ctx = _fetch_context(form, request=request)
-        ctx.update(_sessions_list_context(request))
+        ctx = _fetch_context(form, request=request, provider_name=provider_name)
         if _is_htmx_partial(request):
             response = render(request, STEP_FETCH, ctx)
             return _with_breadcrumbs_oob(response, request)
@@ -204,7 +208,11 @@ class FetchView(ImporterPermissionMixin, View):
     def post(self, request):
         form = FetchForm(request.POST)
         if not form.is_valid():
-            return render(request, STEP_FETCH, _fetch_context(form))
+            return render(
+                request,
+                STEP_FETCH,
+                _fetch_context(form, provider_name=request.POST.get("provider")),
+            )
 
         provider_name = form.cleaned_data["provider"]
         request.session["importer_last_provider"] = provider_name
@@ -227,7 +235,11 @@ class FetchView(ImporterPermissionMixin, View):
             if placeholder:
                 msg += f" Przykład: {placeholder}"
             form.add_error(error_field, msg)
-            return render(request, STEP_FETCH, _fetch_context(form))
+            return render(
+                request,
+                STEP_FETCH,
+                _fetch_context(form, provider_name=provider_name),
+            )
 
         # Wielo-rekordowe wejście (BibTeX z ≥2 wpisami) → paczka, nie
         # pojedyncza sesja. Pojedyncze sesje powstają leniwie przy


### PR DESCRIPTION
## Co i po co

Strona kafelkowa importera jest dobra, ale po kliknięciu kafla trafialiśmy do wspólnego formularza „Krok 1" z pełnym radiowym wyborem źródła **oraz** listą sesji pod spodem. Ten PR upraszcza ten flow i dokłada kilka poprawek zgłoszonych przez użytkownika.

## Zmiany

- **Krok 1 = tylko pole na dane wybranego źródła.** Po kliknięciu kafla (lub deep-linku `?provider=`) widać wyłącznie właściwe pole: `textarea` dla BibTeX, jedno pole identyfikatora (DOI/URL/PBN UID…) dla pozostałych. Znika radiowy wybór źródła (provider jako ukryte pole) i lista sesji pod spodem. Nad polem link **„← Wybierz inne źródło"** wracający do kafelków. Deep-linki admina (`?provider=&identifier=`) nadal prefillują pole.
- **Kafle 3 + 2.** `.tile-grid--providers`: 3 kolumny na desktopie (≥1024px), 2 na tablecie (≥640px), 1 na mobile — zamiast `auto-fit` dającego niesymetryczne 4 + 1.
- **Przyciski nawigacyjne w normalnym rozmiarze.** „Importy w toku / ostatnie", „Powrót do importera", „Powrót do listy", „Anuluj import" — z `tiny`/`small` na normalne. Inline'owe akcje w wierszach tabel (Importuj/Pomiń/Kontynuuj/Usuń…) zostają `tiny` (konwencja).
- **Kolory statusów na liście sesji.** Zielony **tylko** dla „Zakończono"; czerwony dla błędu; pomarańcz dla aktywnego przetwarzania (pobieranie/tworzenie); szary dla pozostałych stanów w toku. Mapowanie w testowalnej property `ImportSession.status_badge_class`.
- **Fix Safari.** Lista „Importy w toku / ostatnie" po nawigacji HTMX i cofnięciu (Wstecz) potrafiła się w Safari zawiesić (nieklikalna strona) — ponowna inicjalizacja DataTable/select2 rzucała `Cannot reinitialise DataTable`, co przerywało przetwarzanie HTMX nowej treści. Inicjalizacja jest teraz idempotentna (guard `isDataTable`, pomijanie już-zainicjalizowanego select2, `try/catch` z logowaniem do konsoli).

## Testy

- Nowe: `test_status_badge.py` (mapowanie property), `test_fetch_single_provider.py` (krok 1 bez radia i bez listy sesji, textarea vs pole identyfikatora, POST-invalid, kolory statusów na liście).
- Moduł `importer_publikacji`: **662 passed** (bez playwright). Pełna suita non-playwright + CI walidują resztę.
- SCSS skompilowane (`grunt sass:blue` OK); skompilowany CSS nie jest w gicie (buduje się na obrazie).

## Do weryfikacji przez zgłaszającego

- **Safari:** potwierdzić, że po `Importy w toku` → interakcje → Wstecz strona jest klikalna (fix wdrożony na najprawdopodobniejszą przyczynę; brak dostępu do Safari po stronie automatu).

Spec: `docs/superpowers/specs/2026-07-13-importer-uproszczenie-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)