### PR TITLE
[STAŁA GAŁĄŹ WERYFIKACYJNA — nie mergować] LEAK-GUARD: twardy gate + tracer, na kodzie z fixem #638

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -367,7 +367,15 @@ jobs:
         # 0-indexed (kept that way so the job names / required checks
         # don't change). Map group = shard + 1.
         GROUP=$((SHARD_ID + 1))
+        # GAŁĄŹ OBSERWACYJNA — NIE MERGOWAĆ DO dev.
+        # BPP_LEAK_GUARD_STRICT=1 zamienia wykrycie wycieku scommitowanych
+        # danych w twardy błąd testu, zamiast cichego TRUNCATE + raportu na
+        # końcu sesji. Na dev to zablokowałoby merge'e (przyczyna wycieku
+        # nieznana), więc siedzi na osobnej gałęzi — żeby ZOBACZYĆ pełny
+        # obraz: przy którym teście następuje wykrycie, czyje są wiersze
+        # i jaki jest wtedy stan izolacji połączenia.
         docker compose $COMPOSE_FILES run --rm \
+          -e BPP_LEAK_GUARD_STRICT=1 \
           test-runner uv run pytest \
             -n auto \
             --splits "$NUM_SHARDS" --group "$GROUP" \

--- a/src/bpp/tests/test_leak_guard_tracer.py
+++ b/src/bpp/tests/test_leak_guard_tracer.py
@@ -5,14 +5,42 @@ zdarzenia czyszczone w złym momencie) i milczenie na CI czytalibyśmy jako
 „zapisów spoza głównego wątku nie ma" zamiast „nie mierzymy".
 """
 
+import sys
 import threading
 
 import pytest
 
 
+def _src_conftest():
+    """Zwraca INSTANCJĘ modułu ``src/conftest.py`` załadowaną przez pytest.
+
+    Gołe ``import conftest`` jest pod pytestem niejednoznaczne: rozstrzyga się
+    na pierwszy ``conftest.py`` na ``sys.path``, a przy shardowaniu xdista bywa
+    to conftest aplikacyjny (np. ``import_pracownikow/tests/conftest.py``), bez
+    tracera → ``AttributeError`` na CI mimo zieleni lokalnie.
+
+    Świeży ``importlib`` też NIE wystarcza: dałby OSOBNĄ instancję z własnym
+    ``_LEAK_GUARD``, a tracer (zainstalowany przez tę właściwą instancję, bo
+    ``BPP_LEAK_GUARD_STRICT`` jest ustawiony) dopisuje zdarzenia do słownika
+    tamtej instancji. Musimy więc znaleźć DOKŁADNIE ten moduł, który pytest
+    już załadował — po obecności ``_zainstaluj_tracer_polaczen`` w ``sys.modules``.
+    """
+    kandydaci = [
+        m
+        for m in sys.modules.values()
+        if m is not None
+        and (getattr(m, "__file__", "") or "")
+        .replace("\\", "/")
+        .endswith("/src/conftest.py")
+        and hasattr(m, "_zainstaluj_tracer_polaczen")
+    ]
+    assert kandydaci, "nie znaleziono załadowanego src/conftest.py z tracerem"
+    return kandydaci[0]
+
+
 @pytest.mark.django_db
 def test_tracer_widzi_polaczenie_z_innego_watku():
-    import conftest
+    conftest = _src_conftest()
 
     conftest._zainstaluj_tracer_polaczen()
     conftest._LEAK_GUARD["zdarzenia"] = []

--- a/src/bpp/tests/test_leak_guard_tracer.py
+++ b/src/bpp/tests/test_leak_guard_tracer.py
@@ -1,0 +1,32 @@
+"""Guard dla guarda: tracer połączeń MUSI widzieć zapis z innego wątku.
+
+Bez tego testu tracer mógłby cicho nie działać (monkey-patch nie założony,
+zdarzenia czyszczone w złym momencie) i milczenie na CI czytalibyśmy jako
+„zapisów spoza głównego wątku nie ma" zamiast „nie mierzymy".
+"""
+
+import threading
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_tracer_widzi_polaczenie_z_innego_watku():
+    import conftest
+
+    conftest._zainstaluj_tracer_polaczen()
+    conftest._LEAK_GUARD["zdarzenia"] = []
+
+    def w_watku():
+        from django.db import connection
+
+        with connection.cursor() as cur:
+            cur.execute("SELECT 1")
+        connection.close()
+
+    t = threading.Thread(target=w_watku)
+    t.start()
+    t.join(10)
+
+    zdarzenia = conftest._LEAK_GUARD["zdarzenia"]
+    assert any("CONNECT w wątku" in z for z in zdarzenia), zdarzenia

--- a/src/bpp/tests/test_leak_guard_tracer.py
+++ b/src/bpp/tests/test_leak_guard_tracer.py
@@ -5,42 +5,41 @@ zdarzenia czyszczone w złym momencie) i milczenie na CI czytalibyśmy jako
 „zapisów spoza głównego wątku nie ma" zamiast „nie mierzymy".
 """
 
-import sys
 import threading
 
 import pytest
 
 
-def _src_conftest():
+def _src_conftest(request):
     """Zwraca INSTANCJĘ modułu ``src/conftest.py`` załadowaną przez pytest.
 
-    Gołe ``import conftest`` jest pod pytestem niejednoznaczne: rozstrzyga się
-    na pierwszy ``conftest.py`` na ``sys.path``, a przy shardowaniu xdista bywa
-    to conftest aplikacyjny (np. ``import_pracownikow/tests/conftest.py``), bez
-    tracera → ``AttributeError`` na CI mimo zieleni lokalnie.
+    Wszystkie prostsze drogi zawodzą pod shardowaniem xdista na CI:
 
-    Świeży ``importlib`` też NIE wystarcza: dałby OSOBNĄ instancję z własnym
-    ``_LEAK_GUARD``, a tracer (zainstalowany przez tę właściwą instancję, bo
-    ``BPP_LEAK_GUARD_STRICT`` jest ustawiony) dopisuje zdarzenia do słownika
-    tamtej instancji. Musimy więc znaleźć DOKŁADNIE ten moduł, który pytest
-    już załadował — po obecności ``_zainstaluj_tracer_polaczen`` w ``sys.modules``.
+    - gołe ``import conftest`` rozstrzyga się na pierwszy ``conftest.py`` na
+      ``sys.path`` — bywa to conftest aplikacyjny bez tracera;
+    - świeży ``importlib`` daje OSOBNĄ instancję z własnym ``_LEAK_GUARD``,
+      a tracer dopisuje zdarzenia do instancji załadowanej przez pytest;
+    - filtr po ``__file__`` w ``sys.modules`` jest kruchy — na CI ścieżka
+      bywa WZGLĘDNA (``src/conftest.py``), więc ``endswith("/src/conftest.py")``
+      nie łapie.
+
+    Deterministycznie: pytest rejestruje KAŻDY ``conftest.py`` jako plugin.
+    Bierzemy ten z zarejestrowanych, który ma ``_zainstaluj_tracer_polaczen``
+    — czyli dokładnie rootdir-owy ``src/conftest.py``, tę samą instancję,
+    której używa runtime.
     """
     kandydaci = [
-        m
-        for m in sys.modules.values()
-        if m is not None
-        and (getattr(m, "__file__", "") or "")
-        .replace("\\", "/")
-        .endswith("/src/conftest.py")
-        and hasattr(m, "_zainstaluj_tracer_polaczen")
+        p
+        for p in request.config.pluginmanager.get_plugins()
+        if hasattr(p, "_zainstaluj_tracer_polaczen")
     ]
-    assert kandydaci, "nie znaleziono załadowanego src/conftest.py z tracerem"
+    assert kandydaci, "nie znaleziono zarejestrowanego src/conftest.py z tracerem"
     return kandydaci[0]
 
 
 @pytest.mark.django_db
-def test_tracer_widzi_polaczenie_z_innego_watku():
-    conftest = _src_conftest()
+def test_tracer_widzi_polaczenie_z_innego_watku(request):
+    conftest = _src_conftest(request)
 
     conftest._zainstaluj_tracer_polaczen()
     conftest._LEAK_GUARD["zdarzenia"] = []

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -298,7 +298,79 @@ _LEAK_GUARD = {
     # capture pytest-a) — inaczej print z fixture'a jest łykany i NIEwidoczny
     # w logach CI (właśnie po to jest ta diagnostyka).
     "raporty": [],
+    # Zdarzenia na połączeniu w trakcie BIEŻĄCEGO testu (czyszczone na setupie).
+    # Patrz _zainstaluj_tracer_polaczen.
+    "zdarzenia": [],
 }
+
+
+# =============================================================================
+# TRACER POŁĄCZEŃ — odpowiada na pytanie „CZEMU to wycieka".
+#
+# Ustalone pomiarem: wyciekające testy to zwykłe ``django_db`` (tx=False), a
+# wyciekłe wiersze to ICH WŁASNE dane (próbki etykiet: „Nowak", „Kat.",
+# „brygadier"). Osobne połączenie sondy je widzi, więc są SCOMMITOWANE —
+# sesja PG na READ COMMITTED nie zobaczy cudzych danych niescommitowanych.
+#
+# Rollback pytest-django jest niemal na pewno sprawny. Zostają dwa sposoby,
+# żeby zapis ominął transakcję testu — i tracer rozróżnia je wprost:
+#
+#   A. ZAPIS Z INNEGO WĄTKU. ``connections`` jest thread-local, więc wątek
+#      spoza głównego dostaje WŁASNE połączenie, w autocommit, poza atomic
+#      blokiem. Tracer notuje każde ``connect()`` spoza MainThread + stos.
+#
+#   B. PODMIANA POŁĄCZENIA W TRAKCIE TESTU. Gdy coś zamknie połączenie,
+#      Django otworzy nowe — atomic block przepada, dalsze zapisy lecą
+#      w autocommit, a rollback na teardownie działa na nowym obiekcie,
+#      który nie ma czego cofać. UWAGA: mierzone wcześniej
+#      ``closed_in_tx=False`` tego NIE wyklucza — flaga siedzi na obiekcie
+#      połączenia, a po podmianie nowy obiekt ma ją czystą. Tracer notuje
+#      ``close()`` wołane wewnątrz atomic bloku + stos.
+#
+# Włączany przez BPP_LEAK_GUARD_TRACE=1 lub BPP_LEAK_GUARD_STRICT=1 (gałąź
+# obserwacyjna). Domyślnie NIEAKTYWNY — monkey-patch na warstwie połączeń
+# nie ma prawa działać w zwykłym przebiegu.
+# =============================================================================
+
+
+def _zainstaluj_tracer_polaczen():
+    import threading
+    import traceback
+
+    from django.db.backends.base.base import BaseDatabaseWrapper
+
+    if getattr(BaseDatabaseWrapper, "_bpp_tracer", False):
+        return
+    BaseDatabaseWrapper._bpp_tracer = True
+
+    def _stos():
+        # Pomijamy ramki samego tracera; 7 ostatnich wystarcza, żeby zobaczyć
+        # KTO zawołał, a nie zalewa logu CI.
+        return " <- ".join(
+            f"{f.filename.rsplit('/', 1)[-1]}:{f.lineno}:{f.name}"
+            for f in traceback.extract_stack()[-9:-2]
+        )
+
+    orig_connect = BaseDatabaseWrapper.connect
+    orig_close = BaseDatabaseWrapper.close
+
+    def connect(self):
+        watek = threading.current_thread()
+        if watek is not threading.main_thread():
+            _LEAK_GUARD["zdarzenia"].append(f"CONNECT w wątku {watek.name}: {_stos()}")
+        return orig_connect(self)
+
+    def close(self):
+        if getattr(self, "in_atomic_block", False):
+            _LEAK_GUARD["zdarzenia"].append(f"CLOSE w atomic bloku: {_stos()}")
+        return orig_close(self)
+
+    BaseDatabaseWrapper.connect = connect
+    BaseDatabaseWrapper.close = close
+
+
+if os.environ.get("BPP_LEAK_GUARD_TRACE") or os.environ.get("BPP_LEAK_GUARD_STRICT"):
+    _zainstaluj_tracer_polaczen()
 _LEAK_GUARD_TABLES = (
     "bpp_autor",
     "bpp_jednostka",
@@ -469,6 +541,7 @@ def _neutralizuj_wyciekle_dane(request):
             f"{', '.join(wyciekle)}. Najprawdopodobniejszy sprawca (poprzedni "
             f"test DB na tym workerze): {_LEAK_GUARD['poprzedni']}"
         )
+    _LEAK_GUARD["zdarzenia"] = []
     _LEAK_GUARD["poprzedni_przed"] = _LEAK_GUARD["poprzedni"]
     _LEAK_GUARD["poprzedni"] = request.node.nodeid
 
@@ -571,6 +644,11 @@ def _stan_izolacji(item):
         f"needs_rollback={getattr(connection, 'needs_rollback', '?')} "
         f"autocommit={autocommit} "
         f"poprzedni={_LEAK_GUARD['poprzedni_przed']}"
+        + (
+            " || ZDARZENIA NA POŁĄCZENIU: " + " ;; ".join(_LEAK_GUARD["zdarzenia"])
+            if _LEAK_GUARD["zdarzenia"]
+            else " || zdarzenia na połączeniu: BRAK"
+        )
     )
 
 


### PR DESCRIPTION
Zastępuje zamknięty #636 (force-push odciął stary head, GitHub odmówił reopen).

## Czym jest

**Stała gałąź weryfikacyjna**, nie do merge'a. Odpala twardy gate `BPP_LEAK_GUARD_STRICT=1` na wszystkich shardach — wykrycie scommitowanych danych po teardownie testu = twardy błąd. Rebase na `dev` + push, kiedy chcemy świeży pomiar.

## Co się zmieniło od poprzedniego przebiegu

Poprzedni run tej gałęzi (na `dev` **sprzed** poprawki) dał **79 wykryć wycieku**. Teraz stoi na `dev` z zmergowanym **#638** (przyczyna naprawiona: liveops raportuje w testach przez `MockProgress`, koniec przełączania wskaźnika pętli przy żywej bazie).

**Ten przebieg jest definitywnym testem poprawki.** Oczekiwanie: shardy **zielone**, zero `[LEAK-GUARD/teardown]` w logach, zero `WykrytoWyciekDanych`.

## Zawartość gałęzi (2 commity nad `dev`)

- **tracer połączeń** — notuje `CONNECT` spoza `MainThread` i `CLOSE` w atomic bloku ze stosem; gdyby jakiś NOWY wyciek się pojawił, od razu wskaże mechanizm;
- **flaga strict** w `tests.yml`.

## Jak czytać wynik

- **zielono** → poprawka #638 potwierdzona pod twardym gate'em;
- **czerwono** z `[LEAK-GUARD/teardown]` → został wyciek, którego #638 nie pokrył — stos z tracera pokaże gdzie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134fYqFag9EXfHXEuC6nTjZ