### PR TITLE
ci(flaky): retry raz na testy Playwright + retry na pull obrazów Docker

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -416,7 +416,37 @@ jobs:
         run: mkdir -p ci-output
 
       - name: Pull test-runner image
-        run: docker compose $COMPOSE_FILES pull test-runner
+        # Retry na transient network/registry error (timeout GHCR/Docker Hub
+        # to najczestszy szum CI — nie regresja kodu). 3 proby, 10s backoff;
+        # dopiero trwala porazka wywala krok.
+        run: |
+          n=0
+          until docker compose $COMPOSE_FILES pull test-runner; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "docker pull test-runner nie powiodl sie po $n probach" >&2
+              exit 1
+            fi
+            echo "pull test-runner padl (proba $n), ponawiam za 10s..." >&2
+            sleep 10
+          done
+
+      - name: Pull service images (db, redis)
+        # Osobny, retry-owany pull obrazow z Docker Huba (iplweb/bpp_dbserver,
+        # redis) PRZED `up -d`. Wczesniej `up -d` pobieral je implicite bez
+        # retry — timeout Docker Huba na iplweb/bpp_dbserver wywalal caly
+        # shard (poz. 3.3 audytu). Teraz `up -d` widzi obrazy juz lokalnie.
+        run: |
+          n=0
+          until docker compose $COMPOSE_FILES pull db redis; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "docker pull db/redis nie powiodl sie po $n probach" >&2
+              exit 1
+            fi
+            echo "pull db/redis padl (proba $n), ponawiam za 10s..." >&2
+            sleep 10
+          done
 
       - name: Start services
         run: docker compose $COMPOSE_FILES up -d db redis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -339,7 +339,37 @@ jobs:
       run: mkdir -p ci-output
 
     - name: Pull test-runner image
-      run: docker compose $COMPOSE_FILES pull test-runner
+      # Retry na transient network/registry error (timeout GHCR/Docker Hub
+      # to najczestszy szum CI — nie regresja kodu). 3 proby, 10s backoff;
+      # dopiero trwala porazka wywala krok.
+      run: |
+        n=0
+        until docker compose $COMPOSE_FILES pull test-runner; do
+          n=$((n + 1))
+          if [ "$n" -ge 3 ]; then
+            echo "docker pull test-runner nie powiodl sie po $n probach" >&2
+            exit 1
+          fi
+          echo "pull test-runner padl (proba $n), ponawiam za 10s..." >&2
+          sleep 10
+        done
+
+    - name: Pull service images (db, redis)
+      # Osobny, retry-owany pull obrazow z Docker Huba (iplweb/bpp_dbserver,
+      # redis) PRZED `up -d`. Wczesniej `up -d` pobieral je implicite bez
+      # retry — timeout Docker Huba na iplweb/bpp_dbserver wywalal caly shard
+      # (poz. 3.3 audytu). Teraz `up -d` widzi obrazy juz lokalnie.
+      run: |
+        n=0
+        until docker compose $COMPOSE_FILES pull db redis; do
+          n=$((n + 1))
+          if [ "$n" -ge 3 ]; then
+            echo "docker pull db/redis nie powiodl sie po $n probach" >&2
+            exit 1
+          fi
+          echo "pull db/redis padl (proba $n), ponawiam za 10s..." >&2
+          sleep 10
+        done
 
     - name: Start services
       run: docker compose $COMPOSE_FILES up -d db redis

--- a/src/bpp/newsfragments/+ci-flaky-playwright-docker-retry.feature.rst
+++ b/src/bpp/newsfragments/+ci-flaky-playwright-docker-retry.feature.rst
@@ -1,0 +1,6 @@
+CI: testy przeglądarkowe (Playwright) są ponawiane raz przy porażce
+(``pytest-rerunfailures``), a pull obrazów Docker (``iplweb/bpp_dbserver``,
+``redis``, test-runner) ma retry z backoffem. Redukuje szum CI z flake'ów
+Playwrighta i timeoutów rejestru, nie maskując przy tym niedeterminizmu w
+testach jednostkowych — retry jest zawężony wyłącznie do testów z markerem
+``playwright``.

