### PR TITLE
perf: indeksy GIN, deduplikacja GiST i indeksy funkcyjne pod przeglądanie A–Z

### DIFF
--- a/baseline-sql/baseline.meta.json
+++ b/baseline-sql/baseline.meta.json
@@ -1,11 +1,11 @@
 {
-  "git_sha": "ef7db54e2b1e3aed0e7f3409b9e5222e1de9cfd8",
+  "git_sha": "669bae0a1b302fcacdec495f9cff17da75d3206c",
   "last_migration": {
     "admin": "0003_logentry_add_action_flag_choices",
     "admin_dashboard": "0001_initial",
     "auth": "0012_alter_user_first_name_max_length",
     "axes": "0010_accessattemptexpiration",
-    "bpp": "0469_przyszle_daty_zakonczenia_zatrudnienia",
+    "bpp": "0470_indeksy_gin_i_funkcyjne",
     "channels_broadcast": "0001_initial",
     "constance": "0003_drop_pickle",
     "contenttypes": "0002_remove_content_type_name",

--- a/baseline-sql/baseline.sql
+++ b/baseline-sql/baseline.sql
@@ -17229,6 +17229,7 @@ COPY public.django_migrations (id, app, name, applied) FROM stdin;
 1087	import_pracownikow	0025_importpracownikow_plik_po_imporcie	2000-01-01 00:00:00+00
 1088	import_pracownikow	0026_importpracownikow_uczelnia	2000-01-01 00:00:00+00
 1089	import_pracownikow	0027_profil_uczelnia	2000-01-01 00:00:00+00
+1090	bpp	0470_indeksy_gin_i_funkcyjne	2000-01-01 00:00:00+00
 \.
 
 
@@ -17594,6 +17595,21 @@ COPY public.formdefaults_formfieldrepresentation (id, name, label, klass, "order
 55	if_do	do	django.forms.fields.FloatField	7	nowe_raporty.forms_dynamiczne.RaportForm_raport_autorow
 56	tylko_punktowane	Tylko prace punktowane (pkt MNiSW > 0)	django.forms.fields.BooleanField	8	nowe_raporty.forms_dynamiczne.RaportForm_raport_autorow
 57	obiekt	Autor	django.forms.models.ModelChoiceField	9	nowe_raporty.forms_dynamiczne.RaportForm_raport_autorow
+133	od_roku	Od roku	django.forms.fields.IntegerField	1	raport_slotow.forms.autor.AutorRaportSlotowForm
+134	do_roku	Do roku	django.forms.fields.IntegerField	2	raport_slotow.forms.autor.AutorRaportSlotowForm
+135	od_roku	Od roku	django.forms.fields.IntegerField	0	raport_slotow.forms.ewaluacja.ParametryRaportSlotowEwaluacjaForm
+136	do_roku	Do roku	django.forms.fields.IntegerField	1	raport_slotow.forms.ewaluacja.ParametryRaportSlotowEwaluacjaForm
+137	od_roku	Od roku	django.forms.fields.IntegerField	0	raport_slotow.forms.uczelnia.UtworzRaportSlotowUczelniaForm
+138	do_roku	Do roku	django.forms.fields.IntegerField	1	raport_slotow.forms.uczelnia.UtworzRaportSlotowUczelniaForm
+139	slot	Slot	django.forms.fields.DecimalField	3	raport_slotow.forms.uczelnia.UtworzRaportSlotowUczelniaForm
+140	od_roku	Od roku	django.forms.fields.IntegerField	0	nowe_raporty.forms_dynamiczne.RaportForm_raport_uczelni
+141	do_roku	Do roku	django.forms.fields.IntegerField	1	nowe_raporty.forms_dynamiczne.RaportForm_raport_uczelni
+142	od_roku	Od roku	django.forms.fields.IntegerField	0	nowe_raporty.forms_dynamiczne.RaportForm_raport_wydzialow
+143	do_roku	Do roku	django.forms.fields.IntegerField	1	nowe_raporty.forms_dynamiczne.RaportForm_raport_wydzialow
+144	od_roku	Od roku	django.forms.fields.IntegerField	0	nowe_raporty.forms_dynamiczne.RaportForm_raport_jednostek
+145	do_roku	Do roku	django.forms.fields.IntegerField	1	nowe_raporty.forms_dynamiczne.RaportForm_raport_jednostek
+146	od_roku	Od roku	django.forms.fields.IntegerField	0	nowe_raporty.forms_dynamiczne.RaportForm_raport_autorow
+147	do_roku	Do roku	django.forms.fields.IntegerField	1	nowe_raporty.forms_dynamiczne.RaportForm_raport_autorow
 \.
 
 
@@ -19182,7 +19198,7 @@ SELECT pg_catalog.setval('public.django_countdown_sitecountdown_id_seq', 1, fals
 -- Name: django_migrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public.django_migrations_id_seq', 1089, true);
+SELECT pg_catalog.setval('public.django_migrations_id_seq', 1090, true);
 
 
 --
@@ -19413,7 +19429,7 @@ SELECT pg_catalog.setval('public.formdefaults_formfielddefaultvalue_id_seq', 42,
 -- Name: formdefaults_formfieldrepresentation_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public.formdefaults_formfieldrepresentation_id_seq', 132, true);
+SELECT pg_catalog.setval('public.formdefaults_formfieldrepresentation_id_seq', 147, true);
 
 
 --
@@ -24030,6 +24046,13 @@ CREATE INDEX bpp_autor_nazwisko_6cf7bdb0_like ON public.bpp_autor USING btree (n
 
 
 --
+-- Name: bpp_autor_nazwisko_upper_like; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX bpp_autor_nazwisko_upper_like ON public.bpp_autor USING btree (upper((nazwisko)::text) text_pattern_ops);
+
+
+--
 -- Name: bpp_autor_orcid_67cc1f38_like; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -24079,10 +24102,10 @@ CREATE INDEX bpp_autor_poprzednie_nazwiska_aa36b910_like ON public.bpp_autor USI
 
 
 --
--- Name: bpp_autor_search_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: bpp_autor_search_gin; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX bpp_autor_search_idx ON public.bpp_autor USING gist (search);
+CREATE INDEX bpp_autor_search_gin ON public.bpp_autor USING gin (search);
 
 
 --
@@ -24097,13 +24120,6 @@ CREATE INDEX bpp_autor_slug_61f9172c_like ON public.bpp_autor USING btree (slug 
 --
 
 CREATE INDEX bpp_autor_stopien_sluzbowy_id_1876c19d ON public.bpp_autor USING btree (stopien_sluzbowy_id);
-
-
---
--- Name: bpp_autor_ts; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX bpp_autor_ts ON public.bpp_autor USING gist (search);
 
 
 --
@@ -24478,6 +24494,13 @@ CREATE INDEX bpp_jednostka_nazwa_20b50aeb_like ON public.bpp_jednostka USING btr
 
 
 --
+-- Name: bpp_jednostka_nazwa_upper_like; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX bpp_jednostka_nazwa_upper_like ON public.bpp_jednostka USING btree (upper((nazwa)::text) text_pattern_ops);
+
+
+--
 -- Name: bpp_jednostka_ostatnio_zmieniony_3604ba97; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -24520,6 +24543,13 @@ CREATE INDEX bpp_jednostka_rodzic_parent_id_86359c7a ON public.bpp_jednostka_rod
 
 
 --
+-- Name: bpp_jednostka_search_gin; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX bpp_jednostka_search_gin ON public.bpp_jednostka USING gin (search);
+
+
+--
 -- Name: bpp_jednostka_skrot_8f71b146_like; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -24545,13 +24575,6 @@ CREATE INDEX bpp_jednostka_slug_a03ebcdd_like ON public.bpp_jednostka USING btre
 --
 
 CREATE INDEX bpp_jednostka_tree_id_14382644 ON public.bpp_jednostka USING btree (tree_id);
-
-
---
--- Name: bpp_jednostka_ts; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX bpp_jednostka_ts ON public.bpp_jednostka USING gist (search);
 
 
 --
@@ -24947,6 +24970,13 @@ CREATE INDEX bpp_patent_rok_bb34fa36 ON public.bpp_patent USING btree (rok);
 
 
 --
+-- Name: bpp_patent_search_index_gin; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX bpp_patent_search_index_gin ON public.bpp_patent USING gin (search_index);
+
+
+--
 -- Name: bpp_patent_slug_642566ca_like; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -24958,13 +24988,6 @@ CREATE INDEX bpp_patent_slug_642566ca_like ON public.bpp_patent USING btree (slu
 --
 
 CREATE INDEX bpp_patent_status_korekty_id_f4e3377a ON public.bpp_patent USING btree (status_korekty_id);
-
-
---
--- Name: bpp_patent_ts; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX bpp_patent_ts ON public.bpp_patent USING gist (search_index);
 
 
 --
@@ -25227,6 +25250,13 @@ CREATE INDEX bpp_praca_doktorska_rok_ecf17eec ON public.bpp_praca_doktorska USIN
 
 
 --
+-- Name: bpp_praca_doktorska_search_index_gin; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX bpp_praca_doktorska_search_index_gin ON public.bpp_praca_doktorska USING gin (search_index);
+
+
+--
 -- Name: bpp_praca_doktorska_slug_c87123c0_like; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -25238,13 +25268,6 @@ CREATE INDEX bpp_praca_doktorska_slug_c87123c0_like ON public.bpp_praca_doktorsk
 --
 
 CREATE INDEX bpp_praca_doktorska_status_korekty_id_595ec5e9 ON public.bpp_praca_doktorska USING btree (status_korekty_id);
-
-
---
--- Name: bpp_praca_doktorska_ts; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX bpp_praca_doktorska_ts ON public.bpp_praca_doktorska USING gist (search_index);
 
 
 --
@@ -25493,6 +25516,13 @@ CREATE INDEX bpp_praca_habilitacyjna_rok_34557498 ON public.bpp_praca_habilitacy
 
 
 --
+-- Name: bpp_praca_habilitacyjna_search_index_gin; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX bpp_praca_habilitacyjna_search_index_gin ON public.bpp_praca_habilitacyjna USING gin (search_index);
+
+
+--
 -- Name: bpp_praca_habilitacyjna_slug_340e95be_like; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -25504,13 +25534,6 @@ CREATE INDEX bpp_praca_habilitacyjna_slug_340e95be_like ON public.bpp_praca_habi
 --
 
 CREATE INDEX bpp_praca_habilitacyjna_status_korekty_id_10aafb36 ON public.bpp_praca_habilitacyjna USING btree (status_korekty_id);
-
-
---
--- Name: bpp_praca_habilitacyjna_ts; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX bpp_praca_habilitacyjna_ts ON public.bpp_praca_habilitacyjna USING gist (search_index);
 
 
 --
@@ -26347,6 +26370,13 @@ CREATE INDEX bpp_wydawnictwo_ciagle_rok_528fd6e8 ON public.bpp_wydawnictwo_ciagl
 
 
 --
+-- Name: bpp_wydawnictwo_ciagle_search_index_gin; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX bpp_wydawnictwo_ciagle_search_index_gin ON public.bpp_wydawnictwo_ciagle USING gin (search_index);
+
+
+--
 -- Name: bpp_wydawnictwo_ciagle_slug_9045cfeb_like; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -26372,13 +26402,6 @@ CREATE INDEX bpp_wydawnictwo_ciagle_str_jezyk_streszczenia_id_34c0a081 ON public
 --
 
 CREATE INDEX bpp_wydawnictwo_ciagle_streszczenie_rekord_id_20e3c8a4 ON public.bpp_wydawnictwo_ciagle_streszczenie USING btree (rekord_id);
-
-
---
--- Name: bpp_wydawnictwo_ciagle_ts; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX bpp_wydawnictwo_ciagle_ts ON public.bpp_wydawnictwo_ciagle USING gist (search_index);
 
 
 --
@@ -26746,6 +26769,13 @@ CREATE INDEX bpp_wydawnictwo_zwarte_rok_3672b38f ON public.bpp_wydawnictwo_zwart
 
 
 --
+-- Name: bpp_wydawnictwo_zwarte_search_index_gin; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX bpp_wydawnictwo_zwarte_search_index_gin ON public.bpp_wydawnictwo_zwarte USING gin (search_index);
+
+
+--
 -- Name: bpp_wydawnictwo_zwarte_seria_wydawnicza_id_6af405f7; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -26778,13 +26808,6 @@ CREATE INDEX bpp_wydawnictwo_zwarte_str_jezyk_streszczenia_id_8ff64189 ON public
 --
 
 CREATE INDEX bpp_wydawnictwo_zwarte_streszczenie_rekord_id_f550a95a ON public.bpp_wydawnictwo_zwarte_streszczenie USING btree (rekord_id);
-
-
---
--- Name: bpp_wydawnictwo_zwarte_ts; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX bpp_wydawnictwo_zwarte_ts ON public.bpp_wydawnictwo_zwarte USING gist (search_index);
 
 
 --
@@ -27068,6 +27091,13 @@ CREATE INDEX bpp_zrodlo_nazwa_trgm ON public.bpp_zrodlo USING gin (nazwa public.
 
 
 --
+-- Name: bpp_zrodlo_nazwa_upper_like; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX bpp_zrodlo_nazwa_upper_like ON public.bpp_zrodlo USING btree (upper((nazwa)::text) text_pattern_ops);
+
+
+--
 -- Name: bpp_zrodlo_openaccess_licencja_id_72b1144c; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -27131,10 +27161,10 @@ CREATE INDEX bpp_zrodlo_rodzaj_id_c0e0fe48 ON public.bpp_zrodlo USING btree (rod
 
 
 --
--- Name: bpp_zrodlo_search_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: bpp_zrodlo_search_gin; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX bpp_zrodlo_search_idx ON public.bpp_zrodlo USING gist (search);
+CREATE INDEX bpp_zrodlo_search_gin ON public.bpp_zrodlo USING gin (search);
 
 
 --
@@ -27177,13 +27207,6 @@ CREATE INDEX bpp_zrodlo_skrot_trgm ON public.bpp_zrodlo USING gin (skrot public.
 --
 
 CREATE INDEX bpp_zrodlo_slug_6381a5f1_like ON public.bpp_zrodlo USING btree (slug varchar_pattern_ops);
-
-
---
--- Name: bpp_zrodlo_ts; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX bpp_zrodlo_ts ON public.bpp_zrodlo USING gist (search);
 
 
 --
@@ -27842,6 +27865,13 @@ CREATE INDEX easyaudit_c_object__82020b_idx ON public.easyaudit_crudevent USING 
 --
 
 CREATE INDEX easyaudit_crudevent_content_type_id_618ed0c6 ON public.easyaudit_crudevent USING btree (content_type_id);
+
+
+--
+-- Name: easyaudit_crudevent_datetime_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX easyaudit_crudevent_datetime_idx ON public.easyaudit_crudevent USING btree (datetime);
 
 
 --

--- a/src/bpp/migrations/0470_indeksy_gin_i_funkcyjne.py
+++ b/src/bpp/migrations/0470_indeksy_gin_i_funkcyjne.py
@@ -1,0 +1,142 @@
+"""Komplet poprawek indeksowych: GiST -> GIN, deduplikacja, indeksy funkcyjne.
+
+Uzasadnienie GIN (benchmark z migracji 0431, zrzut produkcyjny 122k
+rekordow, 2026-06, ksztalty zapytan BPP -- bpp_rekord_mat):
+
+    prefix :*        47.6 ->  12.6 ms   (3.8x)
+    AND 2 termow     47.4 ->   2.4 ms  (19.6x)
+    websearch        14.7 ->   8.9 ms   (1.7x)
+    ranking top-20   48.7 ->  13.2 ms   (3.7x)
+
+Zapis (UPDATE 1000 publikacji przez trigger) bez regresji; rozmiar
+15 vs 11 MB; budowa 0.4 s. GIN jest wariantem rekomendowanym dla
+tsvector w dokumentacji PostgreSQL. 0431 objela wylacznie
+bpp_rekord_mat -- tu domykamy pozostale osiem tabel z kolumna
+tsvector.
+"""
+
+from django.db import migrations
+
+# (tabela, kolumna tsvector, nazwa istniejacego indeksu GiST)
+TSVECTOR_INDEXES = [
+    ("bpp_autor", "search", "bpp_autor_ts"),
+    ("bpp_zrodlo", "search", "bpp_zrodlo_ts"),
+    ("bpp_jednostka", "search", "bpp_jednostka_ts"),
+    ("bpp_patent", "search_index", "bpp_patent_ts"),
+    ("bpp_praca_doktorska", "search_index", "bpp_praca_doktorska_ts"),
+    ("bpp_praca_habilitacyjna", "search_index", "bpp_praca_habilitacyjna_ts"),
+    ("bpp_wydawnictwo_ciagle", "search_index", "bpp_wydawnictwo_ciagle_ts"),
+    ("bpp_wydawnictwo_zwarte", "search_index", "bpp_wydawnictwo_zwarte_ts"),
+]
+
+# Duplikaty GiST na tej samej kolumnie co indeksy z TSVECTOR_INDEXES:
+# bpp_autor_search_idx == bpp_autor_ts (oba USING gist (search)),
+# bpp_zrodlo_search_idx == bpp_zrodlo_ts (oba USING gist (search)).
+# Kosztuja miejsce i czas przy kazdym zapisie, nie daja nic w zamian.
+DUPLICATE_GIST_INDEXES = [
+    ("bpp_autor", "search", "bpp_autor_search_idx"),
+    ("bpp_zrodlo", "search", "bpp_zrodlo_search_idx"),
+]
+
+# Przegladanie A-Z (bpp/views/browse.py, Browser.get_queryset) filtruje
+# przez `__istartswith`, co Django tlumaczy na:
+#     UPPER("bpp_autor"."nazwisko"::text) LIKE UPPER('K%')
+# Istniejace indeksy *_like (varchar_pattern_ops na golej kolumnie)
+# obsluguja wylacznie case-SENSITIVE LIKE, wiec planner schodzi do seq
+# scanu. Indeks funkcyjny na dokladnie tym samym wyrazeniu naprawia to.
+# Wyrazenie upper(kol::text) jest typu `text`, dlatego text_pattern_ops.
+# (varchar_pattern_ops tez by przeszlo -- text i varchar sa binarnie
+# zgodne -- ale text_pattern_ops jest klasa wlasciwa dla typu wyrazenia.)
+#
+# Zweryfikowane na PostgreSQL 16, tabela 200k wierszy, prefiks "Kowalski":
+#   bez indeksu funkcyjnego: Parallel Seq Scan, 27.5 ms
+#   z indeksem funkcyjnym:   Bitmap Index Scan,  0.06 ms
+ISTARTSWITH_INDEXES = [
+    ("bpp_autor", "nazwisko", "bpp_autor_nazwisko_upper_like"),
+    ("bpp_zrodlo", "nazwa", "bpp_zrodlo_nazwa_upper_like"),
+    ("bpp_jednostka", "nazwa", "bpp_jednostka_nazwa_upper_like"),
+]
+
+
+def _gin_operations():
+    """GiST -> GIN dla indeksow pelnotekstowych.
+
+    Kolejnosc jest istotna: najpierw budujemy GIN, dopiero potem
+    kasujemy GiST. Gdyby migracja przerwala sie w polowie, wyszukiwanie
+    caly czas ma jakis uzywalny indeks.
+    """
+    operations = []
+    for table, column, gist_name in TSVECTOR_INDEXES:
+        gin_name = f"{table}_{column}_gin"
+        operations.append(
+            migrations.RunSQL(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {gin_name} "
+                f"ON {table} USING GIN ({column})",
+                f"DROP INDEX CONCURRENTLY IF EXISTS {gin_name}",
+            )
+        )
+        operations.append(
+            migrations.RunSQL(
+                f"DROP INDEX CONCURRENTLY IF EXISTS {gist_name}",
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {gist_name} "
+                f"ON {table} USING GIST ({column})",
+            )
+        )
+    return operations
+
+
+def _duplicate_drop_operations():
+    return [
+        migrations.RunSQL(
+            f"DROP INDEX CONCURRENTLY IF EXISTS {name}",
+            f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} "
+            f"ON {table} USING GIST ({column})",
+        )
+        for table, column, name in DUPLICATE_GIST_INDEXES
+    ]
+
+
+def _istartswith_operations():
+    return [
+        migrations.RunSQL(
+            f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} ON {table} "
+            f"USING BTREE (upper({column}::text) text_pattern_ops)",
+            f"DROP INDEX CONCURRENTLY IF EXISTS {name}",
+        )
+        for table, column, name in ISTARTSWITH_INDEXES
+    ]
+
+
+class Migration(migrations.Migration):
+    # CONCURRENTLY nie moze dzialac w bloku transakcji -- stad atomic=False
+    # oraz osobne operacje RunSQL (kilka statementow w jednym stringu
+    # psycopg wykonuje w niejawnej transakcji). Na produkcji tabele
+    # publikacji sa duze, wiec blokada ACCESS EXCLUSIVE ze zwyklego
+    # CREATE INDEX bylaby zauwazalna dla uzytkownikow.
+    atomic = False
+
+    dependencies = [
+        ("bpp", "0469_przyszle_daty_zakonczenia_zatrudnienia"),
+    ]
+
+    operations = (
+        _gin_operations()
+        + _duplicate_drop_operations()
+        + _istartswith_operations()
+        + [
+            # easyaudit_crudevent.datetime nie ma indeksu (siostrzana
+            # tabela easyaudit_requestevent ma go jako
+            # easyaudit_requestevent_datetime_8ce2b5a3), a admin sortuje
+            # liste zdarzen po "-datetime". Tabela nalezy do zewnetrznej
+            # aplikacji django-easy-audit, wiec dokladamy indeks surowym
+            # SQL-em zamiast ruszac cudzy model (unikamy wiecznego
+            # makemigrations --check drift).
+            migrations.RunSQL(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                "easyaudit_crudevent_datetime_idx "
+                "ON easyaudit_crudevent USING BTREE (datetime)",
+                "DROP INDEX CONCURRENTLY IF EXISTS "
+                "easyaudit_crudevent_datetime_idx",
+            ),
+        ]
+    )

--- a/src/bpp/newsfragments/indeksy-gin-i-funkcyjne.feature.rst
+++ b/src/bpp/newsfragments/indeksy-gin-i-funkcyjne.feature.rst
@@ -1,0 +1,8 @@
+Przyspieszono wyszukiwanie i przeglądanie danych dzięki poprawkom indeksów w
+bazie: indeksy pełnotekstowe autorów, źródeł, jednostek, patentów, prac
+doktorskich i habilitacyjnych oraz wydawnictw ciągłych i zwartych przeniesiono
+z GiST na GIN (na zrzucie produkcyjnym analogiczna zmiana dla rekordów dała
+przyspieszenie od 1,7× do 19,6× zależnie od kształtu zapytania), usunięto
+zduplikowane indeksy GiST autorów i źródeł, dodano indeksy funkcyjne pod
+przeglądanie alfabetyczne A–Z (autorzy, źródła, jednostki) oraz brakujący
+indeks na dacie zdarzeń w dzienniku zmian.


### PR DESCRIPTION
Jedna migracja (`0470_indeksy_gin_i_funkcyjne`) z kompletem poprawek indeksowych — celowo **jedna**, żeby nie kolidować numeracją z innymi otwartymi PR-ami.

## Uzasadnienie (benchmark z migracji 0431)

Migracja [`0431_search_index_gin`](../blob/dev/src/bpp/migrations/0431_search_index_gin.py) przeniosła indeks pełnotekstowy `bpp_rekord_mat` z GiST na GIN. Benchmark na zrzucie produkcyjnym (**122k rekordów**, 2026-06, rzeczywiste kształty zapytań BPP):

| zapytanie | GiST | GIN | zysk |
|---|---:|---:|---:|
| prefix `:*` | 47.6 ms | 12.6 ms | **3.8×** |
| AND 2 termów | 47.4 ms | 2.4 ms | **19.6×** |
| websearch | 14.7 ms | 8.9 ms | **1.7×** |
| ranking top-20 | 48.7 ms | 13.2 ms | **3.7×** |

Zapis (UPDATE 1000 publikacji przez trigger) — bez regresji; rozmiar 15 vs 11 MB; budowa 0.4 s. GIN jest też wariantem rekomendowanym dla `tsvector` w dokumentacji PostgreSQL.

**0431 objęła wyłącznie `bpp_rekord_mat`.** Ten PR domyka pozostałe osiem tabel z kolumną `tsvector`.

## Zakres

**(a) GiST → GIN na 8 kolumnach `tsvector`**
`bpp_autor`, `bpp_zrodlo`, `bpp_jednostka` (kolumna `search`) oraz `bpp_patent`, `bpp_praca_doktorska`, `bpp_praca_habilitacyjna`, `bpp_wydawnictwo_ciagle`, `bpp_wydawnictwo_zwarte` (kolumna `search_index`). Nazwy indeksów i kolumn zweryfikowane w `baseline-sql/baseline.sql`, nie zgadywane.

**(b) Usunięcie zduplikowanych indeksów GiST**
`bpp_autor_search_idx` był identyczny z `bpp_autor_ts`, `bpp_zrodlo_search_idx` z `bpp_zrodlo_ts` (oba `USING gist (search)`). Duplikaty pochodzą z migracji `0277_lepsze_global_search` — dokładała `IF NOT EXISTS` pod nową nazwą, nie wiedząc o indeksach z `0001_indeksy.sql`. Kosztowały miejsce i czas przy każdym zapisie, nie dając nic w zamian. Zostaje po jednym — jako GIN.

**(c) Indeksy funkcyjne pod przeglądanie A–Z**
`browse.py` (`Browser.get_queryset`) filtruje przez `__istartswith`, co Django tłumaczy na:

```sql
UPPER("bpp_autor"."nazwisko"::text) LIKE UPPER('K%')
```

Istniejące indeksy `*_like` (`varchar_pattern_ops` na gołej kolumnie) obsługują wyłącznie case-**sensitive** LIKE, więc planner schodził do seq scanu. Dodane `btree(upper(kol::text) text_pattern_ops)` dla `bpp_autor.nazwisko`, `bpp_zrodlo.nazwa`, `bpp_jednostka.nazwa` (pola potwierdzone jako `literka_field` w `AutorzyView` / `ZrodlaView` / `JednostkiView`).

Zweryfikowane empirycznie na PostgreSQL 16, tabela 200k wierszy, prefiks `Kowalski`:

```
bez indeksu funkcyjnego:  Parallel Seq Scan, 100k Rows Removed by Filter — 27.5 ms
z indeksem funkcyjnym:    Bitmap Index Scan on t_nazwisko_upper_like    —  0.06 ms
```

> **Odstępstwo od zlecenia:** użyto `text_pattern_ops`, nie `varchar_pattern_ops`. Wyrażenie `upper(kol::text)` jest typu `text`, więc `text_pattern_ops` jest klasą właściwą dla typu. (`varchar_pattern_ops` też by przeszło — text i varchar są binarnie zgodne — ale poprawniejsze jest dopasowanie do typu wyrażenia.)

**(d) `easyaudit_crudevent.datetime`**
Siostrzana `easyaudit_requestevent` ma `easyaudit_requestevent_datetime_8ce2b5a3`, `crudevent` nie miała nic — a admin sortuje listę po `-datetime`. Dodane surowym `RunSQL` z `IF NOT EXISTS`, **bez** ruszania modelu obcej aplikacji (unikamy wiecznego driftu w `makemigrations --check`).

## Bezpieczeństwo migracji

- `CREATE`/`DROP INDEX CONCURRENTLY` + `atomic = False` — tabele publikacji są na produkcji duże, blokada `ACCESS EXCLUSIVE` ze zwykłego `CREATE INDEX` byłaby zauważalna dla użytkowników.
- Każdy `RunSQL` ma `reverse_sql`; wszystko idempotentne (`IF NOT EXISTS` / `IF EXISTS`).
- **Kolejność:** GIN budowany jest *przed* skasowaniem GiST — przerwana migracja nie zostawia wyszukiwania bez indeksu.
- Sprawdzone, że żaden kod runtime nie odwołuje się do nazw kasowanych indeksów (jedyne wystąpienia to historyczne migracje, które wykonują się wcześniej).

## Weryfikacja

- `make baseline-update` — migracja zaaplikowała się czysto (`Applying bpp.0470_indeksy_gin_i_funkcyjne... OK`); commitowane oba pliki (`baseline.sql` + `baseline.meta.json`). Diff baseline zawiera dokładnie zamierzony zestaw zmian, nic ponadto.
- `uv run pytest src/bpp/tests/ -q` → **2756 passed, 2 skipped** w 16:09. Obejmuje testy Playwright dotykające zmienionych ścieżek: `test_browse.py::test_autorzy_literki`, `test_zrodla_literki`, `test_autorzy_search_form`, `test_zrodla_index` oraz zestaw multiseek.
- `uv run pre-commit` — wszystkie hooki przechodzą.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
