### PR TITLE
feat(import): uczytelnij stronę wyników importu (filtry + karta rekordu)

### DIFF
--- a/docs/superpowers/specs/2026-07-13-import-rezultaty-filtry-karta-design.md
+++ b/docs/superpowers/specs/2026-07-13-import-rezultaty-filtry-karta-design.md
@@ -1,0 +1,189 @@
+# Przebudowa strony rezultatów importu pracowników — filtry + karta rekordu
+
+Data: 2026-07-13
+Branch: `feat/import-rezultaty-filtry`
+Widok: `ImportPracownikowResultsView` → `/import_pracownikow/<pk>/rezultaty/`
+
+## Cel
+
+Uczytelnić stronę wyników importu: uporządkować pasek filtrów, dodać licznik
+przefiltrowanych rekordów, nie pokazywać pól, których w pliku nie ma, oraz
+przebudować „kartę rekordu" (dwuwierszowy `<tbody>`) tak, by kontrolki autora
+i porównania plik→baza były czytelne.
+
+## Stan obecny (co przebudowujemy)
+
+- `importpracownikowrow_list.html` — pasek filtrów `#filtr-roznic`: pole „Szukaj"
+  + po jednym `<fieldset>` na KAŻDE pole z `POLA_ROZNIC` (8 pól), radia
+  ułożone pionowo. Filtrowanie czysto po froncie (JS czyta `data-diff-*`
+  z 1. `<tr>` każdej karty; tekst z `textContent` 1. `<tr>`).
+- `_wiersz_preview_kom.html` — karta = dwa `<tr>` w `<tbody id="wiersz-{pk}">`:
+  - `<tr>` #1: Poz, Osoba (plik), Pewność, Autor (BPP), Jednostka.
+  - `<tr>` #2 (colspan=5): blok akcji dopasowania autora (`import-blok-akcje`)
+    + pionowa lista porównań plik→baza (`import-blok-porownania`) + przepięcie.
+- `_porownanie_kom.html` — komórka porównania: gdy różnica, żółta plakietka
+  z wartością z pliku + `baza: <stara wartość>` pod spodem.
+- `roznice.py::POLA_ROZNIC` — rejestr 8 pól (klucz, etykieta, ekstraktor).
+- `mapowanie_kolumn` (JSONField na `ImportPracownikow`) = `{nagłówek: pole}` —
+  jedyne źródło prawdy o tym, JAKIE kolumny plik zawiera.
+
+## Zakres zmian
+
+### 1. Pasek filtrów: widoczne + collapsible, radia poziomo
+
+- **Zawsze widoczne** (kolejność): `jednostka` (Jednostka), `tytul`
+  (Tytuł naukowy), `data_od` (Data od), `data_do` (Data do).
+- **Zwijane** (`<details><summary>Więcej filtrów…</summary>`): `email`
+  (E-mail), `stopien` (Stopień służbowy), `funkcja` (Funkcja w jednostce),
+  `stanowisko` (Stanowisko dydaktyczne).
+- „Szukaj:" bez zmian, zostaje na górze paska.
+- Radia w każdym fieldsecie **poziomo** (SCSS: `label { display:block }` →
+  inline/flex-row).
+- `<details>` musi być WEWNĄTRZ `<form id="filtr-roznic">`, żeby radia
+  zwiniętych filtrów nadal działały (JS `querySelectorAll` je znajduje
+  niezależnie od stanu open/closed).
+
+Podział pól robimy w widoku (`get_context_data`): dwie listy kontekstu
+`pola_glowne` i `pola_dodatkowe` (zamiast jednego `pola_roznic`), każda w
+formacie `[(klucz, etykieta), …]`. Kolejność „głównych" jawnie ustalona
+(nie kolejność z `POLA_ROZNIC`).
+
+### 2. Licznik „Pokazano X z Y rekordów"
+
+- Element nad tabelą (np. `<p id="filtr-licznik">`). Aktualizowany w JS
+  `filtruj()`: `Y` = liczba kart (`<tbody>` rekordów), `X` = liczba
+  nieukrytych. Zero zapytań do bazy, czysty front. Aktualizowany też po
+  `htmx:afterSettle` (po swapie karty).
+- **Edge case (review):** gałąź `{% empty %}` renderuje własny `<tbody>` z
+  wierszem „Żadnych wierszy…". Liczenie `Y` musi go pomijać — realne karty
+  oznaczyć np. `<tbody data-rekord>` i liczyć `querySelectorAll('tbody[data-rekord]')`
+  (albo licznik tylko gdy `object_list` niepuste) — inaczej przy 0 rekordach
+  `Y=1` (fałszywy rekord).
+
+### 3. Warunkowe ukrywanie Stopnia służbowego / Stanowiska dydaktycznego
+
+Gdy plik NIE zawiera danej kolumny — pole znika **i z karty, i z filtra**.
+
+- Nowe property na modelu `ImportPracownikow`:
+  ```python
+  @property
+  def ma_kolumne_stopnia(self):
+      return "stopień_służbowy" in (self.mapowanie_kolumn or {}).values()
+
+  @property
+  def ma_kolumne_stanowiska(self):
+      return "stanowisko_dydaktyczne" in (self.mapowanie_kolumn or {}).values()
+  ```
+  (`mapowanie_kolumn` = `{nagłówek: pole_docelowe}`, więc sprawdzamy wartości.)
+- Widok: z `pola_dodatkowe` usuwa `stopien`/`stanowisko`, gdy odpowiednie
+  property = False (to wystarcza dla FILTRA — pasek renderuje się tylko w
+  `importpracownikowrow_list.html`, gdzie `parent_object` jest w kontekście).
+- `_wiersz_preview_kom.html`: `import-porownanie-item` dla Stopnia / Stanowiska
+  owinięte **`{% if parent_object.ma_kolumne_stopnia %}`** /
+  `{% if parent_object.ma_kolumne_stanowiska %}` — WYŁĄCZNIE przez
+  `parent_object`, NIGDY gołą zmienną kontekstu.
+  **[BLOKER z review]** Ten partial jest re-renderowany przez widoki akcji HTMX
+  (`_WierszImportuMixin._render_wiersz`, `views.py:~359`) z kontekstem TYLKO
+  `{"row", "parent_object"}`. Goła `{% if ma_kolumne_stopnia %}` byłaby po
+  KAŻDYM swapie (wybór kandydata / dopasuj-autora / przepnij / utwórz-nowego)
+  undefined → wiersze „Stopień sł."/„Stanowisko dyd." znikałyby z karty MIMO
+  obecnej kolumny. `parent_object.ma_kolumne_*` jest w OBU kontekstach (lista +
+  akcje) → odporne na swap.
+
+### 4. „Zmień autora" pod dopasowanym autorem
+
+- Kontrolki dopasowania autora (link „zmień autora" / dropdown kandydatów dla
+  `wielu` / „dopasuj do istniejącego" + „utwórz nowego" dla `brak`) przenosimy
+  z `<tr>` #2 do komórki **„Autor (BPP)"** w `<tr>` #1, tuż pod
+  `_autor_dane.html`. Widoczne tylko w `edytowalny_podglad`.
+- `<tr>` #2 po zmianie zawiera: log audytu (`sformatowany_log_zmian`, tylko
+  gdy NIE `edytowalny_podglad`) + siatkę porównań + blok przepięcia.
+- Leniwy Select2 + jego `<script>` (guard `window.__bppImportAutorPicker`,
+  rejestrowany raz globalnie, event-delegation) przenosi się razem z
+  kontrolkami — działa niezależnie od miejsca w DOM.
+- HTMX target `#wiersz-{pk}` obejmuje CAŁY `<tbody>` (oba `<tr>`), więc swap
+  innerHTML nadal odświeża i kontrolki (w #1), i porównania (w #2). Bez zmian
+  w widokach akcji.
+
+**Konsekwencja dla filtra tekstowego** (ważne): dziś JS szuka w
+`textContent` całego 1. `<tr>`, świadomie POMIJAJĄC 2. `<tr>` (bo tam był
+skrypt Select2 zaśmiecający dopasowania). Po przeniesieniu kontrolek do #1
+ta ochrona znika. Rozwiązanie: `data-szukaj` na przeszukiwalnych fragmentach +
+w JS czytać `tbody.querySelectorAll('[data-szukaj]')` zamiast całego `<tr>`.
+- **TWARDY WYMÓG (review):** `data-szukaj` owija WYŁĄCZNIE: (a) `<td>` „Osoba
+  z pliku" (nazwisko/imię), (b) osobny `<span data-szukaj>` wokół samego wyniku
+  `_autor_dane` (nazwa autora), (c) `<td>` „Jednostka". Kontrolki dopasowania
+  autora (`.import-autor-zmien`, dropdown kandydatów `{{ k.autor }}`, „utwórz
+  nowego", kontener Select2) MUSZĄ być RODZEŃSTWEM POZA elementem `data-szukaj`
+  — inaczej nazwiska kandydatów i tekst Select2 wyciekają do wyszukiwania
+  (dokładnie problem, który obchodził stary kod pomijając 2. `<tr>`).
+- **Zamierzona regresja zakresu (review):** dziś `textContent` 1. `<tr>` łapie
+  też badge „Pewność" i „Poz" (arkusz/wiersz). Po `data-szukaj` przestają być
+  przeszukiwalne — zgodne z placeholderem „nazwisko / jednostka…", ale to
+  świadoma zmiana zachowania.
+
+### 5. Porównania plik→baza jako siatka 2–3 kolumn
+
+- `import-blok-porownania` z pionowej listy → responsywny CSS grid
+  (`display:grid; grid-template-columns: repeat(auto-fit, minmax(…))`,
+  do 3 kolumn na szerokim, zawija na wąskim).
+- Kolejność pól: E-mail · Tytuł nauk. · Stopień sł.* · Funkcja ·
+  Stanowisko dyd.* · Data od · Data do (`*` = warunkowe wg pkt 3).
+- Zbliżone do szkicu użytkownika:
+  ```
+  E-mail:        Tytuł nauk.:   Funkcja:
+  Stanowisko d.: Data od:       Data do:
+  ```
+
+### 6. Etykieta „baza:" → „obecnie:"
+
+- `_porownanie_kom.html`: `baza: {{ pole.baza }}` → `obecnie: {{ pole.baza }}`.
+
+## Poza zakresem (YAGNI)
+
+- Bez zmian w logice dopasowania jednostek/autorów, bez migracji, bez zmian
+  w `roznice.py` (`POLA_ROZNIC` zostaje jednym rejestrem — podział na
+  główne/dodatkowe robi widok).
+- Bez paginacji / server-side filtrowania — front-only zostaje.
+
+## Testy
+
+- **Aktualizacja istniejącego testu (review):**
+  `test_podglad_ma_pasek_filtrow_radia` (`test_views_preview_render.py:~190`)
+  tworzy import bez `mapowanie_kolumn` (`{}`) i asertuje `name="filtr-stopien"`
+  + `filtr-stanowisko`. Po warunkowym ukrywaniu te radia znikną (pusty dict →
+  False) → test RED. Nadać w nim `mapowanie_kolumn` z obiema kolumnami (albo
+  rozbić na przypadki z/bez). (`test_podglad_wiersz_ma_atrybuty_data_diff`
+  zostaje zielony — `data-diff-*` nie są ukrywane.)
+- `models`: `ma_kolumne_stopnia` / `ma_kolumne_stanowiska` — True/False wg
+  zawartości `mapowanie_kolumn` (w tym pusty dict → False).
+- `views`: `get_context_data` daje `pola_glowne` = 4 pozycje w ustalonej
+  kolejności; `pola_dodatkowe` bez `stopien`/`stanowisko`, gdy brak kolumn;
+  z nimi, gdy kolumny są; flagi `ma_kolumne_*` w kontekście.
+- `render` (istniejące `test_views_*_render.py` jako wzór): karta nie renderuje
+  wiersza „Stopień sł."/„Stanowisko dyd.", gdy brak kolumny; kontrolka „zmień
+  autora" w komórce Autora; etykieta „obecnie:".
+- Regresja: filtr tekstowy nadal działa (szuka po `data-szukaj`), licznik
+  liczy poprawnie (smoke, jeśli testujemy JS — inaczej ręcznie w run-site).
+
+## Frontend
+
+- Zmiany w `_import-pracownikow.scss` → `grunt build` (albo `make assets`):
+  - filtr: radia poziomo (`label` inline zamiast `display:block`),
+  - siatka porównań (`import-blok-porownania` → grid),
+  - **kontrolki autora w komórce „Autor" (review):** dziś szerokość dają im
+    `.import-blok-akcje { flex: 2 1 22rem }`; po przeniesieniu do wąskiego
+    `<td>` w 1. `<tr>` trzeba dać własną rezerwację szerokości/układu (dropdown
+    kandydatów + Select2 „220px" + „utwórz nowego" nie mogą ścisnąć kolumny).
+  - **NIE** nadpisywać klas grida Foundation (reguła projektu — zmieniać klasy
+    w HTML, nie w SCSS).
+- **Komentarze Django `{# #}` jednoliniowe** (reguła CLAUDE.md, powtarzalny
+  błąd): nowy `<details>` i owijki `data-szukaj` — każda linia komentarza
+  z własnym `{# … #}`; bloki przez `{% comment %}…{% endcomment %}`.
+- Weryfikacja wizualna: `run-site` (uwaga: serwuje z GŁÓWNEGO drzewa, nie
+  z worktree — przy weryfikacji trzeba wskazać worktree albo scalić).
+
+## Newsfragment
+
+`src/bpp/newsfragments/<slug>.feature.rst` — po polsku, jedno zdanie o
+przebudowie strony rezultatów importu.

--- a/src/bpp/newsfragments/import-rezultaty-filtry.feature.rst
+++ b/src/bpp/newsfragments/import-rezultaty-filtry.feature.rst
@@ -1,0 +1,7 @@
+Uczytelniono stronę wyników importu pracowników. Pasek filtrów podzielono na
+zawsze widoczne (jednostka, tytuł naukowy, data od/do — radia w poziomie)
+i zwijane („Więcej filtrów…"), dodano licznik „Pokazano X z Y rekordów".
+Kartę rekordu przebudowano: przycisk „zmień autora" trafił pod dopasowanego
+autora, porównania plik→baza układają się w siatkę, a pola stopnia służbowego
+i stanowiska dydaktycznego są ukrywane, gdy plik ich nie zawiera. Etykietę
+„baza:" zmieniono na czytelniejsze „obecnie:".

--- a/src/bpp/static/scss/_import-pracownikow.scss
+++ b/src/bpp/static/scss/_import-pracownikow.scss
@@ -62,8 +62,9 @@
     flex: 1 1 14rem;
   }
 
-  .import-blok-akcje {
-    flex: 2 1 22rem;
+  // Porównania dostają więcej miejsca (siatka 2–3 kolumn niżej).
+  .import-blok-porownania {
+    flex: 3 1 30rem;
   }
 }
 
@@ -74,6 +75,33 @@
 .import-porownanie-etykieta {
   font-weight: bold;
   margin-right: 0.25rem;
+}
+
+// Porównania plik→baza jako siatka 2–3 kolumn (dawniej pionowa lista).
+.import-blok-porownania {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.25rem 1rem;
+}
+
+// Kontrolki dopasowania autora POD dopasowanym autorem (w komórce „Autor").
+.import-autor-akcje {
+  margin-top: 0.4rem;
+  font-size: 0.9em;
+
+  > form,
+  > .import-autor-zmien {
+    margin-bottom: 0.3rem;
+  }
+}
+
+// Audyt zmian (po integracji) — pełna szerokość nad blokami szczegółów.
+.import-blok-audyt {
+  margin-bottom: 0.5rem;
+
+  p {
+    margin: 0 0 0.15rem;
+  }
 }
 
 // Pasek filtrów „zmienione / zgodne / brak" nad tabelą.
@@ -96,13 +124,39 @@
     }
 
     label {
-      display: block;
+      display: inline-block;
       font-size: 0.85em;
-      margin: 0;
+      margin: 0 0.5rem 0 0;
     }
   }
 
   .import-filtr-tekst {
     align-self: center;
   }
