### PR TITLE
perf(browse): usuń wielokrotnie powtarzane zapytania w szablonach publicznych

### DIFF
--- a/src/bpp/models/jednostka.py
+++ b/src/bpp/models/jednostka.py
@@ -385,7 +385,18 @@ class Jednostka(ModelZAdnotacjami, ModelZPBN_ID, ModelZPBN_UID, MPTTModel):
         * autor jest aktualnym współpracownikiem, jeżeli w polu aktualna_jednostka
           (pole obliczane na podstawie triggera bazodanowego) znajduje się ta sama
           jednostka co {self}
+
+        Domyślnie liczone od nowa przy każdym wywołaniu (kod modyfikujący
+        przypisania autorów musi widzieć świeży wynik). Widok strony jednostki
+        — gdzie wynik jest potrzebny dwa razy (``pracownicy()`` ORAZ
+        ``wspolpracowali()``) i nic się w międzyczasie nie zmienia — może
+        zawczasu wypełnić pamięć podręczną przez
+        ``prefetch_aktualnych_autorow()``.
         """
+        cached = getattr(self, "_aktualni_autorzy_cache", None)
+        if cached is not None:
+            return cached
+
         podstawowe_miejsce_pracy = set(
             Autor_Jednostka.objects.filter(
                 Q(
@@ -404,10 +415,22 @@ class Jednostka(ModelZAdnotacjami, ModelZPBN_ID, ModelZPBN_UID, MPTTModel):
 
         return podstawowe_miejsce_pracy.union(aktualni_autorzy)
 
+    def prefetch_aktualnych_autorow(self):
+        """Policz ``aktualni_autorzy()`` raz i zapamiętaj na tej instancji.
+
+        Wywoływane JAWNIE przez widok strony jednostki, tuż przed renderem —
+        dzięki temu domyślne zachowanie modelu (świeży odczyt) zostaje
+        nietknięte dla kodu, który zapisuje przypisania autorów."""
+        self._aktualni_autorzy_cache = self.aktualni_autorzy()
+
     def pracownicy(self):
         """Autorzy, którzy tą jednostkę mają wpisani jako AKTUALNA -- czyli
         aktualni pracownicy, obecni pracownicy"""
-        return Autor.objects.filter(pk__in=self.aktualni_autorzy(), pokazuj=True)
+        # select_related: strona jednostki wypisuje przy nazwisku
+        # 'aktualna_funkcja' — bez tego wychodzi N+1 po liście pracowników.
+        return Autor.objects.filter(
+            pk__in=self.aktualni_autorzy(), pokazuj=True
+        ).select_related("aktualna_funkcja")
 
     def wspolpracowali(self):
         """Autorzy, którzy popełnili jakiekolwiek prace z afiliacją na tę jednostkę,

--- a/src/bpp/models/util.py
+++ b/src/bpp/models/util.py
@@ -129,9 +129,19 @@ class ModelZOpisemBibliograficznym(models.Model):
 
         return safe_opis_bibliograficzny_html(ret)
 
+    #: Atrybut, pod którym ``prefetch_autorzy_dla_opisu`` podstawia gotową
+    #: listę autorów. Ustawiany JAWNIE przez widok na czas renderowania jednej
+    #: strony — dzięki temu nie ma ryzyka, że pamięć podręczna przeżyje zapis
+    #: autorów na tej samej instancji (jak zrobiłaby to ``cached_property``).
+    PREFETCH_AUTORZY_ATTR = "_autorzy_dla_opisu_prefetch"
+
     def autorzy_dla_opisu(self):
         # Takie 'autorzy_set.all()' ale na potrzeby opisu bibliograficznego -- zaciąga
         # rekordy zależne za pomocą .select_related:
+
+        prefetched = getattr(self, self.PREFETCH_AUTORZY_ATTR, None)
+        if prefetched is not None:
+            return prefetched
 
         if not self.pk:
             return []
@@ -282,6 +292,48 @@ class ModelZOpisemBibliograficznym(models.Model):
 
     class Meta:  # noqa: DJ012 - kolejność zastana (sprzed naszego brancha).
         abstract = True
+
+
+def prefetch_dane_strony_rekordu(praca):
+    """Materializuje — jednym zapytaniem na zestaw — dane, po które szablon
+    strony rekordu sięga wielokrotnie: autorów opisu i streszczenia.
+
+    Wywoływane JAWNIE przez widok strony rekordu, tuż przed renderowaniem.
+    Nie jest to ``cached_property`` na modelu: pamięć podręczna ma żyć tylko
+    tyle, co jeden render, a nie tyle, co instancja modelu (inaczej kod,
+    który zapisuje autorów i od razu odświeża opis bibliograficzny na tej
+    samej instancji, zobaczyłby nieaktualne dane).
+    """
+    if praca is None:
+        return
+
+    from django.db.models import Prefetch, prefetch_related_objects
+    from django.db.models.fields.related_descriptors import (
+        ReverseManyToOneDescriptor,
+    )
+
+    descriptor = getattr(type(praca), "autorzy_set", None)
+    attr = getattr(praca, "PREFETCH_AUTORZY_ATTR", None)
+    if attr is not None and isinstance(descriptor, ReverseManyToOneDescriptor):
+        # Praca_Doktorska/Habilitacyjna mają 'autorzy_set' jako property
+        # zwracającą sztuczną listę — tam prefetch nie ma sensu i by się wywalił.
+        autorzy = praca.autorzy_set.model.objects.select_related(
+            "autor", "typ_odpowiedzialnosci"
+        ).order_by("kolejnosc")
+        prefetch_related_objects(
+            [praca],
+            Prefetch(
+                "autorzy_set",
+                queryset=autorzy,
+                to_attr=attr,
+            ),
+        )
+
+    try:
+        prefetch_related_objects([praca], "streszczenia")
+    except AttributeError:
+        # Patent, doktorat, habilitacja: brak relacji 'streszczenia'.
+        pass
 
 
 class ZapobiegajNiewlasciwymCharakterom(models.Model):

--- a/src/bpp/models/util.py
+++ b/src/bpp/models/util.py
@@ -329,11 +329,11 @@ def prefetch_dane_strony_rekordu(praca):
             ),
         )
 
-    try:
+    # Patent, doktorat, habilitacja nie mają relacji 'streszczenia'. Pytamy
+    # o obecność deskryptora zamiast łapać AttributeError — ten ostatni
+    # zamaskowałby prawdziwy błąd wyrzucony ze środka prefetcha.
+    if hasattr(type(praca), "streszczenia"):
         prefetch_related_objects([praca], "streszczenia")
-    except AttributeError:
-        # Patent, doktorat, habilitacja: brak relacji 'streszczenia'.
-        pass
 
 
 class ZapobiegajNiewlasciwymCharakterom(models.Model):

