### PR TITLE
P3: BrakIDPracyPoStroniePBN = alias PublicationNotFound (rozpoznanie 422 w paczce)

### DIFF
--- a/src/bpp/newsfragments/pbn-adopt-statement-helpers.feature.rst
+++ b/src/bpp/newsfragments/pbn-adopt-statement-helpers.feature.rst
@@ -1,0 +1,6 @@
+Narzędzie diagnostyczne ``pbn_test_wysylka_interaktywna`` korzysta teraz z
+pakietowych helperów ``pbn_client`` do dekodowania identyfikatora publikacji
+(``decode_publication_object_id``) oraz porównywania oświadczeń
+(``diff_statements`` + ``statement_key_*``). Przy niejednoznacznej odpowiedzi
+PBN (lista różna od jednego elementu) narzędzie głośno sygnalizuje błąd i pyta
+o kontynuację zamiast po cichu jechać dalej.

--- a/src/bpp/newsfragments/pbn-normalize-author.feature.rst
+++ b/src/bpp/newsfragments/pbn-normalize-author.feature.rst
@@ -1,0 +1,4 @@
+Normalizacja danych osobowych autora z PBN (``lastName``/``familyName`` oraz
+``firstName``/``givenNames``/``name``) korzysta teraz z ``pbn_client.normalize_author_name``
+— jedno źródło prawdy dla niespójnych kształtów PBN, obejmujące także pole
+``familyName``, którego wcześniejsza normalizacja rekordu PBN nie rozpoznawała.

--- a/src/bpp/newsfragments/pbn-publication-not-found.feature.rst
+++ b/src/bpp/newsfragments/pbn-publication-not-found.feature.rst
@@ -1,0 +1,7 @@
+Rozpoznanie „publikacja nie istnieje w PBN” (HTTP 422 „was not exists!”)
+odbywa się teraz RAZ w endpoincie pakietu ``pbn_client``
+(``get_publication_by_id`` rzuca ``PublicationNotFound``), a nie jest
+duplikowane w BPP. ``BrakIDPracyPoStroniePBN`` jest aliasem
+``PublicationNotFound`` (ta sama klasa), więc istniejące handlery działają bez
+zmian. Zwykły HTTP 404 świadomie NIE jest traktowany jako brak pracy (bywa
+przejściowy) i nie kasuje lokalnego cache'u publikacji.

