### PR TITLE
fix(security): XSS (ranking/admin), formula injection (eksport XLSX), zip-bomb (import JCR)

### DIFF
--- a/src/bpp/newsfragments/+sec-xlsx-formula-injection-rozbieznosci.bugfix.rst
+++ b/src/bpp/newsfragments/+sec-xlsx-formula-injection-rozbieznosci.bugfix.rst
@@ -1,0 +1,3 @@
+Bezpieczeństwo: eksport XLSX rozbieżności punktacji sanityzuje tytuły i nazwy
+źródeł zaczynające się od znaku formuły (``=``, ``+``, ``-``, ``@``) — chroni
+przed CSV/Formula Injection przy otwarciu pliku w Excelu/LibreOffice.

--- a/src/bpp/newsfragments/+sec-xss-import-ranking.bugfix.rst
+++ b/src/bpp/newsfragments/+sec-xss-import-ranking.bugfix.rst
@@ -1,0 +1,4 @@
+Bezpieczeństwo: nazwiska autorów pochodzące z importu (np. BibTeX) są teraz
+escapowane przy wyświetlaniu w rankingu autorów oraz w panelu admina importera
+publikacji — usunięto podatność stored XSS (surowa interpolacja do
+``mark_safe()``/``safe()`` zastąpiona przez ``format_html``).

--- a/src/bpp/newsfragments/+sec-zipbomb-import-jcr.bugfix.rst
+++ b/src/bpp/newsfragments/+sec-zipbomb-import-jcr.bugfix.rst
@@ -1,0 +1,3 @@
+Bezpieczeństwo: importer punktacji JCR (Clarivate) odrzuca pliki XLSX będące
+bombami dekompresyjnymi (zip-bomb) PRZED wczytaniem do pamięci — chroni workera
+importu przed wyczerpaniem pamięci (OOM).

--- a/src/import_punktacji_zrodel/parser.py
+++ b/src/import_punktacji_zrodel/parser.py
@@ -107,6 +107,13 @@ def wczytaj_plik_jcr(path: str) -> ParsedJCR:
     if path.lower().endswith(".csv"):
         rows = list(_iter_rows_csv(path))
     else:
+        # XLSX to archiwum ZIP — mała bomba dekompresyjna (~KB → GB) rozłożyłaby
+        # workera importu (OOM) już przy materializacji wierszy do listy niżej.
+        # Odrzucamy ją PRZED otwarciem pliku przez openpyxl (wspólny bezpiecznik
+        # z pozostałymi importerami XLSX w BPP).
+        from import_common.util import sprawdz_bombe_dekompresji
+
+        sprawdz_bombe_dekompresji(path)
         rows = list(_iter_rows_xlsx(path))
 
     hidx = _find_header_index(rows)

--- a/src/import_punktacji_zrodel/tests/test_parser.py
+++ b/src/import_punktacji_zrodel/tests/test_parser.py
@@ -1,8 +1,29 @@
+import zipfile
 from decimal import Decimal
 
 import pytest
 
+from import_common.exceptions import DecompressionBombException
 from import_punktacji_zrodel.parser import wczytaj_plik_jcr
+
+
+def test_odrzuca_bombe_dekompresji(tmp_path):
+    """XLSX-bomba (~KB na dysku, setki MB po rozpakowaniu) jest odrzucana PRZED
+    materializacją wierszy do listy — inaczej ubija workera importu (OOM).
+
+    Zapisujemy jeden silnie kompresowalny wpis (same zera) o zadeklarowanym
+    rozmiarze rozpakowanym powyżej ``MAX_ROZMIAR_PO_DEKOMPRESJI`` (500 MB),
+    streamując go 1-MB kawałkami — plik na dysku to kilkanaście KB, a w RAM
+    trzymamy naraz tylko jeden kawałek.
+    """
+    p = tmp_path / "bomba.xlsx"
+    with zipfile.ZipFile(str(p), "w", zipfile.ZIP_DEFLATED) as zf:
+        with zf.open("xl/worksheets/sheet1.xml", "w") as f:
+            chunk = b"\0" * (1024 * 1024)
+            for _ in range(520):  # 520 MB > 500 MB limit
+                f.write(chunk)
+    with pytest.raises(DecompressionBombException):
+        wczytaj_plik_jcr(str(p))
 
 
 @pytest.mark.parametrize("fmt", ["xlsx", "csv"])

