### PR TITLE
perf(browse): cache HTTP publicznych stron przeglądania dla anonimów

### DIFF
--- a/src/bpp/apps.py
+++ b/src/bpp/apps.py
@@ -35,6 +35,8 @@ class BppConfig(AppConfig):
                 dispatch_uid="bpp.invalidate_uczelnia_cache_on_article_change",
             )
 
+        self._podepnij_inwalidacje_cache_publicznego()
+
         # Ensure BppUserAdmin takes precedence over microsoft_auth's UserAdmin
         self._register_bpp_user_admin()
 
@@ -42,6 +44,56 @@ class BppConfig(AppConfig):
         from bpp.rollbar_config import configure_rollbar
 
         configure_rollbar()
+
+    #: Modele, których zapis zmienia treść publicznych stron przeglądania
+    #: objętych ``bpp.views.cache_publiczny.cache_publiczny``.
+    MODELE_INWALIDUJACE_CACHE_PUBLICZNY = (
+        # Rekordy i ich bezpośredni właściciele.
+        "Wydawnictwo_Ciagle",
+        "Wydawnictwo_Zwarte",
+        "Patent",
+        "Praca_Doktorska",
+        "Praca_Habilitacyjna",
+        "Autor",
+        "Jednostka",
+        "Zrodlo",
+        "Wydzial",
+        "Uczelnia",
+        # Słowniki — ich nazwy trafiają do opisów bibliograficznych, więc
+        # zmiana nazwy zmienia treść publicznych stron. Bez nich obietnica
+        # „zapis w adminie unieważnia natychmiast" byłaby dla tych modeli
+        # nieprawdziwa (odświeżałby je dopiero TTL).
+        "Charakter_Formalny",
+        "Typ_KBN",
+        "Jezyk",
+        "Wydawca",
+        "Konferencja",
+        "Seria_Wydawnicza",
+        "Status_Korekty",
+        "Typ_Odpowiedzialnosci",
+    )
+
+    def _podepnij_inwalidacje_cache_publicznego(self):
+        """Zapis w adminie ma NATYCHMIAST odświeżyć publiczne strony.
+
+        Bez tego jedyną gwarancją świeżości byłby TTL. Inwalidujemy
+        hurtowo (bump generacji), bo mapowanie „ten rekord → te URL-e"
+        jest w BPP nietrywialne, a nadmiarowa inwalidacja jest bezpieczna
+        (najwyżej kosztuje jedno przeliczenie strony).
+        """
+        from django.apps import apps
+        from django.db.models.signals import post_delete, post_save
+
+        from bpp.views.cache_publiczny import uniewaznij_cache_publiczny
+
+        for nazwa in self.MODELE_INWALIDUJACE_CACHE_PUBLICZNY:
+            model = apps.get_model("bpp", nazwa)
+            for etykieta, sygnal in (("save", post_save), ("delete", post_delete)):
+                sygnal.connect(
+                    uniewaznij_cache_publiczny,
+                    sender=model,
+                    dispatch_uid=f"bpp.cache_publiczny.{nazwa}.{etykieta}",
+                )
 
     def _register_bpp_user_admin(self):
         """Re-register BppUserAdmin to override any previous registrations."""

--- a/src/bpp/newsfragments/cache-http-anonim.feature.rst
+++ b/src/bpp/newsfragments/cache-http-anonim.feature.rst
@@ -1,0 +1,8 @@
+Publiczne strony przeglądania (lata, rok, listy autorów, źródeł i jednostek
+oraz strona rekordu) są zapamiętywane w cache'u HTTP dla użytkowników
+niezalogowanych — ścina to ruch robotów indeksujących z bazy danych. Cache
+jest izolowany per domena (multi-hosted: treść jednej uczelni nigdy nie
+trafi pod domenę innej) oraz per stan zgody na ciasteczka (osoba, która
+odmówiła zgody, nigdy nie dostanie strony z włączoną analityką), omija
+użytkowników zalogowanych w obie strony, a zapis danych w panelu
+administracyjnym unieważnia go natychmiast.

