### PR TITLE
perf(zadania): higiena zadań w tle i retencji danych

### DIFF
--- a/src/bpp/newsfragments/higiena-zadan-w-tle.feature.rst
+++ b/src/bpp/newsfragments/higiena-zadan-w-tle.feature.rst
@@ -1,0 +1,20 @@
+Higiena zadań w tle i retencji danych:
+
+* długo działające zadania cykliczne (przeliczanie powiązań autorów, skan
+  duplikatów autorów, automatyczna przebudowa cache dopasowań PBN) dostały
+  limity czasu i blokadę pojedynczej instancji — zawieszone zadanie nie
+  zablokuje już slotu workera na 6 godzin, a dwa równoległe przebiegi nie
+  skasują sobie nawzajem wyników;
+* przeliczanie powiązań autorów buduje wynik w tabeli tymczasowej i dopiero
+  gotowy przepisuje do tabeli docelowej — czas, przez który tabela powiązań
+  jest zablokowana dla zapisów, skrócił się z całego przeliczania do samego
+  przepisania wierszy;
+* dobowa przebudowa cache dopasowań PBN przesunięta z 3:30 na 4:30, żeby nie
+  startowała równocześnie z porządkowaniem kolejności rekordów;
+* nieudane próby logowania (django-axes) są kasowane po 90 dniach — dotąd
+  wpisy generowane przez boty skanujące panel administracyjny zostawały
+  w bazie bezterminowo;
+* pliki XLS importu pracowników są wreszcie kasowane zgodnie z ustawioną
+  retencją — komenda istniała, ale nic jej nie uruchamiało;
+* naprawiono wpis harmonogramu czyszczenia kolejki eksportu do PBN, który
+  wskazywał na nieistniejącą nazwę zadania i przez to nigdy się nie wykonywał.

--- a/src/bpp/newsfragments/higiena-zadan-w-tle.feature.rst
+++ b/src/bpp/newsfragments/higiena-zadan-w-tle.feature.rst
@@ -3,12 +3,16 @@ Higiena zadań w tle i retencji danych:
 * długo działające zadania cykliczne (przeliczanie powiązań autorów, skan
   duplikatów autorów, automatyczna przebudowa cache dopasowań PBN) dostały
   limity czasu i blokadę pojedynczej instancji — zawieszone zadanie nie
-  zablokuje już slotu workera na 6 godzin, a dwa równoległe przebiegi nie
-  skasują sobie nawzajem wyników;
+  zablokuje już slotu workera na 6 godzin;
+* skanowanie duplikatów autorów dostało dodatkowo barierę w bazie danych:
+  przebieg wycofuje się, gdy inny już trwa, i to ZANIM skasuje dotychczasowe
+  wyniki. Sama blokada w Redisie nie wystarczała, bo restart dowolnego
+  workera ją zwalniał. Porzucone przebiegi (po ubitym workerze) są
+  automatycznie przeterminowywane, więc nie blokują skanowania na zawsze;
 * przeliczanie powiązań autorów buduje wynik w tabeli tymczasowej i dopiero
   gotowy przepisuje do tabeli docelowej — czas, przez który tabela powiązań
   jest zablokowana dla zapisów, skrócił się z całego przeliczania do samego
-  przepisania wierszy;
+  przepisania wierszy (na ścieżce zadania cyklicznego);
 * dobowa przebudowa cache dopasowań PBN przesunięta z 3:30 na 4:30, żeby nie
   startowała równocześnie z porządkowaniem kolejności rekordów;
 * nieudane próby logowania (django-axes) są kasowane po 90 dniach — dotąd

--- a/src/bpp/tasks.py
+++ b/src/bpp/tasks.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from pathlib import Path
 
 from celery.utils.log import get_task_logger
@@ -82,6 +83,38 @@ def usun_stare_logi_logowania_easyaudit(
         "easyaudit LoginEvent: usunięto %d wpisów starszych niż %d mies. (cutoff=%s)",
         deleted,
         months,
+        cutoff.date(),
+    )
+    return deleted
+
+
+# Domyślna retencja nieudanych prób logowania (django-axes AccessAttempt) w
+# dniach. AXES_RESET_ON_SUCCESS kasuje wpisy TYLKO po udanym logowaniu tego
+# samego (login, IP) — wpisy generowane przez boty skanujące /admin/login/
+# nigdy nie doczekają się „swojego" udanego logowania i zostawałyby w bazie
+# bezterminowo. 90 dni: wielokrotnie powyżej AXES_COOLOFF_TIME (30 min), więc
+# retencja nigdy nie skasuje wpisu wciąż uczestniczącego w lockoucie, a
+# jednocześnie zostawia okno na forensykę kampanii brute-force.
+AXES_ACCESSATTEMPT_RETENTION_DAYS = 90
+
+
+@app.task(ignore_result=True)
+def usun_stare_proby_logowania_axes(days=AXES_ACCESSATTEMPT_RETENTION_DAYS):
+    """Usuwa wpisy axes AccessAttempt starsze niż `days` dni.
+
+    Dotyczy wyłącznie AccessAttempt (nieudane próby logowania — to ta tabela
+    puchnie od skanerów). AccessLog (udane logowania/wylogowania) NIE jest
+    ruszany.
+    """
+    from axes.models import AccessAttempt
+    from django.utils import timezone
+
+    cutoff = timezone.now() - timedelta(days=days)
+    deleted, _ = AccessAttempt.objects.filter(attempt_time__lt=cutoff).delete()
+    logger.info(
+        "axes AccessAttempt: usunięto %d wpisów starszych niż %d dni (cutoff=%s)",
+        deleted,
+        days,
         cutoff.date(),
     )
     return deleted

