### PR TITLE
Odchudź shimy PBN (usuń pbn_api.const/utils/client.transport)

### DIFF
--- a/src/bpp/admin/filters.py
+++ b/src/bpp/admin/filters.py
@@ -5,10 +5,10 @@ from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, F, IntegerField, Max, Q
 from django.db.models.functions import Cast
+from pbn_client.const import ACTIVE, DELETED
 
 from bpp.models import BppUser, Uczelnia, Wydawnictwo_Zwarte
 from bpp.models.struktura import Jednostka
-from pbn_api.const import ACTIVE, DELETED
 
 
 class SimpleIntegerFilter(SimpleListFilter):

--- a/src/bpp/newsfragments/pbn-slim-shims.doc.rst
+++ b/src/bpp/newsfragments/pbn-slim-shims.doc.rst
@@ -1,0 +1,6 @@
+Usunięto trzy zbędne shimy zgodności (``pbn_api.const``, ``pbn_api.utils``,
+``pbn_api.client.transport``) — czyste re-eksporty z pakietów PBN. Kod importuje
+teraz stałe, helpery słownikowe i transport wprost z ``pbn_client`` (spójnie z
+resztą kodu po ekstrakcji). Warstwa zgodności ``pbn_api.exceptions`` oraz baza
+modeli ``pbn_api.models.base`` pozostają (mają zawartość BPP-specific / stanowią
+punkt rozszerzeń).

--- a/src/bpp/tests/test_autocomplete/test_autocomplete_publications.py
+++ b/src/bpp/tests/test_autocomplete/test_autocomplete_publications.py
@@ -10,6 +10,7 @@ This module contains tests for:
 
 import pytest
 from model_bakery import baker
+from pbn_client.const import PBN_GET_JOURNAL_BY_ID
 
 from bpp.const import PBN_UID_LEN
 from bpp.models.konferencja import Konferencja
@@ -29,7 +30,6 @@ from fixtures.pbn_api import (
     pbn_publisher_json,
 )
 from pbn_api.client import PBN_GET_PUBLICATION_BY_ID_URL, PBN_SEARCH_PUBLICATIONS_URL
-from pbn_api.const import PBN_GET_JOURNAL_BY_ID
 from pbn_api.models import Journal, Publication, Publisher
 
 