--- a/src/importer_publikacji/admin.py
+++ b/src/importer_publikacji/admin.py
@@ -5,7 +5,7 @@ import json
 import logging
 
 from django.contrib import admin
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 
 from bpp.admin.core import DynamicAdminFilterMixin
@@ -208,20 +208,32 @@ class ImportSessionAdmin(DynamicAdminFilterMixin, admin.ModelAdmin):
 
             matched_str = " | ".join(matched_info) if matched_info else "-"
 
+            # format_html escapuje KAŻDĄ wartość dynamiczną. display_name oraz
+            # matched_str pochodzą z danych importu (BibTeX itp.) bez sanityzacji
+            # — surowa interpolacja do mark_safe() dawała stored XSS w adminie.
             rows.append(
-                f"<tr>"
-                f"<td>{author.order}</td>"
-                f'<td><span class="label {color}">{author.get_match_status_display()}</span></td>'
-                f"<td>{author.display_name}</td>"
-                f"<td>{matched_str}</td>"
-                f"</tr>"
+                format_html(
+                    "<tr>"
+                    "<td>{}</td>"
+                    '<td><span class="label {}">{}</span></td>'
+                    "<td>{}</td>"
+                    "<td>{}</td>"
+                    "</tr>",
+                    author.order,
+                    color,
+                    author.get_match_status_display(),
+                    author.display_name,
+                    matched_str,
+                )
             )
 