--- a/src/bpp/tasks.py
+++ b/src/bpp/tasks.py
@@ -97,20 +97,57 @@ def usun_stare_logi_logowania_easyaudit(
 # jednocześnie zostawia okno na forensykę kampanii brute-force.
 AXES_ACCESSATTEMPT_RETENTION_DAYS = 90
 
+# Ile wierszy kasujemy w jednej porcji. `.delete()` po całym queryssecie
+# ściąga do pamięci Pythona PK WSZYSTKICH pasujących wierszy (Django rozwija
+# kaskady po stronie ORM-a) — na instancji z wieloletnim backlogiem prób
+# logowania pierwszy przebieg zjadłby sporo RAM-u i trzymał jedną długą
+# transakcję. Partiami: stałe zużycie pamięci, krótkie transakcje.
+AXES_ACCESSATTEMPT_DELETE_BATCH = 5000
 
-@app.task(ignore_result=True)
+# Limit czasu retencji axes — jako jedyne z zadań retencyjnych nie miało go
+# wcześniej. Kasowanie partiami czyni zadanie przerywalnym bez szkody: każda
+# partia to osobna transakcja, więc ubicie w połowie zostawia bazę spójną, a
+# resztę dokasuje kolejny tygodniowy przebieg.
+AXES_RETENCJA_TIME_LIMIT = 30 * 60
+
+
+@app.task(
+    ignore_result=True,
+    time_limit=AXES_RETENCJA_TIME_LIMIT,
+    soft_time_limit=int(0.95 * AXES_RETENCJA_TIME_LIMIT),
+)
 def usun_stare_proby_logowania_axes(days=AXES_ACCESSATTEMPT_RETENTION_DAYS):
     """Usuwa wpisy axes AccessAttempt starsze niż `days` dni.
 
     Dotyczy wyłącznie AccessAttempt (nieudane próby logowania — to ta tabela
     puchnie od skanerów). AccessLog (udane logowania/wylogowania) NIE jest
     ruszany.
+
+    Kasuje partiami po AXES_ACCESSATTEMPT_DELETE_BATCH wierszy, żeby pierwszy
+    przebieg na instancji z wieloletnim backlogiem nie materializował w
+    pamięci PK całej tabeli.
     """
     from axes.models import AccessAttempt
     from django.utils import timezone
 
     cutoff = timezone.now() - timedelta(days=days)
-    deleted, _ = AccessAttempt.objects.filter(attempt_time__lt=cutoff).delete()
+
+    deleted = 0
+    while True:
+        # Partia PK — LIMIT po stronie bazy, bez ściągania całości.
+        batch = list(
+            AccessAttempt.objects.filter(attempt_time__lt=cutoff).values_list(
+                "pk", flat=True
+            )[:AXES_ACCESSATTEMPT_DELETE_BATCH]
+        )
+        if not batch:
+            break
+        usuniete, _ = AccessAttempt.objects.filter(pk__in=batch).delete()
+        deleted += usuniete
+        # Partia krótsza niż limit = to była ostatnia porcja.
+        if len(batch) < AXES_ACCESSATTEMPT_DELETE_BATCH:
+            break
+
     logger.info(
         "axes AccessAttempt: usunięto %d wpisów starszych niż %d dni (cutoff=%s)",
         deleted,

--- a/src/bpp/tests/test_tasks.py
+++ b/src/bpp/tests/test_tasks.py
@@ -7,10 +7,12 @@ from django.utils import timezone
 
 from bpp.models import Wydawnictwo_Ciagle
 from bpp.tasks import (
+    AXES_ACCESSATTEMPT_RETENTION_DAYS,
     EASYAUDIT_LOGINEVENT_RETENTION_MONTHS,
     _zaktualizuj_liczbe_cytowan,
     remove_file,
     usun_stare_logi_logowania_easyaudit,
+    usun_stare_proby_logowania_axes,
 )
 
 
@@ -168,3 +170,71 @@ def test_usun_stare_logi_logowania_easyaudit():
     assert LoginEvent.objects.filter(pk=nowy.pk).exists()
     # CRUDEvent nietknięty
     assert CRUDEvent.objects.filter(pk=crud.pk).exists()
+
+
+@pytest.mark.django_db
+def test_usun_stare_proby_logowania_axes():
+    """Kasuje AccessAttempt starsze niż retencja, zostawia świeże i nie rusza
+    AccessLog (udane logowania)."""
+    from axes.models import AccessAttempt, AccessLog
+
+    now = timezone.now()
+
+    def _attempt(username):
+        return AccessAttempt.objects.create(
+            username=username,
+            ip_address="10.0.0.1",
+            user_agent="bot",
+            get_data="",
+            post_data="",
+            failures_since_start=1,
+        )
+
+    stary = _attempt("bot-skanujacy")
+    nowy = _attempt("swiezy")
+    log = AccessLog.objects.create(
+        username="ktos", ip_address="10.0.0.2", user_agent="firefox"
+    )
+
+    # attempt_time to auto_now_add — przestawiamy ręcznie przez update()
+    cutoff = now - timedelta(days=AXES_ACCESSATTEMPT_RETENTION_DAYS)
+    AccessAttempt.objects.filter(pk=stary.pk).update(
+        attempt_time=cutoff - timedelta(days=1)
+    )
+    AccessAttempt.objects.filter(pk=nowy.pk).update(
+        attempt_time=now - timedelta(days=1)
+    )
+
+    deleted = usun_stare_proby_logowania_axes()
+
+    assert deleted == 1
+    assert not AccessAttempt.objects.filter(pk=stary.pk).exists()
+    assert AccessAttempt.objects.filter(pk=nowy.pk).exists()
+    # AccessLog (udane logowania) nietknięty
+    assert AccessLog.objects.filter(pk=log.pk).exists()
+
+
+@pytest.mark.django_db
+def test_usun_stare_proby_logowania_axes_respektuje_parametr_days():
+    """Parametr `days` przesuwa próg — ten sam wpis raz przeżywa, raz nie."""
+    from axes.models import AccessAttempt
+
+    attempt = AccessAttempt.objects.create(
+        username="bot",
+        ip_address="10.0.0.1",
+        user_agent="bot",
+        get_data="",
+        post_data="",
+        failures_since_start=1,
+    )
+    AccessAttempt.objects.filter(pk=attempt.pk).update(
+        attempt_time=timezone.now() - timedelta(days=10)
+    )
+
+    # Retencja 30 dni — wpis 10-dniowy zostaje.
+    assert usun_stare_proby_logowania_axes(days=30) == 0
+    assert AccessAttempt.objects.filter(pk=attempt.pk).exists()
+
+    # Retencja 5 dni — ten sam wpis wypada.
+    assert usun_stare_proby_logowania_axes(days=5) == 1
+    assert not AccessAttempt.objects.filter(pk=attempt.pk).exists()

--- a/src/bpp/tests/test_tasks.py
+++ b/src/bpp/tests/test_tasks.py
@@ -238,3 +238,42 @@ def test_usun_stare_proby_logowania_axes_respektuje_parametr_days():
     # Retencja 5 dni — ten sam wpis wypada.
     assert usun_stare_proby_logowania_axes(days=5) == 1
     assert not AccessAttempt.objects.filter(pk=attempt.pk).exists()
+
+
+@pytest.mark.django_db
+def test_usun_stare_proby_logowania_axes_kasuje_partiami(monkeypatch):
+    """Kasowanie idzie partiami (nie jednym .delete() po całym querysecie),
+    a mimo to sprząta CAŁY backlog i nie rusza świeżych wpisów."""
+    from axes.models import AccessAttempt
+
+    from bpp import tasks as bpp_tasks
+
+    # Partia mniejsza niż liczba wpisów → wymusza kilka iteracji pętli.
+    monkeypatch.setattr(bpp_tasks, "AXES_ACCESSATTEMPT_DELETE_BATCH", 2)
+
+    def _attempt(username, ua):
+        return AccessAttempt.objects.create(
+            username=username,
+            ip_address="10.0.0.1",
+            user_agent=ua,
+            get_data="",
+            post_data="",
+            failures_since_start=1,
+        )
+
+    now = timezone.now()
+    stare = [_attempt(f"bot{i}", f"bot{i}") for i in range(7)]
+    swieze = [_attempt(f"user{i}", f"ff{i}") for i in range(3)]
+
+    cutoff = now - timedelta(days=AXES_ACCESSATTEMPT_RETENTION_DAYS)
+    AccessAttempt.objects.filter(pk__in=[a.pk for a in stare]).update(
+        attempt_time=cutoff - timedelta(days=1)
+    )
+    AccessAttempt.objects.filter(pk__in=[a.pk for a in swieze]).update(
+        attempt_time=now - timedelta(days=1)
+    )
+
+    # 7 starych przy partii 2 = kilka iteracji; wszystkie muszą zniknąć.
+    assert usun_stare_proby_logowania_axes() == 7
+    assert not AccessAttempt.objects.filter(pk__in=[a.pk for a in stare]).exists()
+    assert AccessAttempt.objects.filter(pk__in=[a.pk for a in swieze]).count() == 3

--- a/src/deduplikator_autorow/tasks.py
+++ b/src/deduplikator_autorow/tasks.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 from celery import shared_task
 from celery.utils.log import get_task_logger
-from django.db import transaction
+from django.db import connection, transaction
 from django.utils import timezone
 
 from django_bpp.celery_tasks import GlobalSingleton
@@ -47,6 +47,25 @@ SCAN_TIME_LIMIT = 3 * 60 * 60
 # RUNNING zakleszczyłby skanowanie NA ZAWSZE — a to gorsze niż ryzyko, przed
 # którym się bronimy.
 SCAN_STALE_AFTER = SCAN_TIME_LIMIT + 15 * 60
+
+# Klucz Postgresowego advisory locka chroniącego „slot" skanu duplikatów.
+# Patrz `_przejmij_slot_skanu` — to on, a nie `select_for_update`, zapewnia
+# wzajemne wykluczanie (na pustej tabeli nie ma wierszy do zablokowania).
+#
+# Wartość wyprowadzona deterministycznie, żeby dało się ją odtworzyć i żeby
+# nikt nie użył przypadkiem tej samej gdzie indziej:
+#
+#     hashlib.blake2s(
+#         b"deduplikator_autorow.scan_for_duplicates.slot", digest_size=8
+#     ) -> int.from_bytes(..., "big") & (2**63 - 1)
+#
+# CELOWO stała literalna, a nie `abs(hash(...))` — wbudowany `hash()` dla
+# str jest solony PYTHONHASHSEED-em, więc daje INNĄ wartość w każdym procesie
+# Pythona. Klucz liczony w ten sposób nie wyklucza niczego między workerami
+# (każdy zakłada lock na własnym numerze). W repo są takie miejsca
+# (pbn_downloader_app/tasks.py, pbn_wysylka_oswiadczen/views.py) — nie
+# powielamy tego wzorca.
+SCAN_SLOT_LOCK_ID = 8081800802642310148
 
 
 def normalize_confidence(raw_score: int) -> float:
@@ -477,19 +496,31 @@ def _przejmij_slot_skanu(user, celery_task_id):
     Wpisy RUNNING starsze niż SCAN_STALE_AFTER są przeterminowywane na FAILED
     — inaczej jeden SIGKILL workera zakleszczyłby skanowanie na zawsze.
 
-    Całość w jednej transakcji z `select_for_update`, więc dwa workery
-    wchodzące tu równocześnie szeregują się na blokadzie wiersza, a nie
-    ścigają się między SELECT-em a INSERT-em.
+    Wzajemne wykluczanie stoi na `pg_advisory_xact_lock`, NIE na
+    `select_for_update`. To istotne: `SELECT ... FOR UPDATE` blokuje
+    ZNALEZIONE wiersze, a gdy żaden skan nie trwa, zbiór wynikowy jest PUSTY —
+    nie ma czego zablokować i wszystkie równoległe transakcje przechodzą dalej,
+    każda tworząc własny wpis RUNNING (phantom read). Czyli dokładnie w
+    jedynym momencie, w którym bariera ma coś robić, `select_for_update` jest
+    dekoracją. Advisory lock jest zakładany na UMOWNYM obiekcie, który istnieje
+    niezależnie od wierszy, więc działa też przy pustej tabeli. Wariant
+    `_xact_` zwalnia się sam na COMMIT/ROLLBACK i przy zerwaniu połączenia,
+    więc nie wprowadza nowej klasy zombie.
     """
     from .models import DuplicateScanRun
 
     stale_cutoff = timezone.now() - timedelta(seconds=SCAN_STALE_AFTER)
 
     with transaction.atomic():
+        # MUSI być pierwszą instrukcją w transakcji — cała sekcja krytyczna
+        # (odczyt RUNNING + decyzja + INSERT) ma być pod tym lockiem.
+        with connection.cursor() as cur:
+            cur.execute("SELECT pg_advisory_xact_lock(%s)", [SCAN_SLOT_LOCK_ID])
+
         running = list(
-            DuplicateScanRun.objects.select_for_update()
-            .filter(status=DuplicateScanRun.Status.RUNNING)
-            .order_by("pk")
+            DuplicateScanRun.objects.filter(
+                status=DuplicateScanRun.Status.RUNNING
+            ).order_by("pk")
         )
 
         zywe = [r for r in running if r.started_at > stale_cutoff]

--- a/src/deduplikator_autorow/tasks.py
+++ b/src/deduplikator_autorow/tasks.py
@@ -7,6 +7,8 @@ from celery.utils.log import get_task_logger
 from django.db import transaction
 from django.utils import timezone
 
+from django_bpp.celery_tasks import GlobalSingleton
+
 from .utils.constants import MAX_PEWNOSC, MIN_PEWNOSC
 
 logger = get_task_logger(__name__)
@@ -16,6 +18,21 @@ MIN_CONFIDENCE_TO_STORE = 50
 
 # How often to update progress (every N authors)
 PROGRESS_UPDATE_INTERVAL = 100
+
+# Budżet czasu pełnego skanu duplikatów autorów.
+#
+# To najcięższe z zadań cyklicznych: dwie fazy (PBN + general) przechodzą
+# przez wszystkich autorów, budują bucket-y i generują pary kandydatów z
+# fuzzy-scoringiem. Bucketowanie ratuje przed pełnym O(n^2), ale przy dużym
+# korpusie to i tak dziesiątki minut.
+#
+# 3 h to zapas na najgorszy realny przypadek, z dwoma twardymi sufitami:
+#  * `visibility_timeout` brokera = 6 h — limit MUSI być wyraźnie niższy,
+#    inaczej Redis re-dostarczy zadanie jeszcze w trakcie jego wykonywania
+#    i dostaniemy dwa przebiegi „replace mode" naraz,
+#  * start o 3:00 (crontab) — 3 h kończy przebieg przed 6:00, czyli przed
+#    porannym ruchem użytkowników.
+SCAN_TIME_LIMIT = 3 * 60 * 60
 
 
 def normalize_confidence(raw_score: int) -> float:
@@ -429,7 +446,18 @@ def _run_pbn_phase(scan_run, min_confidence=MIN_CONFIDENCE_TO_STORE):
     )
 
 
-@shared_task(bind=True, name="deduplikator_autorow.scan_for_duplicates")
+@shared_task(
+    bind=True,
+    name="deduplikator_autorow.scan_for_duplicates",
+    # GlobalSingleton, nie Singleton: zadanie bierze `user_id`, a zwykły
+    # Singleton kluczuje lock po argumentach — dwóch użytkowników klikających
+    # „skanuj" dostałoby dwa równoległe przebiegi, a każdy zaczyna od
+    # `DuplicateCandidate.objects.all().delete()`. Lock musi być globalny.
+    base=GlobalSingleton,
+    lock_expiry=SCAN_TIME_LIMIT,
+    time_limit=SCAN_TIME_LIMIT,
+    soft_time_limit=int(0.95 * SCAN_TIME_LIMIT),
+)
 def scan_for_duplicates(self, user_id=None, min_confidence=MIN_CONFIDENCE_TO_STORE):
     """Combined task: faza PBN + faza general w jednym przebiegu.
 

--- a/src/deduplikator_autorow/tasks.py
+++ b/src/deduplikator_autorow/tasks.py
@@ -2,6 +2,8 @@
 Celery tasks for author duplicate scanning.
 """
 
+from datetime import timedelta
+
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.db import transaction
@@ -33,6 +35,18 @@ PROGRESS_UPDATE_INTERVAL = 100
 #  * start o 3:00 (crontab) — 3 h kończy przebieg przed 6:00, czyli przed
 #    porannym ruchem użytkowników.
 SCAN_TIME_LIMIT = 3 * 60 * 60
+
+# Po tylu sekundach wpis DuplicateScanRun w statusie RUNNING uznajemy za
+# osierocony (zombie). Worker ubija zadanie twardo po SCAN_TIME_LIMIT, więc
+# przebieg starszy niż limit + margines NIE MOŻE już legalnie trwać — został
+# po SIGKILL-u workera / OOM-ie, gdzie blok `except` nie miał szans się
+# wykonać i przestawić statusu na FAILED.
+#
+# Margines jest po to, żeby nie ubić przebiegu, który właśnie dostaje
+# SIGKILL-a i za moment sam się posprząta. Bez przeterminowania osierocony
+# RUNNING zakleszczyłby skanowanie NA ZAWSZE — a to gorsze niż ryzyko, przed
+# którym się bronimy.
+SCAN_STALE_AFTER = SCAN_TIME_LIMIT + 15 * 60
 
 
 def normalize_confidence(raw_score: int) -> float:
@@ -446,6 +460,72 @@ def _run_pbn_phase(scan_run, min_confidence=MIN_CONFIDENCE_TO_STORE):
     )
 
 
+def _przejmij_slot_skanu(user, celery_task_id):
+    """Atomowo zajmij „slot" skanu: zwróć nowy DuplicateScanRun albo None.
+
+    Druga — NIEZALEŻNA OD REDISA — warstwa ochrony przed równoległymi
+    przebiegami. Lock `GlobalSingleton` sam nie wystarcza, bo
+    `unlock_all`/`clear_locks` na sygnale `worker_ready`
+    (django_bpp/celery_tasks.py) kasuje WSZYSTKIE locki globalnie: przy
+    wielu kontenerach workera rolling restart któregokolwiek z nich zwalnia
+    w środku 3-godzinnego skanu lock chroniący przebieg trwający na INNYM
+    workerze. Bez tej bariery drugi przebieg wszedłby w
+    `DuplicateCandidate.objects.all().delete()` i skasował wyniki pierwszego.
+
+    Zwraca None, gdy trwa już świeży skan (wołający ma się wycofać).
+
+    Wpisy RUNNING starsze niż SCAN_STALE_AFTER są przeterminowywane na FAILED
+    — inaczej jeden SIGKILL workera zakleszczyłby skanowanie na zawsze.
+
+    Całość w jednej transakcji z `select_for_update`, więc dwa workery
+    wchodzące tu równocześnie szeregują się na blokadzie wiersza, a nie
+    ścigają się między SELECT-em a INSERT-em.
+    """
+    from .models import DuplicateScanRun
+
+    stale_cutoff = timezone.now() - timedelta(seconds=SCAN_STALE_AFTER)
+
+    with transaction.atomic():
+        running = list(
+            DuplicateScanRun.objects.select_for_update()
+            .filter(status=DuplicateScanRun.Status.RUNNING)
+            .order_by("pk")
+        )
+
+        zywe = [r for r in running if r.started_at > stale_cutoff]
+        osierocone = [r for r in running if r.started_at <= stale_cutoff]
+
+        for zombie in osierocone:
+            zombie.status = DuplicateScanRun.Status.FAILED
+            zombie.finished_at = timezone.now()
+            zombie.error_message = (
+                f"Przebieg porzucony: status RUNNING utrzymywał się dłużej niż "
+                f"{SCAN_STALE_AFTER}s (prawdopodobnie ubity worker). "
+                f"Przeterminowany automatycznie przy starcie kolejnego skanu."
+            )
+            zombie.save(update_fields=["status", "finished_at", "error_message"])
+            logger.warning(
+                "Przeterminowano osierocony DuplicateScanRun pk=%s (started_at=%s)",
+                zombie.pk,
+                zombie.started_at,
+            )
+
+        if zywe:
+            logger.warning(
+                "Skan duplikatów już trwa (DuplicateScanRun pk=%s, "
+                "started_at=%s) — pomijam to uruchomienie.",
+                zywe[0].pk,
+                zywe[0].started_at,
+            )
+            return None
+
+        return DuplicateScanRun.objects.create(
+            status=DuplicateScanRun.Status.RUNNING,
+            created_by=user,
+            celery_task_id=celery_task_id,
+        )
+
+
 @shared_task(
     bind=True,
     name="deduplikator_autorow.scan_for_duplicates",
@@ -453,8 +533,16 @@ def _run_pbn_phase(scan_run, min_confidence=MIN_CONFIDENCE_TO_STORE):
     # Singleton kluczuje lock po argumentach — dwóch użytkowników klikających
     # „skanuj" dostałoby dwa równoległe przebiegi, a każdy zaczyna od
     # `DuplicateCandidate.objects.all().delete()`. Lock musi być globalny.
+    #
+    # Lock w Redisie to jednak TYLKO pierwsza warstwa — `clear_locks` na
+    # `worker_ready` kasuje go przy restarcie dowolnego workera. Druga,
+    # niezależna warstwa siedzi w `_przejmij_slot_skanu` (bariera w bazie).
     base=GlobalSingleton,
-    lock_expiry=SCAN_TIME_LIMIT,
+    # lock_expiry > time_limit: lock jest brany przy PUBLIKACJI zadania, a
+    # twardy kill dopiero w `start + time_limit`. Gdy zadanie poczeka w
+    # kolejce, lock wygasłby PRZED ubiciem — i otworzył okno na duplikat.
+    # +5 min pokrywa realistyczny czas oczekiwania w kolejce.
+    lock_expiry=SCAN_TIME_LIMIT + 300,
     time_limit=SCAN_TIME_LIMIT,
     soft_time_limit=int(0.95 * SCAN_TIME_LIMIT),
 )
@@ -473,11 +561,10 @@ def scan_for_duplicates(self, user_id=None, min_confidence=MIN_CONFIDENCE_TO_STO
     logger.info("Starting duplicate scan task (combined PBN + general)...")
 
     user = _get_user_by_id(user_id)
-    scan_run = DuplicateScanRun.objects.create(
-        status=DuplicateScanRun.Status.RUNNING,
-        created_by=user,
-        celery_task_id=self.request.id or "",
-    )
+    scan_run = _przejmij_slot_skanu(user, self.request.id or "")
+    if scan_run is None:
+        # Inny przebieg trwa — wycofujemy się PRZED skasowaniem kandydatów.
+        return {"status": "already_running"}
 
     try:
         # Replace mode: clear all previous candidates

--- a/src/deduplikator_autorow/tests/test_scan_slot_concurrency.py
+++ b/src/deduplikator_autorow/tests/test_scan_slot_concurrency.py
@@ -1,0 +1,126 @@
+"""Test WSPÓŁBIEŻNOŚCI bariery slotu skanu duplikatów.
+
+Osobny plik od `test_scan_slot_guard.py`, bo wymaga `django_db(transaction=True)`
+(prawdziwe commity, wiele połączeń), co jest istotnie wolniejsze niż domyślny
+tryb owinięty w transakcję.
+
+DLACZEGO to musi istnieć: wszystkie testy sekwencyjne przechodziły również na
+implementacji opartej o `select_for_update`, która NIE była atomowa —
+`SELECT ... FOR UPDATE` blokuje znalezione wiersze, a przy braku trwającego
+skanu zbiór jest pusty, więc nie blokuje niczego i N równoległych transakcji
+tworzy N wpisów RUNNING (phantom read). Ten test odtwarza dokładnie ten
+scenariusz i jest jedynym, który łapie regresję, gdyby ktoś wrócił do
+`select_for_update` albo usunął advisory lock.
+"""
+
+import threading
+
+import pytest
+from django.db import connections
+
+from deduplikator_autorow.models import DuplicateScanRun
+from deduplikator_autorow.tasks import _przejmij_slot_skanu
+
+LICZBA_WATKOW = 8
+
+
+@pytest.mark.django_db(transaction=True)
+def test_tylko_jeden_watek_przejmuje_slot_skanu():
+    """N wątków startujących RÓWNOCZEŚNIE z pustej tabeli: dokładnie jeden
+    dostaje slot i dokładnie jeden wiersz RUNNING ląduje w bazie.
+
+    Bez tego zabezpieczenia każdy z tych wątków wszedłby w
+    `DuplicateCandidate.objects.all().delete()`.
+    """
+    assert not DuplicateScanRun.objects.exists(), "test startuje z pustej tabeli"
+
+    # Bariera zamiast sleepów: wszystkie wątki ruszają w tej samej chwili,
+    # co maksymalizuje szansę na wyścig (sleep byłby i wolniejszy, i mniej
+    # deterministyczny).
+    start = threading.Barrier(LICZBA_WATKOW)
+    wyniki = [None] * LICZBA_WATKOW
+    bledy = [None] * LICZBA_WATKOW
+
+    def worker(idx):
+        try:
+            start.wait(timeout=30)
+            scan_run = _przejmij_slot_skanu(user=None, celery_task_id=f"t{idx}")
+            wyniki[idx] = scan_run is not None
+        except Exception as exc:  # noqa: BLE001 - re-raise'owane po joinie
+            bledy[idx] = exc
+        finally:
+            # Każdy wątek dostaje własne połączenie — musi je zamknąć, inaczej
+            # zostaje otwarte i teardown bazy się zawiesza.
+            connections.close_all()
+
+    watki = [threading.Thread(target=worker, args=(i,)) for i in range(LICZBA_WATKOW)]
+    for w in watki:
+        w.start()
+    for w in watki:
+        w.join(timeout=60)
+
+    for idx, blad in enumerate(bledy):
+        assert blad is None, f"wątek {idx} wywalił się: {blad!r}"
+
+    przyznane = sum(1 for w in wyniki if w)
+    running_w_bazie = DuplicateScanRun.objects.filter(
+        status=DuplicateScanRun.Status.RUNNING
+    ).count()
+
+    assert przyznane == 1, (
+        f"slot przejęło {przyznane} z {LICZBA_WATKOW} wątków — bariera nie jest atomowa"
+    )
+    assert running_w_bazie == 1, (
+        f"w bazie {running_w_bazie} wierszy RUNNING zamiast 1 — "
+        f"tyle równoległych przebiegów skasowałoby sobie nawzajem wyniki"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_wspolbieznie_tylko_jeden_przejmuje_slot_po_zombie():
+    """Wariant z osieroconym wpisem: N wątków zastaje zombie RUNNING.
+
+    Zombie ma zostać przeterminowany (dokładnie raz — nie N razy), a slot
+    przejąć dokładnie jeden wątek.
+    """
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from deduplikator_autorow.tasks import SCAN_STALE_AFTER
+
+    zombie = DuplicateScanRun.objects.create(status=DuplicateScanRun.Status.RUNNING)
+    DuplicateScanRun.objects.filter(pk=zombie.pk).update(
+        started_at=timezone.now() - timedelta(seconds=SCAN_STALE_AFTER + 60)
+    )
+
+    start = threading.Barrier(LICZBA_WATKOW)
+    wyniki = [None] * LICZBA_WATKOW
+    bledy = [None] * LICZBA_WATKOW
+
+    def worker(idx):
+        try:
+            start.wait(timeout=30)
+            scan_run = _przejmij_slot_skanu(user=None, celery_task_id=f"z{idx}")
+            wyniki[idx] = scan_run is not None
+        except Exception as exc:  # noqa: BLE001 - re-raise'owane po joinie
+            bledy[idx] = exc
+        finally:
+            connections.close_all()
+
+    watki = [threading.Thread(target=worker, args=(i,)) for i in range(LICZBA_WATKOW)]
+    for w in watki:
+        w.start()
+    for w in watki:
+        w.join(timeout=60)
+
+    for idx, blad in enumerate(bledy):
+        assert blad is None, f"wątek {idx} wywalił się: {blad!r}"
+
+    assert sum(1 for w in wyniki if w) == 1
+    zombie.refresh_from_db()
+    assert zombie.status == DuplicateScanRun.Status.FAILED
+    assert (
+        DuplicateScanRun.objects.filter(status=DuplicateScanRun.Status.RUNNING).count()
+        == 1
+    )

--- a/src/deduplikator_autorow/tests/test_scan_slot_guard.py
+++ b/src/deduplikator_autorow/tests/test_scan_slot_guard.py
@@ -1,0 +1,117 @@
+"""Testy bariery bazodanowej chroniącej przed równoległymi skanami.
+
+Lock `GlobalSingleton` (Redis) to pierwsza warstwa, ale `clear_locks` na
+sygnale `worker_ready` kasuje go przy restarcie DOWOLNEGO workera — przy
+wielu kontenerach rolling restart zwalnia lock chroniący przebieg trwający
+gdzie indziej. Tu testujemy drugą, niezależną warstwę: `_przejmij_slot_skanu`.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from model_bakery import baker
+
+from deduplikator_autorow.models import DuplicateCandidate, DuplicateScanRun
+from deduplikator_autorow.tasks import (
+    SCAN_STALE_AFTER,
+    _przejmij_slot_skanu,
+    scan_for_duplicates,
+)
+
+
+def _scan_run(status, wiek_sekund=0):
+    """DuplicateScanRun o zadanym statusie, postarzony o `wiek_sekund`."""
+    run = DuplicateScanRun.objects.create(status=status)
+    if wiek_sekund:
+        DuplicateScanRun.objects.filter(pk=run.pk).update(
+            started_at=timezone.now() - timedelta(seconds=wiek_sekund)
+        )
+        run.refresh_from_db()
+    return run
+
+
+@pytest.mark.django_db
+def test_slot_wolny_gdy_brak_trwajacych():
+    """Bez trwających przebiegów slot się zajmuje i wraca nowy scan run."""
+    scan_run = _przejmij_slot_skanu(user=None, celery_task_id="abc")
+
+    assert scan_run is not None
+    assert scan_run.status == DuplicateScanRun.Status.RUNNING
+    assert scan_run.celery_task_id == "abc"
+
+
+@pytest.mark.django_db
+def test_slot_zajety_gdy_trwa_swiezy_skan():
+    """Świeży RUNNING blokuje — druga próba dostaje None."""
+    trwajacy = _scan_run(DuplicateScanRun.Status.RUNNING)
+
+    assert _przejmij_slot_skanu(user=None, celery_task_id="drugi") is None
+
+    # Nie powstał żaden nowy wpis; trwający nietknięty.
+    assert DuplicateScanRun.objects.count() == 1
+    trwajacy.refresh_from_db()
+    assert trwajacy.status == DuplicateScanRun.Status.RUNNING
+
+
+@pytest.mark.django_db
+def test_osierocony_running_jest_przeterminowany():
+    """RUNNING starszy niż SCAN_STALE_AFTER = zombie po ubitym workerze:
+    przechodzi na FAILED, a slot zostaje zwolniony (brak zakleszczenia)."""
+    zombie = _scan_run(
+        DuplicateScanRun.Status.RUNNING, wiek_sekund=SCAN_STALE_AFTER + 60
+    )
+
+    scan_run = _przejmij_slot_skanu(user=None, celery_task_id="nowy")
+
+    assert scan_run is not None, "osierocony wpis nie może blokować na zawsze"
+    zombie.refresh_from_db()
+    assert zombie.status == DuplicateScanRun.Status.FAILED
+    assert zombie.finished_at is not None
+    assert "porzucony" in zombie.error_message
+
+
+@pytest.mark.django_db
+def test_swiezy_running_tuz_przed_progiem_nadal_blokuje():
+    """Granica: wpis MŁODSZY niż próg to wciąż żywy przebieg."""
+    _scan_run(DuplicateScanRun.Status.RUNNING, wiek_sekund=SCAN_STALE_AFTER - 60)
+
+    assert _przejmij_slot_skanu(user=None, celery_task_id="drugi") is None
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status",
+    [
+        DuplicateScanRun.Status.COMPLETED,
+        DuplicateScanRun.Status.FAILED,
+        DuplicateScanRun.Status.CANCELLED,
+        DuplicateScanRun.Status.PARTIAL_COMPLETED,
+    ],
+)
+def test_zakonczone_przebiegi_nie_blokuja(status):
+    """Tylko RUNNING blokuje — statusy końcowe są bez znaczenia."""
+    _scan_run(status)
+
+    assert _przejmij_slot_skanu(user=None, celery_task_id="nowy") is not None
+
+
+@pytest.mark.django_db
+def test_zadanie_nie_kasuje_kandydatow_gdy_skan_juz_trwa():
+    """NAJWAŻNIEJSZE: przy trwającym skanie zadanie wycofuje się ZANIM
+    wykona `DuplicateCandidate.objects.all().delete()`.
+
+    To jest dokładnie ta szkoda, przed którą broni bariera — bez niej drugi
+    przebieg (wpuszczony po `clear_locks` na restarcie workera) skasowałby
+    wyniki pierwszego."""
+    _scan_run(DuplicateScanRun.Status.RUNNING)
+
+    a1 = baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    a2 = baker.make("bpp.Autor", nazwisko="Kowalski", imiona="Jan")
+    kandydat = baker.make(DuplicateCandidate, main_autor=a1, duplicate_autor=a2)
+
+    result = scan_for_duplicates.apply().result
+
+    assert result["status"] == "already_running"
+    # Kandydat przeżył — nic nie zostało skasowane.
+    assert DuplicateCandidate.objects.filter(pk=kandydat.pk).exists()

--- a/src/deduplikator_autorow/tests/test_scan_views.py
+++ b/src/deduplikator_autorow/tests/test_scan_views.py
@@ -30,13 +30,19 @@ def test_start_scan_warns_but_runs_with_stale_pbn_people_data(client, mocker):
         "deduplikator_autorow.views.scan.is_pbn_people_data_fresh",
         return_value=(False, "Dane autorów PBN nigdy nie były pobrane", None),
     )
