### PR TITLE
security(import_dyscyplin): usuwanie/uruchamianie tylko przez POST+CSRF

### DIFF
--- a/src/bpp/newsfragments/import-dyscyplin-get-mutation.bugfix.rst
+++ b/src/bpp/newsfragments/import-dyscyplin-get-mutation.bugfix.rst
@@ -1,0 +1,1 @@
+Usuwanie importu dyscyplin oraz uruchamianie zadań przetwarzania są teraz dostępne wyłącznie przez POST z tokenem CSRF (wcześniej mutowały stan przez GET).

--- a/src/import_dyscyplin/templates/import_dyscyplin/import_dyscyplin_detail.html
+++ b/src/import_dyscyplin/templates/import_dyscyplin/import_dyscyplin_detail.html
@@ -30,11 +30,14 @@
 
 
     <h2>Import dyscyplin - plik {{ object.plik }}
-        <button class="button warning"
-                data-confirm="Czy na pewno usunąć ten plik z systemu?"
-                data-redirect-url="{% url "import_dyscyplin:usun" object.pk %}">
-            <i class="fi-page-remove"></i> usuń plik
-        </button>
+        <form method="post" action="{% url "import_dyscyplin:usun" object.pk %}"
+              class="usun-import-form" style="display:inline">
+            {% csrf_token %}
+            <button class="button warning" type="submit"
+                    data-confirm="Czy na pewno usunąć ten plik z systemu?">
+                <i class="fi-page-remove"></i> usuń plik
+            </button>
+        </form>
     </h2>
     Rok: <strong>{{ object.rok }}</strong>.
     Utworzono: <strong>{{ object.created }}</strong>.
@@ -48,7 +51,8 @@
                 $("#modal1").foundation('open');
                 $.ajax({
                     url: "{% url "import_dyscyplin:stworz_kolumny" object.pk %}",
-                    method: "GET",
+                    method: "POST",
+                    headers: {"X-CSRFToken": "{{ csrf_token }}"},
                 });
             });
         </script>
@@ -70,7 +74,8 @@
                 $("#modal1").foundation('open');
                 $.ajax({
                     url: "{% url "import_dyscyplin:przetwarzaj" object.pk %}",
-                    method: "GET",
+                    method: "POST",
+                    headers: {"X-CSRFToken": "{{ csrf_token }}"},
                     data: {"web_page_uid": channelsBroadcast.messageCookieId}
                 });
             });
