### PR TITLE
fix(tests): rename dwa_autory_z_jednostka → dwaj_autorzy_z_jednostki w nowych testach

### DIFF
--- a/src/import_pracownikow/tests/test_pipeline/test_analyze.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_analyze.py
@@ -150,8 +150,8 @@ def test_pusty_plik_rzuca_jawny_blad():
 
 
 @pytest.mark.django_db
-def test_analiza_scala_podwojny_wymiar_do_kanonicznego(dwa_autory_z_jednostka):
-    autor, jednostka = dwa_autory_z_jednostka
+def test_analiza_scala_podwojny_wymiar_do_kanonicznego(dwaj_autorzy_z_jednostki):
+    autor, jednostka = dwaj_autorzy_z_jednostki
     imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_UTWORZONY)
     imp.plik_xls.name = "protected/import_pracownikow/x.xlsx"
     wiersz = _wiersz(
@@ -174,8 +174,8 @@ def test_analiza_scala_podwojny_wymiar_do_kanonicznego(dwa_autory_z_jednostka):
 
 
 @pytest.mark.django_db
-def test_analiza_rozbiezny_wymiar_rzuca(dwa_autory_z_jednostka):
-    autor, jednostka = dwa_autory_z_jednostka
+def test_analiza_rozbiezny_wymiar_rzuca(dwaj_autorzy_z_jednostki):
+    autor, jednostka = dwaj_autorzy_z_jednostki
     imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_UTWORZONY)
     imp.plik_xls.name = "protected/import_pracownikow/x.xlsx"
     wiersz = _wiersz(
@@ -196,13 +196,13 @@ def test_analiza_rozbiezny_wymiar_rzuca(dwa_autory_z_jednostka):
 
 @pytest.mark.django_db
 def test_analiza_glowny_zaklad_pracy_nie_traktuje_N_jako_prawda(
-    dwa_autory_z_jednostka,
+    dwaj_autorzy_z_jednostki,
 ):
     # „Gł. zakład pracy" = N → NIE podstawowe miejsce pracy. Pole wiersza liczy
     # normalize_nullboleanfield (poprawnie False); kopia audytowa
     # (dane_znormalizowane) NIE może kłamać True (AutorForm = CharField, nie
     # BooleanField, która „N" koercowała do True).
-    autor, jednostka = dwa_autory_z_jednostka
+    autor, jednostka = dwaj_autorzy_z_jednostki
     imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_UTWORZONY)
     imp.plik_xls.name = "protected/import_pracownikow/x.xlsx"
     wiersz = _wiersz(

--- a/src/import_pracownikow/tests/test_pipeline/test_analyze_wykaz.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_analyze_wykaz.py
@@ -71,8 +71,8 @@ def _naglowki_pliku(path):
 
 
 @pytest.mark.django_db
-def test_wykaz_rozpoznaje_daty_glowny_zaklad_i_wymiar(dwa_autory_z_jednostka, tmp_path):
-    autor, jednostka = dwa_autory_z_jednostka
+def test_wykaz_rozpoznaje_daty_glowny_zaklad_i_wymiar(dwaj_autorzy_z_jednostki, tmp_path):
+    autor, jednostka = dwaj_autorzy_z_jednostki
     plik = str(tmp_path / "wykaz.xlsx")
     _zapisz_wykaz(plik, autor, jednostka)
 


### PR DESCRIPTION
## Problem

`origin/dev` jest **RED**: PR #579 przemianował fixturę
`dwa_autory_z_jednostka` → `dwaj_autorzy_z_jednostki` (gramatyka), ale
równolegle zmergowane testy (`test_analyze.py`, `test_analyze_wykaz.py`)
używają **starej** nazwy → `fixture 'dwa_autory_z_jednostka' not found`
w 4 testach import_pracownikow.

Kolizja rename'u z równoległą pracą — nie wychwycił jej żaden pojedynczy PR
(oba zielone osobno, konflikt semantyczny dopiero po scaleniu obu do dev).

## Fix

Rename pozostałych 8 użyć `dwa_autory_z_jednostka` →
`dwaj_autorzy_z_jednostki` (2 pliki). Fixtura bez zmian.

Weryfikacja: affected testy przechodzą.

🤖 Generated with [Claude Code](https://claude.com/claude-code)