--- a/src/importer_publikacji/providers/pbn.py
+++ b/src/importer_publikacji/providers/pbn.py
@@ -41,9 +41,9 @@ def _get_pbn_client(uczelnia):
     """
     from django.conf import settings
     from pbn_client.conf import settings as pbn_defaults
+    from pbn_client.transport import RequestsTransport
 
     from pbn_api.client import PBNClient
-    from pbn_api.client.transport import RequestsTransport
     from pbn_api.reporting import rollbar_reporter
 
     if not uczelnia or not all(

--- a/src/pbn_api/client/publication_sync.py
+++ b/src/pbn_api/client/publication_sync.py
@@ -9,14 +9,15 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.mail import mail_admins
 from django.db import transaction
 from django.db.models import Model
+from pbn_client.const import (
+    PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
+    PBN_POST_PUBLICATIONS_URL,
+)
+from pbn_client.statements import StatementsMixin
 
 from pbn_api.adapters.wydawnictwo import (
     OplataZaWydawnictwoPBNAdapter,
     WydawnictwoPBNAdapter,
-)
-from pbn_api.const import (
-    PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
-    PBN_POST_PUBLICATIONS_URL,
 )
 from pbn_api.exceptions import (
     CannotDeleteStatementsException,
@@ -35,7 +36,6 @@ from pbn_api.exceptions import (
 )
 from pbn_api.models.pbn_odpowiedzi_niepozadane import PBNOdpowiedziNiepozadane
 from pbn_api.models.sentdata import SentData
-from pbn_client.statements import StatementsMixin
 
 logger = logging.getLogger(__name__)
 

--- a/src/pbn_api/client/transport.py
+++ b/src/pbn_api/client/transport.py
@@ -1,6 +1,0 @@
-"""Shim kompatybilnościowy — transport przeniesiony do ``pbn_client.transport``.
-
-Patrz: docs/superpowers/specs/2026-06-02-pbn-client-split-design.md
-"""
-
-from pbn_client.transport import *  # noqa: F401,F403

--- a/src/pbn_api/const.py
+++ b/src/pbn_api/const.py
@@ -1,6 +1,0 @@
-"""Shim kompatybilnościowy — stałe przeniesione do ``pbn_client.const``.
-
-Patrz: docs/superpowers/specs/2026-06-02-pbn-client-split-design.md
-"""
-
-from pbn_client.const import *  # noqa: F401,F403

--- a/src/pbn_api/management/commands/pbn_test_wysylka_interaktywna.py
+++ b/src/pbn_api/management/commands/pbn_test_wysylka_interaktywna.py
@@ -25,17 +25,17 @@ from typing import Any
 
 from django.core.management.base import CommandError
 from pbn_client import decode_publication_object_id
-
-from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Zwarte
-from bpp.util import zaloguj_polkniety_wyjatek
-from pbn_api.adapters.wydawnictwo import WydawnictwoPBNAdapter
-from pbn_api.const import (
+from pbn_client.const import (
     PBN_DELETE_PUBLICATION_STATEMENT,
     PBN_GET_INSTITUTION_STATEMENTS,
     PBN_POST_INSTITUTION_STATEMENTS_URL,
     PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
     PBN_POST_PUBLICATIONS_URL,
 )
+
+from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Zwarte
+from bpp.util import zaloguj_polkniety_wyjatek
+from pbn_api.adapters.wydawnictwo import WydawnictwoPBNAdapter
 from pbn_api.exceptions import (
     AccessDeniedException,
     DaneLokalneWymagajaAktualizacjiException,

--- a/src/pbn_api/models/sentdata.py
+++ b/src/pbn_api/models/sentdata.py
@@ -4,10 +4,10 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import JSONField
 from django.utils import timezone
+from pbn_client.dict_utils import compare_dicts
 
 from bpp import const
 from bpp.models import LinkDoPBNMixin
-from pbn_api.utils import compare_dicts
 
 
 class SentDataManager(models.Manager):

--- a/src/pbn_api/tests/test_bpp_admin_helpers.py
+++ b/src/pbn_api/tests/test_bpp_admin_helpers.py
@@ -1,6 +1,12 @@
 import pytest
 from django.contrib.messages import get_messages
 from model_bakery import baker
+from pbn_client.const import (
+    PBN_GET_INSTITUTION_PUBLICATIONS_V2,
+    PBN_POST_INSTITUTION_STATEMENTS_URL,
+    PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
+    PBN_POST_PUBLICATIONS_URL,
+)
 
 from bpp.admin.helpers.pbn_api.gui import sprobuj_wyslac_do_pbn_gui
 from bpp.models import Charakter_Formalny, Wydawnictwo_Ciagle
@@ -14,12 +20,6 @@ from pbn_api.adapters.wydawnictwo import WydawnictwoPBNAdapter
 from pbn_api.client import (
     PBN_GET_INSTITUTION_STATEMENTS,
     PBN_GET_PUBLICATION_BY_ID_URL,
-)
-from pbn_api.const import (
-    PBN_GET_INSTITUTION_PUBLICATIONS_V2,
-    PBN_POST_INSTITUTION_STATEMENTS_URL,
-    PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
-    PBN_POST_PUBLICATIONS_URL,
 )
 from pbn_api.exceptions import AccessDeniedException, PBNValidationError
 from pbn_api.models import Publication, SentData

--- a/src/pbn_api/tests/test_client_disciplines.py
+++ b/src/pbn_api/tests/test_client_disciplines.py
@@ -9,10 +9,10 @@ For helper/GUI tests, see test_client_helpers.py
 from pathlib import Path
 
 import pytest
+from pbn_client.const import PBN_GET_DISCIPLINES_URL
 
 from bpp.decorators import json
 from bpp.models import Dyscyplina_Naukowa
-from pbn_api.const import PBN_GET_DISCIPLINES_URL
 from pbn_api.models import TlumaczDyscyplin
 from pbn_api.models.discipline import Discipline
 

--- a/src/pbn_api/tests/test_client_extended.py
+++ b/src/pbn_api/tests/test_client_extended.py
@@ -69,7 +69,7 @@ def test_pbn_client_transport_initialization():
 
 def test_pbn_client_transport_default_base_url():
     """Test PBNClientTransport uses default URL when None provided"""
-    from pbn_api.const import DEFAULT_BASE_URL
+    from pbn_client.const import DEFAULT_BASE_URL
 
     transport = PBNClientTransport("app_id", "app_token", None)
 

--- a/src/pbn_api/tests/test_client_helpers.py
+++ b/src/pbn_api/tests/test_client_helpers.py
@@ -9,6 +9,11 @@ For discipline tests, see test_client_disciplines.py
 import pytest
 from django.contrib.messages import get_messages
 from model_bakery import baker
+from pbn_client.const import (
+    PBN_GET_INSTITUTION_PUBLICATIONS_V2,
+    PBN_POST_INSTITUTION_STATEMENTS_URL,
+    PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
+)
 
 from bpp.admin.helpers.pbn_api.gui import sprobuj_wyslac_do_pbn_gui
 from fixtures.pbn_api import (
@@ -20,11 +25,6 @@ from pbn_api.adapters.wydawnictwo import WydawnictwoPBNAdapter
 from pbn_api.client import (
     PBN_GET_INSTITUTION_STATEMENTS,
     PBN_GET_PUBLICATION_BY_ID_URL,
-)
-from pbn_api.const import (
-    PBN_GET_INSTITUTION_PUBLICATIONS_V2,
-    PBN_POST_INSTITUTION_STATEMENTS_URL,
-    PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
 )
 from pbn_api.models import Institution, Publication
 from pbn_api.tests.utils import middleware

--- a/src/pbn_api/tests/test_client_sync.py
+++ b/src/pbn_api/tests/test_client_sync.py
@@ -24,6 +24,13 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pbn_client.const import (
+    PBN_GET_INSTITUTION_PUBLICATIONS_V2,
+    PBN_POST_INSTITUTION_STATEMENTS_URL,
+    PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
+    PBN_POST_PUBLICATIONS_URL,
+)
+from pbn_client.exceptions import PBNValidationError
 
 from fixtures.pbn_api import (
     MOCK_RETURNED_INSTITUTION_PUBLICATION_V2_DATA,
@@ -36,19 +43,12 @@ from pbn_api.client import (
     PBN_GET_INSTITUTION_STATEMENTS,
     PBN_GET_PUBLICATION_BY_ID_URL,
 )
-from pbn_api.const import (
-    PBN_GET_INSTITUTION_PUBLICATIONS_V2,
-    PBN_POST_INSTITUTION_STATEMENTS_URL,
-    PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
-    PBN_POST_PUBLICATIONS_URL,
-)
 from pbn_api.exceptions import (
     HttpException,
     PKZeroExportDisabled,
     StatementsResendFailedException,
 )
 from pbn_api.models import Publication, SentData
-from pbn_client.exceptions import PBNValidationError
 
 
 def _patch_intended_statements(monkeypatch, statements):

--- a/src/pbn_api/tests/test_client_upload.py
+++ b/src/pbn_api/tests/test_client_upload.py
@@ -8,15 +8,15 @@ For helper/GUI tests, see test_client_helpers.py
 
 import pytest
 from model_bakery import baker
+from pbn_client.const import (
+    PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
+    PBN_POST_PUBLICATIONS_URL,
+)
 
 from pbn_api.adapters.wydawnictwo import WydawnictwoPBNAdapter
 from pbn_api.client import (
     PBN_DELETE_PUBLICATION_STATEMENT,
     PBN_GET_INSTITUTION_STATEMENTS,
-)
-from pbn_api.const import (
-    PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
-    PBN_POST_PUBLICATIONS_URL,
 )
 from pbn_api.exceptions import SameDataUploadedRecently, StatementsMissing
 from pbn_api.models import Publication, SentData
@@ -123,9 +123,9 @@ def test_PBNClient_test_upload_publication_bez_statements_idzie_do_repo(
 
     # Body wysłane do /v1/repositorium/publications: lista, BEZ statements,
     # po konwersji pól (givenNames → firstName).
-    sent_body = pbn_client.transport.input_values[PBN_POST_PUBLICATION_NO_STATEMENTS_URL][
-        "body"
-    ]
+    sent_body = pbn_client.transport.input_values[
+        PBN_POST_PUBLICATION_NO_STATEMENTS_URL
+    ]["body"]
     assert isinstance(sent_body, list) and len(sent_body) == 1
     assert "statements" not in sent_body[0]
     assert "firstName" in sent_body[0]["authors"][0]
@@ -162,12 +162,13 @@ def test_PBNClient_post_publication_no_statements(
     Uczelnia z ``pbn_wysylaj_bez_oswiadczen=True`` pozwala na wysyłkę prac
     bez oświadczeń (inaczej adapter rzuca StatementsMissing w pbn_get_json).
     """
