### PR TITLE
security(importer): pin połączenia do zweryfikowanego IP + limit body (SSRF/DoS)

### DIFF
--- a/src/bpp/newsfragments/importer-ssrf-dns-rebinding.bugfix.rst
+++ b/src/bpp/newsfragments/importer-ssrf-dns-rebinding.bugfix.rst
@@ -1,0 +1,1 @@
+Importer publikacji: pobieranie URL od użytkownika (WWW/DSpace/Omega-PSIR) pinuje połączenie do zweryfikowanego adresu IP (zamknięcie okna na DNS rebinding), nakłada twardy limit rozmiaru pobieranego ciała oraz całkowity budżet czasu na wszystkie przekierowania — utwardzenie przeciw SSRF i wyczerpaniu pamięci.

--- a/src/importer_publikacji/providers/www/network.py
+++ b/src/importer_publikacji/providers/www/network.py
@@ -2,6 +2,9 @@
 
 import ipaddress
 import socket
+import threading
+import time
+from contextlib import contextmanager
 from urllib.parse import urljoin, urlparse
 
 import requests
@@ -13,6 +16,89 @@ FETCH_TIMEOUT = 15
 #: (``allow_redirects=False`` + ponowny ``_host_is_safe``), więc redirect na
 #: adres wewnętrzny nie omija guardu SSRF.
 MAX_REDIRECTS = 5
+
+#: Twardy limit rozmiaru pobieranego ciała (10 MB). ``safe_get`` streamuje
+#: odpowiedź i przerywa po przekroczeniu — bez tego ``resp.text`` ładowałby
+#: całe ciało do pamięci (DoS na pamięć od kontrolowanego serwera).
+MAX_RESPONSE_BYTES = 10 * 1024 * 1024
+
+#: Rozmiar porcji przy streamowaniu ciała.
+_CHUNK = 64 * 1024
+
+#: Całkowity budżet czasu na WSZYSTKIE hopy łącznie (redirecty + pobranie
+#: ciała). ``FETCH_TIMEOUT`` jest per-request; bez tego łańcuch przekierowań
+#: mógłby przeciągać połączenie w nieskończoność (N hopów × timeout).
+TOTAL_DEADLINE = 30
+
+
+# --- Pinowanie DNS (ochrona przed rebindingiem, TOCTOU) -------------------
+#
+# Walidacja rozwiązuje host raz (``_resolve_ips``) i sprawdza ``_ip_is_public``,
+# ale ``requests``/``urllib3`` rozwiązałby nazwę PONOWNIE przy nawiązywaniu
+# połączenia — osobny lookup. Złośliwy DNS z niskim TTL mógłby zwrócić adres
+# publiczny przy walidacji, a loopback/prywatny/``169.254.169.254`` (metadata)
+# przy realnym połączeniu.
+#
+# Pinujemy: zestaw adresów z walidacji jest jedynym, którego używa połączenie.
+# Realizujemy to owijając ``socket.getaddrinfo`` (wołane przez urllib3 w
+# ``create_connection``) w wersję świadomą thread-local mapy host->[IP].
+# Nazwa hosta w URL pozostaje nietknięta, więc SNI (``server_hostname``),
+# walidacja certyfikatu TLS i nagłówek ``Host`` są zachowane — pinujemy tylko
+# warstwę rozwiązywania nazw, nie sam URL.
+
+#: Realny resolver, zachowany przed podmianą. Osobny seam (testy mogą udawać
+#: rebinding, podmieniając to na resolver zwracający adres wewnętrzny).
+_system_getaddrinfo = socket.getaddrinfo
+
+#: Thread-local mapa host->[IP] aktywna tylko w obrębie ``_pin_host``. Dzięki
+#: thread-local pinowanie jednego wątku nie wpływa na równoległe połączenia.
+_pin = threading.local()
+
+_UNSET = object()
+
+
+def _pinning_getaddrinfo(host, *args, **kwargs):
+    """Owijka ``socket.getaddrinfo``: dla hostów pinowanych w tym wątku zwraca
+    rozwiązanie po zweryfikowanym IP (numeryczne — bez sieciowego DNS);
+    pozostałe delegują do realnego resolvera."""
+    pinned = getattr(_pin, "hosts", None)
+    if pinned and host in pinned:
+        results = []
+        for ip in pinned[host]:
+            results.extend(_system_getaddrinfo(ip, *args, **kwargs))
+        return results
+    return _system_getaddrinfo(host, *args, **kwargs)
+
+
+def _install_pinning_resolver():
+    """Zainstaluj owijkę ``socket.getaddrinfo`` raz (idempotentnie)."""
+    current = socket.getaddrinfo
+    if getattr(current, "_bpp_ssrf_pin", False):
+        return
+    _pinning_getaddrinfo._bpp_ssrf_pin = True
+    socket.getaddrinfo = _pinning_getaddrinfo
+
+
+_install_pinning_resolver()
+
+
+@contextmanager
+def _pin_host(hostname: str, ips: list[str]):
+    """Na czas bloku pinuj rozwiązywanie ``hostname`` do ``ips`` (w tym wątku).
+    Zagnieżdżenie i współbieżność są bezpieczne (thread-local + restore)."""
+    hosts = getattr(_pin, "hosts", None)
+    if hosts is None:
+        hosts = {}
+        _pin.hosts = hosts
+    prev = hosts.get(hostname, _UNSET)
+    hosts[hostname] = ips
+    try:
+        yield
+    finally:
+        if prev is _UNSET:
+            hosts.pop(hostname, None)
+        else:
+            hosts[hostname] = prev
 
 
 def _resolve_ips(hostname: str) -> list[str]:
