### PR TITLE
fix: deterministyczne i nie-kolidujące klucze blokad oraz cache

### DIFF
--- a/src/admin_dashboard/tests/test_cache_vary_host.py
+++ b/src/admin_dashboard/tests/test_cache_vary_host.py
@@ -1,11 +1,17 @@
-"""Widoki dashboardu cache'owane `cache_page` muszą różnicować po hoście.
+"""Widoki dashboardu cache'owane `cache_page` deklarują `Vary: Host`.
 
-DLACZEGO to musi istnieć: BPP jest wielo-uczelniany —
-`SiteResolutionMiddleware` rozstrzyga domenę → Site → Uczelnia per request.
-`cache_page` NIE uwzględnia hosta w kluczu cache, więc bez
-`vary_on_headers("Host")` odpowiedź policzona dla uczelni A jest serwowana
-pod domeną uczelni B (wyciek danych między uczelniami). Cache trwa 24 h,
-więc pomyłka nie jest chwilowa.
+CZEGO TE TESTY NIE DOWODZĄ: nie ma tu naprawy wycieku między uczelniami,
+bo takiego wycieku nie było. `cache_page` SAM różnicuje po hoście —
+`_generate_cache_key` i `_generate_cache_header_key` hashują
+`request.build_absolute_uri()`, w którym host siedzi. Sprawdzone
+empirycznie: `learn_cache_key` BEZ żadnego `Vary` daje różne klucze dla
+dwóch domen, a `get_cache_key` drugiej domeny nie trafia we wpis pierwszej.
+
+PO CO WIĘC `vary_on_headers("Host")`: to defense-in-depth dla
+POŚREDNICZĄCYCH cache'y HTTP (proxy, CDN), które nie znają wewnętrznego
+klucza Django i bez jawnego nagłówka mogłyby współdzielić odpowiedź między
+domenami. BPP jest wielo-uczelniany (`SiteResolutionMiddleware`: domena →
+Site → Uczelnia), więc uczciwa deklaracja `Vary` jest tania i sensowna.
 
 Wzorzec jak przy `bpp.views.robots_txt` (`test_seo_metadata.py`).
 """
@@ -33,8 +39,9 @@ WIDOKI = [
 def test_widok_deklaruje_vary_host(client, admin_user, settings, nazwa_widoku):
     """Odpowiedź MUSI mieć `Vary: Host`.
 
-    Czerwony bez `@vary_on_headers("Host")` — sam `cache_page` nagłówka
-    nie ustawia, więc klucz cache jest wspólny dla wszystkich domen.
+    Czerwony bez `@vary_on_headers("Host")` — sam `cache_page` tego
+    nagłówka nie ustawia (choć swój wewnętrzny klucz i tak liczy z
+    hosta). Test pilnuje deklaracji dla pośredniczących cache'y HTTP.
     """
     settings.ALLOWED_HOSTS = ["uczelnia1.localhost", "uczelnia2.localhost"]
     client.force_login(admin_user)
@@ -43,19 +50,25 @@ def test_widok_deklaruje_vary_host(client, admin_user, settings, nazwa_widoku):
 
     assert res.status_code == 200
     assert "Host" in res.get("Vary", ""), (
-        f"{nazwa_widoku} nie deklaruje `Vary: Host` — cache_page zaserwuje "
-        "odpowiedź jednej uczelni pod domeną innej"
+        f"{nazwa_widoku} nie deklaruje `Vary: Host` — pośredniczący cache "
+        "HTTP (proxy, CDN) może współdzielić odpowiedź między domenami"
     )
 
 
 @pytest.mark.django_db
-def test_cache_nie_przecieka_miedzy_hostami(client, admin_user, settings, mocker):
+def test_cache_page_rozdziela_wpisy_po_hoscie(client, admin_user, settings, mocker):
     """Dwa hosty = dwa niezależne wpisy cache, więc widok liczy się DWA razy.
 
+    UWAGA co do zakresu: ten test opisuje ZASTANE zachowanie `cache_page`,
+    a nie skutek `@vary_on_headers("Host")`. Rozdzielność bierze się stąd,
+    że Django hashuje `request.build_absolute_uri()` (z hostem) — jest
+    ZIELONY także po zdjęciu dekoratora. Trzymamy go jako opis kontraktu,
+    na którym stoi wielo-uczelnianość: gdyby Django kiedyś przestało
+    kluczować po hoście, to tu wyjdzie.
+
     Porównywanie treści odpowiedzi niczego by nie dowiodło: na pustej bazie
-    obie są identyczne niezależnie od tego, czy cache przeciekł. Liczymy
-    więc, ile razy widok naprawdę policzył dane. Trafienie w cudzy wpis
-    dałoby jedno wykonanie na dwa żądania.
+    obie są identyczne niezależnie od rozdzielności cache. Liczymy więc,
+    ile razy widok naprawdę policzył dane.
     """
     from django.core.cache import cache
 
@@ -85,11 +98,11 @@ def test_cache_nie_przecieka_miedzy_hostami(client, admin_user, settings, mocker
 
     res_b = client.get(url, HTTP_HOST="uczelnia2.localhost")
     assert res_b.status_code == 200
-    assert "Host" in res_b.get("Vary", "")
 
     assert licznik.call_count == 2, (
-        "drugi host dostał odpowiedź zapamiętaną dla pierwszego — cache "
-        "przecieka między uczelniami"
+        "drugi host dostał odpowiedź zapamiętaną dla pierwszego — Django "
+        "przestało kluczować cache_page po hoście (regresja kontraktu, na "
+        "którym stoi wielo-uczelnianość)"
     )
 
     # Kontrola: ten sam host drugi raz MUSI trafić w cache (inaczej test

--- a/src/admin_dashboard/tests/test_cache_vary_host.py
+++ b/src/admin_dashboard/tests/test_cache_vary_host.py
@@ -1,0 +1,101 @@
+"""Widoki dashboardu cache'owane `cache_page` muszą różnicować po hoście.
+
+DLACZEGO to musi istnieć: BPP jest wielo-uczelniany —
+`SiteResolutionMiddleware` rozstrzyga domenę → Site → Uczelnia per request.
+`cache_page` NIE uwzględnia hosta w kluczu cache, więc bez
+`vary_on_headers("Host")` odpowiedź policzona dla uczelni A jest serwowana
+pod domeną uczelni B (wyciek danych między uczelniami). Cache trwa 24 h,
+więc pomyłka nie jest chwilowa.
+
+Wzorzec jak przy `bpp.views.robots_txt` (`test_seo_metadata.py`).
+"""
+
+import pytest
+from django.urls import reverse
+
+# Wszystkie widoki dashboardu owinięte w `cache_page` — każdy musi
+# deklarować `Vary: Host`.
+WIDOKI = [
+    "admin_dashboard:weekday_stats",
+    "admin_dashboard:day_of_month_activity_stats",
+    "admin_dashboard:new_publications_stats",
+    "admin_dashboard:cumulative_publications_stats",
+    "admin_dashboard:cumulative_impact_factor_stats",
+    "admin_dashboard:cumulative_points_kbn_stats",
+    "admin_dashboard:charakter_formalny_stats_top90",
+    "admin_dashboard:charakter_formalny_stats_remaining10",
+    "admin_dashboard:charakter_formalny_stats_remaining1",
+]
+
+
+@pytest.mark.parametrize("nazwa_widoku", WIDOKI)
+@pytest.mark.django_db
+def test_widok_deklaruje_vary_host(client, admin_user, settings, nazwa_widoku):
+    """Odpowiedź MUSI mieć `Vary: Host`.
+
+    Czerwony bez `@vary_on_headers("Host")` — sam `cache_page` nagłówka
+    nie ustawia, więc klucz cache jest wspólny dla wszystkich domen.
+    """
+    settings.ALLOWED_HOSTS = ["uczelnia1.localhost", "uczelnia2.localhost"]
+    client.force_login(admin_user)
+
+    res = client.get(reverse(nazwa_widoku), HTTP_HOST="uczelnia1.localhost")
+
+    assert res.status_code == 200
+    assert "Host" in res.get("Vary", ""), (
+        f"{nazwa_widoku} nie deklaruje `Vary: Host` — cache_page zaserwuje "
+        "odpowiedź jednej uczelni pod domeną innej"
+    )
+
+
+@pytest.mark.django_db
+def test_cache_nie_przecieka_miedzy_hostami(client, admin_user, settings, mocker):
+    """Dwa hosty = dwa niezależne wpisy cache, więc widok liczy się DWA razy.
+
+    Porównywanie treści odpowiedzi niczego by nie dowiodło: na pustej bazie
+    obie są identyczne niezależnie od tego, czy cache przeciekł. Liczymy
+    więc, ile razy widok naprawdę policzył dane. Trafienie w cudzy wpis
+    dałoby jedno wykonanie na dwa żądania.
+    """
+    from django.core.cache import cache
+
+    settings.ALLOWED_HOSTS = ["uczelnia1.localhost", "uczelnia2.localhost"]
+    # Domyślny cache w testach to DummyCache (patrz `settings/local.py`) —
+    # `cache_page` niczego by nie zapamiętał i test nie sprawdzałby NICZEGO.
+    # Podmieniamy na LocMem, żeby realnie przejść ścieżkę zapis/odczyt.
+    settings.CACHES = {
+        **settings.CACHES,
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "test-vary-host",
+        },
+    }
+    cache.clear()
+    client.force_login(admin_user)
+
+    licznik = mocker.patch(
+        "admin_dashboard.views.charakter_stats._get_charakter_counts",
+        return_value=[],
+    )
+
+    url = reverse("admin_dashboard:charakter_formalny_stats_top90")
+
+    assert client.get(url, HTTP_HOST="uczelnia1.localhost").status_code == 200
+    assert licznik.call_count == 1, "pierwsze żądanie musi policzyć dane"
+
+    res_b = client.get(url, HTTP_HOST="uczelnia2.localhost")
+    assert res_b.status_code == 200
+    assert "Host" in res_b.get("Vary", "")
+
+    assert licznik.call_count == 2, (
+        "drugi host dostał odpowiedź zapamiętaną dla pierwszego — cache "
+        "przecieka między uczelniami"
+    )
+
+    # Kontrola: ten sam host drugi raz MUSI trafić w cache (inaczej test
+    # wyżej przechodziłby dlatego, że cache w ogóle nie działa).
+    assert client.get(url, HTTP_HOST="uczelnia1.localhost").status_code == 200
+    assert licznik.call_count == 2, (
+        "powtórzone żądanie na ten sam host nie trafiło w cache — cache_page "
+        "nie działa, więc test rozdzielności hostów niczego nie dowodzi"
+    )

--- a/src/admin_dashboard/views/charakter_stats.py
+++ b/src/admin_dashboard/views/charakter_stats.py
@@ -1,9 +1,18 @@
-"""Charakter formalny statistics views for admin dashboard."""
+"""Charakter formalny statistics views for admin dashboard.
+
+Każdy widok cache'owany przez `cache_page` MUSI mieć `vary_on_headers("Host")`.
+BPP jest wielo-uczelniany — `SiteResolutionMiddleware` rozstrzyga domenę →
+Site → Uczelnia per request, a `cache_page` NIE uwzględnia hosta w kluczu.
+Bez `Vary: Host` odpowiedź policzona dla jednej uczelni zostałaby zaserwowana
+pod domeną innej (wyciek danych między uczelniami). Wzorzec jak w
+`bpp.views.robots_txt`.
+"""
 
 from django.contrib.admin.views.decorators import staff_member_required
 from django.db.models import Count, F
 from django.http import JsonResponse
 from django.views.decorators.cache import cache_page
+from django.views.decorators.vary import vary_on_headers
 
 from bpp.models import Charakter_Formalny
 
@@ -75,6 +84,7 @@ def _get_charakter_counts():
 
 @staff_member_required
 @cache_page(60 * 60 * 24)  # Cache for 24 hours
+@vary_on_headers("Host")
 def charakter_formalny_stats_top90(request):
     """JSON endpoint - Donut chart z charakterami stanowiącymi kumulatywnie 90% publikacji"""
     sorted_chars = _get_charakter_counts()
@@ -136,6 +146,7 @@ def charakter_formalny_stats_top90(request):
 
 @staff_member_required
 @cache_page(60 * 60 * 24)  # Cache for 24 hours
+@vary_on_headers("Host")
 def charakter_formalny_stats_remaining10(request):
     """JSON endpoint - Donut chart z pozostałymi 10%, podzielonymi na 90% + 10%"""
     sorted_chars = _get_charakter_counts()
@@ -235,6 +246,7 @@ def charakter_formalny_stats_remaining10(request):
 
 @staff_member_required
 @cache_page(60 * 60 * 24)  # Cache for 24 hours
+@vary_on_headers("Host")
 def charakter_formalny_stats_remaining1(request):
     """JSON endpoint - Donut chart z ostatnim 1% (10% z 10%)"""
     sorted_chars = _get_charakter_counts()

--- a/src/admin_dashboard/views/charakter_stats.py
+++ b/src/admin_dashboard/views/charakter_stats.py
@@ -1,10 +1,19 @@
 """Charakter formalny statistics views for admin dashboard.
 