--- a/src/bpp/tests/test_views/test_cache_publiczny.py
+++ b/src/bpp/tests/test_views/test_cache_publiczny.py
@@ -1,0 +1,717 @@
+"""Testy cache'a HTTP publicznych stron przeglądania (anonim).
+
+Najważniejszy jest tu ``test_izolacja_multi_host_*`` — MUSI padać, gdyby
+ktoś usunął hosta z klucza cache'a (``bpp.views.cache_publiczny._klucz``).
+"""
+
+import pytest
+from django.core.cache import cache
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.views.cache_publiczny import (
+    _klucz,
+    _mozna_cachowac_odpowiedz,
+    cache_publiczny,
+    uniewaznij_cache_publiczny,
+)
+
+from fixtures.conftest_multisite import make_request_for_site
+
+# W ``settings/test.py`` CACHES["default"] to DummyCache — nic nie
+# zapamiętuje, więc bez podmiany na LocMem te testy nie mierzyłyby niczego.
+LOCMEM = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-cache-publiczny",
+    }
+}
+
+
+@pytest.fixture
+def cache_locmem(settings):
+    """Podmień domyślny cache na LocMem i wyczyść go przed/po teście."""
+    poprzednie = settings.CACHES
+    settings.CACHES = {**poprzednie, **LOCMEM}
+    cache.clear()
+    yield cache
+    cache.clear()
+    settings.CACHES = poprzednie
+
+
+@pytest.fixture(autouse=True)
+def _zezwol_na_hosty_testowe(settings):
+    settings.ALLOWED_HOSTS = ["*"]
+
+
+@pytest.fixture
+def czysta_kolejka_on_commit(db):
+    """Wyczyść unieważnienia zaplanowane przez fixture'y.
+
+    ``uniewaznij_cache_publiczny`` planuje pracę przez
+    ``transaction.on_commit`` i pomija kolejne zgłoszenia, gdy jedno już
+    czeka w tej transakcji. Pod ``django_db`` transakcja testu NIGDY nie
+    commituje, więc unieważnienia zaplanowane przez fixture'y (zapis
+    ``Uczelnia``, ``Jednostka``…) zostają w kolejce i wyciszyłyby
+    wszystko, co test chce zmierzyć. Czyścimy kolejkę, żeby test
+    startował jak świeża transakcja.
+
+    Zamawiaj ten fixture JAKO OSTATNI, po fixture'ach tworzących modele.
+    """
+    from django.db import transaction
+
+    transaction.get_connection().run_on_commit.clear()
+    yield
+
+
+def uniewaznij_i_zatwierdz(django_capture_on_commit_callbacks):
+    """Unieważnij cache tak, jak zrobiłby to prawdziwy ``COMMIT``.
+
+    Prawdziwy commit wykonuje callbacki I opróżnia ``run_on_commit``.
+    Testowy harness ich nie usuwa, więc bez wyczyszczenia kolejki dedup
+    z ``uniewaznij_cache_publiczny`` uznałby kolejne unieważnienie za już
+    zaplanowane i je pominął. Czyścimy po obu stronach, żeby każde
+    wywołanie startowało z granicy transakcji.
+    """
+    from django.db import transaction
+
+    polaczenie = transaction.get_connection()
+    polaczenie.run_on_commit.clear()
+    with django_capture_on_commit_callbacks(execute=True):
+        uniewaznij_cache_publiczny()
+    polaczenie.run_on_commit.clear()
+
+
+# ---------------------------------------------------------------------------
+# IZOLACJA MULTI-HOST — sedno tego modułu
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_izolacja_multi_host_klucz_zawiera_hosta(
+    cache_locmem, site1, site2, uczelnia1, uczelnia2
+):
+    """Ten sam URL pod dwiema domenami MUSI dać dwa różne klucze cache'a.
+
+    ``cache_locmem`` jest tu WARUNKIEM SENSOWNOŚCI testu, nie ozdobą: pod
+    domyślnym ``DummyCache`` ``cache.get`` zawsze zwraca ``None``, więc
+    ``_generacja()`` losuje nowy identyfikator przy każdym wywołaniu i dwa
+    klucze różniłyby się nawet wtedy, gdyby host w ogóle do nich nie
+    wchodził. Test przechodziłby wtedy z niewłaściwego powodu.
+    """
+    r1 = make_request_for_site(site1, path="/bpp/autorzy/")
+    r2 = make_request_for_site(site2, path="/bpp/autorzy/")
+
+    assert r1.get_full_path() == r2.get_full_path()
+    # Warunek kontrolny: bez zmiany hosta klucz musi być stabilny.
+    assert _klucz(r1) == _klucz(r1)
+    assert _klucz(r1) != _klucz(r2), (
+        "Klucz cache'a nie rozróżnia domen — cache zaserwuje treść jednej "
+        "uczelni pod domeną drugiej. Patrz docstring bpp.views.cache_publiczny."
+    )
+
+
+@pytest.mark.django_db
+def test_izolacja_multi_host_rozne_tresci_pod_roznymi_domenami(
+    client,
+    cache_locmem,
+    site1,
+    site2,
+    uczelnia1,
+    uczelnia2,
+    jednostka_uczelnia1,
+    jednostka_uczelnia2,
+):
+    """Domena A nie może dostać cache'a wygenerowanego dla domeny B.
+
+    To jest test przeciw wyciekowi danych MIĘDZY INSTYTUCJAMI. Jeżeli
+    ktoś usunie ``request.get_host()`` z ``_klucz``, drugie żądanie
+    dostanie zapamiętaną stronę uczelni 1 i asercje niżej padną.
+    """
+    url = reverse("bpp:browse_jednostki")
+
+    # Rozgrzewamy cache pod domeną uczelni 1.
+    odp1 = client.get(url, HTTP_HOST=site1.domain)
+    assert odp1.status_code == 200
+    assert jednostka_uczelnia1.nazwa in odp1.content.decode()
+
+    # A teraz TEN SAM URL pod domeną uczelni 2.
+    odp2 = client.get(url, HTTP_HOST=site2.domain)
+    assert odp2.status_code == 200
+    tresc2 = odp2.content.decode()
+
+    assert jednostka_uczelnia2.nazwa in tresc2
+    assert jednostka_uczelnia1.nazwa not in tresc2, (
+        "WYCIEK MIĘDZY UCZELNIAMI: pod domeną uczelni 2 pojawiła się "
+        "jednostka uczelni 1 — najpewniej z cache'a bez hosta w kluczu."
+    )
+
+    # Drugie żądanie na domenę 1 nadal ma dane uczelni 1 (a nie 2).
+    odp1b = client.get(url, HTTP_HOST=site1.domain)
+    tresc1b = odp1b.content.decode()
+    assert jednostka_uczelnia1.nazwa in tresc1b
+    assert jednostka_uczelnia2.nazwa not in tresc1b
+
+
+# ---------------------------------------------------------------------------
+# ANONIM vs ZALOGOWANY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_cache_dziala_dla_anonima(client, cache_locmem, site1, uczelnia1):
+    """Drugie żądanie anonima jest obsłużone z cache'a (HIT)."""
+    url = reverse("bpp:browse_lata")
+
+    pierwsza = client.get(url, HTTP_HOST=site1.domain)
+    assert pierwsza.status_code == 200
+    assert pierwsza["X-BPP-Cache"] == "MISS"
+
+    druga = client.get(url, HTTP_HOST=site1.domain)
+    assert druga.status_code == 200
+    assert druga["X-BPP-Cache"] == "HIT"
+    assert druga.content == pierwsza.content
+
+
+@pytest.mark.django_db
+def test_cache_dla_anonima_scina_zapytania_do_bazy(
+    client, cache_locmem, site1, uczelnia1, jednostka_uczelnia1
+):
+    """Trafienie w cache eliminuje zapytania widoku o treść strony.
+
+    Zera nie da się tu wymagać: ``SiteResolutionMiddleware`` rozstrzyga
+    ``Host`` → ``Site`` → ``Uczelnia`` ZANIM dekorator w ogóle zobaczy
+    żądanie (i musi to robić — to od tego zależy klucz cache'a). Zostaje
+    więc stała, mała podłoga zapytań middleware'owych. Mierzymy to, co
+    cache faktycznie obiecuje: że znika praca WIDOKU.
+    """
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    url = reverse("bpp:browse_jednostki")
+
+    with CaptureQueriesContext(connection) as zimne:
+        assert client.get(url, HTTP_HOST=site1.domain)["X-BPP-Cache"] == "MISS"
+
+    with CaptureQueriesContext(connection) as cieple:
+        assert client.get(url, HTTP_HOST=site1.domain)["X-BPP-Cache"] == "HIT"
+
+    assert len(cieple) < len(zimne), (
+        f"Cache nie ściął ani jednego zapytania "
+        f"(zimne={len(zimne)}, ciepłe={len(cieple)})."
+    )
+    # Podłoga middleware'owa: rozstrzygnięcie Site/Uczelni. Gdyby urosła,
+    # znaczy że coś poza cache'em zaczęło odpytywać bazę na każdej stronie.
+    assert len(cieple) <= 5, [q["sql"] for q in cieple.captured_queries]
+
+
+@pytest.mark.django_db
+def test_zalogowany_nie_czyta_cache_anonima(
+    client, cache_locmem, site1, uczelnia1, superuser_multisite
+):
+    """Zalogowany dostaje stronę wyrenderowaną dla siebie, nie kopię anonima."""
+    url = reverse("bpp:browse_lata")
+
+    anonim = client.get(url, HTTP_HOST=site1.domain)
+    assert anonim["X-BPP-Cache"] == "MISS"
+
+    client.force_login(superuser_multisite)
+    zalogowany = client.get(url, HTTP_HOST=site1.domain)
+
+    assert zalogowany.status_code == 200
+    assert not zalogowany.has_header("X-BPP-Cache"), (
+        "Zalogowany przeszedł przez warstwę cache'a — a miał ją ominąć."
+    )
+
+
+@pytest.mark.django_db
+def test_anonim_nie_czyta_cache_zalogowanego(
+    client, cache_locmem, site1, uczelnia1, superuser_multisite
+):
+    """Odpowiedź dla zalogowanego nie może trafić do cache'a anonimów."""
+    url = reverse("bpp:browse_lata")
+
+    client.force_login(superuser_multisite)
+    client.get(url, HTTP_HOST=site1.domain)
+
+    client.logout()
+    anonim = client.get(url, HTTP_HOST=site1.domain)
+
+    assert anonim["X-BPP-Cache"] == "MISS", (
+        "Anonim dostał HIT-a, choć cache rozgrzewał tylko zalogowany — "
+        "znaczy, że zapisaliśmy odpowiedź zalogowanego."
+    )
+
+
+# ---------------------------------------------------------------------------
+# INWALIDACJA
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_zapis_publikacji_uniewaznia_cache(
+    client,
+    cache_locmem,
+    site1,
+    uczelnia1,
+    jednostka_uczelnia1,
+    django_capture_on_commit_callbacks,
+    czysta_kolejka_on_commit,
+):
+    """Po zapisie w adminie publiczna strona odświeża się natychmiast.
+
+    Unieważnienie leci przez ``transaction.on_commit`` (patrz
+    ``uniewaznij_cache_publiczny``), a ``django_db`` trzyma test w
+    transakcji, która nigdy nie commituje — stąd jawne wykonanie
+    callbacków.
+    """
+    url = reverse("bpp:browse_jednostki")
+
+    client.get(url, HTTP_HOST=site1.domain)
+    assert client.get(url, HTTP_HOST=site1.domain)["X-BPP-Cache"] == "HIT"
+
+    with django_capture_on_commit_callbacks(execute=True):
+        jednostka_uczelnia1.nazwa = "Jednostka Po Zmianie"
+        jednostka_uczelnia1.save()
+
+    po_zapisie = client.get(url, HTTP_HOST=site1.domain)
+    assert po_zapisie["X-BPP-Cache"] == "MISS"
+    assert "Jednostka Po Zmianie" in po_zapisie.content.decode()
+
+
+@pytest.mark.django_db
+def test_bump_generacji_zawsze_zmienia_klucz(
+    cache_locmem,
+    site1,
+    uczelnia1,
+    django_capture_on_commit_callbacks,
+    czysta_kolejka_on_commit,
+):
+    """Kolejne unieważnienia zawsze dają nowy klucz (nigdy nie wracają)."""
+    request = make_request_for_site(site1, path="/bpp/lata/")
+
+    widziane = {_klucz(request)}
+    for _ in range(5):
+        uniewaznij_i_zatwierdz(django_capture_on_commit_callbacks)
+        widziane.add(_klucz(request))
+
+    assert len(widziane) == 6
+
+
+@pytest.mark.django_db
+def test_utrata_klucza_generacji_nie_wskrzesza_starych_wpisow(
+    cache_locmem,
+    site1,
+    uczelnia1,
+    django_capture_on_commit_callbacks,
+    czysta_kolejka_on_commit,
+):
+    """Eksmisja klucza generacji nie może przywrócić WCZEŚNIEJSZEJ wartości.
+
+    Regresja po recenzji. Poprzednia wersja seedowała licznik zegarem i
+    inkrementowała go przy każdym zapisie: masowy import wyprzedzał zegar,
+    a eksmisja klucza przez ``maxmemory`` Redisa cofała generację poniżej
+    ostatnio używanej — wskrzeszając wpisy z całego okna TTL. Poprzedni
+    test przechodził PUSTO, bo sprawdzał wartość natychmiast po skasowaniu,
+    gdy licznik nie zdążył jeszcze wyprzedzić zegara.
+
+    Tu odtwarzamy właściwy scenariusz: dużo unieważnień, potem eksmisja.
+    """
+    from bpp.views.cache_publiczny import _KLUCZ_GENERACJI, _generacja
+
+    widziane = {_generacja()}
+
+    for _ in range(50):
+        uniewaznij_i_zatwierdz(django_capture_on_commit_callbacks)
+        widziane.add(_generacja())
+
+    # Redis z maxmemory eksmituje klucz generacji.
+    cache.delete(_KLUCZ_GENERACJI)
+    po_eksmisji = _generacja()
+
+    assert len(widziane) == 51, "unieważnienia powtórzyły generację"
+    assert po_eksmisji not in widziane, (
+        "Generacja po eksmisji powtórzyła wcześniejszą wartość — wpisy "
+        "zapamiętane pod nią wracają do obiegu."
+    )
+
+
+@pytest.mark.django_db
+def test_jedna_transakcja_to_jedno_uniewaznienie(
+    cache_locmem,
+    site1,
+    uczelnia1,
+    django_capture_on_commit_callbacks,
+    czysta_kolejka_on_commit,
+):
+    """Importer w bloku ``atomic`` nie robi round-tripu na każdy wiersz."""
+    with django_capture_on_commit_callbacks() as callbacki:
+        for _ in range(20):
+            uniewaznij_cache_publiczny()
+
+    assert len(callbacki) == 1, (
+        f"20 zapisów zaplanowało {len(callbacki)} unieważnień — dedup "
+        "per transakcja nie działa."
+    )
+
+
+@pytest.mark.django_db
+def test_wycofana_transakcja_nie_blokuje_kolejnych_uniewaznien(
+    cache_locmem,
+    site1,
+    uczelnia1,
+    django_capture_on_commit_callbacks,
+    czysta_kolejka_on_commit,
+):
+    """Po rollbacku mechanizm dedup nie może zostać zakleszczony.
+
+    Gdyby dedup opierał się na własnej, „lepkiej" fladze na połączeniu,
+    wycofana transakcja zostawiłaby ją ustawioną i wyciszyła WSZYSTKIE
+    kolejne unieważnienia. Dlatego skanujemy ``run_on_commit``, które
+    Django samo czyści przy rollbacku.
+    """
+    from django.db import transaction
+
+    class _Wycofaj(Exception):
+        pass
+
+    try:
+        with transaction.atomic():
+            uniewaznij_cache_publiczny()
+            raise _Wycofaj()
+    except _Wycofaj:
+        pass
+
+    with django_capture_on_commit_callbacks() as callbacki:
+        uniewaznij_cache_publiczny()
+
+    assert len(callbacki) == 1, (
+        "Unieważnienie po wycofanej transakcji nie zostało zaplanowane — "
+        "mechanizm dedup zakleszczył się."
+    )
+
+
+# ---------------------------------------------------------------------------
+# ZGODA NA CIASTECZKA (cookielaw) — regresja po recenzji
+# ---------------------------------------------------------------------------
+#
+# ``base.html`` renderuje baner cookielaw i snippet Google Analytics na
+# podstawie ciasteczka ``cookielaw_accepted``. Wszystkie trzy warianty są
+# anonimowe, więc bramkowanie na ``is_anonymous`` nic nie dawało: strona
+# rozgrzana przez osobę, która wyraziła zgodę, niosła znacznik GA do
+# WSZYSTKICH, także do tych, którzy kliknęli „nie zgadzam się".
+# Naprawa: stan zgody wchodzi do klucza cache'a (``_stan_zgody``).
+
+
+@pytest.mark.django_db
+def test_klucz_rozroznia_stany_zgody(cache_locmem, site1, uczelnia1):
+    """Trzy stany zgody muszą dać trzy różne klucze."""
+    klucze = set()
+    for ciasteczko in (None, "1", "0"):
+        request = make_request_for_site(site1, path="/bpp/lata/")
+        if ciasteczko is not None:
+            request.COOKIES["cookielaw_accepted"] = ciasteczko
+        klucze.add(_klucz(request))
+
+    assert len(klucze) == 3, (
+        "Klucz nie rozróżnia stanu zgody — cache przeniesie zgodę jednego "
+        "odwiedzającego na wszystkich pozostałych."
+    )
+
+
+@pytest.mark.django_db
+def test_cache_nie_przenosi_zgody_miedzy_odwiedzajacymi(
+    client, cache_locmem, site1, uczelnia1, settings
+):
+    """Scenariusz z recenzji: rozgrzej zgodą, odbierz odmową.
+
+    To jest test przeciw obejściu zgody na śledzenie (RODO/ePrivacy),
+    nie przeciw kosmetyce banera.
+    """
+    settings.GOOGLE_ANALYTICS_PROPERTY_ID = "testowy-identyfikator-ga"
+    url = reverse("bpp:browse_lata")
+
+    client.cookies.clear()
+    client.cookies["cookielaw_accepted"] = "1"
+    akceptujacy = client.get(url, HTTP_HOST=site1.domain)
+    assert akceptujacy["X-BPP-Cache"] == "MISS"
+
+    client.cookies.clear()
+    client.cookies["cookielaw_accepted"] = "0"
+    odmawiajacy = client.get(url, HTTP_HOST=site1.domain)
+
+    assert odmawiajacy["X-BPP-Cache"] == "MISS", (
+        "Odmawiający dostał stronę z cache'a rozgrzanego przez osobę, "
+        "która wyraziła zgodę."
+    )
+    assert "googletagmanager.com" not in odmawiajacy.content.decode(), (
+        "OBEJŚCIE ZGODY: strona dla odmawiającego niesie znacznik Google "
+        "Analytics."
+    )
+
+
+@pytest.mark.django_db
+def test_ten_sam_stan_zgody_wciaz_trafia_w_cache(
+    client, cache_locmem, site1, uczelnia1
+):
+    """Rozdzielenie po zgodzie nie może zabić trafialności w obrębie kubełka."""
+    url = reverse("bpp:browse_lata")
+
+    client.cookies.clear()
+    client.cookies["cookielaw_accepted"] = "1"
+    assert client.get(url, HTTP_HOST=site1.domain)["X-BPP-Cache"] == "MISS"
+    assert client.get(url, HTTP_HOST=site1.domain)["X-BPP-Cache"] == "HIT"
+
+
+@pytest.mark.django_db
+def test_robot_indeksujacy_dzieli_jeden_kubelek(cache_locmem, site1, uczelnia1):
+    """Ruch, który ten cache ma odciążyć, nie jest rozdrabniany.
+
+    Roboty nie wykonują JavaScriptu, więc nigdy nie ustawiają ciasteczka
+    zgody — wszystkie trafiają do tego samego kubełka.
+    """
+    pierwszy = make_request_for_site(site1, path="/bpp/lata/")
+    drugi = make_request_for_site(site1, path="/bpp/lata/")
+
+    assert _klucz(pierwszy) == _klucz(drugi)
+
+
+@pytest.mark.django_db
+def test_dowolna_wartosc_ciasteczka_nie_zalewa_cache(cache_locmem, site1, uczelnia1):
+    """Wartość ciasteczka jest sterowana przez klienta — musi być znormalizowana.
+
+    Bez normalizacji atakujący generuje nieograniczoną liczbę wariantów
+    tej samej strony i zapycha pamięć Redisa.
+    """
+    klucze = set()
+    for smiec in ("1", "0", "", "xxx", "1 ", "TRUE", "../../etc/passwd", "9" * 500):
+        request = make_request_for_site(site1, path="/bpp/lata/")
+        request.COOKIES["cookielaw_accepted"] = smiec
+        klucze.add(_klucz(request))
+
+    assert len(klucze) <= 3, (
+        f"Ciasteczko zgody tworzy {len(klucze)} wariantów klucza — "
+        "brak normalizacji, cache da się zalać."
+    )
+
+
+# ---------------------------------------------------------------------------
+# BEZPIECZNIKI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_nie_cachujemy_odpowiedzi_z_tokenem_csrf():
+    """Współdzielony token CSRF to dziura — taka treść nie może wejść do cache'a.
+
+    Szablony ``browse/autor.html``, ``jednostka.html``, ``zrodlo.html``
+    i ``uczelnia.html`` mają bezwarunkowy ``{% csrf_token %}``, dlatego
+    te widoki celowo NIE są objęte dekoratorem. To bezpiecznik na wypadek,
+    gdyby ktoś dodał formularz do szablonu, który cache'ujemy.
+    """
+    from django.http import HttpResponse
+
+    z_tokenem = HttpResponse(
+        b'<form><input name="csrfmiddlewaretoken" value="abc"></form>'
+    )
+    assert not _mozna_cachowac_odpowiedz(z_tokenem)
+
+    bez_tokenu = HttpResponse(b"<p>zwykla tresc</p>")
+    assert _mozna_cachowac_odpowiedz(bez_tokenu)
+
+
+@pytest.mark.django_db
+def test_bezpiecznik_lapie_takze_gole_csrf_token():
+    """Regresja po recenzji: ``{{ csrf_token }}`` bez pola formularza.
+
+    Bezpiecznik szukał wyłącznie ``csrfmiddlewaretoken``, więc token
+    wstawiony przez gołe ``{{ csrf_token }}`` — idiomatyczne dla
+    ``<meta name="csrf-token">``, globala JS albo atrybutu ``data-`` —
+    przechodził i zostałby współdzielony. Fallback na ``Set-Cookie`` też
+    tu nie działa: ``TemplateResponse`` renderuje się (i callback zapisu
+    odpala) wewnątrz ``_get_response``, ZANIM ``CsrfViewMiddleware``
+    ustawi ciasteczko ``csrftoken`` — więc ``response.cookies`` jest w tym
+    momencie puste.
+    """
+    from django.http import HttpResponse
+
+    # Wartość celowo pozbawiona cech sekretu (małe litery, myślniki, niska
+    # entropia): skanery sekretów flagują wysokoentropijne literały
+    # przypisane do zmiennej o nazwie ``token``. Dla tego testu wartość i
+    # tak nie ma znaczenia — sprawdzamy wyłącznie, czy bezpiecznik
+    # zauważa ciąg „csrf" w treści.
+    udawana_wartosc = "wartosc-z-testu"
+    warianty = {
+        "meta": f'<meta name="csrf-token" content="{udawana_wartosc}">',
+        "js": f'<script>window.CSRF="{udawana_wartosc}";</script>',
+        "data-": f'<div data-csrf="{udawana_wartosc}"></div>',
+    }
+
+    for nazwa, tresc in warianty.items():
+        assert not _mozna_cachowac_odpowiedz(HttpResponse(tresc.encode())), nazwa
+
+
+@pytest.mark.django_db
+def test_powracajacy_odwiedzajacy_dostaje_304(client, cache_locmem, site1, uczelnia1):
+    """ETag pozwala odpowiedzieć 304 zamiast przesyłać całe ciało."""
+    url = reverse("bpp:browse_lata")
+
+    pierwsza = client.get(url, HTTP_HOST=site1.domain)
+    etag = pierwsza["ETag"]
+    assert etag
+
+    trzecia = client.get(url, HTTP_HOST=site1.domain, HTTP_IF_NONE_MATCH=etag)
+    assert trzecia.status_code == 304
+    assert trzecia.content == b""
+
+
+@pytest.mark.django_db
+def test_nie_cachujemy_odpowiedzi_ustawiajacej_ciasteczko():
+    """Zamrożony ``Set-Cookie`` byłby współdzielony przez wszystkich."""
+    from django.http import HttpResponse
+
+    odpowiedz = HttpResponse(b"tresc")
+    odpowiedz.set_cookie("sessionid", "sekret")
+    assert not _mozna_cachowac_odpowiedz(odpowiedz)
+
+
+@pytest.mark.django_db
+def test_nie_cachujemy_bledow():
+    from django.http import HttpResponse
+
+    assert not _mozna_cachowac_odpowiedz(HttpResponse(b"nie ma", status=404))
+
+
+@pytest.mark.django_db
+def test_odpowiedz_z_cache_ma_cache_control_private(
+    client, cache_locmem, site1, uczelnia1
+):
+    """nginx/CDN nie mogą zrobić drugiej, niebramkowanej kopii."""
+    url = reverse("bpp:browse_lata")
+
+    for _ in range(2):
+        odp = client.get(url, HTTP_HOST=site1.domain)
+        assert "private" in odp["Cache-Control"]
+        assert "must-revalidate" in odp["Cache-Control"]
+        assert "max-age=0" in odp["Cache-Control"]
+
+
+@pytest.mark.django_db
+def test_post_nie_jest_cachowany(cache_locmem, site1, uczelnia1):
+    """Dekorator przepuszcza metody inne niż GET/HEAD bez dotykania cache'a."""
+    from django.contrib.auth.models import AnonymousUser
+    from django.http import HttpResponse
+    from django.test import RequestFactory
+
+    wywolania = []
+
+    @cache_publiczny()
+    def widok(request):
+        wywolania.append(1)
+        return HttpResponse(b"ok")
+
+    factory = RequestFactory()
+    for _ in range(2):
+        request = factory.post("/cokolwiek/", HTTP_HOST=site1.domain)
+        request.user = AnonymousUser()
+        widok(request)
+
+    assert len(wywolania) == 2
+
+
+@pytest.mark.django_db
+def test_widoki_z_formularzem_csrf_nie_sa_cachowane(
+    client, cache_locmem, site1, uczelnia1, autor_uczelnia1
+):
+    """Strona autora ma formularz POST — nie wolno jej współdzielić."""
+    url = reverse("bpp:browse_autor", args=(autor_uczelnia1.pk,))
+    odp = client.get(url, HTTP_HOST=site1.domain)
+
+    assert odp.status_code == 200
+    assert not odp.has_header("X-BPP-Cache"), (
+        "Widok autora został objęty cache'em, a zawiera token CSRF."
+    )
+
+
+@pytest.mark.django_db
+def test_rok_jest_cachowany(client, cache_locmem, site1, uczelnia1):
+    """Strona roku (deterministyczna dla anonima) korzysta z cache'a."""
+    url = reverse("bpp:browse_rok", args=("2020",))
+
+    pierwsza = client.get(url, HTTP_HOST=site1.domain)
+    assert pierwsza.status_code == 200
+    assert pierwsza["X-BPP-Cache"] == "MISS"
+    assert client.get(url, HTTP_HOST=site1.domain)["X-BPP-Cache"] == "HIT"
+
+
+@pytest.mark.django_db
+def test_strona_rekordu_naprawde_sie_cachuje(
+    client, cache_locmem, site1, uczelnia1, wydawnictwo_ciagle
+):
+    """Strona rekordu to najcenniejszy cel cache'a — sprawdź, że działa.
+
+    Bezpiecznik CSRF dopasowuje teraz samo „csrf", bez rozróżniania
+    wielkości liter. Gdyby ten ciąg pojawił się gdziekolwiek w
+    wyrenderowanym ``browse/praca.html`` (albo w którymkolwiek z jego
+    include'ów), cache po cichu przestałby zapisywać, a strona nadal
+    wyglądałaby normalnie. Ten test łapie taką cichą regresję.
+    """
+    from django.contrib.contenttypes.models import ContentType
+
+    # Wzorzec jak w istniejących testach (``test_autorzy_dla_opisu_skrocony``):
+    # ``browse_praca`` przekierowuje na URL ze slugiem, stąd ``follow=True``.
+    url = reverse(
+        "bpp:browse_praca",
+        args=(
+            ContentType.objects.get(app_label="bpp", model="wydawnictwo_ciagle").pk,
+            wydawnictwo_ciagle.pk,
+        ),
+    )
+
+    pierwsza = client.get(url, HTTP_HOST=site1.domain, follow=True)
+    assert pierwsza.status_code == 200
+    assert pierwsza["X-BPP-Cache"] == "MISS"
+
+    druga = client.get(url, HTTP_HOST=site1.domain, follow=True)
+    assert druga["X-BPP-Cache"] == "HIT", (
+        "Strona rekordu nie trafiła do cache'a — najpewniej bezpiecznik "
+        "CSRF odrzuca jej treść."
+    )
+
+
+@pytest.mark.django_db
+def test_query_string_rozroznia_klucze(cache_locmem, site1, uczelnia1):
+    """Paginacja (``?page=2``) nie może kolidować ze stroną pierwszą."""
+    r1 = make_request_for_site(site1, path="/bpp/rok/2020/")
+    r2 = make_request_for_site(site1, path="/bpp/rok/2020/?page=2")
+
+    assert _klucz(r1) != _klucz(r2)
+
+
+@pytest.mark.django_db
+def test_baker_rekord_widoczny_po_inwalidacji(
+    client,
+    cache_locmem,
+    site1,
+    uczelnia1,
+    jednostka_uczelnia1,
+    tytuly,
+    django_capture_on_commit_callbacks,
+    czysta_kolejka_on_commit,
+):
+    """Nowy autor pojawia się na liście autorów bez czekania na TTL."""
+    url = reverse("bpp:browse_autorzy")
+
+    client.get(url, HTTP_HOST=site1.domain)
+    assert client.get(url, HTTP_HOST=site1.domain)["X-BPP-Cache"] == "HIT"
+
+    with django_capture_on_commit_callbacks(execute=True):
+        baker.make(
+            "bpp.Autor",
+            imiona="Nowy",
+            nazwisko="Nowakowski",
+            aktualna_jednostka=jednostka_uczelnia1,
+        )
+
+    po = client.get(url, HTTP_HOST=site1.domain)
+    assert po["X-BPP-Cache"] == "MISS"

