### PR TITLE
security(bpp): sanityzuj tytuły i opisy bibliograficzne (stored XSS #3)

### DIFF
--- a/src/bpp/management/commands/sanityzuj_tytuly.py
+++ b/src/bpp/management/commands/sanityzuj_tytuly.py
@@ -1,0 +1,92 @@
+"""Jednorazowa sanityzacja istniejących tytułów publikacji.
+
+Save-hook (``DwaTytuly.save()`` / ``Patent.save()``) czyści tytuły przy każdym
+zapisie, ale dane sprzed wdrożenia mogą nadal zawierać niebezpieczny HTML
+(``<script>``) lub pseudo-znaczniki liter greckich (``<beta>``). Komenda
+przechodzi wszystkie konkretne modele z polem ``tytul_oryginalny``, sanityzuje
+tytuły przez ``safe_tytul_html`` i — z opcją ``--napraw`` — zapisuje zmiany
+(``save()`` wyzwala też przebudowę ``opis_bibliograficzny_cache`` przez denorm).
+
+Bez ``--napraw`` tylko raportuje, ile tytułów wymagałoby zmiany.
+"""
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from bpp.util import safe_tytul_html
+
+
+def _modele_z_tytulem():
+    """Konkretne (nie-abstrakcyjne) modele z polem ``tytul_oryginalny``."""
+    out = []
+    for m in apps.get_models():
+        # Pomijamy modele niezarządzane (np. ``Rekord`` to SQL VIEW — zapis do
+        # nich nie tknąłby realnej tabeli i rzuciłby „did not affect any rows").
+        if m._meta.abstract or not m._meta.managed:
+            continue
+        field_names = {f.name for f in m._meta.get_fields()}
+        if "tytul_oryginalny" in field_names:
+            out.append(m)
+    return sorted(out, key=lambda m: m.__name__)
+
+
+class Command(BaseCommand):
+    help = "Sanityzuje istniejące tytuły publikacji (XSS, litery greckie)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--napraw",
+            action="store_true",
+            help="Zapisz zmiany (domyślnie tylko raport).",
+        )
+
+    @staticmethod
+    def _przypisz_czyste_tytuly(obj, ma_tytul):
+        """Ustaw na obiekcie sanityzowane tytuły; zwróć listę zmienionych pól."""
+        fields = []
+        nowy_oryg = safe_tytul_html(obj.tytul_oryginalny)
+        if nowy_oryg != obj.tytul_oryginalny:
+            obj.tytul_oryginalny = nowy_oryg
+            fields.append("tytul_oryginalny")
+        if ma_tytul:
+            nowy_t = safe_tytul_html(obj.tytul)
+            if nowy_t != obj.tytul:
+                obj.tytul = nowy_t
+                fields.append("tytul")
+        return fields
+
+    def _sanityzuj_model(self, model, napraw):
+        ma_tytul = "tytul" in {f.name for f in model._meta.get_fields()}
+        flt = Q(tytul_oryginalny__contains="<")
+        if ma_tytul:
+            flt |= Q(tytul__contains="<")
+
+        zmienione = 0
+        for obj in model.objects.filter(flt).iterator():
+            fields = self._przypisz_czyste_tytuly(obj, ma_tytul)
+            if not fields:
+                continue
+            zmienione += 1
+            if napraw:
+                # save() (nie update()) — wyzwala denorm → przebudowa
+                # opis_bibliograficzny_cache z czystego tytułu.
+                obj.save(update_fields=fields)
+        return zmienione
+
+    def handle(self, *args, **options):
+        napraw = options["napraw"]
+        laczna_zmiana = 0
+
+        for model in _modele_z_tytulem():
+            zmienione = self._sanityzuj_model(model, napraw)
+            if zmienione:
+                laczna_zmiana += zmienione
+                self.stdout.write(f"{model.__name__}: {zmienione} tytułów")
+
+        czasownik = "naprawiono" if napraw else "do naprawy"
+        self.stdout.write(
+            self.style.SUCCESS(f"Łącznie {czasownik}: {laczna_zmiana} tytułów.")
+        )
+        if not napraw and laczna_zmiana:
+            self.stdout.write("Uruchom ponownie z --napraw, aby zapisać zmiany.")

--- a/src/bpp/models/abstract/naming.py
+++ b/src/bpp/models/abstract/naming.py
@@ -4,7 +4,7 @@ Modele abstrakcyjne związane z nazwami.
 
 from django.db import models
 
-from bpp.util import safe_html
+from bpp.util import safe_tytul_html
 
 
 class ModelZNazwa(models.Model):
@@ -55,6 +55,17 @@ class DwaTytuly(models.Model):
     class Meta:
         abstract = True
 
+    def save(self, *args, **kwargs):
+        self._sanityzuj_tytuly()
+        return super().save(*args, **kwargs)
+
     def clean(self):
