### PR TITLE
fix(ewaluacja_optymalizacja): eliminuj lost update na singletonach statusu (update pól zamiast save całości)

### DIFF
--- a/src/bpp/newsfragments/lost-update-singletony-statusu.bugfix.rst
+++ b/src/bpp/newsfragments/lost-update-singletony-statusu.bugfix.rst
@@ -1,0 +1,6 @@
+Naprawiono gubienie współbieżnych zmian (lost update) na singletonach statusu
+optymalizacji ewaluacji. Metody ``rozpocznij()``/``zakoncz()`` modeli
+``Status*`` zapisują teraz tylko pola, które faktycznie zmieniają (atomowy
+``UPDATE`` po ``pk=1``), zamiast nadpisywać cały wiersz — dzięki czemu status
+„w trakcie" i ``task_id`` ustawione przez współbieżne zadanie nie są już
+cofane, a przycisk nie odblokowuje się przedwcześnie.

--- a/src/ewaluacja_optymalizacja/models/status.py
+++ b/src/ewaluacja_optymalizacja/models/status.py
@@ -75,14 +75,28 @@ class StatusOptymalizacjiZOdpinaniem(models.Model):
         self.data_rozpoczecia = timezone.now()
         self.data_zakonczenia = None
         self.ostatni_komunikat = "Rozpoczęto optymalizację z odpinaniem"
-        self.save()
+        # Zapisz TYLKO pola tej operacji (atomowo), nie cały wiersz —
+        # inaczej gubilibyśmy współbieżne zmiany innych pól (lost update).
+        type(self).objects.filter(pk=1).update(
+            w_trakcie=self.w_trakcie,
+            task_id=self.task_id,
+            data_rozpoczecia=self.data_rozpoczecia,
+            data_zakonczenia=self.data_zakonczenia,
+            ostatni_komunikat=self.ostatni_komunikat,
+        )
 
     def zakoncz(self, komunikat=""):
         """Oznacz zakończenie zadania optymalizacji z odpinaniem."""
         self.w_trakcie = False
         self.data_zakonczenia = timezone.now()
         self.ostatni_komunikat = komunikat or "Zakończono"
-        self.save()
+        # Zapisz TYLKO pola tej operacji — task_id/data_rozpoczecia
+        # ustawione przez współbieżne rozpoczęcie muszą przetrwać.
+        type(self).objects.filter(pk=1).update(
+            w_trakcie=self.w_trakcie,
+            data_zakonczenia=self.data_zakonczenia,
+            ostatni_komunikat=self.ostatni_komunikat,
+        )
 
 
 class StatusOptymalizacjiBulk(models.Model):
@@ -168,14 +182,31 @@ class StatusOptymalizacjiBulk(models.Model):
         self.data_rozpoczecia = timezone.now()
         self.data_zakonczenia = None
         self.ostatni_komunikat = "Rozpoczęto optymalizację całej ewaluacji"
-        self.save()
+        # Zapisz TYLKO pola tej operacji (atomowo), nie cały wiersz.
+        # ``delete(save=False)`` wyżej wyczyścił atrybut pliku na instancji —
+        # utrwalamy to również w bazie (plik_zip_wszystkie_xls=None).
+        type(self).objects.filter(pk=1).update(
+            w_trakcie=self.w_trakcie,
+            task_id=self.task_id,
+            uczelnia=self.uczelnia,
+            data_rozpoczecia=self.data_rozpoczecia,
+            data_zakonczenia=self.data_zakonczenia,
+            ostatni_komunikat=self.ostatni_komunikat,
+            plik_zip_wszystkie_xls=self.plik_zip_wszystkie_xls.name or "",
+        )
 
     def zakoncz(self, komunikat=""):
         """Oznacz zakończenie zadania bulk optimization."""
         self.w_trakcie = False
         self.data_zakonczenia = timezone.now()
         self.ostatni_komunikat = komunikat or "Zakończono"
-        self.save()
+        # Zapisz TYLKO pola tej operacji — task_id/uczelnia/data_rozpoczecia
+        # ustawione przez współbieżne rozpoczęcie muszą przetrwać.
+        type(self).objects.filter(pk=1).update(
+            w_trakcie=self.w_trakcie,
+            data_zakonczenia=self.data_zakonczenia,
+            ostatni_komunikat=self.ostatni_komunikat,
+        )
 
 
 class StatusUnpinningAnalyzy(models.Model):
@@ -245,14 +276,27 @@ class StatusUnpinningAnalyzy(models.Model):
         self.data_rozpoczecia = timezone.now()
         self.data_zakonczenia = None
         self.ostatni_komunikat = "Rozpoczęto analizę możliwości odpinania"
-        self.save()
+        # Zapisz TYLKO pola tej operacji (atomowo), nie cały wiersz.
+        type(self).objects.filter(pk=1).update(
+            w_trakcie=self.w_trakcie,
+            task_id=self.task_id,
+            data_rozpoczecia=self.data_rozpoczecia,
+            data_zakonczenia=self.data_zakonczenia,
+            ostatni_komunikat=self.ostatni_komunikat,
+        )
 
     def zakoncz(self, komunikat=""):
         """Oznacz zakończenie zadania analizy unpinning."""
         self.w_trakcie = False
         self.data_zakonczenia = timezone.now()
         self.ostatni_komunikat = komunikat or "Zakończono"
-        self.save()
+        # Zapisz TYLKO pola tej operacji — task_id/data_rozpoczecia
+        # ustawione przez współbieżne rozpoczęcie muszą przetrwać.
+        type(self).objects.filter(pk=1).update(
+            w_trakcie=self.w_trakcie,
+            data_zakonczenia=self.data_zakonczenia,
+            ostatni_komunikat=self.ostatni_komunikat,
+        )
 
 
 class StatusDisciplineSwapAnalysis(models.Model):
@@ -319,14 +363,27 @@ class StatusDisciplineSwapAnalysis(models.Model):
         self.data_rozpoczecia = timezone.now()
         self.data_zakonczenia = None
         self.ostatni_komunikat = "Rozpoczęto analizę możliwości zamiany dyscyplin"
-        self.save()
+        # Zapisz TYLKO pola tej operacji (atomowo), nie cały wiersz.
+        type(self).objects.filter(pk=1).update(
+            w_trakcie=self.w_trakcie,
+            task_id=self.task_id,
+            data_rozpoczecia=self.data_rozpoczecia,
+            data_zakonczenia=self.data_zakonczenia,
+            ostatni_komunikat=self.ostatni_komunikat,
+        )
 
     def zakoncz(self, komunikat=""):
         """Oznacz zakończenie zadania analizy zamiany dyscyplin."""
         self.w_trakcie = False
         self.data_zakonczenia = timezone.now()
         self.ostatni_komunikat = komunikat or "Zakończono"
-        self.save()
+        # Zapisz TYLKO pola tej operacji — task_id/data_rozpoczecia
+        # ustawione przez współbieżne rozpoczęcie muszą przetrwać.
+        type(self).objects.filter(pk=1).update(
+            w_trakcie=self.w_trakcie,
+            data_zakonczenia=self.data_zakonczenia,
+            ostatni_komunikat=self.ostatni_komunikat,
+        )
 
 
 class StatusPrzegladarkaRecalc(models.Model):
@@ -407,11 +464,26 @@ class StatusPrzegladarkaRecalc(models.Model):
         self.data_zakonczenia = None
         self.punkty_przed = punkty_przed
         self.ostatni_komunikat = "Rozpoczęto przeliczanie ewaluacji"
-        self.save()
+        # Zapisz TYLKO pola tej operacji (atomowo), nie cały wiersz.
+        type(self).objects.filter(pk=1).update(
+            w_trakcie=self.w_trakcie,
+            task_id=self.task_id,
+            uczelnia=self.uczelnia,
+            data_rozpoczecia=self.data_rozpoczecia,
+            data_zakonczenia=self.data_zakonczenia,
+            punkty_przed=self.punkty_przed,
+            ostatni_komunikat=self.ostatni_komunikat,
+        )
 
     def zakoncz(self, komunikat=""):
         """Oznacz zakończenie przeliczania."""
         self.w_trakcie = False
         self.data_zakonczenia = timezone.now()
         self.ostatni_komunikat = komunikat or "Zakończono"
-        self.save()
+        # Zapisz TYLKO pola tej operacji — task_id/uczelnia/data_rozpoczecia/
+        # punkty_przed ustawione przez współbieżne rozpoczęcie muszą przetrwać.
+        type(self).objects.filter(pk=1).update(
+            w_trakcie=self.w_trakcie,
+            data_zakonczenia=self.data_zakonczenia,
+            ostatni_komunikat=self.ostatni_komunikat,
+        )

--- a/src/ewaluacja_optymalizacja/models/status.py
+++ b/src/ewaluacja_optymalizacja/models/status.py
@@ -64,7 +64,13 @@ class StatusOptymalizacjiZOdpinaniem(models.Model):
 
     @classmethod
     def get_or_create(cls):
-        """Pobierz lub utwórz instancję singleton."""
+        """Pobierz lub utwórz instancję singleton.
+
+        Każdy caller wchodzi na wiersz pk=1 przez tę metodę, a żadna ścieżka
+        go nie kasuje — dlatego atomowe `filter(pk=1).update(...)` w
+        `rozpocznij`/`zakoncz` nigdy nie trafia na pusty zbiór (który byłby
+        cichym no-op zamiast INSERT-a robionego dawniej przez `save()`).
+        """
         obj, created = cls.objects.get_or_create(pk=1)
         return obj
 