-    from fixtures.pbn_api import MOCK_RETURNED_MONGODB_DATA
-    from pbn_api.client import PBN_GET_PUBLICATION_BY_ID_URL
-    from pbn_api.const import (
+    from pbn_client.const import (
         PBN_GET_INSTITUTION_PUBLICATIONS_V2,
         PBN_GET_INSTITUTION_STATEMENTS,
     )
+
+    from fixtures.pbn_api import MOCK_RETURNED_MONGODB_DATA
+    from pbn_api.client import PBN_GET_PUBLICATION_BY_ID_URL
 
     uczelnia.pbn_wysylaj_bez_oswiadczen = True
     uczelnia.save()

--- a/src/pbn_api/tests/test_pbn_test_wysylka_interaktywna.py
+++ b/src/pbn_api/tests/test_pbn_test_wysylka_interaktywna.py
@@ -10,15 +10,15 @@ from io import StringIO
 import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
-
-from fixtures.pbn_api import pbn_pageable_json
-from pbn_api.const import (
+from pbn_client.const import (
     PBN_DELETE_PUBLICATION_STATEMENT,
     PBN_GET_INSTITUTION_STATEMENTS,
     PBN_POST_INSTITUTION_STATEMENTS_URL,
     PBN_POST_PUBLICATION_NO_STATEMENTS_URL,
     PBN_POST_PUBLICATIONS_URL,
 )
+
+from fixtures.pbn_api import pbn_pageable_json
 from pbn_api.exceptions import HttpException
 from pbn_api.management.commands import pbn_test_wysylka_interaktywna as cmd_mod
 

--- a/src/pbn_api/tests/test_utils.py
+++ b/src/pbn_api/tests/test_utils.py
@@ -1,4 +1,4 @@
-from pbn_api.utils import rename_dict_key
+from pbn_client.dict_utils import rename_dict_key
 
 
 def test_rename_dict_key_simple():

--- a/src/pbn_api/utils.py
+++ b/src/pbn_api/utils.py
@@ -1,6 +1,0 @@
-"""Shim kompatybilnościowy — helpery przeniesione do ``pbn_client.dict_utils``.
-
-Patrz: docs/superpowers/specs/2026-06-02-pbn-client-split-design.md
-"""
-
-from pbn_client.dict_utils import *  # noqa: F401,F403

--- a/src/pbn_export_queue/views/detail_views.py
+++ b/src/pbn_export_queue/views/detail_views.py
@@ -150,8 +150,9 @@ class PBNExportQueueDetailView(
         if sent_data.api_url:
             return sent_data.api_url
 
+        from pbn_client.const import PBN_POST_PUBLICATION_NO_STATEMENTS_URL
+
         from bpp.models import Uczelnia
-        from pbn_api.const import PBN_POST_PUBLICATION_NO_STATEMENTS_URL
 
         uczelnia = Uczelnia.objects.get_for_request(self.request)
         if uczelnia and uczelnia.pbn_api_root:

--- a/src/pbn_integrator/importer/__init__.py
+++ b/src/pbn_integrator/importer/__init__.py
@@ -6,11 +6,11 @@ in importer.py are re-exported here.
 
 import logging
 
+from pbn_client.const import DELETED
 from tqdm import tqdm
 
 from bpp.models import Dyscyplina_Naukowa, Jednostka, Rekord, Rodzaj_Zrodla
 from pbn_api.client import PBNClient
-from pbn_api.const import DELETED
 from pbn_api.models import Publication
 
 # Re-export publication import functions

--- a/src/pbn_integrator/importer/publishers.py
+++ b/src/pbn_integrator/importer/publishers.py
@@ -4,11 +4,11 @@ import logging
 
 from django.core.management import call_command
 from django.db import transaction
+from pbn_client.const import DELETED
 
 from bpp import const
 from bpp.models import Wydawca
 from bpp.models.wydawca import Poziom_Wydawcy
-from pbn_api.const import DELETED
 from pbn_api.models import Publisher
 from pbn_integrator.utils import zapisz_mongodb
 

--- a/src/pbn_integrator/utils/institutions.py
+++ b/src/pbn_integrator/utils/institutions.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pbn_client.const import ACTIVE, DELETED
+
 from bpp.models import Jednostka, Uczelnia
-from pbn_api.const import ACTIVE, DELETED
 from pbn_api.models import Institution
 from pbn_integrator.utils.mongodb_ops import pobierz_mongodb, zapisz_mongodb
 from pbn_integrator.utils.threaded_page_getter import (

--- a/src/pbn_integrator/utils/journals.py
+++ b/src/pbn_integrator/utils/journals.py
@@ -7,10 +7,10 @@ from functools import reduce
 from typing import TYPE_CHECKING
 
 from django.db.models import F, Func, IntegerField, Q
+from pbn_client.const import ACTIVE, DELETED
 
 from bpp.models import Zrodlo
 from bpp.util import pbar
-from pbn_api.const import ACTIVE, DELETED
 from pbn_api.models import Journal
 from pbn_integrator.utils.threaded_page_getter import (
     ThreadedMongoDBSaver,

--- a/src/pbn_integrator/utils/odswiez_tabele_publikacji.py
+++ b/src/pbn_integrator/utils/odswiez_tabele_publikacji.py
@@ -1,4 +1,5 @@
-from pbn_api.const import DELETED
+from pbn_client.const import DELETED
+
 from pbn_api.exceptions import BrakIDPracyPoStroniePBN
 
 

--- a/src/pbn_integrator/utils/offline_data.py
+++ b/src/pbn_integrator/utils/offline_data.py
@@ -7,9 +7,9 @@ import os
 from typing import TYPE_CHECKING
 
 from django.db import transaction
+from pbn_client.const import ACTIVE, DELETED
 
 from bpp.util import pbar
-from pbn_api.const import ACTIVE, DELETED
 from pbn_api.models import Publication, Scientist
 from pbn_integrator.utils.mongodb_ops import pobierz_mongodb
 from pbn_integrator.utils.multiprocessing_utils import (

--- a/src/pbn_integrator/utils/pobierz_skasowane_prace.py
+++ b/src/pbn_integrator/utils/pobierz_skasowane_prace.py
@@ -42,7 +42,7 @@ def pobierz_skasowane_prace(client):
 
     from multiprocessing import Pool
 
-    from pbn_api.const import DELETED
+    from pbn_client.const import DELETED
 
     from bpp.util import pbar
 

--- a/src/pbn_integrator/utils/publications.py
+++ b/src/pbn_integrator/utils/publications.py
@@ -8,12 +8,12 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING
 
 import rollbar
+from pbn_client.const import ACTIVE
 from tqdm import tqdm
 
 from bpp.const import PBN_MIN_ROK
 from bpp.models import Rekord
 from bpp.util import pbar
-from pbn_api.const import ACTIVE
 from pbn_api.exceptions import (
     BrakIDPracyPoStroniePBN,
     HttpException,

--- a/src/pbn_integrator/utils/scientists.py
+++ b/src/pbn_integrator/utils/scientists.py
@@ -11,10 +11,10 @@ from typing import TYPE_CHECKING
 import rollbar
 from django.db import IntegrityError, transaction
 from django.db.models import Q
+from pbn_client.const import DELETED
 
 from bpp.models import Autor, Autor_Dyscyplina, Tytul, Uczelnia
 from bpp.util import pbar
-from pbn_api.const import DELETED
 from pbn_api.models import Scientist
 from pbn_integrator.utils.constants import CPU_COUNT
 from pbn_integrator.utils.django_imports import _ensure_django_imports

--- a/src/przemapuj_zrodla_pbn/views.py
+++ b/src/przemapuj_zrodla_pbn/views.py
@@ -7,11 +7,11 @@ from django.contrib.postgres.search import TrigramSimilarity
 from django.db import models, transaction
 from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404, redirect, render
+from pbn_client.const import ACTIVE, DELETED
 
 from bpp.models import Rekord, Rodzaj_Zrodla, Uczelnia, Wydawnictwo_Ciagle, Zrodlo
 from bpp.permissions import wprowadzanie_danych_wymagane
 from bpp.util import zaloguj_polkniety_wyjatek
-from pbn_api.const import ACTIVE, DELETED
 from pbn_api.models import Journal
 from pbn_export_queue.models import PBN_Export_Queue
 


### PR DESCRIPTION
Pierwszy z trzech zaplanowanych elementów (kolejność: **shimy → P4 → Faza 3**).
Stack na #607.

## Co i dlaczego
Po ekstrakcji kodu klienta PBN na PyPI trzy pliki w `pbn_api` zostały jako
**czyste re-eksporty** (`from pbn_client.X import *`) — zbędna warstwa pośrednia.
Usunięte, a callery repointowane wprost na paczkę (spójnie z resztą kodu, który
już importuje z `pbn_client`/`django_pbn_client`):

| Usunięty shim | Repoint callerów | # |
|---|---|---|
| `pbn_api/const.py` | `from pbn_client.const import …` | 22 |
| `pbn_api/utils.py` | `from pbn_client.dict_utils import …` | 2 |
| `pbn_api/client/transport.py` | `from pbn_client.transport import …` | 1 |

## Zostawione świadomie
- **`pbn_api/exceptions.py`** — hybryda: definiuje wyjątki BPP-specific + hostuje
  alias `BrakIDPracyPoStroniePBN = PublicationNotFound` (z #606).
- **`pbn_api/models/base.py`** — seam pod przyszłą **Fazę 3** (abstrakcyjne modele
  encji); kasowanie teraz = churn delete-then-recreate.

## Charakter
Czysto mechaniczne — tylko podmiana ścieżki modułu, importowane nazwy bez zmian.
Wszystkie 25 nazw istnieją publicznie w docelowych modułach `pbn_client`.

## Review (sub-agenty, jak w reszcie stacka)
- **fable**: PASS — per-item weryfikacja (brak pominiętych callerów, nazwy
  istnieją, zero churn, `base.py`/`exceptions.py` nietknięte).
- **codex**: SHIP — brak defektów (brak stale-callerów, prywatnych nazw, kolizji).

## Weryfikacja
- `manage.py check`: OK
- `pytest src/pbn_api/tests/`: **339 passed**
- ruff: zero **nowych** naruszeń (pre-existing F401/I001/UP012 w tkniętych
  plikach świadomie nie ruszane — poza zakresem shimów; „Lint changed files"
  jest non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)