### PR TITLE
feat(import): ukryj UI przepinania prac gdy import bez masowego przepięcia

### DIFF
--- a/src/bpp/newsfragments/import-przepinanie-gate.feature.rst
+++ b/src/bpp/newsfragments/import-przepinanie-gate.feature.rst
@@ -1,0 +1,4 @@
+Import pracowników: gdy na starcie nie wybrano masowego przepięcia prac,
+krok z autorami w ogóle nie pokazuje kontrolek przepinania — ani
+per-wierszowych checkboxów, ani przycisku „Zaznacz przepięcie prac dla
+wszystkich z różnicą jednostki”.

--- a/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
+++ b/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
@@ -37,8 +37,10 @@
     {# wzorzec importer_publikacji/index.html. #}
     <script src="https://unpkg.com/htmx.org@2.0.4" crossorigin="anonymous"></script>
 
-    {% if parent_object.edytowalny_podglad %}
+    {% if parent_object.edytowalny_podglad and parent_object.przepnij_wszystkie_prace %}
         {# akcja zbiorcza: zaznacz przepięcie prac dla wierszy z różnicą jednostki #}
+        {# tylko gdy import startował z masowym przepięciem — inaczej cały UI #}
+        {# przepinania jest ukryty (operator świadomie NIE rusza dorobku). #}
         <form method="post"
               action="{% url "import_pracownikow:zaznacz-przepiecia" pk=parent_object.pk %}">
             {% csrf_token %}

--- a/src/import_pracownikow/templates/import_pracownikow/partials/_wiersz_preview_kom.html
+++ b/src/import_pracownikow/templates/import_pracownikow/partials/_wiersz_preview_kom.html
@@ -314,8 +314,9 @@
                 {% endwith %}
             </div>
             <div class="import-blok import-blok-przepnij">
-                {% if parent_object.edytowalny_podglad and row.przepnij_dostepne %}
+                {% if parent_object.edytowalny_podglad and parent_object.przepnij_wszystkie_prace and row.przepnij_dostepne %}
                     {# opt-in przepięcia prac — POST toggluje przepnij_prace #}
+                    {# ukryte, gdy import nie startował z masowym przepięciem #}
                     <form method="post"
                           hx-post="{% url "import_pracownikow:przepnij-prace" parent_object.pk row.pk %}"
                           hx-target="#wiersz-{{ row.pk }}"

--- a/src/import_pracownikow/tests/test_views_przepiecie.py
+++ b/src/import_pracownikow/tests/test_views_przepiecie.py
@@ -14,8 +14,15 @@ def _autor_z_aktualna(nazwa="Stara"):
     return autor, stara
 
 
-def _import(owner, stan=ImportPracownikow.STAN_PRZEANALIZOWANY):
-    return baker.make(ImportPracownikow, owner=owner, stan=stan)
+def _import(
+    owner, stan=ImportPracownikow.STAN_PRZEANALIZOWANY, przepnij_wszystkie=False
+):
+    return baker.make(
+        ImportPracownikow,
+        owner=owner,
+        stan=stan,
+        przepnij_wszystkie_prace=przepnij_wszystkie,
+    )
 
 
 @pytest.mark.django_db
@@ -119,15 +126,19 @@ def test_bulk_pomija_wiersz_gdy_stara_jednostka_w_pliku(admin_client, admin_user
     assert row_b.przepnij_prace is False  # guard „para z pliku”
 
 
-@pytest.mark.django_db
-def test_kolumna_widoczna_tylko_przy_roznicy_jednostki(admin_client, admin_user):
+def _import_z_kwalifikujacym_wierszem(admin_user, przepnij_wszystkie):
+    """Import w stanie podglądu z JEDNYM wierszem kwalifikującym się do
+    przepięcia (autor z pracą w starej jednostce, wiersz kieruje do nowej) i
+    ``finished_successfully`` (by tabela wyników się wyrenderowała). Flaga
+    ``przepnij_wszystkie_prace`` sterowana parametrem — to ona bramkuje UI
+    przepinania na stronie autorów."""
     from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Ciagle_Autor
 
     autor, stara = _autor_z_aktualna()
     nowa = baker.make(Jednostka, nazwa="Nowa", skrot="NW")
     wc = baker.make(Wydawnictwo_Ciagle, tytul_oryginalny="Art", rok=2023)
     baker.make(Wydawnictwo_Ciagle_Autor, rekord=wc, autor=autor, jednostka=stara)
-    imp = _import(admin_user)
+    imp = _import(admin_user, przepnij_wszystkie=przepnij_wszystkie)
     ImportPracownikowRow.objects.create(
         parent=imp,
         autor=autor,
@@ -135,14 +146,44 @@ def test_kolumna_widoczna_tylko_przy_roznicy_jednostki(admin_client, admin_user)
         zmiany_potrzebne=False,
         dane_z_xls={"__xls_loc_sheet__": 0, "__xls_loc_row__": 0},
     )
-    # dodatkowo import ma finished_successfully, by tabela się wyrenderowała
     ImportPracownikow.objects.filter(pk=imp.pk).update(finished_successfully=True)
+    return imp
+
+
+@pytest.mark.django_db
+def test_kolumna_widoczna_tylko_przy_roznicy_jednostki(admin_client, admin_user):
+    # UI przepinania odsłania się TYLKO gdy import ma przepnij_wszystkie_prace —
+    # tu ustawione, więc kolumna z checkboxem musi się pojawić przy różnicy jedn.
+    imp = _import_z_kwalifikujacym_wierszem(admin_user, przepnij_wszystkie=True)
     url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
     resp = admin_client.get(url)
     content = resp.content.decode("utf-8")
-    assert "przepnij_prace" in content
+    assert 'name="przepnij_prace"' in content
     # label przepięcia: „przenieś N prac z „stara” do „nowa”” (pełne nazwy jedn.)
     assert "przenieś 1 prac" in content
+
+
+@pytest.mark.django_db
+def test_ui_przepinania_widoczne_gdy_przepnij_wszystkie(admin_client, admin_user):
+    # Gdy na starcie wybrano masowe przepięcie prac — na stronie autorów widać
+    # ZARÓWNO przycisk zbiorczy JAK I per-wierszowe checkboxy.
+    imp = _import_z_kwalifikujacym_wierszem(admin_user, przepnij_wszystkie=True)
+    url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
+    content = admin_client.get(url).content.decode("utf-8")
+    assert "Zaznacz przepięcie prac dla wszystkich" in content
+    assert 'name="przepnij_prace"' in content
+
+
+@pytest.mark.django_db
+def test_ui_przepinania_ukryte_gdy_bez_przepniecia(admin_client, admin_user):
+    # Gdy na starcie NIE wybrano przepinania prac (domyślnie) — na stronie
+    # autorów NIE MA ani przycisku zbiorczego, ani per-wierszowych checkboxów,
+    # mimo że wiersz kwalifikuje się do przepięcia.
+    imp = _import_z_kwalifikujacym_wierszem(admin_user, przepnij_wszystkie=False)
+    url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
+    content = admin_client.get(url).content.decode("utf-8")
+    assert "Zaznacz przepięcie prac dla wszystkich" not in content
+    assert 'name="przepnij_prace"' not in content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Cel

Wybór na starcie importu pracowników „czy przepinać prace" (pole
`przepnij_wszystkie_prace` — sekcja „Opcje zaawansowane → masowe przepięcie
prac", domyślnie **odznaczone**) działa teraz jako twarda bramka dla całego UI
przepinania w kroku z autorami.

Gdy pole jest **odznaczone**, strona autorów **w ogóle nie renderuje**
kontrolek przepinania:

- per-wierszowych checkboxów „przenieś N prac z X do Y",
- przycisku zbiorczego „Zaznacz przepięcie prac dla wszystkich z różnicą
  jednostki".

Gdy **zaznaczone** — zachowanie bez zmian (analiza pre-zaznacza kwalifikujące
się wiersze, kontrolki widoczne do korekty).

## Zmiany

- `importpracownikowrow_list.html` — bramka `and parent_object.przepnij_wszystkie_prace`
  na przycisku zbiorczym.
- `partials/_wiersz_preview_kom.html` — ta sama bramka na per-wierszowym checkboxie.
  Gałąź audytu (`elif row.log_zmian.przepiecie`) zostaje; przy odznaczonym polu
  nic się nie przepięło, więc i tak nic nie pokaże.
- Model / formularz / `analyze.py` — **nietknięte**. Bez migracji.

## Testy

- `test_views_przepiecie.py`: 2 nowe testy (widoczne przy `=True`, ukryte przy
  `=False`) renderujące realny HTML strony wyników; zaktualizowany istniejący
  test kolumny.
- `test_views_przepiecie.py`: **9 passed**
- Cały moduł `import_pracownikow`: **588 passed, 0 failed**
- ruff: czysto

## Uwagi

Niezweryfikowane wizualnie (pokrycie testowe asertuje bezpośrednio
wyrenderowany HTML strony autorów).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