--- a/src/pbn_api/exceptions.py
+++ b/src/pbn_api/exceptions.py
@@ -11,6 +11,7 @@ from pbn_client.exceptions import (
     PBNValidationError,
     PraceSerwisoweException,
     PublicationDoesNotExistInInstitutionProfile,
+    PublicationNotFound,
     ResourceLockedException,
     SciencistDoesNotExist,
     StatementsResendFailedException,
@@ -46,6 +47,7 @@ __all__ = [
     "PraceSerwisoweException",
     "PublikacjaInstytucjiV2NieZnalezionaException",
     "PublicationDoesNotExistInInstitutionProfile",
+    "PublicationNotFound",
     "ResourceLockedException",
     "SameDataUploadedRecently",
     "SciencistDoesNotExist",
@@ -75,8 +77,14 @@ class BrakZdefiniowanegoObiektuUczelniaWSystemieError(Exception):
     pass
 
 
-class BrakIDPracyPoStroniePBN(HttpException):
-    pass
+# Alias zgodności: to DOKŁADNIE ta sama klasa co pakietowy
+# ``pbn_client.PublicationNotFound`` (przypisanie, nie podklasa — ``is``),
+# żeby istniejące handlery ``except BrakIDPracyPoStroniePBN`` łapały wyjątek
+# rzucany RAZ w endpoincie paczki (``get_publication_by_id`` na PBN 422
+# „was not exists!”). Rozpoznanie nie jest już duplikowane w call-site'ach
+# BPP. Uwaga: to CO INNEGO niż ``BPPPublicationNotFound`` (brak rekordu po
+# stronie BPP, nie PBN).
+BrakIDPracyPoStroniePBN = PublicationNotFound
 
 
 class IntegracjaWylaczonaException(Exception):

--- a/src/pbn_api/management/commands/pbn_test_wysylka_interaktywna.py
+++ b/src/pbn_api/management/commands/pbn_test_wysylka_interaktywna.py
@@ -24,6 +24,7 @@ import time
 from typing import Any
 
 from django.core.management.base import CommandError
+from pbn_client import decode_publication_object_id
 
 from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Zwarte
 from bpp.util import zaloguj_polkniety_wyjatek
@@ -156,7 +157,9 @@ class Command(PBNBaseCommand):
             return
 
         pbn_statements = self._step_get_pbn_statements(pbn_client, object_id)
-        identyczne = self._step_compare_statements(publication, pbn_statements)
+        identyczne = self._step_compare_statements(
+            pbn_client, publication, pbn_statements
+        )
 
         # Zawsze pytamy osobno o DELETE i POST — nawet gdy identyczne.
         # Default zależy od wyniku porównania (False dla identycznych,
@@ -363,7 +366,7 @@ class Command(PBNBaseCommand):
         self._prompt_enter()
         return result
 
-    def _step_compare_statements(self, publication, pbn_statements):
+    def _step_compare_statements(self, pbn_client, publication, pbn_statements):
         self._header("KROK 6/8 — Porównanie: intencja BPP (live) vs PBN")
 
         # Intencja BPP: co wygenerowałby adapter GDYBY teraz wysłać — czyli
@@ -395,33 +398,16 @@ class Command(PBNBaseCommand):
             self._prompt_enter()
             return False  # traktujemy jak "różne"
 
-        def _key(stmt):
-            """Klucz porównania: (person-mongoId, disciplineNumer).
+        # Klucze porównania liczą pakietowe helpery klienta (jedno źródło
+        # prawdy): ``statement_key_pbn`` czyta format PBN GET (``personId``/
+        # ``area``), ``statement_key_intended`` — format adaptera
+        # (``personObjectId``/``disciplineId``). ``diff_statements`` zwraca
+        # (tylko-w-PBN, tylko-w-intencji); część wspólną liczymy tu lokalnie
+        # (paczka jej nie zwraca) na tych samych kluczach.
+        intended_keys = {pbn_client.statement_key_intended(x) for x in intended}
+        pbn_keys = {pbn_client.statement_key_pbn(x) for x in pbn_statements}
 
-            Mapowanie między formatami:
-            - PBN GET response (``/page/statements``): ``personId`` (mongoId),
-              ``area`` (string, numerek dyscypliny MNiSW np. "301").
-            - Adapter ``pbn_get_json_statements()`` (przed konwersją):
-              ``personObjectId`` (mongoId), ``disciplineId`` (int, numerek
-              dyscypliny MNiSW).
-            Oba oznaczają to samo.
-            """
-            if not isinstance(stmt, dict):
-                return (None, None)
-            person = stmt.get("personId") or stmt.get("personObjectId")
-            discipline = stmt.get("area")
-            if discipline is None:
-                discipline = stmt.get("disciplineId")
-            return (
-                str(person) if person else None,
-                str(discipline) if discipline is not None else "",
-            )
-
-        intended_keys = {_key(x) for x in intended}
-        pbn_keys = {_key(x) for x in pbn_statements}
-
-        only_intended = intended_keys - pbn_keys
-        only_pbn = pbn_keys - intended_keys
+        only_pbn, only_intended = pbn_client.diff_statements(pbn_statements, intended)
         common = intended_keys & pbn_keys
 
         self._info(f"Intencja BPP (live):          {len(intended_keys)}")
@@ -536,15 +522,32 @@ class Command(PBNBaseCommand):
     # ------------------------- helpers -------------------------
 
     def _extract_object_id(self, response, endpoint_choice):
-        if endpoint_choice == "publications":
-            if isinstance(response, dict):
-                return response.get("objectId")
-            return None
-        if isinstance(response, list) and len(response) == 1:
-            item = response[0]
-            if isinstance(item, dict):
-                return item.get("id") or item.get("objectId")
-        return None
+        """Dekoduje objectId z odpowiedzi POST-a przez pakietową
+        ``pbn_client.decode_publication_object_id``.
+
+        Mapowanie endpointa na tryb paczki:
+        - ``"publications"`` (all-in-one) → ``bez_oswiadczen=False``
+          (odpowiedź: ``{"objectId": ...}``),
+        - ``"repositorium"`` → ``bez_oswiadczen=True``
+          (odpowiedź: ``[{"id": ...}]``).
+
+        Przy niejednoznacznej odpowiedzi (lista != 1 element, zły typ, brak
+        klucza) paczka **rzuca wyjątkiem** zamiast po cichu zwracać None —
+        w tym rzadko używanym narzędziu diagnostycznym łapiemy to głośno,
+        pokazujemy surową odpowiedź i pytamy usera: wyjść czy jechać dalej
+        z ``objectId=None``.
+        """
+        bez_oswiadczen = endpoint_choice != "publications"
+        try:
+            return decode_publication_object_id(response, bez_oswiadczen=bez_oswiadczen)
+        except Exception as e:  # noqa: BLE001 — narzędzie debug: głośno + pytanie
+            self._err(f"Nie mogę zdekodować objectId z odpowiedzi PBN: {e}")
+            self.stdout.write(_json_truncated(response, max_len=800))
+            if self._prompt_yes_no(
+                "Kontynuować flow mimo to (objectId=None)?", default=False
+            ):
+                return None
+            raise UserAbort() from e
 
     def _print_http_request(self, method, url, body, label=""):
         self._info(f"Wywołanie: {label}" if label else "Żądanie HTTP:")

--- a/src/pbn_api/models/publication.py
+++ b/src/pbn_api/models/publication.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils.functional import cached_property
+from pbn_client import normalize_author_name
 
 from bpp import const
 from bpp.models.abstract import LinkDoPBNMixin
@@ -104,22 +105,15 @@ class Publication(LinkDoPBNMixin, BasePBNMongoDBModel):
     def _normalizuj_autora(autor):
         """Sprowadza pojedynczego autora z PBN do ``{lastName, firstName}``.
 
-        PBN podaje imię raz jako ``firstName``, raz jako ``givenNames``,
-        a w danych zaciągniętych z API instytucji jako ``name``. Czasem
-        zamiast słownika dostajemy goły UID (string) — wtedy nie mamy
-        danych osobowych i zwracamy puste pola (zamiast wysadzać szablon).
+        Deleguje wybór pól do ``pbn_client.normalize_author_name`` (jedno
+        źródło prawdy dla niespójnych kształtów PBN: ``lastName``/``familyName``
+        dla nazwiska, ``firstName``/``givenNames``/``name`` dla imienia; goły
+        UID lub inny nie-dict → brak danych). Paczka używa ``None`` jako
+        sentinela pustki — tu koerujemy go do ``""``, bo szablon rekordu i
+        ``str(autorzy)`` (logi) zakładają puste stringi, nie ``None``.
         """
-        if not isinstance(autor, dict):
-            return {"lastName": "", "firstName": ""}
-        return {
-            "lastName": autor.get("lastName") or "",
-            "firstName": (
-                autor.get("firstName")
-                or autor.get("givenNames")
-                or autor.get("name")
-                or ""
-            ),
-        }
+        normalized = normalize_author_name(autor)
+        return {klucz: (wartosc or "") for klucz, wartosc in normalized.items()}
 
     @cached_property
     def autorzy(self):

--- a/src/pbn_api/tests/test_pbn_test_wysylka_interaktywna.py
+++ b/src/pbn_api/tests/test_pbn_test_wysylka_interaktywna.py
@@ -627,3 +627,62 @@ def test_json_truncated_nie_obcina_krotkiego_tekstu():
     result = cmd_mod._json_truncated(small, max_len=100)
     assert "obcięto" not in result
     assert '"a": 1' in result
+
+
+@pytest.mark.django_db
+def test_niejednoznaczny_objectId_glosno_krzyczy_i_przerywa(
+    pbn_client,
+    pbn_wydawnictwo_zwarte_z_autorem_z_dyscyplina,
+    pbn_publication,
+    monkeypatch,
+):
+    """Repozytorium zwraca listę != 1 element → pakietowe
+    ``decode_publication_object_id`` rzuca zamiast po cichu zwracać None.
+
+    Narzędzie łapie to głośno (pokazuje błąd + surową odpowiedź) i pyta czy
+    kontynuować. Pod ``--yes-all`` pytanie idzie na default (False = nie) →
+    flow przerywany, zamiast jechać dalej z ``objectId=None``.
+    """
+    pbn_wydawnictwo_zwarte_z_autorem_z_dyscyplina.pbn_uid = pbn_publication
+    pbn_wydawnictwo_zwarte_z_autorem_z_dyscyplina.save()
+
+    _patch_get_client(monkeypatch, pbn_client)
+    _patch_intended_statements(monkeypatch, [])
+    # Dwa elementy — sytuacja niejednoznaczna (spodziewamy się dokładnie 1):
+    pbn_client.transport.return_values[PBN_POST_PUBLICATION_NO_STATEMENTS_URL] = [
+        {"id": pbn_publication.pk},
+        {"id": pbn_publication.pk},
+    ]
+    _patch_input(monkeypatch, ["2"])  # endpoint repozytoryjny
+
+    out = StringIO()
+    call_command(
+        "pbn_test_wysylka_interaktywna",
+        "--wydawnictwo-zwarte",
+        str(pbn_wydawnictwo_zwarte_z_autorem_z_dyscyplina.pk),
+        "--yes-all",
+        stdout=out,
+    )
+    output = out.getvalue()
+    assert "Nie mogę zdekodować objectId" in output
+    assert "Przerwano przez użytkownika." in output
+    # Nie dobił do GET oświadczeń (KROK 5) — przerwał już na dekodowaniu:
+    assert not any(
+        k.startswith(PBN_GET_INSTITUTION_STATEMENTS)
+        for k in pbn_client.transport.input_values
+    )
+
+
+def test_extract_object_id_niejednoznaczny_kontynuacja_zwraca_none(monkeypatch):
+    """Gałąź „kontynuuj mimo błędu": user zgadza się jechać dalej →
+    ``_extract_object_id`` zwraca None (zamiast rzucać UserAbort)."""
+    from django.core.management.base import OutputWrapper
+
+    cmd = cmd_mod.Command()
+    cmd.stdout = OutputWrapper(StringIO())
+    monkeypatch.setattr(cmd, "_prompt_yes_no", lambda *args, **kwargs: True)
+
+    result = cmd._extract_object_id(
+        [{"id": 1}, {"id": 2}], endpoint_choice="repositorium"
+    )
+    assert result is None

--- a/src/pbn_api/tests/test_publication_autorzy.py
+++ b/src/pbn_api/tests/test_publication_autorzy.py
@@ -68,6 +68,19 @@ def test_policz_autorow_dziala_dla_dict_kluczowanego_uidem():
 
 
 @pytest.mark.django_db
+def test_autorzy_nazwisko_z_familyName():
+    """Adopcja ``pbn_client.normalize_author_name``: nazwisko bywa podane
+
+    jako ``familyName`` (nie ``lastName``) — delegacja do paczki pokrywa
+    ten kształt, którego lokalna normalizacja wcześniej nie łapała.
+    """
+    pub = _publikacja({"authors": [{"familyName": "Abacki", "givenNames": "Ewa"}]})
+    autorzy = pub.autorzy["authors"]
+    assert autorzy[0]["lastName"] == "Abacki"
+    assert autorzy[0]["firstName"] == "Ewa"
+
+
+@pytest.mark.django_db
 def test_autorzy_goly_uid_bez_danych_osobowych_nie_wybucha():
     """Defensywnie: gdyby PBN podał listę samych UID-ów (stringów),
     nie wysadzamy się — zwracamy puste pola zamiast crashować szablon."""

--- a/src/pbn_import/management/commands/pbn_importuj_uid.py
+++ b/src/pbn_import/management/commands/pbn_importuj_uid.py
@@ -1,5 +1,7 @@
 """Import publikacji z PBN do BPP po PBN UID."""
 
+from pbn_client import normalize_author_name
+
 from pbn_api.exceptions import HttpException
 from pbn_api.management.commands.util import PBNBaseCommand
 from pbn_import.utils.command_helpers import (
@@ -86,9 +88,12 @@ class Command(PBNBaseCommand):
                 )
                 names = []
                 for p in persons_list[:5]:
-                    # PBN uses familyName/givenNames or lastName/name
-                    last = p.get("familyName") or p.get("lastName", "")
-                    first = p.get("givenNames") or p.get("name", "")
+                    # Jedno źródło prawdy dla niespójnych kształtów PBN
+                    # (familyName/lastName, firstName/givenNames/name); paczka
+                    # zwraca None dla braku — koerujemy do "" na potrzeby f-stringa.
+                    autor = normalize_author_name(p)
+                    last = autor["lastName"] or ""
+                    first = autor["firstName"] or ""
                     names.append(f"{last} {first}".strip())
                 if len(persons_list) > 5:
                     names.append(f"... (+{len(persons_list) - 5})")

--- a/src/pbn_integrator/tests/test_pobierz_pojedyncza_prace.py
+++ b/src/pbn_integrator/tests/test_pobierz_pojedyncza_prace.py
@@ -1,12 +1,13 @@
-"""Regresja: 422 „publication not exists" musi rzucać ``BrakIDPracyPoStroniePBN``.
+"""Kontrakt ``_pobierz_pojedyncza_prace`` wobec „praca nie istnieje w PBN”.
 
-Wcześniej ``_pobierz_pojedyncza_prace`` przy realnym 422-not-exists robiło
-``raise BrakIDPracyPoStroniePBN(e)`` — ale ta klasa dziedziczy po
-``HttpException`` (konstruktor ``(status_code, url, content)``), więc jedno-
-argumentowe wywołanie kończyło się ``TypeError`` ZANIM właściwy wyjątek został
-podniesiony. Dodatkowo ``e.content`` bywa ``bytes`` (``smart_content`` zwraca
-surowe bajty przy ``UnicodeDecodeError``), przez co samo ``... in e.content``
-rzucało ``TypeError`` jeszcze wcześniej.
+Po P3 rozpoznanie 422 „was not exists!” robi **RAZ** endpoint paczki
+(``pbn_client``'owy ``get_publication_by_id`` rzuca ``PublicationNotFound``).
+BPP nie duplikuje już tej detekcji — tylko **propaguje** wyjątek do handlerów.
+``BrakIDPracyPoStroniePBN`` jest aliasem ``PublicationNotFound`` (ta sama klasa),
+więc istniejące ``except BrakIDPracyPoStroniePBN`` łapią wyjątek z paczki.
+
+Decyzja 404: zwykły 404 NIE jest mapowany na „brak pracy” (bywa przejściowy) —
+leci dalej jako zwykły ``HttpException`` i nie kasuje lokalnego cache'u.
 """
 
 from unittest.mock import MagicMock
@@ -20,7 +21,53 @@ def _client_raising(exc):
     return client
 
 
-def test_422_not_exists_raises_brak_id_not_typeerror():
+def test_brak_id_to_alias_publication_not_found():
+    """Inwariant P3: to DOKŁADNIE ta sama klasa (``is``), nie podklasa."""
+    from pbn_api.exceptions import BrakIDPracyPoStroniePBN, PublicationNotFound
+
+    assert BrakIDPracyPoStroniePBN is PublicationNotFound
+
+
+def test_publication_not_found_z_paczki_propaguje_jako_brak_id():
+    """Paczka rzuca ``PublicationNotFound`` → BPP propaguje (== BrakID),
+
+    z zachowaniem pól HTTP (status/url/content).
+    """
+    from pbn_api.exceptions import BrakIDPracyPoStroniePBN, PublicationNotFound
+    from pbn_integrator.utils import publications
+
+    pub_id = "60a1f2c3d4e5f60718293a4b"
+    content = f"Publication with ID {pub_id} was not exists!"
+    exc = PublicationNotFound(422, "https://pbn/x", content)
+    with pytest.raises(BrakIDPracyPoStroniePBN) as ei:
+        publications._pobierz_pojedyncza_prace(_client_raising(exc), pub_id)
+    assert ei.value.status_code == 422
+    assert ei.value.url == "https://pbn/x"
+    assert ei.value.content == content
+
+
+def test_zwykly_404_nie_jest_brak_id():
+    """Decyzja P3: 404 (przejściowy) NIE jest „brak pracy” — leci jako
+
+    zwykły ``HttpException`` i nie triggeruje kasowania cache'u.
+    """
+    from pbn_api.exceptions import BrakIDPracyPoStroniePBN, HttpException
+    from pbn_integrator.utils import publications
+
+    pub_id = "60a1f2c3d4e5f60718293a4b"
+    exc = HttpException(404, "https://pbn/x", "Not Found")
+    with pytest.raises(HttpException) as ei:
+        publications._pobierz_pojedyncza_prace(_client_raising(exc), pub_id)
+    assert not isinstance(ei.value, BrakIDPracyPoStroniePBN)
+
+
+def test_goly_422_nie_jest_juz_re_detektowany_przez_bpp():
+    """Regresja P3: BPP NIE re-detektuje już markera w treści. Gdyby paczka
+
+    (wbrew kontraktowi) rzuciła goły ``HttpException`` z 422 zamiast
+    ``PublicationNotFound``, BPP propaguje go bez zmiany typu — rozpoznanie
+    jest odpowiedzialnością endpointu paczki, nie call-site'u BPP.
+    """
     from pbn_api.exceptions import BrakIDPracyPoStroniePBN, HttpException
     from pbn_integrator.utils import publications
 
@@ -28,30 +75,20 @@ def test_422_not_exists_raises_brak_id_not_typeerror():
     exc = HttpException(
         422, "https://pbn/x", f"Publication with ID {pub_id} was not exists!"
     )
-    with pytest.raises(BrakIDPracyPoStroniePBN):
+    with pytest.raises(HttpException) as ei:
         publications._pobierz_pojedyncza_prace(_client_raising(exc), pub_id)
+    assert not isinstance(ei.value, BrakIDPracyPoStroniePBN)
 
 
-def test_422_not_exists_with_bytes_content_raises_brak_id():
-    from pbn_api.exceptions import BrakIDPracyPoStroniePBN, HttpException
+def test_500_internal_server_error_zwraca_none():
+    """500 „Internal server error” to nie „brak pracy” — logujemy i zwracamy
+
+    ``None`` (praca do pominięcia, bez wysadzania batcha).
+    """
+    from pbn_api.exceptions import HttpException
     from pbn_integrator.utils import publications
 
     pub_id = "60a1f2c3d4e5f60718293a4b"
-    content = f"Publication with ID {pub_id} was not exists!".encode()
-    exc = HttpException(422, "https://pbn/x", content)
-    with pytest.raises(BrakIDPracyPoStroniePBN):
-        publications._pobierz_pojedyncza_prace(_client_raising(exc), pub_id)
-
-
-def test_brak_id_preserves_http_fields():
-    from pbn_api.exceptions import BrakIDPracyPoStroniePBN, HttpException
-    from pbn_integrator.utils import publications
-
-    pub_id = "60a1f2c3d4e5f60718293a4b"
-    content = f"Publication with ID {pub_id} was not exists!"
-    exc = HttpException(422, "https://pbn/x", content)
-    with pytest.raises(BrakIDPracyPoStroniePBN) as ei:
-        publications._pobierz_pojedyncza_prace(_client_raising(exc), pub_id)
-    assert ei.value.status_code == 422
-    assert ei.value.url == "https://pbn/x"
-    assert ei.value.content == content
+    exc = HttpException(500, "https://pbn/x", "Internal server error")
+    result = publications._pobierz_pojedyncza_prace(_client_raising(exc), pub_id)
+    assert result is None

--- a/src/pbn_integrator/utils/publications.py
+++ b/src/pbn_integrator/utils/publications.py
@@ -14,7 +14,11 @@ from bpp.const import PBN_MIN_ROK
 from bpp.models import Rekord
 from bpp.util import pbar
 from pbn_api.const import ACTIVE
-from pbn_api.exceptions import BrakIDPracyPoStroniePBN, HttpException
+from pbn_api.exceptions import (
+    BrakIDPracyPoStroniePBN,
+    HttpException,
+    PublicationNotFound,
+)
 from pbn_api.models import Publication, PublikacjaInstytucji_V2
 from pbn_integrator.utils.mongodb_ops import (
     pobierz_mongodb,
@@ -353,6 +357,14 @@ def _pobierz_pojedyncza_prace(client, publicationId):
     """
     try:
         data = client.get_publication_by_id(publicationId)
+    except PublicationNotFound:
+        # Rozpoznanie „praca nie istnieje w PBN” (422 „was not exists!”) robi
+        # RAZ endpoint paczki (``get_publication_by_id``) — tu tylko
+        # propagujemy do handlerów (``odswiez_tabele_publikacji`` kasuje lokalny
+        # cache; worker importu zwraca przyjazny per-item fail). ``PublicationNotFound``
+        # to alias ``BrakIDPracyPoStroniePBN`` — ta sama klasa. Świadomie NIE
+        # łapiemy zwykłego 404: bywa przejściowy, leci dalej jako ``HttpException``.
+        raise
     except HttpException as e:
         # ``e.content`` bywa ``bytes`` (``smart_content`` zwraca surowe bajty
         # przy ``UnicodeDecodeError``) — dekodujemy do str, żeby membership-test
@@ -360,15 +372,6 @@ def _pobierz_pojedyncza_prace(client, publicationId):
         content = e.content
         if isinstance(content, bytes):
             content = content.decode("utf-8", errors="replace")
-
-        if (
-            e.status_code == 422
-            and f"Publication with ID {publicationId} was not exists!" in content
-            # "was not exists" to oryginalna pisownia błędu z PBNu.
-        ):
-            # ``BrakIDPracyPoStroniePBN`` dziedziczy po ``HttpException`` —
-            # trzeba przekazać (status_code, url, content), nie sam wyjątek.
-            raise BrakIDPracyPoStroniePBN(e.status_code, e.url, e.content) from e
 
         if e.status_code == 500 and "Internal server error" in content:
             print(


### PR DESCRIPTION
Kontynuacja adopcji API PBN 0.2 (stack na #604). Centralizuje rozpoznanie
„publikacja nie istnieje w PBN" w endpoincie paczki i upraszcza BPP.

## Zmiana
Rozpoznanie **422 „was not exists!"** robi teraz **RAZ** endpoint paczki
(`pbn_client.get_publication_by_id` → `PublicationNotFound`), zamiast być
duplikowane w call-site BPP.

- **`pbn_api/exceptions.py`**: `BrakIDPracyPoStroniePBN` staje się **aliasem**
  `PublicationNotFound` (przypisanie, ta sama klasa, `is` — nie podklasa).
  Istniejące `except BrakIDPracyPoStroniePBN` (kasowanie cache w
  `odswiez_tabele_publikacji`, per-item fail w workerze importu) łapią wyjątek
  rzucany przez paczkę bez zmian. To **co innego** niż `BPPPublicationNotFound`
  (brak rekordu po stronie BPP).
- **`pbn_integrator/utils/publications.py`** (`_pobierz_pojedyncza_prace`):
  usunięto ręczną re-detekcję markera w treści; `PublicationNotFound`
  propagujemy, zwykły `HttpException` (w tym 404) leci dalej, 500 „Internal
  server error" nadal → `None`.

## Decyzja 404 (wg planu ekstrakcji)
Zwykły **404 bywa przejściowy** → **NIE** jest traktowany jako „brak pracy",
nie kasuje lokalnego cache'u. Ani paczka, ani BPP nie mapują 404 na
`PublicationNotFound` — tylko 422+marker.

## Testy (przepisane na nowy kontrakt)
- alias-identity (`BrakIDPracyPoStroniePBN is PublicationNotFound`),
- `PublicationNotFound` z paczki → propagacja jako BrakID (pola HTTP zachowane),
- **404 ≠ BrakID** (decyzja 404),
- goły 422 **nie jest już re-detektowany** przez BPP (rozpoznanie = odpowiedzialność paczki),
- 500 „Internal server error" → `None`.

## Weryfikacja
- `manage.py check`: OK
- `pytest src/pbn_integrator/tests/ src/pbn_api/tests/`: **540 passed**
- ruff check + format: clean

## Pozostało (świadomie wstrzymane)
`download_to_model`/`iter_pages` w getterach — osobny PR (zmienia ścieżkę
pobierania).

🤖 Generated with [Claude Code](https://claude.com/claude-code)