### PR TITLE
test(cache): pozorne testy cache na realnym backendzie zamiast DummyCache (3.2)

### DIFF
--- a/src/bpp/newsfragments/cache-test-inwalidacja-uczelnia-realny-backend.doc.rst
+++ b/src/bpp/newsfragments/cache-test-inwalidacja-uczelnia-realny-backend.doc.rst
@@ -1,0 +1,7 @@
+Test inwalidacji cache'a strony głównej po zapisie Uczelni biegnie teraz
+na realnym backendzie (``LocMemCache``) i sprawdza SKUTEK zamiast mocka
+``cache.delete``. Dowodzi pełnej ścieżki: pierwsze żądanie zapisuje kontekst,
+zapis Uczelni faktycznie unieważnia klucz, kolejne żądanie dostaje nową
+nazwę zamiast zapamiętanej starej. Dołożono warunek kontrolny (zmiana z
+pominięciem sygnału zostawia starą wartość w cache), który pada, gdyby cache
+przestał działać. Inwalidacja działa poprawnie — bug nie ujawniony.

--- a/src/bpp/newsfragments/cache-test-robots-realny-backend.doc.rst
+++ b/src/bpp/newsfragments/cache-test-robots-realny-backend.doc.rst
@@ -1,0 +1,6 @@
+Test rozdzielności cache'a per-host dla ``robots.txt`` biegnie teraz na
+realnym backendzie (``LocMemCache``) zamiast na wyłączonym ``DummyCache``.
+Wcześniej przechodził trywialnie — nie dowodził, że ``cache_page`` nie
+przecieka między domenami multi-hosted. Dołożono warunek kontrolny
+(trafienie w cache przy powtórzonym żądaniu), który realnie pada, gdy
+cache przestaje działać.

--- a/src/bpp/tests/test_models/test_struktura/test_uczelnia.py
+++ b/src/bpp/tests/test_models/test_struktura/test_uczelnia.py
@@ -426,27 +426,93 @@ def test_uczelnia_do_roku_default(uczelnia, wydawnictwo_zwarte):
     assert Uczelnia.objects.do_roku_default() == 3000
 
 
