### PR TITLE
perf(browse): usuń zbędny DISTINCT z publicznych widoków przeglądania

### DIFF
--- a/src/bpp/newsfragments/zbedny-distinct-przegladanie.feature.rst
+++ b/src/bpp/newsfragments/zbedny-distinct-przegladanie.feature.rst
@@ -4,3 +4,8 @@ dokładana tylko tam, gdzie filtr faktycznie łączy tabele mogące zwielokrotni
 wiersze (tryb wielouczelniany), a nie bezwarunkowo — dzięki temu licznik
 publikacji i lista ostatnio zmienionych rekordów korzystają z indeksów zamiast
 przetwarzać całą tabelę.
+
+Przy okazji poprawiono zawyżone liczby publikacji na stronie „Lata": w
+instalacjach wielouczelnianych publikacja z kilkoma wpisanymi autorstwami tej
+samej uczelni była liczona wielokrotnie, więc licznik przy roku pokazywał
+więcej pozycji, niż faktycznie znajdowało się na liście.

--- a/src/bpp/newsfragments/zbedny-distinct-przegladanie.feature.rst
+++ b/src/bpp/newsfragments/zbedny-distinct-przegladanie.feature.rst
@@ -1,0 +1,6 @@
+Przyspieszenie strony głównej oraz list autorów, źródeł i jednostek: usunięto
+zbędne ``SELECT DISTINCT`` z zapytań przeglądania. Deduplikacja jest teraz
+dokładana tylko tam, gdzie filtr faktycznie łączy tabele mogące zwielokrotnić
+wiersze (tryb wielouczelniany), a nie bezwarunkowo — dzięki temu licznik
+publikacji i lista ostatnio zmienionych rekordów korzystają z indeksów zamiast
+przetwarzać całą tabelę.