-        return mark_safe(
-            f'<table class="hover">'
-            f"<thead><tr><th>Lp.</th><th>Status</th><th>Nazwa</th><th>Dopasowano do</th></tr></thead>"
-            f"<tbody>{''.join(rows)}</tbody>"
-            f"</table>"
+        return format_html(
+            '<table class="hover">'
+            "<thead><tr><th>Lp.</th><th>Status</th><th>Nazwa</th>"
+            "<th>Dopasowano do</th></tr></thead>"
+            "<tbody>{}</tbody>"
+            "</table>",
+            format_html_join("", "{}", ((row,) for row in rows)),
         )
 
     authors_display.short_description = "Autorzy"

--- a/src/importer_publikacji/tests/test_admin.py
+++ b/src/importer_publikacji/tests/test_admin.py
@@ -37,6 +37,41 @@ def test_import_session_admin_list(admin_client, importer_user):
 
 
 @pytest.mark.django_db
+def test_authors_display_escapuje_html_w_nazwisku(importer_user):
+    """Audyt bezpieczeństwa: nazwisko importowanego autora z HTML nie może
+    trafić do panelu admina jako nieescapowany markup (stored XSS). Dane
+    autora pochodzą z pliku importu (BibTeX) bez sanityzacji.
+    """
+    from django.contrib.admin.sites import site
+
+    from importer_publikacji.admin import ImportSessionAdmin
+    from importer_publikacji.models import ImportedAuthor, ImportSession
+
+    session = ImportSession.objects.create(
+        created_by=importer_user,
+        provider_name="BibTeX",
+        identifier="xss_key",
+        status=ImportSession.Status.COMPLETED,
+        raw_data={},
+        normalized_data={},
+    )
+    ImportedAuthor.objects.create(
+        session=session,
+        order=0,
+        family_name="<img src=x onerror=alert(1)>",
+        given_name="Jan",
+        match_status=ImportedAuthor.MatchStatus.UNMATCHED,
+    )
+
+    html = str(ImportSessionAdmin(ImportSession, site).authors_display(session))
+
+    # Payload zescapowany, a nie żywy tag; legalny markup tabeli pozostaje.
+    assert "<img" not in html
+    assert "&lt;img" in html
+    assert "<td>" in html
+
+
+@pytest.mark.django_db
 def test_import_session_admin_detail(admin_client, importer_user):
     """Test szczegółów sesji importu w adminie."""
     from importer_publikacji.models import ImportedAuthor, ImportSession

--- a/src/ranking_autorow/test_xss.py
+++ b/src/ranking_autorow/test_xss.py
@@ -1,0 +1,30 @@
+"""Audyt bezpieczeństwa: stored XSS w publicznym rankingu autorów.
+
+``render_autor`` wstawiał nazwę autora do ``<a>`` i oznaczał całość jako
+bezpieczny HTML. Nazwisko autora (potencjalnie z importu bez sanityzacji)
+zawierające markup trafiało wtedy nieescapowane na PUBLICZNĄ, anonimową
+stronę rankingu.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from model_bakery import baker
+
+from ranking_autorow.views import RankingAutorowTable
+
+
+@pytest.mark.django_db
+def test_render_autor_escapuje_html_w_nazwisku():
+    autor = baker.make(
+        "bpp.Autor",
+        nazwisko="<img src=x onerror=alert(1)>",
+        imiona="Jan",
+    )
+    html = str(RankingAutorowTable([]).render_autor(SimpleNamespace(autor=autor)))
+
+    # Payload zescapowany, a nie wstrzyknięty jako żywy tag.
+    assert "<img" not in html
+    assert "&lt;img" in html
+    # Link (href z reverse()) nadal jest prawdziwym markupem.
+    assert html.startswith("<a ")

--- a/src/ranking_autorow/views.py
+++ b/src/ranking_autorow/views.py
@@ -4,9 +4,9 @@ from urllib.parse import urlencode
 from django.db.models import Q
 from django.db.models.aggregates import Sum
 from django.http.response import HttpResponseRedirect
-from django.template.defaultfilters import safe
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.html import format_html
 from django.views.generic.edit import FormView
 from django_tables2 import Column
 from django_tables2.export.views import ExportMixin
@@ -133,7 +133,10 @@ class RankingAutorowTable(Table):
 
     def render_autor(self, record):
         url = reverse("bpp:browse_autor", args=(record.autor.slug,))
-        return safe(f'<a href="{url}">{record.autor}</a>')
+        # format_html escapuje {record.autor} — nazwisko autora (potencjalnie
+        # z importu bez sanityzacji) nie może wstrzyknąć markupu na publiczną,
+        # anonimową stronę rankingu (stored XSS).
+        return format_html('<a href="{}">{}</a>', url, record.autor)
 
     def value_autor(self, record):
         return str(record.autor)

--- a/src/rozbieznosci/tests/test_views.py
+++ b/src/rozbieznosci/tests/test_views.py
@@ -1,8 +1,38 @@
+from io import BytesIO
+
 import pytest
 from django.urls import reverse
 from model_bakery import baker
+from openpyxl import load_workbook
 
 from rozbieznosci.models import IgnorowanaRozbieznosc
+
+
+@pytest.mark.django_db
+def test_export_sanityzuje_formula_injection(client_with_group):
+    """Eksport XLSX nie może zapisać tytułu/nazwy źródła zaczynających się od
+    znaku formuły (``=``) jako aktywnej formuły (CSV/Formula Injection) — muszą
+    zostać poprzedzone apostrofem przez ``sanitize_xlsx_row``.
+    """
+    zrodlo = baker.make("bpp.Zrodlo", nazwa="=cmd|'/c calc'!A1")
+    baker.make("bpp.Punktacja_Zrodla", zrodlo=zrodlo, rok=2023, impact_factor="2.500")
+    baker.make(
+        "bpp.Wydawnictwo_Ciagle",
+        zrodlo=zrodlo,
+        rok=2023,
+        impact_factor="1.500",
+        tytul_oryginalny='=HYPERLINK("http://evil.example","kliknij")',
+    )
+    url = reverse("rozbieznosci:export", kwargs={"metryka": "if"})
+    resp = client_with_group.get(url)
+    assert resp.status_code == 200
+
+    ws = load_workbook(BytesIO(resp.content)).active
+    tytul, _rok, _wart_pracy, zrodlo_nazwa, _wart_zrodla = next(
+        ws.iter_rows(min_row=2, values_only=True)
+    )
+    assert tytul.startswith("'=")
+    assert zrodlo_nazwa.startswith("'=")
 
 
 @pytest.mark.django_db

--- a/src/rozbieznosci/views.py
+++ b/src/rozbieznosci/views.py
@@ -13,7 +13,11 @@ from django.views.generic import ListView
 from openpyxl import Workbook
 
 from bpp.models import Charakter_Formalny, Uczelnia, Wydawnictwo_Ciagle
-from bpp.util import worksheet_columns_autosize, worksheet_create_table
+from bpp.util import (
+    sanitize_xlsx_row,
+    worksheet_columns_autosize,
+    worksheet_create_table,
+)
 from bpp.util.uczelnia_scope import tylko_jedna_uczelnia
 from rozbieznosci.core import (
     DEFAULT_SORT,
@@ -260,13 +264,15 @@ class RozbieznosciExportView(MetrykaMixin, GroupRequiredMixin, View):
             else:
                 wartosc_zrodla = f"brak wpisu za {elem.rok}"
             ws.append(
-                [
-                    elem.tytul_oryginalny,
-                    elem.rok,
-                    float(v) if v else 0,
-                    elem.zrodlo.nazwa if elem.zrodlo else "",
-                    wartosc_zrodla,
-                ]
+                sanitize_xlsx_row(
+                    [
+                        elem.tytul_oryginalny,
+                        elem.rok,
+                        float(v) if v else 0,
+                        elem.zrodlo.nazwa if elem.zrodlo else "",
+                        wartosc_zrodla,
+                    ]
+                )
             )
 
         worksheet_columns_autosize(ws)


### PR DESCRIPTION
Trzy poprawki bezpieczeństwa z audytu (uwagi #2, #7, #8). Każda pod testem TDD (RED→GREEN), wykorzystuje **istniejące** helpery w repo.

## #2 — HIGH: stored XSS z danych importowanych
Nazwiska autorów pochodzące z importu (BibTeX itd.) trafiały nieescapowane do HTML oznaczonego jako `safe`:
- **publiczny, anonimowy ranking autorów** (`ranking_autorow/views.py` `render_autor`) — najgroźniejszy wektor,
- **panel admina importera** (`importer_publikacji/admin.py` `authors_display`).

Naprawa: surowa interpolacja do `safe()`/`mark_safe()` zastąpiona przez `format_html` / `format_html_join` (escapują każdą wartość dynamiczną: `display_name`, `str(autor)`, `matched_str`).

Testy: `ranking_autorow/test_xss.py`, `importer_publikacji/tests/test_admin.py::test_authors_display_escapuje_html_w_nazwisku` — payload `<img onerror>` wychodzi jako `&lt;img…`.

## #7 — MEDIUM: CSV/Formula Injection w eksporcie XLSX rozbieżności
`rozbieznosci/views.py` wpisywał `tytul_oryginalny` i `zrodlo.nazwa` do `ws.append()` surowo → wartość `=HYPERLINK(...)` zapisywana jako aktywna formuła. Wiersz owinięty w istniejący `bpp.util.sanitize_xlsx_row()`.

Test: `rozbieznosci/tests/test_views.py::test_export_sanityzuje_formula_injection`.

## #8 — MEDIUM: zip-bomb w importerze punktacji JCR
`import_punktacji_zrodel/parser.py` (`wczytaj_plik_jcr`) otwierał XLSX i materializował wszystkie wiersze do listy bez sprawdzenia bomby dekompresyjnej (formularz walidował tylko rozszerzenie). Dodane wywołanie istniejącego `import_common.util.sprawdz_bombe_dekompresji()` PRZED otwarciem pliku — spójne z pozostałymi importerami XLSX.

Test: `import_punktacji_zrodel/tests/test_parser.py::test_odrzuca_bombe_dekompresji`.

## Uwaga #4 (release pipeline) — poza tym PR
Uwaga #4 (nieprzypięty `trivy:latest`/`buildx lab:latest`/`uvx`) to hardening CI, nie kod aplikacji — zostawiona jako osobny follow-up.

## Testy
- Dotknięte suity: `rozbieznosci`, `import_punktacji_zrodel`, `ranking_autorow` → **120 passed**; `importer_publikacji/tests/test_admin.py` → passed.
- `ruff check` / `ruff format --check` / `pre-commit` — czysto.
- Brak migracji → baseline bez zmian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)