### PR TITLE
fix(favicon): favicon podąża za hostem w multi-tenant (3.7)

### DIFF
--- a/src/bpp/apps.py
+++ b/src/bpp/apps.py
@@ -40,10 +40,53 @@ class BppConfig(AppConfig):
         # Ensure BppUserAdmin takes precedence over microsoft_auth's UserAdmin
         self._register_bpp_user_admin()
 
+        # Naprawa clobberingu faviconów między tenantami (multi-host).
+        self._patch_favicon_save_per_site()
+
         # Initialize Rollbar with global hostname handler
         from bpp.rollbar_config import configure_rollbar
 
         configure_rollbar()
+
+    def _patch_favicon_save_per_site(self):
+        """Zawęź „gaszenie pozostałych faviconów" w ``Favicon.save`` do site'u.
+
+        Ograniczenie third-party (``django-favicon-plus-reloaded``):
+        ``Favicon.save()`` robi ``Favicon.on_site.exclude(pk=self.pk).update(
+        isFavicon=False)``, a ``on_site`` to ``CurrentSiteManager`` filtrujący
+        po LITERALNYM ``settings.SITE_ID``. W multi-host BPP zapis favicona
+        DOWOLNEGO tenanta gasi więc ``isFavicon`` faviconom site'u o ``SITE_ID``
+        (realnej uczelni) — niezależnie od tego, czyj favicon zapisujemy.
+        Efekt: utworzenie favicona tenanta B kasuje favicon tenanta A spod
+        ``SITE_ID``.
+
+        Podmieniamy ``Favicon.save`` na wariant resetujący ``isFavicon`` TYLKO
+        w obrębie ``self.site`` (``Favicon.objects.filter(site=self.site)``),
+        nie globalnie po ``SITE_ID``. Patch obejmuje WSZYSTKIE ścieżki zapisu,
+        w tym admin biblioteki (używa modelu ``Favicon`` wprost). Nie forkujemy
+        biblioteki — to osobne przedsięwzięcie.
+        """
+        from favicon.models import Favicon
+
+        if getattr(Favicon.save, "_bpp_per_site_patched", False):
+            return
+
+        def save(self, *args, **kwargs):
+            # Odwzorowanie ``Favicon.save`` z biblioteki, z jedną różnicą:
+            # reset ``isFavicon`` jest per ``self.site`` zamiast globalnego
+            # ``on_site`` (po ``SITE_ID``) — patrz docstring metody.
+            if self.isFavicon:
+                Favicon.objects.filter(site=self.site).exclude(pk=self.pk).update(
+                    isFavicon=False
+                )
+
+            super(Favicon, self).save(*args, **kwargs)
+
+            if self.faviconImage:
+                self.get_favicons(update=True)
+
+        save._bpp_per_site_patched = True
+        Favicon.save = save
 
     #: Modele, których zapis zmienia treść publicznych stron przeglądania
     #: objętych ``bpp.views.cache_publiczny.cache_publiczny``.

--- a/src/bpp/newsfragments/favicon-per-host.bugfix.rst
+++ b/src/bpp/newsfragments/favicon-per-host.bugfix.rst
@@ -1,3 +1,6 @@
 Favicon podąża teraz za hostem w instalacji wielo-uczelnianej: każda domena
 dostaje własny favicon (dotąd wszystkie uczelnie dostawały favicon site'u o
 ``SITE_ID``). Fragment cache faviconu w ``bare.html`` kluczowany jest per host.