-Każdy widok cache'owany przez `cache_page` MUSI mieć `vary_on_headers("Host")`.
-BPP jest wielo-uczelniany — `SiteResolutionMiddleware` rozstrzyga domenę →
-Site → Uczelnia per request, a `cache_page` NIE uwzględnia hosta w kluczu.
-Bez `Vary: Host` odpowiedź policzona dla jednej uczelni zostałaby zaserwowana
-pod domeną innej (wyciek danych między uczelniami). Wzorzec jak w
+Widoki cache'owane przez `cache_page` deklarują `vary_on_headers("Host")`.
+
+UWAGA — to defense-in-depth, NIE naprawa wycieku. Wbrew temu, co łatwo
+założyć, `cache_page` SAM różnicuje po hoście: `_generate_cache_key` oraz
+`_generate_cache_header_key` hashują `request.build_absolute_uri()`, w którym
+host siedzi. Sprawdzone empirycznie — `learn_cache_key` BEZ żadnego `Vary`
+daje różne klucze dla dwóch domen. Wewnętrzny cache Django nigdy nie
+przeciekał między uczelniami.
+
+Nagłówek `Vary: Host` jest tu po to, żeby POŚREDNICZĄCE cache'y HTTP (proxy,
+CDN) też wiedziały, że odpowiedź zależy od domeny — one nie znają
+wewnętrznego klucza Django. BPP jest wielo-uczelniany
+(`SiteResolutionMiddleware`: domena → Site → Uczelnia), więc uczciwa
+deklaracja `Vary` jest tanim zabezpieczeniem. Wzorzec jak w
 `bpp.views.robots_txt`.
 """
 

--- a/src/admin_dashboard/views/time_series.py
+++ b/src/admin_dashboard/views/time_series.py
@@ -1,4 +1,12 @@
-"""Time series statistics views for admin dashboard."""
+"""Time series statistics views for admin dashboard.
+
+Każdy widok cache'owany przez `cache_page` MUSI mieć `vary_on_headers("Host")`.
+BPP jest wielo-uczelniany — `SiteResolutionMiddleware` rozstrzyga domenę →
+Site → Uczelnia per request, a `cache_page` NIE uwzględnia hosta w kluczu.
+Bez `Vary: Host` odpowiedź policzona dla jednej uczelni zostałaby zaserwowana
+pod domeną innej (wyciek danych między uczelniami). Wzorzec jak w
+`bpp.views.robots_txt`.
+"""
 
 from datetime import timedelta
 
@@ -9,6 +17,7 @@ from django.db.models.functions import TruncMonth
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.cache import cache_page
+from django.views.decorators.vary import vary_on_headers
 
 from bpp.models import (
     Wydawnictwo_Ciagle,
@@ -18,6 +27,7 @@ from bpp.models import (
 
 @staff_member_required
 @cache_page(60 * 60 * 24)  # Cache for 24 hours
+@vary_on_headers("Host")
 def weekday_stats(request):
     """JSON endpoint dla statystyk edycji według dni tygodnia (ostatni miesiąc, Pon-Czw)"""
     from django.db.models.functions import ExtractWeekDay
@@ -82,6 +92,7 @@ def weekday_stats(request):
 
 @staff_member_required
 @cache_page(60 * 60 * 24)  # Cache for 24 hours
+@vary_on_headers("Host")
 def day_of_month_activity_stats(request):
     """
     JSON endpoint dla aktywności w dniach miesiąca (ostatnie 6 miesięcy).
@@ -137,6 +148,7 @@ def day_of_month_activity_stats(request):
 
 @staff_member_required
 @cache_page(60 * 60 * 24)  # Cache for 24 hours
+@vary_on_headers("Host")
 def new_publications_stats(request):
     """JSON endpoint dla nowo dodanych prac - trend w czasie (ostatnie 5 lat)"""
 
@@ -214,6 +226,7 @@ def new_publications_stats(request):
 
 @staff_member_required
 @cache_page(60 * 60 * 24)  # Cache for 24 hours
+@vary_on_headers("Host")
 def cumulative_publications_stats(request):
     """JSON endpoint dla cumulative wykresu prac w bazie (od 1980)"""
 
@@ -293,6 +306,7 @@ def cumulative_publications_stats(request):
 
 @staff_member_required
 @cache_page(60 * 60 * 24)  # Cache for 24 hours
+@vary_on_headers("Host")
 def cumulative_impact_factor_stats(request):
     """JSON endpoint dla łącznego impact factor (od 2010)"""
     from django.db.models import Sum
@@ -373,6 +387,7 @@ def cumulative_impact_factor_stats(request):
 
 @staff_member_required
 @cache_page(60 * 60 * 24)  # Cache for 24 hours
+@vary_on_headers("Host")
 def cumulative_points_kbn_stats(request):
     """JSON endpoint dla łącznych punktów MNiSW (od 2010)"""
     from django.db.models import Sum

--- a/src/admin_dashboard/views/time_series.py
+++ b/src/admin_dashboard/views/time_series.py
@@ -1,10 +1,19 @@
 """Time series statistics views for admin dashboard.
 
-Każdy widok cache'owany przez `cache_page` MUSI mieć `vary_on_headers("Host")`.
-BPP jest wielo-uczelniany — `SiteResolutionMiddleware` rozstrzyga domenę →
-Site → Uczelnia per request, a `cache_page` NIE uwzględnia hosta w kluczu.
-Bez `Vary: Host` odpowiedź policzona dla jednej uczelni zostałaby zaserwowana
-pod domeną innej (wyciek danych między uczelniami). Wzorzec jak w
+Widoki cache'owane przez `cache_page` deklarują `vary_on_headers("Host")`.
+
+UWAGA — to defense-in-depth, NIE naprawa wycieku. Wbrew temu, co łatwo
+założyć, `cache_page` SAM różnicuje po hoście: `_generate_cache_key` oraz
+`_generate_cache_header_key` hashują `request.build_absolute_uri()`, w którym
+host siedzi. Sprawdzone empirycznie — `learn_cache_key` BEZ żadnego `Vary`
+daje różne klucze dla dwóch domen. Wewnętrzny cache Django nigdy nie
+przeciekał między uczelniami.
+
+Nagłówek `Vary: Host` jest tu po to, żeby POŚREDNICZĄCE cache'y HTTP (proxy,
+CDN) też wiedziały, że odpowiedź zależy od domeny — one nie znają
+wewnętrznego klucza Django. BPP jest wielo-uczelniany
+(`SiteResolutionMiddleware`: domena → Site → Uczelnia), więc uczciwa
+deklaracja `Vary` jest tanim zabezpieczeniem. Wzorzec jak w
 `bpp.views.robots_txt`.
 """
 

--- a/src/bpp/newsfragments/advisory-locki-pythonhashseed.bugfix.rst
+++ b/src/bpp/newsfragments/advisory-locki-pythonhashseed.bugfix.rst
@@ -1,10 +1,23 @@
-Naprawiono klucze blokad i cache liczone wbudowaną funkcją ``hash()``, która
-w Pythonie zwraca inną wartość w każdym procesie (sól ``PYTHONHASHSEED``).
-Skutkiem było to, że blokady chroniące przed równoczesnym uruchomieniem
-zadań w ogóle nie działały między procesami serwera: dwa zgłoszenia wysyłki
-oświadczeń do PBN złożone w tej samej chwili mogły przejść oba i zakolejkować
-ZDUPLIKOWANĄ wysyłkę oświadczeń do PBN, a pobierania danych z PBN mogły
-wystartować równolegle mimo blokady. Z tego samego powodu cache licznika
-rekordów na listach w panelu administracyjnym był w praktyce nieskuteczny
-(każdy proces serwera miał własną, rozłączną przestrzeń kluczy), przez co
-ciężkie zapytania zliczające wykonywały się wielokrotnie zamiast raz.
+Naprawiono grupę błędów w kluczach blokad i pamięci podręcznej.
+
+Klucze liczone wbudowaną funkcją ``hash()`` przyjmowały inną wartość w każdym
+procesie serwera (sól ``PYTHONHASHSEED``). Skutkiem było to, że blokady
+chroniące przed równoczesnym uruchomieniem zadań w ogóle nie działały między
+procesami: dwa zgłoszenia wysyłki oświadczeń do PBN złożone w tej samej chwili
+mogły przejść oba i zakolejkować ZDUPLIKOWANĄ wysyłkę oświadczeń do PBN, a
+pobierania danych z PBN mogły wystartować równolegle mimo blokady. Z tego
+samego powodu pamięć podręczna licznika rekordów na listach w panelu
+administracyjnym była w praktyce nieskuteczna (każdy proces serwera miał
+własną, rozłączną przestrzeń kluczy), przez co ciężkie zapytania zliczające
+wykonywały się wielokrotnie zamiast raz.
+
+Naprawiono też pamięć podręczną panelu filtrów w panelu administracyjnym,
+która budowała klucz z adresu w pamięci zamiast z parametrów filtrowania.
+Powodowało to, że po zmianie filtrów przez maksymalnie 5 minut wyświetlał się
+panel filtrów wyliczony dla innego, wcześniejszego zestawu parametrów (błędnie
+podświetlone aktywne filtry).
+
+W instalacjach wielouczelnianych statystyki na pulpicie administratora nie
+uwzględniały domeny w kluczu pamięci podręcznej, przez co dane wyliczone dla
+jednej uczelni mogły zostać pokazane pod domeną innej. Odpowiedzi są teraz
+różnicowane po domenie.

--- a/src/bpp/newsfragments/advisory-locki-pythonhashseed.bugfix.rst
+++ b/src/bpp/newsfragments/advisory-locki-pythonhashseed.bugfix.rst
@@ -17,7 +17,8 @@ Powodowało to, że po zmianie filtrów przez maksymalnie 5 minut wyświetlał s
 panel filtrów wyliczony dla innego, wcześniejszego zestawu parametrów (błędnie
 podświetlone aktywne filtry).
 
-W instalacjach wielouczelnianych statystyki na pulpicie administratora nie
-uwzględniały domeny w kluczu pamięci podręcznej, przez co dane wyliczone dla
-jednej uczelni mogły zostać pokazane pod domeną innej. Odpowiedzi są teraz
-różnicowane po domenie.
+Statystyki na pulpicie administratora deklarują teraz jawnie, że ich treść
+zależy od domeny (nagłówek ``Vary: Host``). Wewnętrzna pamięć podręczna
+rozdzielała je po domenie już wcześniej — to zabezpieczenie na wypadek
+pośredniczących pamięci podręcznych HTTP (proxy, CDN), które bez tego
+nagłówka mogłyby współdzielić odpowiedź między domenami.

--- a/src/bpp/newsfragments/advisory-locki-pythonhashseed.bugfix.rst
+++ b/src/bpp/newsfragments/advisory-locki-pythonhashseed.bugfix.rst
@@ -1,0 +1,10 @@
+Naprawiono klucze blokad i cache liczone wbudowaną funkcją ``hash()``, która
+w Pythonie zwraca inną wartość w każdym procesie (sól ``PYTHONHASHSEED``).
+Skutkiem było to, że blokady chroniące przed równoczesnym uruchomieniem
+zadań w ogóle nie działały między procesami serwera: dwa zgłoszenia wysyłki
+oświadczeń do PBN złożone w tej samej chwili mogły przejść oba i zakolejkować
+ZDUPLIKOWANĄ wysyłkę oświadczeń do PBN, a pobierania danych z PBN mogły
+wystartować równolegle mimo blokady. Z tego samego powodu cache licznika
+rekordów na listach w panelu administracyjnym był w praktyce nieskuteczny
+(każdy proces serwera miał własną, rozłączną przestrzeń kluczy), przez co
+ciężkie zapytania zliczające wykonywały się wielokrotnie zamiast raz.

--- a/src/deduplikator_autorow/tasks.py
+++ b/src/deduplikator_autorow/tasks.py
@@ -10,6 +10,7 @@ from django.db import connection, transaction
 from django.utils import timezone
 
 from django_bpp.celery_tasks import GlobalSingleton
+from django_bpp.db_locks import advisory_lock_id
 
 from .utils.constants import MAX_PEWNOSC, MIN_PEWNOSC
 
@@ -52,20 +53,18 @@ SCAN_STALE_AFTER = SCAN_TIME_LIMIT + 15 * 60
 # Patrz `_przejmij_slot_skanu` — to on, a nie `select_for_update`, zapewnia
 # wzajemne wykluczanie (na pustej tabeli nie ma wierszy do zablokowania).
 #
-# Wartość wyprowadzona deterministycznie, żeby dało się ją odtworzyć i żeby
-# nikt nie użył przypadkiem tej samej gdzie indziej:
+# Wartość wyprowadzona deterministycznie (blake2s — patrz
+# `django_bpp.db_locks`), żeby dało się ją odtworzyć i żeby nikt nie użył
+# przypadkiem tej samej gdzie indziej.
 #
-#     hashlib.blake2s(
-#         b"deduplikator_autorow.scan_for_duplicates.slot", digest_size=8
-#     ) -> int.from_bytes(..., "big") & (2**63 - 1)
+# CELOWO nie `abs(hash(...))` — wbudowany `hash()` dla str jest solony
+# PYTHONHASHSEED-em, więc daje INNĄ wartość w każdym procesie Pythona, a
+# klucz liczony w ten sposób nie wyklucza niczego między workerami (każdy
+# zakłada lock na własnym numerze).
 #
-# CELOWO stała literalna, a nie `abs(hash(...))` — wbudowany `hash()` dla
-# str jest solony PYTHONHASHSEED-em, więc daje INNĄ wartość w każdym procesie
-# Pythona. Klucz liczony w ten sposób nie wyklucza niczego między workerami
-# (każdy zakłada lock na własnym numerze). W repo są takie miejsca
-# (pbn_downloader_app/tasks.py, pbn_wysylka_oswiadczen/views.py) — nie
-# powielamy tego wzorca.
-SCAN_SLOT_LOCK_ID = 8081800802642310148
+# Wynik jest bit-w-bit tą samą liczbą (8081800802642310148) co wcześniejsza
+# stała literalna — pilnuje tego test w `tests/test_advisory_lock_id.py`.
+SCAN_SLOT_LOCK_ID = advisory_lock_id("deduplikator_autorow.scan_for_duplicates.slot")
 
 
 def normalize_confidence(raw_score: int) -> float:

--- a/src/django_bpp/db_locks.py
+++ b/src/django_bpp/db_locks.py
@@ -1,0 +1,49 @@
+"""
+Deterministyczne klucze Postgresowych advisory locków.
+
+Advisory locki w PostgreSQL identyfikuje się LICZBĄ, nie nazwą. Klucz musi
+więc być wyprowadzony z jakiejś nazwy — i **musi wyjść identyczny w każdym
+procesie**, inaczej wzajemne wykluczanie nie zachodzi w ogóle.
+
+Nie wolno do tego używać wbudowanego `hash()`: dla `str` (i `bytes`) jest on
+solony `PYTHONHASHSEED`-em, losowanym per proces od Pythona 3.3. `hash("x")`
+daje INNĄ wartość w każdym uruchomieniu interpretera, więc każdy worker
+Celery i każdy proces gunicorna zakładałby lock na własnym, prywatnym
+numerze — dokładnie w wielo-procesowym deploymencie, dla którego locki
+powstały. Do niedawna dwa miejsca w repo robiły `abs(hash(nazwa)) % 2**31`
+i przez to nie chroniły niczego.
+
+Zamiast tego liczymy klucz `blake2s`-em (niesolony, stabilny między
+procesami i wersjami Pythona).
+
+PRZESTRZEŃ NAZW: jedno-argumentowy wariant (`pg_advisory_xact_lock(bigint)`)
+ma JEDNĄ globalną przestrzeń na cały klaster — kolizja klucza między dwoma
+niepowiązanymi podsystemami oznacza, że niepotrzebnie się blokują.
+Dwu-argumentowy wariant (`pg_advisory_xact_lock(int, int)`) ma przestrzeń
+osobną, więc locki z migracji `0421`/`0428`/`0429`/`0432` (kluczowane
+`(classid, objid)`) NIE kolidują z niczym tutaj.
+
+Żeby zminimalizować ryzyko kolizji w przestrzeni jedno-argumentowej:
+
+* nazwy przekazywane tu są w pełni kwalifikowane (`app.funkcja.obiekt`),
+* wynik ma 63 bity entropii, więc przy kilku kluczach w systemie
+  prawdopodobieństwo kolizji jest astronomicznie małe.
+"""
+
+import hashlib
+
+__all__ = ["advisory_lock_id"]
+
+
+def advisory_lock_id(nazwa: str) -> int:
+    """
+    Zwróć deterministyczny klucz advisory locka dla podanej nazwy.
+
+    Wynik mieści się w zakresie dodatnich `bigint`-ów (63 bity), czyli w
+    dziedzinie jedno-argumentowego `pg_advisory_xact_lock(bigint)`.
+
+    Ta sama nazwa daje tę samą liczbę w KAŻDYM procesie Pythona — na tym
+    polega przydatność tej funkcji (patrz docstring modułu).
+    """
+    digest = hashlib.blake2s(nazwa.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big") & (2**63 - 1)

--- a/src/django_bpp/templates/admin/change_list.html
+++ b/src/django_bpp/templates/admin/change_list.html
@@ -970,7 +970,16 @@
                             <!-- FILTERS -->
                             {% if cl.has_filters %}
                                 {% block filters %}
-                                    {% cache 300 admin_filters request.GET.items request.path request.user.username %}
+                                    {# vary_on MUSI być wartością, nie metodą. `request.GET.items` #}
+                                    {# szablon WYWOŁUJE, dostając generator — a klucz fragmentu #}
+                                    {# powstaje z `str(...)` argumentu, czyli z ADRESU generatora #}
+                                    {# na stercie. CPython reużywa zwolniony adres, więc różne #}
+                                    {# query stringi dawały TEN SAM klucz (zmierzone: 3 różne #}
+                                    {# filtry -> 1 klucz) i panel filtrów trafiał w CUDZY wpis. #}
+                                    {# Do tego generator nigdy nie był konsumowany, więc klucz #}
+                                    {# i tak nie zależał od faktycznych parametrów GET. #}
+                                    {# `urlencode` daje stabilny łańcuch zależny od parametrów. #}
+                                    {% cache 300 admin_filters request.GET.urlencode request.path request.user.username %}
                                         <div id="grp-filters" class="g-d-6 g-d-l">
                                             <div class="grp-filter">
                                                 <a href="javascript://"

--- a/src/django_bpp/tests/test_admin_filters_cache_key.py
+++ b/src/django_bpp/tests/test_admin_filters_cache_key.py
@@ -1,0 +1,101 @@
+"""Test klucza cache fragmentu `{% cache %}` panelu filtrów w adminie.
+
+DLACZEGO to musi istnieć: `{% cache 300 admin_filters request.GET.items ... %}`
+przekazywał do `vary_on` **generator**. `MultiValueDict.items` to funkcja
+generatorowa, a szablon Django wywołuje przekazane atrybuty — do klucza
+trafiał więc `str(<generator object ... at 0x7f...>)`, czyli ADRES na stercie.
+
+To groźniejsze niż niestabilny `hash()`: tam cache nie trafiał, tu trafiał
+w CUDZY wpis. CPython reużywa zwolniony adres, więc kolejne requesty z
+RÓŻNYMI filtrami dostawały ten sam klucz i przez 300 s widziały panel
+filtrów wyrenderowany dla innego zestawu parametrów.
+
+Warunek odtworzenia kolizji: generator musi zostać ZWOLNIONY między
+iteracjami (tak jak między kolejnymi requestami) — dopiero wtedy alokator
+reużywa adres.
+"""
+
+from django.core.cache.utils import make_template_fragment_key
+from django.http import QueryDict
+
+QUERY_STRINGI = ["rok=2020", "rok=2025", "rok=2030"]
+
+SCIEZKA = "/admin/bpp/wydawnictwo_ciagle/"
+UZYTKOWNIK = "admin"
+
+
+def _klucz(vary_wartosc):
+    return make_template_fragment_key(
+        "admin_filters", [vary_wartosc, SCIEZKA, UZYTKOWNIK]
+    )
+
+
+def test_rozne_filtry_daja_rozne_klucze():
+    """Sedno naprawy: klucz MUSI zależeć od parametrów GET.
+
+    Czerwony na starej wersji (`request.GET.items`): trzy różne query
+    stringi dawały jeden klucz.
+    """
+    klucze = [_klucz(QueryDict(qs).urlencode()) for qs in QUERY_STRINGI]
+
+    assert len(set(klucze)) == len(QUERY_STRINGI), (
+        f"kolizja kluczy cache panelu filtrów: {klucze} — różne filtry "
+        "trafiają w ten sam wpis cache"
+    )
+
+
+def test_ten_sam_filtr_daje_ten_sam_klucz():
+    """Bez tego cache nigdy by nie trafiał (klucz musi być stabilny)."""
+    assert _klucz(QueryDict("rok=2020&typ=1").urlencode()) == _klucz(
+        QueryDict("rok=2020&typ=1").urlencode()
+    )
+
+
+def test_generator_jako_vary_on_koliduje():
+    """Kontrola metody: dowód, że test wyżej ma zęby.
+
+    Odtwarza STARĄ implementację w warunkach audytu — generator zwalniany
+    między iteracjami, jak między kolejnymi requestami. Jeśli to kiedyś
+    przestanie kolidować, `test_rozne_filtry_daja_rozne_klucze` przechodzi
+    również na zepsutym kodzie i nic nie sprawdza.
+    """
+    klucze = []
+    for qs in QUERY_STRINGI:
+        # `.items()` na MultiValueDict zwraca generator — dokładnie to, co
+        # szablon podawał do vary_on. Nie trzymamy referencji, więc obiekt
+        # jest zwalniany przed następną iteracją.
+        klucze.append(_klucz(QueryDict(qs).items()))
+
+    assert len(set(klucze)) < len(QUERY_STRINGI), (
+        "generator w vary_on przestał kolidować — metodyka testu kolizji "
+        "jest nieważna, popraw ją zanim uwierzysz w zielony wynik"
+    )
+
+
+def test_szablon_nie_uzywa_generatora_w_vary_on():
+    """Regresja: szablon nie może wrócić do `request.GET.items`."""
+    import pathlib
+
+    import django_bpp
+
+    szablon = (
+        pathlib.Path(django_bpp.__file__).parent
+        / "templates"
+        / "admin"
+        / "change_list.html"
+    )
+    tresc = szablon.read_text(encoding="utf-8")
+
+    linie_cache = [
+        linia
+        for linia in tresc.splitlines()
+        if "{% cache" in linia and "admin_filters" in linia
+    ]
+    assert linie_cache, "nie znaleziono tagu {% cache %} panelu filtrów"
+
+    for linia in linie_cache:
+        assert "request.GET.items" not in linia, (
+            "vary_on znowu dostaje generator (`request.GET.items`) — klucz "
+            "powstanie z adresu w pamięci i będzie kolidował"
+        )
+        assert "request.GET.urlencode" in linia

--- a/src/django_bpp/tests/test_advisory_lock_id.py
+++ b/src/django_bpp/tests/test_advisory_lock_id.py
@@ -1,0 +1,158 @@
+"""Testy DETERMINIZMU kluczy Postgresowych advisory locków.
+
+Sedno: klucz musi wyjść IDENTYCZNY w każdym procesie Pythona. Assert
+`klucz == klucz` w obrębie jednego procesu nie dowodzi NICZEGO — wbudowany
+`hash()` jest stabilny wewnątrz procesu, a psuje się dopiero między
+procesami (sól `PYTHONHASHSEED` losowana przy starcie interpretera).
+Dlatego testy niżej odpalają obliczenie w OSOBNYCH procesach z jawnie
+różnymi ziarnami.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from django_bpp.db_locks import advisory_lock_id
+
+# Jawnie różne ziarna soli. `0` wyłącza losowanie, pozostałe wymuszają
+# konkretne, różne sole — gdyby klucz zależał od `hash()`, każdy z tych
+# procesów zwróciłby inną liczbę.
+ZIARNA = ["0", "1", "42", "1000", "123456"]
+
+SRC = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _w_osobnym_procesie(kod: str, ziarno: str) -> str:
+    """Odpal `kod` w świeżym interpreterze z zadanym PYTHONHASHSEED."""
+    env = dict(os.environ, PYTHONHASHSEED=ziarno, PYTHONPATH=SRC)
+    wynik = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(kod)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+        check=True,
+    )
+    return wynik.stdout.strip()
+
+
+def test_klucz_jest_identyczny_miedzy_procesami():
+    """Ten sam klucz w pięciu procesach o różnych PYTHONHASHSEED."""
+    kod = """
+        from django_bpp.db_locks import advisory_lock_id
+        print(advisory_lock_id("pbn_wysylka_oswiadczen.test"))
+    """
+    wyniki = {_w_osobnym_procesie(kod, z) for z in ZIARNA}
+
+    assert len(wyniki) == 1, (
+        f"klucz advisory locka RÓŻNI SIĘ między procesami: {sorted(wyniki)} "
+        "— wzajemne wykluczanie nie zachodzi"
+    )
+    # I zgadza się z wartością liczoną w procesie testowym.
+    assert wyniki == {str(advisory_lock_id("pbn_wysylka_oswiadczen.test"))}
+
+
+def test_wbudowany_hash_rozjezdza_sie_miedzy_procesami():
+    """Kontrola metody: dowód, że test wyżej ma zęby.
+
+    Stara implementacja (`abs(hash(nazwa)) % 2**31`) uruchomiona w tych
+    samych warunkach MUSI dać różne wartości — inaczej test determinizmu
+    przechodziłby również na zepsutym kodzie i nic by nie sprawdzał.
+    """
+    kod = """
+        print(abs(hash("pbn_wysylka_oswiadczen.test")) % (2**31))
+    """
+    wyniki = {_w_osobnym_procesie(kod, z) for z in ZIARNA}
+
+    assert len(wyniki) > 1, (
+        "PYTHONHASHSEED nie wpłynął na hash() — metodyka testu determinizmu "
+        "jest nieważna, popraw ją zanim uwierzysz w zielony wynik"
+    )
+
+
+def _kod_bez_komentarzy(modul: str) -> str:
+    """Źródło modułu z wyciętymi komentarzami, docstringami i literałami.
+
+    Interesuje nas WYWOŁANIE `hash(...)` w kodzie. Komentarze w tych plikach
+    cytują antywzorzec dosłownie, więc skan po surowym tekście dawałby
+    fałszywy alarm. Literały pomijamy przy okazji — klucz locka nigdy nie
+    bierze się z treści stringa.
+    """
+    import importlib
+    import inspect
+    import io
+    import tokenize
+
+    pomijane = {tokenize.COMMENT, tokenize.STRING}
+    # Python 3.12+ rozbija f-stringi na osobne typy tokenów.
+    for nazwa in ("FSTRING_START", "FSTRING_MIDDLE", "FSTRING_END"):
+        if hasattr(tokenize, nazwa):
+            pomijane.add(getattr(tokenize, nazwa))
+
+    zrodlo = inspect.getsource(importlib.import_module(modul))
+    return " ".join(
+        tok.string
+        for tok in tokenize.generate_tokens(io.StringIO(zrodlo).readline)
+        if tok.type not in pomijane
+    )
+
+
+@pytest.mark.parametrize(
+    "modul",
+    [
+        "pbn_downloader_app.tasks",
+        "pbn_wysylka_oswiadczen.views",
+        "deduplikator_autorow.tasks",
+    ],
+)
+def test_produkcyjne_miejsca_nie_uzywaja_wbudowanego_hash(modul):
+    """Regresja: żadne z miejsc liczących klucz locka nie wraca do `hash()`.
+
+    Skanujemy KOD, nie surowy tekst — komentarze w tych plikach objaśniają
+    właśnie ten antywzorzec i cytują `abs(hash(...))` dosłownie.
+    """
+    assert "hash(" not in _kod_bez_komentarzy(modul), (
+        f"{modul} znowu liczy klucz advisory locka wbudowanym hash() — "
+        "to jest solone PYTHONHASHSEED-em i nie wyklucza niczego"
+    )
+
+
+def test_scan_slot_lock_id_bez_zmiany_wartosci():
+    """Refaktor #629 na wspólny helper nie mógł zmienić klucza.
+
+    Gdyby zmienił, wdrożenie mieszane (stary worker + nowy) chwilowo
+    używałoby dwóch różnych kluczy i slot skanu przestałby wykluczać.
+    """
+    from deduplikator_autorow.tasks import SCAN_SLOT_LOCK_ID
+
+    assert SCAN_SLOT_LOCK_ID == 8081800802642310148
+
+
+def test_klucze_nie_koliduja_ze_soba():
+    """Jedno-argumentowe advisory locki dzielą JEDNĄ globalną przestrzeń.
+
+    Kolizja = dwa niepowiązane podsystemy blokują się nawzajem. Wariant
+    dwu-argumentowy (migracje 0421/0428/0429/0432, kluczowane
+    `(classid, objid)`) ma przestrzeń osobną i tu nie wchodzi.
+    """
+    from deduplikator_autorow.tasks import SCAN_SLOT_LOCK_ID
+
+    klucze = [
+        SCAN_SLOT_LOCK_ID,
+        advisory_lock_id("pbn_wysylka_oswiadczen.views.PbnWysylkaOswiadczenTask"),
+    ]
+    for nazwa_modelu in (
+        "PbnDownloadTask",
+        "PbnInstitutionPeopleTask",
+        "PbnJournalsDownloadTask",
+    ):
+        klucze.append(
+            advisory_lock_id(f"pbn_downloader_app.create_task_with_lock.{nazwa_modelu}")
+        )
+
+    assert len(set(klucze)) == len(klucze), f"kolizja kluczy: {klucze}"
+    # Wszystkie mieszczą się w dodatnim bigint (dziedzina jedno-arg. wariantu).
+    assert all(0 < k < 2**63 for k in klucze)

--- a/src/pbn_downloader_app/tasks.py
+++ b/src/pbn_downloader_app/tasks.py
@@ -197,8 +197,16 @@ def create_task_with_lock(task_model, user, initial_step):
     from django.db import connection, transaction
     from django.utils import timezone
 
-    # 32-bit signed int dla pg_advisory_xact_lock(int)
-    lock_key = abs(hash(task_model.__name__)) % (2**31)
+    from django_bpp.db_locks import advisory_lock_id
+
+    # Klucz MUSI być deterministyczny między procesami — poprzednie
+    # `abs(hash(nazwa)) % 2**31` nie było, bo `hash()` dla str jest solony
+    # PYTHONHASHSEED-em: każdy worker Celery zakładał lock na własnym,
+    # prywatnym numerze i wykluczanie nie zachodziło w ogóle.
+    # Patrz `django_bpp.db_locks`.
+    lock_key = advisory_lock_id(
+        f"pbn_downloader_app.create_task_with_lock.{task_model.__name__}"
+    )
 
     with transaction.atomic():
         with connection.cursor() as cursor:

--- a/src/pbn_wysylka_oswiadczen/tests/test_advisory_lock_wykluczanie.py
+++ b/src/pbn_wysylka_oswiadczen/tests/test_advisory_lock_wykluczanie.py
@@ -1,0 +1,76 @@
+"""Test WSPÓŁBIEŻNOŚCI: advisory lock wysyłki oświadczeń naprawdę wyklucza.
+
+Wzorzec z `deduplikator_autorow/tests/test_scan_slot_concurrency.py`:
+`django_db(transaction=True)` (prawdziwe commity, osobne połączenia per
+wątek) + `threading.Barrier`, żeby wszystkie wątki ruszyły w tej samej
+chwili.
+
+DLACZEGO to musi istnieć: sam fakt, że klucz jest deterministyczny, nie
+dowodzi, że sekcja krytyczna jest faktycznie serializowana. Ten test
+sprawdza obserwowalny skutek — z N wątków wchodzących równocześnie
+dokładnie JEDEN widzi pustą tabelę i tworzy zadanie. Gdyby klucz był
+liczony per proces/wątek (albo lock zniknął), przeszłoby ich N i do PBN
+poleciałaby zduplikowana wysyłka oświadczeń.
+"""
+
+import threading
+
+import pytest
+from django.db import connection, connections, transaction
+
+from django_bpp.db_locks import advisory_lock_id
+from pbn_wysylka_oswiadczen.models import PbnWysylkaOswiadczenTask
+
+LICZBA_WATKOW = 8
+
+LOCK_KEY = advisory_lock_id("pbn_wysylka_oswiadczen.views.PbnWysylkaOswiadczenTask")
+
+
+def _sprobuj_zajac_slot(user_id):
+    """Odwzorowuje sekcję krytyczną z `views.py` (lock + exists + create)."""
+    with transaction.atomic():
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_xact_lock(%s)", [LOCK_KEY])
+
+        if PbnWysylkaOswiadczenTask.objects.filter(
+            status__in=("pending", "running")
+        ).exists():
+            return False
+
+        PbnWysylkaOswiadczenTask.objects.create(user_id=user_id, status="pending")
+        return True
+
+
+@pytest.mark.django_db(transaction=True)
+def test_tylko_jeden_watek_zaklada_zadanie_wysylki(django_user_model):
+    assert not PbnWysylkaOswiadczenTask.objects.exists(), "start z pustej tabeli"
+
+    user = django_user_model.objects.create_user(username="lock-test")
+
+    start = threading.Barrier(LICZBA_WATKOW)
+    wyniki = [None] * LICZBA_WATKOW
+    bledy = [None] * LICZBA_WATKOW
+
+    def worker(idx):
+        try:
+            start.wait(timeout=30)
+            wyniki[idx] = _sprobuj_zajac_slot(user.pk)
+        except Exception as exc:  # noqa: BLE001 - re-raise'owane po joinie
+            bledy[idx] = exc
+        finally:
+            # Każdy wątek ma własne połączenie; bez zamknięcia teardown
+            # bazy się zawiesza.
+            connections.close_all()
+
+    watki = [threading.Thread(target=worker, args=(i,)) for i in range(LICZBA_WATKOW)]
+    for w in watki:
+        w.start()
+    for w in watki:
+        w.join(timeout=60)
+
+    for blad in bledy:
+        if blad is not None:
+            raise blad
+
+    assert sum(1 for w in wyniki if w) == 1, f"więcej niż jeden zwycięzca: {wyniki}"
+    assert PbnWysylkaOswiadczenTask.objects.count() == 1

--- a/src/pbn_wysylka_oswiadczen/views.py
+++ b/src/pbn_wysylka_oswiadczen/views.py
@@ -231,7 +231,17 @@ class StartTaskView(View):
         # workerami wysyłającymi oświadczenia naraz.
         from django.db import connection, transaction
 
-        lock_key = abs(hash("PbnWysylkaOswiadczenTask")) % (2**31)
+        from django_bpp.db_locks import advisory_lock_id
+
+        # Klucz MUSI być deterministyczny między procesami — poprzednie
+        # `abs(hash(nazwa)) % 2**31` nie było, bo `hash()` dla str jest
+        # solony PYTHONHASHSEED-em: każdy proces gunicorna zakładał lock na
+        # własnym numerze, więc dwa równoległe POST-y przechodziły oba i
+        # kolejkowały ZDUPLIKOWANĄ wysyłkę oświadczeń do PBN.
+        # Patrz `django_bpp.db_locks`.
+        lock_key = advisory_lock_id(
+            "pbn_wysylka_oswiadczen.views.PbnWysylkaOswiadczenTask"
+        )
         with transaction.atomic():
             with connection.cursor() as cursor:
                 cursor.execute("SELECT pg_advisory_xact_lock(%s)", [lock_key])

--- a/src/rozbieznosci_dyscyplin/admin_utils.py
+++ b/src/rozbieznosci_dyscyplin/admin_utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 
 from django.contrib.admin import SimpleListFilter
@@ -11,6 +12,28 @@ from bpp.models import Uczelnia
 from bpp.util import zaloguj_polkniety_wyjatek
 
 logger = logging.getLogger(__name__)
+
+
+def klucz_cache_licznika(sql: str) -> str:
+    """
+    Zwróć klucz cache dla licznika wierszy danego zapytania.
+
+    Skrót MUSI być deterministyczny między procesami. Wcześniej było tu
+    `hash(sql)`, a wbudowany `hash()` dla str jest solony PYTHONHASHSEED-em
+    (losowanym per proces od Pythona 3.3) — więc każdy worker gunicorna miał
+    WŁASNĄ przestrzeń kluczy. Wpis zapisany przez workera A nigdy nie był
+    odczytany przez B (trafialność spadała ~N-krotnie przy N workerach), a po
+    restarcie procesu wszystkie klucze się zmieniały i stare wpisy zostawały
+    w Redisie jako śmieci do wygaśnięcia TTL. Cały ten paginator istnieje po
+    to, żeby unikać `COUNT(*)` na dużych listach admina — a w produkcji
+    wielo-procesowej był przez to w dużej mierze bezczynny.
+
+    `blake2s` z 8-bajtowym digestem daje 16 znaków hex — krótki klucz
+    (Redis go trzyma) o entropii aż nadto wystarczającej na liczbę
+    równocześnie cache'owanych zapytań admina.
+    """
+    skrot = hashlib.blake2s(sql.encode("utf-8"), digest_size=8).hexdigest()
+    return f"adm:{skrot}:count"
 
 
 class CachingPaginator(Paginator):
@@ -30,7 +53,7 @@ class CachingPaginator(Paginator):
 
         if self._count is None:
             try:
-                key = f"adm:{hash(self.object_list.query.__str__())}:count"
+                key = klucz_cache_licznika(str(self.object_list.query))
                 self._count = cache.get(key, -1)
                 if self._count == -1:
                     # jezeli model._meta.managed = False, to zapewne jest to widok, stąd pytaj o reltuples jedynie

--- a/src/rozbieznosci_dyscyplin/tests/test_klucz_cache_licznika.py
+++ b/src/rozbieznosci_dyscyplin/tests/test_klucz_cache_licznika.py
@@ -1,0 +1,89 @@
+"""Testy DETERMINIZMU klucza cache licznika `CachingPaginator`.
+
+Ten sam defekt co przy advisory lockach (`django_bpp.db_locks`): klucz
+liczony wbudowanym `hash()` jest solony PYTHONHASHSEED-em, więc różni się
+między procesami. Tu nie psuje poprawności, tylko skuteczność cache —
+każdy worker gunicorna miał własną przestrzeń kluczy i nie czytał wpisów
+pozostałych.
+
+Determinizmu nie da się sprawdzić w jednym procesie (tam `hash()` też jest
+stabilny), dlatego klucz liczymy w OSOBNYCH procesach z różnymi ziarnami.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+from rozbieznosci_dyscyplin.admin_utils import klucz_cache_licznika
+
+ZIARNA = ["0", "1", "42", "1000", "123456"]
+
+SRC = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+SQL = 'SELECT "bpp_autor"."id" FROM "bpp_autor" WHERE "bpp_autor"."rok" = 2024'
+
+
+def _w_osobnym_procesie(kod: str, ziarno: str) -> str:
+    env = dict(os.environ, PYTHONHASHSEED=ziarno, PYTHONPATH=SRC)
+    wynik = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(kod)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+        check=True,
+    )
+    return wynik.stdout.strip()
+
+
+def test_klucz_jest_identyczny_miedzy_procesami():
+    """Ten sam klucz w pięciu procesach o różnych PYTHONHASHSEED.
+
+    Bez tego cache licznika w praktyce nie działa w wielo-procesowej
+    produkcji (N workerów = N rozłącznych przestrzeni kluczy).
+    """
+    kod = f"""
+        import hashlib
+        skrot = hashlib.blake2s({SQL!r}.encode("utf-8"), digest_size=8).hexdigest()
+        print(f"adm:{{skrot}}:count")
+    """
+    wyniki = {_w_osobnym_procesie(kod, z) for z in ZIARNA}
+
+    assert len(wyniki) == 1, (
+        f"klucz cache RÓŻNI SIĘ między procesami: {sorted(wyniki)} — "
+        "workery nie współdzielą wpisów"
+    )
+    assert wyniki == {klucz_cache_licznika(SQL)}
+
+
+def test_wbudowany_hash_rozjezdza_sie_miedzy_procesami():
+    """Kontrola metody: stara implementacja MUSI dać różne klucze.
+
+    Inaczej test wyżej przechodziłby również na zepsutym kodzie.
+    """
+    kod = f'print(f"adm:{{hash({SQL!r})}}:count")'
+    wyniki = {_w_osobnym_procesie(kod, z) for z in ZIARNA}
+
+    assert len(wyniki) > 1, (
+        "PYTHONHASHSEED nie wpłynął na hash() — metodyka testu determinizmu "
+        "jest nieważna"
+    )
+
+
+def test_to_samo_zapytanie_ten_sam_klucz():
+    assert klucz_cache_licznika(SQL) == klucz_cache_licznika(SQL)
+
+
+def test_rozne_zapytania_rozne_klucze():
+    inny = SQL.replace("2024", "2025")
+    assert klucz_cache_licznika(SQL) != klucz_cache_licznika(inny)
+
+
+def test_ksztalt_klucza():
+    """Prefiks `adm:` zachowany, klucz krótki (Redis go trzyma)."""
+    klucz = klucz_cache_licznika(SQL)
+
+    assert klucz.startswith("adm:")
+    assert klucz.endswith(":count")
+    assert len(klucz) == len("adm:") + 16 + len(":count")


### PR DESCRIPTION
## Problem

Trzy miejsca w kodzie wyliczały klucz — dwa dla Postgresowych *advisory
locków*, jedno dla klucza cache — wbudowaną funkcją `hash()` na stringu:

```python
abs(hash(nazwa)) % (2**31)                     # locki
f"adm:{hash(str(query))}:count"                # cache licznika w adminie
```

**`hash()` dla `str` jest w Pythonie solony `PYTHONHASHSEED`-em**, losowanym
przy starcie interpretera (domyślnie od Pythona 3.3). Ta sama nazwa daje
INNĄ liczbę w każdym procesie. Zmierzone — pięć procesów, pięć różnych
wartości dla tego samego wejścia:

```
STARA abs(hash())  -> ['577827983', '381115883', '1799247675',
                       '1996347528', '2013472183']   → 5 różnych
NOWA  blake2s      -> ['815827038425695848'] × 5     → 1 wartość
```

## Dlaczego to jest błąd integralności danych, a nie kosmetyka

Advisory lock w PostgreSQL identyfikuje **liczba**. Wzajemne wykluczanie
zachodzi tylko wtedy, gdy dwa procesy proszą o lock na tej **samej** liczbie.
Skoro każdy proces liczył własną, prywatną liczbę — **wykluczanie nie
zachodziło w ogóle**, dokładnie w wielo-procesowym deploymencie (gunicorn,
workery Celery), dla którego te locki powstały. Docstringi w obu miejscach
obiecywały wprost coś przeciwnego („Advisory lock blokuje cały odcinek
krytyczny", „bez tego dwa równoległe POST-y…").

| Miejsce | Skutek |
|---|---|
| `pbn_wysylka_oswiadczen/views.py` | **User-facing.** Dwa równoczesne POST-y trafiające na różne procesy gunicorna przechodziły **oba** i kolejkowały **ZDUPLIKOWANĄ wysyłkę oświadczeń do PBN** — czyli duplikaty w systemie zewnętrznym. |
| `pbn_downloader_app/tasks.py` | To samo między workerami Celery: równoległe pobrania z PBN mimo blokady. |
| `rozbieznosci_dyscyplin/admin_utils.py` | Nie poprawność, ale wydajność: każdy worker miał **rozłączną przestrzeń kluczy** cache (trafialność ~N-krotnie niższa przy N workerach), a po restarcie procesu stare wpisy zostawały w Redisie jako śmieci do wygaśnięcia TTL. Ten paginator istnieje po to, żeby unikać `COUNT(*)` na dużych listach admina — a w produkcji był w dużej mierze bezczynny. |

## Rozwiązanie

Nowy moduł `src/django_bpp/db_locks.py` z `advisory_lock_id(nazwa)` — skrót
`blake2s` (niesolony, stabilny między procesami i wersjami Pythona), obcięty
do 63 bitów, czyli do dziedziny jedno-argumentowego
`pg_advisory_xact_lock(bigint)`.

To **wzorzec już obecny w repo** — `SCAN_SLOT_LOCK_ID` z #629 był wyliczony
dokładnie tą derywacją i zapisany jako stała literalna. Wybrałem spójność z
nim zamiast `zlib.crc32`.

### Decyzja: wspólny helper i refaktor #629

Wydzieliłem helper zamiast wklejać stałe, bo klucz w `pbn_downloader_app`
**nie może** być literałem — zależy od `task_model.__name__` (trzy różne
modele zadań przechodzą przez tę samą funkcję).

`SCAN_SLOT_LOCK_ID` z #629 też przełączyłem na helper, bo derywacja jest
**bit-w-bit identyczna** — sprawdziłem, że daje tę samą liczbę
`8081800802642310148`, i **przypiąłem to testem**. Zmiana zachowania
zmergowanego #629 jest więc wykluczona, a nie tylko „mało prawdopodobna".
Gdyby wartość się zmieniła, wdrożenie mieszane (stary worker + nowy)
chwilowo używałoby dwóch kluczy i slot skanu przestałby wykluczać — test
tego pilnuje.

### Kolizje kluczy

Wariant **jedno-argumentowy** advisory locka ma JEDNĄ globalną przestrzeń na
klaster, więc kolizja = dwa niepowiązane podsystemy blokują się nawzajem.
Przejrzałem całe repo pod `advisory`:

- `SCAN_SLOT_LOCK_ID` (`8081800802642310148`, 1-arg) — sprawdzone, brak
  kolizji z nowymi kluczami (test `test_klucze_nie_koliduja_ze_soba`),
- locki w migracjach `0421`/`0428`/`0429`/`0432` — wariant **dwu-argumentowy**
  (`pg_advisory_xact_lock(classid, objid)`), **osobna przestrzeń**, nie
  kolidują z niczym tutaj,
- migracje `0387`/`0399` — też `hash(...) % 2**31`, ale są ZASTĄPIONE przez
  0421/0429/0432. **Nie ruszane** — modyfikowanie migracji jest w tym
  projekcie zakazane.

### Klucz cache admina

`blake2s` → 16 znaków hex, prefiks `adm:` i sufiks `:count` zachowane
(`adm:<16hex>:count`) — klucz krótki, bo Redis go trzyma. Zmiana kształtu
klucza jest bezpieczna: stare wpisy po prostu nie trafią i wygasną na TTL
(3600 s). Sprawdziłem — **nic w repo nie iteruje po `adm:*`** (jedyne
wystąpienie tego prefiksu to właśnie ten kod).

## Testy

Sedno: `assert klucz == klucz` w jednym procesie **niczego nie dowodzi**, bo
w obrębie procesu `hash()` też jest stabilny. Dlatego testy liczą klucz w
**osobnych procesach** (`subprocess` z jawnie różnymi `PYTHONHASHSEED`) i
asertują, że wartości są identyczne.

Do każdego testu determinizmu dołożyłem **test kontrolny metody**
(`test_wbudowany_hash_rozjezdza_sie_miedzy_procesami`), który sprawdza, że
stara implementacja w tych samych warunkach daje wartości **różne**. Bez
niego test determinizmu przechodziłby również na zepsutym kodzie i nie
sprawdzałby nic.

Dodatkowo:
- `test_produkcyjne_miejsca_nie_uzywaja_wbudowanego_hash` — regresja,
  skanuje **kod** (przez `tokenize`, z pominięciem komentarzy i literałów —
  komentarze w tych plikach cytują antywzorzec dosłownie),
- `test_scan_slot_lock_id_bez_zmiany_wartosci` — pin na `8081800802642310148`,
- `test_klucze_nie_koliduja_ze_soba` — kolizje w przestrzeni 1-argumentowej,
- `pbn_wysylka_oswiadczen/tests/test_advisory_lock_wykluczanie.py` — test
  **funkcjonalny** na realne wykluczanie (8 wątków, `threading.Barrier`,
  `django_db(transaction=True)`, wzorzec z
  `deduplikator_autorow/tests/test_scan_slot_concurrency.py`): z 8 wątków
  wchodzących równocześnie dokładnie **jeden** zakłada zadanie.

Uczciwe zastrzeżenie: test funkcjonalny działa na wątkach w jednym procesie,
więc łapie **usunięcie locka**, ale nie sam defekt `PYTHONHASHSEED` (w
obrębie procesu `hash()` jest stabilny). Dowodem na defekt jest test
cross-procesowy — te dwa testy są komplementarne, nie zamienne.

## Bez migracji

Żadna migracja nie została dodana ani zmodyfikowana.

---

# Rozszerzenie zakresu: dwa dalsze błędy kluczy cache

Ta sama klasa problemu (niestabilne / kolidujące klucze cache), inne skutki —
dlatego **osobne commity**.

## Commit 2 — klucz `{% cache %}` panelu filtrów zbudowany z ADRESU W PAMIĘCI

`src/django_bpp/templates/admin/change_list.html`:

```django
{% cache 300 admin_filters request.GET.items request.path request.user.username %}
```

`MultiValueDict.items` to funkcja **generatorowa**. Szablon Django wywołuje
przekazane atrybuty, więc do `vary_on` trafiał obiekt generatora, a
`make_template_fragment_key` hashuje `str(...)` = `<generator object ... at
0x7f...>` — czyli **adres na stercie**.

**To groźniejsze niż defekt `hash()` z commita 1**: tam cache nie trafiał, tu
**trafiał w cudzy wpis**. Zmierzone — trzy różne query stringi renderowane
sekwencyjnie (jak kolejne requesty, generator zwalniany między użyciami) dają
**jeden identyczny klucz**, bo CPython reużywa zwolniony adres:

```
STARA (request.GET.items — generator):
  rok=2020 -> template.cache.admin_filters.85012ac1e9ebc940b46165690290d9f8
  rok=2025 -> template.cache.admin_filters.85012ac1e9ebc940b46165690290d9f8
  rok=2030 -> template.cache.admin_filters.85012ac1e9ebc940b46165690290d9f8
  unikalnych: 1 z 3  -> KOLIZJA

NOWA (request.GET.urlencode):
  rok=2020 -> template.cache.admin_filters.46cd75127590e8f3536bd8ddbea97aea
  rok=2025 -> template.cache.admin_filters.c4e571357498cc1e78b5e4ea01588edc
  rok=2030 -> template.cache.admin_filters.81f7ba4f78606f684715c76ffdac2a4e
  unikalnych: 3 z 3  -> ok
```

**Skutek dla użytkownika:** ten sam użytkownik, ta sama changelista, inne
filtry → przez 300 s widzi panel filtrów wyrenderowany dla innego zestawu
parametrów (błędnie podświetlone aktywne filtry). Dodatkowo generator nigdy
nie był konsumowany, więc `vary_on` i tak nie zależał od faktycznych
parametrów GET.

Naprawa: `request.GET.urlencode`. **Przejrzałem wszystkie `{% cache %}` w
repo** — pozostałe dostają wartości (`uczelnia.pk`, `jednostka.pk`,
`podjednostka.pk`) albo nie mają `vary_on`. To jedyne wystąpienie wzorca.

## Commit 3 — `@cache_page` + `Vary: Host` (defense-in-depth, NIE naprawa wycieku)

> **KOREKTA po review.** Pierwotnie opisałem ten commit jako naprawę wycieku
> danych między uczelniami. **To była nieprawda** — przyjąłem tezę bez
> zweryfikowania, że opisywana podatność w ogóle istnieje. Reviewer to obalił,
> a ja potwierdziłem obalenie niezależnie. Poniżej wersja zgodna z faktami.

9 widoków w `admin_dashboard/views/time_series.py` (6) i `charakter_stats.py`
(3) dostało `@vary_on_headers("Host")`.

### Czego tu NIE ma: wycieku między uczelniami nie było

`cache_page` **sam różnicuje po hoście**. `_generate_cache_key` oraz
`_generate_cache_header_key` hashują `request.build_absolute_uri()`, w którym
host siedzi. Zmierzone u mnie, `learn_cache_key` **bez żadnego `Vary`**:

```
a.pl -> ...cache_page..GET.2324a332e523710eeac5840b15ed303f.d41d8cd9...
b.pl -> ...cache_page..GET.0567a159eba7d2b68bf3fbd932e49838.d41d8cd9...
rozne?                      True
get_cache_key(b) == klucz a? False
```

Nie ma też „okna pierwszego żądania" — URL z hostem siedzi w OBU kluczach
(nagłówkowym i treści) niezależnie od `Vary`.

**Mój pierwotny „dowód czerwieni" był mylący** i reviewer słusznie to
wytknął: po zdjęciu dekoratora test padał **wyłącznie na asercji
`"Host" in Vary`**, nigdy na asercji rozdzielności. Dowodził obecności
dekoratora, nie naprawy błędu. Sprawdziłem to teraz wprost — z usuniętym
dekoratorem test rozdzielności jest **zielony** (`1 passed`).

Porównanie z #633, którym się posiłkowałem, też było nietrafione: tam jawny
host w kluczu jest konieczny, bo #633 buduje WŁASNY klucz. `cache_page` swój
już kluczuje hostem.

### Po co więc zostawiam dekoratory

`Vary: Host` to uczciwa deklaracja dla **pośredniczących cache'y HTTP**
(proxy, CDN), które nie znają wewnętrznego klucza Django i bez tego nagłówka
mogłyby współdzielić odpowiedź między domenami. Tanie defense-in-depth przy
wielo-uczelnianym deploymencie — ale **nie** naprawa istniejącego buga.
Newsfragment, docstringi i nazwa testu zostały przeredagowane, żeby tego nie
sugerować (`test_cache_nie_przecieka_miedzy_hostami` →
`test_cache_page_rozdziela_wpisy_po_hoscie`, z jawną adnotacją, że opisuje
ZASTANE zachowanie Django, nie skutek dekoratora).

### `{% cache 3600 google %}` w `base.html` — nie ruszany

To snippet Google Analytics, przenoszony do JS w **#633**.

### Znalezisko przy okazji: `DummyCache` w testach

Asercja kontrolna („to samo żądanie drugi raz MUSI trafić w cache") wykryła,
że **domyślny cache w testach to `DummyCache`** (`settings/local.py`) —
`cache_page` nie zapamiętywał NICZEGO. Test podmienia backend na LocMem.
Warto sprawdzić, czy inne testy zakładające działanie `cache_page` nie są z
tego powodu puste.

## Follow-up POZA tym PR-em: `{% cache 3600 favicon %}` (prawdziwy kandydat na przeciek)

Reviewer wskazał realną podatność tej samej klasy co kolizja generatora z
commita 2 — **`src/django_bpp/templates/bare.html:139`**:

```django
{% cache 3600 favicon %}{% load favtags %}{% place_favicon %}{% endcache %}
```

Potwierdziłem: `place_favicon` robi `Favicon.on_site.filter(...)` (manager
site-scoped), a fragment nie ma ŻADNEGO `vary_on`. Kluczowa różnica wobec
commita 3: **fragmenty `{% cache %}` NIE mają hosta w kluczu** — w
odróżnieniu od `cache_page`. Pierwszy host, który wyrenderuje stronę,
ustawia favicon dla WSZYSTKICH domen na godzinę.

Świadomie nie ruszam tego w tym PR — inny obszar, wymaga własnego testu.

## Drobiazgi z review (świadomie zostawione)

- `urlencode` nie jest stabilny przy przestawionej kolejności parametrów
  (`?a=1&b=2` vs `?b=2&a=1`). To tylko **miss**, nie zła treść, a admin
  generuje linki w spójnej kolejności — sortowanie nieopłacalne.
- Test współbieżności wysyłki to replika sekcji krytycznej, nie wywołanie
  widoku. Akceptowalne, ale możliwy drift względem `views.py`.

## Dowód czerwieni — i co dokładnie dowodzi

**Commit 2 (realna naprawa).** Po cofnięciu `request.GET.urlencode` →
`request.GET.items` czerwienieje
`test_admin_filters_cache_key.py::test_szablon_nie_uzywa_generatora_w_vary_on`,
a kolizję kluczy widać w pomiarze wyżej (3 query stringi → 1 klucz).

**Commit 3 (defense-in-depth).** Po usunięciu `@vary_on_headers` w
`charakter_stats.py` czerwienieją **wyłącznie** asercje `"Host" in Vary`
(3 z 9 parametryzacji — pozostałe 6 broni `time_series.py`). To dowodzi, że
dekorator jest na miejscu i nagłówek jest deklarowany — **nie** że naprawiono
jakikolwiek wyciek. Test rozdzielności cache jest po usunięciu dekoratora
**ZIELONY** (`1 passed`), bo rozdzielność zapewnia sam Django. Sprawdzone.

Po przywróceniu obu poprawek: **14 passed**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
