### PR TITLE
security(media): normalizuj ścieżkę przed guardem protected/ (traversal)

### DIFF
--- a/src/bpp/newsfragments/media-protected-traversal.bugfix.rst
+++ b/src/bpp/newsfragments/media-protected-traversal.bugfix.rst
@@ -1,0 +1,1 @@
+Załatano lukę path-traversal w serwowaniu mediów: ścieżka jest teraz normalizowana przed sprawdzeniem guardu, więc obejścia typu ``public/../protected/plik.pdf`` nie omijają już ochrony katalogu ``protected/``.

--- a/src/django_bpp/tests/test_protected_media_serve.py
+++ b/src/django_bpp/tests/test_protected_media_serve.py
@@ -1,0 +1,55 @@
+"""Testy guardu ``protected_media_serve`` — ochrona przed path-traversal.
+
+Widok testujemy BEZPOŚREDNIO (nie przez test client), bo klient normalizuje
+URL zanim trafi do widoku i zamaskowałby lukę. ``static_serve`` jest mockowany,
+żeby test nie zależał od plików na dysku i żeby dało się odróżnić *dlaczego*
+podniesiono Http404 (guard vs. brak pliku).
+"""
+
+from unittest import mock
+
+import pytest
+from django.http import Http404
+from django.test import RequestFactory
+
+from django_bpp.urls import protected_media_serve
+
+
+@pytest.fixture
+def request_get():
+    return RequestFactory().get("/media/whatever")
+
+
+def test_traversal_do_protected_jest_blokowany(request_get):
+    """public/../protected/... zwija się do protected/ — musi być blokowany."""
+    with mock.patch("django_bpp.urls.static_serve") as m:
+        with pytest.raises(Http404, match="Use the download endpoint"):
+            protected_media_serve(request_get, path="public/../protected/secret.pdf")
+        m.assert_not_called()
+
+
+def test_traversal_wielosegmentowy_jest_blokowany(request_get):
+    """Wiele ../ też musi zostać znormalizowane przed sprawdzeniem guardu."""
+    with mock.patch("django_bpp.urls.static_serve") as m:
+        with pytest.raises(Http404, match="Use the download endpoint"):
+            protected_media_serve(request_get, path="a/b/../../protected/x.pdf")
+        m.assert_not_called()
+
+
+def test_bezposredni_protected_dalej_blokowany(request_get):
+    """Regresja: bezpośrednie protected/... ma dalej być blokowane."""
+    with mock.patch("django_bpp.urls.static_serve") as m:
+        with pytest.raises(Http404, match="Use the download endpoint"):
+            protected_media_serve(request_get, path="protected/secret.pdf")
+        m.assert_not_called()
+
+
+def test_legalny_public_jest_serwowany(request_get):
+    """Legalna ścieżka public/ nie może być blokowana przez guard."""
+    sentinel = object()
+    with mock.patch("django_bpp.urls.static_serve", return_value=sentinel) as m:
+        result = protected_media_serve(
+            request_get, path="public/plik.pdf", document_root="/media"
+        )
+    assert result is sentinel
+    m.assert_called_once()

--- a/src/django_bpp/urls.py
+++ b/src/django_bpp/urls.py
@@ -1,3 +1,5 @@
+import posixpath
+
 from django.apps import apps
 from django.conf import settings
 from django.conf.urls.static import static
@@ -45,8 +47,15 @@ def protected_media_serve(request, path, document_root=None):
 
     Files in protected/ directory should only be accessible through authenticated
     views that use django-sendfile.
+
+    Ścieżkę normalizujemy PRZED sprawdzeniem guardu — inaczej traversal typu
+    ``public/../protected/tajne.pdf`` przechodzi (surowe ``startswith`` widzi
+    ``public/``), a ``static_serve`` zwija ``..`` dopiero wewnątrz i serwuje
+    plik z ``protected/``. ``normpath`` na pustej ścieżce daje ``"."``, więc
+    dodatkowe ``lstrip("/")`` i porównanie do ``"protected"`` są bezpieczne.
     """
-    if path.startswith("protected/"):
+    norm = posixpath.normpath(path).lstrip("/")
+    if norm == "protected" or norm.startswith("protected/"):
         raise Http404("Use the download endpoint")
     return static_serve(request, path, document_root)
 


### PR DESCRIPTION
## Bug: path traversal w serwowaniu mediów (check-before-canonicalize)

`protected_media_serve` (w `src/django_bpp/urls.py`, podpięty pod
`^media/(?P<path>.*)$`) sprawdzał **surową** ścieżkę guardem
`path.startswith("protected/")` **przed** normalizacją. Natomiast
`django.views.static.serve` zwija `..` (`posixpath.normpath`) dopiero
**wewnątrz**.

Skutek: żądanie `media/public/../protected/tajne.pdf`:
1. guard widzi prefiks `public/` → `startswith("protected/")` == False → przepuszcza,
2. `static_serve` normalizuje do `protected/tajne.pdf` i serwuje plik.

`safe_join` chroni tylko przed wyjściem **poza** `MEDIA_ROOT`, nie przed
**wejściem** do `protected/` wewnątrz roota. Pliki `protected/` mają być
dostępne wyłącznie przez uwierzytelniony endpoint download (django-sendfile).

## Fix

Normalizacja **przed** guardem:

```python
norm = posixpath.normpath(path).lstrip("/")
if norm == "protected" or norm.startswith("protected/"):
    raise Http404("Use the download endpoint")
return static_serve(request, path, document_root)
```

Samo serwowanie (`static_serve`) i komunikat 404 bez zmian — zmieniono
wyłącznie kolejność normalizacja→guard. Legalne `public/...` działa jak
dotąd.

## Testy (TDD)

Widok testowany **bezpośrednio** przez `RequestFactory` (test client
normalizuje URL zanim dojdzie do widoku i zamaskowałby lukę), ze zmockowanym
`static_serve` — dzięki temu odróżniamy 404 z guardu od 404 „brak pliku":

- `public/../protected/secret.pdf` → Http404, `static_serve` NIE wołany (RED przed fixem),
- `a/b/../../protected/x.pdf` (multi-segment) → Http404 (RED przed fixem),
- `protected/secret.pdf` (wprost) → Http404 (regresja),
- `public/plik.pdf` → `static_serve` wołany, brak Http404 z guardu.

## Obrona w głębi / follow-up

W produkcji nginx zwykle normalizuje ścieżkę zanim dotrze do Django, więc
realny impakt zależy od reverse-proxy — ta poprawka to warstwa obrony w
aplikacji, niezależna od konfiguracji frontu. Sugerowany follow-up:
serwować `protected/` przez nginx `internal;` (X-Accel-Redirect /
sendfile), żeby katalog w ogóle nie był osiągalny bezpośrednio spod
`location /media/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)