### PR TITLE
feat(import): synchronizacja dat zatrudnienia (data_od/data_do) + nowy okres

### DIFF
--- a/docs/superpowers/specs/2026-07-13-import-pracownikow-synchronizacja-dat-zatrudnienia-design.md
+++ b/docs/superpowers/specs/2026-07-13-import-pracownikow-synchronizacja-dat-zatrudnienia-design.md
@@ -1,0 +1,651 @@
+# Import pracowników — synchronizacja dat zatrudnienia (`data_od` / `data_do`)
+
+**Data:** 2026-07-13
+**Moduł:** `src/import_pracownikow/`
+**Bazuje na:** `origin/dev` po scaleniu PR #559 (dwuwierszowa karta rekordu +
+rejestr `POLA_ROZNIC` / `stany_pol_snapshot`).
+**Review:** przeszedł review Fable (2026-07-13) — poprawki naniesione (analyze.py,
+N+1, sygnał świeżego AJ, `MultipleObjectsReturned`, czerwone testy).
+
+---
+
+## 1. Kontekst i cel
+
+Plik importu pracowników niesie dwie kolumny dat zatrudnienia:
+
+| Kolumna w pliku | Klucz znormalizowany | Pole `Autor_Jednostka` | Znaczenie |
+|---|---|---|---|
+| „Data zatrudnienia" | `data_zatrudnienia` | `rozpoczal_prace` | data **od** |
+| „Data końca zatrudnienia" | `data_końca_zatrudnienia` | `zakonczyl_prace` | data **do** |
+
+Daty **już** się synchronizują w integracji (`_integruj_daty_aj`), ale:
+
+1. **są niewidoczne** — porównywarka „plik vs baza" (karta rekordu, §9)
+   pokazuje e-mail / tytuł / stopień / funkcję / stanowisko, ale **nie daty**;
+2. **różnica daty od jest cicho ignorowana** — `_check_autor_jednostka_needs_update`
+   reaguje na „data od" tylko gdy baza ma `NULL`; gdy plik niesie **inną** datę
+   od niż baza, operator tego **nie widzi**;
+3. **brak semantyki okresu** — różna data od to (wg `unique_together`) inny
+   rekord zatrudnienia, ale import traktuje `(autor, jednostka)` jako jeden AJ.
+
+**Cel:** uwidocznić obie daty w porównywarce i domknąć logikę synchronizacji
+wokół pojęcia **okresu zatrudnienia identyfikowanego przez „data od"**, wraz z
+tworzeniem **nowego okresu** (nowy `Autor_Jednostka`), gdy plik niesie inną
+datę od niż baza.
+
+---
+
+## 2. Model semantyczny — „data od" = tożsamość okresu
+
+`Autor_Jednostka` ma `unique_together = (autor, jednostka, rozpoczal_prace)`.
+Zatem **okres zatrudnienia** jest jednoznacznie identyfikowany trójką
+`(autor, jednostka, rozpoczal_prace)`. Wartość „data od" z pliku wybiera, o
+**który okres** chodzi:
+
+- ta sama „data od" → ten sam okres → synchronizujemy do niego „data do";
+- inna „data od" → inny (nowy) okres → tworzymy nowy `Autor_Jednostka`.
+
+To spłaca istniejący dług: dwie ścieżki wyboru AJ zakładają **jeden** AJ na parę
+`(autor, jednostka)`:
+
+- `pewnosc.odtworz_autor_jednostka` — `AJ.filter(autor, jednostka).first()`
+  (naiwny `.first()`);
+- `analyze._wybierz_autor_jednostka` — już **deterministyczny** (aktywny →
+  najświeższy `rozpoczal`, #508 F6), ale nadal ignoruje `plik_od`.
+
+Po zmianie obie ścieżki idą przez **jeden resolver** (§7), który przy „data od"
+z wartością rozstrzyga po **pełnym** kluczu unikalności, a przy pustej „data od"
+zachowuje deterministyczny wybór aktywny→najświeższy (absorbuje semantykę
+`_wybierz_autor_jednostka`).
+
+**Uwaga o `rozpoczal_prace = NULL`:** Postgres traktuje `NULL`-e jako **różne** w
+unikalnym indeksie, a Django pomija walidację `unique_together`, gdy któraś
+wartość jest `None`. Dwa AJ `(A, J, NULL)` mogą więc legalnie istnieć (dane z
+admina / legacy). Dlatego **nie** twierdzimy „pełny klucz nie trafi na >1
+wiersz" dla `None` — lookup po `rozpoczal_prace=None` używa
+`order_by("pk").first()` zamiast `get_or_create` (§8.3), a przy tworzeniu
+nowego AJ z pustym `plik_od` od razu stemplujemy fallback (konkretna data,
+nie `NULL`), więc `None` w kluczu tworzonego rekordu nie występuje.
+
+---
+
+## 3. Tabela decyzyjna — „data od"
+
+Dla wiersza: autor **A**, jednostka **J**, `plik_od` (wartość / puste),
+`plik_do` (wartość / puste). „Puste `plik_od`" = kolumny nie ma w pliku **lub**
+komórka w tym wierszu jest pusta (rozróżnienie nieistotne — patrz §5).
+
+| Stan bazy dla (A, J) | `plik_od` | Akcja na „data od" | Cel |
+|---|---|---|---|
+| brak AJ | wartość | utwórz AJ z `rozpoczal = plik_od` | **NOWY** |
+| brak AJ | puste | utwórz AJ z `rozpoczal =` (fallback: data zmian → dziś) | **NOWY** |
+| AJ istnieje, `rozpoczal = plik_od` | wartość | bez zmian (ten sam okres) | istniejący |
+| AJ istnieje, `rozpoczal = NULL` | wartość | **wypełnij** `plik_od` (to samo, niedatowane) | istniejący |
+| AJ istnieje, `rozpoczal ≠ plik_od` | wartość | pokaż różnicę + **utwórz NOWY okres** | **NOWY** |
+| AJ istnieje | puste | **NIC NIE ZMIENIAJ** (`rozpoczal` zostaje jak jest, nawet `NULL`) | istniejący |
+
+### „data do" (`zakonczyl_prace`)
+
+Zawsze w obrębie **docelowego** okresu (wybranego wyżej):
+
+- `plik_do` ma wartość, `cel.zakonczyl` **puste** → **wstaw** `plik_do`;
+- `plik_do` ma wartość, `cel.zakonczyl` ma wartość → **NIE nadpisuj**; różnicę
+  **pokaż** w porównywarce;
+- `plik_do` puste → nic nie zmieniaj.
+
+To zmiana względem obecnego zachowania (dziś „data do" = *nadpisz-gdy-różna*;
+docelowo *wstaw-tylko-gdy-pusta*).
+
+---
+
+## 4. Precedencja daty przy STEMPLOWANIU pustej „data od"
+
+Gdy stemplujemy pustą datę od (nowy AJ, albo istniejący AJ z `NULL` gdy
+`plik_od` ma wartość):
+
+```
+rozpoczal = plik_od  →  parent.data_zmian_personalnych  →  timezone.localdate()  (dziś)
+```
+
+**Bez zmian** względem obecnego kodu. „Data od" z pliku zawsze wygrywa; globalna
+„data zmian personalnych" jest tylko fallbackiem, gdy wiersz nie niesie własnej
+daty; dziś to ostateczność.
+
+---
+
+## 5. Reguła „pustej kolumny / pustej komórki"
+
+Kluczowe doprecyzowanie: **istniejącego AJ nie ruszamy, gdy `plik_od` jest
+puste.** Nie ma znaczenia, czy kolumny „Data zatrudnienia" w pliku nie ma w
+ogóle, czy jest, ale komórka pusta — oba przypadki znaczą „brak informacji o
+dacie od dla tego wiersza" i oba dają **no-op** na istniejącym AJ (nie
+stemplujemy `data zmian`/dziś na istniejącej dacie od, nie tworzymy nowego
+okresu).
+
+Fallback `data zmian → dziś` obowiązuje **wyłącznie** przy **tworzeniu nowego
+AJ** (dopisanie autora do jednostki) — to udokumentowany sens pola „data zmian
+personalnych". Dla istniejącego AJ pusty `plik_od` = zostaw `rozpoczal` bez
+zmian (nawet gdy `NULL`).
+
+**Decyzja P1 (POTWIERDZONA):** dla **nowego** AJ przy pustym `plik_od`
+stosujemy fallback `data zmian → dziś` (nowe zatrudnienie potrzebuje daty
+startu). Reguła „nic nie zmieniaj" dotyczy tylko *istniejących* AJ.
+
+**Realizacja bez dwuznaczności (poprawka Fable):** rozróżnienie „świeży AJ" vs
+„istniejący AJ z NULL" NIE opiera się na sygnale przekazywanym do
+`_integruj_daty_aj` — zamiast tego **fallback stemplujemy w momencie
+materializacji nowego AJ** (`_materializuj_diff`, §8.3). Dzięki temu:
+
+- nowy AJ powstaje **od razu** z konkretną `rozpoczal_prace` (fallback albo
+  `plik_od`), więc `_integruj_daty_aj` widzi już nie-`NULL` i no-opuje na dacie od;
+- `_integruj_daty_aj` obsługuje na „data od" **wyłącznie** przypadek
+  „istniejący AJ, `rozpoczal = NULL`, `plik_od` ma wartość → wypełnij"; brak
+  gałęzi stemplującej fallback na istniejącym AJ (czyli reguła §5 wynika ze
+  struktury kodu, nie z warunku);
+- znika krucha zależność „fallback zadziała tylko, gdy recheck po materializacji
+  odpali `integrate()`".
+
+---
+
+## 6. Dwie decyzje domyślne (POTWIERDZONE)
+
+- **P2 (POTWIERDZONA) — stary okres NIE jest domykany automatycznie.** Gdy
+  powstaje nowy okres (inna data od), stary `Autor_Jednostka` **zostaje otwarty**
+  (bez `zakonczyl_prace`). Auto-domknięcie starego okresu
+  (`zakonczyl = plik_od − 1`) to ryzyko korupcji historii afiliacji — poza
+  zakresem (§14).
+- **P3 (POTWIERDZONA) — nowy okres dziedziczy** funkcję / stanowisko / grupę
+  pracowniczą / wymiar etatu z wiersza i (domyślnie, jak każdy zaimportowany
+  wiersz) staje się **podstawowym miejscem pracy** — realizowane nie przez
+  `defaults` `get_or_create`, tylko przez istniejącą ścieżkę
+  recheck → `_integrate_autor_jednostka` (świeży AJ ma `podstawowe = None`, co
+  wyzwala recheck; ta ścieżka ustawia P3-pola i primary). Bez dublowania logiki.
+
+---
+
+## 7. Resolver okresu — jedno źródło prawdy (+ wydajność)
+
+Nowa funkcja (proponowana lokalizacja: `pewnosc.py`, obok
+`odtworz_autor_jednostka`, albo nowy `okresy.py`):
+
+```
+rozwiaz_okres_zatrudnienia(autor, jednostka, plik_od, *, aj_lista=None) ->
+    ("istniejacy", aj)               # dopasowany / niedatowany do wypełnienia
+    | ("nowy", rozpoczal_prace|None) # utwórz nowy AJ z tą datą od (lub fallback)
+```
+
+**Jedno zapytanie (poprawka N+1 od Fable):** resolver pobiera listę okresów
+`(A, J)` JEDNYM zapytaniem i rozstrzyga w Pythonie:
+
+```
+aj_lista = list(Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka))
+```
+
+Wołający, który już ma listę (albo prefetch z widoku), przekazuje ją przez
+`aj_lista=` — resolver wtedy nie odpytuje bazy. Reguła (odpowiada tabeli §3):
+
+```
+jeśli plik_od ma wartość:
+    exact = [aj for aj in aj_lista if aj.rozpoczal_prace == plik_od]  # ≤1 (unique)
+    jeśli exact:                      -> ("istniejacy", exact[0])       # ten sam okres
+    inaczej niedat = [aj for aj in aj_lista if aj.rozpoczal_prace is None]
+        posortowane po pk            # determinizm przy >1 NULL (legacy)
+        jeśli niedat:                 -> ("istniejacy", niedat[0])      # wypełnij plik_od
+        inaczej:                      -> ("nowy", plik_od)              # NOWY okres
+jeśli plik_od puste:
+    aj = _wybierz_aktywny_najswiezszy(aj_lista)   # aktywny (zakonczyl IS NULL),
+                                                  # remis → najświeższy rozpoczal
+    jeśli aj:                         -> ("istniejacy", aj)             # NIE ruszaj daty od
+    inaczej:                          -> ("nowy", None)                 # fallback data zmian → dziś
+```
+
+**Współdzielony wybór aktywny→najświeższy.** Gałąź „puste `plik_od`" absorbuje
+semantykę `analyze._wybierz_autor_jednostka` (#508 F6). Wydzielamy **czystą**
+funkcję `_wybierz_aktywny_najswiezszy(aj_lista)` (operuje na już pobranej
+liście, zero zapytań); `_wybierz_autor_jednostka` **deleguje** do niej (albo
+staje się cienką owijką pobierającą listę), więc jej testy
+(`test_wybor_autor_jednostka.py`) zostają ważne bez migracji.
+
+> **Klucz sortowania — parytet z SQL (poprawka N2).** Dziś
+> `_wybierz_autor_jednostka` sortuje w SQL `order_by("-rozpoczal_prace")`, a
+> Postgres przy `DESC` daje **NULLS FIRST** → AJ z `rozpoczal = NULL` jest
+> traktowany jako „najświeższy". Czysta funkcja MUSI zachować ten parytet:
+> naiwne `max`/`sorted(key=rozpoczal_prace)` rzuci `TypeError` przy `None`.
+> Klucz: `key=lambda aj: (aj.zakonczyl_prace is None, aj.rozpoczal_prace is
+> None, aj.rozpoczal_prace or date.min, aj.pk)` z `reverse` na odpowiednich
+> osiach — tj. najpierw aktywny (`zakonczyl IS NULL`), potem `rozpoczal = NULL`
+> jako największe, potem najświeższy `rozpoczal`, a na końcu **tie-break po
+> `pk`** (SQL dziś go NIE gwarantuje → i tak wzmacniamy determinizm).
+
+> **Kontrakt typu `plik_od` (poprawka N5).** Resolver przyjmuje **wyłącznie**
+> `date | None`. Gdyby ścieżka podała ISO-string, `aj.rozpoczal_prace ==
+> "2020-01-01"` jest zawsze `False` → **cichy fałszywy „nowy okres" + duplikat
+> AJ**. Helper `_plik_od()` (patrz niżej) zwraca `date|None`, parsując przez
+> `dane_bardziej_znormalizowane` (nie surowe `dane_znormalizowane`). W analizie
+> (§8.1) — źródłem jest już sparsowany `date` z pipeline'u. Test §13: str na
+> wejściu resolvera → asercja braku duplikatu.
+
+**Memoizacja na wierszu (współdzielona podgląd↔integracja).** Wiersz cache'uje
+wynik na instancji:
+
+```
+def _okres(self):
+    if not hasattr(self, "_okres_cache"):
+        self._okres_cache = rozwiaz_okres_zatrudnienia(
+            self.autor, self.jednostka, self._plik_od(),
+            aj_lista=self._aj_lista(),   # jednorazowe filter(autor, jednostka)
+        )
+    return self._okres_cache
+```
+
+gdzie `_plik_od()` zwraca `date|None` z `dane_bardziej_znormalizowane`
+(kontrakt typu wyżej), a `_aj_lista()` robi jednorazowe
+`list(AJ.filter(autor, jednostka))` na instancji.
+
+Zarówno `porownaj_z_baza()` (§9.2), oba ekstraktory `_stan_data_od/_do` (§9.1),
+jak i ścieżki analizy/`odtworz` czytają `_okres()` → **1 zapytanie o AJ /
+wiersz** (zamiast ~6). Opcjonalnie (jeśli profil pokaże, że i to za dużo)
+batch-prefetch w widoku: jedno zapytanie o AJ wszystkich (autor, jednostka)
+strony → mapa wstrzyknięta do wierszy przez `aj_lista=`.
+
+> **Inwalidacja memo przy zmianie autora/jednostki (poprawka N3).** Memo jest
+> spójne dziś tylko dzięki niejawnemu niezmiennikowi „mutacja → `odtworz` →
+> render". Punkty mutacji: `_zwiaz_autora_z_wierszem` (`row.autor = autor`,
+> views.py) i `_podlacz_wiersze_do_jednostek` (`row.jednostka = jed`,
+> integrate.py). Żeby niezmiennik był jawny: te dwa miejsca (oraz gałąź
+> `jednostka_id is None`) **czyszczą `_okres_cache`** przez dedykowany helper
+> (`_zapomnij_okres()`, nie goły `del`), zanim nastąpi ponowny odczyt. Test
+> §13: odczyt `stany_pol()` przed i po zmianie autora daje różną decyzję.
+
+---
+
+## 8. Zmiany per plik/funkcja
+
+### 8.1 `pipeline/analyze.py` — `_przetworz_wiersz` + `_wybierz_autor_jednostka` (GŁÓWNA ścieżka)
+
+To jest **główna** ścieżka przypisania AJ (twardo dopasowana jednostka):
+`_przetworz_wiersz` woła `_wybierz_autor_jednostka` i odkłada
+`diff["autor_jednostka"]` dla nowych powiązań. Pominięcie jej = „nowy okres"
+nigdy nie powstałby w standardowym flow (rozjazd z podglądem — anty-cel).
+
+Zmiana: `_przetworz_wiersz` woła **resolver** zamiast bezpośrednio
+`_wybierz_autor_jednostka`:
+
+- `("istniejacy", aj)` → `row.autor_jednostka = aj` (jak dziś);
+- `("nowy", rozpoczal)` → `row.autor_jednostka = None`, odkłada
+  `diff["autor_jednostka"] = {"autor": …, "jednostka": …,
+  "rozpoczal_prace": rozpoczal_iso_or_None, "nowy_okres": bool}` i ustawia
+  `zmiany_potrzebne = True` (istniejąca gałąź `else` już to robi dla nowych
+  powiązań — rozszerzamy o `rozpoczal_prace` + `nowy_okres`).
+
+`"nowy_okres": True` **tylko** gdy istnieje jakiś AJ dla (A, J) (czyli tworzymy
+DODATKOWY okres obok istniejącego); dla „pierwszego powiązania" (brak
+jakiegokolwiek AJ) → `False` — potrzebne do licznika/opisu (§10).
+
+### 8.2 `pewnosc.py` — `odtworz_autor_jednostka(row, autor)`
+
+Ścieżka poboczna (zmiana autora w podglądzie / nowy autor / odroczona jednostka).
+Zamiast `AJ.filter(autor, jednostka).first()`:
+
+- woła resolver (`plik_od` z `row.dane_bardziej_znormalizowane`);
+- `("istniejacy", aj)` → `row.autor_jednostka = aj`; przelicza `zmiany_potrzebne`
+  jak dziś (`bool(diff) or _check_autor_jednostka_needs_update()`);
+- `("nowy", rozpoczal)` → `row.autor_jednostka = None`, odkłada
+  `diff_do_utworzenia["autor_jednostka"]` (ten sam kształt co §8.1, z
+  `nowy_okres`), `zmiany_potrzebne = True`.
+
+**Guard odroczonej jednostki:** gdy `row.jednostka_id is None` (jednostka
+odroczona/brak) — resolver się NIE woła; zachowanie jak dziś (brak podpięcia AJ).
+
+`rozpoczal_prace` w diffie serializujemy jako ISO-string (JSON-safe) lub `None`.
+
+### 8.3 `integrate.py` — `_materializuj_diff(row) -> created: bool`
+
+Tworzenie AJ po **pełnym** kluczu, z fallbackiem dat i zwrotem `created`:
+
+```
+d = diff["autor_jednostka"]
+rozpoczal = date.fromisoformat(d["rozpoczal_prace"]) if d.get("rozpoczal_prace") else None
+if rozpoczal is None:
+    # nowy AJ, pusty plik_od → fallback (P1): data zmian → dziś
+    rozpoczal = row.parent.data_zmian_personalnych or timezone.localdate()
+# rozpoczal ZAWSZE ma wartość dla nowego AJ (plik_od albo fallback) → brak None w kluczu
+aj = (Autor_Jednostka.objects
+      .filter(autor_id=d["autor"], jednostka_id=d["jednostka"], rozpoczal_prace=rozpoczal)
+      .order_by("pk").first())
+created = aj is None
+if created:
+    aj = Autor_Jednostka.objects.create(
+        autor_id=d["autor"], jednostka_id=d["jednostka"], rozpoczal_prace=rozpoczal,
+        funkcja=row.funkcja_autora, stanowisko=row.stanowisko_dydaktyczne,
+    )
+row.autor_jednostka = aj
+return created
+```
+
+- **Nie** używamy `get_or_create` — `order_by("pk").first()` + jawny `create`
+  jest deterministyczny i eliminuje `MultipleObjectsReturned` (choć przy
+  konkretnej dacie `unique_together` i tak daje ≤1, to jednolita ścieżka).
+- Stemplowanie fallbacku **tu** (nie w `_integruj_daty_aj`) realizuje P1 bez
+  sygnału „świeży AJ" i bez zależności od recheck→integrate (§5).
+- Weryfikacja przy implementacji: ścieżka `row.parent.data_zmian_personalnych`
+  (analogicznie jak dziś `self.parent…` w `_integruj_daty_aj`).
+- **Przewód `created` (poprawka N1):** `_materializuj_diff` zwraca `created`,
+  ale dziś jego jedyny wołający `_integruj_wiersz` zwraca `None`, a pętla
+  `integruj` zwrot ignoruje. Trzeba **przeprowadzić** sygnał: `_integruj_wiersz`
+  zwraca `created` (i `nowy_okres` — patrz §10), a pętla `integruj` je sumuje.
+  Wczesny return na guardzie `log_zmian is not None` (restart) zwraca `False` —
+  licznik liczy tylko pracę bieżącego przebiegu.
+
+### 8.4 `models.py` — `_integruj_daty_aj(aj, dane)`
+
+- **„data od":** stempluj `aj.rozpoczal_prace` **tylko** gdy
+  `aj.rozpoczal_prace is None` **oraz** wiersz niesie datę
+  (`dane.get("data_zatrudnienia")`) — to przypadek „wypełnienie NULL" dla
+  **istniejącego** AJ (§3 wiersz 4). Świeży AJ ma już `rozpoczal` (§8.3), więc
+  ta gałąź go nie dotyczy. Istniejący AJ + pusty `plik_od` → **nie ruszaj**
+  (brak gałęzi — reguła §5). Ten sam okres (`rozpoczal == plik_od`) → równe,
+  brak zmiany.
+- **„data do":** `if plik_do and aj.zakonczyl_prace is None: aj.zakonczyl_prace =
+  plik_do` (wstaw-gdy-pusta). Usuwamy gałąź *nadpisz-gdy-różna*.
+- **Walidacja** `rozpoczal < zakonczyl` (istniejąca w `_integrate_autor_jednostka`,
+  → `BPPDatabaseError`) obejmuje nowe okresy i wstawioną „data do" — bez zmian.
+
+### 8.5 `models.py` — `_check_autor_jednostka_needs_update(dane)`
+
+- **„data od": bez zmian** — obecny warunek („`data_zatrudnienia` niepuste
+  **oraz** `aj.rozpoczal_prace is None`" = wypełnienie NULL) zostaje. Przypadek
+  „nowy okres" NIE potrzebuje tu obsługi: resolver zwraca wtedy `aj = None`
+  (odroczony do utworzenia), a `zmiany_potrzebne` ustawia `bool(diff)` w §8.1/§8.2.
+- **„data do": jedyna zmiana** — z „różni się" na „`plik_do` niepuste **oraz**
+  `aj.zakonczyl_prace is None`" (wstawienie, nie nadpisanie).
+- **Resolvera tu NIE wołamy** (poprawka Fable) — check jest w gorących miejscach
+  (analyze/integrate), nie dokładamy mu zapytań.
+- reszta pól (funkcja/stanowisko/grupa/wymiar/primary) bez zmian.
+
+---
+
+## 9. Warstwa widoczności (rejestr `POLA_ROZNIC` z #559)
+
+### 9.1 `roznice.py` — dwa nowe wpisy
+
+```
+POLA_ROZNIC = [
+    ("jednostka", "Jednostka", _stan_jednostka),
+    ("email", "E-mail", _stan_email),
+    ("tytul", "Tytuł naukowy", _stan_tytul),
+    ("stopien", "Stopień służbowy", _stan_stopien),
+    ("funkcja", "Funkcja w jednostce", _stan_funkcja),
+    ("stanowisko", "Stanowisko dydaktyczne", _stan_stanowisko),
+    ("data_od", "Data od", _stan_data_od),      # NOWE
+    ("data_do", "Data do", _stan_data_do),      # NOWE
+]
+```
+
+Ekstraktory (kontrakt `"zmienione" | "zgodne" | "brak"`); oba czytają
+`row._okres()` (memo, §7) — bez własnych zapytań:
+
+- `_stan_data_od(row)`:
+  - `"brak"` gdy `plik_od` puste **lub** brak dopasowanego autora **lub**
+    `row.jednostka_id is None`;
+  - `"zmienione"` gdy `plik_od` ma wartość i decyzja resolvera to **nowy okres**
+    (`("nowy", …)`) **lub** wypełnienie pustej daty od (`("istniejacy", aj)`,
+    `aj.rozpoczal_prace is None`);
+  - `"zgodne"` w pozostałych (ta sama data od).
+- `_stan_data_do(row)`:
+  - `"brak"` gdy `plik_do` puste **lub** brak autora **lub** `row.jednostka_id
+    is None`;
+  - `"zmienione"` gdy `plik_do` ma wartość i:
+    - dla `("istniejacy", aj)` — różni się od `aj.zakonczyl_prace`
+      (wstawienie pustej **lub** różnica pokazana bez nadpisania), **lub**
+    - dla `("nowy", …)` — zawsze (nowy okres jeszcze nie ma końca → wstawimy);
+  - `"zgodne"` gdy równe.
+
+> Rozstrzygnięcie sprzeczności (Fable): „brak AJ docelowego" dla `_stan_data_do`
+> znaczy **wyłącznie** brak autora/jednostki. Nowy okres z `plik_do` → „zmienione".
+
+> **Świadoma konsekwencja (N4).** Dla wiersza „nowy okres" (`rozpoczal ≠ plik_od`)
+> analiza ustawia `row.autor_jednostka = None`, więc `_stan_funkcja`/`_stan_stanowisko`
+> i `porownaj_z_baza()["funkcja"]/["stanowisko"]` pokażą **„brak" / pustą bazę**
+> (nie ma istniejącego AJ, z którym porównać). To poprawne semantycznie („nowy
+> okres — nie ma z czym porównywać") — zapisane wprost, żeby implementujący NIE
+> „naprawił" tego przypadkowo, podpinając stary AJ.
+
+### 9.2 `models.py` — `porownaj_z_baza()` + `_porownaj_data`
+
+Nowy statyczny helper (analogiczny do `_porownaj_email` / `_porownaj_fk`):
+
+```
+_porownaj_data(plik_date, baza_date, *, nowy_okres=False) ->
+    {"plik": "YYYY-MM-DD"|"", "baza": "YYYY-MM-DD"|"", "rozne": bool, "nowy_okres": bool}
+```
+
+Musi tolerować `str` / `date` / pusty (`porownaj_z_baza` czyta surowe
+`dane_znormalizowane`; §12 pkt 8).
+
+`porownaj_z_baza()` dostaje klucze `"data_od"` i `"data_do"`, wszystko z jednej
+decyzji `row._okres()` (§7):
+
+- `data_od`: `plik = plik_od`; `nowy_okres`/`rozne` z **decyzji resolvera**.
+  Strona `baza`:
+  - `("istniejacy", aj)` → `baza = aj.rozpoczal_prace` (może być pusta, gdy
+    wypełniamy `NULL`);
+  - `("nowy", …)` → `baza` = `rozpoczal_prace` **okresu-referencyjnego**
+    (`_wybierz_aktywny_najswiezszy(aj_lista)`, §7), żeby operator widział
+    „stara → nowa"; gdy AJ (A, J) w ogóle brak → `baza` pusta;
+- `data_do`: `plik = plik_do`; `baza` = `zakonczyl_prace` **docelowego** okresu
+  (`("istniejacy", aj)` → `aj.zakonczyl_prace`; `("nowy", …)` → pusta, nowy
+  okres nie ma jeszcze końca); `rozne` = obie niepuste i różne, **lub** baza
+  pusta a plik niepusty (wstawienie), **lub** nowy okres z niepustym plik_do;
+- **guard:** gdy brak autora lub `row.jednostka_id is None` → obie strony puste,
+  `rozne=False`.
+
+**Jedno źródło prawdy:** o „istniejący vs nowy okres" i o docelowy AJ decyduje
+TEN SAM `row._okres()` co integracja — podgląd nie może „obiecać" innego okresu
+niż utworzy commit. Data `baza` po stronie *wyświetlania* dla nowego okresu to
+tylko kontekst („z jakiego okresu operator patrzy"), nie wpływa na decyzję.
+
+### 9.3 `stany_pol()` — zgodność snapshotów
+
+`stany_pol()` zwraca zamrożony `stany_pol_snapshot` (utrwalony przy integracji,
+przed mutacją — `_integruj_wiersz` / `integrate()` z guardem `is None`).
+Snapshoty rekordów sprzed tego feature'a **nie mają** kluczy `data_od`/`data_do`;
+filtr po nowym polu (≠ „wszystkie") ukryłby taki rekord. Dopełniamy brakujące
+klucze wartością domyślną (lazy import `POLA_ROZNIC` **przed** gałąź snapshotu):
+
+```
+from .roznice import POLA_ROZNIC          # przed if — używane w obu gałęziach
+if self.stany_pol_snapshot is not None:
+    baza = {k: "brak" for k, _e, _x in POLA_ROZNIC}
+    return {**baza, **self.stany_pol_snapshot}
+# ... ścieżka live (snapshot None, faza analizy) — bez zmian
+```
+
+Snapshot `None` (faza analizy) spada do ścieżki live bez zmian. Stare snapshoty
+pod nowym filtrem dają neutralne „brak".
+
+### 9.4 Szablon `_wiersz_preview_kom.html`
+
+- `data-diff-*` na pierwszym `<tr>` generuje się **automatycznie**
+  (pętla po `row.stany_pol.items`) — bez zmian kodu, dochodzą
+  `data-diff-data_od` / `data-diff-data_do`.
+- W bloku porównywarki (drugi `<tr>`) dwa nowe „item"-y, wzorem istniejących:
+
+```
+<div class="import-porownanie-item">
+    <span class="import-porownanie-etykieta">Data od:</span>
+    {% include "…/_porownanie_kom.html" with pole=porownanie.data_od %}
+</div>
+<div class="import-porownanie-item">
+    <span class="import-porownanie-etykieta">Data do:</span>
+    {% include "…/_porownanie_kom.html" with pole=porownanie.data_do %}
+</div>
+```
+
+- Sygnał „nowy okres": gdy `pole.nowy_okres`, dodatkowy `label` („nowy okres
+  zatrudnienia") w komórce — drobne rozszerzenie `_porownanie_kom.html` albo
+  inline w karcie. Pasek filtrów dostaje „Data od"/„Data do" **automatycznie**
+  (`views.py` iteruje `POLA_ROZNIC` do `ctx["pola_roznic"]`).
+
+---
+
+## 10. Liczniki + audyt
+
+- **Przewód licznika (N1):** `_materializuj_diff` zwraca `created` (§8.3) →
+  `_integruj_wiersz` propaguje `created` (early-return na guardzie `log_zmian`
+  → `False`) → pętla `integruj` **sumuje** i gdy `created` **oraz**
+  `diff["autor_jednostka"].get("nowy_okres")` → inkrementuje
+  `utworzono_nowych_okresow` w słowniku `p.result(...)`; podgląd wyniku pokaże
+  „utworzono N nowych okresów zatrudnienia". Bez tego przewodu licznik nigdy
+  nie zobaczy `created`.
+- `_opisz_utworzone(diff, created)` — gdy `created` **oraz**
+  `diff["autor_jednostka"]["nowy_okres"]`, opis „nowy okres zatrudnienia od
+  `<data>`" (zamiast/obok „powiązanie autor-jednostka"). **Poprawka N6:**
+  przekazujemy `created`, żeby drugi wiersz z tym samym `(A, J, data)`
+  (`created=False`) NIE kłamał „nowy okres" w audycie.
+- `log_zmian["autor_jednostka"]` — istniejące wpisy „data rozpoczęcia pracy na
+  …" / „data końca zatrudnienia na …" zostają (już są).
+
+---
+
+## 11. Migracje
+
+**Brak migracji schematu.** Nowe okresy to rekordy runtime; `stany_pol_snapshot`
+istnieje od #559 (migracja 0024); `diff_do_utworzenia` dostaje dodatkowe klucze
+JSON (`rozpoczal_prace`, `nowy_okres`). Po scaleniu należy jedynie **odświeżyć
+baseline** (`make baseline-update`) zgodnie z regułą projektu — bez nowych
+migracji delta będzie pusta (baseline odświeżamy RAZ przy scalaniu, nie w tym
+branchu).
+
+---
+
+## 12. Przypadki brzegowe
+
+1. **Multi-etat (wiele AJ dla (A, J)):** resolver po pełnym kluczu
+   (`rozpoczal_prace`) rozstrzyga jednoznacznie; przy pustym `plik_od` wybór
+   aktywnego/najświeższego (`_wybierz_aktywny_najswiezszy`).
+2. **`plik_od` present, baza `rozpoczal = NULL`:** wypełnienie, **nie** nowy
+   okres (§3 wiersz 4). Przy >1 AJ z `NULL` (legacy) — deterministyczny wybór
+   po `order_by("pk")`.
+3. **Odwrócony zakres (`plik_do < rozpoczal`):** istniejąca walidacja rzuca
+   `BPPDatabaseError` — dotyczy też nowych okresów i wstawionej „data do".
+4. **Idempotencja restartu integracji:** gwarantem NIE jest `get_or_create`
+   (po stemplu fallbackiem lookup `None` już nie trafia w tworzony rekord) —
+   gwarantują ją: guard `log_zmian is not None` (#508 F2) + per-wierszowy
+   `transaction.atomic`. Drugi przebieg trafia w istniejący okres przez lookup
+   po pełnym kluczu (`filter(...).order_by("pk").first()` → found → reuse).
+5. **Drift bazy analiza→commit** (między analizą a commitem powstał AJ
+   `(A, J, plik_od)` podczas „wypełniania NULL"): `aj.save()` mógłby rzucić
+   `IntegrityError`. To ta sama klasa ryzyka co dziś (stemplowanie NULL→data);
+   `_integrate_autor_jednostka` powinien być odporny (re-check przez lookup /
+   złapanie i pominięcie duplikatu). Zaznaczone jako drobne wzmocnienie.
+6. **Podgląd = integracja:** strona „baza" w porównywarce liczona TYM SAMYM
+   `row._okres()` — podgląd nie może zapowiadać innego okresu niż utworzy commit.
+7. **Odpięcia / przepięcia:** ortogonalne. Odpięcia dotyczą par „spoza pliku";
+   nowy okres to ta sama jednostka (inna data), a przepięcia to **inna**
+   jednostka — nie kolidują. Nowe AJ (aktywne, primary) aktualizuje
+   `aktualna_jednostka` przez istniejący trigger — bez zmian.
+8. **`data_zatrudnienia` jako `date` vs ISO-string:** `dane_bardziej_znormalizowane`
+   parsuje oba pola do `date`; `porownaj_z_baza` czyta `dane_znormalizowane`
+   (surowe) — helper `_porownaj_data` musi tolerować `str`/`date`/pusty.
+
+---
+
+## 13. Plan testów (TDD — najpierw testy)
+
+Nowy plik `tests/test_pipeline/test_integrate_okresy_dat.py` + rozbudowa
+`test_integrate_daty.py`, `test_porownywarka.py`, `test_stany_pol.py`,
+`test_views_preview_render.py`, `test_wybor_autor_jednostka.py`.
+
+**Resolver (`rozwiaz_okres_zatrudnienia`)** — po jednym teście na wiersz §3:
+brak AJ + data / brak AJ + puste / ten sam okres / wypełnienie NULL / nowy
+okres / istniejący + puste (no-op). + multi-etat wybór aktywnego. + `>1` AJ z
+`rozpoczal=NULL` → deterministyczny wybór po pk. + `aj_lista=` nie odpala
+zapytania. **+ (N5)** `plik_od` jako ISO-string → asercja braku fałszywego
+„nowy okres"/duplikatu (kontrakt: resolver dostaje `date|None`).
+
+**`_wybierz_aktywny_najswiezszy` (N2)** — parytet z dzisiejszym SQL
+`order_by("-rozpoczal_prace")` (NULLS FIRST): przy mieszance AJ z `rozpoczal`
+datowanym i `rozpoczal=NULL` funkcja wybiera **ten sam** rekord co dawny SQL
+(NULL jako „najświeższy"); aktywny (`zakonczyl IS NULL`) ma priorytet;
+tie-break po pk. Bez `TypeError` na `None`.
+
+**Analiza (`_przetworz_wiersz`)** — wiersz z `plik_od ≠ baza` na twardo
+dopasowanej jednostce odkłada `diff["autor_jednostka"]` z `rozpoczal_prace` +
+`nowy_okres=True`; wiersz z `plik_od == baza` NIE odkłada nowego okresu; wiersz
+z pustą jednostką → brak resolvera.
+
+**Integracja:**
+- nowy okres tworzy DRUGI `Autor_Jednostka` (stary zostaje otwarty — P2);
+- „data do" wstaw-gdy-pusta; NIE nadpisuje istniejącej (assert wartość z bazy);
+- istniejący AJ + pusty `plik_od` → `rozpoczal_prace` NIE zmienione (nawet gdy
+  `NULL`) i NIE stemplowane dziś/data-zmian;
+- nowy AJ + pusty `plik_od` → `rozpoczal = data zmian` (i → dziś gdy brak);
+- odwrócony zakres → `BPPDatabaseError`;
+- idempotencja: drugi `integruj` nie tworzy trzeciego okresu;
+- `_materializuj_diff` zwraca `created`; licznik `utworzono_nowych_okresow`.
+
+**Porównywarka / stany pól:**
+- `porownaj_z_baza()["data_od"]/["data_do"]` — `plik`/`baza`/`rozne`/`nowy_okres`
+  dla: zgodne / wypełnienie / nowy okres / brak / pusta jednostka;
+- `stany_pol()` daje `data_od`/`data_do` ∈ {zmienione,zgodne,brak};
+- stary snapshot bez kluczy dopełniony do „brak" (nie znika pod filtrem);
+- render karty: dwa nowe „item"-y + `data-diff-data_od/-data_do` na `<tr>`;
+- **(N3) inwalidacja memo:** `stany_pol()`/`porownaj_z_baza()` przed i po zmianie
+  autora (`_zwiaz_autora_z_wierszem`) na tej samej instancji wiersza dają
+  decyzję dla **nowego** autora (cache `_okres_cache` wyczyszczony).
+
+**Wydajność (poprawka Fable):**
+- `assertNumQueries` na renderze podglądu wiersza — liczba zapytań **nie rośnie
+  liniowo** z dodaniem dat (resolver 1×/wiersz przez memo, nie ~6×).
+
+**Testy WYMAGAJĄCE aktualizacji (zidentyfikowane przez Fable — czerwone bez
+zmiany):**
+- `test_integrate_daty.py::test_data_zmian_wypelnia_nowe_aj_bez_daty_w_pliku`
+  (istniejący AJ `rozpoczal=None` + puste dane asertuje stempel `data_zmian`) —
+  wg §5 to teraz **no-op**; przepisać na wariant „**świeży** AJ" (materializacja);
+- `test_integrate_daty.py::test_brak_globalnej_daty_stempluje_date_importu` —
+  jw., przepisać na „świeży AJ";
+- `test_stany_pol.py::test_stany_pol_ma_wszystkie_klucze` — rozszerzyć oczekiwany
+  zbiór o `data_od`/`data_do` (8 kluczy);
+- `test_views_preview_render.py::test_podglad_wiersz_ma_atrybuty_data_diff`
+  oraz `::test_podglad_ma_pasek_filtrow_radia` — pętle po kluczach `POLA_ROZNIC`
+  → dołożyć `data_od`/`data_do`;
+- `test_wybor_autor_jednostka.py` — pozostaje ważny, jeśli
+  `_wybierz_autor_jednostka` deleguje do `_wybierz_aktywny_najswiezszy` (§7);
+  gdyby zdecydować o usunięciu funkcji — zmigrować na resolver.
+
+> Uwaga: dokładne nazwy testów/linie zweryfikować przy implementacji — Fable
+> podał je z bieżącego stanu `origin/dev`; jeśli któraś nazwa się nie zgadza,
+> znaleźć asercję po sensie (stempel daty / zbiór kluczy `POLA_ROZNIC`).
+
+Po implementacji: pełna suita (`make tests`, ~10 min) — 0 regresji; moduł
+`uv run pytest src/import_pracownikow/` zielony.
+
+---
+
+## 14. Poza zakresem (świadomie)
+
+- Auto-domykanie starego okresu (P2) — dopiero na jawną prośbę (opt-in w podglądzie).
+- Edycja/rozdzielanie okresów z poziomu podglądu (operator ręcznie).
+- Wykrywanie „przeniesienia" (data od = koniec innego okresu) — to przepięcia,
+  osobny mechanizm.
+- Batch-prefetch AJ w widoku — tylko jeśli profil pokaże, że memo 1×/wiersz to
+  za mało (resolver już przyjmuje `aj_lista=`).
+
+---
+
+## 15. Ryzyka
+
+- **Rozjazd podgląd ↔ integracja** — mitygacja: jeden `row._okres()` dla obu
+  (w tym GŁÓWNA ścieżka `analyze.py`, §8.1).
+- **N+1 w renderze podglądu** — mitygacja: 1 zapytanie w resolverze + memo na
+  wierszu; test `assertNumQueries`.
+- **`MultipleObjectsReturned` / niedeterminizm na `(A, J, NULL)`** — mitygacja:
+  `order_by("pk").first()` + create (nie `get_or_create`); fallback stempluje
+  konkretną datę, więc tworzony rekord nie ma `NULL` w kluczu.
+- **Snapshoty pre-feature** — mitygacja: dopełnianie kluczy w `stany_pol()`.
+- **Drift bazy analiza→commit** — mitygacja: lookup po pełnym kluczu + odporność
+  `_integrate_autor_jednostka` (§12 pkt 5).
+- **Konflikt z równoległymi branchami importu** — baseline odświeżyć **raz przy
+  scalaniu** (reguła projektu), nie w tym branchu.

--- a/docs/superpowers/specs/2026-07-13-import-pracownikow-synchronizacja-dat-zatrudnienia-design.md
+++ b/docs/superpowers/specs/2026-07-13-import-pracownikow-synchronizacja-dat-zatrudnienia-design.md
@@ -81,8 +81,20 @@ komórka w tym wierszu jest pusta (rozróżnienie nieistotne — patrz §5).
 | brak AJ | puste | utwórz AJ z `rozpoczal =` (fallback: data zmian → dziś) | **NOWY** |
 | AJ istnieje, `rozpoczal = plik_od` | wartość | bez zmian (ten sam okres) | istniejący |
 | AJ istnieje, `rozpoczal = NULL` | wartość | **wypełnij** `plik_od` (to samo, niedatowane) | istniejący |
-| AJ istnieje, `rozpoczal ≠ plik_od` | wartość | pokaż różnicę + **utwórz NOWY okres** | **NOWY** |
+| AJ istnieje **OTWARTY** (`zakonczyl = NULL`), `rozpoczal ≠ plik_od` | wartość | pokaż różnicę, **celuj w aktywny** (bez nowego okresu) | istniejący |
+| AJ istnieje, wszystkie **ZAMKNIĘTE**, `rozpoczal ≠ plik_od` | wartość | pokaż różnicę + **utwórz NOWY okres** | **NOWY** |
 | AJ istnieje | puste | **NIC NIE ZMIENIAJ** (`rozpoczal` zostaje jak jest, nawet `NULL`) | istniejący |
+
+> **KLUCZOWE (odkryte przy implementacji) — niezmiennik `defragmentuj`.**
+> `Autor.save()` woła `defragmentuj_jednostke`, które **scala** nakładające /
+> sąsiadujące / **otwarte** okresy tej samej pary `(autor, jednostka)`. Faza
+> integracji zapisuje autora (`_integrate_autor`), więc dwa **otwarte** okresy
+> naraz są niemożliwe — zostałyby scalone (a świeży AJ skasowany → crash
+> easyaudit z `PROPAGATE_EXCEPTIONS`). Dlatego (decyzja usera **A**): nowy okres
+> powstaje **tylko gdy istniejące okresy są ZAMKNIĘTE** (osoba odeszła i wraca).
+> Przy **otwartym** okresie inną „datę od" tylko **pokazujemy** w podglądzie i
+> celujemy w aktywny okres (nie tworzymy, nie domykamy — spójne z P2). To
+> zawężenie „inna data od → nowy okres" wymuszone niezmiennikiem, nie kaprys.
 
 ### „data do" (`zakonczyl_prace`)
 
@@ -191,7 +203,11 @@ jeśli plik_od ma wartość:
     inaczej niedat = [aj for aj in aj_lista if aj.rozpoczal_prace is None]
         posortowane po pk            # determinizm przy >1 NULL (legacy)
         jeśli niedat:                 -> ("istniejacy", niedat[0])      # wypełnij plik_od
-        inaczej:                      -> ("nowy", plik_od)              # NOWY okres
+        inaczej aktywne = [aj for aj in aj_lista if aj.zakonczyl_prace is None]
+            jeśli aktywne:            -> ("istniejacy", _wybierz_aktywny_najswiezszy(aktywne))
+                                      # OTWARTY okres → pokaż różnicę, NIE twórz
+                                      # nowego (defragmentuj by scalił; decyzja A)
+            inaczej:                  -> ("nowy", plik_od)              # wszystkie ZAMKNIĘTE → NOWY okres
 jeśli plik_od puste:
     aj = _wybierz_aktywny_najswiezszy(aj_lista)   # aktywny (zakonczyl IS NULL),
                                                   # remis → najświeższy rozpoczal
@@ -362,6 +378,21 @@ return created
 - **Resolvera tu NIE wołamy** (poprawka Fable) — check jest w gorących miejscach
   (analyze/integrate), nie dokładamy mu zapytań.
 - reszta pól (funkcja/stanowisko/grupa/wymiar/primary) bez zmian.
+
+### 8.6 `models.py` — `integrate()` guard po defragmentacji (odkryte przy implementacji)
+
+`integrate()` woła `_integrate_autor()` (→ `Autor.save()` → `defragmentuj_jednostke`)
+PRZED `_integrate_autor_jednostka()`. Edge: nowy okres utworzony na granicy
+zamkniętego okresu (sąsiadujący dzień) zostaje przez defragmentację **scalony i
+usunięty** → dalszy `aj.save()` rzuciłby `Autor_Jednostka.DoesNotExist` (easyaudit
++ `DJANGO_EASY_AUDIT_PROPAGATE_EXCEPTIONS=True`) → cały task pada.
+
+Guard `_przepnij_aj_po_defragmentacji()` między tymi wywołaniami: gdy wiersz
+utworzył świeży okres (`_okres_swiezo_utworzony`, ustawiany przez `_integruj_wiersz`)
+a jego AJ już nie istnieje — przepina `row.autor_jednostka` na ocalały
+aktywny/najświeższy AJ (`_wybierz_aktywny_najswiezszy`), zamiast zapisywać
+skasowany rekord. `_integrate_autor_jednostka` dostaje też guard `aj is None`.
+Płaci za dodatkowe zapytanie WYŁĄCZNIE wiersz, który utworzył nowy okres.
 
 ---
 

--- a/src/bpp/newsfragments/import-sync-daty-zatrudnienia.feature.rst
+++ b/src/bpp/newsfragments/import-sync-daty-zatrudnienia.feature.rst
@@ -1,0 +1,6 @@
+Import pracowników synchronizuje teraz daty zatrudnienia (data od / data do)
+wokół pojęcia okresu identyfikowanego przez „datę od": ta sama data od
+uzupełnia „datę do" istniejącego okresu, a inna data od tworzy nowy okres
+zatrudnienia (nowy rekord powiązania autor-jednostka). Obie daty są widoczne w
+porównywarce „plik vs baza" w podglądzie, a „data do" jest wstawiana tylko gdy
+w bazie jest pusta (różnicę pokazujemy, nie nadpisujemy).

--- a/src/import_pracownikow/models.py
+++ b/src/import_pracownikow/models.py
@@ -747,6 +747,85 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
             "rozne": plik_id is not None and baza_id != plik_id,
         }
 
+    @staticmethod
+    def _porownaj_data(plik, baza, *, nowy_okres=False, ma_okres=True):
+        """Trójka+ porównania daty: ``{plik, baza, rozne, nowy_okres}``. Toleruje
+        ``date`` / ISO-``str`` / puste po obu stronach (porównywarka czyta surowe
+        ``dane_znormalizowane``, gdzie data bywa stringiem lub obiektem). ``rozne``
+        (= „zmienione") gdy: nowy okres z niepustym plikiem, LUB baza pusta a plik
+        niepusty (wstawienie), LUB obie niepuste i różne (różnica pokazana bez
+        nadpisania). ``ma_okres=False`` (brak autora/jednostki → brak okresu do
+        rozstrzygnięcia) → ZAWSZE ``rozne=False`` (nie ma z czym porównywać)."""
+
+        def _iso(v):
+            if v is None or v == "":
+                return ""
+            return v.isoformat() if isinstance(v, date) else str(v)
+
+        p = _iso(plik)
+        b = _iso(baza)
+        rozne = ma_okres and (bool(nowy_okres and p) or (bool(p) and p != b))
+        return {"plik": p, "baza": b, "rozne": rozne, "nowy_okres": bool(nowy_okres)}
+
+    def _plik_od(self):
+        """„Data od" z pliku jako ``date | None`` (kontrakt resolvera: nigdy
+        ``str`` — inaczej fałszywy „nowy okres" + duplikat AJ). Pusty/``None``
+        ``dane_znormalizowane`` (stare/puste wiersze) → ``None`` (bez sięgania do
+        ``dane_bardziej_znormalizowane``, które nie znosi ``None``)."""
+        if not self.dane_znormalizowane:
+            return None
+        return self.dane_bardziej_znormalizowane.get("data_zatrudnienia") or None
+
+    def _plik_do(self):
+        """„Data do" z pliku jako ``date | None`` (guard jak w ``_plik_od``)."""
+        if not self.dane_znormalizowane:
+            return None
+        return self.dane_bardziej_znormalizowane.get("data_końca_zatrudnienia") or None
+
+    def _aj_lista(self):
+        """Lista okresów ``Autor_Jednostka`` dla ``(autor, jednostka)`` wiersza —
+        JEDNO zapytanie (memo na instancji), współdzielone przez resolver
+        (``_okres``) i gałąź „nowy okres" w porównywarce (bez N+1)."""
+        if not hasattr(self, "_aj_lista_cache"):
+            if not (self.autor_id and self.jednostka_id):
+                self._aj_lista_cache = []
+            else:
+                from bpp.models import Autor_Jednostka
+
+                self._aj_lista_cache = list(
+                    Autor_Jednostka.objects.filter(
+                        autor_id=self.autor_id, jednostka_id=self.jednostka_id
+                    )
+                )
+        return self._aj_lista_cache
+
+    def _okres(self):
+        """Decyzja resolvera okresu dla tego wiersza (memo na instancji) —
+        ``None`` (brak autora/jednostki) | ``("istniejacy", aj)`` |
+        ``("nowy", rozpoczal|None)``. Współdzielona przez porównywarkę i ekstraktory
+        ``_stan_data_*`` → 1 zapytanie o AJ na wiersz."""
+        if not hasattr(self, "_okres_cache"):
+            if not (self.autor_id and self.jednostka_id):
+                self._okres_cache = None
+            else:
+                from import_pracownikow.okresy import rozwiaz_okres_zatrudnienia
+
+                self._okres_cache = rozwiaz_okres_zatrudnienia(
+                    self.autor,
+                    self.jednostka,
+                    self._plik_od(),
+                    aj_lista=self._aj_lista(),
+                )
+        return self._okres_cache
+
+    def _zapomnij_okres(self):
+        """Inwaliduje memo ``_okres``/``_aj_lista`` — wołane przy zmianie
+        autora/jednostki wiersza (``odtworz_autor_jednostka`` / podłączenie
+        jednostki), żeby kolejny odczyt nie podał decyzji dla nieaktualnej pary."""
+        for atrybut in ("_okres_cache", "_aj_lista_cache"):
+            if hasattr(self, atrybut):
+                delattr(self, atrybut)
+
     def porownaj_z_baza(self):
         """Porównanie „plik vs baza" dla e-maila, stopnia służbowego,
         stanowiska dydaktycznego, tytułu naukowego i funkcji w jednostce
@@ -766,6 +845,23 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
         stanowisko_baza = aj.stanowisko if aj and aj.stanowisko_id else None
         tytul_baza = autor.tytul if autor and autor.tytul_id else None
         funkcja_baza = aj.funkcja if aj and aj.funkcja_id else None
+        # Daty zatrudnienia: strona bazy z DECYZJI resolvera (§9.2) — to samo
+        # źródło prawdy co integracja. „istniejacy" → daty docelowego okresu;
+        # „nowy" → baza `data od` = okres-referencyjny (stara → nowa), `data do`
+        # pusta (nowy okres nie ma jeszcze końca); brak autora/jednostki → puste.
+        okres = self._okres()
+        nowy_okres = bool(okres and okres[0] == "nowy")
+        if okres and okres[0] == "istniejacy":
+            baza_od = okres[1].rozpoczal_prace
+            baza_do = okres[1].zakonczyl_prace
+        elif nowy_okres:
+            from import_pracownikow.okresy import _wybierz_aktywny_najswiezszy
+
+            referencyjny = _wybierz_aktywny_najswiezszy(self._aj_lista())
+            baza_od = referencyjny.rozpoczal_prace if referencyjny else None
+            baza_do = None
+        else:
+            baza_od = baza_do = None
         return {
             "email": self._porownaj_email(
                 dane.get("email"), autor.email if autor else ""
@@ -793,6 +889,18 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
                 funkcja_baza,
                 self.funkcja_autora_id if aj else None,
             ),
+            "data_od": self._porownaj_data(
+                self._plik_od(),
+                baza_od,
+                nowy_okres=nowy_okres,
+                ma_okres=okres is not None,
+            ),
+            "data_do": self._porownaj_data(
+                self._plik_do(),
+                baza_do,
+                nowy_okres=nowy_okres,
+                ma_okres=okres is not None,
+            ),
         }
 
     def stany_pol(self):
@@ -801,12 +909,14 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
         = plik, więc live dałoby „zgodne"), inaczej live wyliczenie z
         ``POLA_ROZNIC`` (jednostka / email / tytuł / stopień / funkcja /
         stanowisko). Zasila filtr stanu pól i atrybuty ``data-diff-*``."""
-        # Uwaga: gdyby POLA_ROZNIC kiedyś zyskało nowy klucz, stare snapshoty go
-        # nie zawierają — wtedy rekord nie ma data-diff-<nowy> i filtr po tym polu
-        # (≠ „wszystkie") go ukryje. Przy dodaniu pola rozważ dopełnienie snapshotu.
-        if self.stany_pol_snapshot is not None:
-            return self.stany_pol_snapshot
+        # Snapshoty sprzed dodania `data_od`/`data_do` nie mają tych kluczy —
+        # dopełniamy je neutralnym „brak", żeby rekord nie znikał pod filtrem
+        # nowego pola (≠ „wszystkie"). Import PRZED gałęzią (używany w obu).
         from import_pracownikow.roznice import POLA_ROZNIC
+
+        if self.stany_pol_snapshot is not None:
+            baza = {klucz: "brak" for klucz, _et, _ekstraktor in POLA_ROZNIC}
+            return {**baza, **self.stany_pol_snapshot}
 
         return {klucz: ekstraktor(self) for klucz, _et, ekstraktor in POLA_ROZNIC}
 
@@ -851,8 +961,11 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
             # #4: rozpoczęcie stemplujemy TYLKO gdy puste (data z pliku / importu)
             # — integracja potrzebna, gdy plik niesie datę, a AJ jej nie ma.
             dane.get("data_zatrudnienia") is not None and aj.rozpoczal_prace is None,
+            # „data do" wstaw-tylko-gdy-pusta (§3): integracja potrzebna, gdy plik
+            # niesie datę końca, a AJ jej nie ma. Różnicy wobec istniejącej NIE
+            # nadpisujemy (pokazuje ją tylko porównywarka), więc tu jej nie liczymy.
             dane.get("data_końca_zatrudnienia") is not None
-            and aj.zakonczyl_prace != dane["data_końca_zatrudnienia"],
+            and aj.zakonczyl_prace is None,
             self.funkcja_autora is not None and aj.funkcja != self.funkcja_autora,
             self.grupa_pracownicza is not None
             and aj.grupa_pracownicza != self.grupa_pracownicza,
@@ -922,26 +1035,24 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
     def _integruj_daty_aj(self, aj, dane):
         """Ustawia daty zatrudnienia na powiązaniu z danych wiersza.
 
-        Polityka „no-overwrite" (#4): ``rozpoczal_prace`` stemplujemy TYLKO gdy
-        puste — nie nadpisujemy istniejącej daty (decyzja usera #4; dawniej data
-        z pliku nadpisywała istniejącą wartość). Priorytet przy stemplowaniu
-        pustej daty: data zatrudnienia z pliku → globalna „data zmian
-        personalnych" z importu (item 8) → dzień importu (dziś). Item 8 dotyczy
-        właśnie dopisywania autora do jednostki (nowe AJ, pusta data), więc jest
-        spójny z no-overwrite."""
-        if aj.rozpoczal_prace is None:
-            nowa_data = (
-                dane.get("data_zatrudnienia")
-                or self.parent.data_zmian_personalnych
-                or timezone.localdate()
-            )
-            aj.rozpoczal_prace = nowa_data
+        „Data od" (``rozpoczal_prace``) na ISTNIEJĄCYM AJ wypełniamy TYLKO gdy
+        baza ma ``NULL`` a plik NIESIE datę (§3: „wypełnienie NULL") — nie
+        nadpisujemy istniejącej daty. Pusty ``plik_od`` na istniejącym AJ →
+        NIC NIE ZMIENIAJ (§5), nawet gdy ``rozpoczal_prace`` jest ``NULL``.
+        Fallback ``data zmian → dziś`` dla NOWEGO okresu stemplujemy przy
+        MATERIALIZACJI (``integrate._materializuj_diff``), nie tutaj — świeży AJ
+        ma już ``rozpoczal_prace``, więc ta gałąź go nie dotyczy.
+
+        „Data do" (``zakonczyl_prace``) — wstaw-tylko-gdy-pusta (§3): różnicę
+        wobec istniejącej daty POKAZUJEMY w porównywarce, ale NIE nadpisujemy."""
+        if aj.rozpoczal_prace is None and dane.get("data_zatrudnienia"):
+            aj.rozpoczal_prace = dane["data_zatrudnienia"]
             self.log_zmian["autor_jednostka"].append(
-                f"data rozpoczęcia pracy na {nowa_data}"
+                f"data rozpoczęcia pracy na {aj.rozpoczal_prace}"
             )
 
         data_konca = dane.get("data_końca_zatrudnienia")
-        if data_konca is not None and aj.zakonczyl_prace != data_konca:
+        if data_konca and aj.zakonczyl_prace is None:
             aj.zakonczyl_prace = data_konca
             self.log_zmian["autor_jednostka"].append(
                 f"data końca zatrudnienia na {data_konca}"
@@ -949,6 +1060,11 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
 
     def _integrate_autor_jednostka(self):
         aj = self.autor_jednostka
+        if aj is None:
+            # Ochrona: świeży okres mógł zostać scalony przez defragmentację i
+            # bez ocalałego AJ (`_przepnij_aj_po_defragmentacji`). Dane zatrudnienia
+            # niesie już scalony rekord — nie ma czego zapisywać.
+            return
         dane = self.dane_bardziej_znormalizowane
 
         self._integruj_daty_aj(aj, dane)
@@ -1027,8 +1143,39 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
             self.stany_pol_snapshot = self.stany_pol()
         self.log_zmian = {"autor": [], "autor_jednostka": []}
         self._integrate_autor()
+        self._przepnij_aj_po_defragmentacji()
         self._integrate_autor_jednostka()
         self.save()
+
+    def _przepnij_aj_po_defragmentacji(self):
+        """``_integrate_autor`` woła ``Autor.save()``, który defragmentuje okresy
+        (``defragmentuj_jednostke`` scala nakładające/sąsiadujące/otwarte AJ).
+        Świeżo utworzony okres, który okazał się sąsiadować z zamkniętym (edge:
+        dzień po końcu poprzedniego), mógł zostać scalony i USUNIĘTY — dalszy
+        ``aj.save()`` w ``_integrate_autor_jednostka`` rzuciłby wtedy
+        ``DoesNotExist`` (easyaudit, PROPAGATE_EXCEPTIONS). Celujemy w ocalały
+        aktywny/najświeższy AJ zamiast zapisywać skasowany rekord.
+
+        Guard aktywny WYŁĄCZNIE dla wierszy, które utworzyły nowy okres
+        (``_okres_swiezo_utworzony`` ustawia pipeline) — reszta nie płaci za
+        dodatkowe zapytanie."""
+        if not getattr(self, "_okres_swiezo_utworzony", False):
+            return
+        if self.autor_jednostka_id is None:
+            return
+        from bpp.models import Autor_Jednostka
+        from import_pracownikow.okresy import _wybierz_aktywny_najswiezszy
+
+        if Autor_Jednostka.objects.filter(pk=self.autor_jednostka_id).exists():
+            return
+        # Świeży okres scalony przez defragmentację — przepnij na ocalały AJ.
+        self.autor_jednostka = _wybierz_aktywny_najswiezszy(
+            list(
+                Autor_Jednostka.objects.filter(
+                    autor_id=self.autor_id, jednostka_id=self.jednostka_id
+                )
+            )
+        )
 
     def sformatowany_log_zmian(self):
         # Renderuje WSZYSTKIE klucze audytu (#513 F1 / #508 M4). Faza integracji

--- a/src/import_pracownikow/okresy.py
+++ b/src/import_pracownikow/okresy.py
@@ -1,0 +1,94 @@
+"""Resolver okresu zatrudnienia (``Autor_Jednostka``) po „dacie od" (§7 spec
+``2026-07-13-import-pracownikow-synchronizacja-dat-zatrudnienia``).
+
+„Data od" = TOŻSAMOŚĆ okresu zatrudnienia (zgodne z ``unique_together =
+(autor, jednostka, rozpoczal_prace)``). Ta sama data od → ten sam okres → do
+niego synchronizujemy „data do"; inna data od → NOWY okres = nowy AJ.
+
+Jedno źródło prawdy dla analizy (``analyze._przetworz_wiersz``), rekonstrukcji
+po zmianie autora (``pewnosc.odtworz_autor_jednostka``) oraz porównywarki
+podglądu (``models.ImportPracownikowRow.porownaj_z_baza``) — podgląd nie może
+zapowiadać innego okresu niż utworzy commit.
+"""
+
+from datetime import date
+
+
+def _wybierz_aktywny_najswiezszy(aj_lista):
+    """Deterministyczny wybór ``Autor_Jednostka`` z gotowej listy (bez ORM).
+
+    Parytet z dawnym SQL ``order_by("-rozpoczal_prace")`` (PostgreSQL przy
+    ``DESC`` daje NULLS FIRST → ``rozpoczal_prace = NULL`` traktowany jako
+    „najświeższy"): preferuje AKTYWNY etat (``zakonczyl_prace IS NULL``); w
+    puli ``rozpoczal_prace = None`` jest „największe", potem najświeższy
+    ``rozpoczal_prace``; tie-break po ``pk`` (SQL go nie gwarantował — tu
+    wzmacniamy determinizm). Zwraca ``None`` dla pustej listy.
+
+    Klucz na ``max`` MUSI unikać ``TypeError`` (porównanie ``date`` z ``None``),
+    dlatego ``None`` mapujemy na ``(True, date.min)`` przez oś boolowską.
+    """
+    if not aj_lista:
+        return None
+    aktywne = [aj for aj in aj_lista if aj.zakonczyl_prace is None]
+    pula = aktywne or aj_lista
+    return max(
+        pula,
+        key=lambda aj: (
+            aj.rozpoczal_prace is None,
+            aj.rozpoczal_prace or date.min,
+            aj.pk or 0,
+        ),
+    )
+
+
+def rozwiaz_okres_zatrudnienia(autor, jednostka, plik_od, *, aj_lista=None):
+    """Rozstrzyga docelowy okres zatrudnienia dla ``(autor, jednostka, plik_od)``.
+
+    Zwraca:
+    - ``("istniejacy", aj)`` — dopasowany okres (ta sama data od) lub okres
+      niedatowany (``rozpoczal_prace = NULL``) do wypełnienia;
+    - ``("nowy", rozpoczal_prace | None)`` — utwórz nowy AJ z tą datą od
+      (``None`` = pusty ``plik_od`` → fallback ``data zmian → dziś`` przy
+      materializacji).
+
+    ``plik_od`` MUSI być ``date | None`` — ISO-string dałby ``rozpoczal_prace ==
+    "2020-01-01"`` zawsze ``False`` → cichy fałszywy „nowy okres" + duplikat AJ.
+
+    ``aj_lista`` (opcjonalnie) to już pobrana lista okresów ``(autor, jednostka)``
+    — pozwala wołającemu wykonać JEDNO zapytanie i współdzielić je z porównywarką
+    (bez N+1). Gdy ``None`` — resolver odpytuje bazę sam.
+    """
+    if aj_lista is None:
+        from bpp.models import Autor_Jednostka
+
+        aj_lista = list(
+            Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka)
+        )
+
+    if plik_od is not None:
+        exact = [aj for aj in aj_lista if aj.rozpoczal_prace == plik_od]
+        if exact:
+            return ("istniejacy", exact[0])
+        niedatowane = sorted(
+            (aj for aj in aj_lista if aj.rozpoczal_prace is None),
+            key=lambda aj: aj.pk or 0,
+        )
+        if niedatowane:
+            return ("istniejacy", niedatowane[0])
+        aktywne = [aj for aj in aj_lista if aj.zakonczyl_prace is None]
+        if aktywne:
+            # Istnieje OTWARTY (trwający) okres: nowy otwarty okres byłby i tak
+            # scalony z powrotem przez ``Autor.defragmentuj_jednostke`` (dwa
+            # równoległe zatrudnienia w jednej jednostce to sprzeczność). Celujemy
+            # więc w aktywny okres — różnicę „data od" POKAZUJEMY w podglądzie, ale
+            # NIE tworzymy nowego okresu i NIE domykamy starego (decyzja usera:
+            # „nowy okres tylko gdy stary zamknięty"; spójne z P2).
+            return ("istniejacy", _wybierz_aktywny_najswiezszy(aktywne))
+        # Wszystkie istniejące okresy zamknięte (osoba odeszła i wraca) → nowy
+        # okres nie nakłada się na aktywny, defragmentuj go nie scali.
+        return ("nowy", plik_od)
+
+    aj = _wybierz_aktywny_najswiezszy(aj_lista)
+    if aj is not None:
+        return ("istniejacy", aj)
+    return ("nowy", None)

--- a/src/import_pracownikow/pewnosc.py
+++ b/src/import_pracownikow/pewnosc.py
@@ -109,24 +109,37 @@ def odtworz_autor_jednostka(row, autor):
     - gdy AJ brak: odkłada create w ``diff_do_utworzenia`` i ustawia
       ``zmiany_potrzebne=True`` (integracja zmaterializuje AJ przez ``get_or_create``).
 
+    Wybór okresu (istniejący vs NOWY) rozstrzyga resolver ``rozwiaz_okres_
+    zatrudnienia`` po „dacie od" z pliku (§7) — TEN SAM co analiza i porównywarka,
+    żeby podgląd nie zapowiadał innego okresu niż utworzy commit. Inna data od niż
+    w bazie → odroczony NOWY okres (``rozpoczal_prace`` + ``nowy_okres`` w diffie).
+
     NIE zapisuje wiersza — caller składa ``save``/``update_fields``. Caller MUSI
     ustawić ``row.autor = autor`` PRZED wywołaniem (``check_if_integration_needed``
-    czyta ``self.autor``). Jedyna funkcja w module sięgająca ORM: import
-    ``Autor_Jednostka`` jest LAZY (w ciele), więc ładowanie modułu pozostaje
-    ORM-free i ``models.py`` dalej może importować ``STATUS_*``.
+    / ``_aj_lista`` czytają ``self.autor``). Jedyne funkcje w module sięgające ORM
+    są LAZY (w ciele), więc ładowanie modułu pozostaje ORM-free i ``models.py``
+    dalej może importować ``STATUS_*``.
     """
-    from bpp.models import Autor_Jednostka
+    from import_pracownikow.okresy import rozwiaz_okres_zatrudnienia
 
     row.diff_do_utworzenia.pop("autor_jednostka", None)
-    aj = Autor_Jednostka.objects.filter(autor=autor, jednostka=row.jednostka).first()
-    row.autor_jednostka = aj
-    if aj is None:
-        row.diff_do_utworzenia["autor_jednostka"] = {
-            "autor": autor.pk,
-            "jednostka": row.jednostka_id,
-        }
-        row.zmiany_potrzebne = True
-    else:
+    # Zmiana autora unieważnia decyzję okresu policzoną dla poprzedniego autora.
+    row._zapomnij_okres()
+    aj_lista = row._aj_lista()
+    rodzaj, wartosc = rozwiaz_okres_zatrudnienia(
+        autor, row.jednostka, row._plik_od(), aj_lista=aj_lista
+    )
+    if rodzaj == "istniejacy":
+        row.autor_jednostka = wartosc
         row.zmiany_potrzebne = bool(row.diff_do_utworzenia) or (
             row.check_if_integration_needed()
         )
+    else:
+        row.autor_jednostka = None
+        row.diff_do_utworzenia["autor_jednostka"] = {
+            "autor": autor.pk,
+            "jednostka": row.jednostka_id,
+            "rozpoczal_prace": wartosc.isoformat() if wartosc else None,
+            "nowy_okres": bool(aj_lista),
+        }
+        row.zmiany_potrzebne = True

--- a/src/import_pracownikow/pipeline/analyze.py
+++ b/src/import_pracownikow/pipeline/analyze.py
@@ -69,6 +69,7 @@ from import_pracownikow.models import (
     ImportPracownikowStopien,
     ImportPracownikowTytul,
 )
+from import_pracownikow.okresy import rozwiaz_okres_zatrudnienia
 from import_pracownikow.parsers.jednostka_zlozona import parsuj_komorke
 from import_pracownikow.parsers.leksykony import zbuduj_parser_kontekst
 from import_pracownikow.parsers.osoba import rozbij_osobe
@@ -475,11 +476,14 @@ def _wybierz_autor_jednostka(autor, jednostka):
     nadpisać zamknięte zatrudnienie — korupcja (#508 F6). Deterministycznie
     preferujemy AKTYWNY etat (bez ``zakonczyl_prace``), najnowszy startem; w
     ostateczności najnowszy AJ. Zwraca ``None``, gdy autor nie ma AJ w jednostce.
+
+    Deleguje do ``okresy._wybierz_aktywny_najswiezszy`` (gałąź „pusty plik_od"
+    resolvera §7) na JEDNEJ pobranej liście — jedno źródło reguły wyboru.
     """
-    aj_qs = Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka)
-    return (
-        aj_qs.filter(zakonczyl_prace__isnull=True).order_by("-rozpoczal_prace").first()
-        or aj_qs.order_by("-rozpoczal_prace").first()
+    from import_pracownikow.okresy import _wybierz_aktywny_najswiezszy
+
+    return _wybierz_aktywny_najswiezszy(
+        list(Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka))
     )
 
 
@@ -631,16 +635,30 @@ def _przetworz_wiersz(
 
     # AJ liczymy TYLKO dla jednostki twardo dopasowanej. Odroczona → jednostka
     # None na wierszu; AJ oraz diff["autor_jednostka"] policzy integracja PO
-    # rozstrzygnięciu — inaczej get_or_create(jednostka_id=None) w
-    # _materializuj_diff wywala cały task (IntegrityError).
+    # rozstrzygnięciu — inaczej create z jednostka_id=None w _materializuj_diff
+    # wywala cały task (IntegrityError). Resolver okresu (§7) rozstrzyga po
+    # „dacie od": ten sam okres → istniejący AJ; inna → NOWY okres (nowy AJ).
     jednostka_na_wierszu = None if jednostka_odroczona else jednostka
     aj = None
     if autor is not None and jednostka_na_wierszu is not None:
-        aj = _wybierz_autor_jednostka(autor, jednostka_na_wierszu)
-        if aj is None:
+        aj_lista = list(
+            Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka_na_wierszu)
+        )
+        # ExcelDateField.to_python → date|None (kontrakt resolvera: nigdy str).
+        plik_od = data.get("data_zatrudnienia") or None
+        rodzaj, wartosc = rozwiaz_okres_zatrudnienia(
+            autor, jednostka_na_wierszu, plik_od, aj_lista=aj_lista
+        )
+        if rodzaj == "istniejacy":
+            aj = wartosc
+        else:
             diff["autor_jednostka"] = {
                 "autor": autor.pk,
                 "jednostka": jednostka_na_wierszu.pk,
+                "rozpoczal_prace": wartosc.isoformat() if wartosc else None,
+                # nowy_okres = tworzymy DODATKOWY okres obok istniejącego (nie
+                # pierwsze powiązanie) → do licznika/opisu (§10).
+                "nowy_okres": bool(aj_lista),
             }
 
     row_tytul, row_tytul_status, row_zrodlo_tytulu = _klasyfikuj_tytul_wiersza(

--- a/src/import_pracownikow/pipeline/integrate.py
+++ b/src/import_pracownikow/pipeline/integrate.py
@@ -22,7 +22,7 @@ dopisywany ręcznie do ``log_zmian``, żeby audyt i licznik ``zintegrowano``
 widziały, że wiersz wykonał realną pracę.
 """
 
-from datetime import timedelta
+from datetime import date, timedelta
 
 from django.db import transaction
 from django.utils import timezone
@@ -65,13 +65,21 @@ from przemapuj_prace_autora import service as przemapuj_service
 
 
 def _materializuj_diff(row):
-    """Tworzy (get_or_create) obiekty odłożone przez analizę i podpina FK.
+    """Tworzy obiekty odłożone przez analizę i podpina FK. Zwraca ``created``
+    (bool) dla ``Autor_Jednostka`` — zasila licznik nowych okresów zatrudnienia.
 
     Wartości w ``diff`` są już znormalizowane przez fazę analizy
     (``import_pracownikow.pipeline.analyze``) — ponowne wołanie
     ``normalize_*`` tutaj jest więc no-opem (normalizery są idempotentne),
     zostawione dla czytelności/obrony w głąb.
-    """
+
+    ``Autor_Jednostka`` tworzymy po PEŁNYM kluczu ``unique_together`` (autor,
+    jednostka, ``rozpoczal_prace``): lookup ``order_by("pk").first()`` + jawny
+    ``create`` (nie ``get_or_create``) jest deterministyczny i nie rzuca
+    ``MultipleObjectsReturned`` przy duplikatach ``(A, J, NULL)`` z admina/legacy.
+    Nowy AJ z pustym „plik_od" dostaje fallback ``data zmian → dziś`` (P1) TU, przy
+    materializacji — świeży AJ ma więc od razu ``rozpoczal_prace`` (nie ``NULL``),
+    a ``_integruj_daty_aj`` już go nie stempluje."""
     diff = row.diff_do_utworzenia or {}
     if "funkcja_autora" in diff:
         nazwa = normalize_funkcja_autora(diff["funkcja_autora"])
@@ -84,29 +92,48 @@ def _materializuj_diff(row):
     if "wymiar_etatu" in diff:
         nazwa = normalize_wymiar_etatu(diff["wymiar_etatu"])
         row.wymiar_etatu, _ = Wymiar_Etatu.objects.get_or_create(nazwa=nazwa)
+    created = False
     if "autor_jednostka" in diff:
-        # Dług Fazy 0: `get_or_create` tutaj pomija `rozpoczal_prace`, mimo
-        # że `unique_together` na Autor_Jednostka to
-        # (autor, jednostka, rozpoczal_prace). Dla autora z wieloma AJ w tej
-        # samej jednostce (multi-etat / historia zatrudnienia) ten lookup
-        # (autor, jednostka) może trafić na >1 wiersz — Django łapie tylko
-        # `DoesNotExist`, więc `get_or_create` rzuci nieobsłużony
-        # `MultipleObjectsReturned`. Akceptowany dług, do naprawy gdy
-        # multi-etat trafi do zakresu importu.
-        row.autor_jednostka, _ = Autor_Jednostka.objects.get_or_create(
-            autor_id=diff["autor_jednostka"]["autor"],
-            jednostka_id=diff["autor_jednostka"]["jednostka"],
-            defaults={
-                "funkcja": row.funkcja_autora,
-                "stanowisko": row.stanowisko_dydaktyczne,
-            },
+        d = diff["autor_jednostka"]
+        rozpoczal = (
+            date.fromisoformat(d["rozpoczal_prace"])
+            if d.get("rozpoczal_prace")
+            else None
         )
+        if rozpoczal is None:
+            # Nowy AJ, pusty plik_od → fallback (P1): data zmian → dziś. Odtąd
+            # tworzony rekord ma konkretną datę (brak NULL w kluczu unikalności).
+            rozpoczal = row.parent.data_zmian_personalnych or timezone.localdate()
+        aj = (
+            Autor_Jednostka.objects.filter(
+                autor_id=d["autor"],
+                jednostka_id=d["jednostka"],
+                rozpoczal_prace=rozpoczal,
+            )
+            .order_by("pk")
+            .first()
+        )
+        created = aj is None
+        if created:
+            aj = Autor_Jednostka.objects.create(
+                autor_id=d["autor"],
+                jednostka_id=d["jednostka"],
+                rozpoczal_prace=rozpoczal,
+                funkcja=row.funkcja_autora,
+                stanowisko=row.stanowisko_dydaktyczne,
+            )
+        row.autor_jednostka = aj
+    return created
 
 
-def _opisz_utworzone(diff):
+def _opisz_utworzone(diff, aj_created=True):
     """Krótkie opisy obiektów utworzonych z ``diff_do_utworzenia`` — do
     ``log_zmian["utworzono"]``, żeby audyt widział realną pracę wykonaną
-    przez materializację nawet gdy świeży recheck nie wykrył driftu."""
+    przez materializację nawet gdy świeży recheck nie wykrył driftu.
+
+    ``aj_created`` (zwrot ``_materializuj_diff``): gdy AJ NIE powstał (drugi
+    wiersz z tym samym ``(A, J, data)`` trafił lookupem w istniejący) — NIE
+    opisujemy „nowy okres" (N6), żeby audyt nie kłamał."""
     opisy = []
     if "nowy_autor" in diff:
         opisy.append(f"nowy autor: {diff['nowy_autor']}")
@@ -116,8 +143,17 @@ def _opisz_utworzone(diff):
         opisy.append(f"grupa pracownicza: {diff['grupa_pracownicza']}")
     if "wymiar_etatu" in diff:
         opisy.append(f"wymiar etatu: {diff['wymiar_etatu']}")
-    if "autor_jednostka" in diff:
-        opisy.append("powiązanie autor-jednostka")
+    if "autor_jednostka" in diff and aj_created:
+        aj_diff = diff["autor_jednostka"]
+        if aj_diff.get("nowy_okres"):
+            rozpoczal = aj_diff.get("rozpoczal_prace")
+            opisy.append(
+                f"nowy okres zatrudnienia od {rozpoczal}"
+                if rozpoczal
+                else "nowy okres zatrudnienia"
+            )
+        else:
+            opisy.append("powiązanie autor-jednostka")
     return opisy
 
 
@@ -130,8 +166,9 @@ def _integruj_wiersz(row):
     # markerem „już zintegrowany". Bez tego guardu drugi przebieg albo nadpisuje
     # audyt `log_zmian` (gałąź materializacji), albo fałszywie oznacza wiersz
     # `pominiety_bo_nieaktualny` (świeży recheck nie widzi już driftu).
+    # Restart (log_zmian już ustawiony) → nie liczymy nowego okresu ponownie.
     if row.log_zmian is not None:
-        return
+        return False
     with transaction.atomic():
         # Sprawdzone PRZED materializacją — po niej `diff_do_utworzenia`
         # nadal jest niepuste (nic go nie czyści), więc to jest jedyny
@@ -144,7 +181,19 @@ def _integruj_wiersz(row):
         # nadpisze (guard `is None`), a gałąź create-only utrwala go tym save.
         if row.stany_pol_snapshot is None:
             row.stany_pol_snapshot = row.stany_pol()
-        _materializuj_diff(row)
+        created = _materializuj_diff(row)
+        # Nowy okres zatrudnienia = utworzono AJ (created), który analiza
+        # oznaczyła jako DODATKOWY okres (nowy_okres) → licznik §10.
+        nowy_okres_utworzony = bool(
+            created
+            and (row.diff_do_utworzenia or {})
+            .get("autor_jednostka", {})
+            .get("nowy_okres")
+        )
+        # Sygnał dla `integrate()._przepnij_aj_po_defragmentacji`: tylko świeży
+        # okres może zostać scalony przez `Autor.save()` (defragmentacja) i
+        # wymagać przepięcia FK przed zapisem AJ.
+        row._okres_swiezo_utworzony = nowy_okres_utworzony
         row.save(
             update_fields=[
                 "funkcja_autora",
@@ -161,9 +210,11 @@ def _integruj_wiersz(row):
                 # `integrate()` nadpisuje `log_zmian` na starcie — ślad
                 # utworzenia dopisujemy DOPIERO PO nim, do klucza
                 # "utworzono", zamiast go nadpisać.
-                row.log_zmian["utworzono"] = _opisz_utworzone(row.diff_do_utworzenia)
+                row.log_zmian["utworzono"] = _opisz_utworzone(
+                    row.diff_do_utworzenia, created
+                )
                 row.save(update_fields=["log_zmian"])
-            return
+            return nowy_okres_utworzony
         if materializowano:
             # Recheck nie widzi driftu (get_or_create już ustawił docelowe
             # wartości), ale wiersz FAKTYCZNIE wykonał pracę: utworzył nowe
@@ -175,14 +226,15 @@ def _integruj_wiersz(row):
             row.log_zmian = {
                 "autor": [],
                 "autor_jednostka": [],
-                "utworzono": _opisz_utworzone(row.diff_do_utworzenia),
+                "utworzono": _opisz_utworzone(row.diff_do_utworzenia, created),
             }
             row.save(update_fields=["log_zmian"])
-            return
+            return nowy_okres_utworzony
         # Prawdziwy drift: diff był pusty (nic nie materializowano) i
         # recheck nie widzi potrzeby zmian — baza zmieniła się od analizy.
         row.pominiety_bo_nieaktualny = True
         row.save(update_fields=["pominiety_bo_nieaktualny"])
+        return False
 
 
 def _wykonaj_odpiecia(parent):
@@ -905,8 +957,10 @@ def integruj(parent, p):
             utworzono_nowych += 1
 
     qs = parent.zmiany_potrzebne_set.all()
+    utworzono_nowych_okresow = 0
     for row in p.track(list(qs), total=qs.count(), label="Integracja"):
-        _integruj_wiersz(row)
+        if _integruj_wiersz(row):
+            utworzono_nowych_okresow += 1
 
     odpieto = _wykonaj_odpiecia(parent)
     przepieto_wierszy, przepieto_prac = _wykonaj_przepiecia(
@@ -953,6 +1007,7 @@ def integruj(parent, p):
             "przepieto_wierszy": przepieto_wierszy,
             "przepieto_prac": przepieto_prac,
             "utworzono_nowych_autorow": utworzono_nowych,
+            "utworzono_nowych_okresow": utworzono_nowych_okresow,
             "utworzono_jednostek": utworzono_jednostek,
             "utworzono_tytulow": utworzono_tytulow,
             "utworzono_stopni": utworzono_stopni,

--- a/src/import_pracownikow/roznice.py
+++ b/src/import_pracownikow/roznice.py
@@ -62,6 +62,28 @@ def _stan_funkcja(row):
     )
 
 
+def _stan_data_od(row):
+    # „brak" gdy plik nie niesie daty od, albo wiersz nie ma autora/jednostki
+    # (nie ma okresu do rozstrzygnięcia). Inaczej stan bierzemy z porównywarki:
+    # „zmienione" = nowy okres LUB wypełnienie pustej daty od w bazie.
+    if row.jednostka_id is None or not row.autor_id:
+        return "brak"
+    if not _dane(row).get("data_zatrudnienia"):
+        return "brak"
+    return "zmienione" if row.porownaj_z_baza()["data_od"]["rozne"] else "zgodne"
+
+
+def _stan_data_do(row):
+    # „brak" gdy plik nie niesie daty końca, albo wiersz nie ma autora/jednostki.
+    # „zmienione" = wstawienie do pustej, różnica pokazana bez nadpisania, albo
+    # nowy okres z niepustą datą końca.
+    if row.jednostka_id is None or not row.autor_id:
+        return "brak"
+    if not _dane(row).get("data_końca_zatrudnienia"):
+        return "brak"
+    return "zmienione" if row.porownaj_z_baza()["data_do"]["rozne"] else "zgodne"
+
+
 POLA_ROZNIC = [
     ("jednostka", "Jednostka", _stan_jednostka),
     ("email", "E-mail", _stan_email),
@@ -69,4 +91,6 @@ POLA_ROZNIC = [
     ("stopien", "Stopień służbowy", _stan_stopien),
     ("funkcja", "Funkcja w jednostce", _stan_funkcja),
     ("stanowisko", "Stanowisko dydaktyczne", _stan_stanowisko),
+    ("data_od", "Data od", _stan_data_od),
+    ("data_do", "Data do", _stan_data_do),
 ]

--- a/src/import_pracownikow/templates/import_pracownikow/import_pracownikow_result.html
+++ b/src/import_pracownikow/templates/import_pracownikow/import_pracownikow_result.html
@@ -4,7 +4,7 @@
 {# total, zmiany_potrzebne, byl_dry_run, stan; faza integracji: #}
 {# zintegrowano, pominieto_nieaktualne, pominieto_niedopasowane, #}
 {# pominieto_bez_jednostki, wymaga_uwagi, odpieto, utworzono_nowych_autorow, #}
-{# przepieto_wierszy, przepieto_prac, stan. #}
+{# utworzono_nowych_okresow, przepieto_wierszy, przepieto_prac, stan. #}
 {# Panel: żółty (warning) gdy integracja coś pominęła (wymaga_uwagi), żeby #}
 {# częściowy import nie udawał pełnego sukcesu (uwaga reviewera #3). #}
 <div class="panel callout {% if byl_dry_run %}secondary{% elif wymaga_uwagi %}warning{% else %}success{% endif %}">
@@ -61,6 +61,10 @@
             <p>Utworzono nowych autorów:
                 <strong>{{ utworzono_nowych_autorow }}</strong>.</p>
         {% endif %}
+        {% if utworzono_nowych_okresow %}
+            <p>Utworzono nowych okresów zatrudnienia:
+                <strong>{{ utworzono_nowych_okresow }}</strong>.</p>
+        {% endif %}
         {% if przepieto_wierszy %}
             <p>Przepięto prace:
                 <strong>{{ przepieto_wierszy }}</strong> wierszy /
@@ -89,6 +93,10 @@
         {% if utworzono_nowych_autorow %}
             <p>Utworzono nowych autorów:
                 <strong>{{ utworzono_nowych_autorow }}</strong>.</p>
+        {% endif %}
+        {% if utworzono_nowych_okresow %}
+            <p>Utworzono nowych okresów zatrudnienia:
+                <strong>{{ utworzono_nowych_okresow }}</strong>.</p>
         {% endif %}
         {% if przepieto_wierszy %}
             <p>Przepięto prace:

--- a/src/import_pracownikow/templates/import_pracownikow/partials/_wiersz_preview_kom.html
+++ b/src/import_pracownikow/templates/import_pracownikow/partials/_wiersz_preview_kom.html
@@ -222,6 +222,18 @@
                         <span class="import-porownanie-etykieta">Stanowisko dyd.:</span>
                         {% include "import_pracownikow/partials/_porownanie_kom.html" with pole=porownanie.stanowisko %}
                     </div>
+                    <div class="import-porownanie-item">
+                        <span class="import-porownanie-etykieta">Data od:</span>
+                        {% include "import_pracownikow/partials/_porownanie_kom.html" with pole=porownanie.data_od %}
+                        {% if porownanie.data_od.nowy_okres %}
+                            <br>
+                            <span class="label primary" title="Inna data od niż w bazie — powstanie nowy okres zatrudnienia">nowy okres</span>
+                        {% endif %}
+                    </div>
+                    <div class="import-porownanie-item">
+                        <span class="import-porownanie-etykieta">Data do:</span>
+                        {% include "import_pracownikow/partials/_porownanie_kom.html" with pole=porownanie.data_do %}
+                    </div>
                 {% endwith %}
             </div>
             <div class="import-blok import-blok-przepnij">

--- a/src/import_pracownikow/tests/test_okresy_resolver.py
+++ b/src/import_pracownikow/tests/test_okresy_resolver.py
@@ -1,0 +1,194 @@
+"""Resolver okresu zatrudnienia po „dacie od" (§7 spec
+``2026-07-13-import-pracownikow-synchronizacja-dat-zatrudnienia``).
+
+Po jednym teście na wiersz tabeli decyzyjnej §3 + parytet sortowania NULL-dat
+(N2), kontrakt typu ``date`` (N5) i brak zapytania przy ``aj_lista=`` (N+1).
+"""
+
+from datetime import date
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from model_bakery import baker
+
+from bpp.models import Autor, Autor_Jednostka, Jednostka
+from import_pracownikow.okresy import (
+    _wybierz_aktywny_najswiezszy,
+    rozwiaz_okres_zatrudnienia,
+)
+
+
+@pytest.fixture
+def para():
+    return baker.make(Autor), baker.make(Jednostka)
+
+
+@pytest.mark.django_db
+def test_brak_aj_data_w_pliku_tworzy_nowy(para):
+    autor, jednostka = para
+    assert rozwiaz_okres_zatrudnienia(autor, jednostka, date(2020, 1, 1)) == (
+        "nowy",
+        date(2020, 1, 1),
+    )
+
+
+@pytest.mark.django_db
+def test_brak_aj_pusty_plik_tworzy_nowy_none(para):
+    autor, jednostka = para
+    assert rozwiaz_okres_zatrudnienia(autor, jednostka, None) == ("nowy", None)
+
+
+@pytest.mark.django_db
+def test_ta_sama_data_od_zwraca_istniejacy(para):
+    autor, jednostka = para
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2020, 1, 1),
+    )
+    assert rozwiaz_okres_zatrudnienia(autor, jednostka, date(2020, 1, 1)) == (
+        "istniejacy",
+        aj,
+    )
+
+
+@pytest.mark.django_db
+def test_wypelnienie_null_zwraca_istniejacy(para):
+    autor, jednostka = para
+    aj = baker.make(
+        Autor_Jednostka, autor=autor, jednostka=jednostka, rozpoczal_prace=None
+    )
+    assert rozwiaz_okres_zatrudnienia(autor, jednostka, date(2021, 5, 5)) == (
+        "istniejacy",
+        aj,
+    )
+
+
+@pytest.mark.django_db
+def test_inna_data_od_przy_zamknietym_okresie_tworzy_nowy(para):
+    # Wszystkie istniejące okresy ZAMKNIĘTE → nowy okres (osoba odeszła i wraca).
+    autor, jednostka = para
+    baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2015, 1, 1),
+    )
+    assert rozwiaz_okres_zatrudnienia(autor, jednostka, date(2022, 9, 1)) == (
+        "nowy",
+        date(2022, 9, 1),
+    )
+
+
+@pytest.mark.django_db
+def test_inna_data_od_przy_otwartym_okresie_celuje_w_aktywny(para):
+    # Otwarty (trwający) okres → inna data od NIE tworzy nowego (defragmentuj by
+    # go scalił); celujemy w aktywny, różnicę pokaże podgląd (decyzja usera A).
+    autor, jednostka = para
+    aktywny = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=None,
+    )
+    assert rozwiaz_okres_zatrudnienia(autor, jednostka, date(2022, 9, 1)) == (
+        "istniejacy",
+        aktywny,
+    )
+
+
+@pytest.mark.django_db
+def test_istniejacy_pusty_plik_zwraca_aktywny_najswiezszy(para):
+    autor, jednostka = para
+    baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2015, 1, 1),
+    )
+    aktywny = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2016, 1, 1),
+        zakonczyl_prace=None,
+    )
+    assert rozwiaz_okres_zatrudnienia(autor, jednostka, None) == ("istniejacy", aktywny)
+
+
+@pytest.mark.django_db
+def test_wiele_null_rozpoczal_deterministyczny_po_pk(para):
+    autor, jednostka = para
+    a1 = baker.make(
+        Autor_Jednostka, autor=autor, jednostka=jednostka, rozpoczal_prace=None
+    )
+    a2 = baker.make(
+        Autor_Jednostka, autor=autor, jednostka=jednostka, rozpoczal_prace=None
+    )
+    _, wybrany = rozwiaz_okres_zatrudnienia(autor, jednostka, date(2020, 1, 1))
+    assert wybrany == min(a1, a2, key=lambda aj: aj.pk)
+
+
+class _AJ:
+    """Lekki obiekt AJ dla czystej funkcji (bez ORM)."""
+
+    def __init__(self, pk, rozpoczal, zakonczyl=None):
+        self.pk = pk
+        self.rozpoczal_prace = rozpoczal
+        self.zakonczyl_prace = zakonczyl
+
+
+def test_wybierz_aktywny_najswiezszy_null_jak_najswiezszy_bez_typeerror():
+    # Parytet z SQL NULLS FIRST (DESC): rozpoczal=None traktowany jako
+    # „najświeższy"; brak TypeError na porównaniu date z None.
+    datowany = _AJ(1, date(2020, 1, 1))
+    nullowy = _AJ(2, None)
+    assert _wybierz_aktywny_najswiezszy([datowany, nullowy]) is nullowy
+    assert _wybierz_aktywny_najswiezszy([nullowy, datowany]) is nullowy
+
+
+def test_wybierz_aktywny_preferuje_aktywny_etat():
+    historyczny = _AJ(1, date(2020, 1, 1), zakonczyl=date(2021, 1, 1))
+    aktywny = _AJ(2, date(2015, 1, 1), zakonczyl=None)
+    assert _wybierz_aktywny_najswiezszy([historyczny, aktywny]) is aktywny
+
+
+def test_wybierz_aktywny_pusta_lista_none():
+    assert _wybierz_aktywny_najswiezszy([]) is None
+
+
+@pytest.mark.django_db
+def test_aj_lista_przekazana_nie_odpala_zapytania(para):
+    autor, jednostka = para
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2020, 1, 1),
+    )
+    with CaptureQueriesContext(connection) as ctx:
+        rozwiaz_okres_zatrudnienia(autor, jednostka, date(2020, 1, 1), aj_lista=[aj])
+    assert len(ctx.captured_queries) == 0
+
+
+@pytest.mark.django_db
+def test_date_na_wejsciu_trafia_w_istniejacy_okres(para):
+    # N5: kontrakt — plik_od jako `date` poprawnie dopasowuje istniejący okres
+    # (ISO-string dałby zawsze „nowy" + duplikat AJ).
+    autor, jednostka = para
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2020, 1, 1),
+    )
+    rodzaj, wartosc = rozwiaz_okres_zatrudnienia(
+        autor, jednostka, date(2020, 1, 1), aj_lista=[aj]
+    )
+    assert rodzaj == "istniejacy"
+    assert wartosc is aj

--- a/src/import_pracownikow/tests/test_pipeline/test_analyze.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_analyze.py
@@ -100,10 +100,13 @@ def test_analiza_nie_tworzy_autor_jednostka_gdy_brak_powiazania(
     # Właściwa asercja: dry-run nie utworzył Autor_Jednostka.
     assert po == przed
     assert row.autor_jednostka is None
-    assert row.diff_do_utworzenia["autor_jednostka"] == {
-        "autor": autor.pk,
-        "jednostka": jednostka.pk,
-    }
+    aj_diff = row.diff_do_utworzenia["autor_jednostka"]
+    assert aj_diff["autor"] == autor.pk
+    assert aj_diff["jednostka"] == jednostka.pk
+    # Pierwsze powiązanie (brak istniejącego AJ) → nie „dodatkowy okres".
+    assert aj_diff["nowy_okres"] is False
+    # Resolver odkłada też „data od" z pliku (ISO-string / None) do materializacji.
+    assert "rozpoczal_prace" in aj_diff
 
 
 @pytest.mark.django_db

--- a/src/import_pracownikow/tests/test_pipeline/test_integrate_daty.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_integrate_daty.py
@@ -17,7 +17,28 @@ from model_bakery import baker
 from bpp.models import Autor_Jednostka
 from import_common.exceptions import BPPDatabaseError
 from import_pracownikow.models import ImportPracownikow, ImportPracownikowRow
-from import_pracownikow.pipeline.integrate import integruj
+from import_pracownikow.pipeline.integrate import _materializuj_diff, integruj
+
+
+def _row_swiezy_okres(imp, autor, jednostka, dane, *, rozpoczal_prace=None):
+    """Wiersz z odroczonym NOWYM okresem (diff_do_utworzenia['autor_jednostka'])
+    do bezpośredniej materializacji — bez istniejącego AJ."""
+    return ImportPracownikowRow.objects.create(
+        parent=imp,
+        autor=autor,
+        jednostka=jednostka,
+        autor_jednostka=None,
+        dane_znormalizowane=dane,
+        diff_do_utworzenia={
+            "autor_jednostka": {
+                "autor": autor.pk,
+                "jednostka": jednostka.pk,
+                "rozpoczal_prace": rozpoczal_prace,
+                "nowy_okres": False,
+            }
+        },
+        zmiany_potrzebne=True,
+    )
 
 
 def _row_z_aj(imp, autor, jednostka, aj, dane):
@@ -37,9 +58,22 @@ def _row_z_aj(imp, autor, jednostka, aj, dane):
 
 
 @pytest.mark.django_db
-def test_data_zmian_wypelnia_nowe_aj_bez_daty_w_pliku(autor_jednostka_fixture):
-    """Item 8: nowe powiązanie (rozpoczal_prace=None) i brak daty w pliku →
-    globalna „data zmian personalnych" z importu jako data początku pracy."""
+def test_swiezy_aj_bez_daty_w_pliku_uzywa_data_zmian(autor_jednostka_fixture):
+    """P1: NOWY okres (świeży AJ z diff) i brak daty w pliku → globalna „data
+    zmian personalnych" jako rozpoczal, stemplowana przy MATERIALIZACJI."""
+    autor, jednostka = autor_jednostka_fixture
+    imp = baker.make(ImportPracownikow, data_zmian_personalnych=date(2024, 9, 1))
+    row = _row_swiezy_okres(imp, autor, jednostka, {})
+    created = _materializuj_diff(row)
+    assert created is True
+    assert row.autor_jednostka.rozpoczal_prace == date(2024, 9, 1)
+
+
+@pytest.mark.django_db
+def test_istniejacy_aj_pusta_data_od_bez_zmian(autor_jednostka_fixture):
+    """§5: istniejący AJ + pusty plik_od → NIC NIE ZMIENIAJ. rozpoczal zostaje
+    NULL — NIE stemplujemy data_zmian/dziś na istniejącym AJ (fallback dotyczy
+    tylko świeżego AJ przy materializacji)."""
     autor, jednostka = autor_jednostka_fixture
     aj = baker.make(
         Autor_Jednostka, autor=autor, jednostka=jednostka, rozpoczal_prace=None
@@ -48,7 +82,7 @@ def test_data_zmian_wypelnia_nowe_aj_bez_daty_w_pliku(autor_jednostka_fixture):
     row = _row_z_aj(imp, autor, jednostka, aj, {})
     row._integrate_autor_jednostka()
     aj.refresh_from_db()
-    assert aj.rozpoczal_prace == date(2024, 9, 1)
+    assert aj.rozpoczal_prace is None
 
 
 @pytest.mark.django_db
@@ -84,20 +118,56 @@ def test_data_zmian_nie_nadpisuje_istniejacej_daty_aj(autor_jednostka_fixture):
 
 
 @pytest.mark.django_db
-def test_brak_globalnej_daty_stempluje_date_importu(autor_jednostka_fixture):
-    """Item 8 × #4: bez globalnej daty (None) i bez daty w pliku — nowe AJ
-    dostaje datę importu (dziś). „data zmian personalnych" jest tylko środkowym
-    ogniwem priorytetu (plik → globalna → dziś); ostatecznym fallbackiem pozostaje
-    polityka #4 (puste rozpoczal_prace zawsze stemplujemy)."""
+def test_swiezy_aj_bez_globalnej_daty_stempluje_dzis(autor_jednostka_fixture):
+    """P1 fallback: świeży AJ (nowy okres), brak daty w pliku i brak globalnej
+    „daty zmian" (None) → dzień importu (dziś). Priorytet: plik → globalna → dziś,
+    stemplowany przy materializacji nowego AJ."""
+    autor, jednostka = autor_jednostka_fixture
+    imp = baker.make(ImportPracownikow, data_zmian_personalnych=None)
+    row = _row_swiezy_okres(imp, autor, jednostka, {})
+    _materializuj_diff(row)
+    assert row.autor_jednostka.rozpoczal_prace == timezone.localdate()
+
+
+@pytest.mark.django_db
+def test_data_do_wstaw_gdy_pusta(autor_jednostka_fixture):
+    """§3: „data do" z pliku wstawiana, gdy AJ nie ma jeszcze końca zatrudnienia."""
     autor, jednostka = autor_jednostka_fixture
     aj = baker.make(
-        Autor_Jednostka, autor=autor, jednostka=jednostka, rozpoczal_prace=None
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=None,
     )
-    imp = baker.make(ImportPracownikow, data_zmian_personalnych=None)
-    row = _row_z_aj(imp, autor, jednostka, aj, {})
+    imp = baker.make(ImportPracownikow)
+    row = _row_z_aj(
+        imp, autor, jednostka, aj, {"data_końca_zatrudnienia": "2023-06-30"}
+    )
     row._integrate_autor_jednostka()
     aj.refresh_from_db()
-    assert aj.rozpoczal_prace == timezone.localdate()
+    assert aj.zakonczyl_prace == date(2023, 6, 30)
+
+
+@pytest.mark.django_db
+def test_data_do_nie_nadpisuje_istniejacej(autor_jednostka_fixture):
+    """§3: „data do" z pliku NIE nadpisuje istniejącej daty końca (różnicę
+    pokazuje tylko porównywarka, wstaw-tylko-gdy-pusta)."""
+    autor, jednostka = autor_jednostka_fixture
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2020, 12, 31),
+    )
+    imp = baker.make(ImportPracownikow)
+    row = _row_z_aj(
+        imp, autor, jednostka, aj, {"data_końca_zatrudnienia": "2023-06-30"}
+    )
+    row._integrate_autor_jednostka()
+    aj.refresh_from_db()
+    assert aj.zakonczyl_prace == date(2020, 12, 31)
 
 
 @pytest.mark.django_db

--- a/src/import_pracownikow/tests/test_pipeline/test_integrate_okresy_dat.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_integrate_okresy_dat.py
@@ -1,0 +1,132 @@
+"""Faza integracji: tworzenie NOWYCH okresów zatrudnienia (nowy Autor_Jednostka)
+gdy plik niesie inną „datę od" niż baza + licznik (§8/§10 spec sync dat).
+"""
+
+from datetime import date
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Autor_Jednostka
+from import_pracownikow.models import ImportPracownikow, ImportPracownikowRow
+from import_pracownikow.pipeline.integrate import _integruj_wiersz
+
+
+def _row_odroczony_okres(imp, autor, jednostka, dane, rozpoczal_iso, *, nowy_okres):
+    return ImportPracownikowRow.objects.create(
+        parent=imp,
+        autor=autor,
+        jednostka=jednostka,
+        autor_jednostka=None,
+        dane_znormalizowane=dane,
+        diff_do_utworzenia={
+            "autor_jednostka": {
+                "autor": autor.pk,
+                "jednostka": jednostka.pk,
+                "rozpoczal_prace": rozpoczal_iso,
+                "nowy_okres": nowy_okres,
+            }
+        },
+        zmiany_potrzebne=True,
+    )
+
+
+@pytest.mark.django_db
+def test_nowy_okres_tworzy_drugi_aj_gdy_stary_zamkniety(autor_jednostka_fixture):
+    """Inna data od przy ZAMKNIĘTYM starym okresie → NOWY Autor_Jednostka OBOK
+    istniejącego (osoba odeszła i wraca). Stary okres nietknięty (P2 — nie
+    domykamy; tu był już zamknięty)."""
+    autor, jednostka = autor_jednostka_fixture
+    stary = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2015, 1, 1),
+    )
+    imp = baker.make(ImportPracownikow)
+    row = _row_odroczony_okres(
+        imp,
+        autor,
+        jednostka,
+        {"data_zatrudnienia": "2022-09-01"},
+        "2022-09-01",
+        nowy_okres=True,
+    )
+    _integruj_wiersz(row)
+    okresy = Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka)
+    assert okresy.count() == 2
+    stary.refresh_from_db()
+    assert stary.zakonczyl_prace == date(2015, 1, 1)
+    assert okresy.filter(rozpoczal_prace=date(2022, 9, 1)).exists()
+
+
+@pytest.mark.django_db
+def test_integruj_wiersz_zwraca_true_dla_nowego_okresu(autor_jednostka_fixture):
+    """Zwrot ``_integruj_wiersz`` = przewód licznika ``utworzono_nowych_okresow``
+    (N1): utworzono AJ oznaczony nowy_okres → True."""
+    autor, jednostka = autor_jednostka_fixture
+    baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2015, 1, 1),
+    )
+    imp = baker.make(ImportPracownikow)
+    row = _row_odroczony_okres(
+        imp,
+        autor,
+        jednostka,
+        {"data_zatrudnienia": "2022-09-01"},
+        "2022-09-01",
+        nowy_okres=True,
+    )
+    assert _integruj_wiersz(row) is True
+
+
+@pytest.mark.django_db
+def test_pierwsze_powiazanie_nie_liczy_sie_jako_nowy_okres(autor_jednostka_fixture):
+    """Pierwsze powiązanie (brak istniejącego AJ) → nowy_okres=False, więc NIE
+    inkrementuje licznika, mimo że AJ powstał."""
+    autor, jednostka = autor_jednostka_fixture
+    imp = baker.make(ImportPracownikow)
+    row = _row_odroczony_okres(
+        imp,
+        autor,
+        jednostka,
+        {"data_zatrudnienia": "2022-09-01"},
+        "2022-09-01",
+        nowy_okres=False,
+    )
+    assert _integruj_wiersz(row) is False
+    assert Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka).count() == 1
+
+
+@pytest.mark.django_db
+def test_idempotencja_drugi_przebieg_nie_tworzy_trzeciego_okresu(
+    autor_jednostka_fixture,
+):
+    """Restart integracji (guard ``log_zmian``) → drugi ``_integruj_wiersz`` nie
+    tworzy kolejnego AJ i zwraca False (nie liczy okresu ponownie)."""
+    autor, jednostka = autor_jednostka_fixture
+    baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2015, 1, 1),
+    )
+    imp = baker.make(ImportPracownikow)
+    row = _row_odroczony_okres(
+        imp,
+        autor,
+        jednostka,
+        {"data_zatrudnienia": "2022-09-01"},
+        "2022-09-01",
+        nowy_okres=True,
+    )
+    assert _integruj_wiersz(row) is True
+    row.refresh_from_db()
+    assert _integruj_wiersz(row) is False
+    assert Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka).count() == 2

--- a/src/import_pracownikow/tests/test_pipeline/test_integrate_podstawowe_miejsce.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_integrate_podstawowe_miejsce.py
@@ -2,15 +2,15 @@
 
 Decyzja usera: import ma ustawiać jednostkę autora (z wiersza) jako PODSTAWOWE
 miejsce pracy, a pozostałe jednostki tego autora oznaczać jako NIE-podstawowe.
-Datę rozpoczęcia pracy stemplujemy TYLKO gdy pusta — priorytet: data z pliku,
-w razie braku data importu (dziś). Kolumna „Podstawowe miejsce pracy"=NIE w
-pliku wyłącza to dla danego wiersza.
+Datę rozpoczęcia pracy istniejącego AJ wypełniamy TYLKO gdy pusta ORAZ plik
+niesie datę (§5); fallback „data importu (dziś)" dotyczy wyłącznie ŚWIEŻEGO AJ
+(materializacja nowego okresu). Kolumna „Podstawowe miejsce pracy"=NIE w pliku
+wyłącza podstawowe dla danego wiersza.
 """
 
 from datetime import date
 
 import pytest
-from django.utils import timezone
 from liveops.testing import MockProgress
 from model_bakery import baker
 
@@ -76,8 +76,10 @@ def test_plik_nie_wylacza_podstawowego_miejsca(autor_jednostka_fixture):
 
 
 @pytest.mark.django_db
-def test_stempluje_date_importu_gdy_brak_w_pliku(autor_jednostka_fixture):
-    """Brak daty w pliku + puste rozpoczal_prace → data importu (dziś)."""
+def test_istniejacy_aj_pusta_data_nie_stemplowany(autor_jednostka_fixture):
+    """§5: istniejący AJ z pustą datą + brak daty w pliku → NIC NIE ZMIENIAJ
+    (rozpoczal zostaje NULL). Fallback „data importu (dziś)" dotyczy WYŁĄCZNIE
+    świeżego AJ (materializacja nowego okresu), nie istniejącego powiązania."""
     autor, jednostka = autor_jednostka_fixture
     aj = baker.make(
         Autor_Jednostka,
@@ -92,7 +94,7 @@ def test_stempluje_date_importu_gdy_brak_w_pliku(autor_jednostka_fixture):
     integruj(imp, MockProgress(imp))
 
     aj.refresh_from_db()
-    assert aj.rozpoczal_prace == timezone.localdate()
+    assert aj.rozpoczal_prace is None
 
 
 @pytest.mark.django_db

--- a/src/import_pracownikow/tests/test_porownywarka_daty.py
+++ b/src/import_pracownikow/tests/test_porownywarka_daty.py
@@ -1,0 +1,197 @@
+"""Porównywarka „plik vs baza" dla dat zatrudnienia (data_od/data_do) w podglądzie
+importu + ekstraktory stanów, dopełnianie snapshotu, inwalidacja memo (§9 spec).
+"""
+
+from datetime import date
+
+import pytest
+from model_bakery import baker
+
+from bpp.models import Autor, Autor_Jednostka, Jednostka
+from import_pracownikow.models import ImportPracownikowRow
+
+
+def _row(dane, autor=None, jednostka=None, aj=None):
+    return baker.make(
+        ImportPracownikowRow,
+        autor=autor,
+        jednostka=jednostka,
+        autor_jednostka=aj,
+        dane_znormalizowane=dane,
+    )
+
+
+@pytest.mark.django_db
+def test_data_od_zgodne_gdy_ta_sama():
+    autor, jednostka = baker.make(Autor), baker.make(Jednostka)
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2020, 1, 1),
+    )
+    row = _row({"data_zatrudnienia": "2020-01-01"}, autor, jednostka, aj)
+    pole = row.porownaj_z_baza()["data_od"]
+    assert pole["rozne"] is False
+    assert pole["nowy_okres"] is False
+    assert row.stany_pol()["data_od"] == "zgodne"
+
+
+@pytest.mark.django_db
+def test_data_od_wypelnienie_null_zmienione():
+    autor, jednostka = baker.make(Autor), baker.make(Jednostka)
+    aj = baker.make(
+        Autor_Jednostka, autor=autor, jednostka=jednostka, rozpoczal_prace=None
+    )
+    row = _row({"data_zatrudnienia": "2021-05-05"}, autor, jednostka, aj)
+    pole = row.porownaj_z_baza()["data_od"]
+    assert pole["rozne"] is True
+    assert pole["nowy_okres"] is False
+    assert row.stany_pol()["data_od"] == "zmienione"
+
+
+@pytest.mark.django_db
+def test_data_od_nowy_okres_gdy_stary_zamkniety():
+    # Stary okres ZAMKNIĘTY → inna data od = nowy okres (flaga + baza referencyjna).
+    autor, jednostka = baker.make(Autor), baker.make(Jednostka)
+    baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2015, 1, 1),
+    )
+    row = _row({"data_zatrudnienia": "2022-09-01"}, autor, jednostka, None)
+    pole = row.porownaj_z_baza()["data_od"]
+    assert pole["nowy_okres"] is True
+    assert pole["rozne"] is True
+    assert pole["plik"] == "2022-09-01"
+    assert pole["baza"] == "2010-01-01"
+    assert row.stany_pol()["data_od"] == "zmienione"
+
+
+@pytest.mark.django_db
+def test_data_od_otwarty_okres_rozne_bez_nowego_okresu():
+    # Otwarty okres → inna data od pokazuje różnicę, ale NIE „nowy okres"
+    # (celujemy w aktywny; decyzja A). Wiersz ma podpięty aktywny AJ.
+    autor, jednostka = baker.make(Autor), baker.make(Jednostka)
+    aktywny = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=None,
+    )
+    row = _row({"data_zatrudnienia": "2022-09-01"}, autor, jednostka, aktywny)
+    pole = row.porownaj_z_baza()["data_od"]
+    assert pole["nowy_okres"] is False
+    assert pole["rozne"] is True
+    assert pole["baza"] == "2010-01-01"
+    assert row.stany_pol()["data_od"] == "zmienione"
+
+
+@pytest.mark.django_db
+def test_data_od_brak_gdy_pusty_plik():
+    autor, jednostka = baker.make(Autor), baker.make(Jednostka)
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2020, 1, 1),
+    )
+    row = _row({}, autor, jednostka, aj)
+    assert row.stany_pol()["data_od"] == "brak"
+
+
+@pytest.mark.django_db
+def test_data_od_brak_gdy_pusta_jednostka():
+    autor = baker.make(Autor)
+    row = _row({"data_zatrudnienia": "2020-01-01"}, autor, None, None)
+    assert row.stany_pol()["data_od"] == "brak"
+    assert row.porownaj_z_baza()["data_od"]["rozne"] is False
+
+
+@pytest.mark.django_db
+def test_data_do_wstawienie_zmienione():
+    autor, jednostka = baker.make(Autor), baker.make(Jednostka)
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=None,
+    )
+    row = _row({"data_końca_zatrudnienia": "2023-06-30"}, autor, jednostka, aj)
+    assert row.porownaj_z_baza()["data_do"]["rozne"] is True
+    assert row.stany_pol()["data_do"] == "zmienione"
+
+
+@pytest.mark.django_db
+def test_data_do_roznica_pokazana_nie_nadpisana():
+    autor, jednostka = baker.make(Autor), baker.make(Jednostka)
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2020, 12, 31),
+    )
+    row = _row({"data_końca_zatrudnienia": "2023-06-30"}, autor, jednostka, aj)
+    pole = row.porownaj_z_baza()["data_do"]
+    assert pole["rozne"] is True
+    assert pole["baza"] == "2020-12-31"
+    assert row.stany_pol()["data_do"] == "zmienione"
+
+
+@pytest.mark.django_db
+def test_data_do_zgodne_gdy_ta_sama():
+    autor, jednostka = baker.make(Autor), baker.make(Jednostka)
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2023, 6, 30),
+    )
+    row = _row({"data_końca_zatrudnienia": "2023-06-30"}, autor, jednostka, aj)
+    assert row.porownaj_z_baza()["data_do"]["rozne"] is False
+    assert row.stany_pol()["data_do"] == "zgodne"
+
+
+@pytest.mark.django_db
+def test_plik_od_zwraca_date_nie_str():
+    # N5: kontrakt — _plik_od parsuje ISO-string do date (resolver wymaga date).
+    row = _row({"data_zatrudnienia": "2020-01-01"})
+    assert row._plik_od() == date(2020, 1, 1)
+
+
+@pytest.mark.django_db
+def test_snapshot_bez_nowych_kluczy_dopelniony_brak():
+    """Stary snapshot (sprzed data_od/data_do) → dopełniony „brak", rekord nie
+    znika pod filtrem nowego pola."""
+    row = baker.make(
+        ImportPracownikowRow,
+        autor=None,
+        dane_znormalizowane={},
+        stany_pol_snapshot={"jednostka": "zgodne"},
+    )
+    stany = row.stany_pol()
+    assert stany["data_od"] == "brak"
+    assert stany["data_do"] == "brak"
+    assert stany["jednostka"] == "zgodne"
+
+
+@pytest.mark.django_db
+def test_memo_okres_inwalidowane_po_zmianie_autora():
+    """N3: zmiana autora + ``_zapomnij_okres`` → kolejny odczyt liczy decyzję dla
+    NOWEGO autora (nie stara memo)."""
+    a1, a2 = baker.make(Autor), baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+    baker.make(
+        Autor_Jednostka, autor=a1, jednostka=jednostka, rozpoczal_prace=date(2020, 1, 1)
+    )
+    row = _row({"data_zatrudnienia": "2020-01-01"}, a1, jednostka, None)
+    assert row._okres()[0] == "istniejacy"
+    row.autor = a2
+    row._zapomnij_okres()
+    assert row._okres() == ("nowy", date(2020, 1, 1))

--- a/src/import_pracownikow/tests/test_stany_pol.py
+++ b/src/import_pracownikow/tests/test_stany_pol.py
@@ -64,6 +64,8 @@ def test_stany_pol_ma_wszystkie_klucze():
         "stopien",
         "funkcja",
         "stanowisko",
+        "data_od",
+        "data_do",
     }
 
 

--- a/src/import_pracownikow/tests/test_views_preview_render.py
+++ b/src/import_pracownikow/tests/test_views_preview_render.py
@@ -173,14 +173,23 @@ def test_podglad_wiersz_ma_atrybuty_data_diff(admin_client, admin_user):
     )
     url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
     tresc = admin_client.get(url).content.decode("utf-8")
-    for klucz in ("jednostka", "email", "tytul", "stopien", "funkcja", "stanowisko"):
+    for klucz in (
+        "jednostka",
+        "email",
+        "tytul",
+        "stopien",
+        "funkcja",
+        "stanowisko",
+        "data_od",
+        "data_do",
+    ):
         assert f"data-diff-{klucz}=" in tresc
 
 
 @pytest.mark.django_db
 def test_podglad_ma_pasek_filtrow_radia(admin_client, admin_user):
     """Pasek filtrów renderuje radia (wszystkie/zmienione/zgodne/brak) dla
-    każdego z 6 pól POLA_ROZNIC."""
+    każdego z pól POLA_ROZNIC (w tym data_od/data_do)."""
     imp = baker.make(
         ImportPracownikow,
         owner=admin_user,
@@ -190,7 +199,16 @@ def test_podglad_ma_pasek_filtrow_radia(admin_client, admin_user):
     url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
     tresc = admin_client.get(url).content.decode("utf-8")
     assert 'id="filtr-roznic"' in tresc
-    for klucz in ("jednostka", "email", "tytul", "stopien", "funkcja", "stanowisko"):
+    for klucz in (
+        "jednostka",
+        "email",
+        "tytul",
+        "stopien",
+        "funkcja",
+        "stanowisko",
+        "data_od",
+        "data_do",
+    ):
         assert f'name="filtr-{klucz}"' in tresc
     assert 'value="zmienione"' in tresc
     assert 'value="brak"' in tresc

--- a/src/import_pracownikow/views.py
+++ b/src/import_pracownikow/views.py
@@ -390,6 +390,8 @@ def _zwiaz_autora_z_wierszem(row, autor):
         row.diff_do_utworzenia.pop("autor_jednostka", None)
         row.autor_jednostka = None
         row.zmiany_potrzebne = False
+        # Zmiana autora unieważnia decyzję okresu (odtworz robi to sam w else).
+        row._zapomnij_okres()
     else:
         odtworz_autor_jednostka(row, autor)
     row.confidence = STATUS_RECZNY


### PR DESCRIPTION
## Cel

Uwidacznia i synchronizuje daty zatrudnienia w imporcie pracowników wokół pojęcia **okresu identyfikowanego przez „datę od"** (`Autor_Jednostka.unique_together = (autor, jednostka, rozpoczal_prace)`).

## Co robi

- **Widoczność (główny ból):** dwie nowe pozycje `Data od` / `Data do` w porównywarce „plik vs baza" (karta rekordu z #559) + filtr + `data-diff-*` — automatycznie przez rejestr `POLA_ROZNIC`.
- **„data od":** wypełnij gdy w bazie `NULL` a plik niesie datę; istniejący AJ + pusty plik → **NIC NIE ZMIENIAJ**; fallback `data zmian → dziś` tylko przy materializacji **świeżego** AJ.
- **„data do":** wstaw-tylko-gdy-pusta (różnicę **pokazujemy**, nie nadpisujemy).
- **Nowy okres** (nowy `Autor_Jednostka`) gdy plik niesie inną „datę od" — **tylko gdy istniejące okresy są ZAMKNIĘTE** (osoba odeszła i wraca). Przy **otwartym** okresie pokazujemy różnicę i celujemy w aktywny (bez tworzenia/domykania).
- **Licznik** `utworzono_nowych_okresow` w panelu wyniku.

## Kluczowa decyzja projektowa (odkryta przy implementacji)

`Autor.save()` → `defragmentuj_jednostke` **scala** nakładające/sąsiadujące/otwarte okresy tej samej pary. Dwa **otwarte** okresy naraz są niemożliwe (zostałyby scalone, a świeży AJ skasowany → crash easyaudit). Dlatego nowy okres powstaje **tylko przy zamkniętych** istniejących okresach; przy otwartym — sama różnica w podglądzie. Guard w `integrate()` (`_przepnij_aj_po_defragmentacji`) chroni przed edge'em „nowy okres dzień po końcu zamkniętego".

## Jakość

- Resolver `rozwiaz_okres_zatrudnienia` = jedno źródło prawdy (analiza + rekonstrukcja + podgląd) → podgląd nie zapowiada innego okresu niż utworzy commit.
- 1 zapytanie o AJ / wiersz + memo (bez N+1). Spłaca dług `MultipleObjectsReturned` (lookup po pełnym kluczu unikalności, `order_by().first()`+`create`).
- **Bez migracji schematu.**
- Dwie rundy review sub-agentem (Fable) na specu przed implementacją.

## Testy

Moduł `import_pracownikow`: **527 zielonych** (nowe: `test_okresy_resolver.py`, `test_integrate_okresy_dat.py`, `test_porownywarka_daty.py` + rozbudowa istniejących). Pełne `make tests` lokalnie w toku równolegle z CI.

Spec: `docs/superpowers/specs/2026-07-13-import-pracownikow-synchronizacja-dat-zatrudnienia-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)