+
+  // Kontenery grup filtrów: widoczne (główne) i zwijane (dodatkowe).
+  .import-filtr-glowne,
+  .import-filtr-dodatkowe {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .import-filtr-wiecej {
+    width: 100%;
+
+    > summary {
+      cursor: pointer;
+      font-size: 0.85em;
+      color: #1468a0;
+      margin-bottom: 0.5rem;
+    }
+  }
+}
+
+// Licznik przefiltrowanych rekordów pod paskiem filtrów.
+.import-filtr-licznik {
+  font-size: 0.9em;
+  color: #767676;
+  margin: 0 0 0.75rem;
 }

--- a/src/import_pracownikow/models.py
+++ b/src/import_pracownikow/models.py
@@ -522,6 +522,22 @@ class ImportPracownikow(LiveOperation):
         )
 
     @property
+    def ma_kolumne_stopnia(self):
+        """Czy plik importu MA kolumnę stopnia służbowego (zmapowaną na
+        ``stopień_służbowy``). Źródło prawdy: wartości ``mapowanie_kolumn``
+        (kształt ``{nagłówek: pole_docelowe}``). Steruje pokazaniem pola
+        „Stopień sł." w karcie wyników i w pasku filtrów — bez kolumny w pliku
+        nie ma czego pokazywać ani po czym filtrować (dane i tak by się nie
+        zmieniły)."""
+        return "stopień_służbowy" in (self.mapowanie_kolumn or {}).values()
+
+    @property
+    def ma_kolumne_stanowiska(self):
+        """Mirror ``ma_kolumne_stopnia`` dla stanowiska dydaktycznego
+        (kolumna zmapowana na ``stanowisko_dydaktyczne``)."""
+        return "stanowisko_dydaktyczne" in (self.mapowanie_kolumn or {}).values()
+
+    @property
     def tytuly_wymagaja_rozstrzygniecia(self):
         """Czy są tytuły z pliku, które import osób UTWORZYŁBY/USTAWIŁ, a które
         NIE zostały jeszcze zmaterializowane (``utworzony=None``) i nie są

--- a/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
+++ b/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
@@ -54,26 +54,33 @@
         <p>Lista modyfikacji do bazy danych, przeprowadzonych na podstawie
             pliku XLS poniżej:</p>
         {# Filtr rekordów po stanie pól — radia per pole (POLA_ROZNIC), AND. #}
+        {# Widoczne (główne) + zwijane (dodatkowe) w <details> — oba w tym #}
+        {# samym <form>, więc JS querySelectorAll łapie radia niezależnie od #}
+        {# stanu open/closed. #}
         <form id="filtr-roznic" class="import-filtr-roznic">
             <label class="import-filtr-tekst">
                 Szukaj:
                 <input type="search" id="filtr-tekst"
                        placeholder="nazwisko / jednostka…">
             </label>
-            {% for klucz, etykieta in pola_roznic %}
-                <fieldset class="import-filtr-pole">
-                    <legend>{{ etykieta }}</legend>
-                    <label><input type="radio" name="filtr-{{ klucz }}"
-                                  value="wszystkie" checked> wszystkie</label>
-                    <label><input type="radio" name="filtr-{{ klucz }}"
-                                  value="zmienione"> zmienione</label>
-                    <label><input type="radio" name="filtr-{{ klucz }}"
-                                  value="zgodne"> zgodne</label>
-                    <label><input type="radio" name="filtr-{{ klucz }}"
-                                  value="brak"> brak w pliku</label>
-                </fieldset>
-            {% endfor %}
+            <div class="import-filtr-glowne">
+                {% for klucz, etykieta in pola_glowne %}
+                    {% include "import_pracownikow/partials/_filtr_pole.html" %}
+                {% endfor %}
+            </div>
+            {% if pola_dodatkowe %}
+                <details class="import-filtr-wiecej">
+                    <summary>Więcej filtrów…</summary>
+                    <div class="import-filtr-dodatkowe">
+                        {% for klucz, etykieta in pola_dodatkowe %}
+                            {% include "import_pracownikow/partials/_filtr_pole.html" %}
+                        {% endfor %}
+                    </div>
+                </details>
+            {% endif %}
         </form>
+        {# Licznik przefiltrowanych rekordów (aktualizowany w JS filtruj()). #}
+        <p id="filtr-licznik" class="import-filtr-licznik"></p>
         <div style="overflow-x: auto;">
             <table id="tabela-autorow">
                 <thead>
@@ -100,9 +107,11 @@
         </div>
 
         {# Filtr rekordów po stanie pól (data-diff-* na 1. <tr> rekordu) + tekst. #}
-        {# Zastępuje DataTables (usunięte): karta = 2×<tr> w <tbody>, sort zbędny; #}
-        {# HTMX swapuje innerHTML <tbody>, więc data-diff-* są zawsze świeże, a #}
-        {# po afterSettle wystarczy ponowić filtr. #}
+        {# Zastępuje DataTables (usunięte): karta = 2×<tr> w <tbody data-rekord>, #}
+        {# sort zbędny; HTMX swapuje innerHTML <tbody>, więc data-diff-* są zawsze #}
+        {# świeże, a po afterSettle wystarczy ponowić filtr. Tekst szukamy tylko #}
+        {# w elementach [data-szukaj] (nazwisko / autor / jednostka) — kontrolki #}
+        {# dopasowania autora i Select2 są POZA nimi, więc nie zaśmiecają. #}
         <script>
         (function () {
             var form = document.getElementById('filtr-roznic');
@@ -129,25 +138,43 @@
                 var el = document.getElementById('filtr-tekst');
                 return (el ? el.value : '').trim().toLowerCase();
             }
+            function tekstRekordu(tbody) {
+                var buf = '';
+                tbody.querySelectorAll('[data-szukaj]').forEach(function (el) {
+                    buf += ' ' + el.textContent;
+                });
+                return buf.toLowerCase();
+            }
             function filtruj() {
                 var ks = klucze();
                 var q = tekst();
-                tabela.querySelectorAll(':scope > tbody').forEach(function (tbody) {
-                    var okStany = ks.every(function (klucz) {
-                        var w = wybor(klucz);
-                        return w === 'wszystkie' || stanPola(tbody, klucz) === w;
+                var widoczne = 0, wszystkich = 0;
+                tabela.querySelectorAll(':scope > tbody[data-rekord]').forEach(
+                    function (tbody) {
+                        wszystkich++;
+                        var okStany = ks.every(function (klucz) {
+                            var w = wybor(klucz);
+                            return w === 'wszystkie'
+                                || stanPola(tbody, klucz) === w;
+                        });
+                        var okTekst = !q
+                            || tekstRekordu(tbody).indexOf(q) !== -1;
+                        var pokaz = okStany && okTekst;
+                        tbody.hidden = !pokaz;
+                        if (pokaz) widoczne++;
                     });
-                    // Szukaj tylko w 1. <tr> (tożsamość) — 2. <tr> zawiera skrypt
-                    // Select2, którego tekst zaśmiecałby dopasowania.
-                    var pierwszy = tbody.querySelector(':scope > tr');
-                    var okTekst = !q || (pierwszy &&
-                        pierwszy.textContent.toLowerCase().indexOf(q) !== -1);
-                    tbody.hidden = !(okStany && okTekst);
-                });
+                var licznik = document.getElementById('filtr-licznik');
+                if (licznik) {
+                    licznik.textContent = wszystkich
+                        ? 'Pokazano ' + widoczne + ' z ' + wszystkich
+                            + ' rekordów'
+                        : '';
+                }
             }
             form.addEventListener('change', filtruj);
             form.addEventListener('input', filtruj);
             document.body.addEventListener('htmx:afterSettle', filtruj);
+            filtruj();
         })();
         </script>
     {% endif %}

--- a/src/import_pracownikow/templates/import_pracownikow/partials/_filtr_pole.html
+++ b/src/import_pracownikow/templates/import_pracownikow/partials/_filtr_pole.html
@@ -1,0 +1,10 @@
+{# Jeden fieldset filtra stanu pola (radia wszystkie/zmienione/zgodne/brak). #}
+{# Kontekst: klucz, etykieta (z pola_glowne / pola_dodatkowe). Współdzielony #}
+{# przez pasek widoczny i sekcję zwijaną <details>. #}
+<fieldset class="import-filtr-pole">
+    <legend>{{ etykieta }}</legend>
+    <label><input type="radio" name="filtr-{{ klucz }}" value="wszystkie" checked> wszystkie</label>
+    <label><input type="radio" name="filtr-{{ klucz }}" value="zmienione"> zmienione</label>
+    <label><input type="radio" name="filtr-{{ klucz }}" value="zgodne"> zgodne</label>
+    <label><input type="radio" name="filtr-{{ klucz }}" value="brak"> brak w pliku</label>
+</fieldset>

--- a/src/import_pracownikow/templates/import_pracownikow/partials/_porownanie_kom.html
+++ b/src/import_pracownikow/templates/import_pracownikow/partials/_porownanie_kom.html
@@ -5,7 +5,7 @@
 {% if pole.rozne %}
     <span class="label warning import-porownanie-rozne">{{ pole.plik }}</span>
     <br>
-    <span class="secondary">baza: {{ pole.baza|default:"—" }}</span>
+    <span class="secondary">obecnie: {{ pole.baza|default:"—" }}</span>
 {% elif pole.plik %}
     {{ pole.plik }}
 {% else %}

--- a/src/import_pracownikow/templates/import_pracownikow/partials/_wiersz_preview.html
+++ b/src/import_pracownikow/templates/import_pracownikow/partials/_wiersz_preview.html
@@ -2,6 +2,6 @@
 {# Akcje HTMX swapują innerHTML tego <tbody> (→ _wiersz_preview_kom.html), #}
 {# więc węzeł <tbody id="wiersz-{pk}"> zostaje stały, a filtr JS odczytuje #}
 {# świeże data-diff-* z pierwszego <tr> po każdym swapie. #}
-<tbody id="wiersz-{{ row.pk }}">
+<tbody id="wiersz-{{ row.pk }}" data-rekord>
     {% include "import_pracownikow/partials/_wiersz_preview_kom.html" %}
 </tbody>

--- a/src/import_pracownikow/templates/import_pracownikow/partials/_wiersz_preview_kom.html
+++ b/src/import_pracownikow/templates/import_pracownikow/partials/_wiersz_preview_kom.html
@@ -1,11 +1,14 @@
-{# Karta rekordu: <tr> nr 1 (tożsamość, read-only, data-diff-*) + <tr> nr 2 #}
-{# (colspan=5: dopasowanie autora / komparatory plik→baza / przepnij prace). #}
-{# Oba <tr> to innerHTML <tbody id="wiersz-{pk}"> — HTMX swapuje całość, więc #}
-{# data-diff-* na pierwszym <tr> są zawsze świeże po akcji. Kolumny Osoba są #}
-{# READ-ONLY (dane z XLS). #}
+{# Karta rekordu: <tr> nr 1 (tożsamość + dopasowanie autora, data-diff-*) + #}
+{# <tr> nr 2 (colspan=5: komparatory plik→baza / audyt / przepnij prace). #}
+{# Oba <tr> to innerHTML <tbody id="wiersz-{pk}" data-rekord> — HTMX swapuje #}
+{# całość, więc data-diff-* na pierwszym <tr> są zawsze świeże po akcji. #}
+{# Kolumny Osoba/Jednostka są READ-ONLY (dane z XLS). Fragmenty [data-szukaj] #}
+{# zasilają filtr tekstowy (nazwisko / autor / jednostka) — kontrolki #}
+{# dopasowania autora są POZA nimi, żeby ich tekst i Select2 nie zaśmiecały #}
+{# wyszukiwania. #}
 <tr{% for klucz, stan in row.stany_pol.items %} data-diff-{{ klucz }}="{{ stan }}"{% endfor %}>
     <td class="import-poz">{{ row.nr_arkusza }}/{{ row.nr_wiersza }}</td>
-    <td>
+    <td data-szukaj>
         <strong>{{ row.dane_znormalizowane.nazwisko }}</strong>
         {{ row.dane_znormalizowane.imię }}
         {% if row.dane_znormalizowane.tytuł_stopień %}
@@ -21,9 +24,170 @@
         {% endwith %}
     </td>
     <td>
-        {% include "import_pracownikow/partials/_autor_dane.html" with autor=row.autor pbn_inst=row.autor_z_pbn_inst %}
+        {# Sama nazwa autora jest przeszukiwalna; kontrolki niżej — NIE. #}
+        <span data-szukaj>
+            {% include "import_pracownikow/partials/_autor_dane.html" with autor=row.autor pbn_inst=row.autor_z_pbn_inst %}
+        </span>
+        {% if parent_object.edytowalny_podglad %}
+            {# Kontrolki dopasowania autora POD dopasowanym autorem (dawniej #}
+            {# w 2. wierszu). RODZEŃSTWO span[data-szukaj], NIE wewnątrz. #}
+            <div class="import-autor-akcje">
+                {% if row.confidence == "wielu" %}
+                    {# dropdown policzonych kandydatów — POST ustawia wybrany_kandydat #}
+                    <form method="post"
+                          hx-post="{% url "import_pracownikow:wybierz-kandydata" parent_object.pk row.pk %}"
+                          hx-target="#wiersz-{{ row.pk }}"
+                          hx-swap="innerHTML">
+                        {% csrf_token %}
+                        <select name="wybrany_kandydat">
+                            {% for k in row.kandydaci.all %}
+                                <option value="{{ k.autor.pk }}">
+                                    {{ k.autor }} ({{ k.pewnosc }})
+                                </option>
+                            {% endfor %}
+                        </select>
+                        <button type="submit" class="button tiny">
+                            <i class="fi-check"></i> wybierz
+                        </button>
+                    </form>
+                    {# poza policzonymi kandydatami: dopasuj do dowolnego autora #}
+                    <div class="import-autor-zmien">
+                        <a href="#" class="js-zmien-autora">
+                            <i class="fi-torso"></i> inny autor…
+                        </a>
+                        <div class="js-autor-picker" hidden>
+                            <form method="post"
+                                  hx-post="{% url "import_pracownikow:dopasuj-autora" parent_object.pk row.pk %}"
+                                  hx-target="#wiersz-{{ row.pk }}"
+                                  hx-swap="innerHTML"
+                                  hx-trigger="change">
+                                {% csrf_token %}
+                                <select name="autor"
+                                        data-autocomplete-url="{% url "bpp:import-autor-autocomplete" %}"></select>
+                            </form>
+                        </div>
+                    </div>
+                {% elif row.confidence == "brak" %}
+                    {# brak dopasowania: dopasuj do istniejącego autora (leniwy #}
+                    {# Select2) albo utwórz nowego (checkbox niżej). #}
+                    <div class="import-autor-zmien">
+                        <a href="#" class="js-zmien-autora">
+                            <i class="fi-magnifying-glass"></i>
+                            Dopasuj do istniejącego autora
+                        </a>
+                        <div class="js-autor-picker" hidden>
+                            <form method="post"
+                                  hx-post="{% url "import_pracownikow:dopasuj-autora" parent_object.pk row.pk %}"
+                                  hx-target="#wiersz-{{ row.pk }}"
+                                  hx-swap="innerHTML"
+                                  hx-trigger="change">
+                                {% csrf_token %}
+                                <select name="autor"
+                                        data-autocomplete-url="{% url "bpp:import-autor-autocomplete" %}"></select>
+                            </form>
+                        </div>
+                    </div>
+                    {# D2: checkbox „utwórz nowego autora" — zmiana → POST toggle #}
+                    <form method="post"
+                          hx-post="{% url "import_pracownikow:utworz-nowego" parent_object.pk row.pk %}"
+                          hx-target="#wiersz-{{ row.pk }}"
+                          hx-swap="innerHTML"
+                          hx-trigger="change">
+                        {% csrf_token %}
+                        <label>
+                            <input type="checkbox" name="utworz_nowego"
+                                   {% if row.utworz_nowego %}checked{% endif %}>
+                            <i class="fi-plus"></i> utwórz nowego autora
+                        </label>
+                    </form>
+                {% else %}
+                    {# twardy / zgadywanie: auto-autor jest już w kol. Autor — #}
+                    {# dyskretny „zmień autora" rozwijający leniwy Select2 (override). #}
+                    <div class="import-autor-zmien">
+                        <a href="#" class="js-zmien-autora">
+                            <i class="fi-pencil"></i> zmień autora
+                        </a>
+                        <div class="js-autor-picker" hidden>
+                            <form method="post"
+                                  hx-post="{% url "import_pracownikow:dopasuj-autora" parent_object.pk row.pk %}"
+                                  hx-target="#wiersz-{{ row.pk }}"
+                                  hx-swap="innerHTML"
+                                  hx-trigger="change">
+                                {% csrf_token %}
+                                <select name="autor"
+                                        data-autocomplete-url="{% url "bpp:import-autor-autocomplete" %}"></select>
+                            </form>
+                        </div>
+                    </div>
+                {% endif %}
+                {# Leniwy Select2 na autocomplete importu. Event-delegation #}
+                {# zarejestrowana RAZ (guard window.__bppImportAutorPicker), bo #}
+                {# partial jest powielany per wiersz i wstrzykiwany OOB przez #}
+                {# HTMX. Klik w „.js-zmien-autora" pokazuje kontener i inicjalizuje #}
+                {# Select2 dopiero na żądanie (tabela bez paginacji, setki wierszy #}
+                {# → nie chcemy setek widgetów na starcie). #}
+                <script>
+                (function () {
+                    if (window.__bppImportAutorPicker) return;
+                    window.__bppImportAutorPicker = true;
+
+                    function initPicker(wrap) {
+                        var sel = wrap.querySelector("select[data-autocomplete-url]");
+                        if (!sel || sel.dataset.select2Init || !window.jQuery) return;
+                        sel.dataset.select2Init = "1";
+                        window.jQuery(sel).select2({
+                            width: "220px",
+                            ajax: {
+                                url: sel.dataset.autocompleteUrl,
+                                dataType: "json",
+                                delay: 250,
+                                data: function (params) { return {q: params.term}; },
+                                processResults: function (data) { return data; }
+                            },
+                            minimumInputLength: 2,
+                            placeholder: "Szukaj autora…",
+                            allowClear: true,
+                            language: "pl"
+                        });
+                        // htmx słucha natywnego "change" (addEventListener); Select2
+                        // emituje "change" przez system zdarzeń jQuery, którego natywny
+                        // listener NIE łapie → POST dopasuj-autora nigdy nie leciał, a
+                        // wybór autora „nie zapisywał się". Mostek: na select2:select /
+                        // select2:unselect wystrzel natywny "change", który htmx podłapie
+                        // i wykona hx-post (bubbles, bo formularz jest rodzicem selecta).
+                        window.jQuery(sel).on(
+                            "select2:select select2:unselect",
+                            function () {
+                                sel.dispatchEvent(
+                                    new Event("change", { bubbles: true })
+                                );
+                            }
+                        );
+                    }
+
+                    document.addEventListener("click", function (e) {
+                        var toggle = e.target.closest(".js-zmien-autora");
+                        if (!toggle) return;
+                        e.preventDefault();
+                        var wrap = toggle.parentElement.querySelector(".js-autor-picker");
+                        if (!wrap) return;
+                        wrap.hidden = false;
+                        toggle.style.display = "none";
+                        initPicker(wrap);
+                    });
+
+                    document.body.addEventListener("htmx:afterSettle", function (e) {
+                        var scope = (e.detail && e.detail.target) || document;
+                        scope
+                            .querySelectorAll(".js-autor-picker:not([hidden])")
+                            .forEach(initPicker);
+                    });
+                })();
+                </script>
+            </div>
+        {% endif %}
     </td>
-    <td>
+    <td data-szukaj>
         {% if row.jednostka %}
             {% if row.autor and row.autor.aktualna_jednostka_id and row.autor.aktualna_jednostka_id != row.jednostka_id %}
                 {{ row.autor.aktualna_jednostka }} → <strong>{{ row.jednostka }}</strong>
@@ -37,169 +201,16 @@
 </tr>
 <tr class="import-wiersz-szczegoly">
     <td colspan="5">
-        <div class="import-szczegoly-bloki">
-            <div class="import-blok import-blok-akcje">
-                {% if parent_object.edytowalny_podglad %}
-                    {% if row.confidence == "wielu" %}
-                        {# dropdown policzonych kandydatów — POST ustawia wybrany_kandydat #}
-                        <form method="post"
-                              hx-post="{% url "import_pracownikow:wybierz-kandydata" parent_object.pk row.pk %}"
-                              hx-target="#wiersz-{{ row.pk }}"
-                              hx-swap="innerHTML">
-                            {% csrf_token %}
-                            <select name="wybrany_kandydat">
-                                {% for k in row.kandydaci.all %}
-                                    <option value="{{ k.autor.pk }}">
-                                        {{ k.autor }} ({{ k.pewnosc }})
-                                    </option>
-                                {% endfor %}
-                            </select>
-                            <button type="submit" class="button tiny">
-                                <i class="fi-check"></i> wybierz
-                            </button>
-                        </form>
-                        {# poza policzonymi kandydatami: dopasuj do dowolnego autora #}
-                        <div class="import-autor-zmien">
-                            <a href="#" class="js-zmien-autora">
-                                <i class="fi-torso"></i> inny autor…
-                            </a>
-                            <div class="js-autor-picker" hidden>
-                                <form method="post"
-                                      hx-post="{% url "import_pracownikow:dopasuj-autora" parent_object.pk row.pk %}"
-                                      hx-target="#wiersz-{{ row.pk }}"
-                                      hx-swap="innerHTML"
-                                      hx-trigger="change">
-                                    {% csrf_token %}
-                                    <select name="autor"
-                                            data-autocomplete-url="{% url "bpp:import-autor-autocomplete" %}"></select>
-                                </form>
-                            </div>
-                        </div>
-                    {% elif row.confidence == "brak" %}
-                        {# brak dopasowania: dopasuj do istniejącego autora (leniwy #}
-                        {# Select2) albo utwórz nowego (checkbox niżej). #}
-                        <div class="import-autor-zmien">
-                            <a href="#" class="js-zmien-autora">
-                                <i class="fi-magnifying-glass"></i>
-                                Dopasuj do istniejącego autora
-                            </a>
-                            <div class="js-autor-picker" hidden>
-                                <form method="post"
-                                      hx-post="{% url "import_pracownikow:dopasuj-autora" parent_object.pk row.pk %}"
-                                      hx-target="#wiersz-{{ row.pk }}"
-                                      hx-swap="innerHTML"
-                                      hx-trigger="change">
-                                    {% csrf_token %}
-                                    <select name="autor"
-                                            data-autocomplete-url="{% url "bpp:import-autor-autocomplete" %}"></select>
-                                </form>
-                            </div>
-                        </div>
-                        {# D2: checkbox „utwórz nowego autora" — zmiana → POST toggle #}
-                        <form method="post"
-                              hx-post="{% url "import_pracownikow:utworz-nowego" parent_object.pk row.pk %}"
-                              hx-target="#wiersz-{{ row.pk }}"
-                              hx-swap="innerHTML"
-                              hx-trigger="change">
-                            {% csrf_token %}
-                            <label>
-                                <input type="checkbox" name="utworz_nowego"
-                                       {% if row.utworz_nowego %}checked{% endif %}>
-                                <i class="fi-plus"></i> utwórz nowego autora
-                            </label>
-                        </form>
-                    {% else %}
-                        {# twardy / zgadywanie: auto-autor jest już w kol. Autor — #}
-                        {# dyskretny „zmień autora" rozwijający leniwy Select2 (override). #}
-                        <div class="import-autor-zmien">
-                            <a href="#" class="js-zmien-autora">
-                                <i class="fi-pencil"></i> zmień autora
-                            </a>
-                            <div class="js-autor-picker" hidden>
-                                <form method="post"
-                                      hx-post="{% url "import_pracownikow:dopasuj-autora" parent_object.pk row.pk %}"
-                                      hx-target="#wiersz-{{ row.pk }}"
-                                      hx-swap="innerHTML"
-                                      hx-trigger="change">
-                                    {% csrf_token %}
-                                    <select name="autor"
-                                            data-autocomplete-url="{% url "bpp:import-autor-autocomplete" %}"></select>
-                                </form>
-                            </div>
-                        </div>
-                    {% endif %}
-                    {# Leniwy Select2 na autocomplete importu. Event-delegation #}
-                    {# zarejestrowana RAZ (guard window.__bppImportAutorPicker), bo #}
-                    {# partial jest powielany per wiersz i wstrzykiwany OOB przez #}
-                    {# HTMX. Klik w „.js-zmien-autora" pokazuje kontener i inicjalizuje #}
-                    {# Select2 dopiero na żądanie (tabela bez paginacji, setki wierszy #}
-                    {# → nie chcemy setek widgetów na starcie). #}
-                    <script>
-                    (function () {
-                        if (window.__bppImportAutorPicker) return;
-                        window.__bppImportAutorPicker = true;
-
-                        function initPicker(wrap) {
-                            var sel = wrap.querySelector("select[data-autocomplete-url]");
-                            if (!sel || sel.dataset.select2Init || !window.jQuery) return;
-                            sel.dataset.select2Init = "1";
-                            window.jQuery(sel).select2({
-                                width: "220px",
-                                ajax: {
-                                    url: sel.dataset.autocompleteUrl,
-                                    dataType: "json",
-                                    delay: 250,
-                                    data: function (params) { return {q: params.term}; },
-                                    processResults: function (data) { return data; }
-                                },
-                                minimumInputLength: 2,
-                                placeholder: "Szukaj autora…",
-                                allowClear: true,
-                                language: "pl"
-                            });
-                            // htmx słucha natywnego "change" (addEventListener); Select2
-                            // emituje "change" przez system zdarzeń jQuery, którego natywny
-                            // listener NIE łapie → POST dopasuj-autora nigdy nie leciał, a
-                            // wybór autora „nie zapisywał się". Mostek: na select2:select /
-                            // select2:unselect wystrzel natywny "change", który htmx podłapie
-                            // i wykona hx-post (bubbles, bo formularz jest rodzicem selecta).
-                            window.jQuery(sel).on(
-                                "select2:select select2:unselect",
-                                function () {
-                                    sel.dispatchEvent(
-                                        new Event("change", { bubbles: true })
-                                    );
-                                }
-                            );
-                        }
-
-                        document.addEventListener("click", function (e) {
-                            var toggle = e.target.closest(".js-zmien-autora");
-                            if (!toggle) return;
-                            e.preventDefault();
-                            var wrap = toggle.parentElement.querySelector(".js-autor-picker");
-                            if (!wrap) return;
-                            wrap.hidden = false;
-                            toggle.style.display = "none";
-                            initPicker(wrap);
-                        });
-
-                        document.body.addEventListener("htmx:afterSettle", function (e) {
-                            var scope = (e.detail && e.detail.target) || document;
-                            scope
-                                .querySelectorAll(".js-autor-picker:not([hidden])")
-                                .forEach(initPicker);
-                        });
-                    })();
-                    </script>
-                {% else %}
-                    {# Poza stanem „przeanalizowany" (np. „zintegrowany") pokazujemy #}
-                    {# audyt zmian — to JEDYNY widok log_zmian dla stanu po integracji. #}
-                    {% for elem in row.sformatowany_log_zmian %}
-                        <p>{{ elem }}</p>
-                    {% endfor %}
-                {% endif %}
+        {% if not parent_object.edytowalny_podglad %}
+            {# Po integracji: audyt zmian — JEDYNY widok log_zmian dla stanu #}
+            {# po integracji (dawniej w bloku akcji, gdy nieedytowalny). #}
+            <div class="import-blok-audyt">
+                {% for elem in row.sformatowany_log_zmian %}
+                    <p>{{ elem }}</p>
+                {% endfor %}
             </div>
+        {% endif %}
+        <div class="import-szczegoly-bloki">
             <div class="import-blok import-blok-porownania">
                 {% with porownanie=row.porownaj_z_baza %}
                     <div class="import-porownanie-item">
@@ -210,18 +221,22 @@
                         <span class="import-porownanie-etykieta">Tytuł nauk.:</span>
                         {% include "import_pracownikow/partials/_porownanie_kom.html" with pole=porownanie.tytul %}
                     </div>
-                    <div class="import-porownanie-item">
-                        <span class="import-porownanie-etykieta">Stopień sł.:</span>
-                        {% include "import_pracownikow/partials/_porownanie_kom.html" with pole=porownanie.stopien %}
-                    </div>
+                    {% if parent_object.ma_kolumne_stopnia %}
+                        <div class="import-porownanie-item">
+                            <span class="import-porownanie-etykieta">Stopień sł.:</span>
+                            {% include "import_pracownikow/partials/_porownanie_kom.html" with pole=porownanie.stopien %}
+                        </div>
+                    {% endif %}
                     <div class="import-porownanie-item">
                         <span class="import-porownanie-etykieta">Funkcja:</span>
                         {% include "import_pracownikow/partials/_porownanie_kom.html" with pole=porownanie.funkcja %}
                     </div>
-                    <div class="import-porownanie-item">
-                        <span class="import-porownanie-etykieta">Stanowisko dyd.:</span>
-                        {% include "import_pracownikow/partials/_porownanie_kom.html" with pole=porownanie.stanowisko %}
-                    </div>
+                    {% if parent_object.ma_kolumne_stanowiska %}
+                        <div class="import-porownanie-item">
+                            <span class="import-porownanie-etykieta">Stanowisko dyd.:</span>
+                            {% include "import_pracownikow/partials/_porownanie_kom.html" with pole=porownanie.stanowisko %}
+                        </div>
+                    {% endif %}
                     <div class="import-porownanie-item">
                         <span class="import-porownanie-etykieta">Data od:</span>
                         {% include "import_pracownikow/partials/_porownanie_kom.html" with pole=porownanie.data_od %}

--- a/src/import_pracownikow/tests/test_models/test_mapowanie_model.py
+++ b/src/import_pracownikow/tests/test_models/test_mapowanie_model.py
@@ -19,6 +19,35 @@ def test_import_ma_pole_mapowanie_kolumn_domyslnie_puste():
 
 
 @pytest.mark.django_db
+def test_ma_kolumne_stopnia_wg_mapowania():
+    """`ma_kolumne_stopnia` = czy plik mapuje kolumnę na `stopień_służbowy`
+    (wartości `mapowanie_kolumn`, kształt `{nagłówek: pole_docelowe}`)."""
+    imp = baker.make(
+        ImportPracownikow,
+        mapowanie_kolumn={"Nazwisko": "nazwisko", "Stopień": "stopień_służbowy"},
+    )
+    assert imp.ma_kolumne_stopnia is True
+    assert imp.ma_kolumne_stanowiska is False
+
+
+@pytest.mark.django_db
+def test_ma_kolumne_stanowiska_wg_mapowania():
+    imp = baker.make(
+        ImportPracownikow,
+        mapowanie_kolumn={"Stanowisko dyd.": "stanowisko_dydaktyczne"},
+    )
+    assert imp.ma_kolumne_stanowiska is True
+    assert imp.ma_kolumne_stopnia is False
+
+
+@pytest.mark.django_db
+def test_ma_kolumne_stopnia_stanowiska_false_gdy_puste_mapowanie():
+    imp = baker.make(ImportPracownikow, mapowanie_kolumn={})
+    assert imp.ma_kolumne_stopnia is False
+    assert imp.ma_kolumne_stanowiska is False
+
+
+@pytest.mark.django_db
 def test_stan_zmapowany_istnieje():
     assert ImportPracownikow.STAN_ZMAPOWANY == "zmapowany"
     kody = [k for k, _ in ImportPracownikow.STAN_CHOICES]

--- a/src/import_pracownikow/tests/test_porownywarka.py
+++ b/src/import_pracownikow/tests/test_porownywarka.py
@@ -85,6 +85,12 @@ def test_tabela_podgladu_renderuje_kolumny_porownania(admin_client, admin_user):
         owner=admin_user,
         stan=ImportPracownikow.STAN_STRUKTURA_ZINTEGROWANA,
         finished_successfully=True,
+        # Kolumny stopnia/stanowiska w pliku — inaczej karta chowa te wiersze
+        # porównania (warunkowe wg mapowanie_kolumn).
+        mapowanie_kolumn={
+            "S": "stopień_służbowy",
+            "SD": "stanowisko_dydaktyczne",
+        },
     )
     ImportPracownikowRow.objects.create(
         parent=imp,

--- a/src/import_pracownikow/tests/test_views_preview_render.py
+++ b/src/import_pracownikow/tests/test_views_preview_render.py
@@ -189,12 +189,17 @@ def test_podglad_wiersz_ma_atrybuty_data_diff(admin_client, admin_user):
 @pytest.mark.django_db
 def test_podglad_ma_pasek_filtrow_radia(admin_client, admin_user):
     """Pasek filtrów renderuje radia (wszystkie/zmienione/zgodne/brak) dla
