### PR TITLE
fix(cache): snippet Google Analytics nie wycieka między uczelniami

### DIFF
--- a/src/bpp/apps.py
+++ b/src/bpp/apps.py
@@ -67,10 +67,23 @@ class BppConfig(AppConfig):
         "Typ_KBN",
         "Jezyk",
         "Wydawca",
-        "Konferencja",
         "Seria_Wydawnicza",
         "Status_Korekty",
         "Typ_Odpowiedzialnosci",
+        # `Konferencja` CELOWO nie jest tu wymieniona — z tego samego powodu,
+        # dla którego nie ma jej w CACHEOPS (settings/production.py):
+        # `pbn_integrator.utils.conferences.integruj_konferencje` robi
+        # bezwarunkowy save() na KAŻDYM wierszu, każdy w osobnym atomic().
+        # Podpięta pod post_save oznaczałaby tyle bumpów generacji, ile
+        # konferencji w PBN — czyli wyzerowanie CAŁEGO cache'a stron
+        # publicznych na czas przebiegu integratora i zimny start po nim.
+        # A zyskać nie ma czego: nazwa konferencji nie pojawia się w ŻADNYM
+        # szablonie renderowanym przez widoki objęte cache'em (`lata`, `rok`,
+        # `autorzy`, `zrodla`, `jednostki`, `praca`) — widok materializowany
+        # `Rekord` niesie wyłącznie `konferencja_id`, nie nazwę. Inwalidacja
+        # nie mogłaby więc naprawić żadnej nieświeżej strony. Gdyby kiedyś
+        # nazwa konferencji trafiła na stronę publiczną, wróć tu — ale
+        # najpierw napraw integrator („zapisuj tylko gdy się zmieniło").
     )
 
     def _podepnij_inwalidacje_cache_publicznego(self):

--- a/src/bpp/newsfragments/cache-google-analytics-per-uczelnia.bugfix.rst
+++ b/src/bpp/newsfragments/cache-google-analytics-per-uczelnia.bugfix.rst
@@ -1,0 +1,7 @@
+Naprawiono wyciek identyfikatora Google Analytics między uczelniami w
+instalacjach wielo-uczelnianych. Snippet GA był cache'owany w szablonie pod
+globalnym kluczem, mimo że ``GOOGLE_ANALYTICS_PROPERTY_ID`` jest ustawiany
+per-uczelnia — pierwszy odwiedzający jednej uczelni „rozgrzewał" fragment
+swoim identyfikatorem, a przez kolejną godzinę goście pozostałych uczelni
+dostawali cudzy snippet, przez co ich ruch raportował się do konta Google
+innej instytucji. Fragment nie jest już cache'owany.

--- a/src/bpp/newsfragments/cache-publiczny-bez-konferencji.feature.rst
+++ b/src/bpp/newsfragments/cache-publiczny-bez-konferencji.feature.rst
@@ -1,0 +1,4 @@
+Zapis konferencji nie unieważnia już cache'u publicznych stron przeglądania.
+Nazwa konferencji nie jest renderowana na żadnej z tych stron, a integrator
+PBN zapisuje każdą konferencję bezwarunkowo — w efekcie każdy przebieg
+integratora zerował cały cache i strony publiczne startowały po nim na zimno.

--- a/src/bpp/newsfragments/wydajnosc-p0.feature.rst
+++ b/src/bpp/newsfragments/wydajnosc-p0.feature.rst
@@ -3,4 +3,6 @@ wykonuje już pełnoskanowego ``UPDATE`` na tabeli wiadomości przy każdym
 requeście zalogowanego użytkownika (odsiew tanim zapytaniem po
 zaindeksowanym ``user_id``), a cache ``cacheops`` objął rozstrzyganie
 domena→``Site``, grupy uprawnień oraz słowniki (tytuł, język, typ KBN,
-charakter formalny, funkcja autora, dyscyplina naukowa, konferencja).
+charakter formalny, funkcja autora, dyscyplina naukowa). Konferencje
+celowo pozostają poza ``cacheops`` — integrator PBN zapisuje każdy rekord
+bezwarunkowo, więc cache generowałby tysiące inwalidacji na przebieg.