+Dodatkowo zapis favicona jednej uczelni nie gasi już aktywnego favicona innej
+uczelni (biblioteczny ``Favicon.save`` resetował flagę globalnie po
+``SITE_ID`` — teraz reset jest ograniczony do site'u zapisywanego favicona).

--- a/src/bpp/newsfragments/favicon-per-host.bugfix.rst
+++ b/src/bpp/newsfragments/favicon-per-host.bugfix.rst
@@ -1,0 +1,3 @@
+Favicon podąża teraz za hostem w instalacji wielo-uczelnianej: każda domena
+dostaje własny favicon (dotąd wszystkie uczelnie dostawały favicon site'u o
+``SITE_ID``). Fragment cache faviconu w ``bare.html`` kluczowany jest per host.

--- a/src/bpp/templatetags/favicon_bpp.py
+++ b/src/bpp/templatetags/favicon_bpp.py
@@ -1,0 +1,45 @@
+"""Favicon podążający za hostem (multi-tenant), bez patchowania biblioteki.
+
+``django-favicon-plus-reloaded`` renderuje favicon tagiem ``place_favicon``,
+który pyta ``Favicon.on_site`` — a ``on_site`` to ``CurrentSiteManager``.
+Jego ``get_queryset()`` filtruje ``.filter(site__id=settings.SITE_ID)``,
+czyli po LITERALNYM ``settings.SITE_ID``. ``SiteResolutionMiddleware`` nie
+podmienia ``SITE_ID`` per request (ustawia tylko ``request.site`` /
+``request._uczelnia``), więc oryginalny tag serwuje ten sam favicon pod
+każdą domeną — favicon w ogóle nie podąża za hostem.
+
+Ten tag omija ograniczenie, NIE dotykając biblioteki: pyta zwykły menedżer
+``Favicon.objects`` (nie ``on_site``) i filtruje po ``request.site``, które
+``SiteResolutionMiddleware`` rozstrzyga z Host → Site. ``Favicon.site`` to
+zwykły FK w modelu biblioteki, a ``as_html()`` jest host-niezależny (renderuje
+tylko ``<link>`` po URL-ach obrazów), więc korzystamy z nich wprost.
+"""
+
+from django import template
+from django.utils.safestring import mark_safe
+from favicon.models import Favicon
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def place_favicon(context):
+    """Wstaw ``<link>`` faviconu dla Site rozstrzygniętego z hosta.
+
+    Fallback: gdy nie ma ``request`` albo ``request.site`` (np. wołanie spoza
+    cyklu żądania, świeża instalacja bez Site), degradujemy do zachowania
+    biblioteki (``Favicon.on_site`` po ``settings.SITE_ID``) — single-host
+    działa jak wcześniej.
+    """
+    request = context.get("request")
+    site = getattr(request, "site", None) if request is not None else None
+
+    if site is None:
+        fav = Favicon.on_site.filter(isFavicon=True).first()
+    else:
+        fav = Favicon.objects.filter(site=site, isFavicon=True).first()
+
+    if not fav:
+        return mark_safe("<!-- no favicon -->")
+
+    return mark_safe(fav.as_html())

--- a/src/bpp/tests/test_views/test_cache_fragmentow_vary_on.py
+++ b/src/bpp/tests/test_views/test_cache_fragmentow_vary_on.py
@@ -19,26 +19,15 @@ KATALOG_ZRODEL = Path(__file__).resolve().parents[3]
 #: Fragmenty cache'owane pod globalnym kluczem, dla których udowodniono,
 #: że ich treść NIE zależy od hosta/uczelni/użytkownika.
 #:
-#: * ``favicon`` (``django_bpp/templates/bare.html``) — renderuje
-#:   ``{% place_favicon %}`` z ``django-favicon-plus-reloaded``, który pyta
-#:   ``Favicon.on_site``, czyli ``CurrentSiteManager``. Jego
-#:   ``get_queryset()`` (``django/contrib/sites/managers.py``) filtruje
-#:   ``.filter(site__id=settings.SITE_ID)`` — BEZPOŚREDNIO po literalnym
-#:   ``settings.SITE_ID``, a nie przez ``Site.objects.get_current()``
-#:   (``get_current()`` siedzi w ``Favicon.save()``, czyli w ścieżce
-#:   ZAPISU, nie odczytu). ``SiteResolutionMiddleware`` nie podmienia
-#:   ``SITE_ID`` per request (ustawia tylko ``request.site`` i
-#:   ``request._uczelnia``), więc odczyt daje ten sam wiersz pod każdą
-#:   domeną i globalny klucz cache'a jest poprawny.
-#:
-#:   UWAGA dla czytającego tę listę: to NIE jest zamierzone zachowanie
-#:   multi-tenant. Favicon w ogóle nie podąża za hostem — wszystkie
-#:   uczelnie dostają favicon site'u o ``SITE_ID``. To pre-existing
-#:   ograniczenie ``django-favicon-plus-reloaded`` (poza zakresem tego
-#:   testu), a nie skutek cache'owania. Gdyby ktoś kiedyś naprawił
-#:   rozdzielczość faviconu per-host, ten wpis MUSI zniknąć z listy, a
-#:   fragment dostać ``vary_on``.
-DOZWOLONE_BEZ_VARY_ON = {"favicon"}
+#: Aktualnie PUSTE. Favicon (``django_bpp/templates/bare.html``) był tu
+#: kiedyś z alibi, że favicon i tak nie podąża za hostem (bug
+#: ``django-favicon-plus-reloaded``: ``Favicon.on_site`` filtruje po
+#: literalnym ``settings.SITE_ID``). Ten bug został naprawiony —
+#: ``bpp.templatetags.favicon_bpp.place_favicon`` pyta ``Favicon.objects``
+#: po ``request.site`` (Host → Site), więc favicon podąża za hostem, a
+#: fragment ``{% cache 3600 favicon request.get_host %}`` dostał
+#: ``vary_on`` na hoście. Alibi przestało obowiązywać, wpis zniknął.
+DOZWOLONE_BEZ_VARY_ON: set[str] = set()
 
 TAG_CACHE = re.compile(r"{%\s*cache\s+(?P<argumenty>[^%]*?)\s*%}")
 

--- a/src/bpp/tests/test_views/test_favicon_per_host.py
+++ b/src/bpp/tests/test_views/test_favicon_per_host.py
@@ -1,0 +1,183 @@
+"""Favicon podąża za hostem (multi-tenant) — bez patchowania biblioteki.
+
+Sedno: ``bpp.templatetags.favicon_bpp.place_favicon`` pyta ``Favicon.objects``
+po ``request.site`` (rozstrzygniętym z Host → Site przez
+``SiteResolutionMiddleware``), a fragment ``{% cache 3600 favicon
+request.get_host %}`` ma ``vary_on`` na hoście.
+
+``test_cache_*`` MUSZĄ biec na REALNYM backendzie (LocMem), nie DummyCache —
+inaczej ``cache.get`` zawsze zwraca ``None`` i test „izolacji" przeszedłby z
+niewłaściwego powodu (bo nic nie byłoby zapamiętane). Wzorzec z
+``test_cache_publiczny.py``.
+"""
+
+from io import BytesIO
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.template import Context, Template
+from PIL import Image
+
+from favicon.models import Favicon
+
+from fixtures.conftest_multisite import make_request_for_site
+
+LOCMEM = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-favicon-per-host",
+    }
+}
+
+
+@pytest.fixture(autouse=True)
+def _zezwol_na_hosty_testowe(settings):
+    """Domeny fixture'ów (``uczelnia1.localhost``) muszą przejść ``get_host``."""
+    settings.ALLOWED_HOSTS = ["*"]
+
+
+@pytest.fixture
+def cache_locmem(settings):
+    """Podmień domyślny (Dummy) cache na LocMem i wyczyść wokół testu."""
+    from django.core.cache import cache
+
+    poprzednie = settings.CACHES
+    settings.CACHES = {**poprzednie, **LOCMEM}
+    cache.clear()
+    yield cache
+    cache.clear()
+    settings.CACHES = poprzednie
+
+
+def _png_bytes(kolor):
+    buf = BytesIO()
+    Image.new("RGB", (32, 32), kolor).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _utworz_favicon(site, tytul, kolor):
+    """Favicon dla danego Site z rozpoznawalnym po tytule URL-em obrazu.
+
+    ``FaviconImg.as_html`` renderuje ``href`` po nazwie pliku
+    (``slugify(title)-<size>s.png``), więc różne tytuły → różne ``<link>``.
+    """
+    fav = Favicon.objects.create(
+        title=tytul,
+        site=site,
+        faviconImage=SimpleUploadedFile(
+            f"{tytul}.png", _png_bytes(kolor), content_type="image/png"
+        ),
+    )
+    # ``Favicon.save()`` woła ``Favicon.on_site.exclude(...).update(
+    # isFavicon=False)`` (on_site = CurrentSiteManager po SITE_ID), więc zapis
+    # faviconu jednego Site potrafi zgasić ``isFavicon`` faviconu spod
+    # SITE_ID. Wymuszamy flagę przez queryset update (omija save()).
+    Favicon.objects.filter(pk=fav.pk).update(isFavicon=True)
+    return fav
+
+
+@pytest.fixture
+def favicon_uczelnia1(site1):
+    return _utworz_favicon(site1, "UczelniaJeden", "red")
+
+
+@pytest.fixture
+def favicon_uczelnia2(site2):
+    return _utworz_favicon(site2, "UczelniaDwa", "blue")
+
+
+@pytest.fixture
+def favicony_obu(favicon_uczelnia1, favicon_uczelnia2):
+    """Oba favicony z re-afirmacją ``isFavicon`` PO utworzeniu obu.
+
+    Zapis drugiego faviconu (``Favicon.save()``) woła ``on_site.update(
+    isFavicon=False)`` po SITE_ID, więc potrafi zgasić flagę faviconu
+    pierwszego. Ustawiamy ją z powrotem dla OBU dopiero gdy oba istnieją.
+    """
+    Favicon.objects.filter(
+        pk__in=[favicon_uczelnia1.pk, favicon_uczelnia2.pk]
+    ).update(isFavicon=True)
+    return favicon_uczelnia1, favicon_uczelnia2
+
+
+FRAGMENT = Template(
+    "{% load cache favicon_bpp %}"
+    "{% cache 3600 favicon request.get_host %}"
+    "{% place_favicon %}"
+    "{% endcache %}"
+)
+
+
+def _renderuj(request):
+    return FRAGMENT.render(Context({"request": request}))
+
+
+# ---------------------------------------------------------------------------
+# TAG — favicon podąża za hostem (bez cache'a)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_tag_zwraca_favicon_wlasciwego_hosta(site1, site2, favicony_obu):
+    """Pod domeną uczelni 1 — favicon uczelni 1, nie uczelni 2."""
+    from bpp.templatetags.favicon_bpp import place_favicon
+
+    html1 = place_favicon({"request": make_request_for_site(site1)})
+    html2 = place_favicon({"request": make_request_for_site(site2)})
+
+    assert "uczelniajeden" in html1
+    assert "uczelniadwa" not in html1, (
+        "Pod domeną uczelni 1 wyrenderował się favicon uczelni 2 — favicon "
+        "nie podąża za hostem."
+    )
+    assert "uczelniadwa" in html2
+    assert "uczelniajeden" not in html2
+
+
+@pytest.mark.django_db
+def test_tag_bez_site_degraduje_do_on_site(site1, favicon_uczelnia1):
+    """Brak ``request`` (wołanie spoza cyklu żądania) nie wysypuje tagu."""
+    from bpp.templatetags.favicon_bpp import place_favicon
+
+    # Nie asertujemy treści (zależy od SITE_ID) — tylko że tag nie rzuca i
+    # zwraca string.
+    assert isinstance(place_favicon({}), str)
+
+
+# ---------------------------------------------------------------------------
+# CACHE FRAGMENTU — izolacja per host na REALNYM backendzie
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_cache_fragmentu_nie_przenosi_faviconu_miedzy_hostami(
+    cache_locmem, site1, site2, favicony_obu
+):
+    """Rozgrzej fragment pod hostem 1, odczytaj pod hostem 2 — różne favicony.
+
+    Bez ``vary_on`` na ``request.get_host`` drugi render dostałby
+    zapamiętany favicon uczelni 1 (fragment-cache NIE ma hosta w kluczu
+    inaczej niż cache_page). Test na LocMem realnie zapamiętuje — pod
+    DummyCache przeszedłby fałszywie.
+    """
+    html1 = _renderuj(make_request_for_site(site1))
+    assert "uczelniajeden" in html1
+
+    html2 = _renderuj(make_request_for_site(site2))
+    assert "uczelniadwa" in html2, (
+        "WYCIEK MIĘDZY UCZELNIAMI: pod domeną uczelni 2 pojawił się favicon "
+        "uczelni 1 z cache'a fragmentu bez hosta w kluczu."
+    )
+    assert "uczelniajeden" not in html2
+
+
+@pytest.mark.django_db
+def test_cache_fragmentu_trafia_dla_tego_samego_hosta(
+    cache_locmem, site1, favicon_uczelnia1
+):
+    """Ten sam host dwa razy — drugi render to trafienie (identyczny wynik)."""
+    pierwszy = _renderuj(make_request_for_site(site1))
+    drugi = _renderuj(make_request_for_site(site1))
+
+    assert pierwszy == drugi
+    assert "uczelniajeden" in pierwszy

