### PR TITLE
fix(pbn_api): unikalne UUID słowników i dyscyplin PBN

### DIFF
--- a/baseline-sql/baseline.meta.json
+++ b/baseline-sql/baseline.meta.json
@@ -1,5 +1,5 @@
 {
-  "git_sha": "669bae0a1b302fcacdec495f9cff17da75d3206c",
+  "git_sha": "3a09d97fbb515258c7b4e2b08b7aa3b74f9e6831",
   "last_migration": {
     "admin": "0003_logentry_add_action_flag_choices",
     "admin_dashboard": "0001_initial",
@@ -52,7 +52,7 @@
     "orcid_integration": "0001_initial",
     "oswiadczenia": "0005_migrate_template_to_dbtemplate",
     "password_policies": "0003_update_passwordprofile",
-    "pbn_api": "0075_sentdata_fee_sent_sentdata_fee_uploaded_okay",
+    "pbn_api": "0077_constrainty_uuid_dyscyplin",
     "pbn_downloader_app": "0004_alter_error_message_fields",
     "pbn_export_queue": "0010_atomowa_kolejka_pbn",
     "pbn_import": "0012_alter_importinconsistency_inconsistency_type",

--- a/baseline-sql/baseline.sql
+++ b/baseline-sql/baseline.sql
@@ -17230,6 +17230,8 @@ COPY public.django_migrations (id, app, name, applied) FROM stdin;
 1088	import_pracownikow	0026_importpracownikow_uczelnia	2000-01-01 00:00:00+00
 1089	import_pracownikow	0027_profil_uczelnia	2000-01-01 00:00:00+00
 1090	bpp	0470_indeksy_gin_i_funkcyjne	2000-01-01 00:00:00+00
+1091	pbn_api	0076_unikalne_uuid_dyscyplin	2000-01-01 00:00:00+00
+1092	pbn_api	0077_constrainty_uuid_dyscyplin	2000-01-01 00:00:00+00
 \.
 
 
@@ -17595,21 +17597,6 @@ COPY public.formdefaults_formfieldrepresentation (id, name, label, klass, "order
 55	if_do	do	django.forms.fields.FloatField	7	nowe_raporty.forms_dynamiczne.RaportForm_raport_autorow
 56	tylko_punktowane	Tylko prace punktowane (pkt MNiSW > 0)	django.forms.fields.BooleanField	8	nowe_raporty.forms_dynamiczne.RaportForm_raport_autorow
 57	obiekt	Autor	django.forms.models.ModelChoiceField	9	nowe_raporty.forms_dynamiczne.RaportForm_raport_autorow
-133	od_roku	Od roku	django.forms.fields.IntegerField	1	raport_slotow.forms.autor.AutorRaportSlotowForm
-134	do_roku	Do roku	django.forms.fields.IntegerField	2	raport_slotow.forms.autor.AutorRaportSlotowForm
-135	od_roku	Od roku	django.forms.fields.IntegerField	0	raport_slotow.forms.ewaluacja.ParametryRaportSlotowEwaluacjaForm
-136	do_roku	Do roku	django.forms.fields.IntegerField	1	raport_slotow.forms.ewaluacja.ParametryRaportSlotowEwaluacjaForm
-137	od_roku	Od roku	django.forms.fields.IntegerField	0	raport_slotow.forms.uczelnia.UtworzRaportSlotowUczelniaForm
-138	do_roku	Do roku	django.forms.fields.IntegerField	1	raport_slotow.forms.uczelnia.UtworzRaportSlotowUczelniaForm
-139	slot	Slot	django.forms.fields.DecimalField	3	raport_slotow.forms.uczelnia.UtworzRaportSlotowUczelniaForm
-140	od_roku	Od roku	django.forms.fields.IntegerField	0	nowe_raporty.forms_dynamiczne.RaportForm_raport_uczelni
-141	do_roku	Do roku	django.forms.fields.IntegerField	1	nowe_raporty.forms_dynamiczne.RaportForm_raport_uczelni
-142	od_roku	Od roku	django.forms.fields.IntegerField	0	nowe_raporty.forms_dynamiczne.RaportForm_raport_wydzialow
-143	do_roku	Do roku	django.forms.fields.IntegerField	1	nowe_raporty.forms_dynamiczne.RaportForm_raport_wydzialow
-144	od_roku	Od roku	django.forms.fields.IntegerField	0	nowe_raporty.forms_dynamiczne.RaportForm_raport_jednostek
-145	do_roku	Do roku	django.forms.fields.IntegerField	1	nowe_raporty.forms_dynamiczne.RaportForm_raport_jednostek
-146	od_roku	Od roku	django.forms.fields.IntegerField	0	nowe_raporty.forms_dynamiczne.RaportForm_raport_autorow
-147	do_roku	Do roku	django.forms.fields.IntegerField	1	nowe_raporty.forms_dynamiczne.RaportForm_raport_autorow
 \.
 
 
@@ -19198,7 +19185,7 @@ SELECT pg_catalog.setval('public.django_countdown_sitecountdown_id_seq', 1, fals
 -- Name: django_migrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public.django_migrations_id_seq', 1090, true);
+SELECT pg_catalog.setval('public.django_migrations_id_seq', 1092, true);
 
 
 --
@@ -23102,11 +23089,27 @@ ALTER TABLE ONLY public.pbn_api_discipline
 
 
 --
+-- Name: pbn_api_discipline pbn_api_discipline_uuid_unikalny_w_slowniku; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pbn_api_discipline
+    ADD CONSTRAINT pbn_api_discipline_uuid_unikalny_w_slowniku UNIQUE (parent_group_id, uuid);
+
+
+--
 -- Name: pbn_api_disciplinegroup pbn_api_disciplinegroup_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.pbn_api_disciplinegroup
     ADD CONSTRAINT pbn_api_disciplinegroup_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pbn_api_disciplinegroup pbn_api_disciplinegroup_uuid_3309f8df_uniq; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pbn_api_disciplinegroup
+    ADD CONSTRAINT pbn_api_disciplinegroup_uuid_3309f8df_uniq UNIQUE (uuid);
 
 
 --

--- a/src/bpp/newsfragments/unikalne-uuid-dyscyplin-pbn.bugfix.rst
+++ b/src/bpp/newsfragments/unikalne-uuid-dyscyplin-pbn.bugfix.rst
@@ -1,0 +1,6 @@
+Naprawiono błąd, przez który import słownika dyscyplin z PBN mógł zablokować
+się trwale. Brak unikalności UUID-ów powodował, że dwa równoległe importy
+tworzyły zduplikowany słownik lub dyscyplinę, a od tego momentu każdy kolejny
+import przerywał się błędem ``MultipleObjectsReturned`` — aż do ręcznego
+uporządkowania bazy danych. Migracja scala istniejące duplikaty (przepinając
+powiązania tłumacza dyscyplin) i zakłada brakujące ograniczenia unikalności.

--- a/src/pbn_api/client/disciplines.py
+++ b/src/pbn_api/client/disciplines.py
@@ -1,6 +1,6 @@
 """Disciplines synchronization mixin for PBN API client."""
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 
 from import_common.core import (
     matchuj_aktualna_dyscypline_pbn,
@@ -9,6 +9,32 @@ from import_common.core import (
 from import_common.normalization import normalize_kod_dyscypliny
 from pbn_api.models import TlumaczDyscyplin
 from pbn_api.models.discipline import Discipline, DisciplineGroup
+
+
+def _update_or_create_odporne_na_wyscig(manager, defaults, **lookup):
+    """``update_or_create`` odporny na równoległy import.
+
+    Właściwej ochrony przed duplikatem dostarcza unikalny constraint na
+    (``uuid``) słownika i na (``parent_group``, ``uuid``) dyscypliny — bez
+    niego dwa równoległe importy po prostu tworzyły dwa wiersze. Constraint
+    sam w sobie zamienia jednak cichy duplikat w ``IntegrityError``, który
+    wywala cały import. Tutaj przegrany wyścig jest domykany: wiersz utworzony
+    przez równoległy proces zostaje pobrany i zaktualizowany.
+
+    ``transaction.atomic()`` w środku to savepoint — dzięki niemu
+    ``IntegrityError`` nie unieważnia transakcji zewnętrznej
+    (``download_disciplines`` jest ``@transaction.atomic``) i da się po nim
+    dalej odpytywać bazę.
+    """
+    try:
+        with transaction.atomic():
+            return manager.update_or_create(defaults=defaults, **lookup)
+    except IntegrityError:
+        obj = manager.get(**lookup)
+        for key, value in defaults.items():
+            setattr(obj, key, value)
+        obj.save()
+        return obj, False
 
 
 class DisciplinesMixin:
@@ -23,7 +49,8 @@ class DisciplinesMixin:
             validityDateTo = elem.get("validityDateTo", None)
             uuid = elem["uuid"]
 
-            parent_group, created = DisciplineGroup.objects.update_or_create(
+            parent_group, created = _update_or_create_odporne_na_wyscig(
+                DisciplineGroup.objects,
                 uuid=uuid,
                 defaults={
                     "validityDateFrom": validityDateFrom,
@@ -32,7 +59,8 @@ class DisciplinesMixin:
             )
 
             for discipline in elem["disciplines"]:
-                Discipline.objects.update_or_create(
+                _update_or_create_odporne_na_wyscig(
+                    Discipline.objects,
                     parent_group=parent_group,
                     uuid=discipline["uuid"],
                     defaults=dict(

--- a/src/pbn_api/migrations/0076_unikalne_uuid_dyscyplin.py
+++ b/src/pbn_api/migrations/0076_unikalne_uuid_dyscyplin.py
@@ -1,0 +1,118 @@
+"""Deduplikacja słowników/dyscyplin PBN (krok 1 z 2).
+
+``PBNClient.download_disciplines`` robił ``update_or_create`` po polach, na
+których nie było unikalnego constraintu. Dwa równoległe importy tworzyły
+duplikat, a od tego momentu każdy kolejny ``update_or_create`` rzucał
+``MultipleObjectsReturned`` — import dyscyplin blokował się nieodwracalnie.
+
+Zanim założymy constraint, trzeba zdeduplikować to, co już jest w bazie
+produkcyjnej — inaczej ``AddConstraint``/``AlterField`` wywali migrację.
+
+Zasada wyboru „którego zostawić": **najniższy pk**. Uzasadnienie:
+
+* to wiersz utworzony jako pierwszy, więc istniejące FK (``TlumaczDyscyplin``,
+  ``Discipline.parent_group``) z dużym prawdopodobieństwem wskazują właśnie na
+  niego → minimum przepięć i minimum zmian w danych,
+* jest deterministyczny (``last_updated_on`` to ``auto_now``, więc przy
+  duplikatach z tego samego przebiegu importu bywa identyczny co do
+  mikrosekundy i nie rozstrzyga),
+* wartości pól i tak nie mają znaczenia — najbliższy import PBN nadpisze
+  ocalały wiersz świeżymi danymi ze słownika.
+
+Same constrainty zakłada dopiero migracja ``0077``. To NIE jest kosmetyka:
+``DELETE`` na tabelach z FK zostawia w PostgreSQL oczekujące (deferred)
+zdarzenia wyzwalaczy, a ``ALTER TABLE ... ADD CONSTRAINT`` w tej samej
+transakcji wywala się wtedy na ``nie można ALTER TABLE ... ponieważ posiada
+oczekujące zdarzenia wyzwalaczy``. Rozdzielenie na dwie migracje daje DDL
+własną, czystą transakcję.
+"""
+
+import logging
+
+from django.db import migrations, models
+
+logger = logging.getLogger(__name__)
+
+
+def _grupy_duplikatow(model, pola):
+    """Zwraca listę list pk-ów: po jednej liście na każdy zduplikowany klucz."""
+    duplikaty = (
+        model.objects.values(*pola)
+        .annotate(ile=models.Count("pk"))
+        .filter(ile__gt=1)
+        .order_by()
+    )
+    return [
+        list(
+            model.objects.filter(**{pole: wpis[pole] for pole in pola})
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+        for wpis in duplikaty
+    ]
+
+
+def deduplikuj(apps, schema_editor):
+    DisciplineGroup = apps.get_model("pbn_api", "DisciplineGroup")
+    Discipline = apps.get_model("pbn_api", "Discipline")
+    TlumaczDyscyplin = apps.get_model("pbn_api", "TlumaczDyscyplin")
+
+    # --- Krok 1: słowniki dyscyplin (unikalny sam ``uuid``) ---------------
+    scalone_grupy = 0
+    for pk_i in _grupy_duplikatow(DisciplineGroup, ["uuid"]):
+        zostaje, do_scalenia = pk_i[0], pk_i[1:]
+        Discipline.objects.filter(parent_group_id__in=do_scalenia).update(
+            parent_group_id=zostaje
+        )
+        DisciplineGroup.objects.filter(pk__in=do_scalenia).delete()
+        scalone_grupy += len(do_scalenia)
+        logger.warning(
+            "pbn_api.DisciplineGroup: scalono %s duplikat(ów) w wiersz pk=%s",
+            len(do_scalenia),
+            zostaje,
+        )
+
+    # --- Krok 2: dyscypliny (unikalna para słownik + uuid) ----------------
+    # Krok 1 mógł dopiero co wygenerować nowe kolizje, przepinając dyscypliny
+    # z kasowanych słowników na ocalały — dlatego liczymy je tutaj, PO nim.
+    scalone_dyscypliny = 0
+    for pk_i in _grupy_duplikatow(Discipline, ["parent_group_id", "uuid"]):
+        zostaje, do_scalenia = pk_i[0], pk_i[1:]
+        for pole in ("pbn_2017_2021", "pbn_2022_2023", "pbn_2024_now"):
+            TlumaczDyscyplin.objects.filter(
+                **{f"{pole}_id__in": do_scalenia}
+            ).update(**{f"{pole}_id": zostaje})
+        Discipline.objects.filter(pk__in=do_scalenia).delete()
+        scalone_dyscypliny += len(do_scalenia)
+        logger.warning(
+            "pbn_api.Discipline: scalono %s duplikat(ów) w wiersz pk=%s",
+            len(do_scalenia),
+            zostaje,
+        )
+
+    logger.warning(
+        "Deduplikacja PBN zakończona: usunięto %s zduplikowanych słowników "
+        "i %s zduplikowanych dyscyplin.",
+        scalone_grupy,
+        scalone_dyscypliny,
+    )
+
+
+def deduplikuj_wstecz(apps, schema_editor):
+    """Deduplikacji się nie cofa.
+
+    Usunięte wiersze były duplikatami powstałymi z błędu — ich odtworzenie nie
+    jest ani możliwe (nie mamy ich pk-ów), ani pożądane. Migracja wstecz zdejmuje
+    tylko constrainty (w ``0077``); dane pozostają zdeduplikowane.
+    """
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pbn_api", "0075_sentdata_fee_sent_sentdata_fee_uploaded_okay"),
+    ]
+
+    operations = [
+        migrations.RunPython(deduplikuj, deduplikuj_wstecz),
+    ]

--- a/src/pbn_api/migrations/0077_constrainty_uuid_dyscyplin.py
+++ b/src/pbn_api/migrations/0077_constrainty_uuid_dyscyplin.py
@@ -1,0 +1,30 @@
+"""Unikalność UUID słowników/dyscyplin PBN (krok 2 z 2).
+
+Deduplikacja jest w ``0076`` — osobna migracja, bo ``DELETE`` na tabelach z FK
+zostawia w PostgreSQL oczekujące zdarzenia wyzwalaczy i ``ALTER TABLE ... ADD
+CONSTRAINT`` w tej samej transakcji się wywala.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pbn_api", "0076_unikalne_uuid_dyscyplin"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="disciplinegroup",
+            name="uuid",
+            field=models.UUIDField(unique=True),
+        ),
+        migrations.AddConstraint(
+            model_name="discipline",
+            constraint=models.UniqueConstraint(
+                fields=("parent_group", "uuid"),
+                name="pbn_api_discipline_uuid_unikalny_w_slowniku",
+            ),
+        ),
+    ]

--- a/src/pbn_api/models/discipline.py
+++ b/src/pbn_api/models/discipline.py
@@ -16,7 +16,11 @@ class DisciplineGroupManager(models.Manager):
 
 
 class DisciplineGroup(BasePBNModel):
-    uuid = models.UUIDField()
+    # unique=True: ``PBNClient.download_disciplines`` robi lookup po samym
+    # ``uuid``. Bez unikalności dwa równoległe importy tworzyły duplikat, a od
+    # tego momentu KAŻDY kolejny ``update_or_create(uuid=...)`` rzucał
+    # ``MultipleObjectsReturned`` — import dyscyplin blokował się na twardo.
+    uuid = models.UUIDField(unique=True)
     validityDateFrom = models.DateField()
     validityDateTo = models.DateField(null=True, blank=True)
 
@@ -63,6 +67,18 @@ class Discipline(BasePBNModel):
         verbose_name = "Dyscyplina PBN"
         verbose_name_plural = "Dyscypliny PBN"
         ordering = ("name", "code")
+        constraints = [
+            # UWAGA: ``uuid`` dyscypliny NIE jest w PBN unikalny globalnie —
+            # ta sama dyscyplina występuje pod tym samym ``uuid`` w wielu
+            # słownikach (w fixture 44 z 59 uuid-ów powtarza się między
+            # słownikiem 2018-2022 a 2022-teraz). Unikalna jest dopiero para
+            # (słownik, uuid) — i dokładnie po takiej parze robi lookup
+            # ``PBNClient.download_disciplines``.
+            models.UniqueConstraint(
+                fields=["parent_group", "uuid"],
+                name="pbn_api_discipline_uuid_unikalny_w_slowniku",
+            )
+        ]
 
     def __str__(self):
         ret = f"Dyscyplina {self.name} ("

--- a/src/pbn_api/tests/test_discipline_uuid_unique.py
+++ b/src/pbn_api/tests/test_discipline_uuid_unique.py
@@ -1,0 +1,235 @@
+"""Testy unikalności UUID słowników i dyscyplin PBN.
+
+Bug: ``PBNClient.download_disciplines`` robił ``update_or_create`` po polach
+bez unikalnego constraintu. Po powstaniu pierwszego duplikatu każdy kolejny
+import wywalał się na ``MultipleObjectsReturned`` — na twardo, aż do ręcznego
+sprzątnięcia bazy.
+"""
+
+import importlib
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from django.apps import apps as django_apps
+from django.core.exceptions import MultipleObjectsReturned
+from django.db import IntegrityError, connection, transaction
+
+from bpp.decorators import json
+from bpp.models import Dyscyplina_Naukowa
+from pbn_api.const import PBN_GET_DISCIPLINES_URL
+from pbn_api.models import TlumaczDyscyplin
+from pbn_api.models.discipline import Discipline, DisciplineGroup
+
+MIGRACJA = importlib.import_module("pbn_api.migrations.0076_unikalne_uuid_dyscyplin")
+
+
+def _zaladuj_fixture_dyscyplin(pbn_client):
+    fixture_path = Path(__file__).parent / "fixture_test_get_disciplines.json"
+    with open(fixture_path, "rb") as f:
+        pbn_client.transport.return_values[PBN_GET_DISCIPLINES_URL] = json.loads(
+            f.read()
+        )
+
+
+def _zdejmij_constrainty_unikalnosci():
+    """Zdejmuje unikalne constrainty, żeby dało się WYPRODUKOWAĆ duplikaty.
+
+    PostgreSQL wykonuje DDL transakcyjnie, więc rollback testu przywraca
+    constrainty — nie zostawiamy po sobie zmienionego schematu.
+    """
+    with connection.cursor() as cursor:
+        for tabela in ("pbn_api_disciplinegroup", "pbn_api_discipline"):
+            cursor.execute(
+                """
+                SELECT conname FROM pg_constraint
+                WHERE conrelid = %s::regclass AND contype = 'u'
+                """,
+                [tabela],
+            )
+            for (conname,) in cursor.fetchall():
+                cursor.execute(f'ALTER TABLE {tabela} DROP CONSTRAINT "{conname}"')
+
+
+@pytest.mark.django_db
+def test_download_disciplines_dwa_razy_nie_tworzy_duplikatow(pbn_client):
+    """Dwukrotny import tego samego słownika nie mnoży wierszy."""
+    _zaladuj_fixture_dyscyplin(pbn_client)
+
+    pbn_client.download_disciplines()
+    grup_po_pierwszym = DisciplineGroup.objects.count()
+    dyscyplin_po_pierwszym = Discipline.objects.count()
+    assert dyscyplin_po_pierwszym > 0
+
+    pbn_client.download_disciplines()
+
+    assert DisciplineGroup.objects.count() == grup_po_pierwszym
+    assert Discipline.objects.count() == dyscyplin_po_pierwszym
+
+
+@pytest.mark.django_db
+def test_baza_odrzuca_duplikat_uuid_slownika():
+    """Constraint na ``DisciplineGroup.uuid`` faktycznie działa w bazie."""
+    wspolny_uuid = uuid4()
+    DisciplineGroup.objects.create(uuid=wspolny_uuid, validityDateFrom="2024-01-01")
+
+    with pytest.raises(IntegrityError), transaction.atomic():
+        DisciplineGroup.objects.create(
+            uuid=wspolny_uuid, validityDateFrom="2025-01-01"
+        )
+
+
+@pytest.mark.django_db
+def test_baza_odrzuca_duplikat_dyscypliny_w_slowniku():
+    """Constraint na parę (słownik, uuid) faktycznie działa w bazie."""
+    grupa = DisciplineGroup.objects.create(
+        uuid=uuid4(), validityDateFrom="2024-01-01"
+    )
+    wspolny_uuid = uuid4()
+    Discipline.objects.create(
+        parent_group=grupa, uuid=wspolny_uuid, code="1.1", name="a"
+    )
+
+    with pytest.raises(IntegrityError), transaction.atomic():
+        Discipline.objects.create(
+            parent_group=grupa, uuid=wspolny_uuid, code="1.1", name="b"
+        )
+
+
+@pytest.mark.django_db
+def test_ten_sam_uuid_dyscypliny_dozwolony_w_roznych_slownikach():
+    """UUID dyscypliny NIE jest w PBN unikalny globalnie — tylko w słowniku.
+
+    Regresja na wypadek, gdyby ktoś „naprawił" to constraintem na samym
+    ``uuid``: PBN powtarza uuid dyscypliny między kolejnymi słownikami.
+    """
+    wspolny_uuid = uuid4()
+    for rok in (2018, 2022):
+        grupa = DisciplineGroup.objects.create(
+            uuid=uuid4(), validityDateFrom=f"{rok}-01-01"
+        )
+        Discipline.objects.create(
+            parent_group=grupa, uuid=wspolny_uuid, code="1.1", name="a"
+        )
+
+    assert Discipline.objects.filter(uuid=wspolny_uuid).count() == 2
+
+
+@pytest.mark.django_db
+def test_migracja_deduplikuje_slowniki_i_przepina_dyscypliny():
+    """Duplikat słownika: zostaje najniższy pk, dyscypliny lecą na niego."""
+    _zdejmij_constrainty_unikalnosci()
+
+    wspolny_uuid = uuid4()
+    zostaje = DisciplineGroup.objects.create(
+        uuid=wspolny_uuid, validityDateFrom="2024-01-01"
+    )
+    duplikat = DisciplineGroup.objects.create(
+        uuid=wspolny_uuid, validityDateFrom="2024-01-01"
+    )
+    assert duplikat.pk > zostaje.pk
+
+    d_uuid = uuid4()
+    Discipline.objects.create(
+        parent_group=zostaje, uuid=d_uuid, code="1.1", name="a"
+    )
+    # ta sama dyscyplina wisząca pod duplikatem słownika — po przepięciu
+    # zrobi się z tego kolizja (słownik, uuid), którą krok 2 musi domknąć
+    Discipline.objects.create(
+        parent_group=duplikat, uuid=d_uuid, code="1.1", name="a"
+    )
+    # dyscyplina występująca WYŁĄCZNIE pod duplikatem — nie wolno jej zgubić
+    inny_uuid = uuid4()
+    Discipline.objects.create(
+        parent_group=duplikat, uuid=inny_uuid, code="2.2", name="b"
+    )
+
+    MIGRACJA.deduplikuj(django_apps, None)
+
+    assert DisciplineGroup.objects.filter(uuid=wspolny_uuid).count() == 1
+    assert DisciplineGroup.objects.filter(pk=zostaje.pk).exists()
+    assert Discipline.objects.filter(parent_group=zostaje).count() == 2
+    assert Discipline.objects.filter(
+        parent_group=zostaje, uuid=inny_uuid
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_migracja_przepina_fk_tlumacza_dyscyplin():
+    """Duplikat dyscypliny: FK z ``TlumaczDyscyplin`` idą na ocalały wiersz."""
+    _zdejmij_constrainty_unikalnosci()
+
+    grupa = DisciplineGroup.objects.create(
+        uuid=uuid4(), validityDateFrom="2024-01-01"
+    )
+    d_uuid = uuid4()
+    zostaje = Discipline.objects.create(
+        parent_group=grupa, uuid=d_uuid, code="1.1", name="a"
+    )
+    duplikat = Discipline.objects.create(
+        parent_group=grupa, uuid=d_uuid, code="1.1", name="a"
+    )
+    assert duplikat.pk > zostaje.pk
+
+    dyscyplina_bpp = Dyscyplina_Naukowa.objects.create(kod="1.1", nazwa="a")
+    tlumacz = TlumaczDyscyplin.objects.create(
+        dyscyplina_w_bpp=dyscyplina_bpp,
+        pbn_2017_2021=duplikat,
+        pbn_2022_2023=duplikat,
+        pbn_2024_now=duplikat,
+    )
+
+    MIGRACJA.deduplikuj(django_apps, None)
+
+    assert Discipline.objects.filter(uuid=d_uuid).count() == 1
+    tlumacz.refresh_from_db()
+    assert tlumacz.pbn_2017_2021_id == zostaje.pk
+    assert tlumacz.pbn_2022_2023_id == zostaje.pk
+    assert tlumacz.pbn_2024_now_id == zostaje.pk
+
+
+@pytest.mark.django_db
+def test_multiple_objects_returned_znika_po_deduplikacji(pbn_client):
+    """Pełny scenariusz buga: duplikat → zakleszczony import → naprawa."""
+    _zdejmij_constrainty_unikalnosci()
+
+    wspolny_uuid = uuid4()
+    for _ in range(2):
+        DisciplineGroup.objects.create(
+            uuid=wspolny_uuid, validityDateFrom="2024-01-01"
+        )
+
+    # PRZED naprawą: import zakleszczony na twardo
+    with pytest.raises(MultipleObjectsReturned):
+        DisciplineGroup.objects.update_or_create(
+            uuid=wspolny_uuid, defaults={"validityDateFrom": "2025-01-01"}
+        )
+
+    MIGRACJA.deduplikuj(django_apps, None)
+
+    # PO naprawie: znowu działa
+    grupa, created = DisciplineGroup.objects.update_or_create(
+        uuid=wspolny_uuid, defaults={"validityDateFrom": "2025-01-01"}
+    )
+    assert not created
+    assert DisciplineGroup.objects.filter(uuid=wspolny_uuid).count() == 1
+
+    # ...a pełny import przechodzi bez wywrotki
+    _zaladuj_fixture_dyscyplin(pbn_client)
+    pbn_client.download_disciplines()
+    assert Discipline.objects.count() > 0
+
+
+@pytest.mark.django_db
+def test_deduplikuj_jest_idempotentne_na_czystej_bazie(pbn_client):
+    """Migracja na bazie BEZ duplikatów niczego nie rusza."""
+    _zaladuj_fixture_dyscyplin(pbn_client)
+    pbn_client.download_disciplines()
+
+    grup = DisciplineGroup.objects.count()
+    dyscyplin = Discipline.objects.count()
+
+    MIGRACJA.deduplikuj(django_apps, None)
+
+    assert DisciplineGroup.objects.count() == grup
+    assert Discipline.objects.count() == dyscyplin

--- a/src/pbn_api/tests/test_migracja_dyscypliny_uuid_e2e.py
+++ b/src/pbn_api/tests/test_migracja_dyscypliny_uuid_e2e.py
@@ -1,0 +1,86 @@
+"""Prawdziwy ``migrate`` 0075 → 0077 na bazie, która JUŻ zawiera duplikaty.
+
+Ten test nie jest ozdobą: pierwotna wersja poprawki trzymała deduplikację i
+``ADD CONSTRAINT`` w JEDNEJ migracji i wywalała się tutaj na
+``nie można ALTER TABLE ... ponieważ posiada oczekujące zdarzenia wyzwalaczy``
+(PostgreSQL nie pozwala na DDL w transakcji, w której ``DELETE`` na tabeli z FK
+zostawił deferred trigger events). Testy wołające samą funkcję ``deduplikuj``
+tego nie łapią — trzeba przepuścić prawdziwy ``MigrationExecutor``.
+"""
+
+from uuid import uuid4
+
+import pytest
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+
+PRZED = ("pbn_api", "0075_sentdata_fee_sent_sentdata_fee_uploaded_okay")
+PO = ("pbn_api", "0077_constrainty_uuid_dyscyplin")
+
+
+def _wstaw_duplikaty(uuid_slownika, uuid_dyscypliny):
+    """Wstawia duplikaty surowym SQL-em — modele Django by ich nie wpuściły."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO pbn_api_disciplinegroup "
+            '(uuid, "validityDateFrom", created_on, last_updated_on) '
+            "VALUES (%s, '2024-01-01', now(), now()), "
+            "(%s, '2024-01-01', now(), now()) RETURNING id",
+            [uuid_slownika, uuid_slownika],
+        )
+        for (id_slownika,) in cursor.fetchall():
+            cursor.execute(
+                "INSERT INTO pbn_api_discipline (parent_group_id, uuid, code, "
+                'name, "polonCode", "scientificFieldName", created_on, '
+                "last_updated_on) "
+                "VALUES (%s, %s, '1.1', 'a', '', '', now(), now())",
+                [id_slownika, uuid_dyscypliny],
+            )
+
+
+def _policz(sql, *params):
+    with connection.cursor() as cursor:
+        cursor.execute(sql, params)
+        return cursor.fetchone()[0]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_migracja_przechodzi_na_bazie_z_duplikatami():
+    uuid_slownika, uuid_dyscypliny = uuid4(), uuid4()
+
+    MigrationExecutor(connection).migrate([PRZED])
+    _wstaw_duplikaty(uuid_slownika, uuid_dyscypliny)
+
+    assert (
+        _policz(
+            "SELECT count(*) FROM pbn_api_disciplinegroup WHERE uuid=%s",
+            uuid_slownika,
+        )
+        == 2
+    )
+
+    # to jest właściwy asert: migracja NIE wywala się na bazie z duplikatami
+    executor = MigrationExecutor(connection)
+    executor.loader.build_graph()
+    executor.migrate([PO])
+
+    assert (
+        _policz(
+            "SELECT count(*) FROM pbn_api_disciplinegroup WHERE uuid=%s",
+            uuid_slownika,
+        )
+        == 1
+    )
+    assert (
+        _policz(
+            "SELECT count(*) FROM pbn_api_discipline WHERE uuid=%s", uuid_dyscypliny
+        )
+        == 1
+    )
+    assert (
+        _policz(
+            "SELECT count(*) FROM pg_constraint WHERE conname=%s",
+            "pbn_api_discipline_uuid_unikalny_w_slowniku",
+        )
+        == 1
+    )


### PR DESCRIPTION
## Problem

`PBNClient.download_disciplines` robił `update_or_create` po polach, na których nie było unikalnego constraintu:

- `DisciplineGroup.objects.update_or_create(uuid=...)` — `uuid` był zwykłym `UUIDField()`
- `Discipline.objects.update_or_create(parent_group=..., uuid=...)` — brak `unique_together`

Dwa równoległe importy tworzyły duplikat, a od tego momentu **każdy** kolejny `update_or_create` rzucał `MultipleObjectsReturned` → import dyscyplin PBN blokował się nieodwracalnie, do ręcznego sprzątnięcia bazy.

## Kluczowe ustalenie: uuid dyscypliny NIE jest globalnie unikalny

Zanim założyłem constraint, sprawdziłem realne dane PBN (`fixture_test_get_disciplines.json`): **44 z 59** uuid-ów dyscyplin powtarza się między słownikiem 2018-2022 a 2022-teraz. Constraint na samym `Discipline.uuid` byłby destrukcyjny — scaliłby rekordy z różnych słowników i rozwalił import.

Unikalna jest dopiero para **(parent_group, uuid)** — i dokładnie po takiej parze robi lookup klient. `DisciplineGroup.uuid` jest natomiast unikalny globalnie.

Jest test regresyjny pilnujący, żeby ktoś tego „nie naprawił" constraintem na samym uuid.

## Migracja: 0076 (deduplikacja) + 0077 (constrainty)

**Dlaczego dwie migracje, a nie jedna:** pierwsza wersja trzymała jedno i drugie razem i **wywalała się** na bazie z duplikatami:

```
django.db.utils.OperationalError: nie można ALTER TABLE "pbn_api_disciplinegroup"
ponieważ posiada oczekujące zdarzenia wyzwalaczy
```

`DELETE` na tabelach z FK zostawia w PostgreSQL deferred trigger events, a `ALTER TABLE ... ADD CONSTRAINT` w tej samej transakcji jest wtedy niedozwolony. Rozdzielenie daje DDL własną, czystą transakcję. Złapał to dopiero test e2e przepuszczający prawdziwy `MigrationExecutor` — testy wołające samą funkcję dedup tego nie widzą.

**Który wiersz zostaje: najniższy pk.** Uzasadnienie:
- utworzony jako pierwszy, więc istniejące FK najpewniej wskazują właśnie na niego → minimum przepięć,
- deterministyczny (`last_updated_on` to `auto_now`, przy duplikatach z jednego przebiegu importu bywa identyczny i nie rozstrzyga),
- wartości pól nie mają znaczenia — najbliższy import PBN i tak nadpisze ocalały wiersz.

**Przepinane FK** (sprawdzone grepem — to wszystkie, które wskazują na te modele):
- `Discipline.parent_group` → przy scalaniu słowników
- `TlumaczDyscyplin.pbn_2017_2021` / `pbn_2022_2023` / `pbn_2024_now` → przy scalaniu dyscyplin

Deduplikacja dyscyplin leci **po** deduplikacji słowników, bo ta pierwsza może dopiero co wygenerować nowe kolizje (przepięcie dyscyplin z kasowanego słownika na ocalały). `RunPython` ma `reverse_code` (no-op z komentarzem — deduplikacji się nie cofa) i loguje liczbę scaleń.

## Kod klienta

Sam constraint zamienia cichy duplikat w `IntegrityError`, który wywala cały import. `_update_or_create_odporne_na_wyscig` domyka przegrany wyścig: pobiera wiersz utworzony przez równoległy proces i aktualizuje go. Wewnętrzny `transaction.atomic()` to savepoint — bez niego `IntegrityError` unieważniłby transakcję zewnętrzną (`download_disciplines` jest `@transaction.atomic`).

## Inne miejsca robiące lookup po uuid

Sprawdzone — brak. Poza klientem `uuid` tych modeli jest używany tylko w `search_fields` admina (`parent_group__uuid`). `import_common.core.dyscyplina` szuka po `code`/`name` + zakresie dat słownika. Fixture'y (`conftest.py`, `fixtures/conftest_disciplines.py`) generują `uuid4()` w `defaults` — bezpieczne.

## Testy

`src/pbn_api/tests/test_discipline_uuid_unique.py` (8 testów) + `test_migracja_dyscypliny_uuid_e2e.py` (1):

- dwa `download_disciplines()` nie tworzą duplikatów
- baza odrzuca duplikat uuid słownika / pary (słownik, uuid)
- ten sam uuid dyscypliny **wolno** mieć w różnych słownikach (regresja)
- migracja scala słowniki i przepina dyscypliny (w tym dyscyplinę istniejącą wyłącznie pod duplikatem — nie wolno jej zgubić)
- migracja przepina wszystkie 3 FK `TlumaczDyscyplin`
- pełny scenariusz buga: duplikat → `MultipleObjectsReturned` → dedup → znowu działa
- dedup idempotentny na czystej bazie
- **e2e:** prawdziwy `migrate` 0075 → 0077 na bazie z duplikatami wstawionymi surowym SQL-em

Duplikaty produkuję zdejmując constrainty przez `ALTER TABLE ... DROP CONSTRAINT` — PostgreSQL wykonuje DDL transakcyjnie, więc rollback testu przywraca schemat.

## Weryfikacja

- `uv run pytest src/pbn_api/ src/pbn_integrator/ -q` → **526 passed**
- `uv run pytest src/import_common/ src/pbn_import/ src/pbn_komparator_zrodel/ src/rozbieznosci_dyscyplin/ src/pbn_wysylka_oswiadczen/ src/komparator_pbn_udzialy/ -q` → **942 passed**
- `makemigrations --check` → No changes detected
- `make baseline-update` → wykonane, oba pliki w commicie (diff 21+/18-)
- `uv run pre-commit` → wszystko Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX