### PR TITLE
feat(zatrudnienie): zezwól na przyszłe daty zakończenia zatrudnienia

### DIFF
--- a/src/bpp/migrations/0469_przyszle_daty_zakonczenia_zatrudnienia.py
+++ b/src/bpp/migrations/0469_przyszle_daty_zakonczenia_zatrudnienia.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+from bpp.migration_util import load_custom_sql
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("bpp", "0468_stopien_sluzbowy_stanowisko_dydaktyczne"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            lambda *args, **kw: load_custom_sql(
+                "0469_przyszle_daty_zakonczenia_zatrudnienia"
+            ),
+        ),
+    ]

--- a/src/bpp/migrations/0469_przyszle_daty_zakonczenia_zatrudnienia.sql
+++ b/src/bpp/migrations/0469_przyszle_daty_zakonczenia_zatrudnienia.sql
@@ -1,0 +1,24 @@
+-- Zdejmujemy dawny zakaz dat zakończenia zatrudnienia w przyszłości
+-- (`bez_dat_do_w_przyszlosci`, wprowadzony w 0064) — zatrudnienie bywa
+-- planowane naprzód („pan X pracuje do zaplanowanej daty"). Jest to spójne
+-- z triggerem `bpp_autor_ustaw_jednostka_aktualna`, który dla przyszłej daty
+-- „do" i tak liczy `aktualny = True`. Dodatkowo `now()` w CHECK to postgresowy
+-- antywzorzec: warunek jest sprawdzany tylko przy zapisie wiersza, nie „w
+-- czasie", więc dawał złudne poczucie niezmienniczości.
+--
+-- W zamian dodajemy odporny na czas CHECK pilnujący, że początek zatrudnienia
+-- jest wcześniejszy niż koniec. NULL-e (otwarty początek albo otwarty koniec)
+-- dają w porównaniu UNKNOWN → warunek CHECK spełniony → dozwolone.
+--
+-- NOT VALID: nie walidujemy wstecznie istniejących wierszy. Import historycznie
+-- tworzy powiązania z pominięciem `Model.clean()` (patrz Autor_Jednostka.clean),
+-- więc w bazie mogą już istnieć rekordy z odwróconym/zerowym zakresem — nie
+-- chcemy, żeby deployment wywalił się na `ADD CONSTRAINT`. Reguła egzekwowana
+-- jest dla wszystkich NOWYCH i ZMIENIANYCH wierszy.
+
+ALTER TABLE bpp_autor_jednostka
+    DROP CONSTRAINT IF EXISTS bez_dat_do_w_przyszlosci;
+
+ALTER TABLE bpp_autor_jednostka
+    ADD CONSTRAINT poczatek_przed_koncem
+    CHECK (rozpoczal_prace < zakonczyl_prace) NOT VALID;

--- a/src/bpp/models/autor.py
+++ b/src/bpp/models/autor.py
@@ -5,7 +5,7 @@ Autorzy
 from __future__ import annotations
 
 import logging
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 from autoslug import AutoSlugField
 from django.contrib.postgres.search import SearchVectorField as VectorField
@@ -709,12 +709,13 @@ class Autor_Jednostka(models.Model):
                     "Początek pracy późniejszy lub równy, jak zakończenie"
                 )
 
-        if self.zakonczyl_prace is not None:
-            if self.zakonczyl_prace >= datetime.now().date():
-                raise ValidationError(
-                    "Czas zakończenia pracy w jednostce nie może być taki sam"
-                    " lub większy, jak obecna data"
-                )
+        # UWAGA: świadomie NIE odrzucamy daty zakończenia w przyszłości —
+        # zatrudnienie bywa planowane naprzód („pan X pracuje do zaplanowanej
+        # daty"). Jest to spójne z triggerem `bpp_autor_ustaw_jednostka_aktualna`,
+        # który dla przyszłej daty „do" i tak liczy `aktualny = True`. Dawny
+        # zakaz (model + DB-owy CHECK `bez_dat_do_w_przyszlosci`) zdjęty w
+        # migracji 0469; w bazie zastąpiony odpornym na czas CHECK
+        # `rozpoczal_prace < zakonczyl_prace`.
 
         # UWAGA: niezmiennik "jedno podstawowe miejsce pracy na autora" NIE jest
         # tu walidowany per-instancja. Eager .exists() (widzacy stan sprzed

