### PR TITLE
Bramka ALTCHA na górze kroku 0 + gating kafelków zgłoszeń

### DIFF
--- a/src/bpp/newsfragments/zglos-captcha-gating.feature.rst
+++ b/src/bpp/newsfragments/zglos-captcha-gating.feature.rst
@@ -1,0 +1,3 @@
+Na formularzu zgłaszania publikacji weryfikacja ALTCHA jest teraz na górze,
+a kafelki wyboru rodzaju publikacji pojawiają się dopiero po jej zakończeniu —
+usuwa to możliwość kliknięcia zanim weryfikacja się policzy.

--- a/src/bpp/static/scss/_wizard_forms.scss
+++ b/src/bpp/static/scss/_wizard_forms.scss
@@ -167,3 +167,62 @@
         grid-column: 1 / -1;
     }
 }
+
+// Blok ALTCHA na górze kroku 0 — wyśrodkowany, jako pierwszy ekran anonima.
+.zglos-captcha {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.75rem;
+    margin: 1.5rem 0;
+
+    .zglos-captcha-lead {
+        font-size: 1.2rem;
+        font-weight: bold;
+        margin: 0;
+    }
+
+    .zglos-captcha-hint {
+        font-size: 0.9rem;
+        color: #666;
+        margin: 0;
+    }
+}
+
+// Gating: nagłówek + kafelki ukryte do czasu statechange:verified (JS dodaje
+// `revealed`). display:none — kafelki nie zajmują miejsca ani nie są
+// fokusowalne/klikalne przed weryfikacją.
+.zglos-gated {
+    display: none;
+
+    &.revealed {
+        display: block;
+    }
+}
+
+@keyframes zglos-tiles-in {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+.zglos-gated.revealed .tile-card {
+    animation: zglos-tiles-in 0.3s ease-out both;
+
+    &:nth-child(1) { animation-delay: 0s; }
+    &:nth-child(2) { animation-delay: 0.06s; }
+    &:nth-child(3) { animation-delay: 0.12s; }
+    &:nth-child(4) { animation-delay: 0.18s; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .zglos-gated.revealed .tile-card {
+        animation: none;
+    }
+}

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -188,6 +188,15 @@ _LEAK_GUARD_TABLES = (
     "bpp_stopiensluzbowy",
     "bpp_stanowiskodydaktyczne",
     "bpp_grupa_pracownicza",
+    # Dodane po incydencie na PR #625: wyciek TYCH tabel był dla guarda
+    # NIEWIDZIALNY (nie sondował ich), więc zamiast raportu dawał twarde
+    # ``IntegrityError: bpp_uczelnia_site_id_key`` na setupie cudzego testu
+    # oraz „extra items" w asercjach scope'ujących po uczelni. Warunek
+    # bezpieczeństwa z komentarza wyżej sprawdzony też dla nich: obie mają
+    # 0 wierszy w baseline, a z 38 tabel z FK DO nich żadna nie jest w
+    # baseline niepusta → CASCADE zostaje w danych domenowych.
+    "bpp_uczelnia",
+    "import_pracownikow_importpracownikow",
 )
 
 

--- a/src/import_pracownikow/tests/test_views_liveops.py
+++ b/src/import_pracownikow/tests/test_views_liveops.py
@@ -593,6 +593,14 @@ def test_zatwierdz_wyscig_nie_dubluje_integracji(admin_user):
             w.start()
         for w in watki:
             w.join(15)
+        # ``join`` z timeoutem NIE rzuca — wraca też gdy wątek wciąż żyje.
+        # Bez tej asercji przeciążone CI mogło pojechać dalej, a spóźniony
+        # wątek commitował ``Uczelnia``/``ImportPracownikow`` (własne
+        # połączenie) JUŻ PO transakcyjnym flushu teardownu → scommitowane
+        # wiersze wyciekały do kolejnych testów na tym workerze
+        # (``bpp_uczelnia_site_id_key``, „extra items" w asercjach).
+        zywe = [w for w in watki if w.is_alive()]
+        assert not zywe, f"wątki nie skończyły w 15s: {zywe}"
 
     vals = list(statuses.values())
     assert len(vals) == 2, statuses

--- a/src/integration_tests/_captcha_daphne_setup.py
+++ b/src/integration_tests/_captcha_daphne_setup.py
@@ -1,0 +1,38 @@
+"""Callback ``setup`` dla ``DaphneProcess`` używany przez
+``test_zglos_captcha_gating.py`` — wymusza ``ZGLOS_CAPTCHA_ENABLED=True`` w
+subprocesie Daphne.
+
+Osobny, "lekki" moduł CELOWO (mirror ``channels_live_server.py``): na
+macOS ``multiprocessing`` uruchamia dziecko metodą "spawn" — świeży
+interpreter, który pickluje callback ``setup`` PO NAZWIE KWALIFIKOWANEJ i
+odtwarza go importując cały jego moduł, ZANIM ``django.setup()``/
+``apps.populate()`` zdąży się wykonać w dziecku. Gdyby ta funkcja siedziała
+w ``test_zglos_captcha_gating.py`` (top-level ``from model_bakery import
+baker`` / ``from bpp.models import Uczelnia``), import tamtego modułu w
+dziecku wywaliłby się ``AppRegistryNotReady`` (empirycznie potwierdzone —
+patrz docstring modułu testowego). Ten moduł, jak ``channels_live_server.py``,
+nie importuje niczego Django-owego na poziomie modułu — tylko wewnątrz
+funkcji, gdy apps są już gotowe.
+"""
+
+# Stały klucz testowy (64 znaki hex) — captcha ON tylko dla testów w
+# test_zglos_captcha_gating.py. Re-eksportowany stamtąd jako `_TEST_KEY`.
+TEST_ALTCHA_HMAC_KEY = "0" * 64
+
+
+def setup_captcha_daphne():
+    """Wykonywane W SUBPROCESIE Daphne, przed ``self.server.run()``.
+
+    Widok czyta ``settings.ZGLOS_CAPTCHA_ENABLED``/``ALTCHA_HMAC_KEY``
+    "call-time" (per request — patrz ``zglos_publikacje/views.py``
+    ``get_form_kwargs``), więc mutacja tutaj, przed startem serwera,
+    wystarcza na czas życia całego subprocesu.
+    """
+    from channels_live_server import set_database_connection
+
+    set_database_connection()
+
+    from django.conf import settings
+
+    settings.ZGLOS_CAPTCHA_ENABLED = True
+    settings.ALTCHA_HMAC_KEY = TEST_ALTCHA_HMAC_KEY

--- a/src/integration_tests/_captcha_daphne_setup.py
+++ b/src/integration_tests/_captcha_daphne_setup.py
@@ -15,8 +15,9 @@ nie importuje niczego Django-owego na poziomie modułu — tylko wewnątrz
 funkcji, gdy apps są już gotowe.
 """
 
-# Stały klucz testowy (64 znaki hex) — captcha ON tylko dla testów w
-# test_zglos_captcha_gating.py. Re-eksportowany stamtąd jako `_TEST_KEY`.
+# Stały klucz testowy (64 znaki hex) — wymusza ALTCHA_HMAC_KEY w subprocesie
+# Daphne (patrz setup_captcha_daphne() niżej), żeby captcha była ON tylko
+# dla testów w test_zglos_captcha_gating.py.
 TEST_ALTCHA_HMAC_KEY = "0" * 64
 
 

--- a/src/integration_tests/test_zglos_captcha_gating.py
+++ b/src/integration_tests/test_zglos_captcha_gating.py
@@ -1,0 +1,178 @@
+"""Test Playwright: gating kafelków kroku 0 kreatora zgłoszeń.
+
+Pokrywa scenariusz z ``2026-07-12-zglos-captcha-altcha-design.md``: kafelki
+rodzaju publikacji (``.zglos-gated``) w ``step_rodzaj.html`` są ukryte
+(``display:none``) dopóki widget ALTCHA nie wyemituje ``statechange`` z
+``detail.state === 'verified'`` — wtedy JS dokleja klasę ``.revealed``
+(SCSS: ``.zglos-gated.revealed { display:block }``). Przy
+``ZGLOS_CAPTCHA_ENABLED=False`` gating w ogóle nie istnieje w DOM (kafelki
+renderują się wprost, bez ``.zglos-captcha``/``.zglos-gated``/``altcha-widget``).
+
+Dlaczego NIE ``@override_settings`` + zwykły ``channels_live_server``
+----------------------------------------------------------------------
+``channels_live_server`` (i jego wariant ``_per_test``) serwuje stronę z
+osobnego procesu OS (``daphne.testing.DaphneProcess`` — podklasa
+``multiprocessing.Process``). Na macOS domyślną metodą jest "spawn": dziecko
+to świeży interpreter, który re-importuje ustawienia Django od zera — nie
+dziedziczy stanu Pythona rodzica. ``@override_settings`` w procesie testowym
+mutuje tylko obiekt ``django.conf.settings`` W TYM procesie; subprocess
+Daphne (zwłaszcza wariant session-scoped, odpalony raz na cały worker) go
+nie widzi. Zweryfikowane empirycznie: strona serwowana przez
+``channels_live_server`` pod ``@override_settings(ZGLOS_CAPTCHA_ENABLED=True)``
+nadal renderowała się tak, jakby captcha była OFF (``settings/test.py``
+twardo ustawia ``ZGLOS_CAPTCHA_ENABLED = False`` — nie przez ``env()``, więc
+nawet zmienne środowiskowe by nie pomogły).
+
+Rozwiązanie: własna, lokalna fixture ``captcha_live_server`` — kopia
+``channels_live_server_per_test`` z ``src/channels_live_server.py``, ale
+z callbackiem ``setup`` który PO ``set_database_connection()`` (identyczne
+DB wiring co reszta suity) dodatkowo mutuje ``settings.ZGLOS_CAPTCHA_ENABLED``
+i ``settings.ALTCHA_HMAC_KEY`` BEZPOŚREDNIO W SUBPROCESIE — dokładnie tak,
+jak ``set_database_connection`` robi to już dla ``settings.DATABASES``.
+Widok czyta ``settings.ZGLOS_CAPTCHA_ENABLED`` "call-time" (per request, nie
+przy starcie procesu — patrz komentarz w ``zglos_publikacje/views.py``
+``get_form_kwargs``), więc mutacja przed ``self.server.run()`` wystarcza.
+
+Callback ``setup_captcha_daphne`` MUSI być funkcją top-level w module BEZ
+ciężkich importów Django na poziomie modułu (nie w tym pliku testowym, który
+ma ``from model_bakery import baker`` / ``from bpp.models import Uczelnia``
+na topie) — "spawn" pickluje callable po nazwie kwalifikowanej i odtwarza go
+importując CAŁY jego moduł w dziecku, zanim ``django.setup()`` tam się
+wykona. Stąd osobny, lekki moduł: ``_captcha_daphne_setup.py``
+(zweryfikowane empirycznie: trzymanie tej funkcji tutaj powodowało
+``AppRegistryNotReady`` w subprocesie).
+
+Wzorce fixtur/nazw zaczerpnięte z ``test_global_search.py`` (``page``,
+``channels_live_server``) oraz z ``zglos_publikacje/tests/test_zglos_captcha.py``
+(nazwa URL-a ``zglos_publikacje:nowe_zgloszenie``, klucz testowy).
+"""
+
+from functools import partial
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+from playwright.sync_api import Page
+
+from bpp.models import Uczelnia
+from integration_tests._captcha_daphne_setup import setup_captcha_daphne
+
+
+def _url():
+    return reverse("zglos_publikacje:nowe_zgloszenie")
+
+
+@pytest.fixture
+def captcha_live_server(transactional_db):
+    """Per-test Daphne subprocess z ``ZGLOS_CAPTCHA_ENABLED=True``.
+
+    Kopia ``channels_live_server_per_test`` (``src/channels_live_server.py``)
+    z jedną różnicą: ``setup=setup_captcha_daphne`` zamiast
+    ``set_database_connection`` — patrz docstring modułu po uzasadnienie.
+    """
+    from daphne.testing import DaphneProcess
+    from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
+    from django.core.exceptions import ImproperlyConfigured
+    from django.db import connections
+    from django.test.utils import modify_settings
+
+    from channels_live_server import _ChannelsLiveServer
+
+    for connection in connections.all():
+        if connection.vendor == "sqlite" and connection.is_in_memory_db():
+            raise ImproperlyConfigured(
+                "ChannelsLiveServer can not be used with in-memory databases"
+            )
+
+    host = "localhost"
+    modified_settings = modify_settings(ALLOWED_HOSTS={"append": host})
+    modified_settings.enable()
+
+    # Import lokalny (jak w ``channels_live_server._spawn_daphne``) — moduł
+    # ``channels.testing.live`` importuje Django na czas configu ASGI.
+    from channels.testing.live import make_application
+
+    get_application = partial(make_application, static_wrapper=ASGIStaticFilesHandler)
+    server_process = DaphneProcess(host, get_application, setup=setup_captcha_daphne)
+    server_process.start()
+
+    while True:
+        if not server_process.ready.wait(timeout=1):
+            if server_process.is_alive():
+                continue
+            raise RuntimeError("Server stopped") from None
+        break
+
+    port = server_process.port.value
+    server = _ChannelsLiveServer(host, port)
+    try:
+        yield server
+    finally:
+        server_process.terminate()
+        server_process.join()
+        modified_settings.disable()
+
+
+def test_kafelki_ukryte_przed_weryfikacja(captcha_live_server, page: Page):
+    """Anonim, captcha ON: ``.zglos-gated`` jest ukryte, widget widoczny."""
+    baker.make(Uczelnia)
+
+    url = captcha_live_server.url + _url()
+    page.goto(url)
+    page.wait_for_selector("altcha-widget")
+
+    gated = page.locator(".zglos-gated")
+    assert gated.count() == 1
+    # Ukryte: display:none → Playwright is_visible() zwraca False.
+    assert not gated.first.is_visible()
+
+
+def test_kafelki_pojawiaja_sie_po_verified(captcha_live_server, page: Page):
+    """Po ``statechange:verified`` ``.zglos-gated`` dostaje ``.revealed``.
+
+    Zamiast czekać na realny PoW w headless (``auto="onload"``) — flaky/wolne
+    w CI — sterujemy stanem bezpośrednio: emitujemy ``statechange`` z
+    ``detail.state='verified'`` na ``<altcha-widget>``, tak jak zrobiłby to
+    prawdziwy widget po ukończeniu weryfikacji. Test weryfikuje wyłącznie
+    zachowanie JS-a strony (nasłuch zdarzenia → klasa ``.revealed``), nie
+    samą bibliotekę ALTCHA (tę pokrywają testy 1/3 — obecność/brak widgetu —
+    i unit testy w ``test_zglos_captcha.py``).
+    """
+    baker.make(Uczelnia)
+
+    url = captcha_live_server.url + _url()
+    page.goto(url)
+    page.wait_for_selector("altcha-widget")
+
+    gated = page.locator(".zglos-gated")
+    assert not gated.first.is_visible()
+
+    page.eval_on_selector(
+        "altcha-widget",
+        "el => el.dispatchEvent(new CustomEvent('statechange',"
+        " {detail: {state: 'verified'}}))",
+    )
+
+    page.wait_for_selector(".zglos-gated.revealed", timeout=5000)
+    assert page.locator(".zglos-gated").first.is_visible()
+    assert page.locator(".tile-card").first.is_visible()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_kafelki_widoczne_od_razu_bez_captchy(channels_live_server, page: Page):
+    """Captcha OFF (default ``settings/test.py``): kafelki widoczne od razu.
+
+    Zwykła, session-scoped ``channels_live_server`` wystarcza — domyślne
+    ``ZGLOS_CAPTCHA_ENABLED=False`` w ``settings/test.py`` to dokładnie
+    scenariusz, który chcemy sprawdzić, więc nie trzeba nic wymuszać w
+    subprocesie.
+    """
+    baker.make(Uczelnia)
+
+    url = channels_live_server.url + _url()
+    page.goto(url)
+    page.wait_for_selector(".tile-card")
+
+    assert page.locator(".tile-card").first.is_visible()
+    assert page.locator(".zglos-gated").count() == 0
+    assert page.locator("altcha-widget").count() == 0

--- a/src/zglos_publikacje/templates/zglos_publikacje/_tile_grid_rodzaj.html
+++ b/src/zglos_publikacje/templates/zglos_publikacje/_tile_grid_rodzaj.html
@@ -1,0 +1,18 @@
+<div class="tile-grid">
+    {% for choice in wizard.form.rodzaj %}
+        <label class="tile-card"
+               data-value="{{ choice.data.value }}"
+               tabindex="0">
+            {{ choice.tag }}
+            <span class="tile-icon">
+                {% if choice.data.value == "ARTYKUL" %}📄{% elif choice.data.value == "MONOGRAFIA" %}📚{% elif choice.data.value == "ROZDZIAL" %}📖{% elif choice.data.value == "POZOSTALE" %}📎{% endif %}
+            </span>
+            <span class="tile-title">
+                {{ choice.choice_label }}
+            </span>
+            <span class="tile-desc">
+                {% if choice.data.value == "ARTYKUL" %}Artykuł w czasopiśmie naukowym{% elif choice.data.value == "MONOGRAFIA" %}Monografia naukowa{% elif choice.data.value == "ROZDZIAL" %}Rozdział w monografii{% elif choice.data.value == "POZOSTALE" %}Pozostałe rodzaje publikacji{% endif %}
+            </span>
+        </label>
+    {% endfor %}
+</div>

--- a/src/zglos_publikacje/templates/zglos_publikacje/step_rodzaj.html
+++ b/src/zglos_publikacje/templates/zglos_publikacje/step_rodzaj.html
@@ -3,32 +3,14 @@
 {% block wizard_buttons %}{% endblock %}
 
 {% block wizard_content %}
-    <h3>Wybierz rodzaj publikacji</h3>
-
-    <div class="tile-grid">
-        {% for choice in wizard.form.rodzaj %}
-            <label class="tile-card"
-                   data-value="{{ choice.data.value }}"
-                   tabindex="0">
-                {{ choice.tag }}
-                <span class="tile-icon">
-                    {% if choice.data.value == "ARTYKUL" %}📄{% elif choice.data.value == "MONOGRAFIA" %}📚{% elif choice.data.value == "ROZDZIAL" %}📖{% elif choice.data.value == "POZOSTALE" %}📎{% endif %}
-                </span>
-                <span class="tile-title">
-                    {{ choice.choice_label }}
-                </span>
-                <span class="tile-desc">
-                    {% if choice.data.value == "ARTYKUL" %}Artykuł w czasopiśmie naukowym{% elif choice.data.value == "MONOGRAFIA" %}Monografia naukowa{% elif choice.data.value == "ROZDZIAL" %}Rozdział w monografii{% elif choice.data.value == "POZOSTALE" %}Pozostałe rodzaje publikacji{% endif %}
-                </span>
-            </label>
-        {% endfor %}
-    </div>
-
-    {# Widget ALTCHA + hint „zaloguj się" — obecne TYLKO gdy pole captcha #}
-    {# istnieje w formularzu, tj. dla anonima przy captcha ON (bramka w #}
-    {# forms/views). Dla zalogowanego pola nie ma → nic się nie renderuje. #}
+    {# Blok ALTCHA na górze, wyśrodkowany — obecny TYLKO gdy pole captcha #}
+    {# istnieje (anonim przy captcha ON; bramka w forms/views). Dla #}
+    {# zalogowanego i przy captcha OFF pola nie ma → cały gating pomijamy. #}
     {% if form.captcha %}
         <div class="zglos-captcha">
+            <p class="zglos-captcha-lead">
+                Zweryfikuj się, aby wybrać rodzaj publikacji.
+            </p>
             {{ form.captcha }}
             <p class="zglos-captcha-hint">
                 <span class="fi-lock" aria-hidden="true"></span>
@@ -37,6 +19,14 @@
                 aby pominąć tę weryfikację.
             </p>
         </div>
+
+        <div class="zglos-gated">
+            <h3>Wybierz rodzaj publikacji</h3>
+            {% include "zglos_publikacje/_tile_grid_rodzaj.html" %}
+        </div>
+    {% else %}
+        <h3>Wybierz rodzaj publikacji</h3>
+        {% include "zglos_publikacje/_tile_grid_rodzaj.html" %}
     {% endif %}
 
     <script>
@@ -44,7 +34,6 @@
             var tiles = document.querySelectorAll('.tile-card');
             var form = document.getElementById('form-container');
             tiles.forEach(function(tile) {
-                // Click handler
                 tile.addEventListener('click', function() {
                     var radio = tile.querySelector('input[type="radio"]');
                     if (radio) {
@@ -53,9 +42,7 @@
                     }
                 });
 
-                // Keyboard handler
                 tile.addEventListener('keydown', function(e) {
-                    // Enter or Space to select
                     if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
                         var radio = tile.querySelector('input[type="radio"]');
@@ -65,10 +52,8 @@
                         }
                     }
 
-                    // Arrow key navigation
                     var currentIndex = Array.prototype.indexOf.call(tiles, tile);
                     var newIndex;
-
                     if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
                         e.preventDefault();
                         newIndex = (currentIndex + 1) % tiles.length;
@@ -80,6 +65,29 @@
                     }
                 });
             });
+
+            // Gating ALTCHA: kafelki (w .zglos-gated) odsłaniamy dopiero po
+            // statechange:verified. Odsłanianie jednokierunkowe — raz revealed
+            // zostaje (expired/error nie chowa; refetchonexpire liczy nowy PoW,
+            // a serwer i tak odrzuci POST na wygasłym challenge).
+            var gated = document.querySelector('.zglos-gated');
+            var widget = document.querySelector('altcha-widget');
+            if (gated && widget) {
+                var reveal = function() { gated.classList.add('revealed'); };
+                widget.addEventListener('statechange', function(e) {
+                    if (e.detail && e.detail.state === 'verified') {
+                        reveal();
+                    }
+                });
+                // Pas bezpieczeństwa na wyścig „verified przed listenerem":
+                // jeśli hidden input ALTCHA jest już wypełniony, odsłoń od razu.
+                // Pole nazywa się `captcha` (AltchaField), więc input ma
+                // id="id_captcha" i jest rodzeństwem <altcha-widget>.
+                var hidden = document.getElementById('id_captcha');
+                if (hidden && hidden.value) {
+                    reveal();
+                }
+            }
         })();
     </script>
 {% endblock %}

--- a/src/zglos_publikacje/templates/zglos_publikacje/step_rodzaj.html
+++ b/src/zglos_publikacje/templates/zglos_publikacje/step_rodzaj.html
@@ -82,7 +82,7 @@
                 // Pas bezpieczeństwa na wyścig „verified przed listenerem":
                 // jeśli hidden input ALTCHA jest już wypełniony, odsłoń od razu.
                 // Pole nazywa się `captcha` (AltchaField), więc input ma
-                // id="id_captcha" i jest rodzeństwem <altcha-widget>.
+                // id="id_captcha" i jest rodzeństwem elementu altcha-widget.
                 var hidden = document.getElementById('id_captcha');
                 if (hidden && hidden.value) {
                     reveal();


### PR DESCRIPTION
## Cel

Na kroku 0 kreatora zgłoszeń publikacji (`/zglos_publikacje/nowe_zgloszenie/`) widget ALTCHA (proof-of-work CAPTCHA dla anonima) był renderowany **na dole** jako zwykłe pole, a kafelki wyboru rodzaju były klikalne od razu. Dawało to race: dało się kliknąć kafelek **zanim** PoW się doliczył → serwerowy błąd „token missing" i re-render kroku 0.

Ten PR przenosi widget **na górę, wyśrodkowany**, a nagłówek + kafelki **ukrywa** do czasu weryfikacji — pojawiają się (z animacją) dopiero po zdarzeniu `statechange: verified`. Race znika deterministycznie: do weryfikacji nie ma czego kliknąć.

## Zakres

Zmiana **czysto frontendowa** — Python (`forms.py`, `views.py`, bramka serwerowa ALTCHA, replay-protection) bez zmian. Gating JS to warstwa UX; źródłem prawdy pozostaje `AltchaField.validate` na POST kroku 0.

- `step_rodzaj.html` — blok ALTCHA na górze; nagłówek+kafelki owinięte w `.zglos-gated` (tylko gdy `form.captcha` istnieje); siatka wyodrębniona do partiala `_tile_grid_rodzaj.html` (DRY); JS słucha `statechange` i jednokierunkowo dodaje `.revealed`.
- `_wizard_forms.scss` — centrowanie `.zglos-captcha`, `.zglos-gated { display:none } / .revealed`, keyframes fade-in + stagger, `@media (prefers-reduced-motion: reduce)`.
- `test_zglos_captcha_gating.py` (+ helper `_captcha_daphne_setup.py`) — Playwright: kafelki ukryte przed weryfikacją, widoczne po `verified`, widoczne od razu przy captcha OFF.

Dla zalogowanego i przy captcha OFF (domyślne) ścieżka renderu jest nietknięta — brak wrappera gatingu, kafelki od razu widoczne.

## Testy

- Nowe testy Playwright bramki: **3 passed** (×3 stabilne).
- Pełna suita `zglos_publikacje/tests/`: **115 passed** (zgodne z `dev`).
- Naprawiono regresję wykrytą w weryfikacji: komentarz JS zawierał literał `<altcha-widget`, który zatruwał naiwny substring-test w `test_zglos_captcha.py` (4 fałszywe faile dla zalogowanego/captcha-off). Widget renderu nie dotyczył.

## Uwagi

- Odsłanianie jednokierunkowe (raz `verified` → zostaje). Przy `expired`/`error` `refetchonexpire` liczy nowy PoW, a serwer odrzuci POST na wygasłym challenge.
- Skompilowane `app-*.css` są gitignorowane — nie w commitach (build-stage/`make assets`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)