--- a/src/bpp/tests/test_views/test_favicon_per_host.py
+++ b/src/bpp/tests/test_views/test_favicon_per_host.py
@@ -60,20 +60,20 @@ def _utworz_favicon(site, tytul, kolor):
 
     ``FaviconImg.as_html`` renderuje ``href`` po nazwie pliku
     (``slugify(title)-<size>s.png``), więc różne tytuły → różne ``<link>``.
+
+    Tworzymy NORMALNĄ ścieżką (``Favicon.objects.create`` → ``save()``), tak
+    jak robi to admin biblioteki. Dzięki patchowi ``_patch_favicon_save_per_site``
+    (``bpp.apps``) reset ``isFavicon`` jest per ``self.site``, więc zapis
+    favicona jednego tenanta NIE gasi już favicona innego — nie trzeba żadnego
+    ``.update()`` omijającego ``save()`` (który wcześniej maskował buga).
     """
-    fav = Favicon.objects.create(
+    return Favicon.objects.create(
         title=tytul,
         site=site,
         faviconImage=SimpleUploadedFile(
             f"{tytul}.png", _png_bytes(kolor), content_type="image/png"
         ),
     )
-    # ``Favicon.save()`` woła ``Favicon.on_site.exclude(...).update(
-    # isFavicon=False)`` (on_site = CurrentSiteManager po SITE_ID), więc zapis
-    # faviconu jednego Site potrafi zgasić ``isFavicon`` faviconu spod
-    # SITE_ID. Wymuszamy flagę przez queryset update (omija save()).
-    Favicon.objects.filter(pk=fav.pk).update(isFavicon=True)
-    return fav
 
 
 @pytest.fixture
@@ -88,15 +88,11 @@ def favicon_uczelnia2(site2):
 
 @pytest.fixture
 def favicony_obu(favicon_uczelnia1, favicon_uczelnia2):
-    """Oba favicony z re-afirmacją ``isFavicon`` PO utworzeniu obu.
+    """Oba favicony utworzone normalną ścieżką ``save()``.
 
-    Zapis drugiego faviconu (``Favicon.save()``) woła ``on_site.update(
-    isFavicon=False)`` po SITE_ID, więc potrafi zgasić flagę faviconu
-    pierwszego. Ustawiamy ją z powrotem dla OBU dopiero gdy oba istnieją.
+    Po naprawie zapis drugiego favicona nie gasi flagi pierwszego, więc obie
+    pozostają aktywne bez re-afirmacji.
     """
-    Favicon.objects.filter(
-        pk__in=[favicon_uczelnia1.pk, favicon_uczelnia2.pk]
-    ).update(isFavicon=True)
     return favicon_uczelnia1, favicon_uczelnia2
 
 
@@ -132,6 +128,52 @@ def test_tag_zwraca_favicon_wlasciwego_hosta(site1, site2, favicony_obu):
     )
     assert "uczelniadwa" in html2
     assert "uczelniajeden" not in html2
+
+
+@pytest.mark.django_db
+def test_zapis_favicona_tenanta_b_nie_gasi_favicona_tenanta_a(site1, site2):
+    """Ścieżka ZAPISU: create favicona site2 NIE gasi ``isFavicon`` site1.
+
+    Regresja Critical z code review: ``Favicon.save()`` biblioteki woła
+    ``on_site.exclude(pk).update(isFavicon=False)`` po ``settings.SITE_ID``.
+    ``site1`` ma ``pk=1`` == ``SITE_ID``, więc BEZ patcha utworzenie favicona
+    ``site2`` gasi flagę favicona ``site1`` (tenant spod SITE_ID traci
+    favicon). Tworzymy oba NORMALNĄ ścieżką ``create()``/``save()`` (jak
+    admin) i sprawdzamy, że oba zostają aktywne.
+
+    Dowód, że test łapie buga: po tymczasowym cofnięciu patcha (przywróceniu
+    ``Favicon.on_site.exclude(...).update(...)`` w ``save``) ten test FAILUJE
+    na asercji ``f1.isFavicon``.
+    """
+    f1 = _utworz_favicon(site1, "UczelniaJeden", "red")
+    assert f1.isFavicon is True
+
+    # Zapis favicona DRUGIEGO tenanta — nie może ruszyć favicona pierwszego.
+    _utworz_favicon(site2, "UczelniaDwa", "blue")
+
+    f1.refresh_from_db()
+    assert f1.isFavicon is True, (
+        "CLOBBERING: zapis favicona site2 zgasił isFavicon favicona site1 "
+        "(spod SITE_ID) — ścieżka save() gasi cudzego tenanta."
+    )
+
+
+@pytest.mark.django_db
+def test_zapis_favicona_gasi_poprzedni_favicon_TEGO_SAMEGO_site(site1):
+    """Semantyka „jeden aktywny favicon per site” MUSI zostać zachowana.
+
+    Drugi favicon TEGO SAMEGO site'u ma zgasić pierwszy (per-site reset),
+    inaczej patch złamałby oryginalne zachowanie biblioteki.
+    """
+    f1 = _utworz_favicon(site1, "PierwszyU1", "red")
+    f2 = _utworz_favicon(site1, "DrugiU1", "green")
+
+    f1.refresh_from_db()
+    assert f1.isFavicon is False, (
+        "Drugi favicon tego samego site'u nie zgasił pierwszego — złamana "
+        "semantyka „jeden aktywny favicon per site”."
+    )
+    assert f2.isFavicon is True
 
 
 @pytest.mark.django_db

