### PR TITLE
fix(pbn): nie dubluj pobierania słownika dyscyplin

### DIFF
--- a/src/bpp/newsfragments/pbn-double-download-disciplines.bugfix.rst
+++ b/src/bpp/newsfragments/pbn-double-download-disciplines.bugfix.rst
@@ -1,0 +1,3 @@
+Usunięto podwójne pobieranie słownika dyscyplin z PBN podczas integracji i
+initial-setupu — ``sync_disciplines()`` samo pobiera słownik, więc dodatkowe
+``download_disciplines()`` tuż przed nim tylko dublowało zapytanie do PBN.

--- a/src/pbn_import/tests/test_initial_setup.py
+++ b/src/pbn_import/tests/test_initial_setup.py
@@ -38,7 +38,9 @@ def test_run_full_setup_uses_existing_client_and_matches_uczelnia(session, uczel
 
     jezyki.assert_called_once_with(client, create_if_not_exists=True)
     kraje.assert_called_once_with(client)
-    client.download_disciplines.assert_called_once()
+    # sync_disciplines() sam pobiera słownik — nie wołamy download_disciplines()
+    # bezpośrednio (regresja: podwójny zaciąg z PBN).
+    client.download_disciplines.assert_not_called()
     client.sync_disciplines.assert_called_once()
     uczelnia.refresh_from_db()
     session.refresh_from_db()
@@ -115,7 +117,8 @@ def test_language_non_authorization_error_uses_minimal_setup(session, uczelnia):
 
 def test_later_pbn_errors_are_delegated_and_import_continues(session, uczelnia):
     client = MagicMock()
-    client.download_disciplines.side_effect = RuntimeError("disciplines failed")
+    # Krok dyscyplin woła teraz tylko sync_disciplines() — tam wstrzykujemy błąd.
+    client.sync_disciplines.side_effect = RuntimeError("disciplines failed")
     setup = InitialSetup(session, client=client, uczelnia=uczelnia)
 
     with patch("pbn_import.utils.initial_setup.integruj_jezyki"):

--- a/src/pbn_import/utils/initial_setup.py
+++ b/src/pbn_import/utils/initial_setup.py
@@ -78,7 +78,8 @@ class InitialSetup(ImportStepBase):
         self.update_progress(2, 4, "Pobieranie dyscyplin")
         self.log("info", "Pobieranie i synchronizacja dyscyplin")
         try:
-            self.client.download_disciplines()
+            # sync_disciplines() sam woła download_disciplines() — nie
+            # dublujemy zaciągu słownika z PBN.
             self.client.sync_disciplines()
         except Exception as e:
             zaloguj_polkniety_wyjatek(

--- a/src/pbn_integrator/management/commands/pbn_integrator.py
+++ b/src/pbn_integrator/management/commands/pbn_integrator.py
@@ -178,7 +178,8 @@ class Command(PBNBaseCommand):
             lambda: (
                 integruj_jezyki(client),
                 integruj_kraje(client),
-                client.download_disciplines(),
+                # sync_disciplines() sam woła download_disciplines() — nie
+                # dublujemy zaciągu słownika z PBN.
                 client.sync_disciplines(),
             ),
         )


### PR DESCRIPTION
## Problem
`sync_disciplines()` (`src/pbn_api/client/disciplines.py:48`) sam woła `download_disciplines()`. Mimo to dwa call-site wołały **oba** pod rząd → podwójny zaciąg słownika dyscyplin z PBN:
- `src/pbn_integrator/management/commands/pbn_integrator.py`
- `src/pbn_import/utils/initial_setup.py`

## Fix
Usunięto zbędne `download_disciplines()` przed `sync_disciplines()` w obu miejscach.

## Testy
`test_initial_setup.py`: asercja `download_disciplines.assert_called_once()` → `assert_not_called()` (straż regresji przed ponownym dublem) + `sync_disciplines.assert_called_once()`; wstrzyknięcie błędu kroku dyscyplin przeniesione z `download_disciplines` na `sync_disciplines` (realny call-site). 7 passed.

Faza 0 planu ekstrakcji PBN (#595).

🤖 Generated with [Claude Code](https://claude.com/claude-code)