-    delay = mocker.patch("deduplikator_autorow.tasks.scan_for_duplicates.delay")
+    # Widok woła apply_async z własnym task_id (żeby wykryć deduplikację
+    # Singletona). Zwracamy AsyncResult o TYM SAMYM id = „realnie
+    # wystartowano".
+    apply_async = mocker.patch(
+        "deduplikator_autorow.tasks.scan_for_duplicates.apply_async",
+        side_effect=lambda **kw: mocker.Mock(id=kw["task_id"]),
+    )
 
     response = client.post(reverse("deduplikator_autorow:start_scan"))
 
     assert response.status_code == 302
     assert response["Location"] == reverse("deduplikator_autorow:duplicate_authors")
-    delay.assert_called_once_with(user_id=user.pk)
+    assert apply_async.call_args.kwargs["kwargs"] == {"user_id": user.pk}
 
     messages = _messages(response)
     assert any(
@@ -49,6 +55,33 @@ def test_start_scan_warns_but_runs_with_stale_pbn_people_data(client, mocker):
         and "Skanowanie duplikatów zostało uruchomione" in str(msg)
         for msg in messages
     )
+
+
+@pytest.mark.django_db
+def test_start_scan_nie_klamie_gdy_singleton_zdeduplikowal_dispatch(client, mocker):
+    """Gdy Singleton zdeduplikował wysyłkę (apply_async zwrócił AsyncResult
+    ISTNIEJĄCEGO zadania, o innym id niż zadane), widok NIE może meldować
+    „uruchomiono" — bo nic się nie uruchomiło."""
+    _login_user_with_group(client)
+    mocker.patch(
+        "deduplikator_autorow.views.scan.is_pbn_people_data_fresh",
+        return_value=(True, None, None),
+    )
+    # Zwracamy id INNE niż zadane = sygnał deduplikacji z celery_singleton.
+    mocker.patch(
+        "deduplikator_autorow.tasks.scan_for_duplicates.apply_async",
+        return_value=mocker.Mock(id="id-juz-trwajacego-zadania"),
+    )
+
+    response = client.post(reverse("deduplikator_autorow:start_scan"))
+
+    assert response.status_code == 302
+    messages = _messages(response)
+    assert any(
+        msg.level == django_messages.WARNING and "już trwa" in str(msg)
+        for msg in messages
+    )
+    assert not any(msg.level == django_messages.SUCCESS for msg in messages)
 
 
 @pytest.mark.django_db