--- a/src/bpp/newsfragments/przyszle-daty-zatrudnienia.feature.rst
+++ b/src/bpp/newsfragments/przyszle-daty-zatrudnienia.feature.rst
@@ -1,0 +1,5 @@
+Zezwolono na planowanie przyszłych dat zakończenia zatrudnienia w powiązaniach
+autor–jednostka (np. z góry ustalony koniec umowy). Import listy pracowników
+z datą końca w przyszłości nie przerywa się już na ograniczeniu bazy danych;
+w miejsce dawnego zakazu wprowadzono odporny na czas warunek „początek pracy
+wcześniejszy niż koniec".

--- a/src/bpp/tests/test_models/test_models_legacy.py
+++ b/src/bpp/tests/test_models/test_models_legacy.py
@@ -1,7 +1,9 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 import pytest
 from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.utils import IntegrityError
 from model_bakery import baker
 
 from bpp.models import (
@@ -303,6 +305,48 @@ def test_autor_jednostka(autor_jednostka_setup):
     aj.zakonczyl_prace = datetime(2011, 1, 1)
     with pytest.raises(ValidationError):
         aj.full_clean()
+
+
+@pytest.mark.django_db
+def test_autor_jednostka_dopuszcza_przyszla_date_zakonczenia():
+    """Planowanie zatrudnienia: data zakończenia w przyszłości jest dozwolona
+    (np. „pan X pracuje do zaplanowanej daty"). Zdejmujemy dawny zakaz
+    ``bez_dat_do_w_przyszlosci`` — spójne z triggerem ``aktualny``, który dla
+    przyszłej daty „do" i tak zwraca True. Egzekwowane w warstwie modelu
+    (``full_clean``) ORAZ w bazie (nowy CHECK dopuszcza przyszłe „do")."""
+    a = baker.make(Autor)
+    j = any_jednostka(nazwa="Przyszłość", skrot="Prz.")
+    przyszlosc = date.today() + timedelta(days=365)
+
+    aj = Autor_Jednostka(
+        autor=a,
+        jednostka=j,
+        rozpoczal_prace=date.today(),
+        zakonczyl_prace=przyszlosc,
+    )
+    aj.full_clean()  # warstwa formularzy/admina — nie odrzuca przyszłej daty
+    aj.save()  # baza — nowy CHECK (rozpoczal < zakonczyl) też przepuszcza
+    aj.refresh_from_db()
+    assert aj.zakonczyl_prace == przyszlosc
+
+
+@pytest.mark.django_db
+def test_autor_jednostka_baza_odrzuca_poczatek_po_koncu():
+    """Nowy, odporny na czas CHECK ``rozpoczal_prace < zakonczyl_prace`` jest
+    egzekwowany także w bazie, nawet gdy ``clean()`` zostaje ominięty (import
+    robi bezpośredni ``create``). Zastępuje dawny ``bez_dat_do_w_przyszlosci``,
+    który nie chronił przed odwróconym zakresem."""
+    a = baker.make(Autor)
+    j = any_jednostka(nazwa="Odwrócony", skrot="Odw.")
+
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            Autor_Jednostka.objects.create(
+                autor=a,
+                jednostka=j,
+                rozpoczal_prace=date(2013, 1, 1),
+                zakonczyl_prace=date(2011, 1, 1),
+            )
 
 
 def test_defragmentuj(autor_jednostka_setup):

--- a/src/bpp/tests/test_models/test_struktura/test_autor_jednostka.py
+++ b/src/bpp/tests/test_models/test_struktura/test_autor_jednostka.py
@@ -76,13 +76,21 @@ def test_autor_jednostka_trigger_nie_mozna_zmienic_id_autora(
 
 
 @pytest.mark.django_db
-def test_autor_jednostka_trigger_nie_mozna_daty_w_przyszlosci(
+def test_autor_jednostka_dopuszcza_przyszla_date_zakonczenia(
     autor_jan_kowalski, jednostka
 ):
+    """Planowana przyszła data zakończenia zatrudnienia jest dozwolona (zdjęty
+    dawny zakaz ``bez_dat_do_w_przyszlosci``, mig 0469). Trigger ``aktualny``
+    liczy ją spójnie: przyszły koniec zatrudnienia = pracownik nadal aktualny,
+    więc ``aktualna_jednostka`` zostaje ustawiona."""
     aj = baker.make(Autor_Jednostka, autor=autor_jan_kowalski, jednostka=jednostka)
-    aj.zakonczyl_prace = date.today()
-    with pytest.raises(IntegrityError):
-        aj.save()
+    aj.zakonczyl_prace = date.today() + timedelta(days=365)
+    aj.save()  # nie rzuca — przyszła data „do" dozwolona
+
+    autor_jan_kowalski.refresh_from_db()
+    # Przyszły koniec zatrudnienia = pracownik nadal aktualny → trigger
+    # `bpp_autor_ustaw_jednostka_aktualna` ustawia aktualną jednostkę.
+    assert autor_jan_kowalski.aktualna_jednostka == jednostka
 
 
 @pytest.mark.django_db

--- a/src/import_pracownikow/models.py
+++ b/src/import_pracownikow/models.py
@@ -1074,6 +1074,26 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
 
         self._integruj_daty_aj(aj, dane)
 
+        # Niezmiennik rozpoczal < zakonczyl walidujemy PRZED jakimkolwiek zapisem.
+        # Model.save() nie woła clean(), a ustaw_podstawowe_miejsce_pracy() niżej
+        # już utrwala aj (i zdejmuje flagę „podstawowe" z innych powiązań autora).
+        # Odwrócony zakres z XLS musi zostać odrzucony (BPPDatabaseError → izolacja
+        # wiersza) zanim cokolwiek trafi do bazy — inaczej przedwczesny save
+        # zderza się z DB-owym CHECK `poczatek_przed_koncem` (mig 0469) i daje
+        # nieizolowany CheckViolation. Reguły „koniec < dziś" celowo NIE
+        # egzekwujemy: import może nieść przyszłe (planowane) daty końca.
+        if (
+            aj.rozpoczal_prace is not None
+            and aj.zakonczyl_prace is not None
+            and aj.rozpoczal_prace >= aj.zakonczyl_prace
+        ):
+            raise BPPDatabaseError(
+                self.dane_z_xls,
+                self,
+                f"data rozpoczęcia pracy ({aj.rozpoczal_prace}) jest późniejsza "
+                f"lub równa dacie zakończenia ({aj.zakonczyl_prace})",
+            )
+
         if self.funkcja_autora is not None and aj.funkcja != self.funkcja_autora:
             aj.funkcja = self.funkcja_autora
             self.log_zmian["autor_jednostka"].append(
@@ -1118,23 +1138,6 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
         elif not aj.podstawowe_miejsce_pracy:
             aj.ustaw_podstawowe_miejsce_pracy()
             self.log_zmian["autor_jednostka"].append("podstawowe_miejsce_pracy -> tak")
-
-        # Autor_Jednostka.clean() waliduje rozpoczal < zakonczyl, ale Model.save()
-        # NIE woła clean() (uwaga reviewera #4). Bronimy niezmiennika tutaj — na
-        # jedynej ścieżce zapisu integracji — żeby odwrócony zakres dat z XLS nie
-        # trafił do bazy. Regułę „koniec < dziś" celowo pomijamy: import może nieść
-        # przyszłe daty końca zatrudnienia (to reguła admina, nie importu).
-        if (
-            aj.rozpoczal_prace is not None
-            and aj.zakonczyl_prace is not None
-            and aj.rozpoczal_prace >= aj.zakonczyl_prace
-        ):
-            raise BPPDatabaseError(
-                self.dane_z_xls,
-                self,
-                f"data rozpoczęcia pracy ({aj.rozpoczal_prace}) jest późniejsza "
-                f"lub równa dacie zakończenia ({aj.zakonczyl_prace})",
-            )
 
         aj.save()
 


### PR DESCRIPTION
## Problem

Import pracowników z **przyszłą datą zakończenia zatrudnienia** wywalał się
w celery na `IntegrityError`:

```
bpp_autor_jednostka narusza ograniczenie sprawdzające "bez_dat_do_w_przyszlosci"
```

Zatrudnienie bywa jednak planowane naprzód („pan X pracuje do zaplanowanej
daty"). Co więcej, zakaz był **sprzeczny z własną logiką systemu**: trigger
`bpp_autor_ustaw_jednostka_aktualna` liczy `aktualny = coalesce(zakonczyl,
'9999') > NOW()::date`, czyli przyszły koniec zatrudnienia = pracownik nadal
aktualny. (`now()` w CHECK to zresztą antywzorzec — sprawdzany tylko przy
zapisie, nie „w czasie".)

## Zmiana

- **Migracja `0469`** — drop `bez_dat_do_w_przyszlosci` na `bpp_autor_jednostka`;
  w zamian odporny na czas `CHECK (rozpoczal_prace < zakonczyl_prace) NOT VALID`
  (NULL-e = otwarty początek/koniec dozwolone; `NOT VALID` nie wywala się na
  historycznych, potencjalnie brudnych wierszach — reguła egzekwowana dla
  nowych/zmienianych).
- **`Autor_Jednostka.clean()`** — zdjęte „koniec ≥ dziś", zostaje „początek <
  koniec".
- **`import_pracownikow/models.py`** — przy okazji naprawiony **ukryty bug
  kolejności**: guard odwróconego zakresu stał *za* `ustaw_podstawowe_miejsce_pracy()`,
  które już utrwala wiersz. Stary CHECK przepuszczał ten przedwczesny zapis,
  guard robił rollback; nowy CHECK odrzucał go → **nieizolowany**
  `CheckViolation` zamiast `BPPDatabaseError`. Guard przeniesiony **przed**
  jakikolwiek zapis → odwrócony wiersz nadal izoluje się per-wiersz jak dotąd.

Bliźniaczy `bez_dat_do_w_przyszlosci` na `bpp_jednostka_wydzial."do"` (inny
sens — historia przynależności jednostki do wydziału) **świadomie nietknięty**.

## Testy

- Nowe: przyszła data „do" OK (model `full_clean` + zapis do DB); DB odrzuca
  odwrócony zakres (`CheckViolation`) nawet z pominięciem `clean()`.
- Przepisany test triggera (dawne „nie można przyszłej" → „można + trigger
  `aktualny` honoruje").
- Pełna suita nie-Playwright: **7505 passed, 0 failed**. Ruff czysto.

## TODO przy scalaniu

- `make baseline-update` — constraint jest w `baseline.sql`; odświeżyć raz,
  przy merge (nie w równoległych branchach).

## Odnotowany edge-case (poza zakresem tego PR)

Logika **odpięć** (`integrate.py:289`) przy ponownym imporcie odpina
nieobecnego pracownika datą *wczorajszą* — z dopuszczonymi przyszłymi datami
nadpisze to zaplanowany przyszły koniec. Decyzja produktowa: chronić plan czy
odpinać. Do rozstrzygnięcia osobno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