--- a/src/bpp/tests/test_views/test_cache_fragmentow_vary_on.py
+++ b/src/bpp/tests/test_views/test_cache_fragmentow_vary_on.py
@@ -20,22 +20,59 @@ KATALOG_ZRODEL = Path(__file__).resolve().parents[3]
 #: że ich treść NIE zależy od hosta/uczelni/użytkownika.
 #:
 #: * ``favicon`` (``django_bpp/templates/bare.html``) — renderuje
-#:   ``{% place_favicon %}`` z pakietu ``django-favicon-plus``, który pyta
-#:   ``Favicon.on_site`` (``CurrentSiteManager``). Ten manager filtruje po
-#:   ``Site.objects.get_current()``, a ta — wywołana bez ``request`` —
-#:   czyta STAŁE ``settings.SITE_ID``. ``SiteResolutionMiddleware`` nie
-#:   podmienia ``SITE_ID`` per request (ustawia tylko ``request.site`` i
-#:   ``request._uczelnia``), więc wynik jest identyczny pod każdą domeną i
-#:   globalny klucz jest poprawny. (Osobna sprawa, że favicon przez to w
-#:   ogóle nie podąża za hostem — to ograniczenie pakietu, nie cache'a.)
+#:   ``{% place_favicon %}`` z ``django-favicon-plus-reloaded``, który pyta
+#:   ``Favicon.on_site``, czyli ``CurrentSiteManager``. Jego
+#:   ``get_queryset()`` (``django/contrib/sites/managers.py``) filtruje
+#:   ``.filter(site__id=settings.SITE_ID)`` — BEZPOŚREDNIO po literalnym
+#:   ``settings.SITE_ID``, a nie przez ``Site.objects.get_current()``
+#:   (``get_current()`` siedzi w ``Favicon.save()``, czyli w ścieżce
+#:   ZAPISU, nie odczytu). ``SiteResolutionMiddleware`` nie podmienia
+#:   ``SITE_ID`` per request (ustawia tylko ``request.site`` i
+#:   ``request._uczelnia``), więc odczyt daje ten sam wiersz pod każdą
+#:   domeną i globalny klucz cache'a jest poprawny.
+#:
+#:   UWAGA dla czytającego tę listę: to NIE jest zamierzone zachowanie
+#:   multi-tenant. Favicon w ogóle nie podąża za hostem — wszystkie
+#:   uczelnie dostają favicon site'u o ``SITE_ID``. To pre-existing
+#:   ograniczenie ``django-favicon-plus-reloaded`` (poza zakresem tego
+#:   testu), a nie skutek cache'owania. Gdyby ktoś kiedyś naprawił
+#:   rozdzielczość faviconu per-host, ten wpis MUSI zniknąć z listy, a
+#:   fragment dostać ``vary_on``.
 DOZWOLONE_BEZ_VARY_ON = {"favicon"}
 
 TAG_CACHE = re.compile(r"{%\s*cache\s+(?P<argumenty>[^%]*?)\s*%}")
 
+#: Katalogi, które nie zawierają szablonów Django renderowanych przez BPP:
+#: artefakty builda/instalacji oraz pliki statyczne (serwowane dosłownie,
+#: nigdy nie przechodzą przez silnik szablonów).
+POMIJANE_KATALOGI = frozenset(
+    (
+        "node_modules",
+        "staticroot",
+        "static",
+        "site-packages",
+        "__pycache__",
+        ".venv",
+        ".tox",
+        "htmlcov",
+    )
+)
+
 
 def _szablony():
-    for katalog in ("bpp", "django_bpp"):
-        yield from (KATALOG_ZRODEL / katalog).rglob("*.html")
+    """Wszystkie szablony pod ``src/`` — CAŁE drzewo, nie tylko ``bpp``.
+
+    Zasięg celowo obejmuje każdą aplikację (``admin_dashboard``,
+    ``rozbieznosci_dyscyplin``, ``ewaluacja_optymalizacja``, …): tag
+    dodany poza ``bpp`` jest dokładnie tym przypadkiem, dla którego ten
+    strażnik istnieje.
+    """
+    for sciezka in KATALOG_ZRODEL.rglob("*.html"):
+        # Tylko część WZGLĘDNA — gdyby któryś katalog NAD repo nazywał się
+        # np. "static", filtr po pełnej ścieżce wyciszyłby cały test.
+        wzgledna = sciezka.relative_to(KATALOG_ZRODEL)
+        if POMIJANE_KATALOGI.isdisjoint(wzgledna.parts):
+            yield sciezka
 
 
 def test_kazdy_fragment_cache_ma_vary_on_albo_alibi():

--- a/src/bpp/tests/test_views/test_cache_fragmentow_vary_on.py
+++ b/src/bpp/tests/test_views/test_cache_fragmentow_vary_on.py
@@ -1,0 +1,60 @@
+"""Każdy fragment-cache w szablonach musi mieć ``vary_on`` — albo alibi.
+
+DLACZEGO to musi istnieć: BPP jest wielo-uczelniane (jeden proces, wiele
+domen; ``SiteResolutionMiddleware`` rozstrzyga Host → Site → Uczelnia).
+Fragment cache'owany pod GLOBALNYM kluczem serwuje treść uczelni A pod
+domeną uczelni B. Tak zdarzyło się ze snippetem Google Analytics
+(``{% cache 3600 google %}`` w ``base.html``) — ruch jednej uczelni
+raportował się do konta Google innej.
+
+Test wymusza świadomą decyzję: albo fragment ma ``vary_on``, albo trafia
+na listę wyjątków RAZEM z uzasadnieniem, dlaczego jest host-niezależny.
+"""
+
+import re
+from pathlib import Path
+
+KATALOG_ZRODEL = Path(__file__).resolve().parents[3]
+
+#: Fragmenty cache'owane pod globalnym kluczem, dla których udowodniono,
+#: że ich treść NIE zależy od hosta/uczelni/użytkownika.
+#:
+#: * ``favicon`` (``django_bpp/templates/bare.html``) — renderuje
+#:   ``{% place_favicon %}`` z pakietu ``django-favicon-plus``, który pyta
+#:   ``Favicon.on_site`` (``CurrentSiteManager``). Ten manager filtruje po
+#:   ``Site.objects.get_current()``, a ta — wywołana bez ``request`` —
+#:   czyta STAŁE ``settings.SITE_ID``. ``SiteResolutionMiddleware`` nie
+#:   podmienia ``SITE_ID`` per request (ustawia tylko ``request.site`` i
+#:   ``request._uczelnia``), więc wynik jest identyczny pod każdą domeną i
+#:   globalny klucz jest poprawny. (Osobna sprawa, że favicon przez to w
+#:   ogóle nie podąża za hostem — to ograniczenie pakietu, nie cache'a.)
+DOZWOLONE_BEZ_VARY_ON = {"favicon"}
+
+TAG_CACHE = re.compile(r"{%\s*cache\s+(?P<argumenty>[^%]*?)\s*%}")
+
+
+def _szablony():
+    for katalog in ("bpp", "django_bpp"):
+        yield from (KATALOG_ZRODEL / katalog).rglob("*.html")
+
+
+def test_kazdy_fragment_cache_ma_vary_on_albo_alibi():
+    bez_vary_on = []
+
+    for szablon in _szablony():
+        for dopasowanie in TAG_CACHE.finditer(szablon.read_text(encoding="utf-8")):
+            argumenty = dopasowanie.group("argumenty").split()
+            # argumenty[0] = czas życia, argumenty[1] = nazwa fragmentu,
+            # reszta (jeśli jest) = vary_on.
+            if len(argumenty) < 2:
+                continue
+            nazwa = argumenty[1]
+            if len(argumenty) > 2 or nazwa in DOZWOLONE_BEZ_VARY_ON:
+                continue
+            bez_vary_on.append(f"{szablon.relative_to(KATALOG_ZRODEL)}: {nazwa}")
+
+    assert not bez_vary_on, (
+        "fragment-cache pod globalnym kluczem — w instalacji wielo-uczelnianej "
+        "treść jednej uczelni wycieknie na domenę innej. Dodaj vary_on albo "
+        "dopisz do DOZWOLONE_BEZ_VARY_ON z uzasadnieniem: " + ", ".join(bez_vary_on)
+    )