--- a/src/ewaluacja_optymalizacja/tests/test_status_lost_update.py
+++ b/src/ewaluacja_optymalizacja/tests/test_status_lost_update.py
@@ -1,0 +1,119 @@
+"""Audyt poz. 1.5 — lost update na singletonach statusu (``pk=1``).
+
+Metody ``rozpocznij()``/``zakoncz()`` modeli ``Status*`` wcześniej
+zapisywały **cały** wiersz przez ``save()``. Ładowały obiekt (kopię w
+Pythonie), mutowały kilka pól i nadpisywały wszystkie kolumny — w tym te,
+których operacja logicznie NIE dotyczy (``task_id``, ``data_rozpoczecia``,
+``uczelnia``, ``punkty_przed``). Gdy inne, współbieżne zadanie w międzyczasie
+zmieniło jedno z tych pól, stary zapis je **gubił** (last-write-wins).
+
+Po naprawie ``zakoncz()`` zapisuje tylko pola, które faktycznie zmienia
+(``w_trakcie``, ``data_zakonczenia``, ``ostatni_komunikat``), więc
+współbieżna zmiana ``task_id`` przetrwa.
+
+Testy:
+- ``test_zakoncz_nie_gubi_wspolbieznej_zmiany_task_id`` — dowód naprawy.
+- ``test_stara_implementacja_calego_wiersza_gubilaby_task_id`` — test
+  kontrolny (reguła #8): stara ścieżka ``save()`` całego wiersza faktycznie
+  gubi współbieżną zmianę ``task_id``.
+- ``test_zakoncz_ustawia_timestamp_jawnie`` — dowód, że brak ``auto_now``
+  nie regresuje: ``data_zakonczenia`` nadal jest ustawiany.
+"""
+
+import pytest
+from django.utils import timezone
+
+from ewaluacja_optymalizacja.models.status import (
+    StatusOptymalizacjiZOdpinaniem,
+)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_zakoncz_nie_gubi_wspolbieznej_zmiany_task_id():
+    """Po naprawie: ``zakoncz()`` nie nadpisuje współbieżnie zmienionego
+    ``task_id``, bo zapisuje tylko własne pola."""
+    status = StatusOptymalizacjiZOdpinaniem.get_or_create()
+    status.rozpocznij(task_id="TASK-ORIGINAL")
+
+    # Załaduj drugą, niezależną kopię tego samego wiersza (symulacja
+    # drugiego procesu/requestu, który wystartował z tego samego stanu).
+    stale = StatusOptymalizacjiZOdpinaniem.objects.get(pk=1)
+
+    # Współbieżnie (inny proces) podmienia task_id w bazie.
+    StatusOptymalizacjiZOdpinaniem.objects.filter(pk=1).update(
+        task_id="TASK-CONCURRENT"
+    )
+
+    # Ta kopia, nieświadoma zmiany, kończy zadanie.
+    stale.zakoncz("Zakończono")
+
+    fresh = StatusOptymalizacjiZOdpinaniem.objects.get(pk=1)
+    # Współbieżny task_id NIE zginął:
+    assert fresh.task_id == "TASK-CONCURRENT"
+    # A pola, które zakoncz() faktycznie zmienia, są zapisane:
+    assert fresh.w_trakcie is False
+    assert fresh.ostatni_komunikat == "Zakończono"
+    assert fresh.data_zakonczenia is not None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_stara_implementacja_calego_wiersza_gubilaby_task_id():
+    """Test kontrolny: stara implementacja (``save()`` całego wiersza)
+    zgubiłaby współbieżną zmianę ``task_id``. Odtwarzamy tu jej zachowanie
+    ręcznie, żeby udowodnić, że powyższy test naprawy testuje realny problem,
+    a nie tautologię."""
+    status = StatusOptymalizacjiZOdpinaniem.get_or_create()
+    status.rozpocznij(task_id="TASK-ORIGINAL")
+
+    stale = StatusOptymalizacjiZOdpinaniem.objects.get(pk=1)
+
+    StatusOptymalizacjiZOdpinaniem.objects.filter(pk=1).update(
+        task_id="TASK-CONCURRENT"
+    )
+
+    # STARE zachowanie zakoncz(): mutacja + save() CAŁEGO wiersza.
+    stale.w_trakcie = False
+    stale.data_zakonczenia = timezone.now()
+    stale.ostatni_komunikat = "Zakończono"
+    stale.save()  # nadpisuje wszystkie kolumny stanem sprzed współbieżnej zmiany
+
+    fresh = StatusOptymalizacjiZOdpinaniem.objects.get(pk=1)
+    # Stary kod gubi współbieżny task_id — cofa go do wartości z kopii:
+    assert fresh.task_id == "TASK-ORIGINAL"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_zakoncz_ustawia_timestamp_jawnie():
+    """Brak ``auto_now`` na modelu → ``.update()`` nie odświeżyłby żadnego
+    timestampu automatycznie. Dowód, że ``data_zakonczenia`` jest ustawiany
+    jawnie i naprawa nie regresuje tego zachowania."""
+    status = StatusOptymalizacjiZOdpinaniem.get_or_create()
+    status.rozpocznij(task_id="T1")
+    assert StatusOptymalizacjiZOdpinaniem.objects.get(pk=1).data_zakonczenia is None
+
+    before = timezone.now()
+    status.zakoncz("Gotowe")
+    after = timezone.now()
+
+    fresh = StatusOptymalizacjiZOdpinaniem.objects.get(pk=1)
+    assert fresh.data_zakonczenia is not None
+    assert before <= fresh.data_zakonczenia <= after
+    # In-memory instancja także zaktualizowana (zachowanie jak przy save()):
+    assert status.data_zakonczenia is not None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_rozpocznij_zapisuje_wlasne_pola():
+    """``rozpocznij()`` po naprawie nadal poprawnie ustawia swój zestaw pól
+    (w bazie i w instancji)."""
+    status = StatusOptymalizacjiZOdpinaniem.get_or_create()
+    status.zakoncz("stan poczatkowy")
+
+    status.rozpocznij(task_id="NOWE-ZADANIE")
+
+    fresh = StatusOptymalizacjiZOdpinaniem.objects.get(pk=1)
+    assert fresh.w_trakcie is True
+    assert fresh.task_id == "NOWE-ZADANIE"
+    assert fresh.data_rozpoczecia is not None
+    assert fresh.data_zakonczenia is None
+    assert fresh.ostatni_komunikat == "Rozpoczęto optymalizację z odpinaniem"


### PR DESCRIPTION
## Problem

Pięć klas statusu-singletona w `ewaluacja_optymalizacja/models/status.py`
(`pk=1`) robiło **read-modify-write**: `rozpocznij()`/`zakoncz()` ładowały
obiekt, mutowały go w Pythonie i zapisywały **cały** wiersz przez `save()`.
Tworzenie jest atomowe (duplikatów wierszy nie ma), ale współbieżne operacje
gubiły się nawzajem — **last-write-wins** na polach `w_trakcie`/`task_id`.
Objaw: status „w trakcie" gubiony, przycisk odblokowuje się za wcześnie.
Tylko jeden caller brał lock; reszta robiła gołe `get_or_create` + mutację
(poz. 1.5 audytu).

## Naprawa

`rozpocznij()`/`zakoncz()` we wszystkich 5 klasach zapisują teraz **tylko pola
danej operacji** atomowym `type(self).objects.filter(pk=1).update(...)` zamiast
całego wiersza. Współbieżna zmiana innego pola nie jest już nadpisywana.
Ścieżka pod `select_for_update` (`bulk_optimization.py`) nietknięta i nadal
poprawna. Migracja niepotrzebna (zmiana kodu, nie schematu).

## Dlaczego bez regresji

`QuerySet.update()` omija sygnały i `auto_now` — więc zweryfikowano niezależnie
(w kodzie, potwierdzone przez recenzenta), że modele Status*:
- dziedziczą **wprost** z `models.Model` (żadnego mixina z `auto_now`/sygnałem),
- nie mają `auto_now`/`auto_now_add` (timestampy ustawiane jawnie przez
  `timezone.now()`) ani `pre_save`/`post_save`.

Więc `.update()` niczego nie pomija. Niezmiennik no-op (`.update()` na pk=1 to
cichy no-op gdy wiersza nie ma) udokumentowany w docstringu `get_or_create` —
bezpieczny, bo każdy caller wchodzi na wiersz przez `get_or_create(pk=1)` i nic
nie kasuje singletona.

## Weryfikacja

- TDD: test naprawy (współbieżna zmiana innego pola nie ginie) + **test
  kontrolny reguły #8** (stara implementacja whole-row `save()` jawnie gubiła
  `task_id`) + test jawnego timestampu.
- `101 passed` w `ewaluacja_optymalizacja` (odtworzone przez recenzenta).
- Review: spec PASS, jakość APPROVED (brak regresji auto_now/sygnałów
  potwierdzony niezależnie).

Poz. 1.5 audytu `HANDOFF-niewdrozone-2026-07-20.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
