### PR TITLE
refactor(pbn): usuń martwy kod integracji słownika dyscyplin

### DIFF
--- a/src/bpp/newsfragments/pbn-remove-dead-disciplines-legacy.removal.rst
+++ b/src/bpp/newsfragments/pbn-remove-dead-disciplines-legacy.removal.rst
@@ -1,0 +1,6 @@
+Usunięto martwy kod integracji słownika dyscyplin (``integruj_dyscypliny``
+i pomocnicze funkcje w ``pbn_integrator/utils/dictionaries.py``). Kod ten
+wywoływał nieistniejącą metodę klienta ``get_discipline_groups()`` i zakładał
+nieaktualny kształt odpowiedzi PBN — nie miał żadnego produkcyjnego wywołania,
+a jedynie testy charakteryzujące zepsuty kontrakt. Właściwa synchronizacja
+dyscyplin odbywa się przez ``download_disciplines()``/``sync_disciplines()``.

--- a/src/pbn_integrator/tests/test_c901_dict_transforms.py
+++ b/src/pbn_integrator/tests/test_c901_dict_transforms.py
@@ -2,22 +2,19 @@
 transforms before refactoring:
 
 * ``integruj_jezyki``     (pbn_integrator/utils/dictionaries.py)
-* ``integruj_dyscypliny`` (pbn_integrator/utils/dictionaries.py)
 * ``integruj_zrodla``     (pbn_integrator/utils/journals.py)
 
 These lock the OBSERVABLE behavior of every branch so the subsequent
 complexity-reducing refactor can be proven behavior-preserving.
 """
 
-from datetime import date
 from unittest.mock import Mock
-from uuid import uuid4
 
 import pytest
 from model_bakery import baker
 
 from bpp.models import Jezyk, Zrodlo
-from pbn_api.models import Discipline, DisciplineGroup, Journal, Language
+from pbn_api.models import Journal, Language
 
 # ---------------------------------------------------------------------------
 # integruj_jezyki
@@ -189,215 +186,6 @@ def test_jezyki_639_1_participates_in_query():
 
     jezyk.refresh_from_db()
     assert jezyk.pbn_uid_id == lang.pk
-
-
-# ---------------------------------------------------------------------------
-# integruj_dyscypliny
-# ---------------------------------------------------------------------------
-
-
-def _make_group():
-    return baker.make(
-        DisciplineGroup,
-        uuid=uuid4(),
-        validityDateFrom=date(2022, 1, 1),
-        validityDateTo=None,
-    )
-
-
-@pytest.mark.django_db
-def test_dyscypliny_creates_group_from_dict():
-    """Group as dict, not present -> created with given pk."""
-    from pbn_integrator.utils import integruj_dyscypliny
-
-    gid = 987654
-    client = Mock()
-    client.get_discipline_groups.return_value = [
-        {
-            "id": gid,
-            "uuid": str(uuid4()),
-            "validityDateFrom": "2022-01-01",
-            "validityDateTo": None,
-        }
-    ]
-    client.get_disciplines.return_value = []
-    integruj_dyscypliny(client)
-
-    assert DisciplineGroup.objects.filter(pk=gid).exists()
-
-
-@pytest.mark.django_db
-def test_dyscypliny_skips_existing_group_dict():
-    """Group as dict, already present -> left untouched (no error)."""
-    from pbn_integrator.utils import integruj_dyscypliny
-
-    grp = _make_group()
-    client = Mock()
-    client.get_discipline_groups.return_value = [
-        {
-            "id": grp.pk,
-            "uuid": str(uuid4()),
-            "validityDateFrom": "2099-01-01",
-            "validityDateTo": None,
-        }
-    ]
-    client.get_disciplines.return_value = []
-    integruj_dyscypliny(client)
-
-    grp.refresh_from_db()
-    # untouched: still original validity date
-    assert grp.validityDateFrom == date(2022, 1, 1)
-
-
-@pytest.mark.django_db
-def test_dyscypliny_model_group_not_in_db_is_skipped():
-    """Group as (unsaved) model object missing from DB -> NOT created."""
-    from pbn_integrator.utils import integruj_dyscypliny
-
-    unsaved = DisciplineGroup(uuid=uuid4(), validityDateFrom=date(2022, 1, 1))
-    before = DisciplineGroup.objects.count()
-
-    client = Mock()
-    client.get_discipline_groups.return_value = [unsaved]
-    client.get_disciplines.return_value = []
-    integruj_dyscypliny(client)
-
-    assert DisciplineGroup.objects.count() == before
-
-
-@pytest.mark.django_db
-def test_dyscypliny_creates_discipline_dict_parent_group_dict():
-    """Discipline dict whose parent_group is a dict -> parent_group_id taken
-    from the nested id; created with explicit pk when 'id' present."""
-    from pbn_integrator.utils import integruj_dyscypliny
-
-    grp = _make_group()
-    client = Mock()
-    client.get_discipline_groups.return_value = []
-    client.get_disciplines.return_value = [
-        {
-            "id": 555001,
-            "uuid": str(uuid4()),
-            "code": "33.1",
-            "name": "Nauka A",
-            "parent_group": {"id": grp.pk},
-        }
-    ]
-    integruj_dyscypliny(client)
-
-    d = Discipline.objects.get(code="33.1")
-    assert d.pk == 555001
-    assert d.parent_group_id == grp.pk
-    assert d.name == "Nauka A"
-
-
-@pytest.mark.django_db
-def test_dyscypliny_creates_discipline_dict_parent_group_model():
-    """Discipline dict whose parent_group is a model object -> uses its pk."""
-    from pbn_integrator.utils import integruj_dyscypliny
-
-    grp = _make_group()
-    client = Mock()
-    client.get_discipline_groups.return_value = []
-    client.get_disciplines.return_value = [
-        {
-            "uuid": str(uuid4()),
-            "code": "33.2",
-            "name": "Nauka B",
-            "parent_group": grp,
-        }
-    ]
-    integruj_dyscypliny(client)
-
-    d = Discipline.objects.get(code="33.2")
-    assert d.parent_group_id == grp.pk
-
-
-@pytest.mark.django_db
-def test_dyscypliny_creates_discipline_dict_parent_group_id_key():
-    """Discipline dict with no parent_group, but a parent_group_id key."""
-    from pbn_integrator.utils import integruj_dyscypliny
-
-    grp = _make_group()
-    client = Mock()
-    client.get_discipline_groups.return_value = []
-    client.get_disciplines.return_value = [
-        {
-            "uuid": str(uuid4()),
-            "code": "33.3",
-            "name": "Nauka C",
-            "parent_group": None,
-            "parent_group_id": grp.pk,
-        }
-    ]
-    integruj_dyscypliny(client)
-
-    d = Discipline.objects.get(code="33.3")
-    assert d.parent_group_id == grp.pk
-
-
-@pytest.mark.django_db
-def test_dyscypliny_updates_name_and_skips_when_same():
-    """Existing discipline: name differs -> updated; name same -> untouched."""
-    from pbn_integrator.utils import integruj_dyscypliny
-
-    grp = _make_group()
-    disc = baker.make(
-        Discipline, code="33.4", name="Stara", parent_group=grp, uuid=uuid4()
-    )
-
-    client = Mock()
-    client.get_discipline_groups.return_value = []
-    client.get_disciplines.return_value = [
-        {
-            "uuid": str(uuid4()),
-            "code": "33.4",
-            "name": "Nowa",
-            "parent_group": grp,
-        }
-    ]
-    integruj_dyscypliny(client)
-    disc.refresh_from_db()
-    assert disc.name == "Nowa"
-
-    # Same name -> no-op; uuid/parent unchanged.
-    client.get_disciplines.return_value = [
-        {
-            "uuid": str(uuid4()),
-            "code": "33.4",
-            "name": "Nowa",
-            "parent_group": grp,
-        }
-    ]
-    integruj_dyscypliny(client)
-    disc.refresh_from_db()
-    assert disc.name == "Nowa"
-
-
-@pytest.mark.django_db
-def test_dyscypliny_discipline_model_object_create_and_update():
-    """Discipline supplied as a model object: create path (new code) then
-    update path (existing code, differing name)."""
-    from pbn_integrator.utils import integruj_dyscypliny
-
-    grp = _make_group()
-    remote = Discipline(code="33.5", name="Mname", parent_group=grp, uuid=uuid4())
-
-    client = Mock()
-    client.get_discipline_groups.return_value = []
-    client.get_disciplines.return_value = [remote]
-    integruj_dyscypliny(client)
-
-    d = Discipline.objects.get(code="33.5")
-    assert d.name == "Mname"
-    assert d.parent_group_id == grp.pk
-
-    # Now an existing discipline returned as model object with new name.
-    remote2 = Discipline(code="33.5", name="Mname2", parent_group=grp, uuid=uuid4())
-    client.get_disciplines.return_value = [remote2]
-    integruj_dyscypliny(client)
-    d.refresh_from_db()
-    assert d.name == "Mname2"
 
 
 # ---------------------------------------------------------------------------

--- a/src/pbn_integrator/tests/test_utils_system_data.py
+++ b/src/pbn_integrator/tests/test_utils_system_data.py
@@ -7,13 +7,12 @@ For performance tests, see test_utils_performance.py
 """
 
 from unittest.mock import Mock