--- a/src/deduplikator_autorow/views/scan.py
+++ b/src/deduplikator_autorow/views/scan.py
@@ -1,6 +1,7 @@
 """Scan-task lifecycle views (start / cancel / status)."""
 
 from datetime import timedelta
+from uuid import uuid4
 
 from django.contrib import messages
 from django.http import JsonResponse
@@ -39,13 +40,34 @@ def start_scan_view(request):
         )
         return redirect("deduplikator_autorow:duplicate_authors")
 
-    # Start new scan
-    scan_for_duplicates.delay(user_id=request.user.pk)
-    messages.success(
-        request,
-        "Skanowanie duplikatów zostało uruchomione w tle. "
-        "Odśwież stronę za chwilę, aby zobaczyć postęp.",
+    # Start new scan.
+    #
+    # Podajemy WŁASNY task_id, żeby odróżnić realny start od deduplikacji:
+    # `scan_for_duplicates` jest Singletonem z `raise_on_duplicate=False`,
+    # więc gdy przebieg już trwa, apply_async NIE startuje nic nowego, tylko
+    # zwraca AsyncResult ISTNIEJĄCEGO zadania. Bez tego porównania widok
+    # meldował „uruchomiono" również wtedy, gdy nic się nie uruchomiło.
+    # (Sprawdzenie `get_running_scan()` wyżej łapie typowy przypadek, ale nie
+    # zamyka wyścigu dwóch równoczesnych POST-ów ani przebiegu wystartowanego
+    # z beata pomiędzy jednym a drugim zapytaniem.)
+    zadany_task_id = str(uuid4())
+    result = scan_for_duplicates.apply_async(
+        kwargs={"user_id": request.user.pk}, task_id=zadany_task_id
     )
+
+    if result.id != zadany_task_id:
+        messages.warning(
+            request,
+            "Skanowanie duplikatów już trwa — to uruchomienie zostało "
+            "pominięte. Odśwież stronę, aby zobaczyć postęp trwającego "
+            "skanowania.",
+        )
+    else:
+        messages.success(
+            request,
+            "Skanowanie duplikatów zostało uruchomione w tle. "
+            "Odśwież stronę za chwilę, aby zobaczyć postęp.",
+        )
     return redirect("deduplikator_autorow:duplicate_authors")
 
 

--- a/src/django_bpp/celery_tasks.py
+++ b/src/django_bpp/celery_tasks.py
@@ -5,12 +5,40 @@ import platform
 import rollbar
 from celery import Celery
 from celery.signals import task_failure, worker_ready
-from celery_singleton import clear_locks
+from celery_singleton import Singleton, clear_locks
+from celery_singleton import util as singleton_util
 from django.apps import apps
 from django.conf import settings
 
 if platform.system() == "Darwin":
     os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
+
+
+class GlobalSingleton(Singleton):
+    """Singleton z lockiem GLOBALNYM dla zadania — niezależnym od argumentów.
+
+    Zwykły ``Singleton`` liczy klucz locka z argumentów wywołania (albo z
+    podzbioru wskazanego przez ``unique_on``), więc dwa wywołania różniące
+    się choćby jednym argumentem biegną RÓWNOLEGLE. Dla zadań, które
+    przebudowują całą tabelę „replace mode" (kasują wszystko i budują od
+    nowa), to jest dokładnie ten przypadek, którego nie wolno dopuścić:
+    ``scan_for_duplicates(user_id=1)`` i ``scan_for_duplicates(user_id=2)``
+    wzajemnie skasowałyby sobie wyniki.
+
+    ``unique_on=[]`` NIE załatwia sprawy — pusta lista jest falsy, więc
+    ``Singleton.generate_lock`` wpada w gałąź „bierz wszystkie argumenty".
+    Stąd jawne nadpisanie: lock zależy WYŁĄCZNIE od nazwy zadania.
+    """
+
+    abstract = True
+
+    def generate_lock(self, task_name, task_args=None, task_kwargs=None):
+        return singleton_util.generate_lock(
+            task_name,
+            [],
+            {},
+            key_prefix=self.singleton_config.key_prefix,
+        )
 
 
 def resolve_worker_config(environ, system, cpu_count):

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -771,7 +771,12 @@ CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(days=5),
     },
     "pbn-api-kolejka-wyczysc-wpisy-bez-rekordow": {
-        "task": "pbn_api.tasks.kolejka_wyczysc_wpisy_bez_rekordow",
+        # Zadanie żyje w pbn_export_queue.tasks, NIE w pbn_api.tasks — wpis
+        # wskazywał na nieistniejącą nazwę, więc beat co tydzień wysyłał
+        # zadanie, którego żaden worker nie potrafił rozwiązać (czyli kolejka
+        # nigdy nie była czyszczona). Ta sama klasa błędu co brak wpisu dla
+        # retencji plików importu pracowników.
+        "task": "pbn_export_queue.tasks.kolejka_wyczysc_wpisy_bez_rekordow",
         "schedule": timedelta(days=7),
     },
     "scan-for-duplicates-daily": {
@@ -791,9 +796,17 @@ CELERYBEAT_SCHEDULE = {
         "task": "zglos_publikacje.tasks.wyczysc_zglos_tmp_pliki",
         "schedule": timedelta(hours=6),
     },
+    # UWAGA na kolizję harmonogramów: o 3:30 startuje `rebuild_kolejnosc`
+    # zaplanowany przez OFELIĘ (repozytorium bpp-deploy,
+    # docker-compose.application.yml) — całkowicie niezależny scheduler, który
+    # nic nie wie o Celery beat i nie ma jak się z nim zsynchronizować. Dwa
+    # ciężkie zadania startujące w tej samej minucie biły się o CPU bazy.
+    # Przesuwamy stronę, którą kontrolujemy z TEGO repo (beat), na 4:30:
+    # godzina po Ofelii i pół godziny po `powiazania-autorow-przelicz-codziennie`
+    # (4:00), które jest krótkie (czysty SQL, minuty).
     "rebuild-pbn-author-match-cache": {
         "task": "importer_autorow_pbn.tasks.auto_rebuild_match_cache_task",
-        "schedule": crontab(hour=3, minute=30),  # Daily at 3:30 AM
+        "schedule": crontab(hour=4, minute=30),  # Daily at 4:30 AM
     },
     "pbn-export-queue-watchdog": {
         "task": "pbn_export_queue.tasks.queue_watchdog",
@@ -813,6 +826,24 @@ CELERYBEAT_SCHEDULE = {
     "easyaudit-purge-stare-logi-logowania": {
         "task": "bpp.tasks.usun_stare_logi_logowania_easyaudit",
         "schedule": crontab(hour=2, minute=0, day_of_month=1),
+    },
+    # Retencja nieudanych prób logowania (django-axes): kasuj AccessAttempt
+    # starsze niż 90 dni. AXES_RESET_ON_SUCCESS czyści tylko po udanym
+    # logowaniu tej samej pary (login, IP) — wpisy od botów skanujących
+    # /admin/login/ nie mają „swojego" udanego logowania i rosłyby bez końca.
+    # Raz w tygodniu (niedziela 2:30), tabela rośnie powoli.
+    "axes-purge-stare-proby-logowania": {
+        "task": "bpp.tasks.usun_stare_proby_logowania_axes",
+        "schedule": crontab(hour=2, minute=30, day_of_week=0),
+    },
+    # Retencja plików XLS importu pracowników (IMPORT_PRACOWNIKOW_RETENCJA_DNI,
+    # domyślnie 90 dni). Kasuje sam blob, zostawiając rekord importu i wiersze.
+    # Komenda zarządzająca istniała od dawna, ale NIKT jej nie wołał (ani beat,
+    # ani Ofelia) — bloby nie były kasowane nigdy. Trzymamy wpis w kodzie, a
+    # nie w labelu Ofelii, żeby harmonogram był wersjonowany razem z aplikacją.
+    "import-pracownikow-usun-stare-pliki": {
+        "task": "import_pracownikow.tasks.usun_stare_pliki_importu_pracownikow",
+        "schedule": crontab(hour=1, minute=15),  # Daily at 1:15 AM
     },
 }
 

--- a/src/import_pracownikow/management/commands/usun_stare_pliki_importu_pracownikow.py
+++ b/src/import_pracownikow/management/commands/usun_stare_pliki_importu_pracownikow.py
@@ -1,23 +1,14 @@
-from datetime import timedelta
-
-from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.utils import timezone
 
-from import_pracownikow.models import ImportPracownikow
+from import_pracownikow.tasks import usun_stare_pliki_importu
 
 
 class Command(BaseCommand):
     help = "Kasuje blob plik_xls importów starszych niż retencja (zostawia rekord)."
 
     def handle(self, *args, **options):
-        dni = getattr(settings, "IMPORT_PRACOWNIKOW_RETENCJA_DNI", 90)
-        prog = timezone.now() - timedelta(days=dni)
-        qs = ImportPracownikow.objects.filter(created_on__lt=prog).exclude(plik_xls="")
-        n = 0
-        for imp in qs:
-            imp.plik_xls.delete(save=False)
-            imp.plik_xls = ""
-            imp.save(update_fields=["plik_xls"])
-            n += 1
+        # Logika żyje w tasks.usun_stare_pliki_importu — ta sama ścieżka kodu,
+        # co zadanie cykliczne Celery, żeby komenda i beat nie mogły się
+        # rozjechać.
+        n = usun_stare_pliki_importu()
         self.stdout.write(f"Skasowano blobów: {n}")

--- a/src/import_pracownikow/tasks.py
+++ b/src/import_pracownikow/tasks.py
@@ -1,0 +1,55 @@
+"""Zadania cykliczne modułu importu pracowników."""
+
+from datetime import timedelta
+
+from celery.utils.log import get_task_logger
+from django.conf import settings
+from django.utils import timezone
+
+from django_bpp.celery_tasks import app
+
+logger = get_task_logger(__name__)
+
+
+def usun_stare_pliki_importu(dni=None):
+    """Kasuje blob `plik_xls` importów starszych niż `dni` dni.
+
+    Rekord ImportPracownikow i jego wiersze ZOSTAJĄ — znika tylko plik
+    źródłowy XLS, czyli jedyna część, która realnie zajmuje miejsce na
+    wolumenie media. Historia dopasowań pozostaje dostępna w adminie.
+
+    Zwraca liczbę skasowanych blobów.
+    """
+    from import_pracownikow.models import ImportPracownikow
+
+    if dni is None:
+        dni = getattr(settings, "IMPORT_PRACOWNIKOW_RETENCJA_DNI", 90)
+
+    prog = timezone.now() - timedelta(days=dni)
+    qs = ImportPracownikow.objects.filter(created_on__lt=prog).exclude(plik_xls="")
+
+    skasowano = 0
+    for imp in qs:
+        imp.plik_xls.delete(save=False)
+        imp.plik_xls = ""
+        imp.save(update_fields=["plik_xls"])
+        skasowano += 1
+
+    logger.info(
+        "import_pracownikow: skasowano %d plików XLS starszych niż %d dni (próg=%s)",
+        skasowano,
+        dni,
+        prog.date(),
+    )
+    return skasowano
+
+
+@app.task(ignore_result=True)
+def usun_stare_pliki_importu_pracownikow():
+    """Wrapper Celery dla retencji plików XLS importu pracowników.
+
+    Wołany z CELERYBEAT_SCHEDULE. Do tej pory istniała wyłącznie komenda
+    zarządzająca o tej samej nazwie, ale nikt jej nie wywoływał (ani beat, ani
+    Ofelia) — bloby XLS nie były kasowane nigdy.
+    """
+    return usun_stare_pliki_importu()

--- a/src/import_pracownikow/tests/test_housekeeping.py
+++ b/src/import_pracownikow/tests/test_housekeeping.py
@@ -7,6 +7,17 @@ from django.utils import timezone
 from model_bakery import baker
 
 from import_pracownikow.models import ImportPracownikow
+from import_pracownikow.tasks import usun_stare_pliki_importu_pracownikow
+
+
+def _import_z_plikiem(dni_temu):
+    """ImportPracownikow z zapisanym blobem, postarzony o `dni_temu` dni."""
+    imp = baker.make(ImportPracownikow)
+    imp.plik_xls.save("x.xlsx", ContentFile(b"dane"))
+    ImportPracownikow.objects.filter(pk=imp.pk).update(
+        created_on=timezone.now() - timedelta(days=dni_temu)
+    )
+    return imp
 
 
 @pytest.mark.django_db
@@ -21,3 +32,34 @@ def test_kasuje_stary_blob_zostawia_rekord(settings):
     imp.refresh_from_db()
     assert not imp.plik_xls  # blob skasowany
     assert ImportPracownikow.objects.filter(pk=imp.pk).exists()  # rekord został
+
+
+@pytest.mark.django_db
+def test_task_kasuje_stare_zostawia_swieze(settings):
+    """Zadanie Celery (wpięte w CELERYBEAT_SCHEDULE) kasuje bloby po retencji,
+    a świeżych nie rusza."""
+    settings.IMPORT_PRACOWNIKOW_RETENCJA_DNI = 90
+
+    stary = _import_z_plikiem(dni_temu=100)
+    swiezy = _import_z_plikiem(dni_temu=10)
+
+    assert usun_stare_pliki_importu_pracownikow() == 1
+
+    stary.refresh_from_db()
+    swiezy.refresh_from_db()
+    assert not stary.plik_xls
+    assert swiezy.plik_xls  # świeży blob nietknięty
+    # Rekordy (i historia dopasowań) zostają w obu przypadkach.
+    assert ImportPracownikow.objects.filter(pk=stary.pk).exists()
+    assert ImportPracownikow.objects.filter(pk=swiezy.pk).exists()
+
+
+@pytest.mark.django_db
+def test_task_jest_idempotentny(settings):
+    """Drugie uruchomienie nie ma już czego kasować (brak podwójnego liczenia
+    importów z pustym plik_xls)."""
+    settings.IMPORT_PRACOWNIKOW_RETENCJA_DNI = 90
+    _import_z_plikiem(dni_temu=100)
+
+    assert usun_stare_pliki_importu_pracownikow() == 1
+    assert usun_stare_pliki_importu_pracownikow() == 0

--- a/src/importer_autorow_pbn/tasks.py
+++ b/src/importer_autorow_pbn/tasks.py
@@ -1,7 +1,22 @@
 from celery import shared_task
+from celery_singleton import Singleton
 
 from .core import get_cache_status
 from .models import MatchCacheRebuildOperation
+
+# Budżet czasu automatycznej przebudowy cache dopasowań PBN.
+#
+# Przebudowa iteruje przez wszystkich naukowców PBN i dla każdego szuka
+# odpowiednika wśród autorów BPP, zapisując CachedScientistMatch. Wszystko
+# lokalnie (dane PBN są już w bazie — bez odpytywania API PBN), więc koszt to
+# CPU + zapisy, nie latencja sieci. Godzina to solidny zapas dla dużej
+# uczelni.
+#
+# Limit ma tu podwójny sens: zadanie chodzi CODZIENNIE z beata, a cache i tak
+# jest ważny 7 dni (CACHE_VALIDITY_DAYS), więc ubity przebieg zostanie
+# spokojnie ponowiony następnej nocy — nie ma powodu, by zawis trzymał slot
+# workera aż do `visibility_timeout` brokera (6 h).
+AUTO_REBUILD_TIME_LIMIT = 60 * 60
 
 
 @shared_task
@@ -19,7 +34,15 @@ def rebuild_match_cache_task(operation_pk):
     operation.task_perform()
 
 
-@shared_task
+@shared_task(
+    # Singleton (zadanie bezargumentowe → lock globalny): dwa równoległe
+    # przebiegi tworzyłyby dwie MatchCacheRebuildOperation i dublowały zapisy
+    # do CachedScientistMatch.
+    base=Singleton,
+    lock_expiry=AUTO_REBUILD_TIME_LIMIT,
+    time_limit=AUTO_REBUILD_TIME_LIMIT,
+    soft_time_limit=int(0.95 * AUTO_REBUILD_TIME_LIMIT),
+)
 def auto_rebuild_match_cache_task():
     """
     Automatic cache rebuild task - triggered by Celery Beat.

--- a/src/importer_autorow_pbn/tasks.py
+++ b/src/importer_autorow_pbn/tasks.py
@@ -39,7 +39,11 @@ def rebuild_match_cache_task(operation_pk):
     # przebiegi tworzyłyby dwie MatchCacheRebuildOperation i dublowały zapisy
     # do CachedScientistMatch.
     base=Singleton,
-    lock_expiry=AUTO_REBUILD_TIME_LIMIT,
+    # lock_expiry > time_limit: lock jest brany przy PUBLIKACJI zadania, a
+    # twardy kill dopiero w `start + time_limit`. Gdy zadanie poczeka w
+    # kolejce, lock wygasłby PRZED ubiciem — otwierając okno na duplikat.
+    # +5 min pokrywa realistyczny czas oczekiwania w kolejce.
+    lock_expiry=AUTO_REBUILD_TIME_LIMIT + 300,
     time_limit=AUTO_REBUILD_TIME_LIMIT,
     soft_time_limit=int(0.95 * AUTO_REBUILD_TIME_LIMIT),
 )

--- a/src/powiazania_autorow/core.py
+++ b/src/powiazania_autorow/core.py
@@ -55,13 +55,22 @@ def calculate_author_connections():
     publikację, patologia przy pracach z setkami współautorów).
 
     **Buduj obok, potem podmień.** Wynik self-joinów ląduje najpierw w tabeli
-    tymczasowej (``TEMP TABLE``, widocznej tylko dla tej sesji), POZA
-    transakcją podmiany. Dopiero gotowy wynik jest przepisywany do tabeli
-    docelowej w krótkiej transakcji ``DELETE`` + ``INSERT ... SELECT`` ze
-    staging-u. Dzięki temu okno, w którym ``AuthorConnection`` jest zablokowana
-    dla pisarzy (m.in. ``update_single_author_connections_task``), skraca się z
-    „czas liczenia + czas zapisu" do samego czasu przepisania wierszy.
-    Czytelnicy nie są blokowani w żadnym wariancie (MVCC).
+    tymczasowej (``TEMP TABLE``, widocznej tylko dla tej sesji), a dopiero
+    gotowy jest przepisywany do tabeli docelowej krótką sekwencją ``DELETE`` +
+    ``INSERT ... SELECT`` ze staging-u, owiniętą w ``atomic()``. Dzięki temu
+    okno, w którym ``AuthorConnection`` jest zablokowana dla pisarzy (m.in.
+    ``update_single_author_connections_task``), skraca się z „czas liczenia +
+    czas zapisu" do samego czasu przepisania wierszy. Czytelnicy nie są
+    blokowani w żadnym wariancie (MVCC).
+
+    ZASTRZEŻENIE: zysk występuje tylko wtedy, gdy funkcja jest wołana POZA
+    zewnętrzną transakcją — czyli na ścieżce produkcyjnej (zadanie Celery,
+    komenda zarządzająca). Gdy woła ją coś, co samo trzyma transakcję —
+    migracja ``0003_*`` (``RunPython`` jest domyślnie atomic) albo test pod
+    ``@pytest.mark.django_db`` — budowanie staging-u dzieje się WEWNĄTRZ tej
+    transakcji, ``atomic()`` poniżej degraduje się do savepointu i okno
+    blokady jest takie samo jak przed zmianą. Poprawność jest identyczna w
+    obu wariantach; różni się wyłącznie długość blokady.
 
     Semantyka: ``shared_publications_count`` = liczba WSPÓLNYCH publikacji
     (DISTINCT rekord), sumowana po typach prac. Para autorów zapisywana jest raz,
@@ -78,11 +87,16 @@ def calculate_author_connections():
 
     logger.info("Przeliczanie powiązań autorów (SQL)...")
     with connection.cursor() as cur:
-        # Faza 1 (długa, BEZ blokady na tabeli docelowej): policz wszystko do
+        # Faza 1 (długa, bez blokady na tabeli docelowej): policz wszystko do
         # tabeli tymczasowej. TEMP TABLE jest prywatna dla tej sesji i znika
         # przy jej zamknięciu; DROP na starcie zabezpiecza przed resztką po
         # poprzednim przebiegu w tej samej, długo żyjącej sesji workera.
-        cur.execute(f'DROP TABLE IF EXISTS "{staging}"')
+        #
+        # Kwalifikacja `pg_temp.` jest istotna: nieskwalifikowana nazwa jest
+        # rozwiązywana przez `search_path`, który przy PIERWSZYM przebiegu w
+        # sesji (brak jeszcze schematu tymczasowego) celuje w `public` — DROP
+        # mierzyłby wtedy w zwykłą tabelę o tej nazwie, nie w nasz staging.
+        cur.execute(f'DROP TABLE IF EXISTS pg_temp."{staging}"')
         cur.execute(
             f"""
             CREATE TEMP TABLE "{staging}" AS
@@ -114,12 +128,12 @@ def calculate_author_connections():
                          shared_publications_count, last_updated)
                     SELECT primary_author_id, secondary_author_id,
                            shared_publications_count, now()
-                      FROM "{staging}"
+                      FROM pg_temp."{staging}"
                     """
                 )
         finally:
             # Staging bywa duży — nie trzymamy go do końca życia sesji workera.
-            cur.execute(f'DROP TABLE IF EXISTS "{staging}"')
+            cur.execute(f'DROP TABLE IF EXISTS pg_temp."{staging}"')
 
     total = AuthorConnection.objects.count()
     logger.info("Przeliczono %s powiązań autorów.", total)

--- a/src/powiazania_autorow/core.py
+++ b/src/powiazania_autorow/core.py
@@ -48,12 +48,20 @@ def _self_join_sql(db_table):
 def calculate_author_connections():
     """Przelicza od zera całą tabelę AuthorConnection z bieżących współautorstw.
 
-    Całość liczona w SQL: ``TRUNCATE`` + ``INSERT ... SELECT`` z self-joinem per
-    tabela autorstwa (Ciągłe / Zwarte / Patenty), zsumowane po parze autorów.
-    Zero round-tripów do Pythona i zero materializacji par w pamięci — w
-    odróżnieniu od dawnej wersji, która streamowała wszystkie wiersze i budowała
-    ogromny słownik par (O(k^2) na publikację, patologia przy pracach z setkami
-    współautorów).
+    Całość liczona w SQL: self-join per tabela autorstwa (Ciągłe / Zwarte /
+    Patenty), zsumowany po parze autorów. Zero round-tripów do Pythona i zero
+    materializacji par w pamięci — w odróżnieniu od dawnej wersji, która
+    streamowała wszystkie wiersze i budowała ogromny słownik par (O(k^2) na
+    publikację, patologia przy pracach z setkami współautorów).
+
+    **Buduj obok, potem podmień.** Wynik self-joinów ląduje najpierw w tabeli
+    tymczasowej (``TEMP TABLE``, widocznej tylko dla tej sesji), POZA
+    transakcją podmiany. Dopiero gotowy wynik jest przepisywany do tabeli
+    docelowej w krótkiej transakcji ``DELETE`` + ``INSERT ... SELECT`` ze
+    staging-u. Dzięki temu okno, w którym ``AuthorConnection`` jest zablokowana
+    dla pisarzy (m.in. ``update_single_author_connections_task``), skraca się z
+    „czas liczenia + czas zapisu" do samego czasu przepisania wierszy.
+    Czytelnicy nie są blokowani w żadnym wariancie (MVCC).
 
     Semantyka: ``shared_publications_count`` = liczba WSPÓLNYCH publikacji
     (DISTINCT rekord), sumowana po typach prac. Para autorów zapisywana jest raz,
@@ -66,29 +74,52 @@ def calculate_author_connections():
     union = "\n        UNION ALL\n".join(
         _self_join_sql(m._meta.db_table) for m in _MODELE_AUTORSTWA
     )
-    insert_sql = f"""
-        INSERT INTO "{table}"
-            (primary_author_id, secondary_author_id,
-             shared_publications_count, last_updated)
-        SELECT p, s, SUM(cnt) AS shared, now()
-          FROM (
-{union}
-          ) sub
-         GROUP BY p, s
-    """
+    staging = "powiazania_autorow_staging"
 
     logger.info("Przeliczanie powiązań autorów (SQL)...")
-    with transaction.atomic():
-        with connection.cursor() as cur:
-            # DELETE (nie TRUNCATE): TRUNCATE wywala się błędem ObjectInUse, gdy
-            # w tej samej transakcji były wcześniej INSERT-y do tabeli (oczekujące
-            # zdarzenia wyzwalaczy FK) — np. w testach owiniętych w transakcję lub
-            # gdy recompute leci po innej operacji na tabeli. DELETE bez WHERE to
-            # jedno zapytanie, transakcyjne i odporne na ten przypadek. Cały blok
-            # jest atomowy: przy błędzie INSERT-u DELETE też się cofa, więc tabela
-            # nigdy nie zostaje pusta.
-            cur.execute(f'DELETE FROM "{table}"')
-            cur.execute(insert_sql)
+    with connection.cursor() as cur:
+        # Faza 1 (długa, BEZ blokady na tabeli docelowej): policz wszystko do
+        # tabeli tymczasowej. TEMP TABLE jest prywatna dla tej sesji i znika
+        # przy jej zamknięciu; DROP na starcie zabezpiecza przed resztką po
+        # poprzednim przebiegu w tej samej, długo żyjącej sesji workera.
+        cur.execute(f'DROP TABLE IF EXISTS "{staging}"')
+        cur.execute(
+            f"""
+            CREATE TEMP TABLE "{staging}" AS
+            SELECT p AS primary_author_id,
+                   s AS secondary_author_id,
+                   SUM(cnt) AS shared_publications_count
+              FROM (
+{union}
+              ) sub
+             GROUP BY p, s
+            """
+        )
+
+        try:
+            # Faza 2 (krótka, pod blokadą): podmiana zawartości.
+            with transaction.atomic():
+                # DELETE (nie TRUNCATE): TRUNCATE wywala się błędem ObjectInUse,
+                # gdy w tej samej transakcji były wcześniej INSERT-y do tabeli
+                # (oczekujące zdarzenia wyzwalaczy FK) — np. w testach owiniętych
+                # w transakcję lub gdy recompute leci po innej operacji na tabeli.
+                # DELETE bez WHERE to jedno zapytanie, transakcyjne i odporne na
+                # ten przypadek. Blok jest atomowy: przy błędzie INSERT-u DELETE
+                # też się cofa, więc tabela nigdy nie zostaje pusta.
+                cur.execute(f'DELETE FROM "{table}"')
+                cur.execute(
+                    f"""
+                    INSERT INTO "{table}"
+                        (primary_author_id, secondary_author_id,
+                         shared_publications_count, last_updated)
+                    SELECT primary_author_id, secondary_author_id,
+                           shared_publications_count, now()
+                      FROM "{staging}"
+                    """
+                )
+        finally:
+            # Staging bywa duży — nie trzymamy go do końca życia sesji workera.
+            cur.execute(f'DROP TABLE IF EXISTS "{staging}"')
 
     total = AuthorConnection.objects.count()
     logger.info("Przeliczono %s powiązań autorów.", total)

--- a/src/powiazania_autorow/tasks.py
+++ b/src/powiazania_autorow/tasks.py
@@ -51,7 +51,11 @@ def _zlicz_wspolautorow(model_autorstwa, author, connections):
     # odtwarza CAŁĄ tabelę AuthorConnection, więc dwa równoległe przebiegi
     # deptałyby sobie po wynikach.
     base=Singleton,
-    lock_expiry=POWIAZANIA_TIME_LIMIT,
+    # lock_expiry > time_limit: lock jest brany przy PUBLIKACJI zadania, a
+    # twardy kill dopiero w `start + time_limit`. Gdy zadanie poczeka w
+    # kolejce, lock wygasłby PRZED ubiciem — otwierając okno na duplikat.
+    # +5 min pokrywa realistyczny czas oczekiwania w kolejce.
+    lock_expiry=POWIAZANIA_TIME_LIMIT + 300,
     time_limit=POWIAZANIA_TIME_LIMIT,
     soft_time_limit=int(0.95 * POWIAZANIA_TIME_LIMIT),
 )

