### PR TITLE
fix(bpp): Autor_Jednostka — unikalne powiązanie bez daty, koniec duplikatów w save() autorstwa

### DIFF
--- a/src/bpp/migrations/0471_deduplikuj_autor_jednostka_bez_daty.py
+++ b/src/bpp/migrations/0471_deduplikuj_autor_jednostka_bez_daty.py
@@ -1,0 +1,156 @@
+"""Deduplikacja powiazan autor-jednostka bez daty rozpoczecia (krok 1 z 2).
+
+``Wydawnictwo_*_Autor.save()`` (``bpp/models/abstract/authors.py``) robilo
+check-then-create na parze ``(autor, jednostka)``, a deklarowany
+``unique_together = [("autor", "jednostka", "rozpoczal_prace")]`` tej pary nie
+chronil: ``rozpoczal_prace`` jest w tej sciezce NULL-em, a NULL-e w indeksie
+unikalnym PostgreSQL sa wzajemnie rozroznialne. Dwa rownolegle zapisy prac
+tego samego autora w tej samej jednostce (import, masowa edycja) tworzyly
+zduplikowane powiazania.
+
+Zanim ``0472`` zalozy czesciowy ``UniqueConstraint``, trzeba zdeduplikowac to,
+co juz jest w bazie — inaczej ``ALTER TABLE ... ADD CONSTRAINT`` sie wywali.
+
+Zasada wyboru "ktorego zostawic": **najnizszy pk**. To wiersz utworzony jako
+pierwszy, wiec istniejace FK z duzym prawdopodobienstwem wskazuja wlasnie na
+niego (minimum przepiec), a wybor jest deterministyczny. Wiersze-duplikaty i
+tak roznia sie co najwyzej polami opisowymi (funkcja, stanowisko, wymiar
+etatu) — na produkcji obserwowane duplikaty byly identyczne co do pola.
+
+Do ``Autor_Jednostka`` wskazuja dwa FK, oba ``on_delete=CASCADE``:
+
+* ``import_pracownikow.ImportPracownikowRow.autor_jednostka`` (nullable),
+* ``import_pracownikow.ImportPracownikowOdpiecie.autor_jednostka``.
+
+Gdybysmy po prostu skasowali duplikaty, CASCADE zabralby ze soba wiersze
+i odpiecia historycznych importow pracownikow (utrata sladu audytowego).
+Dlatego najpierw **przepinamy** je na ocalaly wiersz, a dopiero potem
+kasujemy duplikaty. Dla ``ImportPracownikowOdpiecie`` przepiecie moze
+wytworzyc dwa odpiecia tego samego powiazania w obrebie jednego importu —
+takie nadmiarowe wiersze zwijamy do jednego (OR na flagach
+``zaznaczone``/``wykonane``, zeby nie zgubic decyzji operatora).
+
+Same constrainty zaklada dopiero migracja ``0472``. To NIE jest kosmetyka:
+``DELETE`` na tabelach z FK zostawia w PostgreSQL oczekujace (deferred)
+zdarzenia wyzwalaczy, a ``ALTER TABLE ... ADD CONSTRAINT`` w tej samej
+transakcji wywala sie wtedy na "nie mozna ALTER TABLE ... poniewaz posiada
+oczekujace zdarzenia wyzwalaczy". Rozdzielenie na dwie migracje daje DDL
+wlasna, czysta transakcje.
+"""
+
+import logging
+
+from django.db import migrations, models
+
+logger = logging.getLogger(__name__)
+
+
+def _grupy_duplikatow(Autor_Jednostka):
+    """Listy pk-ow (posortowane rosnaco) dla kazdej zduplikowanej pary."""
+    duplikaty = (
+        Autor_Jednostka.objects.filter(rozpoczal_prace=None)
+        .values("autor_id", "jednostka_id")
+        .annotate(ile=models.Count("pk"))
+        .filter(ile__gt=1)
+        .order_by()
+    )
+    return [
+        list(
+            Autor_Jednostka.objects.filter(
+                rozpoczal_prace=None,
+                autor_id=wpis["autor_id"],
+                jednostka_id=wpis["jednostka_id"],
+            )
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+        for wpis in duplikaty
+    ]
+
+
+def _scal_odpiecia(ImportPracownikowOdpiecie, zostaje):
+    """Zwija odpiecia tego samego powiazania w obrebie jednego importu.
+
+    Przepiecie z duplikatow na ``zostaje`` moze dac kilka odpiec wskazujacych
+    to samo powiazanie w tym samym imporcie. Zostawiamy najstarsze (najnizszy
+    pk), sumujac flagi logicznym OR, zeby nie zgubic decyzji operatora.
+    """
+    nadmiarowe = (
+        ImportPracownikowOdpiecie.objects.filter(autor_jednostka_id=zostaje)
+        .values("parent_id")
+        .annotate(ile=models.Count("pk"))
+        .filter(ile__gt=1)
+        .order_by()
+    )
+    for wpis in nadmiarowe:
+        grupa = list(
+            ImportPracownikowOdpiecie.objects.filter(
+                autor_jednostka_id=zostaje, parent_id=wpis["parent_id"]
+            ).order_by("pk")
+        )
+        glowne, reszta = grupa[0], grupa[1:]
+        glowne.zaznaczone = any(o.zaznaczone for o in grupa)
+        glowne.wykonane = any(o.wykonane for o in grupa)
+        glowne.save(update_fields=["zaznaczone", "wykonane"])
+        ImportPracownikowOdpiecie.objects.filter(
+            pk__in=[o.pk for o in reszta]
+        ).delete()
+
+
+def deduplikuj(apps, schema_editor):
+    Autor_Jednostka = apps.get_model("bpp", "Autor_Jednostka")
+    ImportPracownikowRow = apps.get_model(
+        "import_pracownikow", "ImportPracownikowRow"
+    )
+    ImportPracownikowOdpiecie = apps.get_model(
+        "import_pracownikow", "ImportPracownikowOdpiecie"
+    )
+
+    usuniete = 0
+    for pk_i in _grupy_duplikatow(Autor_Jednostka):
+        zostaje, do_scalenia = pk_i[0], pk_i[1:]
+
+        ImportPracownikowRow.objects.filter(
+            autor_jednostka_id__in=do_scalenia
+        ).update(autor_jednostka_id=zostaje)
+        ImportPracownikowOdpiecie.objects.filter(
+            autor_jednostka_id__in=do_scalenia
+        ).update(autor_jednostka_id=zostaje)
+        _scal_odpiecia(ImportPracownikowOdpiecie, zostaje)
+
+        Autor_Jednostka.objects.filter(pk__in=do_scalenia).delete()
+        usuniete += len(do_scalenia)
+        logger.warning(
+            "bpp.Autor_Jednostka: scalono %s duplikat(ow) w wiersz pk=%s",
+            len(do_scalenia),
+            zostaje,
+        )
+
+    logger.warning(
+        "Deduplikacja powiazan autor-jednostka bez daty rozpoczecia "
+        "zakonczona: usunieto %s zduplikowanych wierszy.",
+        usuniete,
+    )
+
+
+def deduplikuj_wstecz(apps, schema_editor):
+    """Deduplikacji sie nie cofa.
+
+    Usuniete wiersze byly duplikatami powstalymi z bledu — ich odtworzenie nie
+    jest ani mozliwe (nie mamy ich pk-ow), ani pozadane. Migracja wstecz
+    zdejmuje tylko constraint (w ``0472``); dane pozostaja zdeduplikowane.
+    """
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bpp", "0470_indeksy_gin_i_funkcyjne"),
+        # ImportPracownikowOdpiecie (FK do Autor_Jednostka) pojawia sie w 0014;
+        # bez tej zaleznosci apps.get_model(...) w RunPython nie zobaczylby go.
+        ("import_pracownikow", "0014_utworz_nowego_odpiecie"),
+    ]
+
+    operations = [
+        migrations.RunPython(deduplikuj, deduplikuj_wstecz),
+    ]

--- a/src/bpp/migrations/0472_constraint_autor_jednostka_bez_daty.py
+++ b/src/bpp/migrations/0472_constraint_autor_jednostka_bez_daty.py
@@ -1,0 +1,31 @@
+"""Unikalnosc powiazania autor-jednostka bez daty rozpoczecia (krok 2 z 2).
+
+Deduplikacja jest w ``0471`` — osobna migracja, bo ``DELETE`` na tabelach z FK
+zostawia w PostgreSQL oczekujace zdarzenia wyzwalaczy i ``ALTER TABLE ... ADD
+CONSTRAINT`` w tej samej transakcji sie wywala.
+
+Constraint jest CZESCIOWY (``condition=Q(rozpoczal_prace__isnull=True)``) —
+wielokrotne, datowane okresy zatrudnienia tego samego autora w tej samej
+jednostce pozostaja legalne. Domykana jest wylacznie luka po NULL-ach, ktorej
+istniejacy ``unique_together`` nie pokrywal.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bpp", "0471_deduplikuj_autor_jednostka_bez_daty"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="autor_jednostka",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("rozpoczal_prace__isnull", True)),
+                fields=("autor", "jednostka"),
+                name="bpp_autor_jednostka_bez_daty_unikalne",
+            ),
+        ),
+    ]

--- a/src/bpp/models/abstract/authors.py
+++ b/src/bpp/models/abstract/authors.py
@@ -2,15 +2,18 @@
 Modele abstrakcyjne związane z odpowiedzialnością autorów.
 """
 
+import logging
 from decimal import Decimal
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import IntegrityError, models, transaction
 from django.db.models import CASCADE, SET_NULL, Q, Sum
 
 from bpp.models.dyscyplina_naukowa import Autor_Dyscyplina, Dyscyplina_Naukowa
 from bpp.models.util import dodaj_autora
+
+logger = logging.getLogger(__name__)
 
 
 class BazaModeluOdpowiedzialnosciAutorow(models.Model):
@@ -109,10 +112,33 @@ class BazaModeluOdpowiedzialnosciAutorow(models.Model):
                 autor_id=self.autor_id, jednostka_id=self.jednostka_id
             ).exists()
         ):
-            Autor_Jednostka.objects.create(
-                autor_id=self.autor_id,
-                jednostka_id=self.jednostka_id,
-            )
+            try:
+                # Wlasny savepoint: w PostgreSQL IntegrityError uniewaznia
+                # CALA otaczajaca transakcje, wiec bez atomic() nie dalo by
+                # sie po nim kontynuowac zapisu autorstwa.
+                with transaction.atomic():
+                    Autor_Jednostka.objects.create(
+                        autor_id=self.autor_id,
+                        jednostka_id=self.jednostka_id,
+                    )
+            except IntegrityError:
+                # Wyscig: rownolegly zapis utworzyl to samo powiazanie w
+                # okienku miedzy exists() a create(). Stan docelowy —
+                # powiazanie autor-jednostka istnieje — jest osiagniety, wiec
+                # zapis autorstwa (najgoretsza sciezka w systemie) nie ma
+                # powodu sie wywalac uzytkownikowi w twarz. Jesli jednak
+                # powiazania nadal nie ma, IntegrityError mowil o czyms INNYM
+                # (np. zerwany FK) i musi poleciec dalej.
+                if not Autor_Jednostka.objects.filter(
+                    autor_id=self.autor_id, jednostka_id=self.jednostka_id
+                ).exists():
+                    raise
+                logger.debug(
+                    "Powiazanie autor=%s jednostka=%s utworzone rownolegle "
+                    "przez inna transakcje — pomijam.",
+                    self.autor_id,
+                    self.jednostka_id,
+                )
             # olewamy refresh_from_db i autor.aktualna_jednostka
 
         return super().save(*args, **kw)

--- a/src/bpp/models/autor.py
+++ b/src/bpp/models/autor.py
@@ -352,13 +352,21 @@ class Autor(LinkDoPBNMixin, ModelZAdnotacjami, ModelZPBN_ID):
             return czy_juz_istnieje.first()
 
         try:
-            ret = Autor_Jednostka.objects.create(
-                autor=self,
-                jednostka=jednostka,
-                funkcja=funkcja,
-                rozpoczal_prace=start_pracy,
-                zakonczyl_prace=koniec_pracy,
-            )
+            # Wlasny savepoint: ponizszy ``except IntegrityError`` istnial tu
+            # od dawna, ale bez atomic() BYL martwy — w PostgreSQL blad
+            # integralnosci uniewaznia cala otaczajaca transakcje, wiec
+            # "polkniecie" wyjatku zostawialo polamana transakcje. Odkad
+            # (autor, jednostka) z pusta data rozpoczecia jest chronione
+            # czesciowym UniqueConstraintem, ta sciezka realnie potrafi
+            # zlapac wyjatek (wywolanie ``dodaj_jednostke`` bez ``rok``).
+            with transaction.atomic():
+                ret = Autor_Jednostka.objects.create(
+                    autor=self,
+                    jednostka=jednostka,
+                    funkcja=funkcja,
+                    rozpoczal_prace=start_pracy,
+                    zakonczyl_prace=koniec_pracy,
+                )
         except IntegrityError:
             return
         self.defragmentuj_jednostke(jednostka)
@@ -677,6 +685,21 @@ class Autor_Jednostka(models.Model):
         verbose_name_plural = "powiązania autor-jednostka"
         ordering = ["autor__nazwisko", "rozpoczal_prace", "jednostka__nazwa"]
         unique_together = [("autor", "jednostka", "rozpoczal_prace")]
+        constraints = [
+            # unique_together powyzej deklaruje niezmiennik "jedno powiazanie
+            # na trojke", ale w PostgreSQL NULL-e w indeksie unikalnym sa
+            # wzajemnie rozroznialne — wiersze z rozpoczal_prace IS NULL nie
+            # byly wiec chronione niczym. Tymczasem check-then-create w
+            # bpp.models.abstract.authors (save() KAZDEGO autorstwa) tworzy
+            # dokladnie takie wiersze. Ten czesciowy indeks domyka luke;
+            # dotyczy WYLACZNIE wierszy z NULL-owa data rozpoczecia, wiec
+            # wielokrotne (datowane) okresy zatrudnienia sa nadal legalne.
+            models.UniqueConstraint(
+                fields=("autor", "jednostka"),
+                condition=models.Q(rozpoczal_prace__isnull=True),
+                name="bpp_autor_jednostka_bez_daty_unikalne",
+            ),
+        ]
         app_label = "bpp"
         # Niezmiennik "co najwyzej jedno podstawowe miejsce pracy na autora" NIE
         # jest tu egzekwowany przez UniqueConstraint (partial unique index byl

--- a/src/bpp/models/autor.py
+++ b/src/bpp/models/autor.py
@@ -368,19 +368,24 @@ class Autor(LinkDoPBNMixin, ModelZAdnotacjami, ModelZPBN_ID):
                     zakonczyl_prace=koniec_pracy,
                 )
         except IntegrityError:
-            # Wyscig: rownolegly zapis utworzyl to samo powiazanie (autor,
-            # jednostka) bez daty rozpoczecia w okienku miedzy exists() a
-            # create(). Chroni je czesciowy UniqueConstraint
-            # (rozpoczal_prace IS NULL). Jesli powiazanie faktycznie juz
-            # istnieje — stan docelowy jest osiagniety, wiec zachowujemy sie
-            # jak dotad (return None). Jesli jednak nadal go nie ma,
-            # IntegrityError mowil o czyms INNYM (np. zerwany FK, naruszony
-            # datowany unique_together) i musi poleciec dalej — inaczej realny
-            # blad danych podczas importu znikalby bez sladu jako cichy no-op.
+            # Wyscig: rownolegly zapis utworzyl DOKLADNIE ten sam wiersz
+            # (autor, jednostka, rozpoczal_prace=start_pracy) w okienku miedzy
+            # exists() a create(). Chroni go unique_together (autor, jednostka,
+            # rozpoczal_prace) — dla start_pracy=None dodatkowo czesciowy
+            # UniqueConstraint (rozpoczal_prace IS NULL). Post-check pyta o
+            # dokladnie ta trojke: dla braku roku (start_pracy=None) Django
+            # tlumaczy filter(rozpoczal_prace=None) na IS NULL, a dla podanego
+            # roku porownuje z konkretna data — wiec jedno wyrazenie obsluguje
+            # oba przypadki. Jesli wiersz faktycznie juz istnieje — stan
+            # docelowy jest osiagniety, wiec zachowujemy sie jak dotad
+            # (return None). Jesli jednak nadal go nie ma, IntegrityError mowil
+            # o czyms INNYM (np. zerwany FK) i musi poleciec dalej — inaczej
+            # realny blad danych podczas importu znikalby bez sladu jako cichy
+            # no-op.
             if not Autor_Jednostka.objects.filter(
                 autor=self,
                 jednostka=jednostka,
-                rozpoczal_prace__isnull=True,
+                rozpoczal_prace=start_pracy,
             ).exists():
                 raise
             logger.debug(

--- a/src/bpp/models/autor.py
+++ b/src/bpp/models/autor.py
@@ -368,7 +368,28 @@ class Autor(LinkDoPBNMixin, ModelZAdnotacjami, ModelZPBN_ID):
                     zakonczyl_prace=koniec_pracy,
                 )
         except IntegrityError:
-            return
+            # Wyscig: rownolegly zapis utworzyl to samo powiazanie (autor,
+            # jednostka) bez daty rozpoczecia w okienku miedzy exists() a
+            # create(). Chroni je czesciowy UniqueConstraint
+            # (rozpoczal_prace IS NULL). Jesli powiazanie faktycznie juz
+            # istnieje — stan docelowy jest osiagniety, wiec zachowujemy sie
+            # jak dotad (return None). Jesli jednak nadal go nie ma,
+            # IntegrityError mowil o czyms INNYM (np. zerwany FK, naruszony
+            # datowany unique_together) i musi poleciec dalej — inaczej realny
+            # blad danych podczas importu znikalby bez sladu jako cichy no-op.
+            if not Autor_Jednostka.objects.filter(
+                autor=self,
+                jednostka=jednostka,
+                rozpoczal_prace__isnull=True,
+            ).exists():
+                raise
+            logger.debug(
+                "Powiazanie autor=%s jednostka=%s utworzone rownolegle "
+                "przez inna transakcje — pomijam.",
+                self.pk,
+                jednostka.pk,
+            )
+            return None
         self.defragmentuj_jednostke(jednostka)
 
         return ret

--- a/src/bpp/newsfragments/autor-jednostka-dup.bugfix.rst
+++ b/src/bpp/newsfragments/autor-jednostka-dup.bugfix.rst
@@ -1,0 +1,9 @@
+Powiązanie autor-jednostka bez daty rozpoczęcia pracy nie może się już
+zdublować: zapis pracy tworzył je metodą „sprawdź i utwórz", a deklarowana
+unikalność trójki (autor, jednostka, data rozpoczęcia) nie chroniła wierszy
+z pustą datą — dwa równoległe zapisy (import, masowa edycja) produkowały
+duplikat. Dodano częściowy warunek unikalności obejmujący wyłącznie wiersze
+z pustą datą rozpoczęcia (wielokrotne, datowane okresy zatrudnienia pozostają
+dozwolone), a migracja scala istniejące duplikaty, przepinając na ocalały
+wiersz powiązania z importu pracowników. Zapis pracy przy równoległym
+utworzeniu powiązania nie kończy się już błędem.

--- a/src/bpp/tests/test_models/test_autor_jednostka_dedup_migracja.py
+++ b/src/bpp/tests/test_models/test_autor_jednostka_dedup_migracja.py
@@ -1,0 +1,140 @@
+"""Deduplikacja z migracji ``bpp/0471_deduplikuj_autor_jednostka_bez_daty``.
+
+Testujemy funkcje ``deduplikuj`` bezposrednio na aktualnym rejestrze modeli.
+Zeby w ogole dalo sie wyprodukowac duplikaty, trzeba na czas testu zdjac
+constraint zakladany przez ``0472`` — dokladnie taki stan ma baza produkcyjna
+PRZED migracja.
+"""
+
+from importlib import import_module
+
+import pytest
+from django.apps import apps
+from django.db import connection
+from model_bakery import baker
+
+from bpp.models import Autor, Jednostka
+from bpp.models.autor import Autor_Jednostka
+
+migracja = import_module("bpp.migrations.0471_deduplikuj_autor_jednostka_bez_daty")
+
+CONSTRAINT = "bpp_autor_jednostka_bez_daty_unikalne"
+
+
+@pytest.fixture
+def bez_constraintu(db):
+    # Bez teardownu: DDL w PostgreSQL jest transakcyjny, a testy z ``db``
+    # biegna w transakcji wycofywanej na koncu — indeks wraca sam. Proba
+    # recznego CREATE INDEX po DELETE w tej samej transakcji i tak wywalilaby
+    # sie na "posiada oczekujace zdarzenia wyzwalaczy" (to samo, co wymusza
+    # rozdzielenie dedupu i DDL na migracje 0471 i 0472).
+    with connection.cursor() as cur:
+        cur.execute(f'DROP INDEX IF EXISTS "{CONSTRAINT}"')
+    yield
+
+
+@pytest.mark.django_db
+def test_deduplikuj_zostawia_najnizszy_pk_i_przepina_fk(bez_constraintu):
+    from import_pracownikow.models import (
+        ImportPracownikow,
+        ImportPracownikowOdpiecie,
+        ImportPracownikowRow,
+    )
+
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+
+    zostaje = Autor_Jednostka.objects.create(autor=autor, jednostka=jednostka)
+    duplikat = Autor_Jednostka.objects.create(autor=autor, jednostka=jednostka)
+    assert duplikat.pk > zostaje.pk
+
+    parent = baker.make(ImportPracownikow)
+    wiersz = baker.make(ImportPracownikowRow, parent=parent, autor_jednostka=duplikat)
+    odpiecie = baker.make(
+        ImportPracownikowOdpiecie,
+        parent=parent,
+        autor_jednostka=duplikat,
+        zaznaczone=True,
+        wykonane=False,
+    )
+
+    migracja.deduplikuj(apps, None)
+
+    assert list(
+        Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka).values_list(
+            "pk", flat=True
+        )
+    ) == [zostaje.pk]
+
+    # FK przepiete, a nie skasowane kaskadowo:
+    wiersz.refresh_from_db()
+    odpiecie.refresh_from_db()
+    assert wiersz.autor_jednostka_id == zostaje.pk
+    assert odpiecie.autor_jednostka_id == zostaje.pk
+    assert odpiecie.zaznaczone is True
+
+
+@pytest.mark.django_db
+def test_deduplikuj_scala_zdublowane_odpiecia_z_tego_samego_importu(bez_constraintu):
+    from import_pracownikow.models import ImportPracownikow, ImportPracownikowOdpiecie
+
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+
+    zostaje = Autor_Jednostka.objects.create(autor=autor, jednostka=jednostka)
+    duplikat = Autor_Jednostka.objects.create(autor=autor, jednostka=jednostka)
+
+    parent = baker.make(ImportPracownikow)
+    baker.make(
+        ImportPracownikowOdpiecie,
+        parent=parent,
+        autor_jednostka=zostaje,
+        zaznaczone=False,
+        wykonane=False,
+    )
+    baker.make(
+        ImportPracownikowOdpiecie,
+        parent=parent,
+        autor_jednostka=duplikat,
+        zaznaczone=True,
+        wykonane=True,
+    )
+
+    migracja.deduplikuj(apps, None)
+
+    odpiecia = ImportPracownikowOdpiecie.objects.filter(parent=parent)
+    assert odpiecia.count() == 1
+    ocalale = odpiecia.get()
+    assert ocalale.autor_jednostka_id == zostaje.pk
+    # Decyzja operatora (zaznaczone/wykonane) nie ginie przy scalaniu:
+    assert ocalale.zaznaczone is True
+    assert ocalale.wykonane is True
+
+
+@pytest.mark.django_db
+def test_deduplikuj_nie_rusza_datowanych_okresow_zatrudnienia(bez_constraintu):
+    from datetime import date
+
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+
+    pks = [
+        Autor_Jednostka.objects.create(
+            autor=autor,
+            jednostka=jednostka,
+            rozpoczal_prace=date(2010, 1, 1),
+            zakonczyl_prace=date(2012, 12, 31),
+        ).pk,
+        Autor_Jednostka.objects.create(
+            autor=autor, jednostka=jednostka, rozpoczal_prace=date(2015, 1, 1)
+        ).pk,
+        Autor_Jednostka.objects.create(autor=autor, jednostka=jednostka).pk,
+    ]
+
+    migracja.deduplikuj(apps, None)
+
+    assert set(
+        Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka).values_list(
+            "pk", flat=True
+        )
+    ) == set(pks)

--- a/src/bpp/tests/test_models/test_autor_jednostka_unikalnosc.py
+++ b/src/bpp/tests/test_models/test_autor_jednostka_unikalnosc.py
@@ -184,3 +184,79 @@ def test_dodaj_jednostke_nie_polyka_obcego_integrityerror():
     assert not Autor_Jednostka.objects.filter(
         autor=autor, jednostka=jednostka
     ).exists()
+
+
+@pytest.mark.django_db
+def test_dodaj_jednostke_z_rokiem_nie_polyka_obcego_integrityerror():
+    """Genuine IntegrityError na sciezce DATOWANEJ (``rok=X``) PROPAGUJE.
+
+    Symetryczny do wariantu bez roku: ``create()`` rzuca IntegrityError, a
+    wiersz ``(autor, jednostka, rozpoczal_prace=date(X, 1, 1))`` nadal nie
+    istnieje — to nie wyscig, wiec wyjatek musi poleciec dalej, a nie zostac
+    polkniety jako cichy ``return None``.
+    """
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+
+    with patch.object(
+        Autor_Jednostka.objects,
+        "create",
+        side_effect=IntegrityError(
+            "insert or update violates foreign key constraint"
+        ),
+    ):
+        with pytest.raises(IntegrityError):
+            autor.dodaj_jednostke(jednostka, rok=2020)
+
+    assert not Autor_Jednostka.objects.filter(
+        autor=autor, jednostka=jednostka
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_dodaj_jednostke_z_rokiem_wchlania_wyscig_na_datowanej_parze():
+    """Wyscig na datowanej parze -> ``return None`` (bez re-raise).
+
+    Regresja naprawiana tu: post-check pytal na sztywno o
+    ``rozpoczal_prace__isnull=True``, wiec dla ``rok=X`` (wiersz DATOWANY)
+    nigdy nie rozpoznawal prawdziwego wyscigu i re-raise'owal go jako 500.
+
+    Wiersz ``(autor, jednostka, rozpoczal_prace=date(2020, 1, 1))`` juz
+    istnieje (z ``zakonczyl_prace=None``, zeby interwalowy ``czy_juz_istnieje``
+    go NIE zlapal i doszlo do ``create()``). ``create()`` rzuca IntegrityError,
+    a post-check znajduje dokladnie te trojke -> ``return None``.
+    """
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+
+    Autor_Jednostka.objects.create(
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2020, 1, 1),
+        zakonczyl_prace=None,
+    )
+
+    with patch.object(
+        Autor_Jednostka.objects,
+        "create",
+        side_effect=IntegrityError("duplicate key value violates unique constraint"),
+    ):
+        assert autor.dodaj_jednostke(jednostka, rok=2020) is None
+
+    # Nadal jeden wiersz — cichy no-op, bez propagacji:
+    assert (
+        Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka).count() == 1
+    )
+
+
+@pytest.mark.django_db
+def test_filter_rozpoczal_prace_none_generuje_is_null():
+    """``filter(rozpoczal_prace=None)`` musi kompilowac sie do ``IS NULL``.
+
+    Od tego zalezy poprawnosc post-checku dla sciezki bez roku (``start_pracy``
+    = None): gdyby Django wygenerowalo ``= NULL``, warunek nigdy nie zlapalby
+    NULL-owego wyscigu. Weryfikujemy to na wygenerowanym SQL.
+    """
+    sql = str(Autor_Jednostka.objects.filter(rozpoczal_prace=None).query)
+    assert "IS NULL" in sql
+    assert "= NULL" not in sql

--- a/src/bpp/tests/test_models/test_autor_jednostka_unikalnosc.py
+++ b/src/bpp/tests/test_models/test_autor_jednostka_unikalnosc.py
@@ -154,3 +154,33 @@ def test_dodaj_jednostke_bez_roku_dwa_razy_nie_lamie_transakcji():
     assert (
         Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka).count() == 1
     )
+
+
+@pytest.mark.django_db
+def test_dodaj_jednostke_nie_polyka_obcego_integrityerror():
+    """Genuine IntegrityError (nie wyscig) w ``dodaj_jednostke`` PROPAGUJE.
+
+    Do tej gałęzi wpadał każdy ``IntegrityError`` — łącznie z realnym błędem
+    danych (zerwany FK, naruszony datowany unique_together), który cichłby
+    jako ``return None`` ignorowane przez importery. Symulujemy ``create()``
+    rzucający IntegrityError, przy czym powiazanie (autor, jednostka) bez daty
+    NADAL nie istnieje — to znaczy, że nie był to wyścig i wyjątek musi
+    polecieć dalej, a nie zostać połknięty.
+    """
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+
+    with patch.object(
+        Autor_Jednostka.objects,
+        "create",
+        side_effect=IntegrityError(
+            "insert or update violates foreign key constraint"
+        ),
+    ):
+        with pytest.raises(IntegrityError):
+            autor.dodaj_jednostke(jednostka)
+
+    # Nie powstal zaden wiersz — potwierdza, ze to byl genuine blad, nie wyscig:
+    assert not Autor_Jednostka.objects.filter(
+        autor=autor, jednostka=jednostka
+    ).exists()

--- a/src/bpp/tests/test_models/test_autor_jednostka_unikalnosc.py
+++ b/src/bpp/tests/test_models/test_autor_jednostka_unikalnosc.py
@@ -1,0 +1,156 @@
+"""Unikalność powiązania autor-jednostka przy pustym ``rozpoczal_prace``.
+
+``Autor_Jednostka.Meta.unique_together = [("autor", "jednostka",
+"rozpoczal_prace")]`` deklaruje niezmiennik „jedno powiązanie na trójkę",
+ale w PostgreSQL NULL-e w indeksie unikalnym są wzajemnie rozróżnialne —
+wiersze z ``rozpoczal_prace IS NULL`` nie były więc niczym chronione.
+
+Ścieżka ``Wydawnictwo_*_Autor.save()`` (najgorętsza w systemie) robi
+check-then-create dokładnie na parze ``(autor, jednostka)`` z NULL-owym
+``rozpoczal_prace``, więc dwa równoległe zapisy produkowały duplikaty.
+"""
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.db import IntegrityError, transaction
+from model_bakery import baker
+
+from bpp.models import Autor, Jednostka
+from bpp.models.autor import Autor_Jednostka
+
+
+@pytest.mark.django_db
+def test_autor_jednostka_bez_daty_rozpoczecia_nie_moze_sie_dublowac():
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+
+    Autor_Jednostka.objects.create(autor=autor, jednostka=jednostka)
+
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            Autor_Jednostka.objects.create(autor=autor, jednostka=jednostka)
+
+    assert (
+        Autor_Jednostka.objects.filter(
+            autor=autor, jednostka=jednostka, rozpoczal_prace=None
+        ).count()
+        == 1
+    )
+
+
+@pytest.mark.django_db
+def test_wiele_okresow_zatrudnienia_z_datami_nadal_dozwolone():
+    """Constraint jest częściowy — nie rusza legalnych okresów zatrudnienia."""
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+
+    Autor_Jednostka.objects.create(
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2012, 12, 31),
+    )
+    Autor_Jednostka.objects.create(
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2015, 1, 1),
+        zakonczyl_prace=date(2018, 12, 31),
+    )
+    Autor_Jednostka.objects.create(
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2020, 1, 1),
+    )
+
+    assert Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka).count() == 3
+
+
+@pytest.mark.django_db
+def test_wiersz_bez_daty_obok_okresow_z_datami_jest_dozwolony():
+    """Jeden wiersz „bez dat" współistnieje z wierszami datowanymi."""
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+
+    Autor_Jednostka.objects.create(
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+        zakonczyl_prace=date(2012, 12, 31),
+    )
+    Autor_Jednostka.objects.create(autor=autor, jednostka=jednostka)
+
+    assert Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka).count() == 2
+
+
+@pytest.mark.django_db
+def test_zapis_autorstwa_przezywa_wyscig_o_powiazanie(
+    wydawnictwo_ciagle, autor_jan_nowak, jednostka, typy_odpowiedzialnosci
+):
+    """Constraint nie moze wywalac zapisu autorstwa przy wyscigu.
+
+    Symulujemy sytuacje, w ktorej rownolegla transakcja utworzyla powiazanie
+    w okienku miedzy ``exists()`` a ``create()``: pierwsze sprawdzenie zwraca
+    "nie ma", a ``create()`` konczy sie ``IntegrityError``. Zapis autorstwa ma
+    to przezyc, bo stan docelowy (powiazanie istnieje) jest osiagniety.
+    """
+    Autor_Jednostka.objects.create(autor=autor_jan_nowak, jednostka=jednostka)
+
+    with patch.object(
+        Autor_Jednostka.objects,
+        "create",
+        side_effect=IntegrityError("duplicate key value violates unique constraint"),
+    ):
+        with patch.object(
+            Autor_Jednostka.objects,
+            "filter",
+            side_effect=[
+                SimpleNamespace(exists=lambda: False),  # wyscig: "jeszcze nie ma"
+                SimpleNamespace(exists=lambda: True),  # po IntegrityError: "juz jest"
+            ],
+        ):
+            wydawnictwo_ciagle.dodaj_autora(autor_jan_nowak, jednostka)
+
+    assert (
+        Autor_Jednostka.objects.filter(
+            autor=autor_jan_nowak, jednostka=jednostka
+        ).count()
+        == 1
+    )
+
+
+@pytest.mark.django_db
+def test_zapis_autorstwa_nie_polyka_obcego_integrityerror(
+    wydawnictwo_ciagle, autor_jan_nowak, jednostka, typy_odpowiedzialnosci
+):
+    """IntegrityError z INNEGO powodu niz wyscig ma polecec dalej."""
+    with patch.object(
+        Autor_Jednostka.objects,
+        "create",
+        side_effect=IntegrityError("insert or update violates foreign key constraint"),
+    ):
+        with pytest.raises(IntegrityError):
+            wydawnictwo_ciagle.dodaj_autora(autor_jan_nowak, jednostka)
+
+
+@pytest.mark.django_db
+def test_dodaj_jednostke_bez_roku_dwa_razy_nie_lamie_transakcji():
+    """``Autor.dodaj_jednostke`` bez ``rok`` tworzy wiersz z pusta data.
+
+    Drugie wywolanie trafia teraz w constraint. Istniejacy tam
+    ``except IntegrityError: return`` musi zadzialac, a transakcja pozostac
+    uzywalna (savepoint) — inaczej kazdy dalszy SELECT rzucilby
+    ``TransactionManagementError``.
+    """
+    autor = baker.make(Autor)
+    jednostka = baker.make(Jednostka)
+
+    assert autor.dodaj_jednostke(jednostka) is not None
+    assert autor.dodaj_jednostke(jednostka) is None
+
+    # Transakcja zyje — kolejne zapytanie sie wykonuje:
+    assert (
+        Autor_Jednostka.objects.filter(autor=autor, jednostka=jednostka).count() == 1
+    )

--- a/src/bpp/tests/test_models/test_autor_scope.py
+++ b/src/bpp/tests/test_models/test_autor_scope.py
@@ -10,7 +10,7 @@ Zakresy jako czytelne API managera:
 - WSZYSCY = ``Autor.objects.all()`` (bez metody).
 """
 
-from datetime import timedelta
+from datetime import date, timedelta
 
 import pytest
 from django.utils import timezone
@@ -98,8 +98,22 @@ def test_kiedykolwiek_zwiazani_zwraca_aktualnie_zatrudnionego(uczelnia, jednostk
 def test_kiedykolwiek_zwiazani_bez_duplikatow(uczelnia, jednostka):
     """Autor aktualny ORAZ z wieloma wpisami historycznymi = jeden wiersz."""
     autor = baker.make(Autor, aktualna_jednostka=jednostka)
-    baker.make("bpp.Autor_Jednostka", autor=autor, jednostka=jednostka)
-    baker.make("bpp.Autor_Jednostka", autor=autor, jednostka=jednostka)
+    # Rozne daty rozpoczecia: wpisy sa legalne wobec czesciowego constraintu
+    # ``bpp_autor_jednostka_bez_daty_unikalne`` (obejmuje wylacznie wiersze z
+    # NULL-owym ``rozpoczal_prace``), a test dalej sprawdza dokladnie to, co
+    # sprawdzal — ze zakres nie duplikuje autora przy wielu powiazaniach.
+    baker.make(
+        "bpp.Autor_Jednostka",
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2010, 1, 1),
+    )
+    baker.make(
+        "bpp.Autor_Jednostka",
+        autor=autor,
+        jednostka=jednostka,
+        rozpoczal_prace=date(2015, 1, 1),
+    )
 
     wynik = list(Autor.objects.kiedykolwiek_zwiazani(uczelnia))
 

--- a/src/bpp/tests/test_models/test_models_legacy.py
+++ b/src/bpp/tests/test_models/test_models_legacy.py
@@ -294,7 +294,10 @@ def test_autor_jednostka(autor_jednostka_setup):
     aj = Autor_Jednostka.objects.create(autor=a, jednostka=j, funkcja=f)
     assert str(aj) == "Lol Omg ↔ kierownik, L."
 
-    aj = Autor_Jednostka.objects.create(autor=a, jednostka=j, funkcja=None)
+    # Drugie powiazanie tej samej pary z pusta data rozpoczecia jest zabronione
+    # przez ``bpp_autor_jednostka_bez_daty_unikalne``, a i tak nie bylo tu
+    # potrzebne — sprawdzamy tylko ``__str__`` bez funkcji.
+    aj.funkcja = None
     assert str(aj) == "Lol Omg ↔ L."
 
     aj.rozpoczal_prace = datetime(2012, 1, 1)

--- a/src/import_pracownikow/tests/test_okresy_resolver.py
+++ b/src/import_pracownikow/tests/test_okresy_resolver.py
@@ -121,8 +121,23 @@ def test_istniejacy_pusty_plik_zwraca_aktywny_najswiezszy(para):
     assert rozwiaz_okres_zatrudnienia(autor, jednostka, None) == ("istniejacy", aktywny)
 
 
+@pytest.fixture
+def bez_constraintu_bez_daty(db):
+    """Zdejmuje ``bpp_autor_jednostka_bez_daty_unikalne`` na czas testu.
+
+    Kilka powiazan tej samej pary (autor, jednostka) z pustym
+    ``rozpoczal_prace`` to stan sprzed migracji ``bpp/0472`` — nowe dane juz go
+    nie wytworza, ale resolver ma pozostac deterministyczny na danych
+    zastanych, gdyby jakies umknely dedupowi. Bez teardownu: DDL w PostgreSQL
+    jest transakcyjny, a test biegnie w wycofywanej transakcji.
+    """
+    with connection.cursor() as cur:
+        cur.execute('DROP INDEX IF EXISTS "bpp_autor_jednostka_bez_daty_unikalne"')
+    yield
+
+
 @pytest.mark.django_db
-def test_wiele_null_rozpoczal_deterministyczny_po_pk(para):
+def test_wiele_null_rozpoczal_deterministyczny_po_pk(para, bez_constraintu_bez_daty):
     autor, jednostka = para
     a1 = baker.make(
         Autor_Jednostka, autor=autor, jednostka=jednostka, rozpoczal_prace=None

--- a/src/raport_slotow/tests/tests_models/test_uczelnia.py
+++ b/src/raport_slotow/tests/tests_models/test_uczelnia.py
@@ -70,13 +70,20 @@ def test_RaportSlotowUczelnia_zerowi_autorzy(
     Autor_Dyscyplina.objects.create(
         rok=rok, autor=autor_jan_kowalski, dyscyplina_naukowa=dyscyplina1
     )
-    Autor_Jednostka.objects.create(autor=autor_jan_kowalski, jednostka=jednostka)
+    # get_or_create: powiazanie moze juz istniec, bo zapis autorstwa
+    # (fixture ``rekord_slotu``) sam je zaklada, a duplikat pary
+    # (autor, jednostka) bez daty rozpoczecia jest teraz zabroniony.
+    Autor_Jednostka.objects.get_or_create(
+        autor=autor_jan_kowalski, jednostka=jednostka, rozpoczal_prace=None
+    )
 
     # Autor "zerowy", przypisanie do dyscypliny
     Autor_Dyscyplina.objects.create(
         rok=rok, autor=autor_jan_nowak, dyscyplina_naukowa=dyscyplina1
     )
-    Autor_Jednostka.objects.create(autor=autor_jan_nowak, jednostka=jednostka)
+    Autor_Jednostka.objects.get_or_create(
+        autor=autor_jan_nowak, jednostka=jednostka, rozpoczal_prace=None
+    )
 
     assert RaportSlotowUczelniaWiersz.objects.count() == 0
     raport_slotow_uczelnia.create_report()


### PR DESCRIPTION
## Problem

`Autor.dodaj_jednostke` / `abstract/authors.py` robią check-then-create
powiązania autor-jednostka. `unique_together = (autor, jednostka,
rozpoczal_prace)` **nie pokrywa** pary z lookupu, a `rozpoczal_prace` jest tu
NULL — a NULL-e w indeksie unikalnym są wzajemnie rozróżnialne, więc constraint
nie zablokuje nawet duplikatu identycznej trójki. Ścieżka gorąca: `save()`
**każdego** autorstwa. Dwa równoległe zapisy prac tego samego autora w tej samej
jednostce → zduplikowane powiązania.

## Naprawa

Częściowy `UniqueConstraint` na `(autor, jednostka)` `WHERE rozpoczal_prace IS
NULL`. Constraint **nie dotyka** legalnych datowanych okresów zatrudnienia.

- migracja `0471` — dedup (RunPython): dla każdej grupy zostaje najniższe `pk`,
  a dwa FK CASCADE (`ImportPracownikowRow`, `ImportPracownikowOdpiecie`) są
  **przepinane** na ocalały wiersz PRZED `DELETE` (ochrona śladu audytowego
  importów pracowników); zdublowane odpięcia zwijane OR-em na flagach decyzji.
- migracja `0472` — `AddConstraint` (rozdzielone; wzorzec `pbn_api/0076`+`0077`).
- Obsługa `IntegrityError` w OBU ścieżkach zapisu: po wyjątku re-check dokładnie
  tworzonej trójki (`rozpoczal_prace=start_pracy`) — wyścig → `return None`,
  genuine błąd (zerwany FK) → **re-raise** (inaczej błąd importu znikałby cicho).

**Zakres:** wyłącznie wariant prosty (NULL). Wariant przedziałowy (poz. 1.7,
wymaga `EXCLUDE`+`btree_gist`) świadomie NIE tknięty.

## Weryfikacja

- Cała suita projektu `7778 passed`. TDD potwierdzone; testy obsługi wyjątku
  dowodzą w obie strony (genuine `IntegrityError` propaguje, wyścig → `None`).
- **Dedup zweryfikowany na dużym dumpie produkcyjnym** (772 MB, 85 832 wiersze,
  4 426 datowanych okresów): 4 grupy duplikatów, wszystkie polowo identyczne,
  **zero ubytku danych**, migracje 0471/0472 zastosowane naprawdę, FK spójne.
- Review: spec PASS, jakość APPROVED (2 fixy: asymetria połykania `IntegrityError`,
  generalizacja post-check na ścieżkę datowaną).

## Uwaga o baseline

Nie odświeżany (raz, przy scalaniu) → `Check baseline freshness` czerwony,
oczekiwane.

Poz. 1.3 audytu `HANDOFF-niewdrozone-2026-07-20.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
