### PR TITLE
fix(security): hardening z równoległego security review (6 findingów)

### DIFF
--- a/src/api_v1/tests/test_autor_pii_anon.py
+++ b/src/api_v1/tests/test_autor_pii_anon.py
@@ -160,3 +160,43 @@ def test_anon_filtrowanie_po_nazwisku_dziala(autor_jan_kowalski):
     """Fix nie może zepsuć istniejącego filtrowania po nazwisku."""
     res = APIClient().get(reverse("api_v1:autor-list") + "?nazwisko=kowal")
     assert res.json()["count"] == 1
+
+
+@pytest.mark.django_db
+def test_anon_nie_widzi_zatrudnienia_ukrytego_autora():
+    """``/api/v1/autor_jednostka/`` nie może ujawniać powiązań zatrudnienia
+    autora ukrytego (``pokazuj=False``). Inaczej jednostka, daty pracy oraz
+    PK autora wyciekają anonimowi, obchodząc ``pokazuj=False`` egzekwowane
+    przez ``AutorViewSet``."""
+    from bpp.models import Autor_Jednostka, Jednostka
+
+    jednostka = baker.make(Jednostka)
+    widoczny = baker.make(Autor, nazwisko="Widoczny", pokazuj=True)
+    ukryty = baker.make(Autor, nazwisko="Ukryty", pokazuj=False)
+    baker.make(Autor_Jednostka, autor=widoczny, jednostka=jednostka)
+    baker.make(Autor_Jednostka, autor=ukryty, jednostka=jednostka)
+
+    res = APIClient().get(reverse("api_v1:autor_jednostka-list"))
+    autor_urls = {row["autor"] for row in res.json()["results"]}
+    ukryty_url = reverse("api_v1:autor-detail", args=(ukryty.pk,))
+    widoczny_url = reverse("api_v1:autor-detail", args=(widoczny.pk,))
+
+    assert any(widoczny_url in u for u in autor_urls)
+    assert not any(ukryty_url in u for u in autor_urls)
+
+
+@pytest.mark.django_db
+def test_zalogowany_widzi_zatrudnienie_ukrytego_autora():
+    """Regresja w drugą stronę: zalogowany (redaktor) widzi powiązania
+    zatrudnienia także autorów ukrytych."""
+    from bpp.models import Autor_Jednostka, Jednostka
+
+    jednostka = baker.make(Jednostka)
+    ukryty = baker.make(Autor, nazwisko="Ukryty", pokazuj=False)
+    baker.make(Autor_Jednostka, autor=ukryty, jednostka=jednostka)
+
+    res = _staff_client().get(reverse("api_v1:autor_jednostka-list"))
+    autor_urls = {row["autor"] for row in res.json()["results"]}
+    ukryty_url = reverse("api_v1:autor-detail", args=(ukryty.pk,))
+
+    assert any(ukryty_url in u for u in autor_urls)

--- a/src/api_v1/tests/test_throttling.py
+++ b/src/api_v1/tests/test_throttling.py
@@ -39,6 +39,39 @@ def test_search_viewsets_deklaruja_throttle_wyszukiwania():
     assert AutorViewSet.throttle_classes == [SearchAnonThrottle, SearchUserThrottle]
 
 