--- a/src/powiazania_autorow/tasks.py
+++ b/src/powiazania_autorow/tasks.py
@@ -1,7 +1,24 @@
 from celery import shared_task
 from celery.utils.log import get_task_logger
+from celery_singleton import Singleton
 
 logger = get_task_logger(__name__)
+
+# Budżet czasu przeliczania powiązań autorów.
+#
+# Zadanie jest w całości SQL-owe: jeden INSERT..SELECT z trzema self-joinami
+# po tabelach *_Autor (Ciągłe/Zwarte/Patenty) plus kopia do tabeli docelowej.
+# Zero round-tripów do Pythona, zero ruchu sieciowego — realny czas to rząd
+# sekund/minut nawet przy kilkuset tysiącach wpisów autorstwa. 30 minut to
+# kilkunastokrotny zapas: jeśli zadanie tyle biegnie, to znak, że coś jest
+# chore (zakleszczenie na locku, zdegenerowany plan), a nie że „dziś było
+# więcej danych" — wtedy chcemy ubicia, nie czekania.
+#
+# Dlaczego to w ogóle musi mieć limit: bez `time_limit` zawieszone zadanie
+# trzyma slot workera aż do `visibility_timeout` brokera (6 h, patrz
+# CELERY_BROKER_TRANSPORT_OPTIONS w settings/base.py), a zadanie leci
+# codziennie o 4:00 — jeden zawis zjadałby slot na całą dobę.
+POWIAZANIA_TIME_LIMIT = 30 * 60
 
 
 def _zlicz_wspolautorow(model_autorstwa, author, connections):
