### PR TITLE
feat(import): paginacja client-side na ekranie „Rezultaty" (Select2 nie muli)

### DIFF
--- a/src/bpp/newsfragments/import-rezultaty-paginacja.feature.rst
+++ b/src/bpp/newsfragments/import-rezultaty-paginacja.feature.rst
@@ -1,0 +1,6 @@
+Na ekranie „Rezultaty” importu pracowników dodano selektor liczby
+wierszy na stronę (10 / 25 / 50 / 100 / wszystkie, domyślnie 25) wraz
+z pagerem. Paginacja działa po stronie klienta i współgra z istniejącym
+paskiem filtrów. Ogranicza rozmiar renderowanego drzewa DOM, dzięki
+czemu edycja dopasowanego autora przez Select2 nie spowalnia się przy
+importach z dużą liczbą wierszy.

--- a/src/bpp/static/scss/_import-pracownikow.scss
+++ b/src/bpp/static/scss/_import-pracownikow.scss
@@ -151,6 +151,12 @@
     align-self: center;
   }
 
+  // Selektor „na stronę" (client-side paginacja) — wyrównany do pola szukania.
+  .import-filtr-rozmiar {
+    align-self: center;
+    font-size: 0.85em;
+  }
+
   // Kontenery grup filtrów: widoczne (główne) i zwijane (dodatkowe).
   .import-filtr-glowne,
   .import-filtr-dodatkowe {
@@ -176,4 +182,31 @@
   font-size: 0.9em;
   color: #767676;
   margin: 0 0 0.75rem;
+}
+
+// Pager client-side (prev / info / next) nad tabelą. Chowany przy jednej
+// stronie (atrybut [hidden]) — bez display:flex, żeby [hidden] wygrał.
+.import-filtr-pager {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 0.75rem;
+
+  &[hidden] {
+    display: none;
+  }
+
+  // Kompaktowe przyciski pagera — mniejsze niż domyślne, ale bez klasy
+  // Foundation `tiny` (test podglądu banuje ją globalnie, by przycisk
+  // „potwierdź" kandydata pozostał normalny).
+  .import-filtr-pager-btn {
+    margin: 0;
+    padding: 0.35rem 0.6rem;
+    font-size: 0.8em;
+  }
+
+  .import-filtr-pager-info {
+    font-size: 0.9em;
+    color: #767676;
+  }
 }

--- a/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
+++ b/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
@@ -81,6 +81,21 @@
                 <input type="search" id="filtr-tekst"
                        placeholder="nazwisko / jednostka…">
             </label>