--- a/src/bpp/tests/test_views/test_google_analytics_per_uczelnia.py
+++ b/src/bpp/tests/test_views/test_google_analytics_per_uczelnia.py
@@ -1,0 +1,55 @@
+"""Snippet Google Analytics NIE może być współdzielony między uczelniami.
+
+``GOOGLE_ANALYTICS_PROPERTY_ID`` jest per-uczelnia (context processor
+``bpp.context_processors.constance_config`` czyta go z ``request._uczelnia``),
+a ``base.html`` przez pewien czas cache'owało ten fragment pod GLOBALNYM
+kluczem ``{% cache 3600 google %}`` — bez ``vary_on``. Skutek w instalacji
+wielo-uczelnianej: pierwszy odwiedzający uczelni A rozgrzewał fragment swoim
+identyfikatorem, a przez następną godzinę goście uczelni B dostawali snippet
+uczelni A — ruch uczelni B raportował się do konta Google uczelni A.
+"""
+
+import pytest
+from django.template.loader import render_to_string
+
+from fixtures.conftest_multisite import make_request_for_site
+
+GA_UCZELNIA1 = "G-UCZELNIA1XX"
+GA_UCZELNIA2 = "G-UCZELNIA2XX"
+
+
+def _renderuj_stopke(site):
+    """Wyrenderuj ``base.html`` jako anonim z zaakceptowanym cookielaw."""
+    request = make_request_for_site(site)
+    request.COOKIES["cookielaw_accepted"] = "1"
+    return render_to_string("base.html", request=request)
+
+
+@pytest.mark.django_db
+def test_snippet_ga_nie_wycieka_miedzy_uczelniami(
+    settings, site1, site2, uczelnia1, uczelnia2
+):
+    """Każda domena dostaje WŁASNE ID Google Analytics, nie cudze."""
+    settings.ALLOWED_HOSTS = ["*"]
+    # Domyślny cache w testach to DummyCache — nie odtworzyłby błędu, bo
+    # nigdy niczego nie zapamiętuje. Produkcja ma Redis, więc podstawiamy
+    # backend, który faktycznie przechowuje fragmenty.
+    settings.CACHES = {
+        **settings.CACHES,
+        "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+    }
+
+    uczelnia1.google_analytics_property_id = GA_UCZELNIA1
+    uczelnia1.save(update_fields=["google_analytics_property_id"])
+    uczelnia2.google_analytics_property_id = GA_UCZELNIA2
+    uczelnia2.save(update_fields=["google_analytics_property_id"])
+
+    # Kolejność ma znaczenie: uczelnia1 „rozgrzewa" cache jako pierwsza.
+    html1 = _renderuj_stopke(site1)
+    html2 = _renderuj_stopke(site2)
+
+    assert GA_UCZELNIA1 in html1
+    assert GA_UCZELNIA2 not in html1
+
+    assert GA_UCZELNIA2 in html2, "uczelnia2 dostała cudzy snippet GA z cache'a"
+    assert GA_UCZELNIA1 not in html2, "ID uczelni1 wyciekło na domenę uczelni2"

--- a/src/django_bpp/templates/base.html
+++ b/src/django_bpp/templates/base.html
@@ -296,11 +296,21 @@
     </div>
 
     {% if cookielaw.accepted %}
-        {% cache 3600 google %}
-            {% if GOOGLE_ANALYTICS_PROPERTY_ID %}
-                {% include "google_analytics.html" %}
-            {% endif %}
-        {% endcache %}
+        {# CELOWO BEZ fragment-cache. Ten blok był kiedyś opakowany w tag #}
+        {# cache pod GLOBALNYM kluczem "google" — bez vary_on. Tymczasem #}
+        {# GOOGLE_ANALYTICS_PROPERTY_ID jest PER-UCZELNIA (context #}
+        {# processor bpp.context_processors.constance_config czyta go z #}
+        {# request._uczelnia). W instalacji wielo-uczelnianej pierwszy #}
+        {# odwiedzający uczelni A rozgrzewał fragment swoim ID, a przez #}
+        {# kolejną godzinę goście uczelni B dostawali snippet uczelni A — #}
+        {# ruch uczelni B raportował się do KONTA GOOGLE uczelni A. #}
+        {# Nie przywracamy cache'a z poprawnym vary_on, tylko go usuwamy: #}
+        {# treść to jeden warunek i jeden include statycznego snippetu — #}
+        {# zero zapytań do bazy, zero pętli. Round-trip do Redisa kosztuje #}
+        {# więcej niż wyrenderowanie tych dwóch tagów. #}
+        {% if GOOGLE_ANALYTICS_PROPERTY_ID %}
+            {% include "google_analytics.html" %}
+        {% endif %}
     {% endif %}
 
     {% if not TESTING %}


### PR DESCRIPTION
Trzy poprawki ze zbiorczego przeglądu 10 zmergowanych PR-ów.

## Z1 (BUG multi-tenant) — snippet Google Analytics cache'owany globalnie

`src/django_bpp/templates/base.html` opakowywało snippet GA w fragment-cache
pod **globalnym** kluczem `google`, bez `vary_on`. Tymczasem
`GOOGLE_ANALYTICS_PROPERTY_ID` jest **per-uczelnia** — context processor
`bpp.context_processors.constance_config` czyta go z `request._uczelnia`.

Skutek w instalacji wielo-uczelnianej: pierwszy odwiedzający z akceptacją
ciasteczek na uczelni A rozgrzewał fragment swoim ID, a przez kolejną godzinę
goście uczelni B dostawali snippet uczelni A — **ruch uczelni B raportował się
do konta Google uczelni A**. Cache stron publicznych (#633) dodatkowo utrwalał
zły snippet w per-hostowym cache'u całych stron.

**Wybrano wariant (b): usunięcie fragment-cache**, nie dopisanie `vary_on`.
Treść bloku to jeden `{% if %}` i jeden `{% include %}` statycznego snippetu —
zero zapytań do bazy, zero pętli. Round-trip do Redisa kosztuje więcej niż
wyrenderowanie tych dwóch tagów, więc cache nie tylko był niebezpieczny, ale i
bezużyteczny. Usunięcie likwiduje całą klasę błędu zamiast ją łatać.

### Audyt pozostałych `{% cache %}`

| Szablon | Fragment | Werdykt |
|---|---|---|
| `browse/uczelnia.html` | `recent_publications`, `recent_abstracts` | OK — `vary_on = uczelnia.pk` |
| `browse/jednostka.html` | `jednostka_struktura_stats`, `jednostka_struktura_karta`, `kolo_struktura_karta` | OK — `vary_on = <obiekt>.pk` |
| `admin/change_list.html` | `admin_filters` | OK — `vary_on` na GET/path/user, a treść to statyczny przycisk |
| `bare.html` | `favicon` | **OK — potwierdzone** (niżej) |

**Rozstrzygnięcie sporu o favicon:** reviewer ma rację, wcześniejszy audyt się
mylił. `{% place_favicon %}` (django-favicon-plus-reloaded) pyta
`Favicon.on_site`, czyli `CurrentSiteManager`. Jego `get_queryset()`
(`django/contrib/sites/managers.py`) filtruje `.filter(site__id=settings.SITE_ID)`
— **bezpośrednio po literalnym `SITE_ID`**, nie przez
`Site.objects.get_current()` (`get_current()` siedzi w `Favicon.save()`, czyli w
ścieżce zapisu, nie odczytu). `SiteResolutionMiddleware` **nie** podmienia
`SITE_ID` per request (ustawia tylko `request.site` i `request._uczelnia`), więc
odczyt daje ten sam wiersz pod każdą domeną i globalny klucz jest poprawny.

Osobna sprawa, którą warto odnotować: favicon przez to **w ogóle nie podąża za
hostem** — wszystkie uczelnie dostają favicon site'u o `SITE_ID`. To
pre-existing ograniczenie `django-favicon-plus-reloaded`, poza zakresem tego
PR-a, ale nie należy go brać za zamierzone zachowanie multi-tenant. Zapisane
wprost przy wpisie na allowliście.

Doszedł strażnik `test_cache_fragmentow_vary_on.py`: każdy fragment-cache w
**całym `src/`** (49 aplikacji, 395 szablonów, 0,3 s) musi mieć `vary_on` albo
trafić na listę wyjątków **wraz z uzasadnieniem**. Zasięg celowo obejmuje
aplikacje spoza `bpp` (`admin_dashboard`, `rozbieznosci_dyscyplin`,
`ewaluacja_optymalizacja`, …) — tag dodany poza `bpp` to dokładnie ten
scenariusz, dla którego strażnik istnieje. Pomijane są artefakty builda
(`node_modules`, `staticroot`, `__pycache__`, …) i katalogi `static/` (pliki
serwowane dosłownie nigdy nie przechodzą przez silnik szablonów); filtr działa
na ścieżce **względnej** wobec `src/`, żeby katalog nad repo o kolidującej
nazwie nie wyciszył całego testu.

Zweryfikowane sabotażem: tag bez `vary_on` dopisany do
`admin_dashboard/templates/admin_dashboard/partials/recent_logins.html` zapala
test. Powyższa analiza faviconu siedzi w kodzie testu.

## Z2 — newsfragment obiecywał `konferencja` w CACHEOPS

`wydajnosc-p0.feature.rst` wymieniał `konferencja` wśród słowników objętych
`CACHEOPS`, a `settings/production.py` jawnie ją wyklucza. Poprawiono opis i
dodano zdanie *dlaczego* konferencje są poza cacheops.

## Z3 — `Konferencja` wykreślona z inwalidatorów cache'a publicznego

**Wybrano wariant (a).** Sprawdzone najpierw, zgodnie z sugestią: nazwa
konferencji **nie występuje w żadnym szablonie** renderowanym przez widoki
objęte `cache_publiczny` (`lata`, `rok`, `autorzy`, `zrodla`, `jednostki`,
`praca`) — `grep -ri konferencj --include='*.html'` po całym repo trafia tylko
w nagłówek starego raportu i panel importu PBN, oba poza cache'em. Widok
materializowany `Rekord` niesie wyłącznie `konferencja_id`, nie nazwę.

Skoro nazwa nigdy nie trafia na cache'owaną stronę, inwalidacja nie mogła
naprawić żadnej nieświeżej strony — mogła tylko szkodzić.
`integruj_konferencje` robi bezwarunkowy `save()` na **każdym** wierszu, każdy
w osobnym `atomic()` → każdy zapis bumpował generację → wyzerowanie **całego**
cache'a stron publicznych na czas przebiegu integratora i zimny start po nim.
Dokładnie ten sam wzorzec zapisu, dla którego #624 wykluczył `Konferencja` z
`CACHEOPS`.

Wariant (b) (naprawa integratora) odrzucony jako niepotrzebny tutaj: to zmiana
w ścieżce importu, a przy zerowej ekspozycji nazwy na stronach publicznych nic
by nie kupiła. Komentarz w `apps.py` odsyła tam na wypadek, gdyby nazwa
konferencji kiedyś trafiła na stronę publiczną.

## Testy

`test_google_analytics_per_uczelnia.py` — dwie uczelnie z różnymi ID GA,
żądanie na domenę A, potem na domenę B. Na kodzie sprzed poprawki:

```
FAILED test_snippet_ga_nie_wycieka_miedzy_uczelniami
AssertionError: uczelnia2 dostała cudzy snippet GA z cache'a
```

(test podstawia `LocMemCache` pod `default`, bo w testach domyślny backend to
`DummyCache` i błąd by się nie odtworzył).

Zielone po poprawce:

* `src/bpp/tests/test_views/ src/bpp/tests/test_middleware/` — 421 passed, 1 skipped
* `src/bpp/tests/test_multisite/ src/django_bpp/tests/ src/pbn_integrator/tests/test_integruj_konferencje.py` — 115 passed
* `uv run pre-commit` — wszystko Passed
* zweryfikowano osobno, że nowe komentarze `{# #}` w `base.html` nie wyciekają do wyrenderowanego HTML-u

Bez migracji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
