### PR TITLE
style: napraw ruff-format po rename (Lint changed files RED na dev)

### DIFF
--- a/src/import_pracownikow/tests/test_pipeline/test_analyze_wykaz.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_analyze_wykaz.py
@@ -71,7 +71,9 @@ def _naglowki_pliku(path):
 
 
 @pytest.mark.django_db
-def test_wykaz_rozpoznaje_daty_glowny_zaklad_i_wymiar(dwaj_autorzy_z_jednostki, tmp_path):
+def test_wykaz_rozpoznaje_daty_glowny_zaklad_i_wymiar(
+    dwaj_autorzy_z_jednostki, tmp_path
+):
     autor, jednostka = dwaj_autorzy_z_jednostki
     plik = str(tmp_path / "wykaz.xlsx")
     _zapisz_wykaz(plik, autor, jednostka)


### PR DESCRIPTION
Rename `dwaj_autorzy_z_jednostki` (#583) wydłużył sygnaturę
`test_wykaz_rozpoznaje_daty_glowny_zaklad_i_wymiar` do 89 znaków (>88) →
`ruff-format` chce ją zawinąć. Job **Lint changed files** padał na dev.

Fix: zawinięcie sygnatury (`ruff format`). Shardy testowe były zielone —
to jedyny czerwony job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)