--- a/src/bpp/tests/test_views/test_cache_publiczny.py
+++ b/src/bpp/tests/test_views/test_cache_publiczny.py
@@ -477,6 +477,64 @@ def test_robot_indeksujacy_dzieli_jeden_kubelek(cache_locmem, site1, uczelnia1):
 
 
 @pytest.mark.django_db
+def test_smieciowe_ciasteczko_nie_tlumi_banera_zgody(
+    client, cache_locmem, site1, uczelnia1
+):
+    """Spreparowanym ciasteczkiem nie da się ukryć banera nowym osobom.
+
+    Regresja po drugiej recenzji. Wartość nieznana renderuje się jak
+    ``"0"`` (bez banera, bez GA), ale wpadała do kubełka „brak" — razem
+    z ``None``. Rozgrzanie cache'a śmieciem podawało więc świeżemu
+    odwiedzającemu stronę BEZ banera zgody, czyli tłumiło komunikat
+    prawny na czas TTL.
+    """
+    url = reverse("bpp:browse_lata")
+
+    client.cookies.clear()
+    client.cookies["cookielaw_accepted"] = "spreparowana-wartosc"
+    rozgrzewajacy = client.get(url, HTTP_HOST=site1.domain)
+    assert rozgrzewajacy["X-BPP-Cache"] == "MISS"
+    assert "CookielawBanner" not in rozgrzewajacy.content.decode()
+
+    # Świeży odwiedzający — bez żadnego ciasteczka.
+    client.cookies.clear()
+    swiezy = client.get(url, HTTP_HOST=site1.domain)
+
+    assert swiezy["X-BPP-Cache"] == "MISS", (
+        "Świeży odwiedzający dostał stronę z cache'a rozgrzanego "
+        "śmieciowym ciasteczkiem."
+    )
+    assert "CookielawBanner" in swiezy.content.decode(), (
+        "TŁUMIENIE KOMUNIKATU PRAWNEGO: świeży odwiedzający nie dostał "
+        "banera zgody na ciasteczka."
+    )
+
+
+@pytest.mark.django_db
+def test_nieznana_wartosc_ciasteczka_jest_rownowazna_odmowie(
+    cache_locmem, site1, uczelnia1
+):
+    """Kubełek ma odpowiadać RENDEROWANIU, a nie surowej wartości.
+
+    ``base.html`` używa tylko ``cookielaw.notset`` i ``cookielaw.accepted``
+    (``rejected`` nigdzie), więc wartość nieznana renderuje się dokładnie
+    tak jak ``"0"`` — i musi dzielić z nią kubełek.
+    """
+    from bpp.views.cache_publiczny import _stan_zgody
+
+    def stan(wartosc):
+        request = make_request_for_site(site1, path="/bpp/lata/")
+        if wartosc is not None:
+            request.COOKIES["cookielaw_accepted"] = wartosc
+        return _stan_zgody(request)
+
+    assert stan("smiec") == stan("0")
+    assert stan("smiec") != stan(None)
+    assert stan(None) == "brak"
+    assert stan("1") == "zgoda"
+
+
+@pytest.mark.django_db
 def test_dowolna_wartosc_ciasteczka_nie_zalewa_cache(cache_locmem, site1, uczelnia1):
     """Wartość ciasteczka jest sterowana przez klienta — musi być znormalizowana.
 

--- a/src/bpp/views/browse.py
+++ b/src/bpp/views/browse.py
@@ -9,6 +9,7 @@ from django.db.models import Count, Exists, OuterRef
 from django.db.models.functions import Substr
 from django.http import JsonResponse
 from django.utils import timezone
+from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
 
 try:
@@ -51,6 +52,7 @@ from bpp.util.uczelnia_scope import (
     scope_rekord_do_uczelni,
     tylko_jedna_uczelnia,
 )
+from bpp.views.cache_publiczny import cache_publiczny
 
 logger = logging.getLogger(__name__)
 
@@ -408,6 +410,7 @@ class Browser(ListView):
                 raise
 
 
+@method_decorator(cache_publiczny(), name="dispatch")
 class AutorzyView(Browser):
     template_name = "browse/autorzy_modern_bordered.html"
     model = Autor
@@ -503,6 +506,7 @@ class AutorzyView(Browser):
         return context
 
 
+@method_decorator(cache_publiczny(), name="dispatch")
 class ZrodlaView(Browser):
     template_name = "browse/zrodla.html"
     model = Zrodlo
@@ -554,6 +558,7 @@ class ZrodlaView(Browser):
         return context
 
 
+@method_decorator(cache_publiczny(), name="dispatch")
 class JednostkiView(Browser):
     template_name = "browse/jednostki.html"
     model = Jednostka
@@ -621,6 +626,7 @@ class ZrodloView(DetailView):
         return context
 
 
+@method_decorator(cache_publiczny(), name="dispatch")
 class LataView(ListView):
     template_name = "browse/lata.html"
     context_object_name = "years"
@@ -667,6 +673,7 @@ class LataView(ListView):
         return context
 
 
+@method_decorator(cache_publiczny(), name="dispatch")
 class RokView(ListView):
     template_name = "browse/rok.html"
     model = Rekord
@@ -866,6 +873,7 @@ class PracaViewMixin:
 END_NUMBER_REGEX = re.compile(r"(?P<content_type_id>\d+)-(?P<object_id>\d+)$")
 
 
+@method_decorator(cache_publiczny(), name="dispatch")
 class PracaViewBySlug(PracaViewMixin, DetailView):
     template_name = "browse/praca.html"
     model = Rekord
@@ -896,6 +904,7 @@ class PracaViewBySlug(PracaViewMixin, DetailView):
         raise Http404
 
 
+@method_decorator(cache_publiczny(), name="dispatch")
 class PracaView(PracaViewMixin, DetailView):
     template_name = "browse/praca.html"
     model = Rekord

--- a/src/bpp/views/cache_publiczny.py
+++ b/src/bpp/views/cache_publiczny.py
@@ -174,13 +174,25 @@ def _stan_zgody(request):
     Koszt dla ruchu, który ten cache ma odciążyć, jest bliski zeru:
     roboty indeksujące nie wykonują JavaScriptu i nigdy nie ustawiają
     tego ciasteczka, więc wszystkie lądują w kubełku „brak".
+
+    KUBEŁKI ODWZOROWUJĄ RENDEROWANIE, NIE SUROWE WARTOŚCI. Context
+    processor rozróżnia cztery stany surowe (``None`` / ``"1"`` / ``"0"``
+    / wartość nieznana), ale ``base.html`` czyta wyłącznie
+    ``cookielaw.notset`` (baner) i ``cookielaw.accepted`` (snippet GA) —
+    ``cookielaw.rejected`` nie jest używane nigdzie w szablonach. Wartość
+    NIEZNANA renderuje się więc identycznie jak ``"0"``: bez banera i bez
+    GA. Musi trafiać do kubełka „odmowa", nie „brak". Wrzucenie jej do
+    „brak" pozwalało spreparowanym ciasteczkiem rozgrzać cache stroną BEZ
+    banera zgody i podawać ją świeżym odwiedzającym, tłumiąc im komunikat
+    prawny na czas TTL.
     """
     wartosc = request.COOKIES.get(_CIASTECZKO_ZGODY)
