### PR TITLE
fix(compress): COMPRESS_OUTPUT_DIR bez numeru wersji — koniec bustowania cache statyków na każdym deployu

### DIFF
--- a/src/bpp/newsfragments/compress-output-dir-hash.feature.rst
+++ b/src/bpp/newsfragments/compress-output-dir-hash.feature.rst
@@ -1,0 +1,6 @@
+Statyki (JS/CSS) nie są już unieważniane w cache przeglądarki przy każdym
+wydaniu. Katalog wyjściowy django-compressor przestał zawierać numer wersji
+(``CACHE-{VERSION}`` → ``CACHE``); pliki i tak są nazywane hashem swojej
+treści, więc ścieżka zmienia się tylko wtedy, gdy realnie zmieni się JS/CSS —
+deploy bez zmian we front-endzie oszczędza użytkownikom ~305 KB gzip zbędnego
+pobierania.

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -1105,10 +1105,20 @@ CHANNELS_BROADCAST_SUBSCRIPTION_AUTHORIZER = (
 )
 
 
-# django-compressor dla każdej wersji będzie miał swoją nazwę katalogu
-# wyjściowego, z tej prostej przyczyny, że nie wszystkie przeglądarki
-# pamiętają, żeby odświeżyć cache:
-COMPRESS_OUTPUT_DIR = f"CACHE-{VERSION}"
+# django-compressor nazywa każdy plik wyjściowy 12-znakowym hashem jego
+# TREŚCI (compressor.base.Compressor.get_filepath →
+# get_hexdigest(content, 12)): np. "CACHE/js/58a8c0714e59.js". Nazwa pliku
+# zmienia się WTEDY I TYLKO WTEDY, gdy zmienia się treść — to wystarczający,
+# poprawny cache-busting współgrający z nagłówkiem `immutable`.
+#
+# Katalog był wcześniej wersjonowany (`CACHE-{VERSION}`) w intencji wymuszenia
+# odświeżenia cache na deploy. Był to jednak DRUGI, zbędny mechanizm bustujący
+# HURTEM: każde wydanie zmieniało ścieżkę WSZYSTKICH statyków (nowy katalog),
+# więc `immutable` + zmiana ścieżki kazały przeglądarkom pobrać ~305 KB gzip
+# JS/CSS ponownie po każdym deployu, nawet gdy ani bajt JS/CSS się nie zmienił.
+# Content-hash w nazwie pliku już gwarantuje bust dokładnie zmienionych plików,
+# więc katalog jest statyczny:
+COMPRESS_OUTPUT_DIR = "CACHE"
 
 # django-tabular-permissions
 

--- a/src/django_bpp/templates/bare.html
+++ b/src/django_bpp/templates/bare.html
@@ -105,7 +105,7 @@
 
     {# JavaScript bundle - built with esbuild, includes jQuery and all JS deps. #}
     {# Owinięte w {% compress js %}, żeby django-compressor wyemitował plik z #}
-    {# content-hashem (CACHE-<VERSION>/js/output.<hash>.js) — cache-busted tak #}
+    {# content-hashem (CACHE/js/output.<hash>.js) — cache-busted tak #}
     {# samo jak output.<hash>.css. Bez tego nginx serwuje wieczny stary #}
     {# bundle.js spod stałej nazwy (brak hasha => agresywny cache). #}
     {% compress js %}


### PR DESCRIPTION
## Problem

`src/django_bpp/settings/base.py`:

```python
COMPRESS_OUTPUT_DIR = f"CACHE-{VERSION}"
```

Numer wydania trafiał w **ścieżkę** statyków (`/static/CACHE-202607.1397rc1/`).
W połączeniu z nagłówkiem `immutable` znaczyło to, że **każde wydanie
unieważniało cache statyków WSZYSTKIM użytkownikom naraz**, nawet gdy JS/CSS się
nie zmienił — ~305 KB gzip do ponownego pobrania po każdym deployu bez powodu
(poz. 2.2 audytu).

## Naprawa

```python
COMPRESS_OUTPUT_DIR = "CACHE"
```

Rozpoznanie wykazało, że `django-compressor 4.6.0` **już** nadaje każdemu plikowi
wyjściowemu 12-znakowy hash **treści** (`get_filepath` → `get_hexdigest =
sha256(content)[:12]`). Numer wersji w katalogu był więc **drugim, redundantnym**
cache-busterem nałożonym na już-działający pierwszy — i to on psuł sprawę,
zmieniając prefiks ścieżki wszystkich statyków na każdy deploy. Hash w nazwie
pliku pozostaje jedynym, wystarczającym cache-busterem: ścieżka zmienia się
wtedy i tylko wtedy, gdy zmienia się treść. Jawny hash treści w katalogu byłby
trzecim redundantnym mechanizmem — odrzucony.

## Dlaczego bezpieczne dla produkcji

- **Cache-busting nadal działa** — potwierdzone w źródle: `output_file` używa
  `get_filepath(content)`, więc zmiana JS/CSS = nowa nazwa pliku (regresja
  „użytkownik dostaje stary JS" wykluczona).
- **Kontrakt statyków Docker nietknięty** — builder robi tylko `collectstatic`
  do `.baked` (bez `CACHE/`), runtime generuje `CACHE/` przez `compress --force`;
  tag `{% compress %}` i komenda czytają to samo ustawienie z tego samego obrazu.
  `COMPRESS_OFFLINE=False` (render ignoruje manifest, przelicza z hasha).
- Stare katalogi `CACHE-{VERSION}/` zostają jako nieszkodliwe sieroty; zmiana
  wręcz ogranicza ich przyszłą akumulację (statyczny `CACHE` nadpisuje się w miejscu).

## Weryfikacja

- Dwa buildy bez zmian w JS → identyczna nazwa pliku; zmiana treści → inna
  (na faktycznej funkcji nazewniczej compressora).
- `manage.py check` czysto, pre-commit czysto.
- Review: spec PASS, jakość/bezpieczeństwo APPROVED (teza o hashu potwierdzona
  w źródle pakietu). Komentarz szablonu zsynchronizowany z nową ścieżką.

Poz. 2.2 audytu `HANDOFF-niewdrozone-2026-07-20.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
