### PR TITLE
fix(api): napraw endpoint /api/v1/autor/ (regresja #568 — email 500 + widoczność PII)

### DIFF
--- a/src/api_v1/serializers/autor.py
+++ b/src/api_v1/serializers/autor.py
@@ -1,7 +1,6 @@
 from rest_framework import serializers
 
 from api_v1.serializers.util import AbsoluteUrlSerializerMixin
-
 from bpp.models import Autor, Autor_Jednostka, Funkcja_Autora, Tytul
 
 
@@ -66,6 +65,15 @@ class AutorSerializer(
     urodzony = serializers.SerializerMethodField()
     poprzednie_nazwiska = serializers.SerializerMethodField()
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # E-mail to PII: dla anonima pole jest USUWANE z odpowiedzi (klucz
+        # nieobecny), nie tylko maskowane pustym stringiem. ``urodzony`` i
+        # ``poprzednie_nazwiska`` pozostają (maskowane w get_*), bo tego
+        # oczekują testy widoczności.
+        if not self._is_authenticated():
+            self.fields.pop("email", None)
+
     def _is_authenticated(self):
         request = self.context.get("request")
         return bool(request and request.user.is_authenticated)
@@ -96,6 +104,7 @@ class AutorSerializer(
             "aktualna_jednostka",
             "aktualna_funkcja",
             "www",
+            "email",
             "urodzony",
             "zmarl",
             "poprzednie_nazwiska",

--- a/src/api_v1/viewsets/autor.py
+++ b/src/api_v1/viewsets/autor.py
@@ -21,9 +21,10 @@ class AutorFilterSet(django_filters.rest_framework.FilterSet):
 
 
 class AutorViewSet(viewsets.ReadOnlyModelViewSet):
-    # Tylko autorzy oznaczeni jako widoczni — autor z pokazuj=False jest
-    # świadomie ukryty ze stron publicznych i nie może wyciekać przez API.
-    queryset = Autor.objects.filter(pokazuj=True)
+    # Bazowy queryset BEZ filtra widoczności — zawężenie do pokazuj=True robi
+    # get_queryset() TYLKO dla anonima. Autor z pokazuj=False jest świadomie
+    # ukryty ze stron publicznych, ale zalogowany (redaktor) musi go widzieć.
+    queryset = Autor.objects.all()
     serializer_class = AutorSerializer
     filterset_class = AutorFilterSet
     # Filtr nazwisko__icontains skanuje bez indeksu prefiksu — opt-in

--- a/src/bpp/newsfragments/api-autor-email-widocznosc.bugfix.rst
+++ b/src/bpp/newsfragments/api-autor-email-widocznosc.bugfix.rst
@@ -1,0 +1,5 @@
+Naprawiono endpoint ``/api/v1/autor/`` (regresja #568): pole ``email`` było
+zadeklarowane w serializerze, ale pominięte w ``Meta.fields`` — każde żądanie
+kończyło się błędem 500. E-mail jest teraz usuwany z odpowiedzi dla anonimów
+(klucz nieobecny, nie pusty), a zalogowani redaktorzy widzą także autorów
+ukrytych (``pokazuj=False``).


### PR DESCRIPTION
## Problem

`origin/dev` jest **RED** — `Tests` padają na merge'ach #577/#578. Audyt
samowystarczalności testów (na osobnym branchu flake-fix) wyłapał realne,
pre-existing bugi niezależne od flake'a:

**Regresja #568 (PII/anon) — `/api/v1/autor/` zwraca 500 dla WSZYSTKICH:**
`email = SerializerMethodField()` zostało zadeklarowane w `AutorSerializer`,
ale **pominięte w `Meta.fields`** → DRF rzuca
`AssertionError: field 'email' declared but not in fields` przy każdej
serializacji. 17 testów api_v1 (test_autor + test_autor_pii_anon) pada.

Dodatkowo funkcja PII/anon była niedokończona:
- `email` był tylko maskowany pustym stringiem — testy chcą, by dla anonima
  **klucz był nieobecny**.
- viewset filtrował `pokazuj=True` na poziomie klasy → **zalogowany redaktor
  nie widział autorów ukrytych** (404 zamiast 200).

## Fix

- `Meta.fields` += `"email"` (zadeklarowane pole musi tam być).
- `AutorSerializer.__init__` usuwa `email` dla niezalogowanych (klucz nieobecny).
- `AutorViewSet.queryset = Autor.objects.all()`; zawężenie `pokazuj=True` robi
  `get_queryset()` **tylko dla anonima**.

## Weryfikacja

- api_v1 autor: 21 passed (było 17 failed).
- Pełne `src/api_v1/`: 148 passed, zero regresji.
- `ruff` czysto.

**safe_html (#577)** było już naprawione przez #578 (merge `fix/safe-html-dwa-tytuly-nh3`)
— nie wymaga zmian tutaj.

🤖 Generated with [Claude Code](https://claude.com/claude-code)