+    if wartosc is None:
+        return "brak"
     if wartosc == "1":
         return "zgoda"
-    if wartosc == "0":
-        return "odmowa"
-    return "brak"
+    # Każda inna wartość, także śmieciowa, renderuje się jak ``"0"``.
+    return "odmowa"
 
 
 def _klucz(request):

--- a/src/bpp/views/cache_publiczny.py
+++ b/src/bpp/views/cache_publiczny.py
@@ -1,0 +1,337 @@
+"""Cache HTTP publicznych stron przeglądania — wyłącznie dla anonimów.
+
+DLACZEGO NIE ``django.views.decorators.cache.cache_page``
+=========================================================
+
+BPP jest systemem WIELO-UCZELNIANYM (multi-hosted): jeden proces Django
+obsługuje wiele domen. ``bpp.middleware.SiteResolutionMiddleware``
+rozstrzyga ``Host`` → ``Site`` → ``Uczelnia`` i ustawia
+``request._uczelnia``, a każdy publiczny widok przeglądania filtruje
+dane przez tę uczelnię (``scope_rekord_do_uczelni``,
+``scope_jednostki_do_uczelni``). Innymi słowy: TA SAMA ścieżka URL daje
+RÓŻNE treści pod różnymi domenami.
+
+Klucz ``cache_page`` powstaje z metody, pełnej ścieżki URL i nagłówków
+wymienionych w ``Vary``. ``Host`` NIE trafia tam domyślnie. Bez jawnego
+``Vary: Host`` cache zaserwowałby treść uczelni A pod domeną uczelni B —
+wyciek danych między instytucjami.
+
+Ten dekorator wstawia hosta do klucza JAWNIE (patrz ``_klucz``), a nie
+przez ``Vary``. Dzięki temu izolacja nie zależy od tego, czy jakiś inny
+dekorator, middleware albo reverse proxy po drodze nadpisze ``Vary``.
+
+DLACZEGO NIE ``Vary: Cookie``
+=============================
+
+Standardowa recepta na „nie serwuj zalogowanemu cache'a anonima" to
+``Vary: Cookie``. W BPP byłaby bezużyteczna: praktycznie każdy
+odwiedzający dostaje jakieś ciasteczko (``cookielaw``, sesja,
+``csrftoken``), więc każdy miałby własny klucz i hit-rate spadłby do
+zera. Zamiast tego bramkujemy JAWNIE na ``request.user.is_anonymous`` —
+zalogowany nigdy z tego cache'a nie czyta i nigdy do niego nie pisze.
+
+BEZPIECZNIKI
+============
+
+* tylko ``GET``/``HEAD``, tylko odpowiedzi ``200``, tylko nie-streaming,
+* nie zapisujemy odpowiedzi ustawiającej ciasteczka — zamrożony w
+  cache'u ``Set-Cookie`` byłby współdzielony przez wszystkich,
+* nie zapisujemy treści zawierającej token CSRF (``_ZAWIERA_CSRF``);
+  współdzielony token to realna dziura, a szablony ``browse/autor.html``,
+  ``browse/jednostka.html``, ``browse/zrodlo.html`` i
+  ``browse/uczelnia.html`` renderują bezwarunkowy ``{% csrf_token %}``
+  w formularzu „szukaj publikacji" — dlatego te widoki celowo NIE są
+  objęte cache'em, a bezpiecznik pilnuje, żeby nie wśliznęły się tam
+  przez przypadek przy przyszłej zmianie szablonu,
+* ``Cache-Control: private, no-cache`` na wyjściu, żeby nginx/CDN nie
+  zrobiły drugiej, niebramkowanej kopii.
+
+INWALIDACJA I TTL
+=================
+
+Klucz zawiera numer generacji (``_generacja``) trzymany w cache'u.
+``bpp.apps.BppConfig.ready`` podpina ``uniewaznij_cache_publiczny`` pod
+``post_save``/``post_delete`` modeli redagowanych w adminie, więc zapis
+publikacji unieważnia cache NATYCHMIAST (bez enumerowania kluczy).
+
+``DOMYSLNY_TTL`` jest tylko siatką bezpieczeństwa na zmiany, których
+sygnały nie łapią: ``QuerySet.update()``, ``bulk_create``, importery
+masowe i triggery SQL. Stąd 10 minut, a nie doba z
+``CACHE_MIDDLEWARE_SECONDS``.
+"""
+
+import hashlib
+import logging
+from functools import wraps
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.db import transaction
+from django.http import HttpResponse, HttpResponseNotModified
+from django.utils.cache import patch_cache_control
+from django.utils.translation import get_language
+
+logger = logging.getLogger(__name__)
+
+#: Górna granica nieświeżości dla zmian, których sygnały nie widzą
+#: (``QuerySet.update``, ``bulk_create``, importery, triggery SQL).
+DOMYSLNY_TTL = 600
+
+PREFIKS = "bpp-pub-cache:v1"
+
+_KLUCZ_GENERACJI = f"{PREFIKS}:generacja"
+
+#: Nagłówki, których nigdy nie zapamiętujemy ani nie odtwarzamy.
+_NAGLOWKI_POMIJANE = frozenset({"set-cookie", "vary", "cache-control", "expires"})
+
+#: Obecność tego ciągu (bez rozróżniania wielkości liter) oznacza token
+#: CSRF związany z sekretem JEDNEGO odwiedzającego — takiej odpowiedzi nie
+#: wolno współdzielić. Celowo szukamy samego „csrf", a nie
+#: ``csrfmiddlewaretoken``: gołe ``{{ csrf_token }}`` (``<meta
+#: name="csrf-token">``, globalna zmienna JS, atrybut ``data-``) nie
+#: zawiera nazwy pola formularza, a jest równie wrażliwe. Wolimy fałszywie
+#: odmówić zapisu stronie, która tylko wspomina o CSRF, niż współdzielić
+#: cudzy token — bezpiecznik ma zawodzić w stronę bezpieczną.
+_ZAWIERA_CSRF = b"csrf"
+
+
+def _generacja():
+    """Bieżący znacznik generacji cache'a (część klucza).
+
+    Znacznik jest LOSOWY, nie licznikiem. Licznik dałoby się COFNĄĆ:
+    seed z zegara plus ``incr`` na każdy zapis sprawia, że masowy import
+    (>1 zapis/s) wyprzedza zegar, a eksmisja klucza przez ``maxmemory``
+    Redisa cofnęłaby generację do ``int(time.time())`` — czyli PONIŻEJ
+    ostatnio używanej wartości, wskrzeszając każdy wpis z okna TTL.
+    Losowy znacznik nie ma porządku, więc nie ma czego cofać.
+    """
+    wartosc = cache.get(_KLUCZ_GENERACJI)
+    if wartosc is None:
+        wartosc = uuid4().hex
+        cache.set(_KLUCZ_GENERACJI, wartosc, None)
+    return wartosc
+
+
+def _wykonaj_bump():
+    """Ustaw nową, nigdy wcześniej nieużytą generację."""
+    cache.set(_KLUCZ_GENERACJI, uuid4().hex, None)
+
+
+def _bump_juz_zaplanowany(polaczenie):
+    """Czy w tej transakcji zaplanowano już unieważnienie?
+
+    Skanujemy ``run_on_commit`` zamiast trzymać własną flagę, bo tę listę
+    Django czyści przy rollbacku. Własna flaga przetrwałaby wycofaną
+    transakcję i wyciszyła wszystkie kolejne unieważnienia.
+    """
+    return any(_wykonaj_bump in wpis for wpis in polaczenie.run_on_commit)
+
+
+def uniewaznij_cache_publiczny(sender=None, **kwargs):
+    """Unieważnij CAŁY publiczny cache HTTP (nowa generacja).
+
+    Receiver ``post_save``/``post_delete``. Stare wpisy zostają w
+    backendzie, ale ich klucz zawiera poprzednią generację, więc nikt ich
+    już nie trafi; wygasną same po TTL.
+
+    Unieważniamy dopiero PO zatwierdzeniu transakcji i tylko raz na
+    transakcję. Dwa powody:
+
+    * poprawność — ``post_save`` leci przed ``COMMIT``, więc równoległe
+      żądanie mogłoby jeszcze nie widzieć nowych danych, zapamiętać stan
+      sprzed zapisu już pod NOWĄ generacją i utrwalić go na cały TTL;
+    * koszt — importer zapisujący 100 tys. wierszy w jednym bloku
+      ``atomic`` robi jedno unieważnienie, a nie 100 tys. round-tripów.
+    """
+    polaczenie = transaction.get_connection()
+    if _bump_juz_zaplanowany(polaczenie):
+        return
+    # Poza blokiem ``atomic`` ``on_commit`` wykonuje się natychmiast.
+    transaction.on_commit(_wykonaj_bump)
+
+
+#: Nazwa ciasteczka zgody na ciasteczka (pakiet ``cookielaw``).
+_CIASTECZKO_ZGODY = "cookielaw_accepted"
+
+
+def _stan_zgody(request):
+    """Stan zgody na ciasteczka, sprowadzony do TRZECH wartości.
+
+    ``base.html`` renderuje baner cookielaw i snippet Google Analytics
+    warunkowo, na podstawie ``request.COOKIES['cookielaw_accepted']``
+    (patrz ``cookielaw.context_processors``). Treść strony ZALEŻY więc od
+    tego ciasteczka, mimo że wszystkie trzy warianty są anonimowe —
+    bramkowanie na ``is_anonymous`` nic tu nie daje. Bez tego składnika
+    klucza strona rozgrzana przez osobę, która wyraziła zgodę, niosłaby
+    znacznik Google Analytics do WSZYSTKICH, także do tych, którzy zgody
+    odmówili (i odwrotnie: analityka znikałaby akceptującym na czas TTL).
+
+    NORMALIZACJA JEST OBOWIĄZKOWA. Wartość ciasteczka pochodzi od
+    klienta, więc wpuszczenie jej surowej do klucza pozwoliłoby zalać
+    cache nieograniczoną liczbą wariantów tej samej strony — trywialny
+    DoS na pamięć Redisa. Mapujemy na trzy kubełki i nic poza nimi.
+
+    Koszt dla ruchu, który ten cache ma odciążyć, jest bliski zeru:
+    roboty indeksujące nie wykonują JavaScriptu i nigdy nie ustawiają
+    tego ciasteczka, więc wszystkie lądują w kubełku „brak".
+    """
+    wartosc = request.COOKIES.get(_CIASTECZKO_ZGODY)
+    if wartosc == "1":
+        return "zgoda"
+    if wartosc == "0":
+        return "odmowa"
+    return "brak"
+
+
+def _klucz(request):
+    """Klucz cache'a: generacja + HOST + zgoda + język + metoda + ścieżka.
+
+    ``request.get_host()`` jest tu składnikiem KRYTYCZNYM — to on
+    izoluje uczelnie od siebie (patrz docstring modułu). Nie usuwaj go
+    bez przeczytania ``test_izolacja_multi_host_*``.
+
+    ``_stan_zgody`` jest krytyczny z innego powodu — patrz
+    ``test_cache_nie_przenosi_zgody_miedzy_odwiedzajacymi``.
+    """
+    surowy = "|".join(
+        [
+            str(_generacja()),
+            # Nazwy hostów są case-insensitive — bez ``lower()``
+            # ``Uczelnia1.localhost`` i ``uczelnia1.localhost`` robiłyby
+            # dwa wpisy na tę samą stronę (marnotrawstwo, nie wyciek).
+            request.get_host().lower(),
+            _stan_zgody(request),
+            get_language() or "",
+            request.method,
+            request.get_full_path(),
+        ]
+    )
+    return f"{PREFIKS}:{hashlib.sha256(surowy.encode('utf-8')).hexdigest()}"
+
+
+def _mozna_cachowac_zadanie(request):
+    uzytkownik = getattr(request, "user", None)
+    if uzytkownik is None:
+        # Brak ``AuthenticationMiddleware`` (np. surowy RequestFactory) —
+        # nie wiemy, kto pyta, więc nie ryzykujemy.
+        return False
+    if not uzytkownik.is_anonymous:
+        return False
+    return request.method in ("GET", "HEAD")
+
+
+def _mozna_cachowac_odpowiedz(odpowiedz):
+    if odpowiedz.status_code != 200:
+        return False
+    if getattr(odpowiedz, "streaming", False):
+        return False
+    if odpowiedz.cookies:
+        # UWAGA przy ewentualnym usuwaniu tego warunku: chroni on nie tylko
+        # przed zamrożeniem cudzego ``Set-Cookie``. Wyrenderowanie
+        # komunikatu ``django.contrib.messages`` modyfikuje sesję, ta
+        # ustawia ``sessionid`` — i właśnie ten warunek sprawia, że
+        # komunikat zaadresowany do jednego anonima nie trafia do cache'a
+        # i nie wyświetla się wszystkim pozostałym.
+        logger.debug("cache_publiczny: pomijam odpowiedź ustawiającą ciasteczka")
+        return False
+    # ``lower()`` bo ``window.CSRF``/``X-CSRFToken`` też są tokenami —
+    # dopasowanie z rozróżnianiem wielkości liter przepuściłoby je.
+    if _ZAWIERA_CSRF in odpowiedz.content.lower():
+        logger.warning(
+            "cache_publiczny: odpowiedź zawiera token CSRF — NIE zapamiętuję. "
+            "Ten widok nie nadaje się do współdzielonego cache'a."
+        )
+        return False
+    return True
+
+
+def _zapisz(klucz, odpowiedz, ttl):
+    if not _mozna_cachowac_odpowiedz(odpowiedz):
+        return
+    naglowki = {
+        nazwa: wartosc
+        for nazwa, wartosc in odpowiedz.items()
+        if nazwa.lower() not in _NAGLOWKI_POMIJANE
+    }
+    cache.set(klucz, (odpowiedz.status_code, naglowki, odpowiedz.content), ttl)
+
+
+def _etag(tresc):
+    """Słaby ETag z treści — pozwala odpowiedzieć 304 zamiast całym ciałem."""
+    return f'W/"{hashlib.sha256(tresc).hexdigest()[:32]}"'
+
+
+def _odtworz(request, zapamietane):
+    status, naglowki, tresc = zapamietane
+    etag = _etag(tresc)
+
+    if request.headers.get("If-None-Match") == etag:
+        # Przeglądarka ma już tę wersję — oszczędzamy całe ciało odpowiedzi.
+        niezmieniona = HttpResponseNotModified()
+        niezmieniona["ETag"] = etag
+        niezmieniona["X-BPP-Cache"] = "HIT"
+        return niezmieniona
+
+    odpowiedz = HttpResponse(tresc, status=status)
+    for nazwa, wartosc in naglowki.items():
+        odpowiedz[nazwa] = wartosc
+    odpowiedz["ETag"] = etag
+    odpowiedz["X-BPP-Cache"] = "HIT"
+    return odpowiedz
+
+
+def cache_publiczny(ttl=DOMYSLNY_TTL):
+    """Zapamiętaj odpowiedź publicznego widoku przeglądania dla anonima.
+
+    Używaj TYLKO na widokach, których wyrenderowana dla anonima treść
+    zależy wyłącznie od (host, ścieżka, query string, język) — czyli na
+    deterministycznych stronach przeglądania. Zalogowani przechodzą obok
+    cache'a w obie strony.
+
+    Na widokach klasowych::
+
+        @method_decorator(cache_publiczny(), name="dispatch")
+        class RokView(ListView):
+            ...
+    """
+
+    def dekorator(view_func):
+        @wraps(view_func)
+        def _opakowany(request, *args, **kwargs):
+            if not _mozna_cachowac_zadanie(request):
+                return view_func(request, *args, **kwargs)
+
+            klucz = _klucz(request)
+            zapamietane = cache.get(klucz)
+            if zapamietane is not None:
+                odpowiedz = _odtworz(request, zapamietane)
+                patch_cache_control(
+                    odpowiedz, private=True, max_age=0, must_revalidate=True
+                )
+                return odpowiedz
+
+            odpowiedz = view_func(request, *args, **kwargs)
+            odpowiedz["X-BPP-Cache"] = "MISS"
+
+            def _po_renderze(wyrenderowana):
+                _zapisz(klucz, wyrenderowana, ttl)
+                if _mozna_cachowac_odpowiedz(wyrenderowana):
+                    # Ten sam ETag, który wyliczy ``_odtworz`` — dzięki temu
+                    # kolejna wizyta może dostać 304 zamiast całego ciała.
+                    wyrenderowana["ETag"] = _etag(wyrenderowana.content)
+
+            if hasattr(odpowiedz, "render") and callable(odpowiedz.render):
+                # ``TemplateResponse`` nie ma jeszcze ``content`` — zapis
+                # musi poczekać na wyrenderowanie.
+                odpowiedz.add_post_render_callback(_po_renderze)
+            else:
+                _po_renderze(odpowiedz)
+
+            patch_cache_control(
+                odpowiedz, private=True, max_age=0, must_revalidate=True
+            )
+            return odpowiedz
+
+        return _opakowany
+
+    return dekorator


