### PR TITLE
perf(js): pełna minifikacja bundla (-136 KB raw / -21 KB gzip)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -214,8 +214,15 @@ module.exports = function (grunt) {
                          'ln -sf "$(cd "$PY_DIR" && pwd)" .venv/lib/python'
             },
             esbuild: {
+                // --minify = --minify-syntax + --minify-whitespace +
+                // --minify-identifiers. Ten ostatni byl wczesniej pominiety,
+                // przez co bundle wozil pelne nazwy zmiennych (~136 KB raw /
+                // ~21 KB gzip nadmiarowo). Mangling identyfikatorow jest
+                // bezpieczny: kod wchodzacy do bundla siega do globali przez
+                // window.* (patrz jquery-shim.js + sekcja GLOBAL EXPORTS
+                // w bundle-entry.js), a esbuild nie zmienia nazw wlasciwosci.
                 command: 'npx esbuild src/bpp/static/bpp/js/bundle-entry.js ' +
-                         '--bundle --minify-syntax --minify-whitespace --sourcemap ' +
+                         '--bundle --minify --sourcemap ' +
                          '--outfile=src/bpp/static/bpp/js/dist/bundle.js ' +
                          '--format=iife --target=es2018 ' +
                          '--inject:src/bpp/static/bpp/js/jquery-shim.js ' +
@@ -239,12 +246,41 @@ module.exports = function (grunt) {
                          '--outfile=src/powiazania_autorow/static/powiazania_autorow/js/dist/three-bundle.js ' +
                          '--format=iife --target=es2018'
             },
-            // Post-process bundle to fix IIFE scope issues
-            // django-autocomplete-light: yl namespace (esbuild renames to yl2)
+            // Post-process bundle to fix IIFE scope issues.
+            //
+            // django-autocomplete-light: `autocomplete_light.js` deklaruje
+            // `var yl = yl || {}` (u siebie w module), ale `dal_select2/
+            // select2.js` odwoluje sie do `yl` jako do GLOBALA (nigdzie go
+            // nie deklaruje). Po zbundlowaniu kazdy plik ma wlasny scope,
+            // wiec bez tej laty `yl.registerFunction("select2", ...)` leci
+            // ReferenceError i WSZYSTKIE autocomplete'y DAL (admin + zgloszenia)
+            // przestaja dzialac. Lata aliasuje modulowy `yl` na `window.yl`.
+            //
+            // Wzorzec jest odporny na `--minify-identifiers`: NIE zaklada
+            // konkretnej nazwy (esbuild mangluje `yl` do czegos w rodzaju
+            // `Bs`), tylko dopasowuje ksztalt deklaracji zakotwiczony na
+            // dal-owym `.functions`. Na koncu twardy guard: jesli lata sie
+            // nie zaaplikowala, build MUSI paść, zamiast po cichu wypuscic
+            // zepsuty bundle (dokladnie tak zachowywala sie poprzednia,
+            // sztywno wpisana wersja `var yl2=yl2||{}`).
+            //
+            // Celowo BRE (bez `-E`): BSD sed nie obsluguje wstecznych
+            // referencji `\1` we wzorcu ERE, a potrzebujemy ich, zeby
+            // zlapac te sama zmangowana nazwe trzy razy. BRE z `\(...\)`
+            // + `\{1,\}` dziala tak samo na macOS (BSD) i w obrazie
+            // testowym (GNU).
             patchBundle: {
-                command: "sed -i.bak 's/var yl2=yl2||{}/window.yl=window.yl||{};var yl2=window.yl/g' " +
-                    "src/bpp/static/bpp/js/dist/bundle.js && " +
-                    "rm -f src/bpp/static/bpp/js/dist/bundle.js.bak"
+                command:
+                    "F=src/bpp/static/bpp/js/dist/bundle.js && " +
+                    "sed -i.bak 's/var \\([A-Za-z0-9_$]\\{1,\\}\\)=\\1||{};" +
+                    "\\1\\.functions=\\1\\.functions||{}/" +
+                    "window.yl=window.yl||{};var \\1=window.yl;" +
+                    "\\1.functions=\\1.functions||{}/g' \"$F\" && " +
+                    "rm -f \"$F.bak\" && " +
+                    "{ grep -q 'window.yl=window.yl||{}' \"$F\" || " +
+                    "{ echo 'BLAD: lata yl NIE zaaplikowala sie - " +
+                    "autocomplete DAL bylby zepsuty. Sprawdz wzorzec sed " +
+                    "w Gruntfile (patchBundle).' >&2; exit 1; }; }"
             },
             copyRollbar: {
                 command: 'mkdir -p src/bpp/static/rollbar && ' +

--- a/src/bpp/newsfragments/odchudzenie-bundla-js.feature.rst
+++ b/src/bpp/newsfragments/odchudzenie-bundla-js.feature.rst
@@ -1,0 +1,13 @@
+Główny bundle JavaScript jest teraz w pełni minifikowany (esbuild
+``--minify``; wcześniej brakowało ``--minify-identifiers``, więc bundle
+woził pełne nazwy zmiennych). Rozmiar spadł z 921,5 KB do 785,4 KB
+(-136,2 KB, -14,8%), a po kompresji gzip — z 242,6 KB do 221,5 KB
+(-21,0 KB, -8,7%). Bundle ładowany jest render-blocking w ``<head>``,
+więc zysk dotyczy każdego wejścia na stronę.
+
+Przy okazji uodporniono na minifikację łatę eksportującą globalną
+przestrzeń nazw ``yl`` z django-autocomplete-light. Dotąd dopasowywała
+ona sztywną nazwę ``yl2``, którą ``--minify-identifiers`` zmienia — bez
+poprawki autouzupełnianie (select2) w panelu administracyjnym przestałoby
+działać. Łata dopasowuje teraz kształt deklaracji zamiast nazwy, a build
+przerywa się z czytelnym błędem, jeśli nie uda się jej zaaplikować.


### PR DESCRIPTION
## Co i po co

Główny bundle JS jest ładowany **render-blocking w `<head>`**, więc jego rozmiar
uderza w każde wejście na stronę. esbuild dostawał dotąd tylko
`--minify-syntax --minify-whitespace`, **bez `--minify-identifiers`** — bundle
woził pełne nazwy zmiennych. Zmiana na `--minify`.

## Zmierzone rozmiary (`src/bpp/static/bpp/js/dist/bundle.js`)

| | przed | po | zysk |
|---|---|---|---|
| raw | 943 638 B (**921,5 KB**) | 804 200 B (**785,4 KB**) | **-136,2 KB (-14,8%)** |
| gzip -9 | 248 399 B (**242,6 KB**) | 226 848 B (**221,5 KB**) | **-21,0 KB (-8,7%)** |

## ⚠️ Znaleziona przy okazji pułapka: łata `yl` cicho przestała działać

`--minify-identifiers` **rozbroił** łatę `shell:patchBundle`, która eksportuje
globalną przestrzeń nazw `yl` django-autocomplete-light. Ta łata jest
**krytyczna**:

- `dal/autocomplete_light.js` deklaruje `var yl = yl || {}` **w swoim module**,
- `dal_select2/select2.js` odwołuje się do `yl` **jako do globala** (nigdzie go
  nie deklaruje),
- po zbundlowaniu każdy plik ma własny scope → bez łaty
  `yl.registerFunction("select2", …)` leci `ReferenceError` i **przestają
  działać wszystkie autocomplete'y DAL**, w tym `forward=[...]` używane
  w `src/bpp/admin/core.py`.

Sed dopasowywał sztywną nazwę `var yl2=yl2||{}`, którą minifikator zmienia na
np. `Bs` — i **po cichu nie robił nic**. Zweryfikowane empirycznie: w bundlu
bez łaty `yl` występuje **wyłącznie jako odczyt** (`yl.registerFunction`,
`yl.getForwards`), bez ani jednej deklaracji.

Naprawione:
1. wzorzec dopasowuje **kształt deklaracji** (zakotwiczony na dal-owym
   `.functions`) zamiast nazwy → odporny na mangling,
2. **twardy guard** — build pada z czytelnym błędem, jeśli łata się nie
   zaaplikuje, żeby pułapka nie uzbroiła się ponownie,
3. wzorzec celowo w BRE, bo BSD sed nie obsługuje wstecznych referencji w ERE
   (`-E`) — sprawdzone, że działa i na macOS, i na GNU.

**Uwaga dla recenzenta:** testy Playwright **przechodzą także z zepsutą łatą** —
sprawdziłem to jawnie, budując bundle bez łaty (`test_wydawnictwo_autor.py`:
14 passed). Czyli suita **nie chroni** przed tą regresją; chroni dopiero
dodany guard build-time.

## ❌ Czego NIE zrobiłem: usunięcia jQuery UI (244,6 KB)

Pierwotny plan zakładał wyrzucenie jQuery UI z bundla przy założeniu, że jedyne
użycie to `adminsortable2/js/list-sortable.js` (admin, ma własne jQuery UI
z grappelli). **To założenie jest błędne — jQuery UI zostaje.**

`multiseek.js` (wyszukiwanie zaawansowane, **strona publiczna**,
`/multiseek/`, szablon `multiseek/index.html` dziedziczy po `base.html`) jest
zbudowany w całości na **fabryce widgetów jQuery UI** — 11 definicji
z dziedziczeniem:

```
$.widget("multiseek.multiseekBase", {…})
$.widget("multiseek.multiseekStringValue", $.multiseek.multiseekBaseValue, {…})
… ×11
```

`$.widget` **nie było na liście wzorców do zgrepowania** — dlatego to wyszło
dopiero przy ręcznej weryfikacji. Usunięcie jQuery UI wywaliłoby wyszukiwanie
zaawansowane dla anonimowych użytkowników.

### Co dokładnie zweryfikowałem

- Grep całego repo (bez `staticroot/`, `dist/`, `node_modules/`, `*.min.js`) za
  `.sortable( .draggable( .droppable( .resizable( .selectable( .accordion(
  .autocomplete( .datepicker( .dialog( .tabs( .slider( .spinner( .tooltip(
  .progressbar( $.ui jQuery.ui` → **jedyny hit: `list-sortable.js` (admin)**,
  zgodnie z założeniem.
- Rozszerzony grep o `$.widget` / `jQuery.widget` → **w repo 0 hitów**, ale
  w `site-packages`: `multiseek.js` — **blokada**.
- Grep `site-packages/*/static/**.js`: pozostałe hity to `grappelli`,
  `admin_tools` (admin, własne jQuery UI) oraz `rest_framework/default.js`
  (`.tooltip(` = Bootstrap, nie jQuery UI; strony DRF nie ładują bundla BPP).
- `multiseek.js:38` — `element.datepicker($.datepicker.regional[…])` to
  **martwa gałąź else**: `installDatePicker()` preferuje `fdatepicker`
  (foundation-datepicker jest w bundlu). Nie to blokuje, blokuje `$.widget`.
- **Przeczytałem kod** `jinplace` i `foundation-datepicker` (oba UMD) pod kątem
  runtime'owego `$.ui` / `$.widget` → **czysto, zero zależności od jQuery UI**.

Czyli: jedynym blokerem jest `multiseek.js`. Gdyby kiedyś przepisać go z fabryki
widgetów (albo zbudować custom jQuery UI zawierający sam widget factory, ~5 KB),
244,6 KB da się odzyskać — osobny PR.

## Weryfikacja

- `yarn test:js` → **46 passed**
- `pytest src/bpp/tests/test_playwright/test_admin/` → **102 passed** (DAL
  select2, formularze, autocomplete)
- `pytest src/bpp/tests/test_playwright/` (reszta) → **15 passed** (multiseek —
  fabryka widgetów jQuery UI + datepicker, smoke, browse, raporty)
- `pytest src/integration_tests/` → **41 passed, 1 xfailed**
- `node --check` na zbudowanym bundlu → OK
- `uv run pre-commit` → czysto
- Łata `yl` obecna w bundlu po buildzie: `window.yl=window.yl||{};var Bs=window.yl`

Nie ruszałem `defer`/`async` ani code-splitu DataTables (osobne tematy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
