### PR TITLE
fix(js): dalLoadLanguage tree-shaking — przywróć polskie i18n DAL (2.6)

### DIFF
--- a/src/bpp/newsfragments/+dal-i18n-tree-shaking.bugfix.rst
+++ b/src/bpp/newsfragments/+dal-i18n-tree-shaking.bugfix.rst
@@ -1,0 +1,5 @@
+Naprawiono cichy ReferenceError w produkcyjnym bundlu JS: funkcja
+``dalLoadLanguage`` (polskie tłumaczenia autouzupełniania django-autocomplete-light /
+select2) była usuwana przez tree-shaking esbuilda, przez co pola autouzupełniania
+traciły polskie komunikaty. Loader języka jest teraz jawnie eksportowany na
+``window`` w lokalnym wrapperze odpornym na tree-shaking.

--- a/src/bpp/static/bpp/js/bundle-entry.js
+++ b/src/bpp/static/bpp/js/bundle-entry.js
@@ -53,7 +53,14 @@ import '../../../../../.venv/lib/python/site-packages/cookielaw/static/cookielaw
 // It's loaded in multiseek/index.html template.
 import '../../../../../.venv/lib/python/site-packages/session_security/static/session_security/script.js';
 import '../../../../../.venv/lib/python/site-packages/dal/static/autocomplete_light/autocomplete_light.js';
-import '../../../../../.venv/lib/python/site-packages/dal/static/autocomplete_light/i18n/pl.js';
+// UWAGA: NIE importujemy vendored `dal/.../i18n/pl.js` — jego globalna
+// deklaracja `var dalLoadLanguage` jest tree-shakowana przez esbuild (martwy,
+// side-effect-free binding), przez co `autocomplete_light.js` rzuca cichy
+// ReferenceError i DAL select2 traci polskie i18n. Zamiast tego lokalny
+// wrapper eksportuje `dalLoadLanguage` na `window` (odporny na tree-shaking)
+// i odtwarza ten sam side-effect (rejestracja `select2/i18n/pl` + event
+// `dal-language-loaded`).
+import './dal-i18n-pl.js';
 import '../../../../../.venv/lib/python/site-packages/dal_select2/static/autocomplete_light/select2.js';
 
 // ===== 9. DJANGO I18N (static file) =====

--- a/src/bpp/static/bpp/js/dal-i18n-pl.js
+++ b/src/bpp/static/bpp/js/dal-i18n-pl.js
@@ -1,0 +1,81 @@
+// Polish i18n loader for django-autocomplete-light (DAL).
+//
+// DLACZEGO ISTNIEJE:
+// Vendored `dal/static/autocomplete_light/i18n/pl.js` deklaruje
+// `var dalLoadLanguage = function (...) {...}` w zasięgu GLOBALNYM (jako
+// zwykły <script>), a `autocomplete_light.js` odwołuje się do tej funkcji
+// jako do GLOBALA (`typeof dalLoadLanguage !== 'undefined'` oraz wywołanie
+// z nasłuchu na event `dal-language-loaded`). Po zbundlowaniu esbuildem
+// każdy plik ma własny scope modułu, a `var dalLoadLanguage` nie jest
+// nigdzie w module używane — esbuild wycina je jako martwy, wolny od
+// side-effectów binding (initializer to czysty function expression).
+// Zostaje tylko `document.dispatchEvent(...)` (side-effect), więc event
+// leci, listener odpala, ale funkcji NIE ma → ReferenceError i DAL select2
+// traci polskie i18n. To INNY mechanizm niż łata `shell:patchBundle`
+// (tam aliasowanie zmangowanego `yl` na `window.yl`), więc tamta łata
+// tego nie obejmuje.
+//
+// NAPRAWA (jawny eksport na window — wzorzec jak `select2-pl.js`):
+// definiujemy `dalLoadLanguage` na `window`, dzięki czemu wolna referencja
+// z `autocomplete_light.js` rozwiązuje się przez global scope do
+// `window.dalLoadLanguage` w runtime. Import tego pliku zastępuje import
+// vendored `i18n/pl.js` w `bundle-entry.js` (ten sam efekt: rejestracja
+// `select2/i18n/pl` w AMD select2 + dispatch eventu `dal-language-loaded`),
+// ale w postaci odpornej na tree-shaking.
+
+window.dalLoadLanguage = function (jQuery) {
+    var amd = jQuery && jQuery.fn && jQuery.fn.select2 && jQuery.fn.select2.amd
+        ? jQuery.fn.select2.amd
+        : undefined;
+
+    if (!amd) {
+        return;
+    }
+
+    amd.define("select2/i18n/pl", [], function () {
+        function plural(n, forms) {
+            if (n === 1) return forms[0];
+            if (n > 1 && n <= 4) return forms[1];
+            if (n >= 5) return forms[2];
+        }
+
+        var charWords = ["znak", "znaki", "znaków"];
+        var itemWords = ["element", "elementy", "elementów"];
+
+        return {
+            errorLoading: function () {
+                return "Nie można załadować wyników.";
+            },
+            inputTooLong: function (args) {
+                var over = args.input.length - args.maximum;
+                return "Usuń " + over + " " + plural(over, charWords);
+            },
+            inputTooShort: function (args) {
+                var remaining = args.minimum - args.input.length;
+                return "Podaj przynajmniej " + remaining + " " +
+                    plural(remaining, charWords);
+            },
+            loadingMore: function () {
+                return "Trwa ładowanie…";
+            },
+            maximumSelected: function (args) {
+                return "Możesz zaznaczyć tylko " + args.maximum + " " +
+                    plural(args.maximum, itemWords);
+            },
+            noResults: function () {
+                return "Brak wyników";
+            },
+            searching: function () {
+                return "Trwa wyszukiwanie…";
+            },
+            removeAllItems: function () {
+                return "Usuń wszystkie przedmioty";
+            }
+        };
+    });
+};
+
+// Zachowanie side-effectu vendored pl.js: powiadom `autocomplete_light.js`,
+// że język jest gotowy (ścieżka z nasłuchem na event, gdy definicja
+// dotrze po inicjalizacji DAL).
+document.dispatchEvent(new CustomEvent("dal-language-loaded", { lang: "pl" }));


### PR DESCRIPTION
## Problem

`dalLoadLanguage` był w produkcyjnym bundlu JS **odwoływany, ale niezadeklarowany**
— esbuild tree-shakował `dal/i18n/pl.js` jako side-effect-free. Efekt: DAL select2
tracił polskie i18n i rzucał `ReferenceError`. Problem **zastany**, inny mechanizm
niż mangling naprawiony w #627 (poz. 2.6 audytu).

## Zmiana

Nowy wrapper `src/bpp/static/bpp/js/dal-i18n-pl.js` ustawia
`window.dalLoadLanguage = function(...)` i odtwarza side-effect (dispatch eventu
`dal-language-loaded`); `bundle-entry.js` importuje wrapper zamiast vendored
`pl.js`. Wzorzec 1:1 z istniejącym `select2-pl.js`. Bundle gitignored → commit
zawiera tylko źródło.

Odrzucone warianty: `--inject` (więcej magii), `sideEffects` w package.json
(red herring — moduł ma side-effect, wycinany jest tylko wewnętrzny `var`).

## Dowód

Realny build esbuild: **0 deklaracji → 1 deklaracja** `window.dalLoadLanguage`.
Review potwierdziło **empirycznie** (build PRE/POST), że gołe wywołanie
`dalLoadLanguage(...)` z `autocomplete_light.js` rozwiązuje się do
`window.dalLoadLanguage` — brak przesłaniającego leksykalnego bindingu, więc
klasa błędu #627 tu nie zachodzi. Kolejność wykonania potwierdzona bajtowo,
i18n kompletne (8 komunikatów), JS 46/46.

Weryfikacji w przeglądarce (brak ReferenceError w konsoli) nie odtwarzano —
dowód oparty na deklaracji w bundlu + analizie scope. Zalecany szybki smoke po
merge: otworzyć widżet DAL i sprawdzić polskie komunikaty + czystą konsolę.

Poz. 2.6 audytu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