### PR DESCRIPTION
## Co i po co

Publiczne strony przeglądania są dla niezalogowanego użytkownika deterministyczne, a roboty indeksujące generują na nich powtarzalny ruch uderzający prosto w bazę. PR dodaje warstwę cache'a HTTP dla **anonimów** na wybranych widokach.

Objęte: `browse_lata`, `browse_rok`, `browse_autorzy`(+literka), `browse_zrodla`(+literka), `browse_jednostki`(+literka), `browse_praca` / `browse_praca_by_slug`.

Świadomie **nie** włączam `UpdateCacheMiddleware`/`FetchFromCacheMiddleware` — złapałyby też admina i formularze.

Diff: 5 plików, 1193 insertions, **0 deletions**. Bez migracji. `base.html` bit-w-bit jak na `dev`.

## Klucz cache'a

```python
surowy = "|".join([
    str(_generacja()),          # unieważnianie (losowy UUID)
    request.get_host().lower(), # KRYTYCZNE: izolacja uczelni
    _stan_zgody(request),       # KRYTYCZNE: zgoda na ciasteczka
    get_language() or "",
    request.method,
    request.get_full_path(),
])
```

## Ryzyko 1 — multi-host

`SiteResolutionMiddleware` rozstrzyga `Host` → `Site` → `Uczelnia`; każdy widok filtruje dane przez `request._uczelnia`. **Ta sama ścieżka URL daje różne treści pod różnymi domenami.** Klucz `cache_page` nie zawiera hosta → wyciek treści między instytucjami.