-        self.tytul_oryginalny = safe_html(self.tytul_oryginalny)
-        self.tytul = safe_html(self.tytul)
+        self._sanityzuj_tytuly()
+
+    def _sanityzuj_tytuly(self):
+        # Wąska allowlista (kursywa, sub/sup, pogrubienie — bez tagów blokowych
+        # i bez atrybutów) plus zamiana pseudo-znaczników liter greckich na
+        # Unicode. Egzekwowane też w ``save()``, bo ``objects.create()`` i
+        # importery NIE wołają ``full_clean()``.
+        self.tytul_oryginalny = safe_tytul_html(self.tytul_oryginalny)
+        self.tytul = safe_tytul_html(self.tytul)

--- a/src/bpp/models/patent.py
+++ b/src/bpp/models/patent.py
@@ -26,7 +26,7 @@ from bpp.models.abstract import (
 )
 from bpp.models.autor import Autor
 from bpp.models.system import Charakter_Formalny, Jezyk
-from bpp.util import safe_html
+from bpp.util import safe_tytul_html
 
 
 class Patent_Autor(BazaModeluOdpowiedzialnosciAutorow):
@@ -134,8 +134,14 @@ class Patent(
 
     def clean(self):
         # DwaTytuly.clean() w wydaniu jedno-tytułowym...
-        self.tytul_oryginalny = safe_html(self.tytul_oryginalny)
+        self.tytul_oryginalny = safe_tytul_html(self.tytul_oryginalny)
         ModelZeSzczegolami.clean(self)
+
+    def save(self, *args, **kwargs):
+        # Egzekwuj sanityzację tytułu także na ścieżce objects.create()/import,
+        # która nie woła full_clean().
+        self.tytul_oryginalny = safe_tytul_html(self.tytul_oryginalny)
+        return super().save(*args, **kwargs)
 
     #
     # Cache framework by django-denorm-iplweb

--- a/src/bpp/models/util.py
+++ b/src/bpp/models/util.py
@@ -111,7 +111,7 @@ class ModelZOpisemBibliograficznym(models.Model):
         while ret.find("  ") != -1:
             ret = ret.replace("  ", " ")
 
-        return (
+        ret = (
             ret.replace(" , ", ", ")
             .replace(" . ", ". ")
             .replace(". . ", ". ")
@@ -119,6 +119,15 @@ class ModelZOpisemBibliograficznym(models.Model):
             .replace(" .", ".")
             .replace(".</b>[", ".</b> [")
         )
+
+        # Opis powstaje m.in. z (niezaufanego) tytułu i jest renderowany |safe
+        # oraz cache'owany w opis_bibliograficzny_cache. Sanityzujemy złożenie,
+        # żeby żaden <script> z tytułu nie przeżył (obrona w głębi obok
+        # sanityzacji tytułu u źródła), zachowując kursywę, sub/sup i linki
+        # autorów.
+        from bpp.util import safe_opis_bibliograficzny_html
+
+        return safe_opis_bibliograficzny_html(ret)
 
     def autorzy_dla_opisu(self):
         # Takie 'autorzy_set.all()' ale na potrzeby opisu bibliograficznego -- zaciąga

--- a/src/bpp/newsfragments/xss-tytul-opis.bugfix.rst
+++ b/src/bpp/newsfragments/xss-tytul-opis.bugfix.rst
@@ -1,0 +1,6 @@
+Tytuły publikacji i opisy bibliograficzne są sanityzowane wąską allowlistą
+(kursywa, indeksy dolne/górne, pogrubienie) — u źródła przy zapisie oraz przy
+renderowaniu (``|safe_tytul``) — co zamyka trwały XSS z tytułów pochodzących
+z importu i anonimowych zgłoszeń. Przy okazji pseudo-znaczniki liter greckich
+(``<beta>``, ``<Delta>``) są zamieniane na właściwe znaki Unicode zamiast być
+usuwane. Nowa komenda ``sanityzuj_tytuly`` czyści istniejące dane.

--- a/src/bpp/templates/browse/praca.html
+++ b/src/bpp/templates/browse/praca.html
@@ -46,7 +46,7 @@
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url "multiseek:index" %}">Wyszukiwanie</a></li>
-    <li class="current">{{ rekord.tytul_oryginalny|truncatewords_html:15|safe}}</li>
+    <li class="current">{{ rekord.tytul_oryginalny|truncatewords_html:15|safe_tytul }}</li>
 {% endblock %}
 
 

--- a/src/bpp/templates/browse/praca_tabela_mono.html
+++ b/src/bpp/templates/browse/praca_tabela_mono.html
@@ -11,10 +11,10 @@
     <div class="praca-mono__title-section">
         <h2 class="praca-mono__title">
             {% if praca.tytul %}
-                {{ praca.tytul_oryginalny|safe }}
-                <span class="praca-mono__title-translation">({{ praca.tytul|safe }})</span>
+                {{ praca.tytul_oryginalny|safe_tytul }}
+                <span class="praca-mono__title-translation">({{ praca.tytul|safe_tytul }})</span>
             {% else %}
-                {{ praca.tytul_oryginalny|znak_na_koncu:"."|safe }}
+                {{ praca.tytul_oryginalny|znak_na_koncu:"."|safe_tytul }}
             {% endif %}
             {% if praca.charakter_formalny.charakter_ogolny != 'roz' %}
                 <span class="praca-mono__edition-mark">{{ praca.oznaczenie_wydania|default:""|znak_na_koncu:"." }}</span>

--- a/src/bpp/templatetags/prace.py
+++ b/src/bpp/templatetags/prace.py
@@ -117,6 +117,20 @@ def safe_streszczenie(value):
     return mark_safe(safe_streszczenie_html(value))
 
 
+@register.filter(name="safe_tytul")
+def safe_tytul(value):
+    """Wyrenderuj tytuł publikacji bezpiecznie.
+
+    Zamiennik dla ``|safe`` przy ``tytul``/``tytul_oryginalny``: sanityzuje
+    HTML tytułu (wąska allowlista inline — kursywa, pogrubienie, sub/sup),
+    usuwając XSS z tytułów pochodzących z importu/zgłoszeń. Stosować jako
+    OSTATNI filtr (po ``truncatewords_html``/``znak_na_koncu``).
+    """
+    from bpp.util import safe_tytul_html
+
+    return mark_safe(safe_tytul_html(value))
+
+
 @register.filter(name="jsonify")
 def jsonify(value):
     """Convert a value to a JSON literal for use inside a <script> JSON-LD block.

--- a/src/bpp/tests/test_management_commands_sanityzuj_tytuly.py
+++ b/src/bpp/tests/test_management_commands_sanityzuj_tytuly.py
@@ -1,0 +1,32 @@
+import pytest
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+def test_sanityzuj_tytuly_naprawia_xss_i_greke(wydawnictwo_ciagle):
+    # Zapis surowego XSS z pominięciem save-hooka (symulacja legacy danych).
+    type(wydawnictwo_ciagle).objects.filter(pk=wydawnictwo_ciagle.pk).update(
+        tytul_oryginalny="<script>alert(1)</script><i>Genus</i> 17<beta>-ol",
+        tytul="",
+    )
+
+    call_command("sanityzuj_tytuly", "--napraw")
+
+    wydawnictwo_ciagle.refresh_from_db()
+    t = wydawnictwo_ciagle.tytul_oryginalny
+    assert "<script>" not in t
+    assert "alert(1)" not in t
+    assert "<i>Genus</i>" in t
+    assert "β" in t
+
+
+@pytest.mark.django_db
+def test_sanityzuj_tytuly_dry_run_nie_zmienia(wydawnictwo_ciagle):
+    type(wydawnictwo_ciagle).objects.filter(pk=wydawnictwo_ciagle.pk).update(
+        tytul_oryginalny="<script>alert(1)</script>x"
+    )
+
+    call_command("sanityzuj_tytuly")  # bez --napraw = tylko raport
+
+    wydawnictwo_ciagle.refresh_from_db()
+    assert "<script>" in wydawnictwo_ciagle.tytul_oryginalny

--- a/src/bpp/tests/test_safe_tytul.py
+++ b/src/bpp/tests/test_safe_tytul.py
@@ -1,0 +1,137 @@
+"""Sanityzacja tytułów publikacji (XSS) z zachowaniem formatowania inline."""
+
+import pytest
+from django.template import Context, Template
+from model_bakery import baker
+
+from bpp.util import safe_tytul_html
+
+
+def test_safe_tytul_strips_script():
+    out = safe_tytul_html("<script>alert(1)</script>Tytuł pracy")
+    assert "<script>" not in out
+    assert "alert(1)" not in out
+    assert "Tytuł pracy" in out
+
+
+def test_safe_tytul_keeps_italic_and_bold():
+    out = safe_tytul_html("<i>Genus species</i> oraz <b>ważne</b>")
+    assert "<i>Genus species</i>" in out
+    assert "<b>ważne</b>" in out
+
+
+def test_safe_tytul_keeps_sub_and_sup():
+    out = safe_tytul_html("H<sub>2</sub>O oraz CD4<sup>+</sup>")
+    assert "<sub>2</sub>" in out
+    assert "<sup>+</sup>" in out
+
+
+def test_safe_tytul_strips_attributes():
+    # Nawet na dozwolonym tagu — zero atrybutów (kill onerror/class/style).
+    out = safe_tytul_html('<i onmouseover="alert(1)" class="x">a</i>')
+    assert "onmouseover" not in out
+    assert "class" not in out
+    assert "<i>a</i>" in out
+
+
+def test_safe_tytul_strips_img_onerror():
+    out = safe_tytul_html("<img src=x onerror=alert(document.cookie)>")
+    assert "<img" not in out
+    assert "onerror" not in out
+
+
+def test_safe_tytul_strips_links():
+    out = safe_tytul_html('<a href="javascript:alert(1)">klik</a>')
+    assert "<a" not in out
+    assert "javascript" not in out
+    assert "klik" in out
+
+
+def test_safe_tytul_escapes_bare_less_than():
+    # Notacja matematyczna w tytule nie może pożreć układu strony.
+    out = safe_tytul_html("Wartości <30 jednostek")
+    assert "&lt;30" in out
+    assert "<30" not in out
+
+
+def test_safe_tytul_puste_bez_zmian():
+    # Brak '<' → zwracamy wejście bez mutacji (None/'' bez zmian, '&' nietknięty).
+    assert safe_tytul_html(None) is None
+    assert safe_tytul_html("") == ""
+    assert safe_tytul_html("Rak & terapia (100%)") == "Rak & terapia (100%)"
+
+
+def test_safe_tytul_filter_in_template_blocks_xss():
+    tpl = Template("{% load prace %}{{ t|safe_tytul }}")
+    rendered = tpl.render(Context({"t": "<script>alert(1)</script><i>ok</i>"}))
+    assert "<script>" not in rendered
+    assert "alert(1)" not in rendered
+    assert "<i>ok</i>" in rendered
+
+
+def test_safe_tytul_konwertuje_pseudotagi_greckie():
+    assert safe_tytul_html("17<beta>-estradiol") == "17β-estradiol"
+    # Wielka litera → majuskuła grecka.
+    assert "Δ" in safe_tytul_html("<Delta><sup>2</sup>-triazoline")
+    # Kombinacja: greka + XSS + kursywa.
+    out = safe_tytul_html("<alfa> <script>x</script><i>ok</i>")
+    assert out.startswith("α")
+    assert "<script>" not in out
+    assert "<i>ok</i>" in out
+
+
+def test_safe_opis_zachowuje_linki_autorow_i_tnie_xss():
+    from bpp.util import safe_opis_bibliograficzny_html
+
+    out = safe_opis_bibliograficzny_html(
+        '<a href="/autor/x">Kowalski J</a> <i>Nature</i> <script>alert(1)</script>'
+    )
+    assert '<a href="/autor/x">Kowalski J</a>' in out
+    assert "<i>Nature</i>" in out
+    assert "<script>" not in out
+    assert "alert(1)" not in out
+
+
+@pytest.mark.django_db
+def test_zapis_tytulu_sanityzuje_u_zrodla(wydawnictwo_ciagle):
+    """save() (a więc też objects.create()/import) czyści tytuł u źródła."""
+    wydawnictwo_ciagle.tytul_oryginalny = (
+        "<script>alert(1)</script><i>Genus</i> 17<beta>-estradiol"
+    )
+    wydawnictwo_ciagle.save()
+    wydawnictwo_ciagle.refresh_from_db()
+    t = wydawnictwo_ciagle.tytul_oryginalny
+    assert "<script>" not in t
+    assert "alert(1)" not in t
+    assert "<i>Genus</i>" in t
+    assert "β" in t
+
+
+@pytest.mark.django_db
+def test_browse_praca_page_sanitizes_title_xss(client, wydawnictwo_ciagle):
+    """End-to-end na PUBLICZNEJ stronie rekordu: złośliwy tytuł nie może
+    wyrenderować aktywnego ``<script>``, a legalna kursywa ma przetrwać."""
+    from denorm import denorms
+    from django.contrib.contenttypes.models import ContentType
+    from django.urls import reverse
+
+    baker.make("bpp.Uczelnia")
+    wydawnictwo_ciagle.tytul_oryginalny = (
+        "<script>alert(1)</script><i>Genus species</i>"
+    )
+    wydawnictwo_ciagle.save()
+    denorms.flush()
+
+    ct = ContentType.objects.get(app_label="bpp", model="wydawnictwo_ciagle")
+    res = client.get(
+        reverse("bpp:browse_praca", args=(ct.pk, wydawnictwo_ciagle.pk)),
+        follow=True,
+    )
+    assert res.status_code == 200
+    body = res.content.decode()
+    # Żaden aktywny <script> z tytułu — ani bezpośrednio, ani przez
+    # zdenormalizowany opis_bibliograficzny_cache.
+    assert "<script>alert(1)" not in body
+    assert "<script>alert(1)</script>" not in body
+    # Legalna kursywa (nazwa gatunku) przetrwała.
+    assert "<i>Genus species</i>" in body

--- a/src/bpp/util/__init__.py
+++ b/src/bpp/util/__init__.py
@@ -50,6 +50,7 @@ from bpp.util.text import (
     non_url,
     safe_html,
     safe_html_defaults,
+    safe_opis_bibliograficzny_html,
     safe_streszczenie_html,
     safe_tytul_html,
     sanitize_multiseek_title,
@@ -60,6 +61,7 @@ from bpp.util.text import (
     strip_nonalpha_regex,
     strip_nonalphanumeric,
     wytnij_isbn_z_uwag,
+    zamien_pseudotagi_na_greke,
     zrob_cache,
 )
 from bpp.util.wyjatki import zaloguj_polkniety_wyjatek
@@ -143,9 +145,11 @@ __all__ = [
     "non_url",
     "safe_html",
     "safe_html_defaults",
+    "safe_opis_bibliograficzny_html",
     "safe_streszczenie_html",
     "safe_tytul_html",
     "sanitize_multiseek_title",
+    "zamien_pseudotagi_na_greke",
     "slugify_function",
     "strip_extra_spaces",
     "strip_extra_spaces_regex",

--- a/src/bpp/util/text.py
+++ b/src/bpp/util/text.py
@@ -181,6 +181,169 @@ def safe_html(html):
     )
 
 
+# Litery greckie wpisywane przez autorów jako pseudo-znaczniki (``<beta>``,
+# ``<Delta>``, ``<alfa>``) — to NIE jest HTML, tylko nazwa litery w nawiasach
+# ostrokątnych. Bez konwersji sanitizer (nh3) wyrzuciłby je jako nieznany tag,
+# gubiąc literę. Zamieniamy je na właściwy znak Unicode ZANIM zadziała nh3.
+# Nazwa z wielkiej litery (``<Delta>``) → majuskuła (Δ) tam, gdzie majuskuła
+# różni się wizualnie od łacińskiej; inaczej minuskuła.
+_GREEK_LOWER = {
+    "alfa": "α",
+    "alpha": "α",
+    "beta": "β",
+    "gamma": "γ",
+    "delta": "δ",
+    "epsilon": "ε",
+    "zeta": "ζ",
+    "eta": "η",
+    "theta": "θ",
+    "iota": "ι",
+    "kappa": "κ",
+    "lambda": "λ",
+    "my": "μ",
+    "mu": "μ",
+    "ny": "ν",
+    "nu": "ν",
+    "ksi": "ξ",
+    "xi": "ξ",
+    "omikron": "ο",
+    "omicron": "ο",
+    "pi": "π",
+    "rho": "ρ",
+    "ro": "ρ",
+    "sigma": "σ",
+    "tau": "τ",
+    "ypsilon": "υ",
+    "upsilon": "υ",
+    "ipsilon": "υ",
+    "fi": "φ",
+    "phi": "φ",
+    "chi": "χ",
+    "khi": "χ",
+    "psi": "ψ",
+    "omega": "ω",
+}
+_GREEK_UPPER = {
+    # tylko majuskuły wizualnie różne od łacińskich
+    "gamma": "Γ",
+    "delta": "Δ",
+    "theta": "Θ",
+    "lambda": "Λ",
+    "ksi": "Ξ",
+    "xi": "Ξ",
+    "pi": "Π",
+    "sigma": "Σ",
+    "fi": "Φ",
+    "phi": "Φ",
+    "psi": "Ψ",
+    "omega": "Ω",
+}
+_PSEUDO_GREEK_RE = re.compile(
+    r"<(" + "|".join(sorted(_GREEK_LOWER, key=len, reverse=True)) + r")>",
+    re.IGNORECASE,
+)
+
+
+def zamien_pseudotagi_na_greke(text):
+    """Zamień pseudo-znaczniki liter greckich (``<beta>`` → ``β``) na Unicode."""
+    if not text or "<" not in text:
+        return text or ""
+
+    def _repl(m):
+        name = m.group(1)
+        low = name.lower()
+        if name[:1].isupper() and low in _GREEK_UPPER:
+            return _GREEK_UPPER[low]
+        return _GREEK_LOWER.get(low, m.group(0))
+
+    return _PSEUDO_GREEK_RE.sub(_repl, text)
+
+
+class safe_tytul_defaults:
+    # Tytuły publikacji: wyłącznie formatowanie inline typowe dla bibliografii —
+    # kursywa (nazwy gatunków, obce zwroty), pogrubienie, indeks górny/dolny
+    # (wzory: "H<sub>2</sub>O", "CD4<sup>+</sup>", "m<sup>2</sup>") i
+    # podkreślenie. Bez linków, tabel, bloków i BEZ atrybutów — tytuł nie ma
+    # powodu ich nieść, a ich brak dodatkowo domyka wektory (onerror, style).
+    ALLOWED_TAGS = ("i", "em", "b", "strong", "sub", "sup", "u")
+
+
+def safe_tytul_html(tytul):
+    """Zwróć bezpieczny HTML tytułu publikacji.
+
+    Zamiennik dla ``|safe`` przy tytułach (``tytul``/``tytul_oryginalny``),
+    które bywają importowane z niezaufanych źródeł (WWW, zgłoszenia anonimowe)
+    i renderowane w publicznych widokach. Escape'uje gołe operatory '<'/'>'
+    (notacja matematyczna w tytule) i przepuszcza wynik przez nh3 z wąską
+    allowlistą inline, usuwając ``<script>``, atrybuty zdarzeń i pozostały XSS.
+    Pseudo-znaczniki liter greckich (``<beta>``) są wcześniej zamieniane na
+    Unicode (β), a nie wyrzucane jak nieznany tag.
+
+    Sanityzujemy WYŁĄCZNIE gdy tytuł zawiera ``<`` — inaczej zwracamy go bez
+    zmian, żeby nh3 nie zakodował podwójnie ``&`` (korupcja danych w
+    fulltext/eksporcie).
+    """
+    if not tytul or "<" not in tytul:
+        return tytul
+
+    html = zamien_pseudotagi_na_greke(tytul)
+    html = _escape_bare_angle_brackets(html)
+
+    ALLOWED_TAGS = getattr(
+        settings, "TYTUL_ALLOWED_TAGS", safe_tytul_defaults.ALLOWED_TAGS
+    )
+    return nh3.clean(
+        html,
+        tags=set(ALLOWED_TAGS),
+        attributes={},
+        # Usuń także TREŚĆ tych tagów (nie tylko znaczniki), żeby w tytule nie
+        # zostawał goły ``alert(1)`` po wyciętym ``<script>``.
+        clean_content_tags={"script", "style"},
+        link_rel=None,
+    )
+
+
+class safe_opis_bibliograficzny_defaults:
+    # Opis bibliograficzny składa się z tytułu (sanityzowanego jak wyżej) oraz
+    # inline'owego formatowania cytowania; w wariancie linkowanym niesie też
+    # odnośniki autorów (``<a href>``). Dopuszczamy TE SAME tagi co tytuł plus
+    # ``<a>`` z samym ``href``/``rel``/``title`` — bez tagów blokowych, bez
+    # ``style``/``class`` i bez innych atrybutów.
+    ALLOWED_TAGS = safe_tytul_defaults.ALLOWED_TAGS + ("a",)
+    ALLOWED_ATTRIBUTES = {"a": ["href", "title", "rel"]}
+
+
+def safe_opis_bibliograficzny_html(html):
+    """Zwróć bezpieczny HTML opisu bibliograficznego.
+
+    Opis jest budowany z (potencjalnie niezaufanego) tytułu i renderowany
+    ``|safe`` na publicznych stronach oraz cache'owany w
+    ``opis_bibliograficzny_cache``. Sanityzujemy wynik złożenia, żeby żaden
+    ``<script>`` z tytułu nie przeżył — zachowując kursywę, sub/sup oraz
+    odnośniki autorów (``<a href>``). Pseudo-znaczniki liter greckich
+    (``<beta>``) są wcześniej zamieniane na Unicode (β).
+    """
+    html = zamien_pseudotagi_na_greke(html or "")
+    html = _escape_bare_angle_brackets(html)
+    ALLOWED_TAGS = getattr(
+        settings,
+        "OPIS_BIBLIOGRAFICZNY_ALLOWED_TAGS",
+        safe_opis_bibliograficzny_defaults.ALLOWED_TAGS,
+    )
+    ALLOWED_ATTRIBUTES = getattr(
+        settings,
+        "OPIS_BIBLIOGRAFICZNY_ALLOWED_ATTRIBUTES",
+        safe_opis_bibliograficzny_defaults.ALLOWED_ATTRIBUTES,
+    )
+    return nh3.clean(
+        html,
+        tags=set(ALLOWED_TAGS),
+        attributes={k: set(v) for k, v in ALLOWED_ATTRIBUTES.items()},
+        clean_content_tags={"script", "style"},
+        link_rel=None,
+    )
+
+
 def sanitize_multiseek_title(value):
     """Sanityzuj tytuł raportu multiseek zapisywany do sesji.
 
@@ -259,39 +422,6 @@ def safe_streszczenie_html(html):
         html,
         tags=set(ALLOWED_TAGS),
         attributes={k: set(v) for k, v in ALLOWED_ATTRIBUTES.items()},
-        clean_content_tags=set(),
-        link_rel=None,
-    )
-
-
-class safe_tytul_defaults:
-    # Tytuły publikacji renderujemy `|safe` (naukowa notacja inline:
-    # kursywa nazw gatunków, indeksy dolne/górne). Dozwolona tylko wąska
-    # lista tagów inline — bez a/href, obrazków, skryptów itp.
-    ALLOWED_TAGS = ("i", "b", "em", "strong", "sub", "sup", "u")
-
-
-def safe_tytul_html(tytul):
-    """Zwróć bezpieczny tytuł publikacji do renderowania przez ``|safe``.
-
-    Tytuły z importów zewnętrznych (PBN, CrossRef) są nieufne — bez
-    sanityzacji złośliwy rekord upstream mógłby wstrzyknąć ``<script>`` /
-    ``<img onerror>`` renderowany na publicznych stronach (stored XSS).
-
-    Sanityzujemy WYŁĄCZNIE gdy tytuł zawiera ``<`` — XSS wymaga znacznika,
-    a przytłaczająca większość tytułów to czysty tekst (często z ``&``),
-    którego nie wolno podwójnie zakodować przez nh3 (korupcja danych w
-    fulltext/eksporcie). Gdy ``<`` jest obecny: escape gołych ``<``/``>`` +
-    nh3 z wąską allow-listą (zachowuje ``<i>``/``<sub>`` itp., usuwa XSS).
-    """
-    if not tytul or "<" not in tytul:
-        return tytul
-
-    escaped = _escape_bare_angle_brackets(tytul)
-    return nh3.clean(
-        escaped,
-        tags=set(safe_tytul_defaults.ALLOWED_TAGS),
-        attributes={},
         clean_content_tags=set(),
         link_rel=None,
     )

--- a/src/ewaluacja_metryki/templates/ewaluacja_metryki/szczegoly.html
+++ b/src/ewaluacja_metryki/templates/ewaluacja_metryki/szczegoly.html
@@ -2,6 +2,7 @@
 {% load humanize %}
 {% load rodzaj_autora_tags %}
 {% load l10n %}
+{% load prace %}
 
 {% block title %}Metryki - {{ metryka.autor }}{% endblock %}
 
@@ -366,7 +367,7 @@
                         </td>
                         <td>
                             <a href="{% url 'ewaluacja_optymalizuj_publikacje:optymalizuj' praca.rekord.slug %}">
-                                {{ praca.rekord.tytul_oryginalny|safe|truncatewords:10 }}
+                                {{ praca.rekord.tytul_oryginalny|safe_tytul|truncatewords:10 }}
                             </a>
                         </td>
                         <td>{{ praca.rekord.rok }}</td>
@@ -436,7 +437,7 @@
                             </td>
                             <td>
                                 <a href="{% url 'ewaluacja_optymalizuj_publikacje:optymalizuj' praca.rekord.slug %}">
-                                    {{ praca.rekord.tytul_oryginalny|safe|truncatewords:10 }}
+                                    {{ praca.rekord.tytul_oryginalny|safe_tytul|truncatewords:10 }}
                                 </a>
                                 {% if praca.is_nazbierana %}
                                     <span class="label success">Wybrana</span>