@@ -288,15 +293,6 @@
         // Event delegation handlers
         // (data-confirm is handled globally by event-handlers.js)
         document.addEventListener('click', function(e) {
-            // Handle redirect action
-            var redirectBtn = e.target.closest('[data-redirect-url]');
-            if (redirectBtn) {
-                e.preventDefault();
-                var url = redirectBtn.dataset.redirectUrl;
-                location.href = url;
-                return;
-            }
-
             // Handle integrate action
             var integrateBtn = e.target.closest('[data-integrate-action]');
             if (integrateBtn) {
@@ -308,7 +304,8 @@
                 }
                 $.ajax({
                     url: url,
-                    method: 'GET',
+                    method: 'POST',
+                    headers: {"X-CSRFToken": "{{ csrf_token }}"},
                     data: {'web_page_uid': channelsBroadcast.messageCookieId}
                 });
                 return;

--- a/src/import_dyscyplin/tests/test_get_mutation_security.py
+++ b/src/import_dyscyplin/tests/test_get_mutation_security.py
@@ -1,0 +1,128 @@
+"""Testy regresyjne: akcje mutujące stan (usuwanie importu, uruchamianie
+zadań Celery) MUSZĄ być dostępne wyłącznie przez POST + CSRF.
+
+Historycznie widoki obsługiwały te akcje na GET (``get = delete``,
+``UruchomZadaniePrzetwarzania.get``), co pozwalało wywołać skutki uboczne
+zwykłym żądaniem GET (prefetch przeglądarki, skanery, brak ochrony CSRF).
+Poniższe testy pilnują, że GET nic nie mutuje, a POST działa jak dawniej.
+"""
+
+from django.urls import reverse
+from model_bakery import baker
+
+from fixtures.conftest_browser import (
+    NORMAL_DJANGO_USER_LOGIN,
+    NORMAL_DJANGO_USER_PASSWORD,
+    _webtest_login,
+)
+from import_dyscyplin.models import Import_Dyscyplin
+from import_dyscyplin.tasks import przeanalizuj_import_dyscyplin
+from import_dyscyplin.tests.test_views import wyslij
+
+# ---------------------------------------------------------------------------
+# Usuwanie importu (UsunImport_Dyscyplin)
+# ---------------------------------------------------------------------------
+
+
+def test_usun_get_nie_kasuje(csrf_exempt_wd_app, test1_xlsx, transactional_db):
+    """GET na endpoint usuwania NIE może kasować rekordu (405)."""
+    wyslij(csrf_exempt_wd_app, test1_xlsx)
+    i = Import_Dyscyplin.objects.first()
+
+    res = csrf_exempt_wd_app.get(
+        reverse("import_dyscyplin:usun", args=(i.pk,)), expect_errors=True
+    )
+
+    assert res.status_code == 405
+    assert Import_Dyscyplin.objects.filter(pk=i.pk).exists()
+
+
+def test_usun_post_kasuje(csrf_exempt_wd_app, test1_xlsx, transactional_db):
+    """POST (z CSRF) usuwa rekord jak dawniej."""
+    wyslij(csrf_exempt_wd_app, test1_xlsx)
+    i = Import_Dyscyplin.objects.first()
+
+    res = csrf_exempt_wd_app.post(
+        reverse("import_dyscyplin:usun", args=(i.pk,))
+    ).maybe_follow()
+
+    assert res.status_code == 200
+    assert not Import_Dyscyplin.objects.filter(pk=i.pk).exists()
+
+
+def test_usun_post_cudzy_rekord_niewidoczny(
+    csrf_exempt_wd_app, django_user_model, transactional_db
+):
+    """TylkoMojeMixin: cudzy rekord jest niewidoczny (404), nie kasuje się."""
+    obcy = django_user_model.objects.create_user(
+        username="obcy_wlasciciel", password="x"
+    )
+    rec = baker.make(Import_Dyscyplin, owner=obcy)
+
+    res = csrf_exempt_wd_app.post(
+        reverse("import_dyscyplin:usun", args=(rec.pk,)), expect_errors=True
+    )
+
+    assert res.status_code == 404
+    assert Import_Dyscyplin.objects.filter(pk=rec.pk).exists()
+
+
+def test_usun_post_non_member_odmowa(
+    django_app_factory, normal_django_user, transactional_db
+):
+    """Regresja autoryzacji: użytkownik spoza grupy dostaje odmowę."""
+    app = django_app_factory(csrf_checks=False)
+    app = _webtest_login(app, NORMAL_DJANGO_USER_LOGIN, NORMAL_DJANGO_USER_PASSWORD)
+    rec = baker.make(Import_Dyscyplin, owner=normal_django_user)
+
+    res = app.post(reverse("import_dyscyplin:usun", args=(rec.pk,)), expect_errors=True)
+
+    assert res.status_code in (302, 403)
+    assert Import_Dyscyplin.objects.filter(pk=rec.pk).exists()
+
+
+# ---------------------------------------------------------------------------
+# Uruchamianie zadań Celery (UruchomZadaniePrzetwarzania i podklasy)
+# ---------------------------------------------------------------------------
+
+
+def _przygotuj_do_przetwarzania(app, plik):
+    wyslij(app, plik)
+    i = Import_Dyscyplin.objects.first()
+    i.stworz_kolumny()
+    i.zatwierdz_kolumny()
+    i.save()
+    return i
+
+
+def test_przetwarzaj_get_nie_uruchamia(csrf_exempt_wd_app, test1_xlsx, mocker):
+    """GET na endpoint uruchamiający zadanie NIE uruchamia go (405)."""
+    i = _przygotuj_do_przetwarzania(csrf_exempt_wd_app, test1_xlsx)
+    mock = mocker.patch.object(przeanalizuj_import_dyscyplin, "apply_async")
+
+    res = csrf_exempt_wd_app.get(
+        reverse("import_dyscyplin:przetwarzaj", args=(i.pk,)), expect_errors=True
+    )
+
+    assert res.status_code == 405
+    i = Import_Dyscyplin.objects.get(pk=i.pk)
+    assert not i.task_id
+    mock.assert_not_called()
+
+
+def test_przetwarzaj_post_uruchamia(
+    csrf_exempt_wd_app, test1_xlsx, mocker, django_capture_on_commit_callbacks
+):
+    """POST (z CSRF) uruchamia zadanie Celery jak dawniej."""
+    i = _przygotuj_do_przetwarzania(csrf_exempt_wd_app, test1_xlsx)
+    mock = mocker.patch.object(przeanalizuj_import_dyscyplin, "apply_async")
+
+    with django_capture_on_commit_callbacks(execute=True):
+        res = csrf_exempt_wd_app.post(
+            reverse("import_dyscyplin:przetwarzaj", args=(i.pk,))
+        )
+
+    assert res.json["status"] == "ok"
+    i = Import_Dyscyplin.objects.get(pk=i.pk)
+    assert i.task_id
+    mock.assert_called_once()

--- a/src/import_dyscyplin/tests/test_views.py
+++ b/src/import_dyscyplin/tests/test_views.py
@@ -59,23 +59,25 @@ def test_ListImport_Dyscyplin(wd_app, test1_xlsx):
     assert ".xlsx" in res.testbody
 
 
-def test_UruchomPrzetwarzanieImport_Dyscyplin(wd_app, test1_xlsx):
-    wyslij(wd_app, test1_xlsx)
+def test_UruchomPrzetwarzanieImport_Dyscyplin(csrf_exempt_wd_app, test1_xlsx):
+    wyslij(csrf_exempt_wd_app, test1_xlsx)
 
     i = Import_Dyscyplin.objects.all().first()
     i.stworz_kolumny()
     i.zatwierdz_kolumny()
     i.save()
 
-    g = wd_app.get(reverse("import_dyscyplin:przetwarzaj", args=(i.pk,)))
+    g = csrf_exempt_wd_app.post(reverse("import_dyscyplin:przetwarzaj", args=(i.pk,)))
     assert g.json["status"] == "ok"
 
 
-def test_UsunImport_Dyscyplin(wd_app, test1_xlsx, transactional_db):
-    wyslij(wd_app, test1_xlsx)
+def test_UsunImport_Dyscyplin(csrf_exempt_wd_app, test1_xlsx, transactional_db):
+    wyslij(csrf_exempt_wd_app, test1_xlsx)
     assert Import_Dyscyplin.objects.all().count() == 1
     i = Import_Dyscyplin.objects.all().first()
-    g = wd_app.get(reverse("import_dyscyplin:usun", args=(i.pk,))).maybe_follow()
+    g = csrf_exempt_wd_app.post(
+        reverse("import_dyscyplin:usun", args=(i.pk,))
+    ).maybe_follow()
     assert "Brak informacji o importowanych" in g.testbody
     assert Import_Dyscyplin.objects.all().count() == 0
 
@@ -113,12 +115,12 @@ def test_API_Zintegrowane(wd_app, test1_xlsx):
 
 
 def test_UruchomIntegracjeImport_DyscyplinView(
-    wd_app, wprowadzanie_danych_user, test1_xlsx
+    csrf_exempt_wd_app, wprowadzanie_danych_user, test1_xlsx
 ):
-    i = wyslij_i_przeanalizuj(wd_app, test1_xlsx)
+    i = wyslij_i_przeanalizuj(csrf_exempt_wd_app, test1_xlsx)
     i.integruj_dyscypliny()
     i.owner = wprowadzanie_danych_user
     i.save()
 
-    res = wd_app.get(reverse("import_dyscyplin:integruj", args=(i.pk,)))
+    res = csrf_exempt_wd_app.post(reverse("import_dyscyplin:integruj", args=(i.pk,)))
     assert res.json["status"] == "ok"

--- a/src/import_dyscyplin/views.py
+++ b/src/import_dyscyplin/views.py
@@ -114,11 +114,14 @@ class UruchomZadaniePrzetwarzania(
     model = Import_Dyscyplin
     task = None
     stan = None
+    # Uruchomienie zadania Celery mutuje stan (skutek uboczny) — tylko POST,
+    # nigdy GET (prefetch przeglądarki / skanery / brak ochrony CSRF).
+    http_method_names = ["post", "options"]
 
     def get_queryset(self):
         return super(TylkoMojeMixin, self).get_queryset().filter(stan=self.stan)
 
-    def get(self, *args, **kw):
+    def post(self, *args, **kw):
         self.object = self.get_object()
 
         start_task = False
@@ -166,19 +169,20 @@ class UsunImport_Dyscyplin(
     WprowadzanieDanychRequiredMixin, TylkoMojeMixin, BaseDeleteView
 ):
     success_url = reverse_lazy("import_dyscyplin:index")
+    # Usuwanie jest nieodwracalne — tylko POST + CSRF, nigdy GET.
+    http_method_names = ["post", "options"]
 
-    def delete(self, request, *args, **kwargs):
-        self.object = self.get_object()
+    def form_valid(self, form):
+        # Nazwę pliku zapamiętujemy PRZED usunięciem obiektu z bazy.
+        plik_name = self.object.plik.name
         transaction.on_commit(
             lambda: messages.add_message(
                 self.request,
                 messages.INFO,
-                f'Plik importu dyscyplin "{self.object.plik.name}" został usunięty.',
+                f'Plik importu dyscyplin "{plik_name}" został usunięty.',
             )
         )
-        return super().delete(request, *args, **kwargs)
-
-    get = delete
+        return super().form_valid(form)
 
 
 class API_Do_IntegracjiView(


### PR DESCRIPTION
## Problem (unsafe GET → zmiana stanu)

Widoki w `src/import_dyscyplin/views.py` obsługiwały akcje mutujące stan przez **GET**:

- `UsunImport_Dyscyplin` miał `get = delete` → GET na `api/usun/<pk>/` kasował `Import_Dyscyplin`.
- `UruchomZadaniePrzetwarzania.get()` (podklasy: `stworz_kolumny`, `przetwarzaj`, `integruj`) robił `transaction.on_commit(... apply_async(...))` → GET uruchamiał zadania Celery.

GET-mutacje są podatne na prefetch przeglądarki, skanery i nie mają ochrony CSRF. Guard autoryzacji (`GroupRequiredMixin` + `TylkoMojeMixin`) ograniczał impact do własnych rekordów usera, ale mutacje na GET należało zlikwidować.

## Fix (widoki + szablony)

**Widoki:**
- `UsunImport_Dyscyplin`: usunięto `get = delete`; kasowanie realizowane przez `form_valid` (idiomatyczne dla Django 5.2 `BaseDeleteView`), `http_method_names = ["post", "options"]` → GET zwraca 405.
- `UruchomZadaniePrzetwarzania`: logika przeniesiona z `get()` do `post()`; `http_method_names = ["post", "options"]`. Zachowana idempotencja i `transaction.on_commit`.

**Szablon `import_dyscyplin_detail.html` (wyzwalacze GET → POST):**
- Przycisk „usuń plik": `<button data-redirect-url>` (nawigacja GET) → formularz `<form method="post">` z `{% csrf_token %}` i przyciskiem submit (Foundation Icons + potwierdzenie `data-confirm` zachowane).
- AJAX `stworz_kolumny`, `przetwarzaj`, `integruj`: `method: "GET"` → `method: "POST"` + nagłówek `X-CSRFToken`.
- Usunięto martwy handler `data-redirect-url`.

**Autoryzacja bez zmian:** `GroupRequiredMixin`/`WprowadzanieDanychRequiredMixin` + `TylkoMojeMixin` zachowane.

## Zakres / testy

Nowy `src/import_dyscyplin/tests/test_get_mutation_security.py`:
- GET na usuwanie → 405, rekord istnieje; POST → kasuje.
- GET na uruchamianie zadania → 405, task nie startuje; POST → startuje (mock `apply_async`).
- Regresja autoryzacji: cudzy rekord → 404 (`TylkoMojeMixin`); nie-członek grupy → odmowa.

Istniejące testy (`test_UsunImport_Dyscyplin`, `test_UruchomPrzetwarzanieImport_Dyscyplin`, `test_UruchomIntegracjeImport_DyscyplinView`) zaktualizowane z GET na POST.

Cała suita `src/import_dyscyplin/`: 36 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)