### PR TITLE
fix(import): nie nadpisuj zaplanowanej przyszłej daty końca przy odpięciu

### DIFF
--- a/src/bpp/newsfragments/odpiecia-przyszla-data.bugfix.rst
+++ b/src/bpp/newsfragments/odpiecia-przyszla-data.bugfix.rst
@@ -1,0 +1,4 @@
+Odpięcie pracownika przy ponownym imporcie nie kasuje już zaplanowanej
+przyszłej daty zakończenia zatrudnienia. Każda ustawiona data końca (przeszła
+lub przyszła) jest traktowana jako świadoma decyzja i nie jest nadpisywana
+datą wczorajszą; osoba bez ustawionej daty końca nadal jest odpinana normalnie.

--- a/src/import_pracownikow/pipeline/integrate.py
+++ b/src/import_pracownikow/pipeline/integrate.py
@@ -268,8 +268,10 @@ def _wykonaj_odpiecia(parent):
        Dlatego przed wykonaniem sprawdzamy, czy para ``(autor_id, jednostka_id)``
        AJ jest teraz obecna w wierszach importu — jeśli tak, POMIJAMY (spójne z
        definicją „spoza pliku" §9 i duchem świeżego re-checku).
-    2. **AJ zakończone ręcznie od czasu podglądu (drift bazy).** ``zakonczyl_prace
-       is not None and <= today`` → pomijamy (NIE nadpisujemy daty).
+    2. **AJ ma już ustawioną datę końca.** ``zakonczyl_prace is not None`` →
+       pomijamy (NIE nadpisujemy). Dotyczy dat przeszłych (zakończone ręcznie,
+       drift bazy) ORAZ przyszłych (zaplanowany koniec umowy — dozwolony od
+       mig 0469); ustawiona data to świadoma decyzja człowieka.
 
     Wykonane: ``zakonczyl_prace = wczoraj``, ``podstawowe_miejsce_pracy =
     False``, ``wykonane = True``. Zwraca liczbę faktycznie odpiętych."""
@@ -286,8 +288,13 @@ def _wykonaj_odpiecia(parent):
                 autor_id=aj.autor_id, jednostka_id=aj.jednostka_id
             ).exists():
                 continue
-            if aj.zakonczyl_prace is not None and aj.zakonczyl_prace <= today:
-                # zakończone ręcznie — pomijamy, nie nadpisujemy daty.
+            if aj.zakonczyl_prace is not None:
+                # Ma już USTAWIONĄ datę końca — pomijamy, nie nadpisujemy.
+                # Dotyczy dat przeszłych (zakończone ręcznie, drift bazy) ORAZ
+                # przyszłych (zaplanowany koniec umowy, dozwolony od mig 0469):
+                # ustawiona data to świadoma decyzja człowieka, a ponowny import
+                # pomijający tę osobę nie może jej po cichu skasować. Dawny
+                # warunek `<= today` przepuszczał przyszłe daty do nadpisania.
                 continue
             aj.zakonczyl_prace = yesterday
             aj.podstawowe_miejsce_pracy = False

--- a/src/import_pracownikow/tests/test_pipeline/test_wykonaj_odpiecia.py
+++ b/src/import_pracownikow/tests/test_pipeline/test_wykonaj_odpiecia.py
@@ -1,0 +1,67 @@
+"""Jednostkowe testy `_wykonaj_odpiecia` — zakończenie zatrudnienia dla
+zaznaczonych odpięć (§9) oraz ochrona już ustawionej daty końca.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from model_bakery import baker
+
+from bpp.models import Autor, Autor_Jednostka, Jednostka
+from import_pracownikow.models import ImportPracownikow, ImportPracownikowOdpiecie
+from import_pracownikow.pipeline.integrate import _wykonaj_odpiecia
+
+
+@pytest.mark.django_db
+def test_wykonaj_odpiecia_konczy_zatrudnienie_bez_daty_konca():
+    """Ścieżka główna: AJ bez daty końca jest odpinany — koniec = wczoraj,
+    podstawowe miejsce = False, odpięcie oznaczone jako wykonane."""
+    today = timezone.now().date()
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=baker.make(Autor),
+        jednostka=baker.make(Jednostka),
+        zakonczyl_prace=None,
+    )
+    imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
+    odp = ImportPracownikowOdpiecie.objects.create(
+        parent=imp, autor_jednostka=aj, zaznaczone=True
+    )
+
+    odpieto = _wykonaj_odpiecia(imp)
+
+    aj.refresh_from_db()
+    odp.refresh_from_db()
+    assert aj.zakonczyl_prace == today - timedelta(days=1)
+    assert aj.podstawowe_miejsce_pracy is False
+    assert odp.wykonane is True
+    assert odpieto == 1
+
+
+@pytest.mark.django_db
+def test_wykonaj_odpiecia_nie_nadpisuje_przyszlej_daty_konca():
+    """Odpięcie NIE nadpisuje USTAWIONEJ daty końca — także PRZYSZŁEJ
+    (planowanej). Po zdjęciu zakazu dat w przyszłości (mig 0469) guard
+    `zakonczyl_prace <= today` przepuszczał przyszłą datę do nadpisania
+    wczorajszą, kasując świadomie zaplanowany koniec umowy. Ustawiona data
+    końca (przeszła czy przyszła) = decyzja człowieka → pomijamy."""
+    przyszlosc = timezone.now().date() + timedelta(days=365)
+    aj = baker.make(
+        Autor_Jednostka,
+        autor=baker.make(Autor),
+        jednostka=baker.make(Jednostka),
+        zakonczyl_prace=przyszlosc,
+    )
+    imp = baker.make(ImportPracownikow, stan=ImportPracownikow.STAN_ZATWIERDZONY)
+    odp = ImportPracownikowOdpiecie.objects.create(
+        parent=imp, autor_jednostka=aj, zaznaczone=True
+    )
+
+    odpieto = _wykonaj_odpiecia(imp)
+
+    aj.refresh_from_db()
+    odp.refresh_from_db()
+    assert aj.zakonczyl_prace == przyszlosc  # NIE nadpisane wczorajszą datą
+    assert odp.wykonane is False
+    assert odpieto == 0


### PR DESCRIPTION
## Problem

Po zdjęciu zakazu przyszłych dat zakończenia zatrudnienia (#586, mig 0469)
odsłonił się błąd w logice **odpięć** (`_wykonaj_odpiecia`, `integrate.py`).

Odpięcie kończy zatrudnienie osobie obecnej w bazie, ale nieobecnej w pliku
importu (`zakonczyl_prace = wczoraj`). Guard chroniący przed nadpisaniem
istniejącej daty końca brzmiał:

```python
if aj.zakonczyl_prace is not None and aj.zakonczyl_prace <= today:
    continue
```

Warunek `<= today` zakładał, że daty końca są zawsze w przeszłości — co było
prawdą, dopóki przyszłe daty były zabronione. Teraz osoba z **zaplanowaną
przyszłą** datą końca (np. „umowa do 2027‑06‑30"), nieobecna w ponownym
imporcie, była odpinana datą **wczorajszą** → świadomie zaplanowany koniec
umowy znikał po cichu.

## Zmiana

Guard rozszerzony do `if aj.zakonczyl_prace is not None:` — każda **ustawiona**
data końca (przeszła lub przyszła) to świadoma decyzja człowieka i nie jest
nadpisywana. Osoba **bez** daty końca nadal jest odpinana normalnie
(koniec = wczoraj).

## Testy

TDD, jednostkowe na `_wykonaj_odpiecia`:
- brak daty końca → odpięty (koniec = wczoraj, `wykonane=True`),
- przyszła data końca → **chroniona** (bez zmian, `wykonane=False`, 0 odpiętych).

Moduł `import_pracownikow`: **559 passed, 0 failed** (E2E odpięć bez zmian).
Ruff czysto. **Bez migracji.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