@@ -504,7 +505,7 @@
                             <td>{{ forloop.counter }}</td>
                             <td>
                                 <a href="{% url 'bpp:browse_praca_by_slug' praca.rekord.slug %}">
-                                    {{ praca.tytul_oryginalny|safe|truncatewords:10 }}
+                                    {{ praca.tytul_oryginalny|safe_tytul|truncatewords:10 }}
                                 </a>
                                 <span class="label secondary">Odpięta</span>
                             </td>

--- a/src/ewaluacja_optymalizuj_publikacje/templates/ewaluacja_optymalizuj_publikacje/historia.html
+++ b/src/ewaluacja_optymalizuj_publikacje/templates/ewaluacja_optymalizuj_publikacje/historia.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
+{% load prace %}
 
 {% block title %}Historia optymalizacji - {{ publikacja.tytul_oryginalny|truncatewords:10 }}{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
     <li><a href="{% url "multiseek:index" %}">Wyszukiwanie</a></li>
-    <li><a href="{% url "bpp:browse_praca_by_slug" publikacja.slug %}">{{ publikacja.tytul_oryginalny|truncatewords_html:15|safe }}</a></li>
+    <li><a href="{% url "bpp:browse_praca_by_slug" publikacja.slug %}">{{ publikacja.tytul_oryginalny|truncatewords_html:15|safe_tytul }}</a></li>
     <li><a href="{% url "ewaluacja_optymalizuj_publikacje:optymalizuj" publikacja.slug %}">Optymalizuj</a></li>
     <li class="current">Historia</li>
 {% endblock %}

--- a/src/ewaluacja_optymalizuj_publikacje/templates/ewaluacja_optymalizuj_publikacje/optymalizuj.html
+++ b/src/ewaluacja_optymalizuj_publikacje/templates/ewaluacja_optymalizuj_publikacje/optymalizuj.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load prace %}
 
 {% block title %}Optymalizacja publikacji{% endblock %}
 
