### PR TITLE
fix(pbn-queue): stored-XSS przy renderowaniu błędów PBN w kolejce

### DIFF
--- a/src/bpp/newsfragments/pbn-queue-stored-xss.bugfix.rst
+++ b/src/bpp/newsfragments/pbn-queue-stored-xss.bugfix.rst
@@ -1,0 +1,5 @@
+Naprawiono podatność stored-XSS przy wyświetlaniu błędów kolejki eksportu do
+PBN. Treść błędu pochodząca z PBN (niezaufana) była wstawiana do HTML bez
+escapowania — w filtrze ``format_pbn_error``, w widgecie panelu admina oraz
+przez ``|safe`` w szablonie szczegółów. Wszystkie te miejsca escapują teraz
+dane PBN przed wyrenderowaniem.

--- a/src/pbn_export_queue/admin.py
+++ b/src/pbn_export_queue/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin, messages
 from django.contrib.auth import get_user_model
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 from bpp.admin.core import DynamicAdminFilterMixin
@@ -40,7 +41,9 @@ class ZamowilUniqueFilter(admin.SimpleListFilter):
 
 class RenderHTMLWidget(forms.Textarea):
     def render(self, name, value, renderer, attrs=None):
-        return mark_safe((value or "").replace("\n", "<br>"))
+        # value bywa treścią błędu z PBN (niezaufana) — escapujemy przed
+        # zamianą \n na <br>, żeby nie wpuścić HTML-a do panelu admina.
+        return mark_safe(escape(value or "").replace("\n", "<br>"))
 
 
 @admin.register(PBN_Export_Queue)

--- a/src/pbn_export_queue/templates/pbn_export_queue/pbn_export_queue_detail.html
+++ b/src/pbn_export_queue/templates/pbn_export_queue/pbn_export_queue_detail.html
@@ -469,10 +469,10 @@
                                                 <summary class="pbn-export-queue__traceback-summary">
                                                     Wystapil blad (kliknij aby zobaczyc szczegoly)
                                                 </summary>
-                                                <pre class="pbn-export-queue__traceback-pre">{{ msg.content|safe }}</pre>
+                                                <pre class="pbn-export-queue__traceback-pre">{{ msg.content }}</pre>
                                             </details>
                                         {% else %}
-                                            <div class="pbn-export-queue__message-text">{{ msg.content|safe }}</div>
+                                            <div class="pbn-export-queue__message-text">{{ msg.content }}</div>
                                         {% endif %}
                                     </div>
                                 </div>
@@ -481,7 +481,7 @@
 
                             <!-- Raw text view (hidden by default) -->
                             <div id="raw-messages" class="pbn-export-queue__raw-messages">
-                                <pre class="pbn-export-queue__raw-pre">{{ export_queue_item.komunikat|safe }}</pre>
+                                <pre class="pbn-export-queue__raw-pre">{{ export_queue_item.komunikat }}</pre>
                             </div>
 
                             <script>
@@ -507,7 +507,7 @@
                         {% else %}
                             <!-- Fallback to raw view if parsing fails -->
                             <div class="pbn-export-queue__raw-messages" style="display: block;">
-                                <pre class="pbn-export-queue__raw-pre">{{ export_queue_item.komunikat|safe }}</pre>
+                                <pre class="pbn-export-queue__raw-pre">{{ export_queue_item.komunikat }}</pre>
                             </div>
                         {% endif %}
                         {% endwith %}

--- a/src/pbn_export_queue/templatetags/pbn_queue_extras.py
+++ b/src/pbn_export_queue/templatetags/pbn_queue_extras.py
@@ -2,6 +2,7 @@ import json
 import re
 
 from django import template
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 register = template.Library()
@@ -62,6 +63,10 @@ def _parse_exception_parts(exception_line: str) -> tuple[str, str] | None:
     return exception_type, message_part
 
 