-def test_zapis_uczelni_inwaliduje_cache_strony_glownej(uczelnia, mocker):
-    """Zapis Uczelni musi zrzucić cache kontekstu strony głównej.
+# Realny backend dla testu inwalidacji: domyślny DummyCache z autouse
+# ``disable_cache_for_tests`` nic nie zapisuje, więc na nim inwalidacji NIE
+# da się zaobserwować (każdy ``get`` to miss). Podmieniamy na LocMem (wzorzec
+# z ``test_cache_publiczny.py``), by przejść PEŁNĄ ścieżkę zapis→odczyt→
+# inwalidacja context-procesora ``uczelnia`` (górny pasek, strona główna).
+LOCMEM_UCZELNIA = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-invalidacja-uczelnia",
+    }
+}
 
-    ``get_uczelnia_context_data`` to ``@cached`` z cacheops (cache funkcji,
-    nie zapytania ORM), więc cacheops nie czyści go sam przy zapisie modelu —
-    robi to dopiero sygnał ``invalidate_uczelnia_caches``. Bez tego zmiany
-    ustawień uczelni (tytuł, flagi ``pokazuj_*``, logo) nie pojawiają się na
-    stronie głównej do godziny. Weryfikujemy samo podpięcie, niezależnie od
-    backendu cache (w tym module wyłączonego).
+
+def test_zapis_uczelni_inwaliduje_cache_strony_glownej(uczelnia, settings, mocker):
+    """Zapis Uczelni FAKTYCZNIE unieważnia cache kontekstu strony głównej.
+
+    Poprzednia wersja mockowała ``cache.delete`` — dowodziła tylko, że sygnał
+    WOŁA ``delete(klucz)``, a nie że context-procesor czyta ten SAM klucz ani
+    że po zapisie serwuje świeżą wartość (tautologia względem prawdziwego
+    backendu). Tu, na realnym ``LocMemCache``, sprawdzamy skutek: pierwsze
+    żądanie zapisuje kontekst, zapis Uczelni go usuwa, kolejne żądanie dostaje
+    nową nazwę zamiast zapamiętanej starej.
+
+    Zakres: weryfikujemy realnie warstwę Django-cache (klucz
+    ``bpp_uczelnia_<site_pk>``). Druga warstwa — ``get_uczelnia_context_data``
+    (``@cached`` cacheops) — jest w testach globalnie wyłączona (INSTALLED_APPS
+    bez ``cacheops`` + ``CACHEOPS_ENABLED=False``, patrz ``settings/test.py``),
+    a włączanie cacheopsa per-test to landmine (globalny monkey-patch, cross-
+    worker leak w Redisie pod xdist). Jej podpięcie pilnujemy osobno: ``spy``
+    potwierdza, że sygnał woła ``.invalidate()``.
     """
+    from django.core.cache import cache
+    from django.test import RequestFactory
+
+    from bpp.context_processors.uczelnia import _cache_key_for_request
+    from bpp.context_processors.uczelnia import uczelnia as uczelnia_ctx
     from bpp.views.browse import get_uczelnia_context_data
 
-    invalidate = mocker.patch.object(get_uczelnia_context_data, "invalidate")
-    delete = mocker.patch("bpp.context_processors.uczelnia.cache.delete")
+    # Override autouse ``disable_cache_for_tests`` (DummyCache) na realny LocMem.
+    settings.CACHES = {**settings.CACHES, **LOCMEM_UCZELNIA}
+    cache.clear()
 
-    uczelnia.nazwa = "Zmieniona nazwa"
+    # Spy (nie mock): przepuszcza prawdziwe wywołanie, tylko je liczy — pilnuje
+    # podpięcia inwalidacji warstwy cacheopsa (w testach będącej no-opem).
+    spy_invalidate = mocker.spy(get_uczelnia_context_data, "invalidate")
+
+    site = uczelnia.site
+
+    def swiezy_request():
+        # Symuluje osobne żądanie HTTP: ``request.site`` ustawia w produkcji
+        # ``SiteResolutionMiddleware`` — tu ustawiamy je ręcznie tak samo.
+        r = RequestFactory().get("/", HTTP_HOST=site.domain)
+        r.site = site
+        return r
+
+    klucz = _cache_key_for_request(swiezy_request())
+
+    # 1. Pierwsze żądanie zapisuje kontekst strony głównej do cache.
+    assert cache.get(klucz) is None
+    ctx1 = uczelnia_ctx(swiezy_request())
+    assert ctx1["uczelnia"].nazwa == "Testowa uczelnia"
+    assert cache.get(klucz) is not None, "pierwsze żądanie nie zapisało cache"
+
+    # 2. Warunek kontrolny (reguła #8): zmiana z POMINIĘCIEM sygnału
+    #    (``update`` nie wysyła post_save) NIE unieważnia — kolejne żądanie
+    #    dostaje STARĄ wartość z cache. Dowodzi, że cache naprawdę trzyma
+    #    migawkę; inaczej asercja z p. 3 przechodziłaby, bo cache nie działa.
+    Uczelnia.objects.filter(pk=uczelnia.pk).update(nazwa="Nazwa z pominietym sygnalem")
+    ctx_stale = uczelnia_ctx(swiezy_request())
+    assert ctx_stale["uczelnia"].nazwa == "Testowa uczelnia", (
+        "cache nie zwrócił zapamiętanej wartości — LocMem nie działa, więc "
+        "test inwalidacji niczego by nie dowodził"
+    )
+
+    # 3. Zapis przez ``save()`` → sygnał ``invalidate_uczelnia_caches`` →
+    #    ``cache.delete(klucz)``. Kolejne żądanie MUSI dostać świeżą nazwę.
+    uczelnia.nazwa = "Nazwa po zapisie"
     uczelnia.save()
 
-    invalidate.assert_called_once_with()
-    # Po wprowadzeniu kluczowania cache context-processora per-site, sygnał kasuje
-    # ZARÓWNO klucz per-site (bpp_uczelnia_<site_pk>) JAK I legacy b"bpp_uczelnia".
-    assert delete.call_count == 2
-    delete.assert_any_call(f"bpp_uczelnia_{uczelnia.site_id}")
-    delete.assert_any_call(b"bpp_uczelnia")
+    assert cache.get(klucz) is None, (
+        "zapis Uczelni nie usunął klucza cache context-procesora — "
+        "inwalidacja NIE działa"
+    )
+    spy_invalidate.assert_called_once_with()
+
+    ctx2 = uczelnia_ctx(swiezy_request())
+    assert ctx2["uczelnia"].nazwa == "Nazwa po zapisie", (
+        "po zapisie Uczelni strona główna nadal serwuje starą nazwę z cache "
+        "— inwalidacja context-procesora nie działa"
+    )

--- a/src/bpp/tests/test_views/test_seo_metadata.py
+++ b/src/bpp/tests/test_views/test_seo_metadata.py
@@ -10,6 +10,7 @@ import pytest
 from django.urls import reverse
 from model_bakery import baker
 
+from bpp import views as bpp_views
 from bpp.models import Autor, Jednostka
 from bpp.models.cache import Rekord
 from bpp.models.system import Charakter_Formalny, Typ_Odpowiedzialnosci
@@ -155,18 +156,60 @@ def test_robots_txt_wskazuje_sitemap(client):
     assert "Disallow:" in body
 
 
+# ``robots_txt`` jest owinięty w ``cache_page(24h)`` (django_bpp/urls.py).
+# W ``settings/test.py`` CACHES["default"] to DummyCache — nic nie
+# zapamiętuje, więc bez podmiany na LocMem cache_page renderowałby wszystko
+# od nowa i test rozdzielności hostów przechodziłby trywialnie, nie dowodząc,
+# że cache NIE przecieka między domenami multi-hosted.
+LOCMEM_ROBOTS = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-robots-vary-host",
+    }
+}
+
+
 @pytest.mark.django_db
-def test_robots_txt_sitemap_zalezna_od_hosta(client, settings):
-    """Sitemap musi wskazywać host requestu, a odpowiedź mieć Vary: Host.
+def test_robots_txt_sitemap_zalezna_od_hosta(client, settings, mocker):
+    """Sitemap wskazuje host requestu, a cache_page rozdziela wpisy per-host.
 
-    Bez Vary: Host owijający cache_page zaserwowałby pierwszemu hostowi
-    cache współdzielony z innymi domenami multi-hosted.
+    ``LocMemCache`` jest tu WARUNKIEM SENSOWNOŚCI testu, nie ozdobą (wzorzec
+    z ``test_cache_publiczny.py`` i ``admin_dashboard/test_cache_vary_host``):
+    pod domyślnym DummyCache cache_page niczego nie zapisuje, więc drugi host
+    zawsze renderuje świeżo i nie da się wykryć, że dostał cache pierwszego.
+    Na realnym backendzie — gdyby cache_page przestał kluczować po hoście —
+    drugi host dostałby sitemapę pierwszego i asercje niżej padną.
     """