@@ -7,7 +8,7 @@
     {{ block.super }}
     <li><a href="{% url "multiseek:index" %}">Wyszukiwanie</a></li>
     {% if publikacja %}
-        <li><a href="{% url "bpp:browse_praca_by_slug" publikacja.slug %}">{{ publikacja.tytul_oryginalny|truncatewords_html:15|safe }}</a></li>
+        <li><a href="{% url "bpp:browse_praca_by_slug" publikacja.slug %}">{{ publikacja.tytul_oryginalny|truncatewords_html:15|safe_tytul }}</a></li>
         <li class="current">Optymalizuj</li>
     {% else %}
         <li class="current">Optymalizuj</li>
@@ -345,7 +346,7 @@
             </div>
         {% else %}
             <div class="publication-title">
-                <h3>{{ publikacja.tytul_oryginalny|safe }}</h3>
+                <h3>{{ publikacja.tytul_oryginalny|safe_tytul }}</h3>
                 <p>ID: {{ publikacja.pk }} | Typ: {{ publikacja.typ_kbn }}</p>
             </div>
 

--- a/src/ewaluacja_optymalizuj_publikacje/templates/ewaluacja_optymalizuj_publikacje/optymalizuj_fixed.html
+++ b/src/ewaluacja_optymalizuj_publikacje/templates/ewaluacja_optymalizuj_publikacje/optymalizuj_fixed.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load prace %}
 
 {% block title %}Optymalizacja publikacji{% endblock %}
 