-from uuid import uuid4
 
 import pytest
 from model_bakery import baker
 
-from bpp.models import Dyscyplina_Naukowa, Jezyk
-from pbn_api.models import Country, Discipline, DisciplineGroup, Language
+from bpp.models import Jezyk
+from pbn_api.models import Country, Language
 
 # ============================================================================
 # UNIT TESTS - Language Integration
@@ -180,58 +179,3 @@ class TestIntegrujKraje:
 
         # Country should be created or updated
         assert Country.objects.filter(code="PL").exists()
-
-
-# ============================================================================
-# UNIT TESTS - Discipline Integration
-# ============================================================================
-
-
-@pytest.mark.django_db
-class TestIntegrujDyscypliny:
-    """Test integruj_dyscypliny function for discipline system data import"""
-
-    def test_integruj_dyscypliny_creates_disciplines(self):
-        """Should create Discipline records from PBN data"""
-        from pbn_integrator.utils import integruj_dyscypliny
-
-        discipline_group = baker.make(DisciplineGroup)
-
-        mock_client = Mock()
-        mock_client.get_discipline_groups.return_value = [discipline_group]
-        mock_client.get_disciplines.return_value = [
-            {
-                "uuid": uuid4(),
-                "code": "11.1",
-                "name": "Mathematics",
-                "parent_group": discipline_group,
-            },
-        ]
-
-        integruj_dyscypliny(mock_client)
-
-        # Verify discipline was created
-        assert Discipline.objects.filter(code="11.1").exists()
-
-    def test_integruj_dyscypliny_links_to_bpp_disciplines(self):
-        """Should establish mapping to BPP Dyscyplina_Naukowa"""
-        from pbn_integrator.utils import integruj_dyscypliny
-
-        discipline_group = baker.make(DisciplineGroup)
-        baker.make(Dyscyplina_Naukowa, nazwa="Matematyka")
-
-        mock_client = Mock()
-        mock_client.get_discipline_groups.return_value = [discipline_group]
-        mock_client.get_disciplines.return_value = [
-            {
-                "uuid": uuid4(),
-                "code": "11.1",
-                "name": "Matematyka",
-                "parent_group": discipline_group,
-            },
-        ]
-
-        integruj_dyscypliny(mock_client)
-
-        # Verify discipline mapping exists
-        assert Discipline.objects.filter(code="11.1").exists()