--- a/src/bpp/newsfragments/powtarzane-zapytania-szablony-publiczne.feature.rst
+++ b/src/bpp/newsfragments/powtarzane-zapytania-szablony-publiczne.feature.rst
@@ -1,0 +1,22 @@
+Usunięto wielokrotnie powtarzane zapytania do bazy w publicznych szablonach
+(strona rekordu, jednostki i autora). Szablony odwoływały się po kilka razy do
+tych samych metod modelu (``autorzy_dla_opisu``, ``pracownicy``,
+``wspolpracowali``, ``liczba_cytowan``, ``jednostki_gdzie_ma_publikacje``,
+podjednostki, streszczenia, metryki ewaluacyjne), a każde odwołanie budowało
+świeży queryset, czyli osobny roundtrip do bazy. Dane są teraz materializowane
+raz — przez ``prefetch_related`` w widoku, przekazanie gotowych list przez
+kontekst oraz ``{% with %}`` w szablonach. Lista pracowników jednostki dostała
+dodatkowo ``select_related("aktualna_funkcja")``.
+
+Zmierzone liczby zapytań na żądanie (rekord z 6 autorami; jednostka z 12
+pracownikami; jednostka strukturalna z 4 podjednostkami; autor z 3 pracami
+i 3 metrykami):
+
+* strona rekordu: 43 → 41 zapytań ogółem; lista autorów opisu 4 → 1,
+  streszczenia 6 → 1;
+* strona jednostki (lista pracowników): 35 → 27 zapytań ogółem; ``bpp_autor``
+  9 → 4, ``bpp_autor_jednostka`` 4 → 1;
+* strona jednostki (struktura podjednostek): 53 → 33 zapytania ogółem;
+  ``bpp_jednostka`` 16 → 5;
+* strona autora: 39 → 33 zapytania ogółem; agregat cytowań 3 → 2, metryki
+  ewaluacyjne 5 → 1, jednostki autora 2 → 1.

--- a/src/bpp/newsfragments/powtarzane-zapytania-szablony-publiczne.feature.rst
+++ b/src/bpp/newsfragments/powtarzane-zapytania-szablony-publiczne.feature.rst
@@ -3,14 +3,20 @@ Usunięto wielokrotnie powtarzane zapytania do bazy w publicznych szablonach
 tych samych metod modelu (``autorzy_dla_opisu``, ``pracownicy``,
 ``wspolpracowali``, ``liczba_cytowan``, ``jednostki_gdzie_ma_publikacje``,
 podjednostki, streszczenia, metryki ewaluacyjne), a każde odwołanie budowało
-świeży queryset, czyli osobny roundtrip do bazy. Dane są teraz materializowane
+świeży queryset, czyli osobne odpytanie warstwy danych. Dane są teraz materializowane
 raz — przez ``prefetch_related`` w widoku, przekazanie gotowych list przez
 kontekst oraz ``{% with %}`` w szablonach. Lista pracowników jednostki dostała
 dodatkowo ``select_related("aktualna_funkcja")``.
 
-Zmierzone liczby zapytań na żądanie (rekord z 6 autorami; jednostka z 12
-pracownikami; jednostka strukturalna z 4 podjednostkami; autor z 3 pracami
-i 3 metrykami):
+Poniższe liczby zmierzono na konfiguracji testowej, czyli przy WYŁĄCZONYM
+cacheops (``CACHEOPS_ENABLED = False`` w ``settings/test.py``). Na produkcji
+``bpp.jednostka`` oraz ``bpp.wydawnictwo_ciagle_streszczenie`` są w ``CACHEOPS``
+(``get``/``fetch``/``count``/``exists``), więc część usuniętych zapytań trafiała
+tam do Redisa, a nie do PostgreSQL — realny zysk dla strony strukturalnej
+jednostki i dla streszczeń będzie odpowiednio mniejszy. Wartości pokazują skalę
+powtórzeń, a nie gwarantowane przyspieszenie produkcyjne (rekord z 6 autorami;
+jednostka z 12 pracownikami; jednostka strukturalna z 4 podjednostkami; autor
+z 3 pracami i 3 metrykami):
 
 * strona rekordu: 43 → 41 zapytań ogółem; lista autorów opisu 4 → 1,
   streszczenia 6 → 1;

--- a/src/bpp/templates/browse/autor.html
+++ b/src/bpp/templates/browse/autor.html
@@ -159,17 +159,20 @@
             </div>
 
         <!-- Evaluation metrics -->
