### PR TITLE
fix(raport_slotow): limit wierszy na sync eksport szczegółów uczelni (follow-up 2.7)

### DIFF
--- a/src/bpp/newsfragments/uczelnia-export-limit.bugfix.rst
+++ b/src/bpp/newsfragments/uczelnia-export-limit.bugfix.rst
@@ -1,0 +1,5 @@
+Synchroniczny eksport XLSX szczegółów raportu slotów uczelni dostał limit
+wierszy (jak pozostałe raporty slotów): zamiast ryzykować wyczerpanie pamięci
+przy bardzo dużym raporcie, przy przekroczeniu progu zwraca czytelny komunikat
+z prośbą o zawężenie filtrów. Próg jest wyższy niż w pozostałych raportach, bo
+eksport całej uczelni jest z natury najszerszy.

--- a/src/raport_slotow/tests/test_views/test_raport_slotow_uczelnia.py
+++ b/src/raport_slotow/tests/test_views/test_raport_slotow_uczelnia.py
@@ -135,3 +135,72 @@ def test_raport_uczelnia_xlsx(raport_slotow_uczelnia_wiersz, admin_app):
     )
 
     assert res.click("Pobierz w formacie XLSX").status_code == 200
+
+
+def test_raport_uczelnia_xlsx_ponizej_limitu_przechodzi(
+    raport_slotow_uczelnia_wiersz, admin_app, monkeypatch
+):
+    # Poniżej limitu (2 wiersze < 3) → normalny eksport XLSX (HTTP 200).
+    from raport_slotow.views.uczelnia import (
+        SzczegolyRaportSlotowUczelniaListaRekordow,
+    )
+
+    parent = raport_slotow_uczelnia_wiersz.parent
+    parent.raportslotowuczelniawiersz_set.create(
+        autor=raport_slotow_uczelnia_wiersz.autor,
+        jednostka=raport_slotow_uczelnia_wiersz.jednostka,
+        dyscyplina=raport_slotow_uczelnia_wiersz.dyscyplina,
+        pkd_aut_sum=1.0,
+        slot=1.0,
+        avg=1,
+    )
+    monkeypatch.setattr(
+        SzczegolyRaportSlotowUczelniaListaRekordow, "export_max_rows", 3
+    )
+
+    res = admin_app.get(
+        reverse(
+            "raport_slotow:raportslotowuczelnia-results",
+            kwargs={"pk": parent.id},
+        ),
+        params={"_export": "xlsx"},
+    )
+    assert res.status_code == 200
+    assert res.content_type != "text/html"
+
+
+def test_raport_uczelnia_xlsx_powyzej_limitu_zwraca_400(
+    raport_slotow_uczelnia_wiersz, admin_app, monkeypatch
+):
+    # Przekroczenie limitu → HTTP 400 z czytelnym komunikatem (bez cichego
+    # ucięcia pliku). Limit obniżamy monkeypatchem, żeby nie tworzyć dziesiątek
+    # tysięcy wierszy w teście.
+    from raport_slotow.views.uczelnia import (
+        SzczegolyRaportSlotowUczelniaListaRekordow,
+    )
+
+    parent = raport_slotow_uczelnia_wiersz.parent
+    # Drugi wiersz: 2 > limit=1.
+    parent.raportslotowuczelniawiersz_set.create(
+        autor=raport_slotow_uczelnia_wiersz.autor,
+        jednostka=raport_slotow_uczelnia_wiersz.jednostka,
+        dyscyplina=raport_slotow_uczelnia_wiersz.dyscyplina,
+        pkd_aut_sum=1.0,
+        slot=1.0,
+        avg=1,
+    )
+    monkeypatch.setattr(
+        SzczegolyRaportSlotowUczelniaListaRekordow, "export_max_rows", 1
+    )
+
+    res = admin_app.get(
+        reverse(
+            "raport_slotow:raportslotowuczelnia-results",
+            kwargs={"pk": parent.id},
+        ),
+        params={"_export": "xlsx"},
+        expect_errors=True,
+    )
+    assert res.status_code == 400
+    assert "maksymalnie 1" in res.text
+    assert "2" in res.text

--- a/src/raport_slotow/util.py
+++ b/src/raport_slotow/util.py
@@ -18,6 +18,18 @@ from openpyxl.worksheet.table import Table, TableColumn, TableStyleInfo
 # ale nadal ograniczona. Przekroczenie → jasny komunikat (bez cichego ucięcia).
 RAPORT_SLOTOW_EXPORT_MAX_ROWS = 10000
 
+# Osobny, wyższy limit dla synchronicznego eksportu SZCZEGÓŁÓW raportu
+# uczelnianego (SzczegolyRaportSlotowUczelniaListaRekordow). To najszerszy
+# legalny eksport w systemie: jeden wiersz na (autor, dyscyplina), a w trybie
+# „dziel na jednostki i wydziały" na (autor, jednostka, dyscyplina) — dla dużej
+# uczelni realnie kilkanaście–kilkadziesiąt tysięcy wierszy. Limit 10000 z
+# reszty raportów (autor/ewaluacja/zerowy) uciąłby prawdziwe uczelnie, dlatego
+# tu jest wyższy. Nadal ograniczony (openpyxl trzyma cały arkusz w RAM), więc
+# chroni przed patologicznym/DoS-owym wolumenem, a przekroczenie daje czytelny
+# komunikat zamiast cichego OOM. Docelowo ten eksport powinien pójść w tło
+# (jak generacja raportu przez liveops/celery) — patrz follow-up.
+RAPORT_SLOTOW_UCZELNIA_EXPORT_MAX_ROWS = 50000
+
 
 class ExportRowLimitExceeded(Exception):
     """Eksport przekracza limit wierszy (RAPORT_SLOTOW_EXPORT_MAX_ROWS).

--- a/src/raport_slotow/views/uczelnia.py
+++ b/src/raport_slotow/views/uczelnia.py
@@ -25,7 +25,10 @@ from raport_slotow.tables import (
     RaportSlotowUczelniaTable,
 )
 from raport_slotow.uczelnia_helper import uczelnia_dla_odczytu
-from raport_slotow.util import MyExportMixin
+from raport_slotow.util import (
+    RAPORT_SLOTOW_UCZELNIA_EXPORT_MAX_ROWS,
+    MyExportMixin,
+)
 
 # Stany terminalne liveops — restart/regen dozwolony TYLKO w nich (guard §8.4).
 _STANY_TERMINALNE = ("FINISHED_OK", "FINISHED_ERROR", "CANCELLED")
@@ -150,12 +153,19 @@ class SzczegolyRaportSlotowUczelniaListaRekordow(
     template_name = "raport_slotow/raport_slotow_uczelnia.html"
     uczelnia_attr = "pokazuj_raport_slotow_uczelnia"
     export_formats = ["html", "xlsx"]
-    # Raport uczelniany generuje się asynchronicznie (liveops/celery), a jego
-    # szczegóły to widok pochodny — NIE nakładamy tu bramki wierszy, żeby nie
-    # zmieniać zachowania dużych, legalnych eksportów uczelnianych. Widok i tak
-    # korzysta z odchudzonego (strumieniowego) budowania XLSX. Docelowo warto
-    # przenieść i ten eksport na tło — patrz follow-up.
-    export_max_rows = None
+    # Uwaga: przez liveops/celery idzie GENERACJA wierszy raportu, ale sam
+    # eksport XLSX szczegółów biegnie SYNCHRONICZNIE w cyklu request/response i
+    # openpyxl trzyma cały arkusz w RAM — bez bramki największy eksport w
+    # systemie (cała uczelnia) może wyczerpać pamięć procesu web. Nakładamy więc
+    # limit tym samym mechanizmem co reszta raportów (COUNT PRZED materializacją
+    # → ExportRowLimitExceeded → HTTP 400, bez cichego ucięcia), ale z wyższym,
+    # uczelnia-specyficznym progiem (patrz RAPORT_SLOTOW_UCZELNIA_EXPORT_MAX_ROWS).
+    #
+    # Bramka `len(table.rows)` daje tani COUNT (bez materializacji) TYLKO gdy
+    # tabela jest paginowana — tu jest (paginate_by = 25, a `get_table`
+    # bezwarunkowo woła RequestConfig z paginacją), więc `hasattr(table,
+    # "paginator")` jest prawdą i django_tables2 liczy `queryset.count()`.
+    export_max_rows = RAPORT_SLOTOW_UCZELNIA_EXPORT_MAX_ROWS
     filterset_class = RaportSlotowUczelniaFilter
     model = RaportSlotowUczelnia
     paginate_by = 25


### PR DESCRIPTION
> **PR ułożony na #652** (`fix/xlsx-export-memory`). Do zmergowania **po** #652.
> Dopóki #652 nie wejdzie na `dev`, diff pokazuje też jego zmiany — po zmergowaniu
> #652 GitHub przeliczy i zostanie tylko diff residuala.

## Problem (znaleziony w review #652)

Główne 2.7 osłoniło wspólny chokepoint `MyTableExport` (autor/ewaluacja/zerowy/
upowaznienie_pbn), ale eksport **szczegółów uczelni**
(`SzczegolyRaportSlotowUczelniaListaRekordow`) został poza osłoną — biegł
**synchronicznie w cyklu request/response BEZ limitu wierszy**
(`export_max_rows=None`).

Premisa audytu „uczelnia idzie przez celery" jest tu nieścisła: przez celery idzie
GENERACJA wierszy raportu, nie sam eksport XLSX. To potencjalnie **największy**
pojedynczy eksport w systemie (wiersz per autor×dyscyplina; w trybie „dziel na
jednostki/wydziały" per autor×jednostka×dyscyplina) — czyli największa powierzchnia
OOM została otwarta.

## Zmiana

Ten sam mechanizm co 2.7: `export_max_rows` = **50000** (COUNT przed
materializacją → `ExportRowLimitExceeded` → **HTTP 400** z jasnym komunikatem,
**bez cichego ucięcia**). Widok jest paginowany (`paginate_by=25`), więc
`len(table.rows)` = `count()` — bramka nie materializuje querysetu.

**Próg 50000 (nie 10000)** — to najszerszy legalny eksport; 10000 uciąłby duże
uczelnie. 50000 nadal ogranicza pamięć openpyxl (~dziesiątki MB) i chroni przed
patologią/DoS. **Docelowo:** przenieść ten eksport na celery, jak generację.

## Weryfikacja

- Test: poniżej limitu → 200 (realny XLSX), powyżej → 400 z komunikatem (limit
  obniżony `monkeypatch`-em, żeby nie tworzyć dziesiątek tysięcy wierszy).
- `test_raport_slotow_uczelnia.py` + `test_export_xlsx.py` — exit 0.

Follow-up do poz. 2.7 audytu `HANDOFF-niewdrozone-2026-07-20.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GmViAsaif9MXeuDMA5NHX
