### PR TITLE
fix(migrations): napraw rebuild bazy od zera (denorm_init + zależność easyaudit)

### DIFF
--- a/src/bpp/migrations/0400_add_status_optymalizacji_bulk.py
+++ b/src/bpp/migrations/0400_add_status_optymalizacji_bulk.py
@@ -33,8 +33,13 @@ def restore_triggers(apps, schema_editor):
     # Recreate cache triggers
     load_custom_sql("0400_restore_cache_triggers")
 
-    # Reinstall denorm triggers
-    call_command("denorm_init")
+    # UWAGA: świadomie usunięto tu `call_command("denorm_init")`.
+    # Triggery denorm odtwarza teraz sygnał `post_migrate`
+    # (`denorm.apps` → `denorm_install_triggers_after_migrate`) na
+    # KOMPLETNYM schemacie, po wszystkich migracjach. Wołanie `denorm_init`
+    # w środku historii budowało triggery z DZISIEJSZYCH modeli na cofniętym
+    # schemacie i rebuild-od-zera padał na kolumnie z przyszłości
+    # (np. `old.pbn_czy_projekt_fnp`, która dochodzi dopiero w 0406).
 
 
 class Migration(migrations.Migration):

--- a/src/bpp/migrations/0403_autorzy_ostatnio_zmieniony.py
+++ b/src/bpp/migrations/0403_autorzy_ostatnio_zmieniony.py
@@ -33,8 +33,12 @@ def restore_triggers(apps, schema_editor):
     # Recreate cache triggers
     load_custom_sql("0400_restore_cache_triggers")
 
-    # Reinstall denorm triggers
-    call_command("denorm_init")
+    # UWAGA: świadomie usunięto tu `call_command("denorm_init")`.
+    # Triggery denorm odtwarza teraz sygnał `post_migrate`
+    # (`denorm.apps` → `denorm_install_triggers_after_migrate`) na
+    # KOMPLETNYM schemacie, po wszystkich migracjach. Wołanie `denorm_init`
+    # w środku historii budowało triggery z DZISIEJSZYCH modeli na cofniętym
+    # schemacie i rebuild-od-zera padał na kolumnie z przyszłości.
 
 
 def populate_ostatnio_zmieniony(apps, schema_editor):

--- a/src/bpp/migrations/0459_faza_b_ii1_retarget.py
+++ b/src/bpp/migrations/0459_faza_b_ii1_retarget.py
@@ -59,9 +59,18 @@ def drop_denorm_triggers(apps, schema_editor):
 
 
 def init_denorm_triggers(apps, schema_editor):
-    """Zainstaluj triggery denorm na podstawie realnych modeli (``wydzial``
-    jest już self-FK denorm). Instaluje TYLKO triggery — wartości dał remap."""
-    call_command("denorm_init")
+    """Punkt reinstalacji triggerów denorm po retargecie ``wydzial``.
+
+    UWAGA: świadomie usunięto tu ``call_command("denorm_init")``. Triggery
+    denorm odtwarza teraz sygnał ``post_migrate`` (``denorm.apps`` →
+    ``denorm_install_triggers_after_migrate``) na KOMPLETNYM schemacie, po
+    wszystkich migracjach. Wołanie ``denorm_init`` w środku historii budowało
+    triggery z DZISIEJSZYCH modeli na cofniętym schemacie i rebuild-od-zera
+    padał na kolumnie z przyszłości (np. ``old.pbn_czy_projekt_fnp``).
+    Operacja zostaje jako ``RunPython`` (zachowany graf/state migracji), ale
+    jej ciało jest teraz no-opem. ``denorm_drop`` wyżej pozostaje bez zmian.
+    """
+    # Reinstalacja triggerów denorm dzieje się w `post_migrate` — patrz wyżej.
 
 
 def _find_root(node_id, parent_map):

