### PR TITLE
feat(import): filtr „Rodzaj dopasowania" na /rezultaty/ + deep-link z ostrzeżenia

### DIFF
--- a/docs/superpowers/specs/2026-07-14-import-filtr-rodzaj-dopasowania-design.md
+++ b/docs/superpowers/specs/2026-07-14-import-filtr-rodzaj-dopasowania-design.md
@@ -1,0 +1,277 @@
+# Filtr „Rodzaj dopasowania" na `/rezultaty/` importu pracowników
+
+Data: 2026-07-14
+Branch: `feat/import-filtr-rodzaj-dopasowania`
+Moduł: `src/import_pracownikow/`
+
+## Problem
+
+Ostrzeżenie finalizacji importu osób (na stronie przeglądu, Krok 2) mówi:
+
+> „Wiersze bez dopasowania zostaną pominięte przy zapisie: 4. Te osoby nie
+> trafią do bazy. Wróć do tabeli i dla każdej wybierz „Utwórz nowego autora"
+> albo „Dopasuj do istniejącego", jeśli mają zostać zaimportowane."
+
+Ale na `/rezultaty/` **nie da się odnaleźć** tych wierszy. Pasek filtrów
+filtruje wyłącznie po **stanie pól** (jednostka / e-mail / tytuł / … →
+wszystkie / zmienione / zgodne / brak) oraz po tekście (nazwisko / jednostka).
+Nie ma filtra po **rodzaju dopasowania autora** (`confidence`), mimo że kolumna
+„Pewność" ten rodzaj pokazuje. Operator nie ma jak wyizolować wierszy „do
+pominięcia" spośród dziesiątek/setek poprawnie dopasowanych.
+
+## Kontekst techniczny (stan obecny)
+
+- Widok: `ImportPracownikowResultsView` (`views.py`), template
+  `importpracownikowrow_list.html`. Tabela + pasek filtrów renderują się gdy
+  `parent_object.finished_successfully` (analiza dry-run zakończona OK — także
+  w edytowalnym podglądzie, gdzie pada ostrzeżenie).
+- Filtrowanie jest **w 100% po stronie JS** (inline `<script>` w
+  `importpracownikowrow_list.html`). Nie ma round-tripu do serwera: JS chowa
+  `<tbody data-rekord>` na podstawie `data-diff-*` na pierwszym `<tr>` karty
+  oraz tekstu z elementów `[data-szukaj]`. Po każdej akcji HTMX
+  (`htmx:afterSettle`) filtr jest ponawiany, a `data-diff-*` są świeże, bo
+  HTMX swapuje `innerHTML` `<tbody>` (partial `_wiersz_preview_kom.html`).
+- Rejestr pól: `roznice.py::POLA_ROZNIC`. Widok dzieli je na `pola_glowne` /
+  `pola_dodatkowe` i podaje do template (radia z `_filtr_pole.html`).
+- Statusy `confidence` (`pewnosc.py`): `twardy`, `zgadywanie`, `wielu`,
+  `brak`, `reczny`, `dedup`. Mapowanie na plakietkę: `STATUS_DISPLAY` /
+  `row.confidence_badge`. Etykiety w `CONFIDENCE_CHOICES`.
+- Kolumna „Pewność" w `_wiersz_preview_kom.html` (pierwszy `<tr>`) renderuje
+  `row.confidence_badge`. Pierwszy `<tr>` ma już pętlę
+  `data-diff-{klucz}="{stan}"` z `row.stany_pol`.
+
+### Kluczowy niuans: „do pominięcia" ≠ tylko `brak`
+
+`ImportPracownikow.liczba_wierszy_do_pominiecia()` liczy wiersze z
+`autor IS NULL AND utworz_nowego=False` (brak decyzji operatora). `autor` jest
+`NULL` przy **dwóch** statusach:
+
+- `brak` — zero kandydatów,
+- `wielu` — kilku kandydatów, auto-match wstrzymany (operator musi wybrać).
+
+(`twardy` / `zgadywanie` / `reczny` / `dedup` mają autora ustawionego.)
+
+Dlatego zbiór „do pominięcia" = `{brak, wielu}` **bez** `utworz_nowego`.
+Filtr sztywno po `confidence=brak` **przeoczyłby** wiersze `wielu`, które też
+zostaną pominięte, i licznik z ostrzeżenia (4) nie zgodziłby się z tym, co
+widać. Ponadto wiersz `brak` z ręcznie ustawionym „Utwórz nowego" **nie** jest
+już pomijany — więc filtr po samym statusie jest nieprecyzyjny.
+
+Wniosek: potrzebny osobny, **wyliczany na żywo** predykat „do pominięcia"
+(`autor IS NULL AND NOT utworz_nowego`), niezależny od czystego statusu.
+
+## Rozwiązanie
+
+Wyłącznie **template + widok + JS + testy**. Bez migracji (`confidence`,
+`utworz_nowego` już istnieją).
+
+### 1. Atrybuty na wierszu (`_wiersz_preview_kom.html`)
+
+Na pierwszym `<tr>` karty (obok istniejącej pętli `data-diff-*`) dokładamy:
+
+- `data-confidence="{{ row.confidence|default:'' }}"` — do filtra po statusie.
+- `data-do-pominiecia="1"` **tylko** gdy wiersz zostanie pominięty. Predykat:
+  `row.autor_id is None and not row.utworz_nowego`. Wyliczany przez nową
+  właściwość modelu `row.do_pominiecia` (jedno źródło prawdy z
+  `liczba_wierszy_do_pominiecia`, patrz niżej), renderowany warunkowo, żeby
+  atrybut po prostu nie istniał, gdy wiersz ma decyzję.
+
+Oba atrybuty żyją na **swapowanej** treści (`_wiersz_preview_kom.html`), więc
+po akcji HTMX (np. „Utwórz nowego" / „Dopasuj autora") przeliczają się i filtr
+po `htmx:afterSettle` pokazuje aktualny obraz (naprawiony wiersz znika z „do
+pominięcia").
+
+### 2. Model: właściwość `ImportPracownikowRow.do_pominiecia`
+
+```python
+@property
+def do_pominiecia(self):
+    """Czy wiersz zostanie PO CICHU pominięty przy zapisie osób — brak
+    dopasowanego autora i bez „Utwórz nowego". Jedno źródło prawdy z
+    ``ImportPracownikow.liczba_wierszy_do_pominiecia`` (ten sam predykat:
+    ``autor IS NULL AND utworz_nowego=False``); używane przez atrybut
+    filtra ``data-do-pominiecia`` w podglądzie."""
+    return self.autor_id is None and not self.utworz_nowego
+```
+
+`liczba_wierszy_do_pominiecia` zostaje na wersji queryset (`.filter(...).count()`
+— jeden SQL), ale komentarz podkreśla, że predykat jest identyczny z
+`row.do_pominiecia` (żeby nie zdryfowały). Nie refaktoryzujemy zliczania do
+Pythona (N+1).
+
+### 3. Kontrolka filtra (`importpracownikowrow_list.html`)
+
+`<select id="filtr-rodzaj" name="filtr-rodzaj">` jako **pierwsza, wyróżniona**
+kontrolka w `<form id="filtr-roznic">` (przed polami stanu — mapuje się na
+najważniejszą kolumnę „Pewność"). `<select>` zamiast radiów, bo 8 opcji z
+długimi etykietami rozjechałoby pasek poziomo.
+
+Opcje (label + value):
+
+- `wszystkie` → „wszystkie" (domyślnie zaznaczone, gdy brak/niepoprawny
+  query-param)
+- `do-pominiecia` → „⚠ do pominięcia (bez decyzji)" — celuje w zbiór z
+  ostrzeżenia
+- separator: jedna `<option disabled>──────</option>` (prościej niż
+  `<optgroup>`, który przy jednej grupie renderuje się dziwnie)
+- `twardy` → „twardy match"
+- `zgadywanie` → „zgadywanie"
+- `wielu` → „wielu kandydatów"
+- `brak` → „brak dopasowania"
+- `reczny` → „ręczny (wybór użytkownika)"
+- `dedup` → „rekord główny (deduplikacja)"
+
+Etykiety statusów bierzemy z jednego źródła — nowa lista w kontekście widoku
+zbudowana z `CONFIDENCE_CHOICES` (żeby template nie hardkodował). Opcja
+`selected` ustawiana serwerowo z `wybrany_rodzaj` (patrz pkt 5), żeby
+pre-selekcja działała także przed wykonaniem JS.
+
+**Decyzja o etykietach**: świadomie używamy `CONFIDENCE_CHOICES` (opisowe:
+„ręczny (wybór użytkownika)", „rekord główny (deduplikacja)"), a NIE etykiet
+plakietek z `STATUS_DISPLAY` (terse: „wybór użytkownika", „rekord główny").
+Filtr-dropdown zyskuje na jednoznaczności; drobna kosmetyczna rozbieżność z
+kolumną „Pewność" jest akceptowalna.
+
+**Obsługa `confidence=None` (stare wiersze)**: renderujemy
+`data-confidence=""`, które NIE zrówna się z żadnym statusem — taki wiersz jest
+osiągalny tylko przez „wszystkie" oraz (jeśli bez decyzji) „do pominięcia".
+Świadomie NIE koalescujemy `None → brak` w atrybucie: plakietka pokazuje wtedy
+„—" (nie „brak dopasowania"), więc koalescencja kłamałaby względem kolumny.
+Niska szkodliwość — nowa analiza zawsze ustawia `confidence`.
+
+**Semantyka po integracji**: pasek renderuje się też po pełnym commicie
+(`finished_successfully` zostaje `True`, widok audytu). Predykat „do pominięcia"
+przeżywa commit (integracja tworzy autorów tylko dla `utworz_nowego=True`), więc
+filtr dalej działa — tyle że po integracji znaczy „ZOSTAŁY pominięte" (historia),
+a nie „zostaną". Kopia opcji („do pominięcia") jest akceptowalna w obu fazach;
+nie komplikujemy jej wariantami zależnymi od stanu (YAGNI).
+
+### 4. JS — rozszerzenie `filtruj()`
+
+Istniejący inline `<script>` dostaje odczyt `<select>` i AND-uje go z filtrami
+pól + tekstem. Minimalny dopisek (bez ruszania generycznej maszynerii radiów):
+
+```js
+function wyborRodzaj() {
+    var el = document.getElementById('filtr-rodzaj');
+    return el ? el.value : 'wszystkie';
+}
+function okRodzaj(tbody) {
+    var w = wyborRodzaj();
+    if (w === 'wszystkie') return true;
+    var tr = tbody.querySelector(':scope > tr[data-confidence]');
+    if (!tr) return false;
+    if (w === 'do-pominiecia')
+        return tr.getAttribute('data-do-pominiecia') === '1';
+    return tr.getAttribute('data-confidence') === w;
+}
+```
+
+W `filtruj()`: `var pokaz = okStany && okTekst && okRodzaj(tbody);`.
+`<select>` jest w tym samym `<form>`, więc istniejące
+`form.addEventListener('change'/'input', filtruj)` już go obsłużą. `filtruj()`
+odpalany na starcie (respektuje serwerową pre-selekcję) i po
+`htmx:afterSettle`.
+
+### 5. Widok — walidacja i pre-selekcja `?rodzaj=`
+
+W `ImportPracownikowResultsView.get_context_data`:
+
+```python
+DOZWOLONE_RODZAJE = {"do-pominiecia"} | {k for k, _ in CONFIDENCE_CHOICES}
+rodzaj = self.request.GET.get("rodzaj", "")
+ctx["wybrany_rodzaj"] = rodzaj if rodzaj in DOZWOLONE_RODZAJE else ""
+ctx["rodzaje_confidence"] = list(CONFIDENCE_CHOICES)  # (value, label) do <select>
+```
+
+Śmieciowy / nieznany `?rodzaj=` → `wybrany_rodzaj = ""` (traktowane jak
+„wszystkie", brak `selected` na opcjach innych niż „wszystkie"). Template
+oznacza `selected` na opcji, której `value == wybrany_rodzaj` (dla `""` →
+„wszystkie").
+
+### 6. Deep-link z ostrzeżenia (`_ostrzezenie_brak_dopasowania.html`)
+
+Goły tekst „Wróć do tabeli…" dostaje przycisk/link:
+
+```django
+<a href="{% url "import_pracownikow:importpracownikow-results" parent_object.pk %}?rodzaj=do-pominiecia"
+   class="button primary">
+    <span class="fi-magnifying-glass"></span> Pokaż wiersze do pominięcia
+</a>
+```
+
+Partial jest include'owany z kontekstem huba — wymaga `parent_object` (jest
+dostępny w `przeglad.html`). Ścieżka operatora: ostrzeżenie → jeden klik →
+`/rezultaty/?rodzaj=do-pominiecia` → tabela odfiltrowana dokładnie do wierszy z
+ostrzeżenia; licznik „Pokazano N z M" pokazuje N = liczbie z ostrzeżenia.
+
+## Testy (TDD, pytest + `model_bakery`)
+
+Plik: `src/import_pracownikow/tests/test_filtr_rodzaj.py` (nowy).
+
+**Warunki wstępne scaffoldingu (zweryfikowane w review — WPROST w testach):**
+
+- Testy tworzą `ImportPracownikowRow` **bezpośrednio** przez `objects.create`
+  (NIE przez pipeline `analyze`) — dzięki temu nie dotyczy ich pułapka
+  `icontains`-ambient (dopasuj_jednostke) pod xdist. `create` wymaga jawnego
+  `zmiany_potrzebne=...` (BooleanField bez defaultu — wzorzec
+  `test_views_preview_render.py`).
+- Testy **widoku wyników** muszą ustawić `finished_successfully=True` na
+  rodzicu (`ImportPracownikow.objects.filter(pk=...).update(...)`), inaczej
+  pasek/tabela się nie wyrenderują (bramka
+  `{% if parent_object.finished_successfully %}`).
+- Test deep-linku (#9) renderuje **stronę przeglądu**: wymaga
+  `stan=STAN_STRUKTURA_ZINTEGROWANA` ORAZ braku nierozstrzygniętych słowników
+  (ostrzeżenie żyje w gałęzi `{% else %}` po
+  `{% if slowniki_wymagaja_rozstrzygniecia %}`). Wzorzec:
+  `test_przeglad.py::test_hub_ostrzega_o_wierszach_do_pominiecia`.
+- NIE fabrykujemy kombinacji `confidence=wielu` + `utworz_nowego=True` — jest
+  nieosiągalna przez UI (guard w `PrzelaczUtworzNowegoView` zwraca 400 dla
+  nie-`brak`). Dla „ma decyzję" używamy `confidence=brak` + `utworz_nowego=True`.
+
+1. **`test_wiersz_ma_data_confidence`** — render karty ma
+   `data-confidence="brak"` dla wiersza `confidence=brak` (i analogicznie dla
+   innego statusu).
+2. **`test_data_do_pominiecia_gdy_brak_decyzji`** — wiersz `autor=None`,
+   `utworz_nowego=False` → `data-do-pominiecia="1"` w HTML.
+3. **`test_brak_data_do_pominiecia_gdy_utworz_nowego`** — ten sam wiersz z
+   `utworz_nowego=True` → **brak** `data-do-pominiecia` w HTML.
+4. **`test_brak_data_do_pominiecia_gdy_autor_dopasowany`** — wiersz z autorem →
+   brak atrybutu.
+5. **`test_model_do_pominiecia_property`** — `row.do_pominiecia` zwraca True/False
+   zgodnie z predykatem (i pokrywa się z `liczba_wierszy_do_pominiecia`).
+6. **`test_select_rodzaj_ma_wszystkie_opcje`** — `<select id="filtr-rodzaj">`
+   zawiera opcje: `do-pominiecia`, `twardy`, `zgadywanie`, `wielu`, `brak`,
+   `reczny`, `dedup`.
+7. **`test_query_param_preselekcja`** — GET `?rodzaj=do-pominiecia` → opcja
+   `do-pominiecia` ma `selected` (asercja luźna/regex — NIE dokładny string
+   `<option value="do-pominiecia" selected>`, bo kolejność atrybutów zależy od
+   zapisu template).
+8. **`test_query_param_smieciowy_ignorowany`** — GET `?rodzaj=XXX` → żadna
+   opcja poza „wszystkie" nie ma `selected` (fallback bezpieczny).
+9. **`test_ostrzezenie_ma_link_do_filtra`** — na stronie przeglądu (Krok 2 z
+   wierszami do pominięcia) ostrzeżenie zawiera link
+   `...?rodzaj=do-pominiecia`.
+
+Filtrowanie samo (chowanie wierszy) jest w JS — nie testujemy Playwrightem
+(YAGNI); testujemy kontrakt HTML/atrybutów, na którym JS operuje.
+
+## Poza zakresem (YAGNI)
+
+- Brak filtrowania server-side / paginacji (tabela jest w całości w DOM, filtr
+  JS wystarcza — spójne z istniejącym paskiem).
+- Brak zapisu wybranego filtra w sesji / cookie.
+- Brak testu Playwright samego chowania wierszy.
+
+## Pliki
+
+- `src/import_pracownikow/models.py` — `+ do_pominiecia` property.
+- `src/import_pracownikow/views.py` — kontekst `wybrany_rodzaj`,
+  `rodzaje_confidence`, walidacja `?rodzaj=`.
+- `.../templates/import_pracownikow/importpracownikowrow_list.html` — `<select>`
+  + rozszerzenie JS.
+- `.../partials/_wiersz_preview_kom.html` — `data-confidence`,
+  `data-do-pominiecia`.
+- `.../partials/_ostrzezenie_brak_dopasowania.html` — link deep-link.
+- `src/import_pracownikow/tests/test_filtr_rodzaj.py` — testy.
+- `src/bpp/newsfragments/<slug>.feature.rst` — newsfragment.

--- a/src/bpp/newsfragments/import-filtr-rodzaj-dopasowania.feature.rst
+++ b/src/bpp/newsfragments/import-filtr-rodzaj-dopasowania.feature.rst
@@ -1,0 +1,5 @@
+Import pracowników: na stronie wyników (``/rezultaty/``) doszedł filtr
+„Rodzaj dopasowania" (twardy / zgadywanie / wielu / brak / ręczny / rekord
+główny) oraz skrót „do pominięcia (bez decyzji)". Ostrzeżenie finalizacji o
+wierszach do pominięcia prowadzi teraz jednym kliknięciem wprost do tabeli
+odfiltrowanej do tych wierszy.

--- a/src/import_pracownikow/models.py
+++ b/src/import_pracownikow/models.py
@@ -773,6 +773,17 @@ class ImportPracownikowRow(ImportRowMixin, models.Model):
             self.confidence, ("secondary", "fi-minus", self.confidence or "—")
         )
 
+    @property
+    def do_pominiecia(self):
+        """Czy wiersz zostanie PO CICHU pominięty przy zapisie osób — brak
+        dopasowanego autora i bez „Utwórz nowego". JEDNO źródło prawdy z
+        ``ImportPracownikow.liczba_wierszy_do_pominiecia`` (identyczny predykat
+        ``autor IS NULL AND utworz_nowego=False``) — nie rozjeżdżać. Zasila
+        atrybut ``data-do-pominiecia`` filtra „Rodzaj dopasowania" w podglądzie,
+        żeby deep-link „do pominięcia" trafiał dokładnie w zbiór z ostrzeżenia
+        finalizacji (obejmuje ``brak`` ORAZ ``wielu`` — oba mają ``autor=None``)."""
+        return self.autor_id is None and not self.utworz_nowego
+
     @staticmethod
     def _porownaj_email(plik, baza):
         """Trójka porównania e-maila: ``{plik, baza, rozne}``. ``rozne`` = obie

--- a/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
+++ b/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
@@ -58,6 +58,22 @@
         {# samym <form>, więc JS querySelectorAll łapie radia niezależnie od #}
         {# stanu open/closed. #}
         <form id="filtr-roznic" class="import-filtr-roznic">
+            {# Filtr „Rodzaj dopasowania" (kolumna „Pewność") — <select>, bo 8 #}
+            {# opcji z długimi etykietami rozjechałoby pasek jak radia. „do #}
+            {# pominięcia" = syntetyczny predykat (autor NULL + brak „Utwórz #}
+            {# nowego"), celuje w zbiór z ostrzeżenia finalizacji. Pre-selekcja #}
+            {# z ?rodzaj= (wybrany_rodzaj) — działa też przed JS. #}
+            <label class="import-filtr-rodzaj">
+                Rodzaj dopasowania:
+                <select id="filtr-rodzaj" name="filtr-rodzaj">
+                    <option value="wszystkie"{% if not wybrany_rodzaj %} selected{% endif %}>wszystkie</option>
+                    <option value="do-pominiecia"{% if wybrany_rodzaj == "do-pominiecia" %} selected{% endif %}>⚠ do pominięcia (bez decyzji)</option>
+                    <option disabled>──────────</option>
+                    {% for wartosc, etykieta in rodzaje_confidence %}
+                        <option value="{{ wartosc }}"{% if wybrany_rodzaj == wartosc %} selected{% endif %}>{{ etykieta }}</option>
+                    {% endfor %}
+                </select>
+            </label>
             <label class="import-filtr-tekst">
                 Szukaj:
                 <input type="search" id="filtr-tekst"
@@ -145,6 +161,22 @@
                 });
                 return buf.toLowerCase();
             }
+            function wyborRodzaj() {
+                var el = document.getElementById('filtr-rodzaj');
+                return el ? el.value : 'wszystkie';
+            }
+            function okRodzaj(tbody) {
+                // Filtr rodzaju dopasowania (data-confidence na 1. <tr>).
+                // „do-pominiecia" czyta osobny warunkowy atrybut (autor NULL +
+                // brak „Utwórz nowego"), inne wartości → równość statusu.
+                var w = wyborRodzaj();
+                if (w === 'wszystkie') return true;
+                var tr = tbody.querySelector(':scope > tr[data-confidence]');
+                if (!tr) return false;
+                if (w === 'do-pominiecia')
+                    return tr.getAttribute('data-do-pominiecia') === '1';
+                return tr.getAttribute('data-confidence') === w;
+            }
             function filtruj() {
                 var ks = klucze();
                 var q = tekst();
@@ -159,7 +191,7 @@
                         });
                         var okTekst = !q
                             || tekstRekordu(tbody).indexOf(q) !== -1;
-                        var pokaz = okStany && okTekst;
+                        var pokaz = okStany && okTekst && okRodzaj(tbody);
                         tbody.hidden = !pokaz;
                         if (pokaz) widoczne++;
                     });

--- a/src/import_pracownikow/templates/import_pracownikow/partials/_ostrzezenie_brak_dopasowania.html
+++ b/src/import_pracownikow/templates/import_pracownikow/partials/_ostrzezenie_brak_dopasowania.html
@@ -11,4 +11,13 @@
         „Utwórz nowego autora” albo „Dopasuj do istniejącego”, jeśli mają
         zostać zaimportowane.
     </p>
+    {# Deep-link: filtr „Rodzaj dopasowania" ustawiony na „do pominięcia" — #}
+    {# widok waliduje ?rodzaj= i pre-selekcjonuje <select>, a JS od razu #}
+    {# odfiltrowuje tabelę dokładnie do tych wierszy (licznik = powyższa liczba). #}
+    <p>
+        <a href="{% url "import_pracownikow:importpracownikow-results" parent_object.pk %}?rodzaj=do-pominiecia"
+           class="button primary">
+            <span class="fi-magnifying-glass"></span> Pokaż wiersze do pominięcia
+        </a>
+    </p>
 </div>

--- a/src/import_pracownikow/templates/import_pracownikow/partials/_wiersz_preview_kom.html
+++ b/src/import_pracownikow/templates/import_pracownikow/partials/_wiersz_preview_kom.html
@@ -7,7 +7,11 @@
 {# zasilają filtr tekstowy (nazwisko / autor / jednostka) — kontrolki #}
 {# dopasowania autora są POZA nimi, żeby ich tekst i Select2 nie zaśmiecały #}
 {# wyszukiwania. #}
-<tr{% for klucz, stan in row.stany_pol.items %} data-diff-{{ klucz }}="{{ stan }}"{% endfor %}>
+{# data-confidence: filtr „Rodzaj dopasowania" (JS okRodzaj). data-do-pominiecia #}
+{# renderowane WARUNKOWO (tylko gdy wiersz bez decyzji) — filtr „do pominięcia" #}
+{# zrównuje się wtedy z licznikiem ostrzeżenia. Oba na SWAPOWANEJ treści, więc #}
+{# świeże po akcji HTMX (np. „Utwórz nowego" → wiersz znika z „do pominięcia"). #}
+<tr{% for klucz, stan in row.stany_pol.items %} data-diff-{{ klucz }}="{{ stan }}"{% endfor %} data-confidence="{{ row.confidence|default:'' }}"{% if row.do_pominiecia %} data-do-pominiecia="1"{% endif %}>
     <td class="import-poz">{{ row.nr_arkusza }}/{{ row.nr_wiersza }}</td>
     <td data-szukaj>
         <strong>{{ row.dane_znormalizowane.nazwisko }}</strong>

--- a/src/import_pracownikow/tests/test_filtr_rodzaj.py
+++ b/src/import_pracownikow/tests/test_filtr_rodzaj.py
@@ -1,0 +1,154 @@
+"""Filtr „Rodzaj dopasowania" na /rezultaty/ importu pracowników.
+
+Testujemy KONTRAKT HTML/atrybutów, na którym operuje inline-JS filtra (samo
+chowanie wierszy jest w JS — nie testujemy Playwrightem, YAGNI). Wiersze
+tworzymy BEZPOŚREDNIO (``objects.create``, jawne ``zmiany_potrzebne``) — bez
+pipeline'u ``analyze``, więc bez pułapki ``icontains``-ambient pod xdist.
+"""
+
+import re
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.models import Autor
+from import_pracownikow.models import ImportPracownikow, ImportPracownikowRow
+from import_pracownikow.pewnosc import STATUS_BRAK, STATUS_TWARDY
+
+
+def _imp(admin_user, stan=ImportPracownikow.STAN_STRUKTURA_ZINTEGROWANA):
+    """Import w fazie osób (Krok 2, edytowalny podgląd) z
+    ``finished_successfully`` — inaczej pasek filtrów/tabela się nie
+    wyrenderują (bramka ``{% if parent_object.finished_successfully %}``)."""
+    imp = baker.make(ImportPracownikow, owner=admin_user, stan=stan)
+    ImportPracownikow.objects.filter(pk=imp.pk).update(finished_successfully=True)
+    imp.refresh_from_db()
+    return imp
+
+
+def _row(imp, confidence=STATUS_BRAK, autor=None, utworz_nowego=False, **kw):
+    return ImportPracownikowRow.objects.create(
+        parent=imp,
+        confidence=confidence,
+        autor=autor,
+        utworz_nowego=utworz_nowego,
+        zmiany_potrzebne=False,
+        dane_znormalizowane={"imię": "Jan", "nazwisko": "Kowalski"},
+        dane_z_xls={"__xls_loc_sheet__": 0, "__xls_loc_row__": 7},
+        **kw,
+    )
+
+
+def _results_url(imp):
+    return reverse(
+        "import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk}
+    )
+
+
+def _get(admin_client, imp, **params):
+    return admin_client.get(_results_url(imp), params).content.decode("utf-8")
+
+
+def _opcja_selected(tresc, val):
+    """Czy ``<option value="val" ... selected>`` (kolejność atrybutów swobodna
+    — asercja luźna, nie kruchy dokładny string)."""
+    return bool(
+        re.search(rf'<option[^>]*value="{re.escape(val)}"[^>]*selected', tresc)
+        or re.search(rf'<option[^>]*selected[^>]*value="{re.escape(val)}"', tresc)
+    )
+
+
+@pytest.mark.django_db
+def test_wiersz_ma_data_confidence(admin_client, admin_user):
+    imp = _imp(admin_user)
+    _row(imp, confidence=STATUS_BRAK)
+    assert 'data-confidence="brak"' in _get(admin_client, imp)
+
+
+@pytest.mark.django_db
+def test_data_confidence_dla_twardego(admin_client, admin_user):
+    imp = _imp(admin_user)
+    _row(imp, confidence=STATUS_TWARDY, autor=baker.make(Autor))
+    assert 'data-confidence="twardy"' in _get(admin_client, imp)
+
+
+@pytest.mark.django_db
+def test_data_do_pominiecia_gdy_brak_decyzji(admin_client, admin_user):
+    imp = _imp(admin_user)
+    _row(imp, confidence=STATUS_BRAK, autor=None, utworz_nowego=False)
+    assert 'data-do-pominiecia="1"' in _get(admin_client, imp)
+
+
+@pytest.mark.django_db
+def test_brak_data_do_pominiecia_gdy_utworz_nowego(admin_client, admin_user):
+    imp = _imp(admin_user)
+    _row(imp, confidence=STATUS_BRAK, autor=None, utworz_nowego=True)
+    # Zawężone do RENDEROWANEGO atrybutu na <tr> — sam string „data-do-pominiecia"
+    # występuje też w inline-JS (getAttribute), więc nie asertujemy go gołego.
+    assert 'data-do-pominiecia="1"' not in _get(admin_client, imp)
+
+
+@pytest.mark.django_db
+def test_brak_data_do_pominiecia_gdy_autor_dopasowany(admin_client, admin_user):
+    imp = _imp(admin_user)
+    _row(imp, confidence=STATUS_TWARDY, autor=baker.make(Autor))
+    assert 'data-do-pominiecia="1"' not in _get(admin_client, imp)
+
+
+@pytest.mark.django_db
+def test_model_do_pominiecia_property(admin_user):
+    imp = _imp(admin_user)
+    r_brak = _row(imp, confidence=STATUS_BRAK, autor=None, utworz_nowego=False)
+    r_decyzja = _row(imp, confidence=STATUS_BRAK, autor=None, utworz_nowego=True)
+    r_autor = _row(imp, confidence=STATUS_TWARDY, autor=baker.make(Autor))
+    assert r_brak.do_pominiecia is True
+    assert r_decyzja.do_pominiecia is False
+    assert r_autor.do_pominiecia is False
+
+
+@pytest.mark.django_db
+def test_select_rodzaj_ma_wszystkie_opcje(admin_client, admin_user):
+    imp = _imp(admin_user)
+    _row(imp)
+    tresc = _get(admin_client, imp)
+    assert 'id="filtr-rodzaj"' in tresc
+    for val in [
+        "do-pominiecia",
+        "twardy",
+        "zgadywanie",
+        "wielu",
+        "brak",
+        "reczny",
+        "dedup",
+    ]:
+        assert f'value="{val}"' in tresc
+
+
+@pytest.mark.django_db
+def test_query_param_preselekcja(admin_client, admin_user):
+    imp = _imp(admin_user)
+    _row(imp)
+    tresc = _get(admin_client, imp, rodzaj="do-pominiecia")
+    assert _opcja_selected(tresc, "do-pominiecia")
+
+
+@pytest.mark.django_db
+def test_query_param_smieciowy_ignorowany(admin_client, admin_user):
+    imp = _imp(admin_user)
+    _row(imp)
+    tresc = _get(admin_client, imp, rodzaj="XXX")
+    # Śmieciowy param → żadna „prawdziwa" opcja statusu nie jest zaznaczona
+    # (fallback do „wszystkie").
+    assert not _opcja_selected(tresc, "do-pominiecia")
+    assert not _opcja_selected(tresc, "brak")
+
+
+@pytest.mark.django_db
+def test_ostrzezenie_ma_link_do_filtra(admin_client, admin_user):
+    imp = _imp(admin_user, stan=ImportPracownikow.STAN_STRUKTURA_ZINTEGROWANA)
+    _row(imp, confidence=STATUS_BRAK, autor=None, utworz_nowego=False)
+    url = reverse("import_pracownikow:przeglad", kwargs={"pk": imp.pk})
+    tresc = admin_client.get(url).content.decode("utf-8")
+    assert "zostaną pominięte przy zapisie: 1" in tresc  # ostrzeżenie obecne
+    assert f"{_results_url(imp)}?rodzaj=do-pominiecia" in tresc

--- a/src/import_pracownikow/views.py
+++ b/src/import_pracownikow/views.py
@@ -46,6 +46,7 @@ from import_pracownikow.models import (
 )
 from import_pracownikow.pbn import adnotuj_pbn_instytucjonalny
 from import_pracownikow.pewnosc import (
+    CONFIDENCE_CHOICES,
     STATUS_BRAK,
     STATUS_DEDUP,
     STATUS_RECZNY,
@@ -705,6 +706,15 @@ class ImportPracownikowResultsView(GroupRequiredMixin, ListView):
             klucze_dodatkowe.remove("stanowisko")
         ctx["pola_glowne"] = [(k, etykiety[k]) for k in klucze_glowne]
         ctx["pola_dodatkowe"] = [(k, etykiety[k]) for k in klucze_dodatkowe]
+        # Filtr „Rodzaj dopasowania" — opcje statusów (jedno źródło:
+        # CONFIDENCE_CHOICES) + syntetyczne „do pominięcia" (autor IS NULL AND
+        # NOT utworz_nowego, patrz row.do_pominiecia). Deep-link z ostrzeżenia
+        # finalizacji przychodzi jako ?rodzaj=do-pominiecia; walidujemy go tu,
+        # a śmieciowa wartość degraduje do "" (traktowane jak „wszystkie").
+        ctx["rodzaje_confidence"] = list(CONFIDENCE_CHOICES)
+        dozwolone_rodzaje = {"do-pominiecia"} | {k for k, _ in CONFIDENCE_CHOICES}
+        rodzaj = self.request.GET.get("rodzaj", "")
+        ctx["wybrany_rodzaj"] = rodzaj if rodzaj in dozwolone_rodzaje else ""
         return ctx
 
 


### PR DESCRIPTION
## Problem

Ostrzeżenie finalizacji importu osób mówi „Wróć do tabeli i dla każdej [z N wierszy bez dopasowania] wybierz «Utwórz nowego autora» albo «Dopasuj»", ale na `/rezultaty/` **nie było jak tych wierszy znaleźć** — pasek filtrów filtrował tylko po stanie pól (jednostka/e-mail/tytuł…) i tekście, bez filtra po **rodzaju dopasowania** autora, mimo że kolumna „Pewność" ten rodzaj pokazuje.

## Rozwiązanie

- **Filtr „Rodzaj dopasowania"** (`<select>`, pierwsza kontrolka paska) ze statusami: twardy / zgadywanie / wielu / brak / ręczny / rekord główny, plus syntetyczny **„⚠ do pominięcia (bez decyzji)"**.
- **Deep-link z ostrzeżenia**: przycisk „Pokaż wiersze do pominięcia" → `/rezultaty/?rodzaj=do-pominiecia`. Widok waliduje `?rodzaj=` i pre-selekcjonuje `<select>` serwerowo; JS na starcie odfiltrowuje tabelę dokładnie do tych wierszy (licznik „Pokazano N z M" = liczbie z ostrzeżenia).

### Kluczowy niuans — „do pominięcia" ≠ tylko `brak`

`liczba_wierszy_do_pominiecia` liczy `autor IS NULL AND utworz_nowego=False`. `autor` jest `NULL` przy **dwóch** statusach: `brak` (zero kandydatów) **oraz** `wielu` (auto-match wstrzymany). Filtr po samym `confidence=brak` przeoczyłby wiersze `wielu`. Dlatego „do pominięcia" to osobny, **liczony na żywo** predykat (`ImportPracownikowRow.do_pominiecia`) — jedno źródło prawdy z licznikiem ostrzeżenia — renderowany jako warunkowy atrybut `data-do-pominiecia` (znika po naprawie wiersza dzięki HTMX `afterSettle`).

## Implementacja

- `models.py`: `ImportPracownikowRow.do_pominiecia`.
- `views.py`: kontekst `rodzaje_confidence` (z `CONFIDENCE_CHOICES`) + walidacja/pre-selekcja `wybrany_rodzaj` z `?rodzaj=`.
- `_wiersz_preview_kom.html`: `data-confidence` + warunkowy `data-do-pominiecia` na 1. `<tr>` (świeże po swapie HTMX).
- `importpracownikowrow_list.html`: `<select id="filtr-rodzaj">` + `okRodzaj()` AND-owane do istniejącego `filtruj()`.
- `_ostrzezenie_brak_dopasowania.html`: deep-link.
- **Bez migracji** (pola `confidence`/`utworz_nowego` już istnieją).

## Testy

TDD, `src/import_pracownikow/tests/test_filtr_rodzaj.py` — 10 testów kontraktu HTML/atrybutów (data-atrybuty, opcje `<select>`, walidacja i pre-selekcja `?rodzaj=`, `do_pominiecia`, deep-link). Samo chowanie wierszy jest w JS (nie testowane Playwrightem — YAGNI).

- ✅ `test_filtr_rodzaj.py` — 10 passed
- ✅ pełny moduł `import_pracownikow/` — 596 passed
- ✅ ruff + djLint + pre-commit — czysto

**Niezweryfikowane wizualnie w przeglądarce** (chowanie wierszy przez JS / deep-link na żywo) — kontrakt HTML pokryty testami; do klik-sprawdzenia na `run-site`.

Spec: `docs/superpowers/specs/2026-07-14-import-filtr-rodzaj-dopasowania-design.md` (self-review sub-agentem Fable, 0 blockerów).

🤖 Generated with [Claude Code](https://claude.com/claude-code)