+# UWAGA bezpieczeństwo: treść błędu pochodzi z PBN (niezaufana) i trafia do
+# ``mark_safe``. KAŻDA dynamiczna wartość interpolowana do HTML MUSI przejść
+# przez ``escape()`` — inaczej payload w odpowiedzi PBN (np. ``<script>``) daje
+# stored-XSS w tabeli/detalu kolejki. Statyczne etykiety i klasy CSS są bezpieczne.
 def _format_error_list(
     exception_type: str,
     error_code: str,
@@ -75,7 +80,8 @@ def _format_error_list(
     # For MERYTORYCZNY errors, skip redundant header
     if rodzaj_bledu != "MERYT":
         html_parts.append(
-            f'<div class="pbn-error-header">{exception_type}: HTTP {error_code}</div>'
+            f'<div class="pbn-error-header">'
+            f"{escape(exception_type)}: HTTP {escape(error_code)}</div>"
         )
 
     for error_item in errors:
@@ -86,16 +92,16 @@ def _format_error_list(
             if error_code_pbn:
                 html_parts.append(
                     f'<div class="pbn-error-detail">'
-                    f"<strong>Kod błędu:</strong> {error_code_pbn}</div>"
+                    f"<strong>Kod błędu:</strong> {escape(error_code_pbn)}</div>"
                 )
             if error_desc:
                 html_parts.append(
                     f'<div class="pbn-error-detail">'
-                    f"<strong>Opis:</strong> {error_desc}</div>"
+                    f"<strong>Opis:</strong> {escape(error_desc)}</div>"
                 )
 
     html_parts.append(
-        f'<div class="pbn-error-endpoint"><em>Endpoint: {endpoint}</em></div>'
+        f'<div class="pbn-error-endpoint"><em>Endpoint: {escape(endpoint)}</em></div>'
     )
     return "\n".join(html_parts)
 
@@ -112,11 +118,13 @@ def _format_details(details) -> list[str]:
                 ", ".join(str(v) for v in val) if isinstance(val, list) else str(val)
             )
             html_parts.append(
-                f'<div class="pbn-error-detail-item">• <em>{key}:</em> {val_str}</div>'
+                f'<div class="pbn-error-detail-item">'
+                f"• <em>{escape(key)}:</em> {escape(val_str)}</div>"
             )
     else:
         html_parts.append(
-            f'<div class="pbn-error-detail"><strong>Szczegóły:</strong> {details}</div>'
+            f'<div class="pbn-error-detail">'
+            f"<strong>Szczegóły:</strong> {escape(details)}</div>"
         )
     return html_parts
 
@@ -135,17 +143,20 @@ def _format_error_object(
     # and show only the validation details
     if rodzaj_bledu != "MERYT":
         html_parts.append(
-            f'<div class="pbn-error-header">{exception_type}: HTTP {error_code}</div>'
+            f'<div class="pbn-error-header">'
+            f"{escape(exception_type)}: HTTP {escape(error_code)}</div>"
         )
 
         if "message" in error:
             html_parts.append(
-                f'<div class="pbn-error-detail"><strong>Wiadomość:</strong> {error["message"]}</div>'
+                f'<div class="pbn-error-detail">'
+                f"<strong>Wiadomość:</strong> {escape(error['message'])}</div>"
             )
 
         if "description" in error:
             html_parts.append(
-                f'<div class="pbn-error-detail"><strong>Opis:</strong> {error["description"]}</div>'
+                f'<div class="pbn-error-detail">'
+                f"<strong>Opis:</strong> {escape(error['description'])}</div>"
             )
 
     # Always show details (this is what users need for MERYTORYCZNY errors)
@@ -154,7 +165,7 @@ def _format_error_object(
 
     # Always show endpoint for technical debugging
     html_parts.append(
-        f'<div class="pbn-error-endpoint"><em>Endpoint: {endpoint}</em></div>'
+        f'<div class="pbn-error-endpoint"><em>Endpoint: {escape(endpoint)}</em></div>'
     )
     return "\n".join(html_parts)
 
@@ -209,13 +220,15 @@ def format_pbn_error(value, rodzaj_bledu=None):
     exception_line = _extract_exception_line(value)
     if not exception_line:
         return mark_safe(
-            f'<div class="pbn-error-text">{_get_fallback_line(value)}</div>'
+            f'<div class="pbn-error-text">{escape(_get_fallback_line(value))}</div>'
         )
 
     try:
         parsed = _parse_exception_parts(exception_line)
         if not parsed:
-            return mark_safe(f'<div class="pbn-error-text">{exception_line}</div>')
+            return mark_safe(
+                f'<div class="pbn-error-text">{escape(exception_line)}</div>'
+            )
 
         exception_type, message_part = parsed
 
@@ -230,15 +243,18 @@ def format_pbn_error(value, rodzaj_bledu=None):
                 return mark_safe(result)
             # JSON parsing failed, return raw error
             return mark_safe(
-                f'<div class="pbn-error-text">{exception_type}: HTTP {error_code} - {json_str}</div>'
+                f'<div class="pbn-error-text">'
+                f"{escape(exception_type)}: HTTP {escape(error_code)} "
+                f"- {escape(json_str)}</div>"
             )
 
         # Simple exception format (e.g., StatementsMissing)
         return mark_safe(
-            f'<div class="pbn-error-text">{exception_type}: {message_part}</div>'
+            f'<div class="pbn-error-text">'
+            f"{escape(exception_type)}: {escape(message_part)}</div>"
         )
 
     except (ValueError, AttributeError, IndexError):
         pass
 
-    return mark_safe(f'<div class="pbn-error-text">{exception_line}</div>')
+    return mark_safe(f'<div class="pbn-error-text">{escape(exception_line)}</div>')

--- a/src/pbn_export_queue/tests/test_template_filters.py
+++ b/src/pbn_export_queue/tests/test_template_filters.py
@@ -6,10 +6,10 @@ from pbn_export_queue.templatetags.pbn_queue_extras import format_pbn_error
 @pytest.mark.django_db
 def test_format_pbn_error_merytoryczny_hides_header():
     """MERYTORYCZNY errors should hide redundant header/message/description"""
-    komunikat = '''Traceback (most recent call last):
+    komunikat = """Traceback (most recent call last):
   File "/app/src/pbn_export_queue/models.py", line 358, in send_to_pbn
 pbn_api.exceptions.HttpException: (400, '/api/v1/publications', '{"code":400,"message":"Bad Request","description":"Validation failed.","details":{"isbn":"Publikacja o identycznym ISBN już istnieje!"}}')
-'''
+"""
 
     result = format_pbn_error(komunikat, "MERYT")
 
@@ -30,10 +30,10 @@ pbn_api.exceptions.HttpException: (400, '/api/v1/publications', '{"code":400,"me
 @pytest.mark.django_db
 def test_format_pbn_error_techniczny_shows_full_header():
     """TECHNICZNY errors should show full header information"""
-    komunikat = '''Traceback (most recent call last):
+    komunikat = """Traceback (most recent call last):
   File "/app/src/pbn_export_queue/models.py", line 358, in send_to_pbn
 pbn_api.exceptions.HttpException: (500, '/api/v1/publications', '{"code":500,"message":"Internal Server Error"}')
-'''
+"""
 
     result = format_pbn_error(komunikat, "TECH")
 
@@ -46,10 +46,10 @@ pbn_api.exceptions.HttpException: (500, '/api/v1/publications', '{"code":500,"me
 @pytest.mark.django_db
 def test_format_pbn_error_no_rodzaj_bledu_shows_full_header():
     """When rodzaj_bledu is not provided, show full header (backward compatibility)"""
-    komunikat = '''Traceback (most recent call last):
+    komunikat = """Traceback (most recent call last):
   File "/app/src/pbn_export_queue/models.py", line 358, in send_to_pbn
 pbn_api.exceptions.HttpException: (400, '/api/v1/publications', '{"code":400,"message":"Bad Request","description":"Validation failed.","details":{"doi":"Duplicate"}}')
-'''
+"""
 
     result = format_pbn_error(komunikat)  # No rodzaj_bledu parameter
 
@@ -57,3 +57,54 @@ pbn_api.exceptions.HttpException: (400, '/api/v1/publications', '{"code":400,"me
     assert "HttpException: HTTP 400" in result
     assert "Wiadomość:" in result
     assert "Opis:" in result
+
+
+@pytest.mark.django_db
+def test_format_pbn_error_escapes_html_in_fallback_line():
+    """Treść błędu PBN w ścieżce fallback musi być escapowana (stored-XSS)."""
+    result = format_pbn_error("<script>alert('xss')</script>")
+
+    assert "<script>" not in result
+    assert "&lt;script&gt;" in result
+
+
+@pytest.mark.django_db
+def test_format_pbn_error_escapes_html_in_description_and_details():
+    """Pola description/details z payloadu PBN muszą być escapowane."""
+    komunikat = (
+        "pbn_api.exceptions.HttpException: (400, '/api/v1/publications', "
+        '\'{"code":400,"description":"<script>alert(1)</script>",'
+        '"details":{"isbn":"<img src=x onerror=alert(2)>"}}\')'
+    )
+
+    result = format_pbn_error(komunikat)
+
+    assert "<script>" not in result
+    assert "<img src=x" not in result
+    assert "&lt;script&gt;" in result
+    assert "&lt;img" in result
+
+
+@pytest.mark.django_db
+def test_format_pbn_error_escapes_simple_exception_message():
+    """Prosty komunikat wyjątku również escapowany."""
+    komunikat = "pbn_api.exceptions.StatementsMissing: </pre><script>alert(3)</script>"
+
+    result = format_pbn_error(komunikat)
+
+    assert "<script>" not in result
+    assert "&lt;" in result
+
+
+def test_render_html_widget_escapes_value():
+    """Widget admina kolejki renderuje TextField jako HTML — musi escapować."""
+    from pbn_export_queue.admin import RenderHTMLWidget
+
+    out = RenderHTMLWidget().render(
+        "field", "<script>alert(1)</script>\ndruga linia", renderer=None
+    )
+
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+    # nowa linia dalej zamieniana na <br>
+    assert "<br>" in out


### PR DESCRIPTION
## Problem (bezpieczeństwo)
Treść błędu pochodząca z **PBN** (niezaufana) trafiała do HTML **bez escapowania** w kilku miejscach kolejki eksportu:
- `format_pbn_error` (`templatetags/pbn_queue_extras.py`) — ~10 surowych interpolacji (opis, `details`, endpoint, message, kod) przed `mark_safe`, używane w `pbn_export_queue_table.html`,
- `RenderHTMLWidget` (`admin.py`) — renderuje TextField jako zaufany HTML,
- `pbn_export_queue_detail.html` — `msg.content|safe` (×2) i `komunikat|safe` (×2) = surowe traceback z ciałem odpowiedzi PBN.

Payload w odpowiedzi PBN (np. `</pre><script>alert(1)</script>`) → **stored-XSS** w widoku kolejki.

## Fix
- `escape()` na **wszystkich** dynamicznych wartościach PBN w filtrze i widgecie,
- usunięcie `|safe` z sinków treści PBN (Django auto-escapuje; tekst w `<pre>` renderuje się tak samo),
- `opis_bibliograficzny_cache|safe` (zaufany, wyrenderowany HTML BPP) **pozostaje**.

## Testy (TDD)
Repro w `test_template_filters.py`: fallback, description/details, prosty wyjątek, widget admina. Przed fixem **4 fail** (payload przechodził), po fixie **7 passed** (3 istniejące bez zmian).

## Poza zakresem
Martwy `pbn_api/admin/helpers.py:format_json` (ta sama klasa problemu, ale **zero konsumentów produkcyjnych**) — zostawiony do D1 (toolkit admina), żeby ten PR trzymał się żywego wektora.

B0b z planu ekstrakcji PBN (#595).

🤖 Generated with [Claude Code](https://claude.com/claude-code)