### PR TITLE
fix(pbn_api): PublikacjaInstytucji — constraint na trójce FK, koniec cichych duplikatów w imporcie PBN

### DIFF
--- a/src/bpp/newsfragments/publikacja-instytucji-duplikaty.bugfix.rst
+++ b/src/bpp/newsfragments/publikacja-instytucji-duplikaty.bugfix.rst
@@ -1,0 +1,4 @@
+Import PBN nie tworzy już zdublowanych powiązań publikacja-instytucja-osoba:
+trójka (instytucja, publikacja, osoba) w ``PublikacjaInstytucji`` dostała
+unikalny constraint, a migracja usuwa duplikaty istniejące w bazie
+(zostawiając z każdej grupy wiersz o najniższym identyfikatorze).

--- a/src/pbn_api/migrations/0078_deduplikacja_publikacji_instytucji.py
+++ b/src/pbn_api/migrations/0078_deduplikacja_publikacji_instytucji.py
@@ -1,0 +1,93 @@
+"""Deduplikacja ``PublikacjaInstytucji`` (krok 1 z 2).
+
+``zapisz_publikacje_instytucji`` robił ``get_or_create`` po trójce
+(``institutionId``, ``publicationId``, ``insPersonId``), na której nie było
+żadnego unikalnego constraintu. Import PBN biegnie wielowątkowo, więc dwa
+wątki na tej samej trójce **cicho** tworzyły dwa wiersze — bez wyjątku, bez
+logu. Duplikaty narastały z każdym importem.
+
+Zanim założymy constraint, trzeba zdeduplikować to, co już jest w bazie
+produkcyjnej — inaczej ``AddConstraint`` wywali migrację.
+
+Zasada wyboru „którego zostawić": **najniższy pk** — wiersz utworzony jako
+pierwszy, deterministycznie wybrany. Pola niekluczowe (``snapshot``,
+``publicationYear`` itd.) nie mają znaczenia: najbliższy import PBN i tak
+nadpisze ocalały wiersz świeżymi danymi z serwera.
+
+**Nic nie ma FK do ``PublikacjaInstytucji``** (sprawdzone: model nie jest
+celem żadnego ``ForeignKey``/``ManyToMany`` w repo — jest liściem grafu,
+odwołuje się do ``Scientist``/``Institution``/``Publication``/``Uczelnia``,
+ale nikt nie odwołuje się do niego). Nie ma więc czego przepinać ani czego
+osierocić — kasujemy duplikaty wprost.
+
+Sam constraint zakłada dopiero migracja ``0079``. To NIE jest kosmetyka:
+``DELETE`` na tabeli z FK zostawia w PostgreSQL oczekujące (deferred)
+zdarzenia wyzwalaczy, a ``ALTER TABLE ... ADD CONSTRAINT`` w tej samej
+transakcji wywala się wtedy na ``nie można ALTER TABLE ... ponieważ posiada
+oczekujące zdarzenia wyzwalaczy``. Rozdzielenie na dwie migracje daje DDL
+własną, czystą transakcję. (Wzorzec: ``0076`` + ``0077``.)
+"""
+
+import logging
+
+from django.db import migrations, models
+
+logger = logging.getLogger(__name__)
+
+POLA_KLUCZA = ("institutionId_id", "publicationId_id", "insPersonId_id")
+
+
+def deduplikuj(apps, schema_editor):
+    PublikacjaInstytucji = apps.get_model("pbn_api", "PublikacjaInstytucji")
+
+    duplikaty = (
+        PublikacjaInstytucji.objects.values(*POLA_KLUCZA)
+        .annotate(ile=models.Count("pk"))
+        .filter(ile__gt=1)
+        .order_by()
+    )
+
+    usunietych = 0
+    for wpis in duplikaty:
+        klucz = {pole: wpis[pole] for pole in POLA_KLUCZA}
+        pk_i = list(
+            PublikacjaInstytucji.objects.filter(**klucz)
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+        zostaje, do_usuniecia = pk_i[0], pk_i[1:]
+        PublikacjaInstytucji.objects.filter(pk__in=do_usuniecia).delete()
+        usunietych += len(do_usuniecia)
+        logger.warning(
+            "pbn_api.PublikacjaInstytucji: usunięto %s duplikat(ów) trójki %s, "
+            "zostaje wiersz pk=%s",
+            len(do_usuniecia),
+            klucz,
+            zostaje,
+        )
+
+    logger.warning(
+        "Deduplikacja pbn_api.PublikacjaInstytucji zakończona: usunięto %s "
+        "zduplikowanych wierszy.",
+        usunietych,
+    )
+
+
+def deduplikuj_wstecz(apps, schema_editor):
+    """Deduplikacji się nie cofa.
+
+    Usunięte wiersze były duplikatami powstałymi z błędu — ich odtworzenie nie
+    jest ani możliwe (nie mamy ich pk-ów), ani pożądane. Migracja wstecz
+    zdejmuje tylko constraint (w ``0079``); dane pozostają zdeduplikowane.
+    """
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pbn_api", "0077_constrainty_uuid_dyscyplin"),
+    ]
+
+    operations = [
+        migrations.RunPython(deduplikuj, deduplikuj_wstecz),
+    ]