--- a/src/pbn_integrator/utils/__init__.py
+++ b/src/pbn_integrator/utils/__init__.py
@@ -51,7 +51,6 @@ from pbn_integrator.utils.constants import (  # noqa
 
 # Dictionaries (languages, countries, disciplines)
 from pbn_integrator.utils.dictionaries import (  # noqa
-    integruj_dyscypliny,
     integruj_jezyki,
     integruj_kraje,
 )
@@ -223,7 +222,6 @@ __all__ = [
     "zapisz_oswiadczenie_instytucji",
     "zapisz_publikacje_instytucji",
     # Dictionaries
-    "integruj_dyscypliny",
     "integruj_jezyki",
     "integruj_kraje",
     # Institutions

--- a/src/pbn_integrator/utils/dictionaries.py
+++ b/src/pbn_integrator/utils/dictionaries.py
@@ -1,4 +1,4 @@
-"""Integration of dictionary data: languages, countries, disciplines."""
+"""Integration of dictionary data: languages and countries."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import warnings
 from django.db.models import Q
 
 from bpp.models import Jezyk
-from pbn_api.models import Country, Discipline, DisciplineGroup, Language
+from pbn_api.models import Country, Language
 
 
 def _sync_remote_languages(client):
@@ -100,82 +100,3 @@ def integruj_kraje(client):
         if remote_country["description"] != c.description:
             c.description = remote_country["description"]
             c.save()
-
-
-def _ensure_discipline_groups(client):
-    """Create any missing discipline groups (dict payloads only)."""
-    for remote_group in client.get_discipline_groups():
-        is_dict = isinstance(remote_group, dict)
-        group_id = remote_group.get("id") if is_dict else remote_group.pk
-        if DisciplineGroup.objects.filter(pk=group_id).exists():
-            continue
-        if is_dict:
-            DisciplineGroup.objects.create(
-                pk=group_id,
-                **{k: v for k, v in remote_group.items() if k != "id"},
-            )
-        # else: remote_group is a DisciplineGroup model object missing from
-        # the DB -- skip, as the original code did.
-
-
-def _parent_group_id_from_dict(remote_discipline):
-    """Resolve ``parent_group_id`` for a dict discipline payload."""
-    parent_group = remote_discipline.get("parent_group")
-    if isinstance(parent_group, dict):
-        return parent_group.get("id")
-    if hasattr(parent_group, "pk"):
-        return parent_group.pk
-    return remote_discipline.get("parent_group_id")
-
-
-def _discipline_fields(remote_discipline):
-    """Normalize a dict-or-model discipline payload into a field mapping."""
-    if isinstance(remote_discipline, dict):
-        return {
-            "code": remote_discipline.get("code"),
-            "disc_id": remote_discipline.get("id"),
-            "name": remote_discipline.get("name"),
-            "uuid": remote_discipline.get("uuid"),
-            "parent_group_id": _parent_group_id_from_dict(remote_discipline),
-        }
-
-    parent_group = getattr(remote_discipline, "parent_group", None)
-    return {
-        "code": remote_discipline.code,
-        "disc_id": remote_discipline.pk,
-        "name": remote_discipline.name,
-        "uuid": getattr(remote_discipline, "uuid", None),
-        "parent_group_id": parent_group.pk if parent_group else None,
-    }
-
-
-def _upsert_discipline(fields):
-    """Create a missing discipline or update its name in place."""
-    try:
-        d = Discipline.objects.get(code=fields["code"])
-    except Discipline.DoesNotExist:
-        create_kwargs = {
-            "code": fields["code"],
-            "name": fields["name"],
-            "parent_group_id": fields["parent_group_id"],
-            "uuid": fields["uuid"],
-        }
-        if fields["disc_id"]:
-            create_kwargs["pk"] = fields["disc_id"]
-        Discipline.objects.create(**create_kwargs)
-        return
-
-    if fields["name"] != d.name:
-        d.name = fields["name"]
-        d.save()
-
-
-def integruj_dyscypliny(client):
-    """Import discipline groups and disciplines from PBN.
-
-    Args:
-        client: PBN client.
-    """
-    _ensure_discipline_groups(client)
-    for remote_discipline in client.get_disciplines():
-        _upsert_discipline(_discipline_fields(remote_discipline))


### PR DESCRIPTION
## Problem
`integruj_dyscypliny` i jego helpery (`pbn_integrator/utils/dictionaries.py`) to **martwy kod**:
- wołają **nieistniejącą** metodę klienta `get_discipline_groups()` (nigdzie niezdefiniowaną),
- zakładają nieaktualny, płaski kształt payloadu dyscyplin,
- **zero produkcyjnych call-site** — jedynie testy charakteryzujące zepsuty kontrakt (mockujące nieistniejącą metodę).

Realny sync dyscyplin działa przez `download_disciplines()`/`sync_disciplines()` (`pbn_api/client/disciplines.py`) na poprawnym, zagnieżdżonym payloadzie grupowym.

## Zmiana
Usunięto martwe funkcje + ich eksport z `utils/__init__.py` + sekcje testów charakteryzujących (`test_c901_dict_transforms.py`, `test_utils_system_data.py`). **Żywe** testy `integruj_jezyki`/`integruj_kraje`/`integruj_zrodla` pozostają.

## Weryfikacja
`ruff` clean, `manage.py check` OK, dotknięte testy **21 passed**. `integruj_dyscypliny` jako nazwa opcji CLI w `fix_pbn_import_oswiadczen_ksiazki` to inny byt — nietknięte.

B0c z planu ekstrakcji PBN (#595). Odblokowuje D3 (sync słowników na aktualnym payloadzie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)