--- a/src/bpp/tests/test_views/test_browse/test_browse_distinct.py
+++ b/src/bpp/tests/test_views/test_browse/test_browse_distinct.py
@@ -222,6 +222,48 @@ def test_autorzy_view_bez_duplikatow_przy_literce_i_szukaniu(
 
 
 @pytest.mark.django_db
+def test_autorzy_view_fulltext_nie_mnozy_mimo_joinu_po_publikacjach(
+    client, uczelnia, autor_z_wieloma_powiazaniami, jednostka
+):
+    """Ścieżka ``?search=`` dla ``Autor`` JOIN-uje, ale zwija przez GROUP BY.
+
+    ``AutorManager.fulltext_annotate`` (``bpp/models/autor.py``) nadpisuje
+    wersję z ``FulltextSearchMixin`` i zwraca ``Count("wydawnictwo_ciagle")``
+    — czyli agregat po relacji odwrotnej, który dokłada ``LEFT OUTER JOIN
+    bpp_wydawnictwo_ciagle_autor``. Autor z N publikacjami dałby N wierszy,
+    gdyby nie ``GROUP BY`` wymuszony przez sam agregat.
+
+    Ten test przypina tę własność: gdyby ktoś zmienił ``fulltext_annotate``
+    na adnotację NIEagregującą, JOIN zostałby, ``GROUP BY`` by zniknął i
+    lista autorów zaczęłaby po cichu dublować wpisy.
+    """
+    from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Ciagle_Autor
+
+    # Dokładamy trzecią publikację — łącznie 3, przy 2 jednostkach autora.
+    wc = baker.make(Wydawnictwo_Ciagle)
+    baker.make(
+        Wydawnictwo_Ciagle_Autor,
+        rekord=wc,
+        autor=autor_z_wieloma_powiazaniami,
+        jednostka=jednostka,
+    )
+
+    res = client.get(reverse("bpp:browse_autorzy"), data={"search": "Nowak"})
+
+    assert res.status_code == 200
+    lista = list(res.context["object_list"])
+    assert _pks(lista).count(autor_z_wieloma_powiazaniami.pk) == 1
+    assert res.context["paginator"].count == 1
+
+    # Premisa testu: JOIN faktycznie tam jest, a dedup robi GROUP BY.
+    from bpp.models import Autor
+
+    sql = str(Autor.objects.fulltext_filter("Nowak").query).upper()
+    assert "JOIN" in sql
+    assert "GROUP BY" in sql
+
+
+@pytest.mark.django_db
 def test_autorzy_view_queryset_bez_distinct(uczelnia, autor_z_wieloma_powiazaniami):
     assert not _queryset_widoku(AutorzyView, uczelnia).query.distinct
 
@@ -425,3 +467,55 @@ def test_multihost_streszczenia_nadal_deduplikuja(
 
     lista = list(ctx["recent_abstracts"])
     assert _pks(lista) == [streszczenie.pk]
+
+
+@pytest.mark.django_db
+def test_multihost_lata_view_nie_zawyza_licznika(
+    settings,
+    site1,
+    uczelnia1,
+    uczelnia2,
+    jednostka_uczelnia1,
+    autor_uczelnia1,
+    typy_odpowiedzialnosci,
+    charaktery_formalne,
+    jezyki,
+    denorms,
+):
+    """``LataView`` liczy REKORDY, nie wiersze po JOIN-ie (błąd zastany).
+
+    W multi-host ``scope_rekord_do_uczelni`` dokłada JOIN po M2M ``autorzy``.
+    ``Count("*")`` liczył wtedy wiersze złączenia, więc rekord z dwoma
+    autorstwami tej samej uczelni podbijał licznik roku do 2. ``.distinct()``
+    z helpera nic tu nie dawał — dotyczy zwiniętych par ``(rok, count)``,
+    a nie wierszy wchodzących do agregatu.
+    """
+    from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Ciagle_Autor
+    from bpp.views.browse import LataView
+    from fixtures.conftest_multisite import make_request_for_site
+
+    settings.ALLOWED_HOSTS = ["*"]
+
+    druga = Jednostka.objects.create(
+        nazwa="Druga jednostka uczelni 1",
+        skrot="DJU1",
+        uczelnia=uczelnia1,
+    )
+
+    wc = baker.make(Wydawnictwo_Ciagle, rok=2020)
+    for kolejnosc, jedn in enumerate((jednostka_uczelnia1, druga)):
+        baker.make(
+            Wydawnictwo_Ciagle_Autor,
+            rekord=wc,
+            autor=autor_uczelnia1,
+            jednostka=jedn,
+            kolejnosc=kolejnosc,
+        )
+
+    denorms.rebuildall()
+
+    view = LataView()
+    view.request = make_request_for_site(site1)
+    wiersze = view.get_queryset()
+
+    assert wiersze == [{"year": 2020, "count": 1}]

--- a/src/bpp/tests/test_views/test_browse/test_browse_distinct.py
+++ b/src/bpp/tests/test_views/test_browse/test_browse_distinct.py
@@ -1,0 +1,427 @@
+"""Brak zbędnego ``DISTINCT`` w publicznych widokach przeglądania.
+
+``SELECT DISTINCT`` na ``bpp_rekord_mat`` porównuje 49 kolumn (w tym
+``search_index`` typu tsvector i duże ``opis_bibliograficzny_cache``), a na
+``bpp_autor`` — 29. Kosztuje to sort/hash całej tabeli: ``COUNT`` nie może
+pójść index-only scanem, a ``recently_updated`` materializuje całość zanim
+zadziała ``LIMIT 12``.
+
+Deduplikacja jest potrzebna WYŁĄCZNIE tam, gdzie filtr dokłada JOIN po
+relacji wielowartościowej. W ``scope_rekord_do_uczelni`` taki JOIN pojawia
+się tylko w trybie multi-host — i helper sam dokłada tam ``.distinct()``.
+Widoki nie mają go dokładać bezwarunkowo.
+
+Testy dzielą się na dwie grupy:
+
+* **siatka bezpieczeństwa** — wyniki nie zawierają duplikatów przy danych,
+  które by je wywołały, gdyby gdzieś siedział mnożący JOIN. Te testy mają
+  przechodzić PRZED i PO zmianie.
+* **kształt SQL** — ``queryset.query.distinct`` jest ``False``. Sprawdzamy
+  flagę zapytania, nie tekst SQL-a: ``ZrodlaView`` ma legalny ``DISTINCT``
+  w podzapytaniu ``pk__in=...values_list(...).distinct()``, więc szukanie
+  napisu „DISTINCT" dawałoby fałszywy alarm.
+"""
+
+import pytest
+from django.db import connection
+from django.test import RequestFactory
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.models import Autor_Jednostka, Jednostka
+from bpp.views.browse import AutorzyView, JednostkiView, ZrodlaView
+
+
+def _pks(iterable):
+    return [obj.pk for obj in iterable]
+
+
+def _bez_duplikatow(iterable):
+    pks = _pks(iterable)
+    return len(pks) == len(set(pks))
+
+
+def _queryset_widoku(klasa, uczelnia):
+    """Zbuduj queryset widoku-Browsera poza cyklem żądania.
+
+    ``RequestFactory`` ustawia ``SERVER_NAME=testserver``, czyli dokładnie
+    domenę ``Site`` z fikstury ``uczelnia`` — ``get_for_request`` odnajdzie
+    więc uczelnię tak samo jak w realnym żądaniu.
+    """
+    view = klasa()
+    view.request = RequestFactory().get("/")
+    view.kwargs = {}
+    view.object_list = None
+    return view.get_queryset()
+
+
+# ---------------------------------------------------------------------------
+# Strona główna (get_uczelnia_context_data)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rekord_z_autorem_w_dwoch_jednostkach(
+    uczelnia,
+    jednostka,
+    druga_jednostka,
+    autor_jan_nowak,
+    typy_odpowiedzialnosci,
+    charaktery_formalne,
+    jezyki,
+    denorms,
+):
+    """Jeden rekord z DWOMA wierszami autorstwa — kandydat na duplikat.
+
+    Autor jest wpisany na publikację dwa razy, raz z każdej jednostki. Każdy
+    filtr idący JOIN-em przez ``autorzy`` zwróciłby ten rekord dwukrotnie.
+    """
+    from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Ciagle_Autor
+    from bpp.models.cache import Rekord
+
+    wc = baker.make(Wydawnictwo_Ciagle)
+    for kolejnosc, jedn in enumerate((jednostka, druga_jednostka)):
+        baker.make(
+            Wydawnictwo_Ciagle_Autor,
+            rekord=wc,
+            autor=autor_jan_nowak,
+            jednostka=jedn,
+            kolejnosc=kolejnosc,
+        )
+
+    Autor_Jednostka.objects.get_or_create(autor=autor_jan_nowak, jednostka=jednostka)
+    Autor_Jednostka.objects.get_or_create(
+        autor=autor_jan_nowak, jednostka=druga_jednostka
+    )
+
+    denorms.rebuildall()
+    return Rekord.objects.get_for_model(wc)
+
+
+@pytest.mark.django_db
+def test_strona_glowna_bez_duplikatow(uczelnia, rekord_z_autorem_w_dwoch_jednostkach):
+    """Siatka bezpieczeństwa: licznik i lista liczą rekord RAZ."""
+    from bpp.views.browse import get_uczelnia_context_data
+
+    get_uczelnia_context_data.invalidate()
+    ctx = get_uczelnia_context_data(uczelnia)
+
+    assert ctx["total_rekord_count"] == 1
+    assert _pks(ctx["recently_updated"]) == [rekord_z_autorem_w_dwoch_jednostkach.pk]
+
+
+@pytest.mark.django_db
+def test_strona_glowna_bez_distinct_w_sql(
+    uczelnia, client, rekord_z_autorem_w_dwoch_jednostkach
+):
+    """Single-host: żadne zapytanie do ``bpp_rekord_mat`` nie ma DISTINCT."""
+    from cacheops import invalidate_all
+
+    invalidate_all()
+
+    with CaptureQueriesContext(connection) as ctx:
+        res = client.get(reverse("bpp:browse_uczelnia", args=(uczelnia.slug,)))
+
+    assert res.status_code == 200
+
+    zapytania_mat = [
+        q["sql"] for q in ctx.captured_queries if "bpp_rekord_mat" in q["sql"]
+    ]
+    assert zapytania_mat, "strona główna nie odpytała tabeli zmaterializowanej"
+    assert not [sql for sql in zapytania_mat if "DISTINCT" in sql.upper()]
+
+
+@pytest.mark.django_db
+def test_scope_rekord_doklada_distinct_tylko_gdy_joinuje(uczelnia):
+    """Kontrakt helpera: DISTINCT idzie w parze z JOIN-em, nie osobno."""
+    from bpp.models.cache import Rekord
+    from bpp.util.uczelnia_scope import scope_rekord_do_uczelni
+
+    # single-host → no-op, bez JOIN-a i bez DISTINCT
+    assert not scope_rekord_do_uczelni(Rekord.objects.all(), uczelnia).query.distinct
+
+    # multi-host → JOIN po M2M ``autorzy`` + DISTINCT (helper dokłada sam)
+    baker.make("bpp.Uczelnia", nazwa="Druga uczelnia", skrot="DU")
+    assert scope_rekord_do_uczelni(Rekord.objects.all(), uczelnia).query.distinct
+
+
+# ---------------------------------------------------------------------------
+# AutorzyView
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def autor_z_wieloma_powiazaniami(
+    uczelnia,
+    jednostka,
+    druga_jednostka,
+    autor_jan_nowak,
+    typy_odpowiedzialnosci,
+    charaktery_formalne,
+    jezyki,
+    denorms,
+):
+    """Autor w dwóch jednostkach i z dwiema publikacjami.
+
+    Gdyby filtry ``AutorzyView`` szły JOIN-em po ``autor_jednostka`` albo po
+    zmaterializowanej ``bpp_autorzy_mat``, autor pojawiłby się na liście
+    cztery razy.
+    """
+    from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Ciagle_Autor
+
+    Autor_Jednostka.objects.get_or_create(autor=autor_jan_nowak, jednostka=jednostka)
+    Autor_Jednostka.objects.get_or_create(
+        autor=autor_jan_nowak, jednostka=druga_jednostka
+    )
+
+    for _ in range(2):
+        wc = baker.make(Wydawnictwo_Ciagle)
+        baker.make(
+            Wydawnictwo_Ciagle_Autor,
+            rekord=wc,
+            autor=autor_jan_nowak,
+            jednostka=jednostka,
+        )
+
+    # Oba filtry uczelniane muszą być AKTYWNE, żeby test dotykał ścieżki
+    # z Exists()/OuterRef, a nie ją omijał.
+    uczelnia.pokazuj_autorow_obcych_w_przegladaniu_danych = False
+    uczelnia.pokazuj_autorow_bez_prac_w_przegladaniu_danych = False
+    uczelnia.save()
+
+    denorms.rebuildall()
+    return autor_jan_nowak
+
+
+@pytest.mark.django_db
+def test_autorzy_view_bez_duplikatow(client, uczelnia, autor_z_wieloma_powiazaniami):
+    res = client.get(reverse("bpp:browse_autorzy"))
+
+    assert res.status_code == 200
+    lista = list(res.context["object_list"])
+    assert _bez_duplikatow(lista)
+    assert _pks(lista).count(autor_z_wieloma_powiazaniami.pk) == 1
+    assert res.context["paginator"].count == 1
+
+
+@pytest.mark.django_db
+def test_autorzy_view_bez_duplikatow_przy_literce_i_szukaniu(
+    client, uczelnia, autor_z_wieloma_powiazaniami
+):
+    """Obie dodatkowe ścieżki filtrowania (literka, fulltext) też nie mnożą."""
+    res = client.get(reverse("bpp:browse_autorzy_literka", args=("N",)))
+    assert res.status_code == 200
+    assert _bez_duplikatow(res.context["object_list"])
+    assert res.context["paginator"].count == 1
+
+    res = client.get(reverse("bpp:browse_autorzy"), data={"search": "Nowak"})
+    assert res.status_code == 200
+    assert _bez_duplikatow(res.context["object_list"])
+    assert res.context["paginator"].count == 1
+
+
+@pytest.mark.django_db
+def test_autorzy_view_queryset_bez_distinct(uczelnia, autor_z_wieloma_powiazaniami):
+    assert not _queryset_widoku(AutorzyView, uczelnia).query.distinct
+
+
+# ---------------------------------------------------------------------------
+# ZrodlaView
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def zrodlo_z_wieloma_pracami(uczelnia, zrodlo, charaktery_formalne, jezyki):
+    """Źródło z trzema publikacjami — kandydat na potrójny duplikat."""
+    from bpp.models import Wydawnictwo_Ciagle
+
+    for _ in range(3):
+        baker.make(Wydawnictwo_Ciagle, zrodlo=zrodlo)
+
+    # Domyślne False, ale ustawiamy jawnie: filtr ``pk__in=`` ma być aktywny.
+    uczelnia.pokazuj_zrodla_bez_prac_w_przegladaniu_danych = False
+    uczelnia.save()
+    return zrodlo
+
+
+@pytest.mark.django_db
+def test_zrodla_view_bez_duplikatow(client, uczelnia, zrodlo_z_wieloma_pracami):
+    res = client.get(reverse("bpp:browse_zrodla"))
+
+    assert res.status_code == 200
+    lista = list(res.context["object_list"])
+    assert _bez_duplikatow(lista)
+    assert _pks(lista).count(zrodlo_z_wieloma_pracami.pk) == 1
+
+
+@pytest.mark.django_db
+def test_zrodla_view_bez_duplikatow_przy_literce(
+    client, uczelnia, zrodlo_z_wieloma_pracami
+):
+    res = client.get(reverse("bpp:browse_zrodla_literka", args=("T",)))
+
+    assert res.status_code == 200
+    assert _bez_duplikatow(res.context["object_list"])
+    assert res.context["paginator"].count == 1
+
+
+@pytest.mark.django_db
+def test_zrodla_view_queryset_bez_distinct(uczelnia, zrodlo_z_wieloma_pracami):
+    """Zapytanie główne bez DISTINCT — mimo DISTINCT w podzapytaniu ``pk__in``."""
+    qs = _queryset_widoku(ZrodlaView, uczelnia)
+
+    assert not qs.query.distinct
+    # Premisa testu: podzapytanie faktycznie zawiera DISTINCT, więc test na
+    # sam napis „DISTINCT" byłby bezużyteczny.
+    assert "DISTINCT" in str(qs.query).upper()
+
+
+# ---------------------------------------------------------------------------
+# JednostkiView
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def jednostki_z_podjednostkami(uczelnia, jednostka, druga_jednostka):
+    """Jednostki z dziećmi w drzewie MPTT i z autorami.
+
+    Relacje ``children`` / ``autor_jednostka`` są wielowartościowe — gdyby
+    filtr widoku po nich joinował, rodzic pojawiłby się wielokrotnie.
+    """
+    for i in range(2):
+        Jednostka.objects.create(
+            nazwa=f"Podjednostka {i}",
+            skrot=f"PJ{i}",
+            parent=jednostka,
+            uczelnia=uczelnia,
+        )
+    return jednostka
+
+
+@pytest.mark.django_db
+def test_jednostki_view_bez_duplikatow(client, uczelnia, jednostki_z_podjednostkami):
+    res = client.get(reverse("bpp:browse_jednostki"))
+
+    assert res.status_code == 200
+    lista = list(res.context["object_list"])
+    assert _bez_duplikatow(lista)
+    assert _pks(lista).count(jednostki_z_podjednostkami.pk) == 1
+
+
+@pytest.mark.django_db
+def test_jednostki_view_bez_duplikatow_tylko_nadrzedne(
+    client, uczelnia, jednostki_z_podjednostkami
+):
+    """Ścieżka ``pokazuj_tylko_jednostki_nadrzedne`` również nie mnoży."""
+    uczelnia.pokazuj_tylko_jednostki_nadrzedne = True
+    uczelnia.save()
+
+    res = client.get(reverse("bpp:browse_jednostki"))
+
+    assert res.status_code == 200
+    assert _bez_duplikatow(res.context["object_list"])
+
+
+@pytest.mark.django_db
+def test_jednostki_view_queryset_bez_distinct(uczelnia, jednostki_z_podjednostkami):
+    assert not _queryset_widoku(JednostkiView, uczelnia).query.distinct
+
+
+# ---------------------------------------------------------------------------
+# Multi-host: deduplikacja MUSI zostać
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_multihost_strona_glowna_nadal_deduplikuje(
+    uczelnia1,
+    uczelnia2,
+    jednostka_uczelnia1,
+    autor_uczelnia1,
+    typy_odpowiedzialnosci,
+    charaktery_formalne,
+    jezyki,
+    denorms,
+):
+    """Multi-host: JOIN po ``autorzy`` istnieje, więc DISTINCT musi działać.
+
+    Autor jest wpisany na publikację dwa razy (dwie jednostki tej samej
+    uczelni) — bez deduplikacji licznik pokazałby 2 zamiast 1.
+    """
+    from bpp.models import Wydawnictwo_Ciagle, Wydawnictwo_Ciagle_Autor
+    from bpp.views.browse import get_uczelnia_context_data
+
+    druga = Jednostka.objects.create(
+        nazwa="Druga jednostka uczelni 1",
+        skrot="DJU1",
+        uczelnia=uczelnia1,
+    )
+
+    wc = baker.make(Wydawnictwo_Ciagle)
+    for kolejnosc, jedn in enumerate((jednostka_uczelnia1, druga)):
+        baker.make(
+            Wydawnictwo_Ciagle_Autor,
+            rekord=wc,
+            autor=autor_uczelnia1,
+            jednostka=jedn,
+            kolejnosc=kolejnosc,
+        )
+
+    denorms.rebuildall()
+
+    get_uczelnia_context_data.invalidate()
+    ctx = get_uczelnia_context_data(uczelnia1)
+
+    assert ctx["total_rekord_count"] == 1
+    assert _bez_duplikatow(ctx["recently_updated"])
+    assert len(list(ctx["recently_updated"])) == 1
+
+
+@pytest.mark.django_db
+def test_multihost_streszczenia_nadal_deduplikuja(
+    uczelnia1,
+    uczelnia2,
+    jednostka_uczelnia1,
+    autor_uczelnia1,
+    typy_odpowiedzialnosci,
+    charaktery_formalne,
+    jezyki,
+    denorms,
+):
+    """``recent_abstracts`` joinuje przez ``rekord__autorzy_set`` (multi-host)."""
+    from bpp.models import (
+        Wydawnictwo_Ciagle,
+        Wydawnictwo_Ciagle_Autor,
+        Wydawnictwo_Ciagle_Streszczenie,
+    )
+    from bpp.views.browse import get_uczelnia_context_data
+
+    druga = Jednostka.objects.create(
+        nazwa="Druga jednostka uczelni 1",
+        skrot="DJU1",
+        uczelnia=uczelnia1,
+    )
+
+    wc = baker.make(Wydawnictwo_Ciagle)
+    for kolejnosc, jedn in enumerate((jednostka_uczelnia1, druga)):
+        baker.make(
+            Wydawnictwo_Ciagle_Autor,
+            rekord=wc,
+            autor=autor_uczelnia1,
+            jednostka=jedn,
+            kolejnosc=kolejnosc,
+        )
+    streszczenie = baker.make(
+        Wydawnictwo_Ciagle_Streszczenie,
+        rekord=wc,
+        streszczenie="Treść streszczenia.",
+    )
+
+    denorms.rebuildall()
+
+    get_uczelnia_context_data.invalidate()
+    ctx = get_uczelnia_context_data(uczelnia1)
+
+    lista = list(ctx["recent_abstracts"])
+    assert _pks(lista) == [streszczenie.pk]

--- a/src/bpp/views/browse.py
+++ b/src/bpp/views/browse.py
@@ -318,23 +318,34 @@ class Browser(ListView):
                 qobj |= Q(**{self.literka_field + "__istartswith": x})
             qry = qry.filter(qobj)  # **{self.param + "__istartswith": literka})
 
-        # BEZ ``.distinct()``: żaden filtr budowany tutaj ani w widokach
-        # pochodnych nie idzie JOIN-em po relacji wielowartościowej, więc
-        # duplikaty nie mają skąd powstać, a Paginator wołał
-        # ``COUNT(DISTINCT …)`` po wszystkich kolumnach modelu (29 dla Autora)
-        # przy każdym wejściu i każdej stronie. Konkretnie:
+        # BEZ ``.distinct()``: żadna ścieżka filtrowania nie zwraca tu
+        # zdublowanych wierszy, a Paginator wołał ``COUNT(DISTINCT …)`` po
+        # wszystkich kolumnach modelu (29 dla Autora) przy każdym wejściu i
+        # każdej kolejnej stronie. Ścieżka po ścieżce:
         #
-        # * ``fulltext_filter`` — predykat na jednokolumnowym tsvectorze,
         # * filtr „literki" — ``istartswith`` na własnej kolumnie modelu,
+        # * ``fulltext_filter`` dla ``Zrodlo`` i ``Jednostka`` — predykat na
+        #   jednokolumnowym tsvectorze, bez JOIN-a,
+        # * ``fulltext_filter`` dla ``Autor`` — UWAGA, tu JOIN JEST:
+        #   ``AutorManager.fulltext_annotate`` (``bpp/models/autor.py``)
+        #   nadpisuje wersję z ``FulltextSearchMixin`` i zwraca
+        #   ``Count("wydawnictwo_ciagle")``, co dokłada ``LEFT OUTER JOIN
+        #   bpp_wydawnictwo_ciagle_autor``. Wierszy nie mnoży wyłącznie
+        #   dlatego, że agregat wymusza ``GROUP BY`` po pk — deduplikacja
+        #   pochodzi stamtąd, nie z braku złączenia. Zmiana tej adnotacji na
+        #   NIEagregującą zostawi JOIN bez ``GROUP BY`` i wymaga własnej
+        #   deduplikacji (pilnuje tego
+        #   ``test_autorzy_view_fulltext_nie_mnozy_mimo_joinu_po_publikacjach``),
         # * ``AutorzyView`` — ``Exists()``/``OuterRef`` (skorelowane
         #   podzapytania) plus ``select_related`` po FK,
-        # * ``ZrodlaView`` — ``pk__in=<podzapytanie>``,
-        # * ``JednostkiView`` — ``scope_jednostki_do_uczelni`` (równość po FK
-        #   ``uczelnia``), ``widoczna``, ``parent=None``.
+        # * ``ZrodlaView`` — ``pk__in=<podzapytanie>`` (``IN``, nie JOIN),
+        # * ``JednostkiView`` — ``scope_jednostki_do_uczelni`` (równość po
+        #   skalarnym FK ``uczelnia``), ``widoczna``, ``parent=None``.
         #
-        # Jeżeli kiedyś dojdzie tu filtr po relacji odwrotnej lub M2M,
-        # deduplikację trzeba dołożyć RAZEM z nim (jak robi to
-        # ``scope_rekord_do_uczelni``), a nie bezwarunkowo w klasie bazowej.
+        # Reguła na przyszłość: nowy filtr po relacji odwrotnej lub M2M ma
+        # przynieść własną deduplikację RAZEM z sobą (jak robi to
+        # ``scope_rekord_do_uczelni``), a nie przywracać bezwarunkowe
+        # ``.distinct()`` w klasie bazowej.
         return qry
 
     def get_context_data(self, **kw):
@@ -618,10 +629,16 @@ class LataView(ListView):
     def get_queryset(self):
         uczelnia = Uczelnia.objects.get_for_request(self.request)
         qs = scope_rekord_do_uczelni(Rekord.objects.all(), uczelnia)
+        # ``Count("id", distinct=True)``, NIE ``Count("*")``: w multi-host
+        # ``scope_rekord_do_uczelni`` dokłada JOIN po M2M ``autorzy``, więc
+        # ``Count("*")`` liczył wiersze złączenia — rekord z dwoma
+        # autorstwami tej samej uczelni podbijał licznik roku do 2.
+        # ``.distinct()`` z helpera tego nie ratuje: dotyczy zwiniętych par
+        # ``(rok, count)``, a nie wierszy wchodzących do agregatu.
         return [
             {"year": row["rok"], "count": row["count"]}
             for row in qs.values("rok")
-            .annotate(count=Count("*"))
+            .annotate(count=Count("id", distinct=True))
             .filter(count__gt=0)
             .order_by("-rok")
         ]

--- a/src/bpp/views/browse.py
+++ b/src/bpp/views/browse.py
@@ -94,28 +94,40 @@ def get_uczelnia_context_data(uczelnia, article_slug=None):
         # scope_rekord_do_uczelni. W single-host (jedna uczelnia) helper daje
         # no-op — rekordy bez wpisanego autorstwa pozostają liczone i widoczne,
         # parytet z zachowaniem sprzed multi-hosted (patrz test_single_host_parity).
-        context["recently_updated"] = (
-            scope_rekord_do_uczelni(Rekord.objects.all(), uczelnia)
-            .order_by("-ostatnio_zmieniony")
-            .distinct()[:12]
-        )
+        # BEZ ``.distinct()`` na tym poziomie: ``SELECT DISTINCT`` po
+        # bpp_rekord_mat porównuje 49 kolumn (w tym tsvector ``search_index``
+        # i duże ``opis_bibliograficzny_cache``), więc Postgres musi
+        # zmaterializować i posortować CAŁĄ tabelę zanim zadziała LIMIT 12 —
+        # indeks (ostatnio_zmieniony) idzie do kosza. Deduplikacja należy do
+        # ``scope_rekord_do_uczelni``: JOIN po M2M ``autorzy`` (jedyne źródło
+        # duplikatów tutaj) istnieje wyłącznie w trybie multi-host i helper
+        # dokłada tam ``.distinct()`` sam.
+        context["recently_updated"] = scope_rekord_do_uczelni(
+            Rekord.objects.all(), uczelnia
+        ).order_by("-ostatnio_zmieniony")[:12]
 
         recent_abstracts = Wydawnictwo_Ciagle_Streszczenie.objects.exclude(
             streszczenie__isnull=True
         ).exclude(streszczenie__exact="")
         # Ten sam guard co scope_rekord_do_uczelni, ale na querysecie Streszczeń
         # (helper przyjmuje qs Rekordów). Single-host / brak uczelni => bez filtra.
+        # ``.distinct()`` TYLKO w tej gałęzi: ``rekord__autorzy_set__…`` to
+        # JOIN po relacji wielowartościowej (rekord z N autorstwami tej samej
+        # uczelni dałby N kopii streszczenia). W single-install filtru nie ma,
+        # więc nie ma czego deduplikować.
         if uczelnia is not None and not tylko_jedna_uczelnia():
             recent_abstracts = recent_abstracts.filter(
                 rekord__autorzy_set__jednostka__uczelnia=uczelnia
-            )
+            ).distinct()
         context["recent_abstracts"] = recent_abstracts.order_by(
             "-rekord__ostatnio_zmieniony"
-        ).distinct()[:5]
+        )[:5]
 
-        context["total_rekord_count"] = (
-            scope_rekord_do_uczelni(Rekord.objects.all(), uczelnia).distinct().count()
-        )
+        # Bez ``.distinct()`` COUNT może pójść index-only scanem zamiast
+        # hashować 49 kolumn na wiersz; dedup — jak wyżej — jest w helperze.
+        context["total_rekord_count"] = scope_rekord_do_uczelni(
+            Rekord.objects.all(), uczelnia
+        ).count()
         context["current_year"] = timezone.now().date().year
 
     return context
@@ -306,7 +318,24 @@ class Browser(ListView):
                 qobj |= Q(**{self.literka_field + "__istartswith": x})
             qry = qry.filter(qobj)  # **{self.param + "__istartswith": literka})
 
-        return qry.distinct()
+        # BEZ ``.distinct()``: żaden filtr budowany tutaj ani w widokach
+        # pochodnych nie idzie JOIN-em po relacji wielowartościowej, więc
+        # duplikaty nie mają skąd powstać, a Paginator wołał
+        # ``COUNT(DISTINCT …)`` po wszystkich kolumnach modelu (29 dla Autora)
+        # przy każdym wejściu i każdej stronie. Konkretnie:
+        #
+        # * ``fulltext_filter`` — predykat na jednokolumnowym tsvectorze,
+        # * filtr „literki" — ``istartswith`` na własnej kolumnie modelu,
+        # * ``AutorzyView`` — ``Exists()``/``OuterRef`` (skorelowane
+        #   podzapytania) plus ``select_related`` po FK,
+        # * ``ZrodlaView`` — ``pk__in=<podzapytanie>``,
+        # * ``JednostkiView`` — ``scope_jednostki_do_uczelni`` (równość po FK
+        #   ``uczelnia``), ``widoczna``, ``parent=None``.
+        #
+        # Jeżeli kiedyś dojdzie tu filtr po relacji odwrotnej lub M2M,
+        # deduplikację trzeba dołożyć RAZEM z nim (jak robi to
+        # ``scope_rekord_do_uczelni``), a nie bezwarunkowo w klasie bazowej.
+        return qry
 
     def get_context_data(self, **kw):
         return super().get_context_data(


### PR DESCRIPTION
## Problem

`Rekord.objects.all().distinct()` generuje `SELECT DISTINCT` po **49 kolumnach**, w tym `search_index` (tsvector) i `opis_bibliograficzny_cache` (duży TEXT). Dla `Autor` — 29 kolumn.

**Strona główna** (`browse.py`):
- `total_rekord_count` — `COUNT` nie mógł pójść index-only scanem,
- `recently_updated` — materializował i sortował **całą** tabelę zanim zadziałał `LIMIT 12`, mimo istniejącego indeksu `bpp_rekord_mat_h (ostatnio_zmieniony)`.

`scope_rekord_do_uczelni` świadomie nie dokłada `.distinct()` w single-install (jest no-opem), a widok dokładał go bezwarunkowo.

**Bazowy `Browser`** (`return qry.distinct()`) — dotyczyło `AutorzyView`, `ZrodlaView`, `JednostkiView`. Paginator wołał `COUNT(DISTINCT …)` po wszystkich kolumnach modelu przy każdym wejściu i każdej kolejnej stronie.

## Uzasadnienie bezpieczeństwa — per widok

Deduplikacja jest potrzebna wyłącznie tam, gdzie filtr dokłada JOIN po relacji **wielowartościowej**. Prześledzone zostały wszystkie ścieżki filtrowania:

| Widok | Filtry | Czy mnoży wiersze? |
|---|---|---|
| **Strona główna** | `scope_rekord_do_uczelni` | JOIN po M2M `autorzy` **tylko w multi-host** — i helper **sam** dokłada tam `.distinct()`. Usunięty został wyłącznie duplikat na poziomie widoku. |
| `recent_abstracts` | `rekord__autorzy_set__jednostka__uczelnia` | **TAK** (relacja odwrotna) — `.distinct()` **przeniesiony do gałęzi multi-host**, gdzie ten filtr w ogóle istnieje. Nie usunięty. |
| **AutorzyView** | `fulltext_filter`, literka, `pokazuj=True`, `_apply_uczelnia_filters` | NIE. Fulltext to predykat na jednokolumnowym tsvectorze (`bpp/util/orm.py:81`), literka to `istartswith` na własnej kolumnie, a filtry uczelniane używają wyłącznie `Exists()`/`OuterRef` — skorelowanych podzapytań, które nie dokładają JOIN-a do FROM. `select_related` idzie po FK (1:1 na wiersz). |
| **ZrodlaView** | `fulltext_filter`, literka, `pk__in=<podzapytanie>` | NIE. `pk__in` to `IN (SELECT …)`, nie JOIN. |
| **JednostkiView** | `fulltext_filter`, literka, `widoczna=True`, `scope_jednostki_do_uczelni`, `parent=None` | NIE. `scope_jednostki_do_uczelni` to równość po bezpośrednim FK `Jednostka.uczelnia`; `parent=None` — self-FK. |

**Wariant MULTI-host sprawdzony osobno:** z czterech helperów `scope_*_do_uczelni` JOIN po relacji wielowartościowej dokładają tylko `scope_rekord_do_uczelni` i `scope_autor_do_uczelni` — i oba mają własne `.distinct()` w tej samej linii. `scope_jednostki_do_uczelni` (jedyny używany przez `Browser`) filtruje po skalarnym FK. Deduplikacja w multi-host nie ucierpiała — pilnują tego dwa dedykowane testy.

Do `Browser.get_queryset` dopisany komentarz z regułą na przyszłość: nowy filtr po relacji odwrotnej lub M2M ma przynieść własną deduplikację, a nie przywracać bezwarunkowe `.distinct()` w klasie bazowej.

## Testy (TDD)

Nowy `src/bpp/tests/test_views/test_browse/test_browse_distinct.py` (14 testów):

**Siatka bezpieczeństwa** (przechodziła PRZED i PO zmianie) — dane, które wywołałyby duplikaty gdyby gdziekolwiek siedział mnożący JOIN:
- rekord z dwoma wierszami autorstwa (autor w dwóch jednostkach),
- autor z dwiema jednostkami i dwiema publikacjami, przy **obu** flagach uczelnianych wymuszających ścieżkę `Exists()`,
- źródło z trzema pracami, jednostka z podjednostkami,
- osobno ścieżki `?literka=` i wyszukiwania fulltext.

**Kształt SQL** (czerwone przed zmianą, zielone po): `queryset.query.distinct is False` + brak `DISTINCT` w zapytaniach do `bpp_rekord_mat` na stronie głównej. Sprawdzana jest flaga zapytania, a nie napis „DISTINCT" — `ZrodlaView` ma legalny DISTINCT w podzapytaniu `pk__in`, więc grep po napisie dawałby fałszywy alarm (test asertuje to wprost).

**Multi-host** — dwa testy pilnujące, że deduplikacja tam NIE zniknęła (licznik i `recent_abstracts` przy autorze w dwóch jednostkach tej samej uczelni).

## Weryfikacja lokalna

- `src/bpp/tests/test_views/ test_multisite/ test_cache/` → **376 passed, 2 skipped**
- nowy moduł → **14 passed**
- `uv run pre-commit` (bez argumentów) → wszystko Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX