### PR TITLE
docs: ostrzeż przed make clean-testcontainers na współdzielonym hoście (3.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,8 +525,16 @@ Konfiguracja jest w `[tool.pytest-testcontainers-django]` w `pyproject.toml`.
   plugin jawnie je zatrzymuje w `pytest_unconfigure` (+ `atexit`
   jako safety net), Ryuk to ostatnia linia obrony. Przy restarcie
   Docker Desktop albo `SIGKILL` na pytest cleanup może zawieść;
-  wtedy `make clean-testcontainers` usuwa wszystkie osierocone
-  kontenery.
+  wtedy `make clean-testcontainers` usuwa osierocone kontenery.
+  **UWAGA (host współdzielony):** `make clean-testcontainers` usuwa
+  **wszystkie** kontenery pasujące do wzorca — także **cudze,
+  wciąż działające** (równoległy przebieg pytest z innego worktree,
+  aktywne stacki `run-site`). Na maszynie, gdzie biegnie kilka rzeczy
+  naraz, **nie odpalaj go w ciemno** — najpierw `docker ps` i usuń
+  po nazwie/ID tylko własne osierocone kontenery. To ta sama zasada,
+  co „celuj po PID / po ścieżce worktree, nie `pkill`": komenda
+  zbiorcza jest wygodna, ale na współdzielonym hoście ubija cudzą
+  pracę.
 - CI (`docker-compose.test.yml`) ma `PYTEST_TESTCONTAINERS_DISABLE=1` —
   usługi dostarcza tam docker-compose.
 


### PR DESCRIPTION
## Problem

`CLAUDE.md` polecał `make clean-testcontainers` jako lekarstwo na osierocone
kontenery testcontainers — a akapit o `run-site` ostrzega przed `pkill` na
współdzielonym hoście. Sprzeczność: `make clean-testcontainers` usuwa
**wszystkie** pasujące kontenery, także cudze **działające** (równoległy pytest
z innego worktree, aktywne stacki `run-site`). W tej sesji dwukrotnie ubiło to
cudze kontenery.

## Zmiana

Doprecyzowanie dokumentacji: ostrzeżenie, że na współdzielonym hoście
`make clean-testcontainers` nie odpalać w ciemno — najpierw `docker ps`, usuwać
tylko własne osierocone kontenery po nazwie/ID. Ta sama zasada co „celuj po PID,
nie `pkill`".

Poz. 3.5 audytu `HANDOFF-niewdrozone-2026-07-20.md`. Zmiana tylko w dokumentacji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