--- a/src/django_bpp/templates/bare.html
+++ b/src/django_bpp/templates/bare.html
@@ -136,8 +136,11 @@
     {% block extrahead %}
     {% endblock %}
     {% load cache %}
-    {% cache 3600 favicon %}
-        {% load favtags %}
+    {# vary_on host: favicon podąża za Site (multi-tenant), więc fragment #}
+    {# MUSI być kluczowany per host — inaczej cache podałby favicon jednej #}
+    {# uczelni pod domeną innej. Patrz favicon_bpp.place_favicon. #}
+    {% cache 3600 favicon request.get_host %}
+        {% load favicon_bpp %}
         {% place_favicon %}
     {% endcache %}
 </head>


### PR DESCRIPTION
## Problem

Favicon nie podążał za hostem w multi-tenant — `django-favicon-plus-reloaded`
używa `CurrentSiteManager` filtrującego po **literalnym `settings.SITE_ID`**,
którego `SiteResolutionMiddleware` nie podmienia. Wszystkie uczelnie dostawały
favicon site'u o `SITE_ID` (poz. 3.7 audytu).

## Zmiana (ścieżka w repo, bez forka biblioteki)

1. **Odczyt per-host:** nowy tag `place_favicon` pyta
   `Favicon.objects.filter(site=request.site, isFavicon=True)` zamiast globalnego
   managera.
2. **Fragment cache dostał `vary_on`:** `{% cache 3600 favicon request.get_host %}`,
   wpis zdjęty z allowlisty strażnika `test_cache_fragmentow_vary_on.py` (bo
   fragmenty `{% cache %}` nie mają hosta w kluczu — reguła #4 audytu; bez tego
   cache podałby favicon jednej uczelni innej).
3. **Naprawa ścieżki ZAPISU (Critical z review):** `Favicon.save()` biblioteki
   gasił `isFavicon` po `on_site` (SITE_ID) → zapis favicona dowolnego tenanta
   gasił favicon tenanta `SITE_ID`. Monkeypatch `Favicon.save` w `BppConfig.ready()`
   zawęża reset do `filter(site=self.site)`. Idempotentny (guard
   `_bpp_per_site_patched`), obejmuje wszystkie ścieżki zapisu (w tym admin).

## Weryfikacja

- Różne hosty → różne favicony (multi-tenant) na **realnym** backendzie cache.
- `vary_on` (`request.get_host`) spójny z wymiarem rozdzielczości (host) — brak
  „ten sam klucz, inny favicon"; strażnik zielony, regresja zapewniona z konstrukcji.
- Test kontrolny clobberingu: **bez** monkeypatcha zapis tenanta B gasi favicon
  tenanta A (test pada), z patchem przeżywa. Fixture'y używają realnej ścieżki
  `save()` (nie obchodzą jej przez `.update()`).
- Review + re-review: PASS + APPROVED (Critical domknięty, patch idempotentny,
  admin objęty, sygnatura zachowana). 7 passed.

Poz. 3.7 audytu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