@@ -7,7 +8,7 @@
     {{ block.super }}
     <li><a href="{% url "multiseek:index" %}">Wyszukiwanie</a></li>
     {% if publikacja %}
-        <li><a href="{% url "bpp:browse_praca_by_slug" publikacja.slug %}">{{ publikacja.tytul_oryginalny|truncatewords_html:15|safe }}</a></li>
+        <li><a href="{% url "bpp:browse_praca_by_slug" publikacja.slug %}">{{ publikacja.tytul_oryginalny|truncatewords_html:15|safe_tytul }}</a></li>
         <li class="current">Optymalizuj</li>
     {% else %}
         <li class="current">Optymalizuj</li>

--- a/src/ewaluacja_optymalizuj_publikacje/templates/ewaluacja_optymalizuj_publikacje/partials/content_wrapper.html
+++ b/src/ewaluacja_optymalizuj_publikacje/templates/ewaluacja_optymalizuj_publikacje/partials/content_wrapper.html
@@ -1,4 +1,5 @@
 {% load bpp_formdefaults %}
+{% load prace %}
 <div id="content-wrapper" class="ewaluacja-optymalizuj__content-wrapper">
     {% if not publikacja %}
         <div class="panel">
@@ -16,7 +17,7 @@
         <div class="ewaluacja-optymalizuj__publication-header publication-header">
             <h3><a href="{% url 'bpp:browse_praca_by_slug' publikacja.slug %}"
                    class="ewaluacja-optymalizuj__publication-link">
-                {{ publikacja.tytul_oryginalny|safe }}</a></h3>
+                {{ publikacja.tytul_oryginalny|safe_tytul }}</a></h3>
             <p>ID: {{ publikacja.pk }} | Typ: {{ publikacja.typ_kbn|default:"" }}</p>
         </div>
 


### PR DESCRIPTION
## Luka (WYSOKIE, #3 z security-review)

Tytuły publikacji (`tytul`/`tytul_oryginalny`) pochodzą z niezaufanych źródeł
(importy WWW/PBN/CrossRef, anonimowe zgłoszenia) i są renderowane `|safe` na
publicznych stronach — **także pośrednio** przez zdenormalizowany
`opis_bibliograficzny_cache` (budowany z tytułu przez DB-owy szablon i
renderowany `|safe` w ~6 miejscach, m.in. w `data-records` dla JS). Dawało to
trwały (stored) XSS. `DwaTytuly.clean()` sanityzował tytuł, ale `objects.create()`
/importery **nie wołają** `full_clean()`.

Test end-to-end na realnej stronie rekordu złapał wyciek przez cache, którego
testy jednostkowe nie widziały.

## Fix — obrona wielowarstwowa

Bazuje na istniejącym już w `dev` `safe_tytul_html` (wąska allowlista inline:
`i, em, b, strong, sub, sup, u` — bez tagów blokowych i atrybutów).