-    settings.ALLOWED_HOSTS = ["bpp.uczelnia-a.pl", "bpp.uczelnia-b.pl"]
+    from django.core.cache import cache
 
-    res_a = client.get(reverse("robots_txt"), HTTP_HOST="bpp.uczelnia-a.pl")
-    res_b = client.get(reverse("robots_txt"), HTTP_HOST="bpp.uczelnia-b.pl")
+    settings.ALLOWED_HOSTS = ["bpp.uczelnia-a.pl", "bpp.uczelnia-b.pl"]
+    settings.CACHES = {**settings.CACHES, **LOCMEM_ROBOTS}
+    cache.clear()
+
+    # Liczymy realne renderowania widoku: trafienie w cache_page NIE woła
+    # ``_read_static_robots`` po raz kolejny.
+    licznik = mocker.spy(bpp_views, "_read_static_robots")
+    url = reverse("robots_txt")
+
+    res_a = client.get(url, HTTP_HOST="bpp.uczelnia-a.pl")
+    assert licznik.call_count == 1, "pierwsze żądanie musi wyrenderować widok"
+
+    res_b = client.get(url, HTTP_HOST="bpp.uczelnia-b.pl")
+    assert licznik.call_count == 2, (
+        "drugi host dostał sitemapę zapamiętaną dla pierwszego — cache_page "
+        "przestał kluczować po hoście, wielo-uczelnianość przecieka między "
+        "domenami"
+    )
 
     assert "Sitemap: http://bpp.uczelnia-a.pl/sitemap.xml" in res_a.content.decode()
     assert "Sitemap: http://bpp.uczelnia-b.pl/sitemap.xml" in res_b.content.decode()
     assert "Host" in res_a.get("Vary", "")
+
+    # Warunek kontrolny: ten sam host drugi raz MUSI trafić w cache (inaczej
+    # asercja rozdzielności przechodziłaby dlatego, że cache w ogóle nie działa).
+    res_a2 = client.get(url, HTTP_HOST="bpp.uczelnia-a.pl")
+    assert licznik.call_count == 2, (
+        "powtórzone żądanie na ten sam host nie trafiło w cache — cache_page "
+        "nie działa, więc test rozdzielności hostów niczego nie dowodzi"
+    )
+    assert res_a2.content == res_a.content


### PR DESCRIPTION
## Problem

Cała warstwa cache jest w testach wyłączona (`CACHEOPS_ENABLED=False` +
`DummyCache`). Testy, które **twierdziły**, że sprawdzają cache, przechodziły
z niewłaściwego powodu — zielony, który niczego nie dowodził (poz. 3.2 audytu).

## Zmiana (test-only)

Testy sprawdzające zachowanie cache przełączone na **realny** `LocMemCache`
przez jawny, lokalny fixture (wzorzec `test_cache_publiczny.py`) — bez zmiany
globalnych ustawień testów:
- `test_robots_txt_sitemap_zalezna_od_hosta` (separacja host) — na LocMem
  z asercją kontrolną,
- `test_zapis_uczelni_inwaliduje_cache_strony_glownej` — odmockowany
  (był tautologią na `cache.delete`), teraz dowodzi realnej inwalidacji.

## Wynik

**Inwalidacja Django-cache DZIAŁA naprawdę** — potwierdzone sabotażem (wyłączenie
`cache.delete` w sygnale → test pada). **0 realnych bugów** — separacja hostów
po `build_absolute_uri` nie przecieka. Warstwa cacheops pozostaje testowana przez
spy na `.invalidate()` (globalnie wyłączona w testach; włączanie per-test
niebezpieczne pod xdist — monkey-patch ORM + cross-worker leak w Redisie).

Review: PASS + APPROVED (brak wycieku fixture — 70 passed razem z sąsiednimi plikami).

Poz. 3.2 audytu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