-    każdego z pól POLA_ROZNIC (w tym data_od/data_do)."""
+    każdego z pól POLA_ROZNIC (w tym data_od/data_do). `mapowanie_kolumn`
+    z kolumnami stopnia i stanowiska, żeby oba filtry (zwijane) się pojawiły."""
     imp = baker.make(
         ImportPracownikow,
         owner=admin_user,
         stan=ImportPracownikow.STAN_PRZEANALIZOWANY,
         finished_successfully=True,
+        mapowanie_kolumn={
+            "S": "stopień_służbowy",
+            "SD": "stanowisko_dydaktyczne",
+        },
     )
     url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
     tresc = admin_client.get(url).content.decode("utf-8")
@@ -212,3 +217,150 @@ def test_podglad_ma_pasek_filtrow_radia(admin_client, admin_user):
         assert f'name="filtr-{klucz}"' in tresc
     assert 'value="zmienione"' in tresc
     assert 'value="brak"' in tresc
+
+
+@pytest.mark.django_db
+def test_results_context_dzieli_pola_glowne_dodatkowe(admin_client, admin_user):
+    """Widok dzieli POLA_ROZNIC na `pola_glowne` (zawsze widoczne: jednostka,
+    tytuł, data od/do) i `pola_dodatkowe` (collapsible: email, stopień,
+    funkcja, stanowisko)."""
+    imp = baker.make(
+        ImportPracownikow,
+        owner=admin_user,
+        stan=ImportPracownikow.STAN_PRZEANALIZOWANY,
+        finished_successfully=True,
+        mapowanie_kolumn={
+            "S": "stopień_służbowy",
+            "SD": "stanowisko_dydaktyczne",
+        },
+    )
+    url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
+    ctx = admin_client.get(url).context
+    assert [k for k, _ in ctx["pola_glowne"]] == [
+        "jednostka",
+        "tytul",
+        "data_od",
+        "data_do",
+    ]
+    assert [k for k, _ in ctx["pola_dodatkowe"]] == [
+        "email",
+        "stopien",
+        "funkcja",
+        "stanowisko",
+    ]
+
+
+@pytest.mark.django_db
+def test_results_context_ukrywa_stopien_stanowisko_bez_kolumn(admin_client, admin_user):
+    """Bez kolumny w pliku (`mapowanie_kolumn` puste) — stopień i stanowisko
+    wypadają z `pola_dodatkowe` (nie filtrujemy po polu, którego nie ma)."""
+    imp = baker.make(
+        ImportPracownikow,
+        owner=admin_user,
+        stan=ImportPracownikow.STAN_PRZEANALIZOWANY,
+        finished_successfully=True,
+        mapowanie_kolumn={},
+    )
+    url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
+    ctx = admin_client.get(url).context
+    assert [k for k, _ in ctx["pola_dodatkowe"]] == ["email", "funkcja"]
+    assert [k for k, _ in ctx["pola_glowne"]] == [
+        "jednostka",
+        "tytul",
+        "data_od",
+        "data_do",
+    ]
+
+
+@pytest.mark.django_db
+def test_karta_ukrywa_stopien_stanowisko_bez_kolumny(admin_client, admin_user):
+    """Plik bez kolumny stopnia/stanowiska → karta NIE renderuje tych wierszy
+    porównania (dane i tak by się nie zmieniły)."""
+    imp = baker.make(
+        ImportPracownikow,
+        owner=admin_user,
+        stan=ImportPracownikow.STAN_PRZEANALIZOWANY,
+        finished_successfully=True,
+        mapowanie_kolumn={},
+    )
+    jednostka = baker.make(Jednostka, nazwa="Kat.", skrot="K.")
+    autor = baker.make(Autor, nazwisko="Nowak", imiona="Ewa")
+    ImportPracownikowRow.objects.create(
+        parent=imp,
+        jednostka=jednostka,
+        autor=autor,
+        confidence=STATUS_TWARDY,
+        zmiany_potrzebne=False,
+        dane_znormalizowane={"imię": "Ewa", "nazwisko": "Nowak"},
+        dane_z_xls={"__xls_loc_sheet__": 0, "__xls_loc_row__": 3},
+    )
+    url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
+    tresc = admin_client.get(url).content.decode("utf-8")
+    assert "Stopień sł.:" not in tresc
+    assert "Stanowisko dyd.:" not in tresc
+    # Pozostałe pola porównania zostają.
+    assert "E-mail:" in tresc
+    assert "Funkcja:" in tresc
+
+
+@pytest.mark.django_db
+def test_karta_pokazuje_stopien_stanowisko_z_kolumnami(admin_client, admin_user):
+    """Plik z kolumnami stopnia/stanowiska → karta renderuje oba wiersze."""
+    imp = baker.make(
+        ImportPracownikow,
+        owner=admin_user,
+        stan=ImportPracownikow.STAN_PRZEANALIZOWANY,
+        finished_successfully=True,
+        mapowanie_kolumn={
+            "S": "stopień_służbowy",
+            "SD": "stanowisko_dydaktyczne",
+        },
+    )
+    jednostka = baker.make(Jednostka, nazwa="Kat.", skrot="K.")
+    autor = baker.make(Autor, nazwisko="Nowak", imiona="Ewa")
+    ImportPracownikowRow.objects.create(
+        parent=imp,
+        jednostka=jednostka,
+        autor=autor,
+        confidence=STATUS_TWARDY,
+        zmiany_potrzebne=False,
+        dane_znormalizowane={"imię": "Ewa", "nazwisko": "Nowak"},
+        dane_z_xls={"__xls_loc_sheet__": 0, "__xls_loc_row__": 3},
+    )
+    url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
+    tresc = admin_client.get(url).content.decode("utf-8")
+    assert "Stopień sł.:" in tresc
+    assert "Stanowisko dyd.:" in tresc
+
+
+@pytest.mark.django_db
+def test_karta_zmien_autora_pod_autorem_i_etykieta_obecnie(admin_client, admin_user):
+    """Kontrolka „zmień autora" przeniesiona do bloku akcji w komórce Autora;
+    różnica e-maila renderuje etykietę „obecnie:" (dawniej „baza:")."""
+    imp = baker.make(
+        ImportPracownikow,
+        owner=admin_user,
+        stan=ImportPracownikow.STAN_PRZEANALIZOWANY,
+        finished_successfully=True,
+    )
+    jednostka = baker.make(Jednostka, nazwa="Kat.", skrot="K.")
+    autor = baker.make(Autor, nazwisko="Nowak", imiona="Ewa", email="stary@x.pl")
+    ImportPracownikowRow.objects.create(
+        parent=imp,
+        jednostka=jednostka,
+        autor=autor,
+        confidence=STATUS_TWARDY,
+        zmiany_potrzebne=False,
+        dane_znormalizowane={
+            "imię": "Ewa",
+            "nazwisko": "Nowak",
+            "email": "nowy@y.pl",
+        },
+        dane_z_xls={"__xls_loc_sheet__": 0, "__xls_loc_row__": 3},
+    )
+    url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
+    tresc = admin_client.get(url).content.decode("utf-8")
+    assert "import-autor-akcje" in tresc
+    assert "zmień autora" in tresc
+    assert "obecnie:" in tresc
+    assert "baza:" not in tresc

--- a/src/import_pracownikow/views.py
+++ b/src/import_pracownikow/views.py
@@ -683,10 +683,21 @@ class ImportPracownikowResultsView(GroupRequiredMixin, ListView):
         if parent.edytowalny_podglad:
             oznacz_przepiecie_prac(list(ctx["object_list"]), parent)
         # Pasek filtrów stanu pól — etykiety z rejestru POLA_ROZNIC (jedno źródło
-        # prawdy z modelem/szablonem).
+        # prawdy z modelem/szablonem). Dzielimy na ZAWSZE WIDOCZNE (główne) i
+        # ZWIJANE (dodatkowe, w <details>). Stopień/stanowisko wypadają całkiem,
+        # gdy plik nie ma takiej kolumny — nie filtrujemy po polu, którego nie
+        # ma (spójne z ukryciem wiersza w karcie).
         from import_pracownikow.roznice import POLA_ROZNIC
 
-        ctx["pola_roznic"] = [(k, etykieta) for k, etykieta, _ in POLA_ROZNIC]
+        etykiety = {k: etykieta for k, etykieta, _ in POLA_ROZNIC}
+        klucze_glowne = ["jednostka", "tytul", "data_od", "data_do"]
+        klucze_dodatkowe = ["email", "stopien", "funkcja", "stanowisko"]
+        if not parent.ma_kolumne_stopnia:
+            klucze_dodatkowe.remove("stopien")
+        if not parent.ma_kolumne_stanowiska:
+            klucze_dodatkowe.remove("stanowisko")
+        ctx["pola_glowne"] = [(k, etykiety[k]) for k in klucze_glowne]
+        ctx["pola_dodatkowe"] = [(k, etykiety[k]) for k in klucze_dodatkowe]
         return ctx
 
 


### PR DESCRIPTION
Uczytelnienie strony wyników importu pracowników
(`/import_pracownikow/<pk>/rezultaty/`) wg uwag operatora.

## Zmiany

- **Pasek filtrów** — zawsze widoczne: Jednostka · Tytuł naukowy · Data od ·
  Data do (radia w poziomie); reszta (E-mail · Stopień · Funkcja · Stanowisko)
  w zwijanym `<details>` „Więcej filtrów…". „Szukaj" bez zmian.
- **Licznik** „Pokazano X z Y rekordów" (czysty front, w `filtruj()`; pomija
  pusty `<tbody>` gałęzi `{% empty %}`).
- **Warunkowe pola** — Stopień służbowy i Stanowisko dydaktyczne znikają
  z karty **i** z filtra, gdy plik nie ma takiej kolumny (property
  `ma_kolumne_stopnia` / `ma_kolumne_stanowiska` po `mapowanie_kolumn.values()`).
- **„Zmień autora"** przeniesione **pod dopasowanego autora** (komórka „Autor"),
  zamiast osobnego bloku w 2. wierszu.
- **Porównania plik→baza** w siatce 2–3 kolumn zamiast pionowej listy.
- **Etykieta „baza:" → „obecnie:"** (czytelniejsza — bieżąca wartość w BPP).

## Uwagi techniczne (z review sub-agentem)

- Flagi kolumn w karcie idą przez `{% if parent_object.ma_kolumne_* %}`, NIE
  gołą zmienną — widoki akcji HTMX re-renderują partial z kontekstem
  `{row, parent_object}`, więc goła zmienna znikałaby po każdym swapie.
- Filtr tekstowy szuka po `[data-szukaj]` (nazwisko / autor / jednostka);
  kontrolki dopasowania i Select2 są POZA nimi, więc nie zaśmiecają
  wyszukiwania (wcześniej chronił to `<tr>` pomijany celowo).

## Testy

TDD: property (3), kontekst widoku (2), render karty (3). Zaktualizowane
istniejące testy (pasek filtrów + porównywarka wymagają teraz
`mapowanie_kolumn`). **Moduł `import_pracownikow`: 557 passed, 0 failed.**
`grunt build` kompiluje SCSS bez błędów, ruff czysto. **Bez migracji.**

Spec + wpięta recenzja:
`docs/superpowers/specs/2026-07-13-import-rezultaty-filtry-karta-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