@@ -28,7 +45,16 @@ def _zlicz_wspolautorow(model_autorstwa, author, connections):
             connections[coauthor_id] += 1
 
 
-@shared_task(name="powiazania_autorow.calculate_author_connections")
+@shared_task(
+    name="powiazania_autorow.calculate_author_connections",
+    # Singleton (bez argumentów → lock i tak jest globalny): zadanie kasuje i
+    # odtwarza CAŁĄ tabelę AuthorConnection, więc dwa równoległe przebiegi
+    # deptałyby sobie po wynikach.
+    base=Singleton,
+    lock_expiry=POWIAZANIA_TIME_LIMIT,
+    time_limit=POWIAZANIA_TIME_LIMIT,
+    soft_time_limit=int(0.95 * POWIAZANIA_TIME_LIMIT),
+)
 def calculate_author_connections_task():
     """
     Celery task to calculate author connections in the background.


### PR DESCRIPTION
Higiena zadań cyklicznych: limity czasu, blokady pojedynczej instancji, retencja danych, które rosły bez końca. Wszystkie zmiany małe i lokalne. **Bez migracji** — świadomie, bo 0470 powstaje w równoległym PR i kolizja numeracji zepsułaby oba.

## (a) `Singleton` + `time_limit` na długich zadaniach

Bez `time_limit` zawieszone zadanie trzyma slot workera aż do `visibility_timeout` brokera — a ten jest ustawiony na **6 godzin**. Zadania chodzą codziennie, więc jeden zawis zjadał slot na całą dobę.

| zadanie | limit | uzasadnienie |
|---|---|---|
| `calculate_author_connections_task` | 30 min | czysty SQL (3 self-joiny + kopia), realnie sekundy/minuty. 30 min to kilkunastokrotny zapas — jeśli tyle biegnie, to patologia, a nie „więcej danych" |
| `deduplikator_autorow.scan_for_duplicates` | 3 h | najcięższe: dwie fazy po wszystkich autorach z fuzzy-scoringiem. Bucketowanie ratuje przed pełnym O(n²), ale przy dużym korpusie to dziesiątki minut. Sufit twardy: musi być wyraźnie poniżej `visibility_timeout` (6 h), inaczej Redis re-dostarczy zadanie w trakcie jego wykonywania i dostaniemy dwa przebiegi „replace mode" naraz. Start 3:00 → koniec przed 6:00, czyli przed porannym ruchem |
| `auto_rebuild_match_cache_task` | 1 h | iteracja po naukowcach PBN lokalnie (dane już w bazie, bez API PBN) — koszt to CPU, nie latencja. Cache jest ważny 7 dni, więc ubity przebieg spokojnie ponowi się następnej nocy |

**`GlobalSingleton`** (nowa klasa w `django_bpp/celery_tasks.py`) dla `scan_for_duplicates`. Zwykły `Singleton` kluczuje lock po argumentach, a to zadanie przyjmuje `user_id` — dwóch userów klikających „skanuj" dostałoby dwa **równoległe** przebiegi, a każdy zaczyna od `DuplicateCandidate.objects.all().delete()`. `unique_on=[]` nie załatwia sprawy (pusta lista jest falsy → biblioteka wpada w gałąź „bierz wszystkie argumenty"), stąd jawne nadpisanie `generate_lock`. Pozostałe dwa zadania są bezargumentowe, więc zwykły `Singleton` wystarcza.

## (b) `calculate_author_connections` — zrobione, nie odłożone

Było: `DELETE` całej tabeli + `INSERT ... SELECT` z self-joinami w **jednej** transakcji → `AuthorConnection` zablokowana dla pisarzy (m.in. `update_single_author_connections_task`) na cały czas liczenia.

Jest: **buduj obok, potem podmień.** Self-joiny lecą do `TEMP TABLE` poza transakcją; pod blokadą jest już tylko przepisanie gotowych wierszy. Okno blokady zapisów skraca się z „liczenie + zapis" do samego zapisu. Czytelnicy nie byli i nie są blokowani (MVCC).

Zachowane: atomowość podmiany (`DELETE` cofa się razem z nieudanym `INSERT`, tabela nigdy nie zostaje pusta) oraz `DELETE` zamiast `TRUNCATE` (`TRUNCATE` wywala `ObjectInUse`, gdy w tej samej transakcji były wcześniej INSERT-y). `TEMP TABLE` jest prywatna dla sesji i sprzątana w `finally`. Wybrałem tę drogę zamiast swapu tabel, bo swap wymagałby DDL/migracji — a tych w tym PR nie ma. Wszystkie 55 istniejących testów `powiazania_autorow` przechodzą bez zmian, więc zachowanie jest identyczne.

## (c) Kolizja harmonogramu 03:30

`rebuild-pbn-author-match-cache` przesunięty **3:30 → 4:30**. O 3:30 startuje `rebuild_kolejnosc` zaplanowany przez **Ofelię** — to całkowicie niezależny scheduler w repo **`bpp-deploy`** (`docker-compose.application.yml:123`), który nic nie wie o Celery beat i nie da się z nim zsynchronizować z tego repo. Ruszam wyłącznie stronę, którą kontroluję stąd (beat); **`bpp-deploy` nietknięte**.

4:30, a nie 4:00, bo o 4:00 stoi `powiazania-autorow-przelicz-codziennie`. Po zmianie beat nie ma ani jednej kolizji minutowej i slot 3:30 jest po jego stronie wolny.

## (d) `axes_accessattempt` bez retencji

`AXES_RESET_ON_SUCCESS=True` czyści wpisy tylko po udanym logowaniu **tej samej pary** (login, IP). Wpisy od botów skanujących `/admin/login/` nigdy nie doczekają się „swojego" udanego logowania → zostawały bezterminowo.

Nowe `bpp.tasks.usun_stare_proby_logowania_axes`, retencja **90 dni**, w beacie co tydzień (niedziela 2:30). 90 dni jest wielokrotnie powyżej `AXES_COOLOFF_TIME` (30 min), więc retencja nie skasuje wpisu wciąż uczestniczącego w lockoucie, a zostawia okno na forensykę kampanii brute-force. Kasowany jest wyłącznie `AccessAttempt` (nieudane próby) — `AccessLog` nietknięty.

## (e) `usun_stare_pliki_importu_pracownikow` nigdy nie wołane

Komenda i `IMPORT_PRACOWNIKOW_RETENCJA_DNI` istniały, ale nic ich nie uruchamiało — bloby XLS nie ginęły **nigdy**. Nowe `import_pracownikow/tasks.py` + wpis w `CELERYBEAT_SCHEDULE` (codziennie 1:15), zgodnie z ustaleniem trzymamy to w kodzie, a nie w labelu Ofelii. Logika wyekstrahowana do `usun_stare_pliki_importu()`, a komenda zarządzająca teraz ją woła — jedna ścieżka kodu, komenda i beat nie mogą się rozjechać.

## Znaleziska przy okazji

**Martwy wpis w harmonogramie.** `pbn-api-kolejka-wyczysc-wpisy-bez-rekordow` wskazywał na `pbn_api.tasks.kolejka_wyczysc_wpisy_bez_rekordow`, a zadanie żyje w `pbn_export_queue.tasks`. Beat co tydzień wysyłał nazwę, której żaden worker nie umiał rozwiązać → kolejka eksportu nigdy nie była czyszczona. Dokładnie ta sama klasa błędu co (e), więc naprawione tu (jedna linia). Weryfikacja: przelecenie wszystkich wpisów `CELERYBEAT_SCHEDULE` przez rejestr zadań Celery — teraz **wszystkie** się rozwiązują.

## Testy

Nowe (pytest, funkcje, `@pytest.mark.django_db`, `baker.make`):
- `test_usun_stare_proby_logowania_axes` — kasuje stare, zostawia świeże, nie rusza `AccessLog`
- `test_usun_stare_proby_logowania_axes_respektuje_parametr_days` — ten sam wpis raz przeżywa, raz nie
- `test_task_kasuje_stare_zostawia_swieze` — retencja XLS przez ścieżkę Celery
- `test_task_jest_idempotentny` — drugi przebieg nie liczy ponownie pustych `plik_xls`

Zieleń: `powiazania_autorow` **55 passed** (dowód, że przepisanie (b) nie zmienia zachowania) · `bpp/tests/test_tasks.py` + `import_pracownikow` + `importer_autorow_pbn` + `deduplikator_autorow` + `pbn_export_queue` **446 passed** · `uv run pre-commit` (bez argumentów) czysty, poprawki ręczne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX