### PR TITLE
fix(pbn): 422 publication-not-exists rzucało TypeError

### DIFF
--- a/src/bpp/newsfragments/pbn-422-typeerror.bugfix.rst
+++ b/src/bpp/newsfragments/pbn-422-typeerror.bugfix.rst
@@ -1,0 +1,4 @@
+Naprawiono błąd, przez który pobranie z PBN pracy nieistniejącej po stronie
+PBN (odpowiedź HTTP 422) kończyło się ``TypeError`` zamiast poprawnego
+rozpoznania braku pracy. Obsłużono też przypadek, gdy treść odpowiedzi PBN
+przychodzi jako bajty.

--- a/src/pbn_integrator/tests/test_pobierz_pojedyncza_prace.py
+++ b/src/pbn_integrator/tests/test_pobierz_pojedyncza_prace.py
@@ -1,0 +1,57 @@
+"""Regresja: 422 „publication not exists" musi rzucać ``BrakIDPracyPoStroniePBN``.
+
+Wcześniej ``_pobierz_pojedyncza_prace`` przy realnym 422-not-exists robiło
+``raise BrakIDPracyPoStroniePBN(e)`` — ale ta klasa dziedziczy po
+``HttpException`` (konstruktor ``(status_code, url, content)``), więc jedno-
+argumentowe wywołanie kończyło się ``TypeError`` ZANIM właściwy wyjątek został
+podniesiony. Dodatkowo ``e.content`` bywa ``bytes`` (``smart_content`` zwraca
+surowe bajty przy ``UnicodeDecodeError``), przez co samo ``... in e.content``
+rzucało ``TypeError`` jeszcze wcześniej.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _client_raising(exc):
+    client = MagicMock()
+    client.get_publication_by_id.side_effect = exc
+    return client
+
+
+def test_422_not_exists_raises_brak_id_not_typeerror():
+    from pbn_api.exceptions import BrakIDPracyPoStroniePBN, HttpException
+    from pbn_integrator.utils import publications
+
+    pub_id = "60a1f2c3d4e5f60718293a4b"
+    exc = HttpException(
+        422, "https://pbn/x", f"Publication with ID {pub_id} was not exists!"
+    )
+    with pytest.raises(BrakIDPracyPoStroniePBN):
+        publications._pobierz_pojedyncza_prace(_client_raising(exc), pub_id)
+
+
+def test_422_not_exists_with_bytes_content_raises_brak_id():
+    from pbn_api.exceptions import BrakIDPracyPoStroniePBN, HttpException
+    from pbn_integrator.utils import publications
+
+    pub_id = "60a1f2c3d4e5f60718293a4b"
+    content = f"Publication with ID {pub_id} was not exists!".encode()
+    exc = HttpException(422, "https://pbn/x", content)
+    with pytest.raises(BrakIDPracyPoStroniePBN):
+        publications._pobierz_pojedyncza_prace(_client_raising(exc), pub_id)
+
+
+def test_brak_id_preserves_http_fields():
+    from pbn_api.exceptions import BrakIDPracyPoStroniePBN, HttpException
+    from pbn_integrator.utils import publications
+
+    pub_id = "60a1f2c3d4e5f60718293a4b"
+    content = f"Publication with ID {pub_id} was not exists!"
+    exc = HttpException(422, "https://pbn/x", content)
+    with pytest.raises(BrakIDPracyPoStroniePBN) as ei:
+        publications._pobierz_pojedyncza_prace(_client_raising(exc), pub_id)
+    assert ei.value.status_code == 422
+    assert ei.value.url == "https://pbn/x"
+    assert ei.value.content == content

--- a/src/pbn_integrator/utils/publications.py
+++ b/src/pbn_integrator/utils/publications.py
@@ -354,14 +354,23 @@ def _pobierz_pojedyncza_prace(client, publicationId):
     try:
         data = client.get_publication_by_id(publicationId)
     except HttpException as e:
+        # ``e.content`` bywa ``bytes`` (``smart_content`` zwraca surowe bajty
+        # przy ``UnicodeDecodeError``) — dekodujemy do str, żeby membership-test
+        # niżej sam nie rzucił ``TypeError``.
+        content = e.content
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+
         if (
             e.status_code == 422
-            and f"Publication with ID {publicationId} was not exists!" in e.content
+            and f"Publication with ID {publicationId} was not exists!" in content
             # "was not exists" to oryginalna pisownia błędu z PBNu.
         ):
-            raise BrakIDPracyPoStroniePBN(e) from e
+            # ``BrakIDPracyPoStroniePBN`` dziedziczy po ``HttpException`` —
+            # trzeba przekazać (status_code, url, content), nie sam wyjątek.
+            raise BrakIDPracyPoStroniePBN(e.status_code, e.url, e.content) from e
 
-        if e.status_code == 500 and "Internal server error" in e.content:
+        if e.status_code == 500 and "Internal server error" in content:
             print(
                 f"\r\nSerwer PBN zwrocil blad 500 dla PBN UID {publicationId} --> {e.content}"
             )


### PR DESCRIPTION
## Problem
`_pobierz_pojedyncza_prace` (`src/pbn_integrator/utils/publications.py`) przy odpowiedzi PBN **422 „…was not exists!"** robiło `raise BrakIDPracyPoStroniePBN(e)`. Ta klasa dziedziczy po `HttpException` z konstruktorem `(status_code, url, content)`, więc jednoargumentowe wywołanie → **`TypeError`** zamiast właściwego wyjątku. Dodatkowo `e.content` bywa `bytes` (`smart_content` zwraca surowe bajty przy `UnicodeDecodeError`), więc `... in e.content` rzucało `TypeError` jeszcze wcześniej.

## Fix
- dekodowanie `content` do `str` przed membership-testem (bytes-safe, dotyczy też gałęzi 500),
- `raise BrakIDPracyPoStroniePBN(e.status_code, e.url, e.content)`.

## Testy
Repro (`test_pobierz_pojedyncza_prace.py`): 422/str, 422/bytes, zachowanie pól HTTP. Przed fixem 3× `TypeError`, po fixie 3 passed.

Pierwszy z serii Fazy 0 planu ekstrakcji PBN (#595).

🤖 Generated with [Claude Code](https://claude.com/claude-code)