Host wchodzi do klucza **jawnie**, nie przez `Vary` — izolacja nie zależy więc od tego, czy coś po drodze nadpisze nagłówek `Vary`. Strona rekordu jest tu szczególnie wrażliwa: `PracaViewMixin` ustawia `_uczelnia_ogladajacego`, więc tabela punktacji różni się per domena.

**Dowód:** usunięcie `request.get_host()` z klucza wywala `test_izolacja_multi_host_klucz_zawiera_hosta` i `test_izolacja_multi_host_rozne_tresci_pod_roznymi_domenami`.

## Ryzyko 2 — zalogowani

`Vary: Cookie` byłoby bezużyteczne: każdy odwiedzający dostaje jakieś ciasteczko (`cookielaw`, sesja, `csrftoken`), więc hit rate spadłby do zera. Bramkowanie jawne na `request.user.is_anonymous`, w obie strony.

## Ryzyko 3 — zgoda na ciasteczka (RODO/ePrivacy)

`base.html` renderuje baner cookielaw i snippet Google Analytics warunkowo, na podstawie ciasteczka `cookielaw_accepted`. **Wszystkie trzy warianty są anonimowe**, więc bramkowanie na `is_anonymous` nic tu nie daje — bez tego składnika klucza strona rozgrzana przez osobę, która wyraziła zgodę, niosłaby znacznik GA do wszystkich, także do tych, którzy zgody odmówili.