--- a/src/fixtures/conftest.py
+++ b/src/fixtures/conftest.py
@@ -61,6 +61,21 @@ def pytest_collection_modifyitems(items):
         fixtures = getattr(item, "fixturenames", ())
         if "page" in fixtures or "admin_page" in fixtures or "zrodla_page" in fixtures:
             item.add_marker("playwright")
+            # Ponów raz KAŻDY test przeglądarkowy (Playwright), który padł —
+            # łapie niedeterministyczne flake'i (wait_for_* timeout,
+            # ElementClickIntercepted, expect()→AssertionError), które nie
+            # są regresją kodu. Zawężenie jest REALNE: markera dostają tylko
+            # testy używające fikstur 'page'/'admin_page'/'zrodla_page', a
+            # globalnego `--reruns` w pytest.ini NIE ma, więc testy
+            # jednostkowe NIGDY nie są ponawiane — ich niedeterminizm to bug
+            # do naprawy, nie do maskowania. `--only-rerun` w pytest.ini
+            # dodatkowo ogranicza reruny do konkretnych wyjątków.
+            #
+            # Nie nadpisuj jawnego @pytest.mark.flaky(reruns=N) (np.
+            # test_bpp_with_notifications ma reruns=3) — jego wyższa liczba
+            # ponowień ma pierwszeństwo.
+            if item.get_closest_marker("flaky") is None:
+                item.add_marker(pytest.mark.flaky(reruns=1))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

W jednej sesji CI padło **8 razy**, z czego tylko **2** z winy zmienianego kodu.
Reszta to szum: flake Playwrighta (`wait_for_function` timeout) i timeout Docker
Huba przy pobieraniu obrazu `iplweb/bpp_dbserver`. Realne regresje padają
**powtarzalnie**, więc retry ich nie zamaskuje — a odzyskuje godziny na PR
(poz. 3.3 audytu).

## Naprawa

1. **`pytest-rerunfailures` z `reruns=1` zawężony do testów Playwrighta** — przez
   **marker `playwright`** (auto-nadawany testom z fiksturą `page`/`admin_page`/
   `zrodla_page`), nie po ścieżce. To kanoniczny mechanizm repo (`-m playwright`,
   jak `make tests-only-playwright`), odporniejszy niż ścieżka: nowy test
   przeglądarkowy poza `integration_tests/` też dostanie retry automatycznie.
   Jawny `@flaky(reruns=3)` gdzie indziej nie jest nadpisywany (guard
   `get_closest_marker`).
2. **Retry na pull obrazów Docker** (`db`, `redis`) w krokach CI — realna pętla
   3 prób z `exit 1` po wyczerpaniu (NIE `|| true`, które maskowałoby trwały błąd).

## Dlaczego to bezpieczne (nie maskuje prawdziwych bugów)

Retry **NIE dotyka testów jednostkowych** — zweryfikowane niezależnie przez
recenzenta własną kolekcją pytest: 34 testy jednostkowe `reruns=None` (bez
ponawiania), 6 Playwright `reruns=1`, 3 jawne `@flaky(reruns=3)` nietknięte.
Brak globalnego `--reruns` w repo (tylko whitelist `--only-rerun`), pakiet
`flaky` standalone niezainstalowany (brak konfliktu pluginów o marker).
Niedeterministyczne testy jednostkowe nadal padają powtarzalnie — trzeba je
naprawiać, nie ponawiać.

## Weryfikacja

- Kolekcja z dumpem markerów potwierdza zawężenie (liczby wyżej).
- Runtime-test syntetycznego flaka: RERUN→PASSED.
- Review: spec PASS, jakość APPROVED (recenzent odtworzył liczby co do sztuki).
- Pełny efekt retry na CI (transient timeout Docker Huba) widoczny dopiero
  statystycznie na realnych runach — z natury.

Poz. 3.3 audytu `HANDOFF-niewdrozone-2026-07-20.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