--- a/src/pbn_api/migrations/0079_constraint_publikacja_instytucji.py
+++ b/src/pbn_api/migrations/0079_constraint_publikacja_instytucji.py
@@ -1,0 +1,25 @@
+"""Unikalność trójki FK w ``PublikacjaInstytucji`` (krok 2 z 2).
+
+Deduplikacja jest w ``0078`` — osobna migracja, bo ``DELETE`` na tabeli z FK
+zostawia w PostgreSQL oczekujące zdarzenia wyzwalaczy i ``ALTER TABLE ... ADD
+CONSTRAINT`` w tej samej transakcji się wywala.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pbn_api", "0078_deduplikacja_publikacji_instytucji"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="publikacjainstytucji",
+            constraint=models.UniqueConstraint(
+                fields=("institutionId", "publicationId", "insPersonId"),
+                name="pbn_api_publikacjainstytucji_trojka_unikalna",
+            ),
+        ),
+    ]

--- a/src/pbn_api/models/publikacja_instytucji.py
+++ b/src/pbn_api/models/publikacja_instytucji.py
@@ -26,6 +26,17 @@ class PublikacjaInstytucji(models.Model):
     class Meta:
         verbose_name = "Publikacja instytucji"
         verbose_name_plural = "Publikacje instytucji"
+        # Import PBN robi ``get_or_create`` po tej trójce, w wielu wątkach.
+        # Bez constraintu dwa wątki cicho tworzyły dwa wiersze. Wszystkie
+        # trzy FK są NOT NULL, więc zwykły UniqueConstraint wystarcza — nie
+        # ma NULL-i, które byłyby w indeksie unikalnym wzajemnie
+        # rozróżnialne i wymagałyby dodatkowego indeksu częściowego.
+        constraints = [
+            models.UniqueConstraint(
+                fields=("institutionId", "publicationId", "insPersonId"),
+                name="pbn_api_publikacjainstytucji_trojka_unikalna",
+            )
+        ]
 
 
 class PublikacjaInstytucji_V2(models.Model):

--- a/src/pbn_api/tests/test_migracja_publikacja_instytucji_e2e.py
+++ b/src/pbn_api/tests/test_migracja_publikacja_instytucji_e2e.py
@@ -33,28 +33,42 @@ def test_migracja_przechodzi_na_bazie_z_duplikatami():
     # cofnij się PRZED constraint — dopiero wtedy baza wpuści duplikaty
     MigrationExecutor(connection).migrate([PRZED])
 
-    trojka = {
-        "institutionId": baker.make(Institution),
-        "publicationId": baker.make(Publication),
-        "insPersonId": baker.make(Scientist),
-    }
-    zostaje = PublikacjaInstytucji.objects.create(**trojka)
-    PublikacjaInstytucji.objects.create(**trojka)
-    PublikacjaInstytucji.objects.create(**trojka)
+    try:
+        trojka = {
+            "institutionId": baker.make(Institution),
+            "publicationId": baker.make(Publication),
+            "insPersonId": baker.make(Scientist),
+        }
+        zostaje = PublikacjaInstytucji.objects.create(**trojka)
+        PublikacjaInstytucji.objects.create(**trojka)
+        PublikacjaInstytucji.objects.create(**trojka)
 
-    assert PublikacjaInstytucji.objects.filter(**trojka).count() == 3
+        assert PublikacjaInstytucji.objects.filter(**trojka).count() == 3
 
-    # to jest właściwy asert: migracja NIE wywala się na bazie z duplikatami
-    executor = MigrationExecutor(connection)
-    executor.loader.build_graph()
-    executor.migrate([PO])
+        # to jest właściwy asert: migracja NIE wywala się na bazie z duplikatami
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()
+        executor.migrate([PO])
 
-    assert PublikacjaInstytucji.objects.filter(**trojka).count() == 1
-    assert PublikacjaInstytucji.objects.filter(pk=zostaje.pk).exists()
-    assert (
-        _policz(
-            "SELECT count(*) FROM pg_constraint WHERE conname=%s",
-            NAZWA_CONSTRAINTU,
+        assert PublikacjaInstytucji.objects.filter(**trojka).count() == 1
+        assert PublikacjaInstytucji.objects.filter(pk=zostaje.pk).exists()
+        assert (
+            _policz(
+                "SELECT count(*) FROM pg_constraint WHERE conname=%s",
+                NAZWA_CONSTRAINTU,
+            )
+            == 1
         )
-        == 1
-    )
+    finally:
+        # Baza MUSI wrócić na docelową migrację (0079) niezależnie od tego,
+        # czy powyższe asercje przeszły — inaczej worker testowy zostaje na
+        # 0077 (bez constraintu) i psuje WSZYSTKIE kolejne testy w tym
+        # procesie kaskadą niezrozumiałych błędów zamiast jednego czytelnego
+        # AssertionError z bloku try.
+        #
+        # Same dane testowe nie wymagają tu ręcznego kasowania: migracja
+        # 0078 (RunPython dedup) dedupikuje dowolną liczbę pozostawionych
+        # wierszy trójki jako część forward-migrate, więc nie ma osobnego
+        # kroku „usuń dane" przed „odtwórz stan", który mógłby rzucić
+        # wyjątkiem maskującym oryginalny AssertionError z bloku try.
+        MigrationExecutor(connection).migrate([PO])

--- a/src/pbn_api/tests/test_migracja_publikacja_instytucji_e2e.py
+++ b/src/pbn_api/tests/test_migracja_publikacja_instytucji_e2e.py
@@ -1,0 +1,60 @@
+"""Prawdziwy ``migrate`` 0077 → 0079 na bazie, która JUŻ zawiera duplikaty.
+
+Ten test nie jest ozdobą: gdyby deduplikacja i ``ADD CONSTRAINT`` siedziały
+w JEDNEJ migracji, wywaliłoby się tutaj na ``nie można ALTER TABLE ...
+ponieważ posiada oczekujące zdarzenia wyzwalaczy`` (PostgreSQL nie pozwala na
+DDL w transakcji, w której ``DELETE`` na tabeli z FK zostawił deferred trigger
+events). Testy wołające samą funkcję ``deduplikuj`` tego nie łapią — trzeba
+przepuścić prawdziwy ``MigrationExecutor``. Patrz
+``test_migracja_dyscypliny_uuid_e2e`` (PR #635) — ten sam mechanizm.
+"""
+
+import pytest
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from model_bakery import baker
+
+from pbn_api.models import Institution, Publication, Scientist
+from pbn_api.models.publikacja_instytucji import PublikacjaInstytucji
+
+PRZED = ("pbn_api", "0077_constrainty_uuid_dyscyplin")
+PO = ("pbn_api", "0079_constraint_publikacja_instytucji")
+NAZWA_CONSTRAINTU = "pbn_api_publikacjainstytucji_trojka_unikalna"
+
+
+def _policz(sql, *params):
+    with connection.cursor() as cursor:
+        cursor.execute(sql, params)
+        return cursor.fetchone()[0]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_migracja_przechodzi_na_bazie_z_duplikatami():
+    # cofnij się PRZED constraint — dopiero wtedy baza wpuści duplikaty
+    MigrationExecutor(connection).migrate([PRZED])
+
+    trojka = {
+        "institutionId": baker.make(Institution),
+        "publicationId": baker.make(Publication),
+        "insPersonId": baker.make(Scientist),
+    }
+    zostaje = PublikacjaInstytucji.objects.create(**trojka)
+    PublikacjaInstytucji.objects.create(**trojka)
+    PublikacjaInstytucji.objects.create(**trojka)
+
+    assert PublikacjaInstytucji.objects.filter(**trojka).count() == 3
+
+    # to jest właściwy asert: migracja NIE wywala się na bazie z duplikatami
+    executor = MigrationExecutor(connection)
+    executor.loader.build_graph()
+    executor.migrate([PO])
+
+    assert PublikacjaInstytucji.objects.filter(**trojka).count() == 1
+    assert PublikacjaInstytucji.objects.filter(pk=zostaje.pk).exists()
+    assert (
+        _policz(
+            "SELECT count(*) FROM pg_constraint WHERE conname=%s",
+            NAZWA_CONSTRAINTU,
+        )
+        == 1
+    )

--- a/src/pbn_api/tests/test_publikacja_instytucji_unique.py
+++ b/src/pbn_api/tests/test_publikacja_instytucji_unique.py
@@ -1,0 +1,81 @@
+"""Testy unikalności trójki FK w ``PublikacjaInstytucji``.
+
+Bug: ``zapisz_publikacje_instytucji`` (``pbn_integrator``) robi
+``get_or_create`` po (``institutionId``, ``publicationId``, ``insPersonId``),
+a na tej trójce nie było żadnego unikalnego constraintu. Import PBN biegnie
+wielowątkowo (``pobierz_mongodb(use_threads=True)``), więc dwa wątki na tej
+samej trójce **cicho** tworzyły dwa wiersze — bez wyjątku, bez logu. Efekt:
+zawyżone liczby powiązań publikacja-instytucja-osoba, narastające z każdym
+importem.
+
+Uwaga o nullach: wszystkie trzy FK w trójce są NOT NULL (brak ``null=True``
+w modelu), więc zwykły ``UniqueConstraint`` wystarcza — nie ma problemu
+„NULL-e są w indeksie unikalnym rozróżnialne", który wymagałby dodatkowego
+indeksu częściowego.
+"""
+
+import pytest
+from django.db import IntegrityError, connection, transaction
+from model_bakery import baker
+
+from pbn_api.models import Institution, Publication, Scientist
+from pbn_api.models.publikacja_instytucji import PublikacjaInstytucji
+
+NAZWA_CONSTRAINTU = "pbn_api_publikacjainstytucji_trojka_unikalna"
+
+
+@pytest.fixture
+def trojka(db):
+    return {
+        "institutionId": baker.make(Institution),
+        "publicationId": baker.make(Publication),
+        "insPersonId": baker.make(Scientist),
+    }
+
+
+def _zdejmij_constraint_unikalnosci():
+    """Zdejmuje unikalny constraint, żeby dało się WYPRODUKOWAĆ duplikaty.
+
+    PostgreSQL wykonuje DDL transakcyjnie, więc rollback testu przywraca
+    constraint — nie zostawiamy po sobie zmienionego schematu.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "ALTER TABLE pbn_api_publikacjainstytucji "
+            f'DROP CONSTRAINT IF EXISTS "{NAZWA_CONSTRAINTU}"'
+        )
+
+
+@pytest.mark.django_db
+def test_baza_odrzuca_duplikat_trojki(trojka):
+    """Constraint na trójce FK faktycznie działa w bazie."""
+    PublikacjaInstytucji.objects.create(**trojka)
+
+    with pytest.raises(IntegrityError), transaction.atomic():
+        PublikacjaInstytucji.objects.create(**trojka)
+
+
+@pytest.mark.django_db
+def test_wszystkie_trzy_fk_sa_not_null():
+    """Gdyby któryś FK stał się nullowalny, sam UniqueConstraint przestałby
+    wystarczać (NULL-e są w indeksie unikalnym wzajemnie rozróżnialne)."""
+    for nazwa in ("insPersonId", "institutionId", "publicationId"):
+        assert not PublikacjaInstytucji._meta.get_field(nazwa).null, nazwa
+
+
+@pytest.mark.django_db
+def test_ta_sama_publikacja_i_instytucja_ale_inna_osoba_jest_dozwolona(trojka):
+    """Constraint obejmuje CAŁĄ trójkę, nie samą parę publikacja+instytucja."""
+    PublikacjaInstytucji.objects.create(**trojka)
+    PublikacjaInstytucji.objects.create(
+        institutionId=trojka["institutionId"],
+        publicationId=trojka["publicationId"],
+        insPersonId=baker.make(Scientist),
+    )
+
+    assert (
+        PublikacjaInstytucji.objects.filter(
+            publicationId=trojka["publicationId"]
+        ).count()
+        == 2
+    )