Stan zgody wchodzi więc do klucza, **znormalizowany do trzech kubełków**. Normalizacja jest kontrolą bezpieczeństwa, nie kosmetyką: wartość ciasteczka pochodzi od klienta, więc surowa w kluczu pozwoliłaby zalać cache nieograniczoną liczbą wariantów tej samej strony (DoS na pamięć Redisa).

**Kubełki odwzorowują renderowanie, nie surowe wartości.** Context processor rozróżnia cztery stany surowe (`None` / `"1"` / `"0"` / wartość nieznana), ale szablony czytają tylko `cookielaw.notset` i `cookielaw.accepted` — `cookielaw.rejected` nie występuje nigdzie. Wartość nieznana renderuje się identycznie jak `"0"`, więc dzieli z nią kubełek. Wrzucenie jej do „brak" pozwalało spreparowanym ciasteczkiem stłumić baner zgody świeżym odwiedzającym na czas TTL.

Koszt trafialności dla ruchu, który ten cache ma odciążyć, jest bliski zeru: roboty nie wykonują JavaScriptu i nigdy nie ustawią tego ciasteczka, więc wszystkie lądują w jednym kubełku.

### Dlaczego nie wariant z JavaScriptem

Rozważałem przeniesienie banera i GA na stronę klienta, żeby uniezależnić dokument od zgody i w ogóle nie dzielić kubełków. **Zbudowane i wycofane** — wywaliło 10 z 12 shardów CI. Dwa niezależne sprzężenia:

1. `_cookie-banner.scss` stylizuje `#CookielawBanner` jako pełnoekranową nakładkę modalną z `display: flex !important`; ukrycie bez `!important` przegrywało specyficznością i baner przechwytywał każde kliknięcie.
2. Nie do naprawienia CSS-em: `Cookielaw.accept()` kończy się `window.location.reload()`, a strażnik `if(window.Cookielaw)` w trzech modułach testowych polega na tym, że przy nieustawionym banerze globalny obiekt **nie istnieje**.

Koszt: przepisanie kilkunastu testów Playwrighta. Zysk dla ruchu robotów: żaden.

## Ryzyko 4 — świeżość

TTL 600 s to wyłącznie siatka bezpieczeństwa na zmiany, których sygnały nie widzą (`QuerySet.update`, `bulk_create`, importery, triggery SQL). Właściwą świeżość daje unieważnienie przez nową generację w kluczu, podpięte pod `post_save`/`post_delete` modeli redagowanych w adminie — wraz ze słownikami, których nazwy trafiają do opisów bibliograficznych.

Generacja to **losowy UUID, nie licznik**: licznik seedowany zegarem i inkrementowany per zapis dałoby się cofnąć (masowy import wyprzedza zegar, eksmisja klucza przez `maxmemory` wraca do `time.time()`), co wskrzesiłoby wpisy z całego okna TTL.

Unieważnienie idzie przez `transaction.on_commit`, raz na transakcję. To nie tylko oszczędza round-tripy przy imporcie, ale naprawia wyścig: `post_save` leci przed `COMMIT`-em, więc równoległe żądanie mogło zapamiętać stan sprzed zapisu już pod nową generacją.

## Czego celowo NIE cache'uję

Szablony `browse/autor.html`, `jednostka.html`, `zrodlo.html`, `uczelnia.html` renderują bezwarunkowy `{% csrf_token %}`. Współdzielony token CSRF to realna dziura, więc te widoki zostają poza cache'em. Bezpiecznik odmawia zapisu treści zawierającej `csrf` (bez rozróżniania wielkości liter — łapie też gołe `{{ csrf_token }}` w `<meta>`, globalu JS czy atrybucie `data-`). Fallback na `Set-Cookie` by tu nie zadziałał: `TemplateResponse` renderuje się zanim `CsrfViewMiddleware` ustawi ciasteczko.

Pozostałe bezpieczniki: tylko GET/HEAD, tylko 200, nie-streaming, odrzucanie odpowiedzi z `Set-Cookie` (chroni również przed wyciekiem `django.contrib.messages` do cache'a anonimów), `private, max-age=0, must-revalidate` + ETag → 304 dla powracających.

## Testy

`src/bpp/tests/test_views/test_cache_publiczny.py` — **30 testów**: izolacja multi-host (×2), anonim vs zalogowany (×2), skuteczność cache'a i licznik zapytań, zgoda na ciasteczka (×6, w tym anty-zalanie i anty-tłumienie banera), inwalidacja/generacja/transakcje (×5), bezpieczniki (×8), realne trafianie strony rekordu i roku.

Sabotaże potwierdzone — każdy wywala właściwe testy:

| usunięte z kodu | co pada |
|---|---|
| `request.get_host()` | 2 testy izolacji multi-host |
| `_stan_zgody(request)` | 2 testy zgody |
| mapowanie „nieznana → odmowa" | 2 testy tłumienia banera |

Uwaga do licznika zapytań: zera nie da się wymagać, bo `SiteResolutionMiddleware` odpytuje bazę **zanim** dekorator zobaczy żądanie (i musi — od tego zależy klucz). Test mierzy to, co cache faktycznie obiecuje: że znika praca widoku, a podłoga middleware'owa nie rośnie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