1. **Źródło (save-hook):** `DwaTytuly.save()` i `Patent.save()` sanityzują
   tytuły przy KAŻDYM zapisie — domyka ścieżkę `objects.create()`/import.
2. **Opis przy budowie:** wynik `opis_bibliograficzny()` sanityzowany
   (`safe_opis_bibliograficzny_html` — allowlista tytułu **+ `<a href>`** dla
   linków autorów) → czysty `opis_bibliograficzny_cache` po przebudowie.
3. **Render-time:** nowy filtr `|safe_tytul` na bezpośrednich renderach
   tytułów (7 szablonów).

Bonus: pseudo-znaczniki liter greckich (`<beta>`, `<Delta>`) → Unicode (β, Δ)
zamiast wyrzucania (to nie markup, tylko litery wklepane przez autorów).

## Allowlista potwierdzona danymi

Skan obu realnych baz (MAŁA 2 tys. + DUŻA 122 tys. rekordów): jedyne legalne
tagi w tytułach to **`<i>`, `<sub>`, `<sup>`** (+ szum: `<beta>`/`<Delta>` =
litery greckie, `<p>`/`<scp>` = pojedyncze śmieci z importu). Wąska allowlista
pokrywa wszystko legalne.

## Dane istniejące

Nowa komenda `python src/manage.py sanityzuj_tytuly [--napraw]` czyści
zapisane tytuły (i przez `save()` przebudowuje opis cache). Skan realnych baz
NIE wykrył żadnego XSS w tytułach — ryzyko jest teoretyczne (przyszły import).

## Uwaga

Dwa szablony (`praca_tabela.html`, `opis_bibliograficzny.html`) mają
**pre-existing** naruszenia djlinta (H025 na warunkowych `<a>`, H022 http DOI)
niezwiązane z tą zmianą; zostawiono w nich `|safe` (chronione u źródła +
przy budowie opisu), by nie ściągać tego szumu. `|safe_tytul` w pozostałych 7.

## Testy

`test_safe_tytul.py` (13, w tym end-to-end na stronie rekordu), rozszerzony
`test_util.py` (dev), `test_management_commands_sanityzuj_tytuly.py`. Regresja
opisu/modeli/render zielona (opis, cache, api, dspace, ewaluacja: 200+ testów).

🤖 Generated with [Claude Code](https://claude.com/claude-code)