--- a/src/pbn_api/tests/test_publikacja_instytucji_unique.py
+++ b/src/pbn_api/tests/test_publikacja_instytucji_unique.py
@@ -14,12 +14,20 @@ w modelu), więc zwykły ``UniqueConstraint`` wystarcza — nie ma problemu
 indeksu częściowego.
 """
 
+import importlib
+
 import pytest
+from django.apps import apps as django_apps
 from django.db import IntegrityError, connection, transaction
+from django.db.models.query import QuerySet
 from model_bakery import baker
 
 from pbn_api.models import Institution, Publication, Scientist
 from pbn_api.models.publikacja_instytucji import PublikacjaInstytucji
+
+MIGRACJA = importlib.import_module(
+    "pbn_api.migrations.0078_deduplikacja_publikacji_instytucji"
+)
 
 NAZWA_CONSTRAINTU = "pbn_api_publikacjainstytucji_trojka_unikalna"
 
@@ -79,3 +87,95 @@ def test_ta_sama_publikacja_i_instytucja_ale_inna_osoba_jest_dozwolona(trojka):
         ).count()
         == 2
     )
+
+
+@pytest.mark.django_db
+def test_get_or_create_przezywa_przegrany_wyscig(trojka, monkeypatch):
+    """Constraint NIE wywala importu, gdy równoległy wątek zdążył pierwszy.
+
+    Django ``get_or_create`` sam implementuje wzorzec
+    ``_update_or_create_odporne_na_wyscig``: ``create`` idzie w savepoint
+    (``transaction.atomic``), a ``IntegrityError`` jest domykany ponownym
+    ``get``. Dlatego gorąca ścieżka w ``zapisz_publikacje_instytucji`` NIE
+    wymaga własnej obsługi ``IntegrityError`` — ten test tego pilnuje.
+
+    Symulacja przegranego wyścigu: wiersz JUŻ jest w bazie, ale pierwszy
+    ``get`` (ten sprzed ``create``) udaje, że go nie widzi.
+    """
+    istniejacy = PublikacjaInstytucji.objects.create(**trojka)
+
+    prawdziwy_get = QuerySet.get
+    wywolania = {"ile": 0}
+
+    def get_slepy_za_pierwszym_razem(self, *args, **kwargs):
+        if self.model is PublikacjaInstytucji:
+            wywolania["ile"] += 1
+            if wywolania["ile"] == 1:
+                raise PublikacjaInstytucji.DoesNotExist()
+        return prawdziwy_get(self, *args, **kwargs)
+
+    monkeypatch.setattr(QuerySet, "get", get_slepy_za_pierwszym_razem)
+
+    rec, utworzony = PublikacjaInstytucji.objects.get_or_create(
+        institutionId_id=trojka["institutionId"].pk,
+        publicationId_id=trojka["publicationId"].pk,
+        insPersonId_id=trojka["insPersonId"].pk,
+    )
+
+    assert wywolania["ile"] == 2, "IntegrityError nie został domknięty przez get()"
+    assert not utworzony
+    assert rec.pk == istniejacy.pk
+    assert PublikacjaInstytucji.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_migracja_usuwa_duplikaty_zostawiajac_najnizszy_pk(trojka):
+    """Dedup zostawia po jednym wierszu z grupy — ten o najniższym pk."""
+    _zdejmij_constraint_unikalnosci()
+
+    zostaje = PublikacjaInstytucji.objects.create(**trojka, publicationYear=2020)
+    duplikat_a = PublikacjaInstytucji.objects.create(**trojka, publicationYear=2021)
+    duplikat_b = PublikacjaInstytucji.objects.create(**trojka, publicationYear=2022)
+    assert duplikat_a.pk > zostaje.pk and duplikat_b.pk > duplikat_a.pk
+
+    # wiersz spoza grupy duplikatów — nie wolno go ruszyć
+    nietkniety = PublikacjaInstytucji.objects.create(
+        institutionId=trojka["institutionId"],
+        publicationId=trojka["publicationId"],
+        insPersonId=baker.make(Scientist),
+    )
+
+    MIGRACJA.deduplikuj(django_apps, None)
+
+    assert PublikacjaInstytucji.objects.count() == 2
+    assert PublikacjaInstytucji.objects.filter(pk=zostaje.pk).exists()
+    assert PublikacjaInstytucji.objects.filter(pk=nietkniety.pk).exists()
+    assert not PublikacjaInstytucji.objects.filter(
+        pk__in=[duplikat_a.pk, duplikat_b.pk]
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_migracja_jest_idempotentna_na_bazie_bez_duplikatow(trojka):
+    """Dedup na bazie BEZ duplikatów niczego nie rusza."""
+    PublikacjaInstytucji.objects.create(**trojka)
+    przed = set(PublikacjaInstytucji.objects.values_list("pk", flat=True))
+
+    MIGRACJA.deduplikuj(django_apps, None)
+
+    assert set(PublikacjaInstytucji.objects.values_list("pk", flat=True)) == przed
+
+
+@pytest.mark.django_db
+def test_nic_nie_ma_fk_do_publikacji_instytucji():
+    """Dedup kasuje duplikaty wprost — wolno mu, bo model jest liściem grafu.
+
+    Gdyby ktoś dołożył FK do ``PublikacjaInstytucji``, migracja ``0078``
+    zaczęłaby kasadowo osierocać/kasować powiązane wiersze. Ten test to
+    wykryje i wymusi dopisanie przepinania FK do dedupu.
+    """
+    powiazania = [
+        f"{rel.related_model._meta.label}.{rel.field.name}"
+        for rel in PublikacjaInstytucji._meta.related_objects
+    ]
+    assert powiazania == []

--- a/src/pbn_integrator/utils/mongodb_ops.py
+++ b/src/pbn_integrator/utils/mongodb_ops.py
@@ -195,6 +195,15 @@ def zapisz_publikacje_instytucji(elem, klass, client=None, **extra):
         else:
             raise
 
+    # Import biegnie wielowątkowo (``pobierz_mongodb(use_threads=True)``).
+    # Przed dołożeniem unikalnego constraintu na tej trójce (migracje 0078 +
+    # 0079) dwa wątki cicho tworzyły dwa wiersze. Constraint zamienia to
+    # w ``IntegrityError``, ale WŁASNA obsługa wyjątku jest tu zbędna:
+    # ``get_or_create`` sam robi ``create`` w savepoincie
+    # (``transaction.atomic``) i domyka ``IntegrityError`` ponownym ``get``
+    # — czyli dokładnie to, co ``_update_or_create_odporne_na_wyscig``
+    # z ``pbn_api/client/disciplines.py``. Pilnuje tego
+    # ``test_get_or_create_przezywa_przegrany_wyscig``.
     rec, _ign = PublikacjaInstytucji.objects.get_or_create(
         institutionId_id=elem["institutionId"],
         publicationId_id=elem["publicationId"],


### PR DESCRIPTION
## Problem

`PublikacjaInstytucji` łączy publikację, instytucję i osobę przez trzy FK, ale
`Meta` ma **wyłącznie** `verbose_name` — zero `unique_together`, zero
`UniqueConstraint`. `pbn_integrator/utils/mongodb_ops.py` woła
`get_or_create()` na tej trójce w **wielowątkowym** imporcie PBN
(`use_threads=True`). Dwa wątki na tej samej trójce **cicho** tworzą duplikaty —
bez wyjątku, bez logu. Objaw: narastające z każdym importem zdublowane
powiązania, wykrywalne dopiero jako zawyżone liczby w raportach.

## Naprawa

`UniqueConstraint` na trójce `(institutionId, publicationId, insPersonId)`.
Wszystkie trzy FK są `NOT NULL` → zwykły constraint wystarcza (bez partial
indexu). Model jest liściem grafu FK (nic na niego nie wskazuje) → dedup kasuje
duplikaty wprost, zachowując najniższe `pk`.

- migracja `0078` — dedup (RunPython),
- migracja `0079` — `AddConstraint` (rozdzielone; wzorzec `pbn_api/0076`+`0077`
  z PR #635 — dokładnie ten problem, ta sama aplikacja).

**Bez własnego `try/except IntegrityError`** w gorącej ścieżce — zweryfikowano
w źródle Django 5.2.16, że `get_or_create` opakowuje `create()` w savepoint i
po `IntegrityError` ponawia `get()`; ścieżka wołająca biegnie w autocommit (grep
potwierdził brak `atomic`), więc constraint **nie wywali importu** przy wyścigu.

## Weryfikacja

- Test czerwony przed (`DID NOT RAISE IntegrityError`), `534 passed` po
  (`pbn_api` + `pbn_integrator`), plus e2e prawdziwej migracji 0077→0079 na bazie
  z duplikatami.
- Review: spec PASS, jakość APPROVED. Teza o `get_or_create` obroniona pod
  naciskiem recenzenta (źródło Django + grep ścieżki + izolacja READ COMMITTED).

## Uwagi

- Baseline **nie odświeżany** (raz, przy scalaniu) → `Check baseline freshness`
  czerwony do tego czasu, oczekiwane.
- Przed deployem warto zmierzyć skalę duplikatów na produkcji (zapytanie w
  opisie migracji) — dedup kasuje bez scalania pola `snapshot`, więc do
  najbliższego importu PBN istnieje wąskie okno regresu danych.

Poz. 1.2 audytu `HANDOFF-niewdrozone-2026-07-20.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
