### PR TITLE
test(admin): oczekuj pustego tytułu po sanityzacji <script> (nh3)

### DIFF
--- a/src/bpp/tests/test_admin/test_admin.py
+++ b/src/bpp/tests/test_admin/test_admin.py
@@ -69,9 +69,12 @@ def test_safe_html_dwa_tytuly_DwaTytuly(
 
     i.refresh_from_db()
 
-    assert i.tytul_oryginalny == "hi"
+    # nh3 usuwa znaczniki <script>/<style> WRAZ z ich zawartością, więc po
+    # sanityzacji pole jest puste (bleach zostawiał tekst "hi" — to była stara
+    # semantyka). Pusty wynik potwierdza, że sanityzacja się wykonała.
+    assert i.tytul_oryginalny == ""
     if hasattr(i, "tytul"):
-        assert i.tytul == "hi"
+        assert i.tytul == ""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`test_safe_html_dwa_tytuly` (`src/bpp/tests/test_admin/test_admin.py`) był **czerwony na `dev`** we wszystkich 5 parametryzacjach (`Wydawnictwo_Ciagle`, `Wydawnictwo_Zwarte`, `Patent`, `Praca_Doktorska`, `Praca_Habilitacyjna`) — wywalał fazę `tests-without-playwright`, więc `make tests` nie dochodził nawet do Playwrighta/JS.

```
assert i.tytul_oryginalny == "hi"
AssertionError: assert '' == 'hi'
```

## Przyczyna

Test wstrzykuje `<script>hi</script>` i oczekiwał, że po sanityzacji pole będzie zawierać `"hi"` — to **semantyka bleach** (strip tagów, zachowaj tekst). Sanityzacja korzysta teraz z **nh3/ammonia** (migracja w `7620f974a`), które usuwa znaczniki `<script>`/`<style>` **wraz z ich zawartością** → pole jest puste. Wpięcie sanityzacji na pola `DwaTytuly` z #577 odsłoniło tę rozbieżność.

## Zmiana

Aktualizacja oczekiwań testu na `== ""`. Pusty wynik nadal potwierdza, że sanityzacja się wykonała — i jest bezpieczniejszym zachowaniem (cała zawartość `<script>` znika, nie tylko znaczniki). Zmiana wyłącznie w teście; samo zachowanie sanityzacji shipnęło z #577.

## Weryfikacja

```
uv run pytest src/bpp/tests/test_admin/test_admin.py::test_safe_html_dwa_tytuly_DwaTytuly
5 passed
```
ruff check + format: czysto.

> Uwaga: to jedna z dwóch grup czerwonych testów na `dev`. Druga (17× `src/api_v1/tests/test_autor*` — brak `"email"` w `AutorSerializer.Meta.fields`) jest naprawiana osobnym wątkiem i **nie** wchodzi w zakres tego PR-a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)