@@ -42,30 +128,44 @@ def _ip_is_public(ip: ipaddress._BaseAddress) -> bool:
     )
 
 
-def _host_is_safe(hostname: str | None) -> bool:
-    """True tylko gdy KAŻDY adres, na który rozwiązuje się host, jest publiczny.
+def _safe_resolve(hostname: str | None) -> list[str] | None:
+    """Rozwiąż host i zwróć listę adresów IP — ale TYLKO gdy każdy z nich jest
+    publiczny; inaczej ``None`` (fail-closed).
+
+    Zwrócony zestaw służy podwójnie: jako decyzja („wolno pobrać") oraz jako
+    zestaw adresów do zapinowania połączenia (ten sam wynik rozwiązywania, bez
+    drugiego lookupu → brak okna na DNS rebinding).
 
     Fail-closed: brak hosta, błąd DNS, brak wyników lub choćby jeden
-    nie-publiczny adres → False (blokujemy). Chroni przed SSRF na loopback,
-    sieci prywatne i endpointy metadata (169.254.169.254), także gdy host
-    to nazwa DNS rozwiązywana do sieci wewnętrznej.
+    nie-publiczny adres → ``None``. Chroni przed SSRF na loopback, sieci
+    prywatne i endpointy metadata (169.254.169.254), także gdy host to nazwa
+    DNS rozwiązywana do sieci wewnętrznej.
     """
     if not hostname:
-        return False
+        return None
     try:
         ips = _resolve_ips(hostname)
     except (socket.gaierror, UnicodeError, ValueError):
-        return False
+        return None
     if not ips:
-        return False
+        return None
     for ip_str in ips:
         try:
             ip = ipaddress.ip_address(ip_str)
         except ValueError:
-            return False
+            return None
         if not _ip_is_public(ip):
-            return False
-    return True
+            return None
+    return ips
+
+
+def _host_is_safe(hostname: str | None) -> bool:
+    """True tylko gdy KAŻDY adres, na który rozwiązuje się host, jest publiczny.
+
+    Cienka nakładka na ``_safe_resolve`` (zachowana dla ``_validate_url`` i
+    testów, które sprawdzają samą decyzję bez potrzeby listy adresów).
+    """
+    return _safe_resolve(hostname) is not None
 
 
 def safe_get(
@@ -82,27 +182,49 @@ def safe_get(
     schemat inny niż http/https, błąd sieci, odpowiedź 4xx/5xx albo
     przekroczony limit przekierowań.
 
+    Utwardzenia poza samą walidacją hosta:
+
+    * **pinowanie połączenia** do zweryfikowanego IP (zestaw z ``_safe_resolve``
+      jest jedynym, jaki widzi połączenie) — zamyka okno na DNS rebinding
+      (TOCTOU) między walidacją a realnym ``getaddrinfo`` urllib3;
+    * **twardy limit rozmiaru ciała** (``MAX_RESPONSE_BYTES``) — streamujemy i
+      przerywamy po przekroczeniu (DoS na pamięć);
+    * **całkowity deadline** (``TOTAL_DEADLINE``) na wszystkie hopy łącznie,
+      obok per-request ``timeout``.
+
     Wspólny bezpieczny klient dla wszystkich providerów pobierających URL od
     użytkownika (WWW, DSpace, Omega-PSIR) — ochrona nie rozjeżdża się
     per-provider.
     """
     current = url
+    deadline = time.monotonic() + TOTAL_DEADLINE
     try:
         for _ in range(MAX_REDIRECTS + 1):
             parsed = urlparse(current)
             if parsed.scheme not in ("http", "https"):
                 return None
-            if not _host_is_safe(parsed.hostname):
+            ips = _safe_resolve(parsed.hostname)
+            if ips is None:
                 return None
 
-            resp = requests.get(
-                current,
-                timeout=timeout,
-                allow_redirects=False,
-                headers=headers,
-            )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            hop_timeout = min(timeout, remaining)
+
+            # Pin obejmuje moment nawiązania połączenia (getaddrinfo urllib3).
+            # Ciało czytamy już po connect — nie wymaga aktywnego pinu.
+            with _pin_host(parsed.hostname, ips):
+                resp = requests.get(
+                    current,
+                    timeout=hop_timeout,
+                    allow_redirects=False,
+                    headers=headers,
+                    stream=True,
+                )
 
             if 300 <= resp.status_code < 400:
+                resp.close()
                 location = resp.headers.get("Location")
                 if not location:
                     return None
@@ -110,11 +232,51 @@ def safe_get(
                 continue
 
             resp.raise_for_status()
+            if not _read_capped_body(resp, deadline):
+                return None
             return resp
     except requests.RequestException:
         return None
     # Wyczerpaliśmy limit przekierowań bez finalnej odpowiedzi.
     return None
+
+
+def _read_capped_body(
+    resp: requests.Response,
+    deadline: float,
+) -> bool:
+    """Wczytaj ciało odpowiedzi z twardym limitem rozmiaru i deadline'em.
+
+    Materializuje ``resp._content`` (żeby ``resp.text``/``resp.json()`` działały
+    mimo ``stream=True``). Zwraca ``True`` przy sukcesie; ``False`` gdy ciało
+    przekracza ``MAX_RESPONSE_BYTES`` albo deadline — wtedy zamyka ``resp``.
+    """
+    declared = resp.headers.get("Content-Length")
+    if declared is not None:
+        try:
+            if int(declared) > MAX_RESPONSE_BYTES:
+                resp.close()
+                return False
+        except ValueError:
+            pass  # nagłówek śmieciowy — polegamy na twardym limicie niżej
+    chunks = bytearray()
+    try:
+        for chunk in resp.iter_content(_CHUNK):
+            if not chunk:
+                continue
+            chunks += chunk
+            if len(chunks) > MAX_RESPONSE_BYTES:
+                resp.close()
+                return False
+            if time.monotonic() > deadline:
+                resp.close()
+                return False
+    except requests.RequestException:
+        resp.close()
+        return False
+    resp._content = bytes(chunks)
+    resp._content_consumed = True
+    return True
 
 
 def _fetch_page(

--- a/src/importer_publikacji/tests/_dspace_provider_samples.py
+++ b/src/importer_publikacji/tests/_dspace_provider_samples.py
@@ -4,6 +4,7 @@ Shared between ``test_dspace_provider*.py`` modules. Not a pytest module
 (leading underscore + no ``test_`` prefix) — pytest won't collect it.
 """
 
+import json
 from unittest.mock import MagicMock
 
 SAMPLE_UUID = "276895f0-2d8a-4d99-8e45-8c9bc891da24"
@@ -128,6 +129,11 @@ def _mock_response(json_data, status_code=200):
     resp = MagicMock()
     resp.json.return_value = json_data
     resp.status_code = status_code
+    resp.headers = {}
+    # ``safe_get`` streamuje ciało i limituje rozmiar — dostarcz je jako
+    # ``iter_content`` (treść nieistotna dla asercji, liczy się ``.json()``).
+    body = json.dumps(json_data).encode("utf-8")
+    resp.iter_content = lambda chunk_size=1: iter([body])
     resp.raise_for_status = MagicMock()
     if status_code >= 400:
         resp.raise_for_status.side_effect = __import__(

--- a/src/importer_publikacji/tests/_www_provider_samples.py
+++ b/src/importer_publikacji/tests/_www_provider_samples.py
@@ -160,6 +160,12 @@ def _mock_response(text="", status_code=200, json_data=None):
     resp = MagicMock()
     resp.text = text
     resp.status_code = status_code
+    resp.headers = {}
+    # ``safe_get`` streamuje ciało (stream=True) i wczytuje je przez
+    # ``iter_content`` z limitem rozmiaru — mock musi je dostarczyć.
+    resp.iter_content = lambda chunk_size=1: iter(
+        [text.encode("utf-8")] if text else []
+    )
     resp.raise_for_status = MagicMock()
     if json_data is not None:
         resp.json.return_value = json_data

--- a/src/importer_publikacji/tests/test_dspace_provider_fetch.py
+++ b/src/importer_publikacji/tests/test_dspace_provider_fetch.py
@@ -80,6 +80,7 @@ def test_fetch_dspace7_success(mock_get):
         timeout=15,
         allow_redirects=False,
         headers=None,
+        stream=True,
     )
 
 
@@ -269,6 +270,7 @@ def test_fetch_dspace6_success(mock_get):
         timeout=15,
         allow_redirects=False,
         headers=None,
+        stream=True,
     )
 
 

--- a/src/importer_publikacji/tests/test_dspace_provider_ssrf.py
+++ b/src/importer_publikacji/tests/test_dspace_provider_ssrf.py
@@ -31,6 +31,7 @@ def _benign_get():
     resp.status_code = 200
     resp.headers = {}
     resp.json.return_value = {"metadata": []}
+    resp.iter_content = lambda chunk_size=1: iter([b'{"metadata": []}'])
     return MagicMock(return_value=resp)
 
 

--- a/src/importer_publikacji/tests/test_network_hardening.py
+++ b/src/importer_publikacji/tests/test_network_hardening.py
@@ -1,0 +1,171 @@
+"""Testy utwardzenia ``safe_get`` przeciw SSRF (DNS rebinding) i DoS.
+
+Trzy niezależne wektory zamykane tutaj — poza istniejącym guardem hosta
+(``test_www_provider_ssrf.py``):
+
+1. **DNS rebinding (TOCTOU)** — walidacja rozwiązuje host raz i widzi adres
+   publiczny, ale ``requests``/``urllib3`` rozwiązałby nazwę PONOWNIE przy
+   połączeniu. Kontrolowany DNS z niskim TTL mógłby zwrócić publiczny IP przy
+   walidacji, a loopback/metadata przy realnym połączeniu. Fix pinuje
+   połączenie do zweryfikowanego IP (ten sam zestaw adresów, bez drugiego
+   lookupu), zachowując nazwę hosta dla SNI/Host/walidacji certyfikatu.
+2. **Nielimitowane ciało** — ``resp.text`` ładował całą odpowiedź do pamięci
+   (DoS). Fix streamuje z twardym limitem bajtów.
+3. **Brak całkowitego deadline'u** — ``FETCH_TIMEOUT`` był per-hop. Fix nakłada
+   budżet czasu na wszystkie hopy łącznie.
+"""
+
+import ipaddress
+import json
+import socket
+from unittest.mock import MagicMock
+
+import requests
+
+from importer_publikacji.providers.www import network
+
+
+def _addrinfo(ip: str, port: int):
+    """Zbuduj listę krotek addrinfo dla numerycznego IP (jak realny
+    ``getaddrinfo`` dla literału adresu — bez sieciowego DNS)."""
+    fam = (
+        socket.AF_INET6
+        if isinstance(ipaddress.ip_address(ip), ipaddress.IPv6Address)
+        else socket.AF_INET
+    )
+    sockaddr = (ip, port) if fam == socket.AF_INET else (ip, port, 0, 0)
+    return [(fam, socket.SOCK_STREAM, 6, "", sockaddr)]
+
+
+class _FakeResp:
+    """Minimalna namiastka ``requests.Response`` w trybie ``stream=True``."""
+
+    def __init__(self, *, status_code=200, headers=None, chunks=()):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._chunks = list(chunks)
+        self.closed = False
+        self._content = None
+
+    def iter_content(self, chunk_size=1):
+        yield from self._chunks
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(response=self)
+
+    def close(self):
+        self.closed = True
+
+    @property
+    def text(self):
+        return (self._content or b"").decode("utf-8", "replace")
+
+    def json(self):
+        return json.loads(self._content or b"null")
+
+
+# --- 1. DNS rebinding -----------------------------------------------------
+
+
+def test_pin_host_overrides_system_resolution():
+    """W obrębie ``_pin_host`` wrapper ``socket.getaddrinfo`` zwraca pinowany
+    adres nawet gdyby systemowy resolver zwrócił coś innego (rebinding)."""
+    with network._pin_host("evil.example.com", ["93.184.216.34"]):
+        infos = socket.getaddrinfo("evil.example.com", 443)
+    assert infos[0][4][0] == "93.184.216.34"
+    # Poza kontekstem pin znika (nie przecieka na inne wywołania).
+    assert getattr(network._pin, "hosts", None) in (None, {})
+
+
+def test_safe_get_pins_connection_to_validated_ip(monkeypatch):
+    """Walidacja widzi publiczny IP; systemowy resolver (użyty przy realnym
+    połączeniu) udaje rebinding na loopback. ``safe_get`` MUSI połączyć się z
+    zweryfikowanym IP, nie z podmienionym."""
+    host = "rebind.example.com"
+    validated = "93.184.216.34"
+
+    monkeypatch.setattr(network, "_resolve_ips", lambda h: [validated])
+
+    def _rebinding_system(h, *a, **k):
+        port = a[0] if a else 0
+        try:
+            ipaddress.ip_address(h)  # literał IP → zwróć bez zmian
+            return _addrinfo(h, port or 0)
+        except ValueError:
+            return _addrinfo("127.0.0.1", port or 0)  # nazwa → rebinding
+
+    monkeypatch.setattr(network, "_system_getaddrinfo", _rebinding_system)
+
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        # Symuluj to, co urllib3 robi przy connect: rozwiąż host przez
+        # (owinięty) socket.getaddrinfo i zapamiętaj docelowy adres.
+        infos = socket.getaddrinfo("rebind.example.com", 443)
+        captured["ip"] = infos[0][4][0]
+        return _FakeResp(chunks=[b"<html><title>ok</title></html>"])
+
+    monkeypatch.setattr(network.requests, "get", fake_get)
+
+    network.safe_get(f"https://{host}/x")
+    assert captured["ip"] == validated  # pinowane, NIE 127.0.0.1
+
+
+# --- 2. Twardy limit rozmiaru ciała --------------------------------------
+
+
+def test_safe_get_aborts_on_oversized_body(monkeypatch):
+    monkeypatch.setattr(network, "_resolve_ips", lambda h: ["93.184.216.34"])
+    monkeypatch.setattr(network, "MAX_RESPONSE_BYTES", 50)
+
+    resp = _FakeResp(chunks=[b"x" * 30, b"x" * 30])  # 60 B > 50 B
+    monkeypatch.setattr(network.requests, "get", lambda *a, **k: resp)
+
+    assert network.safe_get("https://example.com/big") is None
+    assert resp.closed
+
+
+def test_safe_get_aborts_on_declared_oversized_content_length(monkeypatch):
+    monkeypatch.setattr(network, "_resolve_ips", lambda h: ["93.184.216.34"])
+    monkeypatch.setattr(network, "MAX_RESPONSE_BYTES", 50)
+
+    resp = _FakeResp(
+        headers={"Content-Length": "1000000"},
+        chunks=[b"x"],  # nie powinno być nawet czytane
+    )
+    monkeypatch.setattr(network.requests, "get", lambda *a, **k: resp)
+
+    assert network.safe_get("https://example.com/big") is None
+    assert resp.closed
+
+
+# --- 3. Całkowity deadline ------------------------------------------------
+
+
+def test_safe_get_enforces_total_deadline(monkeypatch):
+    monkeypatch.setattr(network, "_resolve_ips", lambda h: ["93.184.216.34"])
+    monkeypatch.setattr(network, "TOTAL_DEADLINE", 0)  # budżet z góry wyczerpany
+
+    get = MagicMock(return_value=_FakeResp(chunks=[b"ok"]))
+    monkeypatch.setattr(network.requests, "get", get)
+
+    assert network.safe_get("https://example.com/") is None
+    get.assert_not_called()
+
+
+# --- Regresja: legalne pobranie nadal działa ------------------------------
+
+
+def test_safe_get_returns_capped_body_for_public_host(monkeypatch):
+    monkeypatch.setattr(network, "_resolve_ips", lambda h: ["93.184.216.34"])
+
+    body = b"<html><head><title>ok</title></head><body>hej</body></html>"
+    resp = _FakeResp(chunks=[body[:10], body[10:]])
+    monkeypatch.setattr(network.requests, "get", lambda *a, **k: resp)
+
+    got = network.safe_get("https://example.com/ok")
+    assert got is resp
+    assert got._content == body
+    assert got.text == body.decode("utf-8")
+    assert not resp.closed

--- a/src/importer_publikacji/tests/test_omega_psir_ssrf.py
+++ b/src/importer_publikacji/tests/test_omega_psir_ssrf.py
@@ -47,6 +47,7 @@ def test_omega_psir_fetch_allows_public_host(monkeypatch):
     resp.status_code = 200
     resp.headers = {}
     resp.json.return_value = []
+    resp.iter_content = lambda chunk_size=1: iter([b"[]"])
     get = MagicMock(return_value=resp)
     monkeypatch.setattr(network.requests, "get", get)
 


### PR DESCRIPTION
## Wektor

`importer_publikacji.providers.www.network.safe_get` to wspólny bezpieczny klient dla providerów pobierających URL podany przez zalogowanego operatora (grupa `GR_WPROWADZANIE_DANYCH`): WWW, DSpace, Omega-PSIR.

Walidacja hosta rozwiązywała DNS raz (`_resolve_ips` → `getaddrinfo`) i sprawdzała `_ip_is_public`. Następnie OSOBNO wołała `requests.get(...)`, a requests/urllib3 rozwiązywał nazwę **ponownie** przy nawiązywaniu połączenia. To okno **DNS rebinding (TOCTOU)**: kontrolowany DNS z niskim TTL zwraca publiczny IP przy walidacji, a `127.0.0.1` / adres prywatny / `169.254.169.254` (metadata cloud) przy realnym połączeniu — omijając cały guard SSRF.

Dodatkowo: `resp.text` ładował całe ciało bez limitu (**DoS pamięci** od kontrolowanego serwera), a `FETCH_TIMEOUT=15` był per-hop bez **całkowitego deadline'u** (łańcuch przekierowań mógł przeciągać połączenie).

## Fix

1. **Pinowanie połączenia do zweryfikowanego IP** — `_safe_resolve` rozwiązuje host raz i zwraca zestaw IP tylko gdy wszystkie publiczne. Ten sam zestaw pinuje połączenie: owijka `socket.getaddrinfo` (thread-local mapa host→[IP], instalowana raz przy imporcie) sprawia, że urllib3 przy `create_connection` nie robi drugiego lookupu, tylko łączy się z zweryfikowanym adresem. Brak drugiego rozwiązania = brak okna na rebinding.
2. **Twardy limit rozmiaru** — `stream=True` + `iter_content` z capem `MAX_RESPONSE_BYTES` (10 MB), abort po przekroczeniu; dodatkowo szybkie odrzucenie po zadeklarowanym `Content-Length`. Ciało materializowane w `resp._content`, więc `resp.text`/`resp.json()` działają jak dotąd.
3. **Całkowity deadline** — `TOTAL_DEADLINE` (30 s) na wszystkie hopy łącznie; per-hop timeout = `min(timeout, pozostały_budżet)`.

Nietknięta zostaje działająca re-walidacja redirectów (`allow_redirects=False`, per-hop `_safe_resolve`, `MAX_REDIRECTS=5`).

## TLS SNI przy pinowaniu po IP (najtrudniejszy punkt)

Zamiast podmieniać host w URL na IP (co zepsułoby SNI, walidację certyfikatu i nagłówek `Host`), pinowanie działa **wyłącznie na warstwie rozwiązywania nazw**: URL zachowuje oryginalną nazwę hosta, a przechwycony `socket.getaddrinfo` zwraca dla tej nazwy zweryfikowany numeryczny IP. Ponieważ urllib3 buduje `HTTPSConnection` z nazwą hosta (nie IP), **SNI (`server_hostname`), walidacja certyfikatu TLS i nagłówek `Host` pozostają poprawne** — do właściwego hosta, po zweryfikowanym adresie. To najczystszy wariant pod kątem TLS: nic w połączeniu poza docelowym adresem gniazda się nie zmienia.

Wybór owijki `getaddrinfo` (zamiast własnego `HTTPAdapter`/`Session`) był też podyktowany zgodnością z istniejącym wzorcem testów, które mockują `requests.get` jako punkt wywołania — adapter/Session przesunąłby ten seam i zepsuł całą istniejącą suitę SSRF/fetch.

## Testy

Nowy `test_network_hardening.py`: pin nadpisuje systemowe rozwiązywanie; `safe_get` pinuje połączenie do zweryfikowanego IP mimo symulowanego rebindingu na loopback; abort po przekroczeniu rozmiaru (stream i po `Content-Length`); egzekwowanie całkowitego deadline'u; regresja — legalne pobranie zwraca ograniczone ciało. Istniejące mocki odpowiedzi dostały `iter_content` (nowy kontrakt `stream=True`). Cała suita `importer_publikacji`: 668 passed, 1 skipped.

## Follow-up (nie w tym PR)

- Owijka `getaddrinfo` jest procesowo-globalna (thread-local aktywacja). Rozważyć docelowo dedykowany `HTTPAdapter` z własnym poolem, gdyby pojawiła się potrzeba izolacji na poziomie sesji.
- Pin obejmuje moment `connect`; ewentualny późniejszy re-connect w obrębie odczytu ciała (nie występuje przy pojedynczej odpowiedzi) nie byłby pinowany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)