-        {% if autor.metryki.exists %}
+        {# Metryki pobierane RAZ — licznik był wcześniej liczony #}
+        {# osobnym COUNT-em wewnątrz pętli po metrykach (N+1). #}
+        {% with metryki=autor.metryki.all %}
+        {% if metryki %}
             <div class="author-info-section">
                 <h3><i class="fi-graph-trend"></i> Metryki ewaluacyjne</h3>
                 <div class="grid-x grid-margin-x autor-page__grid-gap">
-                    {% for metryka in autor.metryki.all %}
+                    {% for metryka in metryki %}
                         <div class="cell shrink">
                             <a href="{{ metryka.get_absolute_url }}"
                                class="button primary autor-page__metrics-btn">
                                 <i class="fi-eye autor-page__icon--mr-md"></i>
                                 Metryka dla {{ metryka.dyscyplina_naukowa.nazwa }}
-                                {% if autor.metryki.count > 1 and metryka.jednostka %}
+                                {% if metryki|length > 1 and metryka.jednostka %}
                                     ({{ metryka.jednostka.skrot|default:metryka.jednostka.nazwa }})
                                 {% endif %}
                             </a>
@@ -179,6 +182,7 @@
             </div>
             <div class="shaded-hr-div-small"></div>
         {% endif %}
+        {% endwith %}
 
         <!-- Academic degrees -->
         {% if autor.praca_doktorska_set.exists or autor.praca_habilitacyjna %}
@@ -230,14 +234,18 @@
         <!-- Citations -->
         {% load czy_pokazywac %}
         {% czy_pokazywac liczbe_cytowan_na_stronie_autora ignoruj_grupe %}
-            {% if autor.liczba_cytowan %}
+            {# liczba_cytowan to ciężki agregat po bpp_rekord_mat; #}
+            {# szablon pytał o nią dwa razy (warunek + wypisanie). #}
+            {% with liczba_cytowan=autor.liczba_cytowan %}
+            {% if liczba_cytowan %}
                 <div class="author-info-section">
                     <h3><i class="fi-graph-trend"></i> Cytowania</h3>
-                    <p><strong>Liczba cytowań:</strong> {{ autor.liczba_cytowan }}</p>
+                    <p><strong>Liczba cytowań:</strong> {{ liczba_cytowan }}</p>
                     <p><strong>Liczba cytowań z jednostek afiliowanych:</strong> {{ autor.liczba_cytowan_afiliowane|default:"brak" }}</p>
                 </div>
                 <div class="shaded-hr-div-small"></div>
             {% endif %}
+            {% endwith %}
         {% end_czy_pokazywac %}
     </div>
 </div>
@@ -270,14 +278,16 @@
             </div>
         </div>
 
-        {% if autor.jednostki_gdzie_ma_publikacje %}
+        {# Jednostki autora — jeden queryset na warunek i pętlę. #}
+        {% with jednostki_autora=autor.jednostki_gdzie_ma_publikacje %}
+        {% if jednostki_autora %}
             <div class="card autor-page__search-card">
                 <div class="card-section">
                     <h6 class="autor-page__search-card-title">
                         <i class="fi-home autor-page__icon--mr-sm"></i>Opracowane w jednostkach:
                     </h6>
                     <div class="grid-x grid-margin-x">
-                        {% for jednostka in autor.jednostki_gdzie_ma_publikacje %}
+                        {% for jednostka in jednostki_autora %}
                             <div class="cell medium-6 autor-page__checkbox-item">
                                 <input type="checkbox"
                                        name="jednostka"
@@ -299,6 +309,7 @@
                 </div>
             </div>
         {% endif %}
+        {% endwith %}
 
         <!-- Years Selection Card -->
         <div class="card autor-page__search-card">

--- a/src/bpp/templates/browse/bibliography_metadata.html
+++ b/src/bpp/templates/browse/bibliography_metadata.html
@@ -28,7 +28,7 @@ like Zotero, Mendeley, EndNote, etc.
 {% if praca.issn %}
     <meta name="DC.identifier" content="issn:{{ praca.issn }}" />
 {% endif %}
-{% if praca.streszczenia.exists %}
+{% if praca.streszczenia.all %}
     {% for streszczenie in praca.streszczenia.all %}
         {% if forloop.first %}
             <meta name="DC.description" content="{{ streszczenie.streszczenie|striptags|truncatewords:150 }}" />
@@ -131,7 +131,7 @@ tu zostaje tylko citation_pmid, którego tamten szablon nie ma.
     }
   ],
   {% endif %}
-  {% if praca.streszczenia.exists %}
+  {% if praca.streszczenia.all %}
     {% for streszczenie in praca.streszczenia.all %}
       {% if forloop.first %}
   "description": {{ streszczenie.streszczenie|striptags|truncatewords:150|jsonify }},

--- a/src/bpp/templates/browse/google_scholar.html
+++ b/src/bpp/templates/browse/google_scholar.html
@@ -39,7 +39,7 @@ These tags are recognized by Google Scholar and most reference managers
 {% elif praca.www %}
     <meta name="citation_pdf_url" content="{{ praca.www }}">
 {% endif %}
-{% if praca.streszczenia.exists %}
+{% if praca.streszczenia.all %}
     {% for streszczenie in praca.streszczenia.all %}
         {% if forloop.first %}
     <meta name="citation_abstract" content="{{ streszczenie.streszczenie|striptags|truncatewords:250 }}">

--- a/src/bpp/templates/browse/jednostka.html
+++ b/src/bpp/templates/browse/jednostka.html
@@ -18,6 +18,9 @@
 {% endblock %}
 
 {% block content %}
+    {# Potomkowie w drzewie: formularze wstawiają ich pk jako pola #}
+    {# ukryte. Bez {% with %} każdy formularz robił własne zapytanie. #}
+    {% with descendants=jednostka.get_descendants %}
     {% if jednostka.rodzaj.pokazuj_strukture_podjednostek %}
         {# Styl wydziałowy (dawna strona wydziału, Faza B / #438, III-2): #}
         {# węzeł tego rodzaju (np. "Wydział") nie pokazuje własnych prac ani #}
@@ -40,8 +43,12 @@
                         </div>
                     {% endif %}
 
+                    {# aktualne_podjednostki / kola_naukowe / historyczne_podjednostki #}
+                    {# przychodzą z kontekstu (JednostkaView i tak je liczy, żeby #}
+                    {# zdecydować o przekierowaniu) — szablon nie woła metod modelu, #}
+                    {# bo każde wywołanie to osobne zapytanie. #}
                     {% cache 3600 jednostka_struktura_stats jednostka.pk %}
-                        {% with total_jednostki=jednostka.aktualne_podjednostki.count kola_count=jednostka.kola_naukowe.count hist_count=jednostka.historyczne_podjednostki.count %}
+                        {% with total_jednostki=aktualne_podjednostki|length kola_count=kola_naukowe|length hist_count=historyczne_podjednostki|length %}
                             <div class="wydzial-stats">
                                 {% if total_jednostki > 0 %}
                                     <div class="stat-item stat-jednostki">
@@ -91,7 +98,7 @@
                     {% endif %}
                 {% else %}
                     <input type="hidden" name="jednostka" value="{{ jednostka.pk }}"/>
-                    {% for descendant in jednostka.get_descendants %}
+                    {% for descendant in descendants %}
                         <input type="hidden" name="jednostka" value="{{ descendant.pk }}"/>
                     {% endfor %}
                 {% endif %}
@@ -103,23 +110,26 @@
         </div>
 
         <!-- Modern Navigation -->
-        {% if jednostka.wymaga_nawigacji %}
+        {# Nawigacja gdy niepuste są >= 2 z 3 kategorii. Liczymy to na już #}
+        {# zmaterializowanych listach zamiast wołać jednostka.wymaga_nawigacji, #}
+        {# które robiło trzy dodatkowe EXISTS-y. #}
+        {% if aktualne_podjednostki and kola_naukowe or aktualne_podjednostki and historyczne_podjednostki or kola_naukowe and historyczne_podjednostki %}
             <div data-sticky-container id="navStickyContainer" class="wydzial-nav">
                 <div data-sticky class="sticky"
                      data-anchor="listyJednostek" data-margin-top="4">
                     <nav class="sticky-container">
                         <ul class="menu expanded" data-magellan>
-                            {% if jednostka.aktualne_podjednostki.exists %}
+                            {% if aktualne_podjednostki %}
                                 <li><a href="#aktualne">
                                     <i class="fi-home"></i>Jednostki aktualne
                                 </a></li>
                             {% endif %}
-                            {% if jednostka.kola_naukowe.exists %}
+                            {% if kola_naukowe %}
                                 <li><a href="#kola_naukowe">
                                     <i class="fi-torsos-all"></i>Koła naukowe
                                 </a></li>
                             {% endif %}
-                            {% if jednostka.historyczne_podjednostki.exists %}
+                            {% if historyczne_podjednostki %}
                                 <li><a href="#historyczne">
                                     <i class="fi-clock"></i>Jednostki historyczne
                                 </a></li>
@@ -131,16 +141,16 @@
         {% endif %}
 
         <div class="sections" id="listyJednostek">
-            {% if jednostka.aktualne_podjednostki.exists %}
+            {% if aktualne_podjednostki %}
                 <section id="aktualne" data-magellan-target="aktualne" style="margin-bottom: 40px;">
                     <div class="section-header">
                         <h2>
                             <i class="fi-home"></i>Jednostki aktualne
-                            <span>({{ jednostka.aktualne_podjednostki.count }})</span>
+                            <span>({{ aktualne_podjednostki|length }})</span>
                         </h2>
                     </div>
                     <div class="grid-x grid-margin-x">
-                        {% for col in jednostka.aktualne_podjednostki|columns:3 %}
+                        {% for col in aktualne_podjednostki|columns:3 %}
                             <div class="large-4 medium-6 small-12 cell">
                                 {% for podjednostka in col %}
                                     <div class="jednostka-card card-aktualne">
@@ -168,16 +178,16 @@
                 </section>
             {% endif %}
 
-            {% if jednostka.kola_naukowe.exists %}
+            {% if kola_naukowe %}
                 <section id="kola_naukowe" data-magellan-target="kola_naukowe" style="margin-bottom: 40px;">
                     <div class="section-header">
                         <h2>
                             <i class="fi-torsos-all"></i>Koła naukowe
-                            <span>({{ jednostka.kola_naukowe.count }})</span>
+                            <span>({{ kola_naukowe|length }})</span>
                         </h2>
                     </div>
                     <div class="grid-x grid-margin-x">
-                        {% for col in jednostka.kola_naukowe|columns:3 %}
+                        {% for col in kola_naukowe|columns:3 %}
                             <div class="large-4 medium-6 small-12 cell">
                                 {% for podjednostka in col %}
                                     <div class="jednostka-card card-kola">
@@ -205,16 +215,16 @@
                 </section>
             {% endif %}
 
-            {% if jednostka.historyczne_podjednostki.exists %}
+            {% if historyczne_podjednostki %}
                 <section id="historyczne" data-magellan-target="historyczne" style="margin-bottom: 40px;">
                     <div class="section-header">
                         <h2>
                             <i class="fi-clock"></i>Jednostki historyczne
-                            <span>({{ jednostka.historyczne_podjednostki.count }})</span>
+                            <span>({{ historyczne_podjednostki|length }})</span>
                         </h2>
                     </div>
                     <div class="grid-x grid-margin-x">
-                        {% for col in jednostka.historyczne_podjednostki|columns:3 %}
+                        {% for col in historyczne_podjednostki|columns:3 %}
                             <div class="large-4 medium-6 small-12 cell">
                                 {% for podjednostka in col %}
                                     <div class="jednostka-card card-historyczne">
@@ -332,7 +342,7 @@
         <form method="post" action="{% url "bpp:browse_build_search" %}" class="jednostka__quick-actions-form">
             {% csrf_token %}
             <input type="hidden" name="jednostka" value="{{ jednostka.pk }}"/>
-            {% for descendant in jednostka.get_descendants %}
+            {% for descendant in descendants %}
                 <input type="hidden" name="jednostka" value="{{ descendant.pk }}"/>
             {% endfor %}
             <input type="hidden" name="suggested-title" value="{{ jednostka }}"/>
@@ -359,7 +369,7 @@
               class="browserForm">
             {% csrf_token %}
             <input type="hidden" name="jednostka" value="{{ jednostka.pk }}"/>
-            {% for descendant in jednostka.get_descendants %}
+            {% for descendant in descendants %}
                 <input type="hidden" name="jednostka" value="{{ descendant.pk }}"/>
             {% endfor %}
             <input type="hidden" name="suggested-title" value="{{ jednostka }}"/>
@@ -373,14 +383,17 @@
                 </div>
             </div>
 
-            {% if jednostka.pracownicy.exists and jednostka.pracownicy.count < MAX_NO_AUTHORS_ON_BROWSE_JEDNOSTKA_PAGE %}
+            {# Listy autorów pobierane RAZ — bez tego każdy z warunków #}
+            {# (.exists, .count) i każda pętla robiły osobne zapytanie. #}
+            {% with pracownicy=jednostka.pracownicy wspolpracowali=jednostka.wspolpracowali autorzy_publikacji=jednostka.autorzy_na_strone_jednostki %}
+            {% if pracownicy and pracownicy|length < MAX_NO_AUTHORS_ON_BROWSE_JEDNOSTKA_PAGE %}
                 <div class="card jednostka__card">
                     <div class="card-section">
                         <h6 class="jednostka__card-title">
                             <i class="fi-torsos-all jednostka__icon--mr-xs"></i>Obecni pracownicy:
                         </h6>
                         <div class="grid-x grid-margin-x">
-                            {% for col in jednostka.pracownicy|columns:2 %}
+                            {% for col in pracownicy|columns:2 %}
                                 <div class="cell medium-6">
                                     {% for autor in col %}
                                         <div class="jednostka__checkbox-item">
@@ -405,7 +418,7 @@
                     </div>
                 </div>
 
-                {% if jednostka.wspolpracowali.exists and jednostka.wspolpracowali.count < MAX_NO_AUTHORS_ON_BROWSE_JEDNOSTKA_PAGE %}
+                {% if wspolpracowali and wspolpracowali|length < MAX_NO_AUTHORS_ON_BROWSE_JEDNOSTKA_PAGE %}
                     <div class="card jednostka__card">
                         <div class="card-section">
                             <h6 class="jednostka__card-title">
@@ -418,7 +431,7 @@
                                     </a>
                                     <div class="accordion-content jednostka__accordion-content" data-tab-content>
                                         <div class="grid-x grid-margin-x">
-                                            {% for col in jednostka.wspolpracowali|columns:2 %}
+                                            {% for col in wspolpracowali|columns:2 %}
                                                 <div class="cell medium-6">
                                                     {% for autor in col %}
                                                         <div class="jednostka__checkbox-item">
@@ -445,14 +458,14 @@
                     </div>
                 {% endif %}
             {% else %}
-                {% if jednostka.autorzy_na_strone_jednostki.exists and jednostka.autorzy_na_strone_jednostki.count < MAX_NO_AUTHORS_ON_BROWSE_JEDNOSTKA_PAGE %}
+                {% if autorzy_publikacji and autorzy_publikacji|length < MAX_NO_AUTHORS_ON_BROWSE_JEDNOSTKA_PAGE %}
                     <div class="card jednostka__card">
                         <div class="card-section">
                             <h6 class="jednostka__card-title">
                                 <i class="fi-torsos-all jednostka__icon--mr-xs"></i>Autorzy publikacji:
                             </h6>
                             <div class="grid-x grid-margin-x">
-                                {% for col in jednostka.autorzy_na_strone_jednostki|columns:2 %}
+                                {% for col in autorzy_publikacji|columns:2 %}
                                     <div class="cell medium-6">
                                         {% for autor in col %}
                                             <div class="jednostka__checkbox-item">
@@ -476,6 +489,7 @@
                     </div>
                 {% endif %}
             {% endif %}
+            {% endwith %}
 
             <!-- Years Selection Card -->
             <div class="card jednostka__card">
@@ -541,4 +555,5 @@
     </div>
     {% endif %}
 
+    {% endwith %}
 {% endblock %}

--- a/src/bpp/templates/browse/praca_tabela_mono.html
+++ b/src/bpp/templates/browse/praca_tabela_mono.html
@@ -1,4 +1,8 @@
 {% load prace user_in_group dspace_links %}
+{# Streszczenia pobierane RAZ: szablon odwołuje się do nich w kilku #}
+{# miejscach (warunki, pętla, licznik języków). Widok dodatkowo robi #}
+{# prefetch, więc całość to jedno zapytanie na stronę. #}
+{% with streszczenia=praca.streszczenia.all %}
 
 {# Metadane bibliograficzne (citation_*, DC, PRISM, JSON-LD) są teraz #}
 {# wstrzykiwane do <head> przez browse/praca.html (blok extrahead) — #}
@@ -198,15 +202,15 @@
             </div>
 
             <!-- Abstracts Card -->
-            {% if praca.streszczenia.exists %}
+            {% if streszczenia %}
                 <div class="praca-mono__card">
                     <h3 class="praca-mono__card-title">
                         <span class="fi-page-edit"></span> Streszczenia
                         <div class="shaded-hr-div-small"></div>
                     </h3>
-                    {% for streszczenie in praca.streszczenia.all %}
+                    {% for streszczenie in streszczenia %}
                         <div class="praca-mono__abstract">
-                            {% if praca.streszczenia.count > 1 %}
+                            {% if streszczenia|length > 1 %}
                                 <strong class="praca-mono__abstract-label">
                                     {{ streszczenie.jezyk_streszczenia.nazwa }}:
                                 </strong>
@@ -584,7 +588,7 @@
     </div>
 
     <!-- Additional Information Card - Show here if no abstracts, taking full width -->
-    {% if not praca.streszczenia.exists %}
+    {% if not streszczenia %}
         <div class="praca-mono__additional-info">
             <div class="praca-mono__card">
                 <h3 class="praca-mono__card-title">
@@ -636,7 +640,7 @@
                                 <th class="praca-mono__table-cell--vertical-top">Odpowiedzialność za powstanie pracy:
                                 </th>
                                 <td class="praca-mono__table-cell">
-                                    {% for autor in praca.autorzy_set.all %}
+                                    {% for autor in autorzy %}
                                         {% if autor.procent %}
                                             {{ autor.procent }}% {{ autor.zapisany_jako }}<br/>
                                         {% endif %}
@@ -822,7 +826,7 @@
     {% endif %}
 
     <!-- Additional Information Card - Show here if there are abstracts -->
-    {% if praca.streszczenia.exists %}
+    {% if streszczenia %}
         <div class="praca-mono__additional-info">
             <div class="praca-mono__card">
                 <h3 class="praca-mono__card-title">
@@ -874,7 +878,7 @@
                                 <th class="praca-mono__table-cell--vertical-top">Odpowiedzialność za powstanie pracy:
                                 </th>
                                 <td class="praca-mono__table-cell">
-                                    {% for autor in praca.autorzy_set.all %}
+                                    {% for autor in autorzy %}
                                         {% if autor.procent %}
                                             {{ autor.procent }}% {{ autor.zapisany_jako }}<br/>
                                         {% endif %}
@@ -1283,3 +1287,4 @@
         }
     }
 </script>
+{% endwith %}

--- a/src/bpp/tests/test_views/test_browse/test_powtarzane_zapytania_szablonow.py
+++ b/src/bpp/tests/test_views/test_browse/test_powtarzane_zapytania_szablonow.py
@@ -135,7 +135,7 @@ def test_strona_jednostki_pracownicy_bez_powtorzen(client, uczelnia):
     # aktualna_funkcja ma być dociągnięta przez select_related, nie N+1
     # (strażnik na wypadek, gdyby ktoś usunął select_related z pracownicy())
     funkcje = _queries(ctx, 'FROM "bpp_funkcja_autora"')
-    assert len(funkcje) == 0, f"N+1 na aktualna_funkcja:\n" + "\n".join(funkcje)
+    assert len(funkcje) == 0, "N+1 na aktualna_funkcja:\n" + "\n".join(funkcje)
 
     # PRZED: 4 (aktualni_autorzy() liczone od nowa dla pracownicy()
     # i wspolpracowali(), każde po 3 wywołania z szablonu). PO: 1.
@@ -156,7 +156,7 @@ def test_strona_jednostki_podjednostki_bez_powtorzen(client, uczelnia):
         skupia_pracownikow=True,
         widoczna=True,
     )
-    for i in range(4):
+    for _ in range(4):
         baker.make(
             Jednostka,
             uczelnia=uczelnia,
@@ -208,23 +208,13 @@ def test_strona_autora_agregaty_liczone_raz(
         praca = any_ciagle(rok=rok, liczba_cytowan=10)
         praca.dodaj_autora(autor_jan_kowalski, jednostka)
 
-    # jawne wartości pól DecimalField — losowe z model_bakery przepełniają
-    # numeric(5,2) / numeric(4,2)
+    # procent_wykorzystania_slotow to jedyne numeric(5,2) w MetrykaAutora
+    # (reszta Decimali ma 10,4) — losowa wartość z model_bakery je przepełnia.
     for _ in range(3):
         baker.make(
             MetrykaAutora,
             autor=autor_jan_kowalski,
-            slot_maksymalny=Decimal("4.00"),
-            slot_nazbierany=Decimal("2.00"),
-            punkty_nazbierane=Decimal("100.00"),
-            srednia_za_slot_nazbierana=Decimal("50.00"),
-            slot_wszystkie=Decimal("3.00"),
-            punkty_wszystkie=Decimal("150.00"),
-            srednia_za_slot_wszystkie=Decimal("50.00"),
             procent_wykorzystania_slotow=Decimal("50.00"),
-            liczba_prac_wszystkie=3,
-            rok_min=2020,
-            rok_max=2022,
         )
 
     with CaptureQueriesContext(connection) as ctx:
@@ -247,9 +237,7 @@ def test_strona_autora_agregaty_liczone_raz(
     )
 
     # jednostki_gdzie_ma_publikacje — raz, nie dwa razy
-    jgmp = [
-        q for q in _queries(ctx, "bpp_autorzy_mat") if 'FROM "bpp_jednostka"' in q
-    ]
+    jgmp = [q for q in _queries(ctx, "bpp_autorzy_mat") if 'FROM "bpp_jednostka"' in q]
     assert len(jgmp) == 1, f"{len(jgmp)} zapytań o jednostki autora:\n" + "\n".join(
         jgmp
     )

--- a/src/bpp/tests/test_views/test_browse/test_powtarzane_zapytania_szablonow.py
+++ b/src/bpp/tests/test_views/test_browse/test_powtarzane_zapytania_szablonow.py
@@ -1,0 +1,237 @@
+"""Testy liczby zapytań dla publicznych stron: rekordu, jednostki, autora.
+
+Szablony tych stron wielokrotnie odwoływały się do tych samych METOD modelu
+(``autorzy_dla_opisu``, ``pracownicy``, ``wspolpracowali``,
+``liczba_cytowan``, ``jednostki_gdzie_ma_publikacje``), a każde odwołanie
+budowało świeży, niezmaterializowany QuerySet — czyli osobny roundtrip do
+bazy. Te testy pilnują, żeby każdy taki zestaw danych był pobierany raz.
+"""
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.models import Autor, Autor_Jednostka, Jednostka, RodzajJednostki
+from bpp.models.autor import Funkcja_Autora
+from bpp.models.fields import OpcjaWyswietlaniaField
+from bpp.tests.util import any_ciagle
+
+
+def _queries(ctx, fragment):
+    """Zapytania, których SQL zawiera podany fragment (nazwę tabeli)."""
+    return [q["sql"] for q in ctx.captured_queries if fragment in q["sql"]]
+
+
+def _dodaj_autorow(wydawnictwo_ciagle, jednostka, ile):
+    for i in range(ile):
+        autor = baker.make(Autor, nazwisko=f"Nazwisko{i:03d}", imiona="Imię")
+        wydawnictwo_ciagle.dodaj_autora(
+            autor,
+            jednostka,
+            zapisany_jako=f"Nazwisko{i:03d} Imię",
+            kolejnosc=i,
+        )
+
+
+@pytest.mark.django_db
+def test_strona_rekordu_autorzy_pobierani_raz(client, uczelnia, wydawnictwo_ciagle):
+    """Strona rekordu ma pobrać listę autorów JEDNYM zapytaniem."""
+    jednostka = baker.make(Jednostka, uczelnia=uczelnia, skupia_pracownikow=True)
+    _dodaj_autorow(wydawnictwo_ciagle, jednostka, 6)
+
+    url = reverse(
+        "bpp:browse_praca",
+        args=(
+            ContentType.objects.get(app_label="bpp", model="wydawnictwo_ciagle").pk,
+            wydawnictwo_ciagle.pk,
+        ),
+    )
+
+    with CaptureQueriesContext(connection) as ctx:
+        res = client.get(url, follow=True)
+
+    assert res.status_code == 200
+    # Interesuje nas queryset z autorzy_dla_opisu(), czyli ten z JOIN-em
+    # na bpp_autor + bpp_typ_odpowiedzialnosci. (Pozostałe zapytania do tej
+    # tabeli — EXISTS-y ma_procenty / odpiete_dyscypliny — to co innego.)
+    autorzy = [
+        q
+        for q in _queries(ctx, "bpp_wydawnictwo_ciagle_autor")
+        if "bpp_typ_odpowiedzialnosci" in q
+    ]
+    assert len(autorzy) == 1, f"{len(autorzy)} zapytań o autorów:\n" + "\n".join(
+        autorzy
+    )
+
+
+@pytest.mark.django_db
+def test_strona_rekordu_streszczenia_pobierane_raz(
+    client, uczelnia, wydawnictwo_ciagle
+):
+    """Streszczenia rekordu mają być pobrane jednym zapytaniem."""
+    jednostka = baker.make(Jednostka, uczelnia=uczelnia, skupia_pracownikow=True)
+    _dodaj_autorow(wydawnictwo_ciagle, jednostka, 2)
+
+    url = reverse(
+        "bpp:browse_praca",
+        args=(
+            ContentType.objects.get(app_label="bpp", model="wydawnictwo_ciagle").pk,
+            wydawnictwo_ciagle.pk,
+        ),
+    )
+
+    with CaptureQueriesContext(connection) as ctx:
+        res = client.get(url, follow=True)
+
+    assert res.status_code == 200
+    # PRZED: 6 zapytań (3x EXISTS + 2x SELECT + 1x COUNT). PO: 1 prefetch.
+    streszczenia = _queries(ctx, "bpp_wydawnictwo_ciagle_streszczenie")
+    assert len(streszczenia) == 1, (
+        f"{len(streszczenia)} zapytań o streszczenia:\n" + "\n".join(streszczenia)
+    )
+
+
+@pytest.mark.django_db
+def test_strona_jednostki_pracownicy_bez_powtorzen(client, uczelnia):
+    """Lista pracowników i współpracowników — bez powtarzanych zapytań
+    i bez N+1 na ``autor.aktualna_funkcja``."""
+    jednostka = baker.make(
+        Jednostka, uczelnia=uczelnia, skupia_pracownikow=True, widoczna=True
+    )
+    funkcja = baker.make(Funkcja_Autora, pokazuj_za_nazwiskiem=True)
+    for i in range(12):
+        autor = baker.make(
+            Autor,
+            nazwisko=f"Pracownik{i:03d}",
+            imiona="Imię",
+            aktualna_jednostka=jednostka,
+            aktualna_funkcja=funkcja,
+            pokazuj=True,
+        )
+        baker.make(
+            Autor_Jednostka,
+            autor=autor,
+            jednostka=jednostka,
+            podstawowe_miejsce_pracy=True,
+        )
+
+    with CaptureQueriesContext(connection) as ctx:
+        res = client.get(reverse("bpp:browse_jednostka", args=(jednostka.slug,)))
+
+    assert res.status_code == 200
+
+    # bpp_autor — PRZED: 9, PO: 4 (kierownik jednostki, PK aktualnych
+    # autorów, lista pracowników, lista współpracowników).
+    autorzy = _queries(ctx, 'FROM "bpp_autor"')
+    assert len(autorzy) <= 4, f"{len(autorzy)} zapytań o autorów:\n" + "\n".join(
+        autorzy
+    )
+
+    # aktualna_funkcja ma być dociągnięta przez select_related, nie N+1
+    # (strażnik na wypadek, gdyby ktoś usunął select_related z pracownicy())
+    funkcje = _queries(ctx, 'FROM "bpp_funkcja_autora"')
+    assert len(funkcje) == 0, f"N+1 na aktualna_funkcja:\n" + "\n".join(funkcje)
+
+    # PRZED: 4 (aktualni_autorzy() liczone od nowa dla pracownicy()
+    # i wspolpracowali(), każde po 3 wywołania z szablonu). PO: 1.
+    aj = _queries(ctx, 'FROM "bpp_autor_jednostka"')
+    assert len(aj) == 1, f"{len(aj)} zapytań o Autor_Jednostka:\n" + "\n".join(aj)
+
+
+@pytest.mark.django_db
+def test_strona_jednostki_podjednostki_bez_powtorzen(client, uczelnia):
+    """Podjednostki (aktualne / koła / historyczne) — po jednym zapytaniu."""
+    # rodzaj z 'pokazuj_strukture_podjednostek' => strona w stylu wydziałowym,
+    # czyli ta z sekcjami podjednostek
+    rodzaj = baker.make(RodzajJednostki, pokazuj_strukture_podjednostek=True)
+    jednostka = baker.make(
+        Jednostka,
+        uczelnia=uczelnia,
+        rodzaj=rodzaj,
+        skupia_pracownikow=True,
+        widoczna=True,
+    )
+    for i in range(4):
+        baker.make(
+            Jednostka,
+            uczelnia=uczelnia,
+            parent=jednostka,
+            wydzial=jednostka,
+            widoczna=True,
+            aktualna=True,
+            zarzadzaj_automatycznie=False,
+        )
+
+    assert jednostka.aktualne_podjednostki().count() == 4
+
+    with CaptureQueriesContext(connection) as ctx:
+        res = client.get(reverse("bpp:browse_jednostka", args=(jednostka.slug,)))
+
+    assert res.status_code == 200
+
+    # {% with %} nie może "zgubić" danych — sekcja z podjednostkami i jej
+    # licznik mają się nadal renderować.
+    tresc = res.content.decode()
+    assert "Jednostki aktualne" in tresc
+    assert ">4<" in tresc
+
+    # Trzy kategorie podjednostek (aktualne / koła / historyczne) — po jednym
+    # zapytaniu na kategorię. PRZED: 16 (widok liczył je raz, a szablon jeszcze
+    # trzy razy każdą: nawigacja, licznik w nagłówku, pętla — plus 3 EXISTS-y
+    # z wymaga_nawigacji()). PO: 5.
+    podjednostki = _queries(ctx, 'FROM "bpp_jednostka"')
+    assert len(podjednostki) <= 5, (
+        f"{len(podjednostki)} zapytań o podjednostki:\n" + "\n".join(podjednostki)
+    )
+
+
+@pytest.mark.django_db
+def test_strona_autora_agregaty_liczone_raz(
+    client, uczelnia, autor_jan_kowalski, jednostka, typy_odpowiedzialnosci
+):
+    """``liczba_cytowan`` i ``jednostki_gdzie_ma_publikacje`` — po jednym
+    zapytaniu, a ``metryki.count`` nie może być liczone w pętli."""
+    from ewaluacja_metryki.models import MetrykaAutora
+
+    uczelnia.pokazuj_liczbe_cytowan_na_stronie_autora = (
+        OpcjaWyswietlaniaField.POKAZUJ_ZAWSZE
+    )
+    uczelnia.save()
+
+    # realistyczne dane: kilka prac z cytowaniami + kilka metryk
+    for rok in (2020, 2021, 2022):
+        praca = any_ciagle(rok=rok, liczba_cytowan=10)
+        praca.dodaj_autora(autor_jan_kowalski, jednostka)
+
+    for _ in range(3):
+        baker.make(MetrykaAutora, autor=autor_jan_kowalski)
+
+    with CaptureQueriesContext(connection) as ctx:
+        res = client.get(reverse("bpp:browse_autor", args=(autor_jan_kowalski.slug,)))
+
+    assert res.status_code == 200
+
+    # ciężki agregat SUM(liczba_cytowan) po bpp_rekord_mat — maks. 2 razy
+    # (liczba_cytowan + liczba_cytowan_afiliowane), nie 3.
+    cytowania = [q for q in _queries(ctx, "bpp_rekord_mat") if "SUM(" in q.upper()]
+    assert len(cytowania) <= 2, f"{len(cytowania)} agregatów cytowań:\n" + "\n".join(
+        cytowania
+    )
+
+    # metryki: 1 EXISTS + 1 SELECT; COUNT w pętli po metrykach = regresja
+    # PRZED: 5 (EXISTS + SELECT + COUNT dla każdej z 3 metryk). PO: 1.
+    metryki = _queries(ctx, "ewaluacja_metryki_metrykaautora")
+    assert len(metryki) == 1, f"{len(metryki)} zapytań o metryki:\n" + "\n".join(
+        metryki
+    )
+
+    # jednostki_gdzie_ma_publikacje — raz, nie dwa razy
+    jgmp = [
+        q for q in _queries(ctx, "bpp_autorzy_mat") if 'FROM "bpp_jednostka"' in q
+    ]
+    assert len(jgmp) == 1, f"{len(jgmp)} zapytań o jednostki autora:\n" + "\n".join(
+        jgmp
+    )

--- a/src/bpp/tests/test_views/test_browse/test_powtarzane_zapytania_szablonow.py
+++ b/src/bpp/tests/test_views/test_browse/test_powtarzane_zapytania_szablonow.py
@@ -208,13 +208,22 @@ def test_strona_autora_agregaty_liczone_raz(
         praca = any_ciagle(rok=rok, liczba_cytowan=10)
         praca.dodaj_autora(autor_jan_kowalski, jednostka)
 
-    # procent_wykorzystania_slotow to jedyne numeric(5,2) w MetrykaAutora
-    # (reszta Decimali ma 10,4) — losowa wartość z model_bakery je przepełnia.
+    # MetrykaAutora.save() wylicza pola pochodne z ilorazów: procent =
+    # slot_nazbierany / slot_maksymalny * 100 (kolumna numeric(5,2), więc
+    # < 1000), a srednia_za_slot_* = punkty / slot (numeric(10,4)). Losowe
+    # wartości z model_bakery dają ilorazy przepełniające te kolumny —
+    # dlatego podajemy jawnie wszystkie cztery składniki tych działań.
+    # (Samo procent_wykorzystania_slotow ustawiać nie ma sensu — save() je
+    # nadpisze.)
     for _ in range(3):
         baker.make(
             MetrykaAutora,
             autor=autor_jan_kowalski,
-            procent_wykorzystania_slotow=Decimal("50.00"),
+            slot_maksymalny=Decimal("4.0000"),
+            slot_nazbierany=Decimal("2.0000"),
+            punkty_nazbierane=Decimal("100.0000"),
+            slot_wszystkie=Decimal("3.0000"),
+            punkty_wszystkie=Decimal("150.0000"),
         )
 
     with CaptureQueriesContext(connection) as ctx:

--- a/src/bpp/tests/test_views/test_browse/test_powtarzane_zapytania_szablonow.py
+++ b/src/bpp/tests/test_views/test_browse/test_powtarzane_zapytania_szablonow.py
@@ -7,6 +7,8 @@ budowało świeży, niezmaterializowany QuerySet — czyli osobny roundtrip do
 bazy. Te testy pilnują, żeby każdy taki zestaw danych był pobierany raz.
 """
 
+from decimal import Decimal
+
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
@@ -206,8 +208,24 @@ def test_strona_autora_agregaty_liczone_raz(
         praca = any_ciagle(rok=rok, liczba_cytowan=10)
         praca.dodaj_autora(autor_jan_kowalski, jednostka)
 
+    # jawne wartości pól DecimalField — losowe z model_bakery przepełniają
+    # numeric(5,2) / numeric(4,2)
     for _ in range(3):
-        baker.make(MetrykaAutora, autor=autor_jan_kowalski)
+        baker.make(
+            MetrykaAutora,
+            autor=autor_jan_kowalski,
+            slot_maksymalny=Decimal("4.00"),
+            slot_nazbierany=Decimal("2.00"),
+            punkty_nazbierane=Decimal("100.00"),
+            srednia_za_slot_nazbierana=Decimal("50.00"),
+            slot_wszystkie=Decimal("3.00"),
+            punkty_wszystkie=Decimal("150.00"),
+            srednia_za_slot_wszystkie=Decimal("50.00"),
+            procent_wykorzystania_slotow=Decimal("50.00"),
+            liczba_prac_wszystkie=3,
+            rok_min=2020,
+            rok_max=2022,
+        )
 
     with CaptureQueriesContext(connection) as ctx:
         res = client.get(reverse("bpp:browse_autor", args=(autor_jan_kowalski.slug,)))

--- a/src/bpp/views/browse.py
+++ b/src/bpp/views/browse.py
@@ -34,6 +34,7 @@ from bpp.models import (
     Wydzial,
     Zrodlo,
 )
+from bpp.models.util import prefetch_dane_strony_rekordu
 from bpp.multiseek_registry import (
     JednostkaNadrzednaQueryObject,
     JednostkaQueryObject,
@@ -175,6 +176,11 @@ class JednostkaView(DetailView):
     template_name = "browse/jednostka.html"
     model = Jednostka
 
+    #: Listy podjednostek policzone w ``get()`` dla stylu strukturalnego —
+    #: szablon dostaje je przez kontekst, zamiast wołać metody modelu (i tak
+    #: potrzebne są tu na decyzję o przekierowaniu).
+    podjednostki = None
+
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
 
@@ -193,11 +199,23 @@ class JednostkaView(DetailView):
             if len(wszystkie) == 1:
                 return redirect("bpp:browse_jednostka", slug=wszystkie[0].slug)
 
+            self.podjednostki = {
+                "aktualne_podjednostki": aktualne,
+                "kola_naukowe": kola,
+                "historyczne_podjednostki": historyczne,
+            }
+
+        # Szablon woła zarówno pracownicy(), jak i wspolpracowali() — obie te
+        # metody potrzebują tego samego zbioru PK aktualnych autorów.
+        self.object.prefetch_aktualnych_autorow()
+
         context = self.get_context_data(object=self.object)
         return self.render_to_response(context)
 
     def get_context_data(self, **kwargs):
-        return super().get_context_data(typy=TYPY, **kwargs)
+        return super().get_context_data(
+            typy=TYPY, **(self.podjednostki or {}), **kwargs
+        )
 
 
 class AutorView(DetailView):
@@ -812,6 +830,11 @@ class PracaViewMixin:
             return HttpResponseRedirect(
                 reverse("bpp:browse_praca_by_slug", args=(self.object.slug,))
             )
+
+        # Szablon strony rekordu sięga po autorów opisu i po streszczenia
+        # z kilku miejsc (metadane w <head>, opis bibliograficzny, tabela
+        # informacji dodatkowych). Materializujemy je raz, przed renderem.
+        prefetch_dane_strony_rekordu(self.object.original)
 
         context = self.get_context_data(object=self.object)
         return self.render_to_response(context)


### PR DESCRIPTION
## Problem

Szablony publicznych stron (rekord, jednostka, autor) odwoływały się po kilka
razy do tych samych **metod** modelu. Metoda nie jest `cached_property`, więc
każde odwołanie budowało świeży, niezmaterializowany queryset — osobny
roundtrip do bazy.

## Zmiany

**Strona rekordu** — nowy `prefetch_dane_strony_rekordu()` (autorzy opisu +
streszczenia) wołany JAWNIE przez widok tuż przed renderem; szablony korzystają
z przekazanej listy autorów zamiast `praca.autorzy_set.all`, streszczenia przez
`{% with %}`.

**Strona jednostki** — `JednostkaView` i tak liczy trzy listy podjednostek
(decyzja o przekierowaniu), więc przekazuje je teraz przez kontekst;
`pracownicy` / `wspolpracowali` / `autorzy_na_strone_jednostki` oraz
`get_descendants` przez `{% with %}`; `wymaga_nawigacji` policzone na gotowych
listach zamiast trzech EXISTS-ów; `pracownicy()` dostało
`select_related("aktualna_funkcja")`; opcjonalny, jawny
`prefetch_aktualnych_autorow()`.

**Strona autora** — metryki (COUNT w pętli!), `liczba_cytowan` (ciężki agregat
liczony 2×) i `jednostki_gdzie_ma_publikacje` przez `{% with %}`.

## Świadoma decyzja: żadnych `cached_property` na modelach

Pamięć podręczna żyłaby tyle, co instancja, a istniejący
`test_Jednostka_aktualni_autorzy` pokazuje kod, który modyfikuje przypisania
autorów i oczekuje świeżego odczytu na tej samej instancji. Dlatego memoizacja
jest wszędzie **opt-in**, uruchamiana z widoku.

## Liczby (zmierzone `CaptureQueriesContext` na `client.get()`)

| strona | metryka | przed | po |
|---|---|---|---|
| rekord (6 autorów) | zapytania ogółem | 43 | **41** |
| | lista autorów opisu | 4 | **1** |
| | streszczenia | 6 | **1** |
| jednostka (12 pracowników) | zapytania ogółem | 35 | **27** |
| | `bpp_autor` | 9 | **4** |
| | `bpp_autor_jednostka` | 4 | **1** |
| jednostka (4 podjednostki) | zapytania ogółem | 53 | **33** |
| | `bpp_jednostka` | 16 | **5** |
| autor (3 prace, 3 metryki) | zapytania ogółem | 39 | **33** |
| | agregat cytowań | 3 | **2** |
| | metryki ewaluacyjne | 5 | **1** |
| | jednostki autora | 2 | **1** |

## Testy

`src/bpp/tests/test_views/test_browse/test_powtarzane_zapytania_szablonow.py`
— 5 testów liczby zapytań na realistycznych danych. Zweryfikowane jako
**CZERWONE** na kodzie sprzed poprawki i **ZIELONE** po. Test podjednostek
sprawdza dodatkowo, że `{% with %}` nie „zgubił" treści sekcji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX