### PR TITLE
feat(import): weryfikacja jednostek — Select2 + pole-cel wg decyzji

### DIFF
--- a/src/bpp/newsfragments/import-jednostki-mapuj-select2.feature.rst
+++ b/src/bpp/newsfragments/import-jednostki-mapuj-select2.feature.rst
@@ -1,0 +1,4 @@
+Import pracowników — ekran weryfikacji jednostek: pole „Mapuj na" jest teraz
+przeszukiwalną listą (Select2), a widoczne pole-cel zależy od decyzji: „Mapuj"
+pokazuje listę jednostek, „Utwórz nową" — wybór wydziału (z opcją utworzenia
+w korzeniu). Wybór wydziału nie ogranicza już listy w „Mapuj na".

--- a/src/import_pracownikow/templates/import_pracownikow/weryfikacja_jednostek.html
+++ b/src/import_pracownikow/templates/import_pracownikow/weryfikacja_jednostek.html
@@ -62,7 +62,7 @@
                                 {% else %}—{% endif %}
                             </td>
                             <td>
-                                <select name="dec_{{ dec.pk }}_decyzja"
+                                <select name="dec_{{ dec.pk }}_decyzja" class="js-decyzja"
                                         {% if not moze_edytowac %}disabled{% endif %}>
                                     <option value="{{ DECYZJA_AKCEPTUJ }}"
                                             {% if dec.decyzja == DECYZJA_AKCEPTUJ %}selected{% endif %}>
@@ -79,7 +79,8 @@
                                 </select>
                             </td>
                             <td>
-                                <select name="dec_{{ dec.pk }}_wybrana"
+                                <span class="js-wybrana-wrap">
+                                <select name="dec_{{ dec.pk }}_wybrana" class="js-wybrana"
                                         {% if not moze_edytowac %}disabled{% endif %}>
                                     <option value="">— wybierz (dla „Mapuj”) —</option>
                                     {% for j in mapuj_opcje %}
@@ -93,6 +94,7 @@
                                     <br>
                                     <span class="label alert">wskaż jednostkę docelową</span>
                                 {% endif %}
+                                </span>
                             </td>
                         </tr>
                     {% endfor %}
@@ -124,7 +126,7 @@
                             <td>{{ dec.nazwa_zrodlowa }}</td>
                             <td>{{ dec.liczba_osob }}</td>
                             <td>
-                                <select name="dec_{{ dec.pk }}_decyzja"
+                                <select name="dec_{{ dec.pk }}_decyzja" class="js-decyzja"
                                         {% if not moze_edytowac %}disabled{% endif %}>
                                     <option value="{{ DECYZJA_AKCEPTUJ }}"
                                             {% if dec.decyzja == DECYZJA_AKCEPTUJ %}selected{% endif %}>
@@ -142,9 +144,10 @@
                             </td>
                             {% if uzywaj_wydzialow %}
                                 <td>
-                                    <select name="dec_{{ dec.pk }}_parent"
+                                    <span class="js-wydzial-wrap">
+                                    <select name="dec_{{ dec.pk }}_parent" class="js-wydzial"
                                             {% if not moze_edytowac %}disabled{% endif %}>
-                                        <option value="">— Wydział Domyślny (auto) —</option>
+                                        <option value="">— w korzeniu / wydział domyślny (auto) —</option>
                                         {% for w in parent_opcje %}
                                             <option value="{{ w.pk }}"
                                                     {% if dec.wybrany_parent_id == w.pk %}selected{% endif %}>
@@ -152,10 +155,12 @@
                                             </option>
                                         {% endfor %}
                                     </select>
+                                    </span>
                                 </td>
                             {% endif %}
                             <td>
-                                <select name="dec_{{ dec.pk }}_wybrana"
+                                <span class="js-wybrana-wrap">
+                                <select name="dec_{{ dec.pk }}_wybrana" class="js-wybrana"
                                         {% if not moze_edytowac %}disabled{% endif %}>
                                     <option value="">— wybierz (dla „Mapuj”) —</option>
                                     {% for j in mapuj_opcje %}
@@ -169,6 +174,7 @@
                                     <br>
                                     <span class="label alert">wskaż jednostkę docelową</span>
                                 {% endif %}
+                                </span>
                             </td>
                         </tr>
                     {% endfor %}
@@ -190,5 +196,62 @@
                class="button secondary">Wróć do przeglądu</a>
         </div>
     </form>
+
+    <style>
+        {# wrappery pól-celu jako blok: JS chowa je przez display:none, a przy #}
+        {# pokazaniu czyści inline-style → wraca tu do display:block. Blok jest #}
+        {# potrzebny, by Select2 width:100% policzyło się względem kolumny. #}
+        .js-wybrana-wrap, .js-wydzial-wrap { display: block; }
+        .js-wybrana-wrap .select2-container { min-width: 220px; }
+    </style>
+
+    <script>
+    // Weryfikacja jednostek: pole-cel widoczne w wierszu zależnie od „Decyzji".
+    //  - MAPUJ            → widać tylko „Mapuj na" (przeszukiwalna lista jednostek),
+    //  - AKCEPTUJ (utwórz nową / użyj auto-dopasowania) → widać „Wydział (parent)"
+    //    z opcją utworzenia w korzeniu (o ile uczelnia używa wydziałów),
+    //  - POMIŃ            → żadnego pola-celu.
+    // Wybór wydziału znaczy więc „utwórz nową jednostkę w tym wydziale" i NIE
+    // ogranicza listy „Mapuj na" (obie pule są niezależne po stronie serwera).
+    (function () {
+        if (window.__bppWeryfikacjaJednostekInit) return;
+        window.__bppWeryfikacjaJednostekInit = true;
+
+        var D_MAPUJ = "{{ DECYZJA_MAPUJ }}";
+        var D_AKCEPTUJ = "{{ DECYZJA_AKCEPTUJ }}";
+
+        function pokaz(el, widoczny) {
+            if (el) el.style.display = widoczny ? "" : "none";
+        }
+
+        function zastosuj(decyzjaSelect) {
+            var wiersz = decyzjaSelect.closest("tr");
+            if (!wiersz) return;
+            var v = decyzjaSelect.value;
+            pokaz(wiersz.querySelector(".js-wybrana-wrap"), v === D_MAPUJ);
+            pokaz(wiersz.querySelector(".js-wydzial-wrap"), v === D_AKCEPTUJ);
+        }
+
+        document.addEventListener("DOMContentLoaded", function () {
+            // Select2 na „Mapuj na" — płaska lista wszystkich jednostek jest długa,
+            // bez wyszukiwarki trudno trafić we właściwą. Init PRZED ukryciem pól,
+            // żeby szerokość policzyła się na widocznym elemencie.
+            if (window.jQuery && window.jQuery.fn && window.jQuery.fn.select2) {
+                window.jQuery(".js-wybrana").select2({
+                    width: "100%",
+                    allowClear: true,
+                    placeholder: "— wybierz jednostkę (dla „Mapuj”) —",
+                    language: "pl"
+                });
+            }
+            document.querySelectorAll(".js-decyzja").forEach(function (sel) {
+                zastosuj(sel);
+                sel.addEventListener("change", function () {
+                    zastosuj(sel);
+                });
+            });
+        });
+    })();
+    </script>
     {% endif %}
 {% endblock %}

--- a/src/import_pracownikow/tests/test_views_jednostki.py
+++ b/src/import_pracownikow/tests/test_views_jednostki.py
@@ -4,7 +4,7 @@ import pytest
 from django.urls import reverse
 from model_bakery import baker
 
-from bpp.models import Jednostka
+from bpp.models import Jednostka, Uczelnia
 from import_pracownikow.models import ImportPracownikow, ImportPracownikowJednostka
 
 AKCEPTUJ = ImportPracownikowJednostka.DECYZJA_AKCEPTUJ
@@ -229,3 +229,46 @@ def test_toggle_tworz_brakujace_w_mapowaniu_zapisuje_false(admin_client, admin_u
     assert resp.status_code == 302
     imp.refresh_from_db()
     assert imp.tworz_brakujace_jednostki is False
+
+
+@pytest.mark.django_db
+def test_jednostki_ma_wiring_select2_i_widocznosc(admin_client, admin_user):
+    """Ekran ma okablowanie JS: Select2 na „Mapuj na" + sterowanie widocznością
+    pola-celu wartością „Decyzja". Regresja na klasy hooków i inicjalizację."""
+    imp = _imp(admin_user)
+    _dec(imp, "Zrodlowa")
+    url = reverse("import_pracownikow:jednostki", kwargs={"pk": imp.pk})
+    tresc = admin_client.get(url).content.decode("utf-8")
+    # klasy hooków JS obecne na kontrolkach
+    assert 'class="js-decyzja"' in tresc
+    assert 'class="js-wybrana"' in tresc
+    assert "js-wybrana-wrap" in tresc
+    # Select2 inicjalizowany na przeszukiwalnej liście „Mapuj na"
+    assert ".js-wybrana" in tresc and ".select2(" in tresc
+    # mechanizm widoczności czyta wartość decyzji „mapuj" z kontekstu
+    assert f'var D_MAPUJ = "{MAPUJ}"' in tresc
+
+
+@pytest.mark.django_db
+def test_jednostki_wydzial_ma_wrap_i_opcje_root(admin_client, admin_user, uczelnia):
+    """Gdy uczelnia używa wydziałów, kolumna „Wydział (parent)" ma wrapper do
+    ukrywania (js-wydzial-wrap) i jawną opcję utworzenia w korzeniu."""
+    uczelnia.uzywaj_wydzialow = True
+    uczelnia.save()
+    # uczelnia=uczelnia: bez tego baker auto-tworzy powiązaną Uczelnia (FK
+    # wymagany) → w bazie są 2 uczelnie.
+    baker.make(Jednostka, nazwa="Wydział X", skrot="WX", parent=None, uczelnia=uczelnia)
+    imp = _imp(admin_user)
+    _dec(imp, "Zrodlowa")  # tryb=BRAK → tabela „Do utworzenia"
+    # „dokładnie jedna uczelnia" — get_single_uczelnia_or_none() degraduje do
+    # None przy >1 (ambient-data / baker) i kolumna wydziału by nie
+    # wyrenderowała. Jednostka wskazuje na fixture'ową uczelnię, więc kasowanie
+    # nadmiaru nie kaskaduje na nią.
+    Uczelnia.objects.exclude(pk=uczelnia.pk).delete()
+    url = reverse("import_pracownikow:jednostki", kwargs={"pk": imp.pk})
+    tresc = admin_client.get(url).content.decode("utf-8")
+    # pełny <th>, nie samo „Wydział (parent)" — ta fraza jest też w komentarzu JS
+    assert "<th>Wydział (parent)</th>" in tresc
+    assert 'class="js-wydzial"' in tresc  # select z hookiem JS
+    assert "js-wydzial-wrap" in tresc
+    assert "w korzeniu" in tresc  # jawna opcja utworzenia w korzeniu


### PR DESCRIPTION
## Co i po co

Ekran `/import_pracownikow/<uuid>/jednostki/` (weryfikacja jednostek). Trzy usprawnienia UX zgłoszone przez usera:

1. **„Mapuj na" → Select2** — płaska lista wszystkich jednostek jest długa; bez wyszukiwarki trudno trafić we właściwą.
2. **Widoczne pole-cel zależy od „Decyzji"** (JS show/hide):
   - **Mapuj** → widać tylko listę jednostek („Mapuj na"),
   - **Utwórz nową** / Użyj auto-dopasowania → widać **Wydział (parent)** z jawną opcją utworzenia **w korzeniu** (gdy uczelnia używa wydziałów),
   - **Pomiń** → żadnego pola-celu.
3. Wybór wydziału znaczy „**utwórz nową jednostkę w tym wydziale**" (NIE przełącza na MAPUJ) i **nie ogranicza** listy „Mapuj na" — pule pozostają niezależne po stronie serwera.

## Zakres zmian

- **Wyłącznie szablon** `weryfikacja_jednostek.html` (markup + `<script>` + `<style>`).
- **ZERO** zmian w modelu, widoku POST, walidacji, migracjach — zapis i walidacja bez zmian.
- Select2 z globalnego `bundle.js` (theme `foundation` + `language: pl` ustawione globalnie w `bare.html`).

## Testy

- `test_views_jednostki.py`: **12 passed** (+2 nowe testy okablowania: Select2/klasy hooków + kolumna wydziału z opcją „w korzeniu").
- Cała apka `import_pracownikow`: **551 passed**, 0 regresji. Pre-commit (ruff, djLint) czysty.

⚠️ Sam JS (show/hide + Select2 w akcji) nie był jeszcze klikany w przeglądarce — testy sprawdzają renderowany markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)