+def test_zapytanie_viewsety_deklaruja_throttle_uzytkownika():
+    """DjangoQL po API (``/api/v1/zapytanie/*``) to ciężki multi-join —
+    endpointy wymagają logowania, więc throttle po użytkowniku wystarcza."""
+    from api_v1.viewsets.zapytanie import ZapytanieAPIBaseViewSet
+
+    assert ZapytanieAPIBaseViewSet.throttle_classes == [SearchUserThrottle]
+
+
+@override_settings(CACHES=_LOCMEM)
+@pytest.mark.django_db
+def test_zapytanie_throttluje_zalogowanego_po_przekroczeniu_limitu(monkeypatch):
+    from model_bakery import baker
+    from rest_framework.test import APIClient
+
+    monkeypatch.setattr(
+        SearchUserThrottle,
+        "THROTTLE_RATES",
+        {"search_user": "2/min", "search_anon": "60/min"},
+    )
+    cache.clear()
+
+    u = baker.make("bpp.BppUser", is_staff=True, is_superuser=True)
+    client = APIClient()
+    client.force_authenticate(user=u)
+    url = "/api/v1/zapytanie/autor/"
+    params = {"q": 'nazwisko ~ "x"'}
+
+    assert client.get(url, params).status_code == 200
+    assert client.get(url, params).status_code == 200
+    # Trzecie wywołanie przekracza limit 2/min → 429 Too Many Requests.
+    assert client.get(url, params).status_code == 429
+
+
 @override_settings(CACHES=_LOCMEM)
 @pytest.mark.django_db
 def test_szukaj_throttluje_anonima_po_przekroczeniu_limitu(

--- a/src/api_v1/viewsets/autor.py
+++ b/src/api_v1/viewsets/autor.py
@@ -50,8 +50,20 @@ class Funkcja_AutoraViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class Autor_JednostkaViewSet(viewsets.ReadOnlyModelViewSet):
+    # Bazowy queryset BEZ filtra widoczności — zawężenie robi get_queryset()
+    # TYLKO dla anonima (analogicznie do AutorViewSet).
     queryset = Autor_Jednostka.objects.all()
     serializer_class = Autor_JednostkaSerializer
+
+    def get_queryset(self):
+        # Anonim nie może zobaczyć powiązań zatrudnienia autora ukrytego
+        # (autor.pokazuj=False) — inaczej jednostka, daty pracy oraz PK autora
+        # wyciekają mimo że AutorViewSet ukrywa samego autora. Zalogowany
+        # (redaktor) widzi wszystkich.
+        qs = super().get_queryset()
+        if self.request.user.is_authenticated:
+            return qs
+        return qs.filter(autor__pokazuj=True)
 
 
 class TytulViewSet(viewsets.ReadOnlyModelViewSet):

--- a/src/api_v1/viewsets/zapytanie.py
+++ b/src/api_v1/viewsets/zapytanie.py
@@ -21,6 +21,7 @@ from api_v1.serializers.zapytanie import (
     AutorKompaktSerializer,
     AutorzyKompaktSerializer,
 )
+from api_v1.throttling import SearchUserThrottle
 from api_v1.viewsets.szukaj import MODELE_DETAIL_VIEWNAME, POLA_REKORDU_DLA_SZUKAJ
 from bpp.djangoql_errors import error_payload
 from bpp.djangoql_schema import RekordLLMSchema
@@ -48,6 +49,11 @@ class ZapytanieAPIBaseViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     ``model`` i ``serializer_class``."""
 
     permission_classes = [MoznaUzywacZapytania]
+    # DjangoQL to ciężki multi-join .distinct() po mat-view Rekord — cięższy niż
+    # /szukaj/. Timeout 8s ogranicza pojedyncze zapytanie, ale nie liczbę
+    # równoległych; endpointy wymagają logowania, więc throttle po użytkowniku
+    # (globalny throttling API świadomie wyłączony — patrz throttling.py).
+    throttle_classes = [SearchUserThrottle]
     pagination_class = _ZapytaniePagination
     model = None
 

--- a/src/bpp/djangoql_schema.py
+++ b/src/bpp/djangoql_schema.py
@@ -17,6 +17,8 @@ True, ``disabled``/``ukryty``… = False). FK do modeli bez pola-etykiety
 pomijane.
 """
 
+from functools import lru_cache
+
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models import Q
@@ -24,6 +26,18 @@ from django.utils.html import strip_tags
 from djangoql.extras import AutocompleteField, ExtrasSchema
 
 from bpp.models import Charakter_Formalny, Jednostka
+
+
+@lru_cache(maxsize=1)
+def _modele_wykluczone_z_schematu():
+    """Modele auth/credential twardo niedostępne w DjangoQL (lazy — bez
+    top-level importu ``get_user_model``, który przy ładowaniu modeli bywa
+    przedwczesny). ``BppUser`` niesie ``pbn_token`` (żywy credential PBN),
+    ``email``, ``is_superuser`` — nie mogą być filtrowalne."""
+    from django.contrib.auth import get_user_model
+
+    return frozenset({get_user_model()})
+
 
 #: Pola-etykiety wg priorytetu — czym opisać i po czym szukać obiekt w pickerze.
 #: Opis bibliograficzny jako pierwszy: dla publikacji jest najczytelniejszy.
@@ -237,6 +251,20 @@ class BppQLSchema(RelPickerSchemaMixin, ExtrasSchema):
     schemat obsługuje dowolny model (Rekord, Autor, Wydawnictwo_*, Patent,
     Praca_Doktorska/Habilitacyjna, …).
     """
+
+    def excluded(self, model):
+        # Twarde odcięcie modelu użytkownika (BppUser) od CAŁEGO schematu.
+        # Bez tego reverse-relacja Autor.user wystawiała pbn_token/email/
+        # is_superuser jako pola filtrowalne — blind oracle pozwalający
+        # zalogowanemu redaktorowi wyeksfiltrować cudzy (nawet superusera)
+        # token PBN znak-po-znaku (``user.pbn_token startswith "…"``).
+        # Robimy to w excluded(), a NIE przez atrybut klasy ``exclude``, bo
+        # podklasa BppQLSchemaOgraniczony ustawia ``include`` — a djangoql
+        # zabrania include i exclude naraz. Cięcie na poziomie modelu łapie
+        # KAŻDĄ ścieżkę do BppUser (nie tylko Autor.user) oraz przyszłe pola.
+        if model in _modele_wykluczone_z_schematu():
+            return True
+        return super().excluded(model)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bpp/newsfragments/sec-autor-jednostka-ukryci.bugfix.rst
+++ b/src/bpp/newsfragments/sec-autor-jednostka-ukryci.bugfix.rst
@@ -1,0 +1,3 @@
+Publiczne API ``/api/v1/autor_jednostka/`` nie ujawnia już powiązań
+zatrudnienia (jednostka, daty, funkcja, identyfikator) autorów oznaczonych
+jako ukryci (``pokazuj=False``) użytkownikom niezalogowanym.

--- a/src/bpp/newsfragments/sec-djangoql-admin-bppuser.bugfix.rst
+++ b/src/bpp/newsfragments/sec-djangoql-admin-bppuser.bugfix.rst
@@ -1,0 +1,4 @@
+Adminowa wyszukiwarka DjangoQL nie udostępnia już modelu użytkownika
+(``BppUser``) przez relację ``Autor.user`` — pola ``pbn_token``, ``email`` i
+``is_superuser`` przestały być filtrowalne, co eliminowało możliwość
+odczytania cudzego tokenu PBN metodą blind-oracle.

--- a/src/bpp/newsfragments/sec-import-rozmiar-readonly.bugfix.rst
+++ b/src/bpp/newsfragments/sec-import-rozmiar-readonly.bugfix.rst
@@ -1,0 +1,3 @@
+Import plików XLSX odrzuca teraz nadmiernie duże pliki przed przetwarzaniem i
+wczytuje skoroszyt strumieniowo (tryb read-only), co zabezpiecza workera
+importu przed wyczerpaniem pamięci (OOM) na „grubym" pliku.

--- a/src/bpp/newsfragments/sec-przemapuj-xss.bugfix.rst
+++ b/src/bpp/newsfragments/sec-przemapuj-xss.bugfix.rst
@@ -1,0 +1,3 @@
+Naprawiono podatność stored-XSS w panelu administracyjnym „Przemapowanie prac
+autora": tytuł/źródło/wydawnictwo publikacji są teraz escapowane przy
+renderowaniu historii przemapowań.

--- a/src/bpp/newsfragments/sec-secret-key-guard.bugfix.rst
+++ b/src/bpp/newsfragments/sec-secret-key-guard.bugfix.rst
@@ -1,0 +1,4 @@
+Produkcja nie uruchomi się już po cichu z placeholderowym ``SECRET_KEY``
+(nieustawiona zmienna środowiskowa lub niezmieniony ``.env.docker``) —
+zamiast startować z publicznie znanym kluczem (ryzyko forgowania sesji i
+tokenów resetu hasła) proces przerywa start z czytelnym komunikatem.

--- a/src/bpp/newsfragments/sec-zapytanie-throttling.bugfix.rst
+++ b/src/bpp/newsfragments/sec-zapytanie-throttling.bugfix.rst
@@ -1,0 +1,3 @@
+Endpointy zapytań DjangoQL ``/api/v1/zapytanie/*`` są teraz objęte
+throttlingiem po użytkowniku, co ogranicza ryzyko przeciążenia bazy przez
+zalogowanego użytkownika wysyłającego wiele równoległych, kosztownych zapytań.

--- a/src/bpp/tests/test_djangoql_admin_bppuser_exclude.py
+++ b/src/bpp/tests/test_djangoql_admin_bppuser_exclude.py
@@ -1,0 +1,53 @@
+"""Regresja bezpieczeństwa (#1 z security review): adminowa wyszukiwarka
+DjangoQL (``BppQLSchema``) nie może odsłaniać modelu użytkownika (``BppUser``)
+przez reverse-relację ``Autor.user``.
+
+Bez wykluczenia pola ``pbn_token`` (żywy token PBN), ``email`` i ``is_superuser``
+stają się filtrowalne → blind oracle: zalogowany redaktor eksfiltruje cudzy
+(nawet superusera) token PBN znak-po-znaku (``user.pbn_token startswith "…"``).
+API i publiczny ``/zapytanie/`` używają schematu z allow-listą i NIE były
+podatne — luka dotyczyła wyłącznie pełnego ``BppQLSchema`` (adminy).
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from djangoql.exceptions import DjangoQLError
+from djangoql.queryset import apply_search
+from model_bakery import baker
+
+from bpp.djangoql_schema import BppQLSchema
+from bpp.models import Autor
+
+
+def test_schemat_admina_wyklucza_model_uzytkownika():
+    """BppUser jest wykluczony z BppQLSchema niezależnie od modelu bazowego."""
+    assert BppQLSchema(Autor).excluded(get_user_model()) is True
+
+
+def test_relacja_user_autora_nie_istnieje_w_schemacie():
+    """Reverse-relacja ``Autor.user`` jest wycięta → 'user' to nieznane pole."""
+    schema = BppQLSchema(Autor)
+    pola_autora = schema.models[schema.model_label(Autor)]
+    assert "user" not in pola_autora
+
+
+@pytest.mark.django_db
+def test_filtr_po_user_pbn_token_jest_odrzucony():
+    """Filtr po ``user.pbn_token`` musi być odrzucony jako nieznane pole —
+    a nie wykonany jako oracle zwracający tak/nie."""
+    with pytest.raises(DjangoQLError):
+        apply_search(
+            Autor.objects.all(),
+            'user.pbn_token = "sekret"',
+            schema=BppQLSchema,
+        )
+
+
+@pytest.mark.django_db
+def test_zwykly_filtr_po_polu_autora_nadal_dziala():
+    """Fix nie może zepsuć normalnego filtrowania po polach Autora."""
+    baker.make(Autor, nazwisko="Kowalski")
+    wynik = apply_search(
+        Autor.objects.all(), 'nazwisko = "Kowalski"', schema=BppQLSchema
+    )
+    assert wynik.count() == 1

--- a/src/django_bpp/settings/production.py
+++ b/src/django_bpp/settings/production.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ImproperlyConfigured
 from django_minify_html.middleware import MinifyHtmlMiddleware
 
 from .base import *  # noqa
@@ -9,8 +10,22 @@ from .base import (  # noqa
     REDIS_HOST,
     REDIS_PORT,
     ROLLBAR,
+    SECRET_KEY,
+    SECRET_KEY_UNSET,
     env,
 )
+from .secret_key_guard import secret_key_niebezpieczny_placeholder
+
+# Fail-closed: produkcja NIE wstaje z placeholderem SECRET_KEY (patrz
+# secret_key_guard). Odpala się przy imporcie ustawień, więc gate'uje web,
+# celery i migrate — nie tylko komendy z system-checkami.
+if secret_key_niebezpieczny_placeholder(SECRET_KEY, unset_sentinel=SECRET_KEY_UNSET):
+    raise ImproperlyConfigured(
+        "DJANGO_BPP_SECRET_KEY nie jest ustawiony lub to placeholder — "
+        "produkcja nie wystartuje z publicznie znanym kluczem (ryzyko "
+        "forgowania sesji i tokenów resetu hasła). Ustaw realny klucz "
+        "(auto-gen w bpp-deploy; ręcznie: `openssl rand -hex 50`)."
+    )
 
 DEBUG = False
 DEBUG_TOOLBAR = False

--- a/src/django_bpp/settings/secret_key_guard.py
+++ b/src/django_bpp/settings/secret_key_guard.py
@@ -1,0 +1,37 @@
+"""Fail-closed guard na placeholder ``SECRET_KEY`` (używany w ``production.py``).
+
+``SECRET_KEY`` podpisuje sesje i tokeny resetu hasła — start produkcji z
+publicznie znanym placeholderem = ryzyko forgowania sesji/tokenów (przejęcie
+konta). ``production.py`` jest importowany w KAŻDYM procesie produkcyjnym
+(web/celery/migrate), inaczej niż system-checki, które nie odpalają się na
+daphne — dlatego twardy ``raise`` tutaj realnie fail-closuje serwowanie.
+
+Predykat jest czystą funkcją (bez importu ``settings``), żeby był testowalny
+bez pełnego środowiska produkcyjnego.
+"""
+
+#: Wartość SECRET_KEY używana przez ``collectstatic`` w buildzie obrazu
+#: (docker/bpp_base/Dockerfile). Świadomie BEZPIECZNA: artefakt buildu nigdy
+#: nie obsługuje ruchu, a jej blokada wywaliłaby build (dlatego istniejący
+#: check ALTCHA jest tylko Warning). Nie flagujemy jej.
+SECRET_KEY_BUILD_DUMMY = "build-time-only-not-used"
+
+
+def secret_key_niebezpieczny_placeholder(key, *, unset_sentinel):
+    """Czy ``key`` to placeholder, którego NIE wolno użyć w produkcji.
+
+    :param key: wartość ``SECRET_KEY``.
+    :param unset_sentinel: default z ``base.py`` (``SECRET_KEY_UNSET``) —
+        wpada, gdy env ``DJANGO_BPP_SECRET_KEY`` w ogóle nie jest ustawiony.
+
+    Łapiemy realne misdeploye: pusty klucz, nieustawiony env (sentinel) oraz
+    ``.env.docker`` zostawiony bez zmian (``ZMIEN_KONIECZNIE_...``). Wartość
+    build-owa jest jawnie przepuszczana.
+    """
+    if key == SECRET_KEY_BUILD_DUMMY:
+        return False
+    if not key:
+        return True
+    if key == unset_sentinel:
+        return True
+    return "ZMIEN" in key

--- a/src/django_bpp/tests/test_secret_key_guard.py
+++ b/src/django_bpp/tests/test_secret_key_guard.py
@@ -1,0 +1,40 @@
+"""Testy predykatu fail-closed guard SECRET_KEY (#4 z security review)."""
+
+import pytest
+
+from django_bpp.settings.secret_key_guard import (
+    SECRET_KEY_BUILD_DUMMY,
+    secret_key_niebezpieczny_placeholder,
+)
+
+# Sentinel z base.py (default gdy env DJANGO_BPP_SECRET_KEY nieustawiony).
+SENTINEL = "Please set the DJANGO_BPP_SECRET_KEY variable."
+
+
+@pytest.mark.parametrize(
+    "key,oczekiwane",
+    [
+        # Realne misdeploye — MUSZĄ zablokować start produkcji.
+        ("", True),
+        (SENTINEL, True),
+        ("ZMIEN_KONIECZNIE_PRZED_URUCHOMIENIEM_PRODUKCJI", True),
+        # Wartości bezpieczne — produkcja/build wstaje normalnie.
+        (SECRET_KEY_BUILD_DUMMY, False),
+        ("k9$2mZ!q7wR4tY6uI8oP1aS3dF5gH0jL2xC4vB6nM8", False),
+    ],
+)
+def test_wykrywanie_placeholdera_secret_key(key, oczekiwane):
+    assert (
+        secret_key_niebezpieczny_placeholder(key, unset_sentinel=SENTINEL) is oczekiwane
+    )
+
+
+def test_wartosc_buildowa_nie_jest_flagowana_nawet_gdyby_zawierala_zmien():
+    """Wartość build-owa jest whitelisowana bezwarunkowo — sanity guard, żeby
+    nikt nie 'poprawił' predykatu tak, że wywali collectstatic w buildzie."""
+    assert (
+        secret_key_niebezpieczny_placeholder(
+            SECRET_KEY_BUILD_DUMMY, unset_sentinel=SENTINEL
+        )
+        is False
+    )

--- a/src/import_common/exceptions.py
+++ b/src/import_common/exceptions.py
@@ -24,6 +24,14 @@ class DecompressionBombException(Exception):
     pass
 
 
+class PlikZaDuzyException(Exception):
+    """Wgrany plik przekracza dopuszczalny rozmiar na dysku — odrzucany PRZED
+    załadowaniem do pamięci (obrona przed OOM workera importu na „grubym",
+    formalnie legalnym pliku, który przechodzi bomb-check dekompresji)."""
+
+    pass
+
+
 class XLSParseError(Exception):
     def __init__(self, elem, form, reason):
         self.elem = elem

--- a/src/import_common/tests/test_rozmiar_pliku.py
+++ b/src/import_common/tests/test_rozmiar_pliku.py
@@ -1,0 +1,34 @@
+"""#5 (security review): guard przed „grubym" plikiem importu.
+
+Bomb-check pilnuje rozmiaru PO dekompresji, ale formalnie legalny, wielki plik
+(setki MB), który po dekompresji mieści się pod progiem, i tak wciągnąłby cały
+skoroszyt do RAM. Guard odrzuca taki plik PRZED przetwarzaniem.
+"""
+
+import openpyxl
+import pytest
+
+from import_common.exceptions import PlikZaDuzyException
+from import_common.util import MAX_ROZMIAR_PLIKU, sprawdz_rozmiar_pliku
+
+
+def test_guard_odrzuca_zbyt_duzy_plik(tmp_path):
+    p = tmp_path / "gruby.xlsx"
+    p.write_bytes(b"\0" * (2 * 1024 * 1024))  # 2 MB
+    with pytest.raises(PlikZaDuzyException):
+        sprawdz_rozmiar_pliku(str(p), max_bajtow=1024 * 1024)  # limit 1 MB
+
+
+def test_guard_przepuszcza_normalny_plik(tmp_path):
+    p = tmp_path / "ok.xlsx"
+    wb = openpyxl.Workbook()
+    wb.active["A1"] = "test"
+    wb.save(str(p))
+    # Domyślny limit (dziesiątki MB) — realny plik przechodzi bez wyjątku.
+    sprawdz_rozmiar_pliku(str(p))
+    assert MAX_ROZMIAR_PLIKU >= 50 * 1024 * 1024
+
+
+def test_guard_ignoruje_brak_pliku(tmp_path):
+    # Nieistniejąca ścieżka — nie ten wektor; niech padnie dalej (open()).
+    sprawdz_rozmiar_pliku(str(tmp_path / "nie_ma.xlsx"))

--- a/src/import_common/util.py
+++ b/src/import_common/util.py
@@ -12,6 +12,7 @@ from .exceptions import (
     DecompressionBombException,
     HeaderNotFoundException,
     ImproperFileException,
+    PlikZaDuzyException,
 )
 
 # Limit rozmiaru pliku XLSX PO dekompresji. Realne pliki importowe (nawet
@@ -19,6 +20,27 @@ from .exceptions import (
 # 500 MB daje spory zapas, a bomba zip (KB → GB) go przekracza i jest
 # odrzucana przed załadowaniem do pamięci (obrona przed OOM workera importu).
 MAX_ROZMIAR_PO_DEKOMPRESJI = 500 * 1024 * 1024
+
+# Limit rozmiaru samego pliku NA DYSKU. Bomb-check pilnuje rozmiaru po
+# dekompresji, ale „gruby" formalnie-legalny XLSX (~setki MB), który po
+# dekompresji mieści się pod progiem, i tak wciągnąłby cały skoroszyt do RAM.
+# 100 MB z zapasem pokrywa realne importy, a odcina wektor OOM przed load.
+MAX_ROZMIAR_PLIKU = 100 * 1024 * 1024
+
+
+def sprawdz_rozmiar_pliku(sciezka, max_bajtow=MAX_ROZMIAR_PLIKU):
+    """Odrzuca plik większy niż ``max_bajtow`` PRZED załadowaniem do pamięci."""
+    import os
+
+    try:
+        rozmiar = os.path.getsize(sciezka)
+    except OSError:
+        return  # nie ma pliku / nie-ścieżka — nie ten wektor, niech padnie dalej
+    if rozmiar > max_bajtow:
+        raise PlikZaDuzyException(
+            f"Rozmiar pliku ({rozmiar} B) przekracza bezpieczny limit "
+            f"({max_bajtow} B) — plik odrzucony przed przetwarzaniem."
+        )
 
 
 def sprawdz_bombe_dekompresji(sciezka, max_rozpakowany=MAX_ROZMIAR_PO_DEKOMPRESJI):
@@ -133,9 +155,14 @@ def znajdz_naglowek(
     import openpyxl
     from openpyxl.utils.exceptions import InvalidFileException
 
+    sprawdz_rozmiar_pliku(sciezka)
     sprawdz_bombe_dekompresji(sciezka)
     try:
-        f: openpyxl.workbook.workbook.Workbook = openpyxl.load_workbook(sciezka)
+        # read_only: czytamy strumieniowo (tylko cell.value + iteracja rows),
+        # bez wciągania całego skoroszytu do RAM — obrona przed OOM workera.
+        f: openpyxl.workbook.workbook.Workbook = openpyxl.load_workbook(
+            sciezka, read_only=True
+        )
     except InvalidFileException as e:
         raise ImproperFileException(e) from e
 
@@ -186,8 +213,11 @@ class XLSImportFile:
     def xl_workbook(self) -> openpyxl.workbook.workbook.Workbook:
         import openpyxl
 
+        sprawdz_rozmiar_pliku(self.xls_path)
         sprawdz_bombe_dekompresji(self.xls_path)
-        return openpyxl.load_workbook(self.xls_path)
+        # read_only: strumieniowy odczyt (iteracja rows + cell.value) bez
+        # ładowania całego skoroszytu do RAM — obrona przed OOM workera.
+        return openpyxl.load_workbook(self.xls_path, read_only=True)
 
     @cached_property
     def sheet_limit_range_end(self):

--- a/src/import_pracownikow/tests/test_eksport.py
+++ b/src/import_pracownikow/tests/test_eksport.py
@@ -413,4 +413,8 @@ def test_zapisz_snapshot_populuje_pole_i_zgadza_sie_z_builderem():
     # jako ``assert b'PK\x03\x04...' == b'PK\x03\x04...'``. Intencja testu to
     # „snapshot zawiera to samo, co zwraca builder" — tresc, nie identycznosc
     # kontenera ZIP.
-    assert _wczytaj(zapisane) == _wczytaj(zbuduj_plik_po_imporcie(imp))
+    naglowki, wiersze = _wczytaj(zapisane)
+    assert (naglowki, wiersze) == _wczytaj(zbuduj_plik_po_imporcie(imp))
+    # Sanity na kilku komorkach — snapshot odbija autorow z bazy.
+    plaskie = {str(c) for w in wiersze for c in w}
+    assert {"Snap", "Jeden", "Shot", "Dwa"} <= plaskie

--- a/src/przemapuj_prace_autora/admin.py
+++ b/src/przemapuj_prace_autora/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 from bpp.admin.core import DynamicAdminFilterMixin
@@ -96,11 +97,13 @@ class PrzemapoaniePracAutoraAdmin(DynamicAdminFilterMixin, admin.ModelAdmin):
         html += "</tr></thead><tbody>"
 
         for praca in obj.prace_ciagle_historia:
+            # tytuł/źródło publikacji to niezaufany HTML (import/zgłoszenie) —
+            # escape() przed wstrzyknięciem w mark_safe-owany string (stored-XSS).
             html += "<tr>"
-            html += f"<td>{praca.get('id', '—')}</td>"
-            html += f"<td>{praca.get('tytul', '—')}</td>"
-            html += f"<td>{praca.get('rok', '—')}</td>"
-            html += f"<td>{praca.get('zrodlo', '—') or '—'}</td>"
+            html += f"<td>{escape(praca.get('id', '—'))}</td>"
+            html += f"<td>{escape(praca.get('tytul', '—'))}</td>"
+            html += f"<td>{escape(praca.get('rok', '—'))}</td>"
+            html += f"<td>{escape(praca.get('zrodlo', '—') or '—')}</td>"
             html += "</tr>"
 
         html += "</tbody></table></div>"
@@ -125,12 +128,14 @@ class PrzemapoaniePracAutoraAdmin(DynamicAdminFilterMixin, admin.ModelAdmin):
         html += "</tr></thead><tbody>"
 
         for praca in obj.prace_zwarte_historia:
+            # tytuł/isbn/wydawnictwo to niezaufany HTML (import/zgłoszenie) —
+            # escape() przed wstrzyknięciem w mark_safe-owany string (stored-XSS).
             html += "<tr>"
-            html += f"<td>{praca.get('id', '—')}</td>"
-            html += f"<td>{praca.get('tytul', '—')}</td>"
-            html += f"<td>{praca.get('rok', '—')}</td>"
-            html += f"<td>{praca.get('isbn', '—') or '—'}</td>"
-            html += f"<td>{praca.get('wydawnictwo', '—') or '—'}</td>"
+            html += f"<td>{escape(praca.get('id', '—'))}</td>"
+            html += f"<td>{escape(praca.get('tytul', '—'))}</td>"
+            html += f"<td>{escape(praca.get('rok', '—'))}</td>"
+            html += f"<td>{escape(praca.get('isbn', '—') or '—')}</td>"
+            html += f"<td>{escape(praca.get('wydawnictwo', '—') or '—')}</td>"
             html += "</tr>"
 
         html += "</tbody></table></div>"

--- a/src/przemapuj_prace_autora/test_history.py
+++ b/src/przemapuj_prace_autora/test_history.py
@@ -250,3 +250,33 @@ def test_admin_display_methods():
 
     assert admin_instance.display_prace_ciagle_historia(empty_log) == "Brak danych"
     assert admin_instance.display_prace_zwarte_historia(empty_log) == "Brak danych"
+
+
+@pytest.mark.django_db
+def test_admin_display_methods_escape_html():
+    """Regresja stored-XSS: tytuł/źródło/wydawnictwo publikacji to niezaufany
+    HTML (może pochodzić z importu/zgłoszenia). display_* budują HTML f-stringiem
+    i mark_safe-ują go — muszą escapować wartości, inaczej ``<img onerror>`` w
+    tytule wykona się gdy admin otwiera historię (ta sama klasa co fix PBN)."""
+    from .admin import PrzemapoaniePracAutoraAdmin
+
+    xss = "<img src=x onerror=alert(1)>"
+    log = baker.make(
+        PrzemapoaniePracAutora,
+        prace_ciagle_historia=[
+            {"id": 1, "tytul": xss, "rok": 2023, "zrodlo": xss},
+        ],
+        prace_zwarte_historia=[
+            {"id": 2, "tytul": xss, "rok": 2023, "isbn": xss, "wydawnictwo": xss},
+        ],
+    )
+    admin_instance = PrzemapoaniePracAutoraAdmin(PrzemapoaniePracAutora, None)
+
+    ciagle_html = str(admin_instance.display_prace_ciagle_historia(log))
+    zwarte_html = str(admin_instance.display_prace_zwarte_historia(log))
+
+    # Surowy payload NIE może trafić do HTML-a; ma być zescapowany.
+    assert "<img src=x onerror=" not in ciagle_html
+    assert "&lt;img src=x onerror=" in ciagle_html
+    assert "<img src=x onerror=" not in zwarte_html
+    assert "&lt;img src=x onerror=" in zwarte_html


### PR DESCRIPTION
Wynik równoległego security review (5 sub-agentów, attack-surface newralgiczny: auth · API+PII · DjangoQL · upload/import · injection/XSS/sekrety). Sześć potwierdzonych findingów, każdy z repro-testem (TDD: RED bez fixu → GREEN po).

## Findingi

| # | Sev | Problem | Fix |
|---|-----|---------|-----|
| **1** | **HIGH** | Adminowa wyszukiwarka DjangoQL (`BppQLSchema`, brak allow-listy) schodziła przez reverse-relację `Autor.user` do `BppUser` — `pbn_token` (żywy token PBN), `email`, `is_superuser` były **filtrowalne** → blind oracle: redaktor eksfiltruje cudzy (nawet superusera) token PBN znak-po-znaku (`user.pbn_token startswith "…"`). API/web nie były podatne (allow-lista). | Override `excluded()` wykluczający `get_user_model()` z całego schematu (nie atrybutem `exclude` — konflikt z `include` podklasy). |
| **2** | MED | Stored-XSS: admin „Przemapowanie prac autora" budował HTML f-stringiem z nieescapowanym tytułem/źródłem/wydawnictwem publikacji (niezaufany HTML) i `mark_safe`-ował. | `escape()` na wartościach przed interpolacją. |
| **3** | MED | IDOR: `/api/v1/autor_jednostka/` zwracał zatrudnienie (jednostka, daty, PK autora) także autorów ukrytych (`pokazuj=False`), obchodząc `AutorViewSet`. | `get_queryset()` filtruje `autor__pokazuj=True` dla anonima. |
| **6** | MED | `/api/v1/zapytanie/*` (ciężki multi-join DjangoQL) bez throttlingu → saturacja DB. | `throttle_classes = [SearchUserThrottle]` (endpointy wymagają logowania). |
| **4** | MED | `SECRET_KEY` fallbackował po cichu do placeholdera z repo, gdy env nieustawiony → produkcja startowała z publicznie znanym kluczem (forgowanie sesji/tokenów). | Fail-closed `raise ImproperlyConfigured` w `production.py` (importowany w każdym procesie — inaczej niż system-checki, które nie odpalają się na daphne). Build-owy dummy świadomie przepuszczony. |
| **5** | MED | Import XLSX bez limitu rozmiaru pliku + `load_workbook` bez `read_only` → „gruby" plik (setki MB) wciągał cały skoroszyt do RAM → OOM workera. | Limit rozmiaru (`sprawdz_rozmiar_pliku`, 100 MB) przed load + `read_only=True` (strumieniowy odczyt). Zweryfikowane, że cała ścieżka parsowania tylko czyta. |

## Przy okazji
Naprawiony **pre-existing flaky test** snapshotu #605: porównywał plik XLSX bajt-w-bajt, a openpyxl stempluje `docProps/core.xml` aktualnym czasem przy każdym `save()`. Zmienione na porównanie zawartości (nagłówki + wiersze).

## Weryfikacja
- Każdy repro-test RED przed fixem → GREEN po.
- Pełne suity bez regresji: `import_common` + `import_pracownikow` (1028), `api_v1` + `przemapuj` + admin DjangoQL.
- `ruff check` + `ruff format` czyste; 6 newsfragmentów (`bugfix`, PL).

## Poza zakresem
Drobne **LOW** z review (brak `AUTH_PASSWORD_VALIDATORS` na ścieżce admin/CLI, TOCTOU w rate-limicie resetu hasła, `FileExtensionValidator` na `plik_xls`, ekspozycja pól `uwagi`/nie-`public_`) — do osobnego przejścia lub świadomego pominięcia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)