--- a/src/bpp/migrations/0470_indeksy_gin_i_funkcyjne.py
+++ b/src/bpp/migrations/0470_indeksy_gin_i_funkcyjne.py
@@ -117,6 +117,14 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("bpp", "0469_przyszle_daty_zakonczenia_zatrudnienia"),
+        # Ostatnia operacja zakłada indeks na `easyaudit_crudevent` (tabela
+        # aplikacji django-easy-audit, model CRUDEvent tworzony w
+        # easyaudit.0001_initial). Bez tej krawędzi sortowanie topologiczne
+        # przy rebuildzie-od-zera mogło ustawić migracje easyaudit PO 0470 i
+        # `CREATE INDEX ... ON easyaudit_crudevent` wywalał się na
+        # nieistniejącej tabeli. Na istniejących bazach zależność jest już
+        # dawno spełniona → no-op dla prod, zmienia tylko kolejność rebuildu.
+        ("easyaudit", "0001_initial"),
     ]
 
     operations = (

--- a/src/bpp/newsfragments/denorm-init-rebuild-od-zera.bugfix.rst
+++ b/src/bpp/newsfragments/denorm-init-rebuild-od-zera.bugfix.rst
@@ -1,0 +1,9 @@
+Przebudowa bazy od zera (odtworzenie wszystkich migracji na pustej bazie)
+nie pada już na dwóch latentnych blokerach kolejności. Po pierwsze, usunięto
+wywołania ``denorm_init`` w środku historii migracji, które budowały triggery
+z dzisiejszych modeli i odwoływały się do kolumn dochodzących dopiero w
+późniejszych migracjach — triggery denorm odtwarza teraz sygnał
+``post_migrate`` na kompletnym schemacie. Po drugie, migracja indeksów GIN
+zakładająca indeks na tabeli ``easyaudit_crudevent`` deklaruje teraz zależność
+od aplikacji ``easyaudit``, więc tabela istnieje, zanim indeks zostanie
+utworzony. Obie zmiany są no-opem dla istniejących baz.


### PR DESCRIPTION
## Problem

Rebuild bazy **od zera** (odtworzenie wszystkich migracji od `0001` na pustej
bazie — ścieżka `baseline_rebuild` / workflow „Refresh baseline pg_dump") pada
od ≥2026-07-13 na `bpp.0400` z „kolumna `old.pbn_czy_projekt_fnp` nie istnieje".
Maskuje się czerwonym checkiem, na który nikt nie patrzy (poz. 3.1 audytu).

Przyczyna: trzy migracje wołają w środku historii `call_command("denorm_init")`,
a `denorm_init` buduje triggery z **żywych** modeli. W środku historii schemat
jest cofnięty, modele są dzisiejsze → trigger odwołuje się do kolumny z
przyszłości (`pbn_czy_projekt_fnp` dochodzi dopiero w `0406`) → wywrotka.

## Naprawa

> ⚠️ Ta gałąź **edytuje istniejące pliki migracji** — normalnie zakazane w tym
> repo. Zmiana autoryzowana jawnie, pod twardym warunkiem: rebuild od zera musi
> przejść na zielono (spełnione).

1. Usunięto mid-historyczny `call_command("denorm_init")` z `0400`, `0403`,
   `0459`. Triggery denorm i tak odtwarza hook `post_migrate` (`denorm/apps.py`,
   `DENORM_INSTALL_TRIGGERS_AFTER_MIGRATE` default `True`) — **raz, na
   kompletnym schemacie po wszystkich migracjach**, wołając tę **samą**
   `install_triggers`. Mid-historyczne inity były względem tego redundantne.
   `denorm_drop` zostaje (idempotentny, nie zależy od żywych modeli).
2. Dodano `("easyaudit","0001_initial")` do `dependencies` migracji `0470`
   (robi `CREATE INDEX ON easyaudit_crudevent`, ale nie deklarowała zależności
   od migracji tworzącej tę tabelę). Precedens: `bpp/0340`.

**Bezpieczne dla istniejących baz:** edycja ciała `RunPython` już-zastosowanej
migracji nie re-runuje jej ani nie zmienia autodetektora — działa wyłącznie na
ścieżce rebuild-od-zera. Na produkcji te migracje są już zastosowane; dodanie
spełnionej zależności to no-op.

## Weryfikacja

- `make rebuild-baseline` przechodzi na **zielono** (exit 0) — wszystkie migracje
  od `0001` do HEAD na pustej bazie. Cztery blokery naprawione, żadnych dalszych.
- Review (wysokiego ryzyka): spec PASS, jakość/bezpieczeństwo APPROVED. Tezy
  potwierdzone KODEM: pokrycie `post_migrate` (ta sama `install_triggers`), no-op
  dla prod, brak cyklu `0470→easyaudit`. Sanity `148 passed`.

## Uwaga o baseline

Zregenerowany `baseline-sql/baseline.sql` **świadomie NIE w commicie** — baseline
odświeża się raz, przy scalaniu (`make baseline-update`), który przy okazji
niezależnie potwierdza zielony rebuild.

Poz. 3.1 audytu `HANDOFF-niewdrozone-2026-07-20.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