+            {# Rozmiar „na stronę" — client-side paginacja. Tabela renderuje #}
+            {# WSZYSTKIE wiersze w DOM (setki), a wielki DOM wymusza reflow → #}
+            {# Select2 muli przy pisaniu. Pokazujemy tylko okno strony, resztę #}
+            {# chowamy (display:none wypada z layoutu). „wszystkie" (value=0) = #}
+            {# opt-in na komplet (i związany z tym jank). Default 25. #}
+            <label class="import-filtr-rozmiar">
+                Na stronę:
+                <select id="filtr-strona-rozmiar" name="filtr-strona-rozmiar">
+                    <option value="10">10</option>
+                    <option value="25" selected>25</option>
+                    <option value="50">50</option>
+                    <option value="100">100</option>
+                    <option value="0">wszystkie</option>
+                </select>
+            </label>
             <div class="import-filtr-glowne">
                 {% for klucz, etykieta in pola_glowne %}
                     {% include "import_pracownikow/partials/_filtr_pole.html" %}
@@ -99,6 +114,17 @@
         </form>
         {# Licznik przefiltrowanych rekordów (aktualizowany w JS filtruj()). #}
         <p id="filtr-licznik" class="import-filtr-licznik"></p>
+        {# Pager client-side (JS steruje widocznością i disabled). Ukryty przy #}
+        {# jednej stronie / „wszystkie". type="button" — NIE submituje formularza. #}
+        <nav id="filtr-pager" class="import-filtr-pager" hidden aria-label="Stronicowanie">
+            <button type="button" id="filtr-pager-prev" class="button secondary import-filtr-pager-btn">
+                <span class="fi-arrow-left"></span> poprzednia
+            </button>
+            <span id="filtr-pager-info" class="import-filtr-pager-info"></span>
+            <button type="button" id="filtr-pager-next" class="button secondary import-filtr-pager-btn">
+                następna <span class="fi-arrow-right"></span>
+            </button>
+        </nav>
         <div style="overflow-x: auto;">
             <table id="tabela-autorow">
                 <thead>
@@ -179,10 +205,23 @@
                     return tr.getAttribute('data-do-pominiecia') === '1';
                 return tr.getAttribute('data-confidence') === w;
             }
+            // Numer bieżącej strony (0-based). Reset do 0 tylko przy zmianie
+            // filtra/rozmiaru — NIE przy htmx:afterSettle (edytowany wiersz
+            // zostaje na swojej stronie).
+            var strona = 0;
+            function rozmiarStrony() {
+                var el = document.getElementById('filtr-strona-rozmiar');
+                var v = el ? parseInt(el.value, 10) : 25;
+                // 0 / puste / błędne → „wszystkie" (brak limitu).
+                return (isNaN(v) || v <= 0) ? Infinity : v;
+            }
             function filtruj() {
                 var ks = klucze();
                 var q = tekst();
-                var widoczne = 0, wszystkich = 0;
+                // 1) Zbierz rekordy przechodzące filtr (w kolejności DOM);
+                //    niepasujące od razu chowamy.
+                var pasujace = [];
+                var wszystkich = 0;
                 tabela.querySelectorAll(':scope > tbody[data-rekord]').forEach(
                     function (tbody) {
                         wszystkich++;
@@ -193,20 +232,69 @@
                         });
                         var okTekst = !q
                             || tekstRekordu(tbody).indexOf(q) !== -1;
-                        var pokaz = okStany && okTekst && okRodzaj(tbody);
-                        tbody.hidden = !pokaz;
-                        if (pokaz) widoczne++;
+                        if (okStany && okTekst && okRodzaj(tbody)) {
+                            pasujace.push(tbody);
+                        } else {
+                            tbody.hidden = true;
+                        }
                     });
+                // 2) Okno strony nad przefiltrowanym zbiorem. Chowamy rekordy
+                //    spoza okna, żeby DOM w layoucie był mały (Select2 nie muli).
+                var N = pasujace.length;
+                var r = rozmiarStrony();
+                var stronMax = (r === Infinity || N === 0)
+                    ? 1 : Math.ceil(N / r);
+                if (strona > stronMax - 1) strona = stronMax - 1;
+                if (strona < 0) strona = 0;
+                var start = (r === Infinity) ? 0 : strona * r;
+                var end = (r === Infinity) ? N : Math.min(start + r, N);
+                pasujace.forEach(function (tbody, i) {
+                    tbody.hidden = !(i >= start && i < end);
+                });
+                // 3) Licznik + pager.
                 var licznik = document.getElementById('filtr-licznik');
                 if (licznik) {
-                    licznik.textContent = wszystkich
-                        ? 'Pokazano ' + widoczne + ' z ' + wszystkich
-                            + ' rekordów'
-                        : '';
+                    if (!wszystkich) {
+                        licznik.textContent = '';
+                    } else if (!N) {
+                        licznik.textContent =
+                            'Nie znaleziono rekordów (0 z ' + wszystkich + ')';
+                    } else {
+                        licznik.textContent =
+                            'Pokazano ' + (start + 1) + '–' + end
+                            + ' z ' + N + ' rekordów'
+                            + (N !== wszystkich
+                                ? ' (odfiltrowano z ' + wszystkich + ')' : '');
+                    }
+                }
+                var pager = document.getElementById('filtr-pager');
+                if (pager) {
+                    pager.hidden = !(r !== Infinity && stronMax > 1);
+                    var info = document.getElementById('filtr-pager-info');
+                    if (info) {
+                        info.textContent =
+                            'strona ' + (strona + 1) + ' / ' + stronMax;
+                    }
+                    var prev = document.getElementById('filtr-pager-prev');
+                    var next = document.getElementById('filtr-pager-next');
+                    if (prev) prev.disabled = strona <= 0;
+                    if (next) next.disabled = strona >= stronMax - 1;
                 }
             }
-            form.addEventListener('change', filtruj);
-            form.addEventListener('input', filtruj);
+            // Zmiana filtra/rozmiaru → wróć na stronę 1 (inaczej można wylądować
+            // na pustej stronie za końcem nowego, węższego zbioru).
+            function przefiltrujOdNowa() { strona = 0; filtruj(); }
+            form.addEventListener('change', przefiltrujOdNowa);
+            form.addEventListener('input', przefiltrujOdNowa);
+            var prevBtn = document.getElementById('filtr-pager-prev');
+            var nextBtn = document.getElementById('filtr-pager-next');
+            if (prevBtn) prevBtn.addEventListener('click', function () {
+                strona -= 1; filtruj();
+            });
+            if (nextBtn) nextBtn.addEventListener('click', function () {
+                strona += 1; filtruj();
+            });
+            // Po swapie HTMX zachowaj bieżącą stronę (filtruj sam się klampuje).
             document.body.addEventListener('htmx:afterSettle', filtruj);
             filtruj();
         })();

--- a/src/import_pracownikow/tests/test_views_liveops.py
+++ b/src/import_pracownikow/tests/test_views_liveops.py
@@ -454,6 +454,48 @@ def test_importpracownikow_results_ma_pasek_filtrow(admin_client, admin_user):
     assert ".DataTable(" not in content
 
 
+@pytest.mark.django_db
+def test_importpracownikow_results_ma_selektor_rozmiaru_strony(
+    admin_client, admin_user
+):
+    """Tabela autorów (bez serwerowej paginacji, setki wierszy) ma client-side
+    selektor „na stronę" + pager, żeby nie renderować całego DOM naraz — duży
+    DOM wymusza reflow i muli Select2 przy pisaniu. Default 25; „wszystkie"
+    (value=0) świadomie pokazuje komplet."""
+    imp = baker.make(
+        ImportPracownikow,
+        owner=admin_user,
+        finished_successfully=True,
+        stan=ImportPracownikow.STAN_ZINTEGROWANY,
+    )
+    autor = baker.make(Autor, nazwisko="Testowy", imiona="Jan")
+    jednostka = baker.make(Jednostka, nazwa="Testowa Jednostka", skrot="Test. Jedn.")
+    baker.make(
+        ImportPracownikowRow,
+        parent=imp,
+        autor=autor,
+        jednostka=jednostka,
+        zmiany_potrzebne=True,
+    )
+    url = reverse("import_pracownikow:importpracownikow-results", kwargs={"pk": imp.pk})
+    content = admin_client.get(url).content.decode()
+
+    # selektor rozmiaru strony z opcjami 10/25/50/100/wszystkie, default 25
+    assert 'id="filtr-strona-rozmiar"' in content
+    assert 'value="10"' in content
+    assert 'value="25" selected' in content
+    assert 'value="50"' in content
+    assert 'value="100"' in content
+    assert 'value="0"' in content  # „wszystkie"
+    # pager (prev/next + info) — sterowanie client-side
+    assert 'id="filtr-pager"' in content
+    assert 'id="filtr-pager-prev"' in content
+    assert 'id="filtr-pager-next"' in content
+    # JS faktycznie wpina paginację (nie sam martwy markup)
+    assert "filtr-strona-rozmiar" in content
+    assert "strona" in content
+
+
 def test_importpracownikow_results_bez_pagination_include():
     """Martwy ``{% include "pagination.html" %}`` (widok bez ``paginate_by``)
     usunięty — nie-``<tr>`` w ``<tbody>`` psułby strukturę tabeli/karty."""


### PR DESCRIPTION
## Problem

Na ekranie `/rezultaty/` importu pracowników edycja dopasowanego autora przez Select2 **bardzo mieliła przy dużej liczbie wierszy**. Na realnych danych zgłaszającego to **492 rekordy → ~2 MB HTML**. Tak ogromny DOM wymusza synchroniczny reflow przy każdym naciśnięciu klawisza w Select2 → jank. (Endpoint autocomplete sprawdzony — nie on jest wąskim gardłem.)

Strona świadomie renderowała wszystkie wiersze naraz (DataTables zostało z niej wcześniej usunięte, bo kłóciło się z HTMX-owym swapowaniem wierszy i własnym paskiem filtrów).

## Rozwiązanie

Selektor **„Na stronę”** (10 / 25 / 50 / 100 / wszystkie, domyślnie **25**) + pager, wpięte w istniejący client-side `filtruj()`:

- `filtruj()` liczy zbiór rekordów przechodzących filtr, po czym pokazuje tylko **okno bieżącej strony**, a resztę chowa (`display:none` = wypada z layoutu). Select2 przelatuje po ~20× mniejszym wyrenderowanym drzewie.
- Zmiana filtra/rozmiaru → powrót na stronę 1. Po swapie HTMX zostajesz na bieżącej stronie (klamrowanie numeru strony). „wszystkie” świadomie renderuje komplet (i wraca ów jank — opt-in).
- Pager chowany przy jednej stronie; przyciski `type="button"` (nie submitują formularza).

**Bez migracji.** Pager używa własnej klasy `import-filtr-pager-btn` zamiast Foundation `tiny` — globalny ban tej klasy w teście podglądu chroni przycisk „potwierdź” kandydata.

## Weryfikacja

- ✅ `pytest src/import_pracownikow/` — **609 passed**
- ✅ realna strona (492 wiersze) renderuje cały markup paginacji, default 25 zaznaczone
- ✅ wyrenderowany JS przechodzi `node --check` (brak błędu składni, który cicho zabiłby filtr)
- ⚠️ runtime w przeglądarce nie zweryfikowany automatycznie (rozszerzenie Chrome offline) — do klik-testu przez zgłaszającego; run-site serwuje szablon na żywo

🤖 Generated with [Claude Code](https://claude.com/claude-code)