### PR TITLE
feat(zglos_publikacje): zgłoszenie domknięte importerem oznacza się samo (FD#443)

### DIFF
--- a/docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md
+++ b/docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md
@@ -1,0 +1,271 @@
+# Domknięcie pętli: zgłoszenie publikacji ↔ importer prac
+
+**Zgłoszenie:** FD#443 „Oznaczanie zgłoszeń jako zużyte"
+(<https://iplweb.freshdesk.com/a/tickets/443>), zgłaszający Jan Bichałowicz
+(`jbihalowicz@apoz.edu.pl`), klient `bpp.apoz.edu.pl`.
+Powiązane: FD#430 (przycisk „Użyj importera" nad tabelą), FD#425 (oryginał).
+
+**Data:** 2026-07-22 · **Wersja bazowa:** `202607.1397` · **Gałąź:**
+`fix-fd443-zgloszenie-zaimportowane`
+
+---
+
+## 1. Problem
+
+Operator otwiera zgłoszenie publikacji w adminie, klika „Użyj importera",
+przechodzi przez importer i tworzy rekord. Zgłoszenie zostaje w stanie
+`NOWY` — wygląda, jakby nikt się nim nie zajął. Nie widać, że praca została
+już zaimportowana, kto to zrobił ani kiedy.
+
+Przyczyną nie są trzy osobne braki, tylko **jedna przerwana krawędź**:
+`ImportSession` nie wie, że uruchomiono ją ze zgłoszenia. Link „Użyj
+importera" jest bezstanowy — przekazuje wyłącznie `?provider=&identifier=`
+(`src/zglos_publikacje/admin/zgloszenie_publikacji.py:404-410`), po czym
+kontekst ginie.
+
+### Co już jest w kodzie (i jest martwe)
+
+| Element | Stan |
+|---|---|
+| `Zgloszenie_Publikacji.odpowiednik_w_bpp` — GenericFK do rekordu (`models.py:82`) | pole istnieje, **nic w `src/` go nie zapisuje** |
+| `Statusy.ZAAKCEPTOWANY = 1` („dodany do bazy BPP") | **nigdy nie ustawiany programowo** |
+| `ImportSession.created_by`, `created_record` | wypełniane poprawnie (`tasks.py:226-231`) |
+| `_find_matching_zgloszenie()` (`importer_publikacji/views/authors.py:148-188`) | heurystyka DOI → tytuł, używana **wyłącznie** do prefilla dyscyplin |
+
+### Pułapka do obejścia
+
+`ImportSession.modified` to `auto_now=True` — znaczy „kiedy ostatnio cokolwiek
+ruszyło wiersz", nie „kiedy zaimportowano". Watchdog `mark_stalled()`
+(`importer_publikacji/models.py:305-321`) czy ponowne wejście na sesję
+przesuwają tę datę. Dlatego moment importu wymaga **jawnego pola**.
+
+## 2. Cel
+
+Po zakończeniu importu uruchomionego ze zgłoszenia:
+
+1. zgłoszenie automatycznie dostaje status **`ZAIMPORTOWANY`** i przestaje
+   wyglądać na wymagające obsługi,
+2. przy zgłoszeniu widać **kto** i **o której** je zaimportował oraz **jaki
+   rekord** powstał,
+3. operator dostaje **informację zwrotną** w trzech miejscach: na stronie
+   zgłoszenia, na stronie wyników importera i jako flash message.
+
+## 3. Decyzje projektowe
+
+| # | Decyzja | Uzasadnienie |
+|---|---|---|
+| D1 | Nowy status `ZAIMPORTOWANY = 6`, nie ożywianie `ZAAKCEPTOWANY = 1` | odróżnia „dodane importerem" od „dodane ręcznie"; słowo z prośby klienta |
+| D2 | Audyt denormalizowany na zgłoszeniu (`zaimportowano`, `zaimportowal`) | filtrowalny i sortowalny na liście; przeżywa skasowanie sesji importu |
+| D3 | Jawne pole czasu, nie `auto_now` | `ImportSession.modified` nie jest wiarygodnym znacznikiem zakończenia |
+| D4 | Wiązanie jawne (`?zgloszenie=`) + fallback po DOI | determinizm; DOI to identyfikator mocny |
+| D5 | Dopasowanie po **tytule wykluczone** z wiązania | dwa zgłoszenia o tym samym tytule → oznaczono by przypadkowe (korupcja danych) |
+| D6 | Przy ≥2 kandydatach — operator wybiera, system nie zgaduje | jawny wybór zamiast cichego pominięcia |
+| D7 | Bez soft-delete zgłoszenia po imporcie | jawny status niesie tę samą informację, a zachowuje ślad na liście |
+
+## 4. Zmiany w modelach
+
+### 4.1 `zglos_publikacje` — migracja `0027`
+
+Na `Zgloszenie_Publikacji` (`src/zglos_publikacje/models.py:60`):
+
+| Pole | Definicja |
+|---|---|
+| `Statusy.ZAIMPORTOWANY` | `= 6, "zaimportowany przez importer prac"` |
+| `zaimportowano` | `DateTimeField("Zaimportowano", null=True, blank=True, db_index=True)` |
+| `zaimportowal` | `FK(settings.AUTH_USER_MODEL, on_delete=SET_NULL, null=True, blank=True, related_name="+", verbose_name="Zaimportował")` |
+| `odpowiednik_w_bpp` | bez zmian — istniejący GenericFK, zaczyna być zapisywany |
+
+`SET_NULL` na `zaimportowal`: skasowanie konta operatora nie może kasować ani
+blokować zgłoszenia.
+
+### 4.2 `importer_publikacji` — migracja
+
+Na `ImportSession` (`src/importer_publikacji/models.py:15`):
+
+| Pole | Definicja |
+|---|---|
+| `zgloszenie` | `FK("zglos_publikacje.Zgloszenie_Publikacji", on_delete=SET_NULL, null=True, blank=True, related_name="sesje_importu", verbose_name="Zgłoszenie publikacji")` |
+| `zgloszenie_odrzucone_przez_operatora` | `BooleanField(default=False)` — operator kliknął „żadne z nich"; wycisza baner |
+
+FK jest wymogiem technicznym, nie ozdobą: `create_publication_task` dostaje
+wyłącznie id sesji, więc bez tego pola zadanie Celery nie ma jak ustalić,
+które zgłoszenie oznaczyć.
+
+**Kierunek zależności** jest już ustalony — `importer_publikacji` importuje
+`Zgloszenie_Publikacji` (`views/authors.py`), więc FK nie tworzy cyklu.
+
+### 4.3 Baseline
+
+Dwie nowe migracje. Zgodnie z regułą repo `make baseline-update` wykonuje się
+**raz, przy scalaniu**, nie w gałęzi feature.
+
+## 5. Wiązanie sesji ze zgłoszeniem
+
+### Ścieżka A — jawna (z przycisku)
+
+`importer_url()` (`admin/zgloszenie_publikacji.py:389-417`) dokłada
+`&zgloszenie={pk}`. `IndexView` (`views/wizard.py:87-119`) odczytuje parametr
+i przekazuje do `_start_import_session` (`:183-202`), które zapisuje FK.
+
+Parametr jest **walidowany** przy odczycie: musi być liczbą i wskazywać
+istniejące, nie-usunięte zgłoszenie. Wartość niepoprawna jest ignorowana
+(import startuje bez wiązania), nie powoduje błędu.
+
+### Ścieżka B — auto po DOI (dokładnie jedno trafienie)
+
+W istniejącym etapie `prefill_zgl` (`tasks.py:87-90`), gdy `session.zgloszenie`
+jest puste. Kandydaci:
+
+```
+Zgloszenie_Publikacji.objects            # SoftDeleteManager — pomija usunięte
+    .filter(doi__iexact=<doi sesji>)
+    .exclude(status__in=(ODRZUCONO, SPAM, ZAIMPORTOWANY, ZAAKCEPTOWANY))
+```
+
+Dokładnie jeden wynik → `session.zgloszenie` ustawione. Zero → nic.
+Dwa lub więcej → ścieżka C.
+
+Dopasowanie po tytule **nie bierze udziału** w wiązaniu. Pozostaje bez zmian
+tam, gdzie jest dziś — w prefillu dyscyplin, gdzie pomyłka jest nieszkodliwa.
+
+### Ścieżka C — dwuznaczna (≥2 kandydatów)
+
+Baner na pierwszym ekranie po pobraniu danych, z listą kandydatów:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ ℹ  Mamy 2 zgłoszenia publikacji na to DOI (10.1234/abc). │
+│    Które z nich domknąć tym importem?                    │
+│                                                          │
+│    [ #402 — Kowalski J., „Wpływ…", 2025 ]                │
+│    [ #417 — Nowak A., „Wpływ…", 2025 ]                   │
+│    [ Pokaż wszystkie w adminie ↗ ]  [ Żadne z nich ]     │
+└──────────────────────────────────────────────────────────┘
+```
+
+Przy **jednym** kandydacie baner pokazuje się w wersji potwierdzającej:
+*„Ten import domknie zgłoszenie #402 [zobacz] [odepnij]"* — operator może
+zaprotestować, zanim import się wykona.
+
+Wybór to `POST` na nowy widok. Widok **waliduje, że wskazane id znajduje się
+wśród aktualnie wyliczonych kandydatów** — bez tego byłby to IDOR: operator
+mógłby oznaczyć jako zaimportowane dowolne zgłoszenie w systemie.
+„Żadne z nich" ustawia `zgloszenie_odrzucone_przez_operatora = True`.
+
+Kandydaci są **wyliczani przy renderowaniu**, nie cache'owani w polu — DOI
+jest stabilne, a dzięki temu lista nie starzeje się względem stanu bazy.
+
+## 6. Zapis zwrotny
+
+W `create_publication_task` (`src/importer_publikacji/tasks.py:217-239`),
+w tej samej transakcji, która tworzy rekord, tuż po `status = COMPLETED`:
+
+```
+jeżeli session.zgloszenie istnieje i jego status != ZAIMPORTOWANY:
+    status            ← Statusy.ZAIMPORTOWANY
+    zaimportowano     ← timezone.now()
+    zaimportowal      ← session.created_by
+    odpowiednik_w_bpp ← utworzony rekord
+```
+
+Własności:
+
+- **idempotentny** — ponowienie zadania nie przesuwa daty ani nie zmienia
+  autora,
+- **odporny na wyścig** — zgłoszenie skasowane w międzyczasie nie wywala
+  importu; brak wiersza jest logowany, nie podnoszony,
+- `zaimportowal` z `created_by`, nie `modified_by` — „kto to zrobił" znaczy
+  kto uruchomił import, nie kto ostatnio dotknął wiersza,
+- **niepowodzenie importu nie zmienia statusu zgłoszenia** — zapis siedzi
+  w gałęzi sukcesu, przed blokiem `except` (`tasks.py:232-239`).
+
+### Efekt uboczny, którego nie trzeba kodować
+
+Przyciski „Zwróć do autora", „Dodaj wyd. ciągłe", „Dodaj wyd. zwarte" mają
+warunki `status in (NOWY, PO_ZMIANACH)` (`models.py:275, 281, 288` oraz
+`templates/.../change_form.html`). Po zmianie statusu **znikają same** —
+zgłoszenie przestaje wyglądać na wymagające obsługi.
+
+## 7. Informacja zwrotna
+
+| Miejsce | Co pokazuje | Gdzie w kodzie |
+|---|---|---|
+| Strona zgłoszenia w adminie | panel readonly: „📥 Zaimportowane 22.07.2026 16:40 przez jkowalski · rekord ↗ · sesja importu ↗" | `admin/zgloszenie_publikacji.py` + `change_form.html` |
+| Strona wyników importera | baner „Domknięto zgłoszenie #402 ↗" | `DoneView` (`views/wizard.py:1069-1084`) |
+| Flash message | `messages.success(...)` przy wejściu na `DoneView` | tamże |
+
+Flash **musi** powstawać w cyklu żądania, **nie w zadaniu Celery** — worker
+jawnie wyrzuca wiadomości do kosza (`_NoopMessageStorage`,
+`tasks.py:254-265`), więc flash postawiony w tasku przepadłby bez śladu.
+
+Panel w adminie jest wyłącznie prezentacją: admin ma
+`has_change_permission → False` (`admin/zgloszenie_publikacji.py:144`), więc
+nowe pola i tak nie są edytowalne przez formularz.
+
+## 8. Lista zgłoszeń w adminie
+
+`ZAIMPORTOWANY` wchodzi automatycznie do istniejącego filtra `"status"`
+(`admin/zgloszenie_publikacji.py:96-107`).
+
+Dodatkowo filtr **„Do obsługi / Załatwione / Wszystkie"**, domyślnie
+*Do obsługi* (`NOWY`, `PO_ZMIANACH`). Realizuje prośbę „żeby przestało się
+pokazywać jako otwarte" — dziś takiego filtra nie ma w ogóle, a lista pokazuje
+wszystko łącznie z odrzuconymi i spamem.
+
+Kolumny listy zyskują `zaimportowano`; `list_filter` — `zaimportowal`.
+
+## 9. Testy
+
+`src/zglos_publikacje/tests/` i `src/importer_publikacji/tests/`; pytest bez
+klas, `@pytest.mark.django_db`, `model_bakery.baker.make`.
+
+**Wiązanie**
+
+- przycisk „Użyj importera" zawiera `zgloszenie=<pk>` w URL
+- `IndexView` z `?zgloszenie=N` zapisuje FK na sesji
+- `?zgloszenie=` niepoprawne / nieistniejące / usunięte → import startuje bez wiązania, bez błędu
+- auto-wiązanie przy dokładnie jednym zgłoszeniu z tym DOI
+- brak auto-wiązania przy dwóch zgłoszeniach z tym samym DOI + oba na liście kandydatów
+- brak wiązania po samym tytule (dwa zgłoszenia o identycznym tytule, różne DOI)
+- kandydaci pomijają zgłoszenia `ODRZUCONO`, `SPAM`, `ZAIMPORTOWANY`, soft-deleted
+
+**Wybór operatora**
+
+- `POST` z id kandydata ustawia FK
+- `POST` z id **spoza** listy kandydatów jest odrzucany (regresja IDOR)
+- „żadne z nich" wycisza baner
+
+**Zapis zwrotny**
+
+- po `COMPLETED` zgłoszenie ma status, datę, autora i `odpowiednik_w_bpp`
+- ponowienie zadania nie przesuwa `zaimportowano` (idempotencja)
+- import zakończony błędem nie zmienia statusu zgłoszenia
+- zgłoszenie skasowane w trakcie importu nie wywala zadania
+- po imporcie znikają przyciski „Zwróć do autora" i „Dodaj wyd. …"
+
+**Prezentacja**
+
+- panel w adminie pokazuje datę, użytkownika i link do rekordu
+- `DoneView` renderuje baner i flash message
+
+## 10. Poza zakresem
+
+- **Ścieżka ręczna „Dodaj wyd. ciągłe/zwarte"** (`?numer_zgloszenia=`,
+  `bpp/const.py:131`) nadal nie oznacza zgłoszenia — numer trafia wyłącznie do
+  pola tekstowego `adnotacje` (`bpp/admin/zglos_publikacje_helpers.py:72-77`).
+  Ta sama luka, innym korytarzem; osobne zgłoszenie.
+- **Import wielu prac** (`MultipleWorksImport`) — wiązanie ze zgłoszeniami
+  per-wpis; poza zakresem.
+- **Powiadomienie po zamknięciu karty** (liveops / e-mail) — importer nie
+  używa dziś żadnego z trzech mechanizmów powiadomień obecnych w projekcie.
+  Osobna decyzja produktowa.
+- **Soft-delete zgłoszenia po imporcie** — świadomie odrzucone (D7).
+
+## 11. Ryzyka
+
+| Ryzyko | Mitygacja |
+|---|---|
+| Oznaczenie cudzego zgłoszenia | wiązanie tylko jawne albo po DOI przy jednym trafieniu; tytuł wykluczony (D5) |
+| IDOR przy wyborze kandydata | walidacja id względem wyliczonej listy kandydatów (§5C) |
+| Dwie migracje w jednej gałęzi | `make baseline-update` raz, przy scalaniu — nie w gałęzi |
+| Rozjazd `zaimportowano` z sesją importu | pole zapisywane wyłącznie w jednym miejscu, w transakcji tworzącej rekord |

--- a/docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md
+++ b/docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md
@@ -89,7 +89,23 @@ Po zakończeniu importu uruchomionego ze zgłoszenia:
 | D7 | Bez soft-delete zgłoszenia po imporcie | jawny status niesie tę samą informację, a zachowuje ślad na liście |
 | **D8** | **Kandydaci po DOI ograniczeni do uczelni sesji importu** | `Zgloszenie_Publikacji` nie ma `uczelnia`; bez zawężenia baner pokazałby tytuł i e-mail zgłaszającego z cudzej uczelni, a auto-wiązanie oznaczyłoby cudze zgłoszenie |
 | **D9** | **`WYMAGA_ZMIAN` wykluczony z auto-wiązania** | zgłoszenie jest w rękach autora (aktywny `kod_do_edycji`); przestemplowanie go w trakcie edycji zabrałoby mu pracę |
-| **D10** | **Zapis zwrotny w osobnym `transaction.atomic` razem z `COMPLETED`** | transakcja tworząca rekord (`publikacja.py:327`) commituje przed powrotem do taska; „ta sama transakcja" i „tuż po COMPLETED" wykluczają się |
+| **D10** | **Zapis zwrotny osobno, po zapisie `COMPLETED`** | transakcja tworząca rekord (`publikacja.py:327`) commituje przed powrotem do taska; „ta sama transakcja" i „tuż po COMPLETED" wykluczają się |
+
+### Decyzje dodane po adwersarialnej recenzji PR #657
+
+Recenzja wykazała, że trzy założenia projektu były błędne. Poniższe decyzje je
+zastępują.
+
+| # | Decyzja | Uzasadnienie |
+|---|---|---|
+| **D11** | **DOI zgłoszenia czytamy z `doi` **oraz** ze `strona_www`** | pole `doi` jest produkcyjnie **zawsze puste**: publiczny formularz (`forms.py:277-283`) go nie ma, a help-text (`forms.py:121`) każe wkleić DOI do `strona_www`. Samo `doi__iexact` czyniło ścieżki B i C martwym kodem. Tę samą kolejność stosuje już `importer_url()` |
+| **D12** | **Prefiltr SQL `icontains` + dokładne porównanie w Pythonie** | LIKE nie umie rozpoznać, gdzie w URL-u kończy się DOI. Bez dofiltrowania DOI będące **prefiksem** innego (`10.1/abc` vs `10.1/abc.2`) dawałoby ciche oznaczenie cudzego zgłoszenia |
+| **D13** | **Ścieżka jawna egzekwuje te same reguły co kandydaci** (`zgloszenie_dozwolone`) | pierwotnie `_zgloszenie_z_pola` robiło gołe `objects.filter(pk=…)` — bez granicy uczelni i bez filtra statusów. Redaktor jednej uczelni mógł POST-em przestemplować zgłoszenie innej |
+| **D14** | **Zapis zwrotny to warunkowy `UPDATE`, rewalidujący status** | między związaniem a zapisem mija cała praca operatora w kreatorze. Guard „przeczytaj, potem zapisz" pozwalał przestemplować zgłoszenie zwrócone w międzyczasie autorowi. Warunek w `WHERE` usuwa przy okazji wyścig |
+| **D15** | **`kod_do_edycji` kasowany przy oznaczaniu** | widok edycji autoryzuje **samym kodem**, nie statusem. Żywy kod na zgłoszeniu `ZAIMPORTOWANY` pozwalał autorowi cofnąć status na `PO_ZMIANACH` → panel audytu znikał → przycisk „Użyj importera" wracał → duplikat rekordu |
+| **D16** | **`WYMAGA_ZMIAN` należy do grupy „Do obsługi"** | zgłoszenie u autora jest „w toku" — operator musi je widzieć. Poza żadną grupą znikało wszędzie poza „Wszystkie", co było regresem widoczności wobec stanu sprzed zmiany |
+| **D17** | **Filtr „Stan obsługi" przepuszcza queryset, gdy jawnie wybrano `status`** | oba filtry składały się koniunkcją, więc kliknięcie „status → spam" dawało pustą listę bez wyjaśnienia. `choices()` nie zaznacza wtedy „Do obsługi", żeby UI nie kłamał o zawężeniu |
+| **D18** | **Informację zwrotną niesie callout, nie flash** | `base.html` renderuje ramkę komunikatów **dwukrotnie** (`:184`, `:210`), więc flash pokazywałby się 2×, a z calloutem 3×. Callout jest idempotentny i trwały (przeżywa F5); znika ~25 linii maszynerii „pokaż dokładnie raz" |
 
 ## 4. Zmiany w modelach
 
@@ -153,13 +169,25 @@ def oznacz_jako_zaimportowane(session, record) -> bool:
 doi = normalize_doi(session.normalized_data.get("doi"))   # jak authors.py:160-162
 jeśli brak doi → pusty queryset
 
-Zgloszenie_Publikacji.objects            # SoftDeleteManager pomija usunięte
-    .filter(doi__iexact=doi)
+baza = Zgloszenie_Publikacji.objects      # SoftDeleteManager pomija usunięte
     .exclude(status__in=(ODRZUCONO, SPAM, ZAIMPORTOWANY, ZAAKCEPTOWANY,
                          WYMAGA_ZMIAN))                              # D9
-    .filter(<zawężenie do session.uczelnia>)                         # D8
-    .distinct()
+    .filter(<zawężenie do uczelni>)                                  # D8
+
+# prefiltr zgrubny — LIKE nie wie, gdzie w URL-u kończy się DOI      # D11, D12
+kandydaci_pk = {
+    pk for pk, doi_pola, strona_www in baza.order_by()
+                                           .values_list("pk", "doi", "strona_www")
+    if normalize_doi(doi_pola) == doi or extract_doi_from_url(strona_www) == doi
+}
+→ Zgloszenie_Publikacji.objects.filter(pk__in=kandydaci_pk)
 ```
+
+Zwracany jest **QuerySet**, nie lista — reszta kodu (walidacja wyboru
+operatora przez `.filter(pk=…)`, liczenie, iteracja w szablonie) na tym polega.
+
+`order_by()` kasuje domyślne `Meta.ordering`: bez tego `SELECT DISTINCT`
+z `ORDER BY` po kolumnie spoza listy pól wywala się na PostgreSQL-u.
 
 **Zawężenie do uczelni (D8).** `Zgloszenie_Publikacji` nie ma `uczelnia`;
 jedyna droga w ORM prowadzi przez autorów zgłoszenia:
@@ -175,19 +203,31 @@ nieszkodliwa.
 
 ### 5.2 `oznacz_jako_zaimportowane`
 
+Jeden **warunkowy `UPDATE`** — nie „przeczytaj, sprawdź, zapisz" (D14):
+
 ```
 zgl = session.zgloszenie
-pomiń (zwróć False) gdy: brak zgl
-                       | zgl.deleted_at is not None     # soft-delete, patrz §1.3
-                       | zgl.status == ZAIMPORTOWANY    # idempotencja
+pomiń (zwróć False) gdy: brak zgl | zgl.deleted_at is not None   # patrz §1.3
 
-w transaction.atomic:
-    zgl.status            = ZAIMPORTOWANY
-    zgl.zaimportowano     = timezone.now()
-    zgl.zaimportowal      = session.created_by
-    zgl.odpowiednik_w_bpp = record
-    zgl.save(update_fields=[...])
+zaktualizowane = (
+    Zgloszenie_Publikacji.objects.filter(pk=zgl.pk)
+        .exclude(status__in=_wykluczone_statusy())   # rewalidacja W CHWILI ZAPISU
+        .update(
+            status            = ZAIMPORTOWANY,
+            zaimportowano     = timezone.now(),
+            zaimportowal      = session.created_by,
+            content_type      = ...,                 # GenericFK to DWIE kolumny
+            object_id         = record.pk,
+            kod_do_edycji     = None,                # D15
+        )
+)
+jeśli zaktualizowane == 0 → zaloguj (ze świeżo odczytanym statusem) i zwróć False
 ```
+
+Warunek w `WHERE` załatwia trzy rzeczy naraz: idempotencję (`ZAIMPORTOWANY` jest
+na liście wykluczonych), rewalidację statusu (D14) i wyścig — nie ma okna między
+odczytem a zapisem. `content_type` i `object_id` muszą być wymienione jawnie:
+`odpowiednik_w_bpp` to `GenericForeignKey`, czyli nie kolumna, tylko para kolumn.
 
 `zaimportowal` z `created_by`, nie `modified_by` — „kto to zrobił" znaczy kto
 uruchomił import, nie kto ostatnio dotknął wiersza.
@@ -207,14 +247,35 @@ To **cztery** zmiany, nie jedna — parametr musi przeżyć GET → render → P
 4. `FetchView.post` (`wizard.py:205-281`) odczytuje z `cleaned_data`
    i przekazuje do `_start_import_session` (`:183-202`).
 
-**Walidacja przy odczycie:** wartość musi być liczbą i wskazywać istniejące,
-nie-usunięte zgłoszenie. Wartość niepoprawna jest ignorowana (import startuje
-bez wiązania), nie powoduje błędu.
+**Walidacja przy odczycie (D13) — kluczowa.** Nie wystarczy sprawdzić, że
+zgłoszenie istnieje: ścieżka jawna musi egzekwować **te same reguły co
+kandydaci** — granicę uczelni (D8) i wykluczone statusy (D9). Służy do tego
+`zgloszenie_dozwolone(pk, uczelnia)` z `zgloszenia.py`, dzieląca implementację
+z `kandydaci_dla_sesji` (jedno źródło reguł, zero duplikacji).
 
-**Gałąź idempotency** (`wizard.py:259-273`) zwraca istniejącą sesję in-flight
+Bez tego pole `zgloszenie` jest zwykłym ukrytym inputem, a enumeracja `pk` to
+jedno `curl`: redaktor jednej uczelni POST-em wiąże i przestemplowuje
+zgłoszenie innej — także takie w statusie `SPAM` czy `WYMAGA_ZMIAN`.
+
+Wartość niepoprawna, spoza uczelni albo o wykluczonym statusie jest **ignorowana
+po cichu** (import startuje bez wiązania), nigdy nie powoduje błędu widocznego
+dla użytkownika.
+
+**Gałąź idempotency** (`wizard.py`) zwraca istniejącą sesję in-flight
 z pominięciem `_start_import_session` — wiązanie zostałoby po cichu zgubione.
-Reguła: jeśli zwrócona sesja ma `zgloszenie` puste, dopisz je; jeśli ma już
-inne, **nie nadpisuj**.
+Reguła „dopisz gdy puste, nie nadpisuj gdy zajęte" jest realizowana **atomowym
+warunkowym UPDATE**, nie sekwencją odczyt-zapis:
+
+```python
+ImportSession.objects.filter(pk=…, zgloszenie__isnull=True).update(zgloszenie=…)
+```
+
+Sekwencja odczyt-zapis nie wystarcza, bo dla tej sesji **równolegle biegnie**
+`fetch_session_task`, który trzyma własną, wcześniej załadowaną instancję.
+Jego pełne `session.save()` wpisywałoby `zgloszenie_id = NULL` z nieaktualnego
+stanu. Dlatego zadania zapisują wyłącznie przez `update_fields` (zawsze
+z `modified`, bo `auto_now` odpala się tylko dla pól z listy, a `is_stalled()`
+czyta to pole), a przed etapem `prefill_zgl` przeładowują `zgloszenie` z bazy.
 
 ### Ścieżka B — auto po DOI (dokładnie jeden kandydat)
 
@@ -280,18 +341,34 @@ powrocie z `_create_publication`, którego własna transakcja
 ```
 with transaction.atomic():
     session.status = COMPLETED; session.created_record = record; …
-    session.save(...)
-    oznacz_jako_zaimportowane(session, record)
+    session.save(update_fields=[…, "modified"])
+
+# POZA transakcją i w wąskim try/except — uzasadnienie niżej
+_oznacz_zgloszenie_nie_wywracajac_importu(session, record)
 ```
 
 Własności:
 
 - **idempotentny** — ponowienie zadania nie przesuwa daty ani nie zmienia
-  autora (guard `status == ZAIMPORTOWANY`),
+  autora (`ZAIMPORTOWANY` jest wśród statusów wykluczonych w `WHERE`),
 - **odporny na soft-delete** — guard `deleted_at is None`; przypadek jest
   logowany, nie podnoszony,
 - **niepowodzenie importu nie zmienia statusu zgłoszenia** — zapis siedzi
-  w gałęzi sukcesu, przed blokiem `except` (`tasks.py:232-239`).
+  w gałęzi sukcesu, przed blokiem `except`,
+- **przeładowuje `zgloszenie` z bazy** — żeby uszanować „Odepnij" / „Żadne
+  z nich" kliknięte przez operatora w trakcie trwania zadania.
+
+**Dlaczego poza transakcją i w `try/except`.** Zapis zwrotny wykonuje się
+*po* commicie `_create_publication`, czyli gdy rekord już istnieje. Gdyby
+rzucił wyjątek wewnątrz `atomic`, transakcja zostałaby zatruta, `COMPLETED`
+wycofane, a blok `except` ustawiłby `IMPORT_FAILED` — operator kliknąłby
+„Ponów" i powstałby **drugi rekord tej samej publikacji**. Dlatego wyjątek
+jest tu przechwytywany wąsko: `logger.exception(...)` + `rollbar.report_exc_info()`,
+**bez re-raise**. Najgorszy skutek to nieoznaczone zgłoszenie, nie duplikat.
+
+To wyjątek od reguły repo „nigdy nie połykaj wyjątków" uzasadniony tym, że
+zdarzenie jest w pełni raportowane (log + Rollbar), a alternatywa jest
+gorsza od problemu.
 
 ### Efekt uboczny w szablonie
 
@@ -311,15 +388,21 @@ statusu** (`change_form.html:4-6`) — trzeba go jawnie ukryć dla
 | Miejsce | Co pokazuje | Gdzie w kodzie |
 |---|---|---|
 | Strona zgłoszenia w adminie | panel readonly: „📥 Zaimportowane 22.07.2026 16:40 przez jkowalski · rekord ↗ · sesja importu ↗" | `admin/zgloszenie_publikacji.py` + `change_form.html` |
-| Strona wyników importera | baner „Domknięto zgłoszenie #402 ↗" | `DoneView` (`views/wizard.py:1069-1083`) |
-| Flash message | `messages.success(...)` przy pierwszym wejściu na `DoneView` | tamże |
+| Strona wyników importera | callout „Domknięto zgłoszenie #402 ↗" | `partials/step_done.html` + `DoneView` |
 
-Flash **musi** powstawać w cyklu żądania, **nie w zadaniu Celery** — worker
-jawnie wyrzuca wiadomości do kosza (`_NoopMessageStorage`,
-`tasks.py:254-265`), więc flash postawiony w tasku przepadłby bez śladu.
+**Bez flash message** (D18). Pierwotny projekt przewidywał `messages.success(…)`
+przy wejściu na `DoneView`, ale `base.html` renderuje ramkę komunikatów
+**dwukrotnie** (`:184` i `:210`), więc flash pokazywałby się 2×, a razem
+z calloutem 3×. Callout daje dokładnie jedno wystąpienie, jest trwały (przeżywa
+F5 i powrót na stronę) i nie wymaga maszynerii „pokaż dokładnie raz" — znika
+flaga w sesji HTTP, jej limit i cała obsługa.
 
-`DoneView.get` jest odświeżalny (F5), więc flash musi być stawiany **raz** —
-flaga w sesji HTTP kluczowana id-em sesji importu.
+Gdyby ktoś jednak chciał prawdziwego flasha: trzeba najpierw naprawić podwójne
+renderowanie w `base.html`, co dotyka **każdego** komunikatu w BPP.
+
+Niezależnie od wariantu obowiązuje reguła: komunikat **musi** powstawać
+w cyklu żądania, **nie w zadaniu Celery** — worker jawnie wyrzuca wiadomości do
+kosza (`_NoopMessageStorage`, `tasks.py:254-265`).
 
 Panel w adminie jest wyłącznie prezentacją: admin ma
 `has_change_permission → False` (`admin/zgloszenie_publikacji.py:144`), więc
@@ -331,11 +414,34 @@ nowe pola i tak nie są edytowalne przez formularz.
 (`admin/zgloszenie_publikacji.py:96-107`).
 
 Dodatkowo filtr **„Do obsługi / Załatwione / Wszystkie"**, domyślnie
-*Do obsługi* (`NOWY`, `PO_ZMIANACH`). Realizuje prośbę „żeby przestało się
-pokazywać jako otwarte" — dziś takiego filtra nie ma w ogóle, a lista pokazuje
-wszystko łącznie z odrzuconymi i spamem.
+*Do obsługi*. Realizuje prośbę „żeby przestało się pokazywać jako otwarte" —
+dotąd takiego filtra nie było w ogóle, a lista pokazywała wszystko łącznie
+z odrzuconymi i spamem.
 
-Kolumny listy zyskują `zaimportowano`; `list_filter` — `zaimportowal`.
+Podział grup (D16):
+
+| Grupa | Statusy |
+|---|---|
+| **Do obsługi** (domyślnie) | `NOWY`, `WYMAGA_ZMIAN`, `PO_ZMIANACH` |
+| Załatwione | `ZAIMPORTOWANY`, `ZAAKCEPTOWANY`, `ODRZUCONO`, `SPAM` |
+| Wszystkie | bez zawężenia |
+
+`WYMAGA_ZMIAN` **należy do „Do obsługi"** — zgłoszenie u autora jest w toku,
+operator musi je widzieć (przypomnieć, po czasie odrzucić). Poza żadną grupą
+znikałoby wszędzie poza „Wszystkie", co byłoby regresem widoczności.
+
+**Przezroczystość wobec filtra `status` (D17).** Oba filtry składają się
+koniunkcją, więc bez tego kliknięcie „status → spam" na widoku domyślnym
+dawałoby pustą listę bez wyjaśnienia. Reguła: gdy `stan_obslugi` nie został
+wybrany ręcznie, a w `request.GET` jest `status` (lub dowolne `status__*`),
+filtr przepuszcza queryset bez zmian, a `choices()` nie zaznacza „Do obsługi" —
+inaczej UI kłamałby o zastosowanym zawężeniu. Przy jawnym wyborze obu filtrów
+koniunkcja zostaje (obie pozycje są widocznie zaznaczone, więc pustka jest
+zrozumiała).
+
+Kolumny listy zyskują `zaimportowano`; `list_filter` — `zaimportowal`
+przez `RelatedOnlyFieldListFilter` (gołe pole renderowałoby pozycję dla
+**każdego** użytkownika w bazie).
 
 ## 10. Testy
 
@@ -390,8 +496,13 @@ klas, `@pytest.mark.django_db`, `model_bakery.baker.make`.
   `bpp/const.py:131`) nadal nie oznacza zgłoszenia — numer trafia wyłącznie do
   pola tekstowego `adnotacje` (`bpp/admin/zglos_publikacje_helpers.py:72-77`).
   Ta sama luka, innym korytarzem; osobne zgłoszenie.
-- **Import wielu prac** (`MultipleWorksImport`) — wiązanie ze zgłoszeniami
-  per-wpis; poza zakresem.
+- **Import wielu prac** (`MultipleWorksImport`) — ~~poza zakresem~~.
+  Sprostowanie po recenzji: wpisy paczki idą przez `_start_import_session` →
+  `fetch_session_task` → `zwiaz_automatycznie`, więc **auto-wiązanie po DOI
+  działa tam samo z siebie**. Zostawione świadomie — to sensowne zachowanie,
+  a wyłączanie go wymagałoby dodatkowego guardu bez powodu. Poza zakresem
+  zostaje jedynie *jawne* wiązanie per-wpis (paczka nie ma skąd wziąć numeru
+  zgłoszenia).
 - **Powiadomienie po zamknięciu karty** (liveops / e-mail) — importer nie
   używa dziś żadnego z trzech mechanizmów powiadomień obecnych w projekcie.
   Osobna decyzja produktowa.
@@ -404,12 +515,33 @@ klas, `@pytest.mark.django_db`, `model_bakery.baker.make`.
 
 | Ryzyko | Mitygacja |
 |---|---|
-| Oznaczenie cudzego zgłoszenia (inny autor) | wiązanie tylko jawne albo po DOI przy jednym kandydacie; tytuł wykluczony (D5) |
-| Oznaczenie cudzego zgłoszenia (inna uczelnia) | zawężenie kandydatów przez autorów do `session.uczelnia` (D8) |
+| Oznaczenie cudzego zgłoszenia (inny autor) | wiązanie tylko jawne albo po DOI przy jednym kandydacie; tytuł wykluczony (D5); prefiks DOI odsiany porównaniem w Pythonie (D12) |
+| Oznaczenie cudzego zgłoszenia (inna uczelnia) | zawężenie przez autorów do uczelni — **na obu ścieżkach**, jawnej i po DOI (D8 + D13) |
 | IDOR przy wyborze kandydata | walidacja id względem wyliczonej listy kandydatów + `ImporterPermissionMixin` + scoping sesji (§6C) |
-| Utrata wiązania na gałęzi idempotency | jawna reguła „dopisz, gdy puste; nie nadpisuj" (§6A) |
+| Przestemplowanie zgłoszenia zwróconego autorowi | warunkowy `UPDATE` rewalidujący status w chwili zapisu (D14) |
+| Cofnięcie statusu przez autora → duplikat rekordu | `kod_do_edycji` kasowany przy oznaczaniu (D15) |
+| Utrata wiązania na gałęzi idempotency | atomowy `UPDATE … WHERE zgloszenie IS NULL` + `update_fields` w zadaniach, żeby task nie nadpisał wiązania swoją nieaktualną instancją |
 | Oznaczenie soft-usuniętego zgłoszenia | guard `deleted_at is None` (§5.2) |
-| Podwójny import tego samego zgłoszenia | ukrycie przycisku „Użyj importera" dla `ZAIMPORTOWANY` (§7) |
+| Podwójny import tego samego zgłoszenia | ukrycie przycisku „Użyj importera" dla `ZAIMPORTOWANY` (§7) + D15 |
+| Wyjątek w zapisie zwrotnym → duplikat po „Ponów" | zapis zwrotny poza `atomic`, w wąskim `try/except` z `logger.exception` + Rollbar, bez re-raise: sesja zostaje `COMPLETED` |
+| Watchdog uzna żywe sesje za martwe | `update_fields` w zadaniach **zawsze** zawiera `modified` — `auto_now` odpala się tylko dla pól z listy, a `is_stalled()` czyta to pole |
+| Dane nieosiągalne z UI po dodaniu filtra | przezroczystość filtra przy jawnym wyborze statusu (D17) + `WYMAGA_ZMIAN` w „Do obsługi" (D16) |
 | Rozjazd paska postępu | reużycie etapu `prefill_zgl`, zero nowych nazw (§6B) |
 | Kolizja numerów migracji importera | numer `0020` podany jawnie (§4.2) |
 | Dwie migracje w jednej gałęzi | `make baseline-update` raz, przy scalaniu — nie w gałęzi |
+
+### Ograniczenia świadomie zaakceptowane
+
+- **Przeciek D8 przy współautorstwie międzyuczelnianym.** Join przez autorów
+  daje semantykę OR: zgłoszenie, którego autorzy siedzą w jednostkach dwóch
+  uczelni, jest kandydatem dla obu. Bez pola `uczelnia` na samym zgłoszeniu nie
+  da się tego rozstrzygnąć czysto — praca współautorska naprawdę „należy" do
+  obu. Wariant restrykcyjny (*wszyscy* autorzy z jednej uczelni) ukrywałby takie
+  zgłoszenia przed obiema. Mitygacja częściowa: baner **nie pokazuje e-maila
+  zgłaszającego**.
+- **Zgłoszenia bez autorów wypadają** w instalacji wielouczelnianej (INNER JOIN
+  nie ma czego dopasować). Decyzja **fail-closed**: takiego zgłoszenia nie da
+  się przypisać do uczelni, więc lepiej nie pokazać go nikomu niż wszystkim.
+- **`base.html` renderuje ramkę komunikatów dwukrotnie** (`:184`, `:210`) —
+  defekt dotyczący **każdego** komunikatu w BPP, nie tylko tej funkcji.
+  Poza zakresem; nadaje się na osobne zgłoszenie.

--- a/docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md
+++ b/docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md
@@ -43,9 +43,22 @@ kontekst ginie.
    przez `_start_import_session` (`:183-202`). Parametr GET nieprzeniesiony
    ukrytym polem formularza **ginie bezpowrotnie**.
 3. **Soft-delete nie usuwa wiersza.** `Zgloszenie_Publikacji` dziedziczy
-   `SoftDeleteModel` (`models.py:61`); kasowanie ustawia `deleted_at`.
-   `on_delete=SET_NULL` nigdy się nie uruchomi, a dostęp przez FK idzie
-   `_base_manager`, który **nie filtruje usuniętych**.
+   `SoftDeleteModel` (`models.py:61`); kasowanie ustawia `deleted_at`,
+   a dostęp przez FK idzie `_base_manager`, który **nie filtruje
+   usuniętych** — sam FK nie ochroni przed oznaczeniem skasowanego
+   zgłoszenia.
+
+   Uściślenie po testach: `SoftDeleteModel.delete()` **emuluje `on_delete`**
+   dla relacji odwrotnych (`django_softdelete/models.py:281-283`), więc na
+   typowej ścieżce (operator kasuje zgłoszenie w module redagowania) FK na
+   sesji **zostanie wyzerowany**. Guard `deleted_at is None` pozostaje
+   konieczny dla ścieżek omijających `delete()`: bulk `UPDATE deleted_at`,
+   surowy SQL, migracje danych, wyścig transakcji.
+
+   Uboczna konsekwencja emulacji: skasowanie zgłoszenia **po cichu gubi
+   wiązanie**, więc po `restore()` sesja już go nie wskaże. Zachowanie
+   przypięte testem charakteryzującym, żeby zmiana biblioteki nie przeszła
+   niezauważona.
 4. **`report_progress` rzuca `ValueError` na nieznanym etapie**
    (`progress.py:49-50`), a wagi `FETCH_STAGES` sumują się do 100. Nie wolno
    dokładać nowych nazw etapów — trzeba reużyć istniejący `prefill_zgl`.

--- a/docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md
+++ b/docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md
@@ -5,7 +5,7 @@
 (`jbihalowicz@apoz.edu.pl`), klient `bpp.apoz.edu.pl`.
 Powiązane: FD#430 (przycisk „Użyj importera" nad tabelą), FD#425 (oryginał).
 
-**Data:** 2026-07-22 · **Wersja bazowa:** `202607.1397` · **Gałąź:**
+**Data:** 2026-07-22 · **Wersja bazowa:** `202607.1398` · **Gałąź:**
 `fix-fd443-zgloszenie-zaimportowane`
 
 ---
@@ -20,7 +20,7 @@ już zaimportowana, kto to zrobił ani kiedy.
 Przyczyną nie są trzy osobne braki, tylko **jedna przerwana krawędź**:
 `ImportSession` nie wie, że uruchomiono ją ze zgłoszenia. Link „Użyj
 importera" jest bezstanowy — przekazuje wyłącznie `?provider=&identifier=`
-(`src/zglos_publikacje/admin/zgloszenie_publikacji.py:404-410`), po czym
+(`src/zglos_publikacje/admin/zgloszenie_publikacji.py:389-417`), po czym
 kontekst ginie.
 
 ### Co już jest w kodzie (i jest martwe)
@@ -29,15 +29,28 @@ kontekst ginie.
 |---|---|
 | `Zgloszenie_Publikacji.odpowiednik_w_bpp` — GenericFK do rekordu (`models.py:82`) | pole istnieje, **nic w `src/` go nie zapisuje** |
 | `Statusy.ZAAKCEPTOWANY = 1` („dodany do bazy BPP") | **nigdy nie ustawiany programowo** |
-| `ImportSession.created_by`, `created_record` | wypełniane poprawnie (`tasks.py:226-231`) |
-| `_find_matching_zgloszenie()` (`importer_publikacji/views/authors.py:148-188`) | heurystyka DOI → tytuł, używana **wyłącznie** do prefilla dyscyplin |
+| `ImportSession.created_by` (`wizard.py:190-198`), `created_record` (`tasks.py:226-231`) | wypełniane poprawnie |
+| `_find_matching_zgloszenie()` (`importer_publikacji/views/authors.py:148-188`) | heurystyka DOI → tytuł, używana **wyłącznie** do prefilla dyscyplin (`:200`) |
 
-### Pułapka do obejścia
+### Pułapki potwierdzone w kodzie
 
-`ImportSession.modified` to `auto_now=True` — znaczy „kiedy ostatnio cokolwiek
-ruszyło wiersz", nie „kiedy zaimportowano". Watchdog `mark_stalled()`
-(`importer_publikacji/models.py:305-321`) czy ponowne wejście na sesję
-przesuwają tę datę. Dlatego moment importu wymaga **jawnego pola**.
+1. **`ImportSession.modified` to `auto_now=True`** (`models.py:188`) — znaczy
+   „kiedy ostatnio cokolwiek ruszyło wiersz", nie „kiedy zaimportowano".
+   `mark_stalled()` (`models.py:305-321`) przesuwa tę datę. Moment importu
+   wymaga **jawnego pola**.
+2. **`IndexView` nie tworzy sesji.** Renderuje tylko `FetchForm`
+   (`wizard.py:87-126`). Sesję zakłada `FetchView.post` (`wizard.py:205-281`)
+   przez `_start_import_session` (`:183-202`). Parametr GET nieprzeniesiony
+   ukrytym polem formularza **ginie bezpowrotnie**.
+3. **Soft-delete nie usuwa wiersza.** `Zgloszenie_Publikacji` dziedziczy
+   `SoftDeleteModel` (`models.py:61`); kasowanie ustawia `deleted_at`.
+   `on_delete=SET_NULL` nigdy się nie uruchomi, a dostęp przez FK idzie
+   `_base_manager`, który **nie filtruje usuniętych**.
+4. **`report_progress` rzuca `ValueError` na nieznanym etapie**
+   (`progress.py:49-50`), a wagi `FETCH_STAGES` sumują się do 100. Nie wolno
+   dokładać nowych nazw etapów — trzeba reużyć istniejący `prefill_zgl`.
+5. **`Zgloszenie_Publikacji` nie ma pola `uczelnia`** — zapytanie po DOI jest
+   z natury cross-uczelniane.
 
 ## 2. Cel
 
@@ -54,17 +67,20 @@ Po zakończeniu importu uruchomionego ze zgłoszenia:
 
 | # | Decyzja | Uzasadnienie |
 |---|---|---|
-| D1 | Nowy status `ZAIMPORTOWANY = 6`, nie ożywianie `ZAAKCEPTOWANY = 1` | odróżnia „dodane importerem" od „dodane ręcznie"; słowo z prośby klienta |
+| D1 | Nowy status `ZAIMPORTOWANY = 6`, nie ożywianie `ZAAKCEPTOWANY = 1` | odróżnia „dodane importerem" od „dodane ręcznie"; słowo z prośby klienta. Wartość 6 jest wolna (`Statusy` kończy się na `SPAM = 5`) |
 | D2 | Audyt denormalizowany na zgłoszeniu (`zaimportowano`, `zaimportowal`) | filtrowalny i sortowalny na liście; przeżywa skasowanie sesji importu |
 | D3 | Jawne pole czasu, nie `auto_now` | `ImportSession.modified` nie jest wiarygodnym znacznikiem zakończenia |
 | D4 | Wiązanie jawne (`?zgloszenie=`) + fallback po DOI | determinizm; DOI to identyfikator mocny |
 | D5 | Dopasowanie po **tytule wykluczone** z wiązania | dwa zgłoszenia o tym samym tytule → oznaczono by przypadkowe (korupcja danych) |
 | D6 | Przy ≥2 kandydatach — operator wybiera, system nie zgaduje | jawny wybór zamiast cichego pominięcia |
 | D7 | Bez soft-delete zgłoszenia po imporcie | jawny status niesie tę samą informację, a zachowuje ślad na liście |
+| **D8** | **Kandydaci po DOI ograniczeni do uczelni sesji importu** | `Zgloszenie_Publikacji` nie ma `uczelnia`; bez zawężenia baner pokazałby tytuł i e-mail zgłaszającego z cudzej uczelni, a auto-wiązanie oznaczyłoby cudze zgłoszenie |
+| **D9** | **`WYMAGA_ZMIAN` wykluczony z auto-wiązania** | zgłoszenie jest w rękach autora (aktywny `kod_do_edycji`); przestemplowanie go w trakcie edycji zabrałoby mu pracę |
+| **D10** | **Zapis zwrotny w osobnym `transaction.atomic` razem z `COMPLETED`** | transakcja tworząca rekord (`publikacja.py:327`) commituje przed powrotem do taska; „ta sama transakcja" i „tuż po COMPLETED" wykluczają się |
 
 ## 4. Zmiany w modelach
 
-### 4.1 `zglos_publikacje` — migracja `0027`
+### 4.1 `zglos_publikacje` — migracja `0027` (ostatnia istniejąca: `0026`)
 
 Na `Zgloszenie_Publikacji` (`src/zglos_publikacje/models.py:60`):
 
@@ -78,7 +94,10 @@ Na `Zgloszenie_Publikacji` (`src/zglos_publikacje/models.py:60`):
 `SET_NULL` na `zaimportowal`: skasowanie konta operatora nie może kasować ani
 blokować zgłoszenia.
 
-### 4.2 `importer_publikacji` — migracja
+### 4.2 `importer_publikacji` — migracja `0020`
+
+Numer podany jawnie: historia tej aplikacji ma już zdublowane numery
+i merge'e (0005/0006/0007/0012), więc równoległa gałąź łatwo dorobi kolejny dub.
 
 Na `ImportSession` (`src/importer_publikacji/models.py:15`):
 
@@ -99,34 +118,101 @@ które zgłoszenie oznaczyć.
 Dwie nowe migracje. Zgodnie z regułą repo `make baseline-update` wykonuje się
 **raz, przy scalaniu**, nie w gałęzi feature.
 
-## 5. Wiązanie sesji ze zgłoszeniem
+## 5. Nowy moduł `src/importer_publikacji/zgloszenia.py`
 
-### Ścieżka A — jawna (z przycisku)
+Cała logika wiązania mieszka w jednym module, żeby `tasks.py`, `wizard.py`
+i nowy widok nie powielały reguł. Kontrakt publiczny:
 
-`importer_url()` (`admin/zgloszenie_publikacji.py:389-417`) dokłada
-`&zgloszenie={pk}`. `IndexView` (`views/wizard.py:87-119`) odczytuje parametr
-i przekazuje do `_start_import_session` (`:183-202`), które zapisuje FK.
+```python
+def kandydaci_dla_sesji(session) -> QuerySet:
+    """Zgłoszenia, które ta sesja importu mogłaby domknąć."""
 
-Parametr jest **walidowany** przy odczycie: musi być liczbą i wskazywać
-istniejące, nie-usunięte zgłoszenie. Wartość niepoprawna jest ignorowana
-(import startuje bez wiązania), nie powoduje błędu.
+def zwiaz_automatycznie(session) -> bool:
+    """Ustawia session.zgloszenie, gdy kandydat jest dokładnie jeden."""
 
-### Ścieżka B — auto po DOI (dokładnie jedno trafienie)
+def oznacz_jako_zaimportowane(session, record) -> bool:
+    """Zapis zwrotny na zgłoszeniu. Idempotentny."""
+```
+
+### 5.1 `kandydaci_dla_sesji`
+
+```
+doi = normalize_doi(session.normalized_data.get("doi"))   # jak authors.py:160-162
+jeśli brak doi → pusty queryset
+
+Zgloszenie_Publikacji.objects            # SoftDeleteManager pomija usunięte
+    .filter(doi__iexact=doi)
+    .exclude(status__in=(ODRZUCONO, SPAM, ZAIMPORTOWANY, ZAAKCEPTOWANY,
+                         WYMAGA_ZMIAN))                              # D9
+    .filter(<zawężenie do session.uczelnia>)                         # D8
+    .distinct()
+```
+
+**Zawężenie do uczelni (D8).** `Zgloszenie_Publikacji` nie ma `uczelnia`;
+jedyna droga w ORM prowadzi przez autorów zgłoszenia:
+`zgloszenie_publikacji_autor_set__jednostka__uczelnia`. Reguła:
+
+- gdy `session.uczelnia` jest ustawione → filtruj po tej ścieżce,
+- gdy `session.uczelnia` jest `NULL` **lub** instalacja ma jedną uczelnię →
+  bez zawężenia (zachowanie jak dziś).
+
+Dopasowanie po tytule **nie bierze udziału** w wiązaniu (D5). Pozostaje bez
+zmian tam, gdzie jest dziś — w prefillu dyscyplin, gdzie pomyłka jest
+nieszkodliwa.
+
+### 5.2 `oznacz_jako_zaimportowane`
+
+```
+zgl = session.zgloszenie
+pomiń (zwróć False) gdy: brak zgl
+                       | zgl.deleted_at is not None     # soft-delete, patrz §1.3
+                       | zgl.status == ZAIMPORTOWANY    # idempotencja
+
+w transaction.atomic:
+    zgl.status            = ZAIMPORTOWANY
+    zgl.zaimportowano     = timezone.now()
+    zgl.zaimportowal      = session.created_by
+    zgl.odpowiednik_w_bpp = record
+    zgl.save(update_fields=[...])
+```
+
+`zaimportowal` z `created_by`, nie `modified_by` — „kto to zrobił" znaczy kto
+uruchomił import, nie kto ostatnio dotknął wiersza.
+
+## 6. Wiązanie sesji ze zgłoszeniem
+
+### Ścieżka A — jawna (z przycisku), przez rundę formularza
+
+To **cztery** zmiany, nie jedna — parametr musi przeżyć GET → render → POST:
+
+1. `importer_url()` (`admin/zgloszenie_publikacji.py:389-417`) dokłada
+   `&zgloszenie={pk}`.
+2. `FetchForm` (`forms.py:38-55`) zyskuje ukryte pole
+   `zgloszenie = IntegerField(required=False, widget=HiddenInput)`.
+3. `IndexView._get_fetch_form` (`wizard.py:87-126`) wypełnia je z
+   `request.GET`.
+4. `FetchView.post` (`wizard.py:205-281`) odczytuje z `cleaned_data`
+   i przekazuje do `_start_import_session` (`:183-202`).
+
+**Walidacja przy odczycie:** wartość musi być liczbą i wskazywać istniejące,
+nie-usunięte zgłoszenie. Wartość niepoprawna jest ignorowana (import startuje
+bez wiązania), nie powoduje błędu.
+
+**Gałąź idempotency** (`wizard.py:259-273`) zwraca istniejącą sesję in-flight
+z pominięciem `_start_import_session` — wiązanie zostałoby po cichu zgubione.
+Reguła: jeśli zwrócona sesja ma `zgloszenie` puste, dopisz je; jeśli ma już
+inne, **nie nadpisuj**.
+
+### Ścieżka B — auto po DOI (dokładnie jeden kandydat)
 
 W istniejącym etapie `prefill_zgl` (`tasks.py:87-90`), gdy `session.zgloszenie`
-jest puste. Kandydaci:
+jest puste. Wywołanie `zwiaz_automatycznie(session)`. Dokładnie jeden kandydat
+→ FK ustawione. Zero → nic. Dwa lub więcej → ścieżka C.
 
-```
-Zgloszenie_Publikacji.objects            # SoftDeleteManager — pomija usunięte
-    .filter(doi__iexact=<doi sesji>)
-    .exclude(status__in=(ODRZUCONO, SPAM, ZAIMPORTOWANY, ZAAKCEPTOWANY))
-```
-
-Dokładnie jeden wynik → `session.zgloszenie` ustawione. Zero → nic.
-Dwa lub więcej → ścieżka C.
-
-Dopasowanie po tytule **nie bierze udziału** w wiązaniu. Pozostaje bez zmian
-tam, gdzie jest dziś — w prefillu dyscyplin, gdzie pomyłka jest nieszkodliwa.
+**Nie wolno dokładać nowego etapu** — `report_progress` rzuca `ValueError` na
+nieznanej nazwie (`progress.py:49-50`), a wagi `FETCH_STAGES` sumują się do 100.
+DOI jest dostępne przed tym etapem: `normalized_data["doi"]` powstaje
+w `create_session` (`tasks.py:60-62`, `:114`).
 
 ### Ścieżka C — dwuznaczna (≥2 kandydatów)
 
@@ -147,62 +233,86 @@ Przy **jednym** kandydacie baner pokazuje się w wersji potwierdzającej:
 *„Ten import domknie zgłoszenie #402 [zobacz] [odepnij]"* — operator może
 zaprotestować, zanim import się wykona.
 
-Wybór to `POST` na nowy widok. Widok **waliduje, że wskazane id znajduje się
-wśród aktualnie wyliczonych kandydatów** — bez tego byłby to IDOR: operator
-mógłby oznaczyć jako zaimportowane dowolne zgłoszenie w systemie.
-„Żadne z nich" ustawia `zgloszenie_odrzucone_przez_operatora = True`.
+**Nowy widok wyboru:**
+
+- URL `<int:session_id>/zgloszenie/wybierz/` — `pk` sesji jest **int**, wzorem
+  reszty `urls.py`,
+- `ImporterPermissionMixin` (superuser lub grupa `GR_WPROWADZANIE_DANYCH`)
+  + `get_scoped_or_404(ImportSession, pk=session_id)` — jak wszystkie widoki
+  importera (`permissions.py:7-54`),
+- **waliduje, że wskazane id znajduje się wśród `kandydaci_dla_sesji(session)`**
+  — bez tego byłby to IDOR: operator mógłby oznaczyć jako zaimportowane
+  dowolne zgłoszenie w systemie,
+- „żadne z nich" ustawia `zgloszenie_odrzucone_przez_operatora = True`.
 
 Kandydaci są **wyliczani przy renderowaniu**, nie cache'owani w polu — DOI
 jest stabilne, a dzięki temu lista nie starzeje się względem stanu bazy.
 
-## 6. Zapis zwrotny
+### Wpływ na prefill dyscyplin
+
+`_prefill_dyscypliny_z_zgloszen` (`authors.py:191-224`) woła dziś
+`_find_matching_zgloszenie` (`:200`), które po Ścieżce A mogłoby zwrócić
+**inne** zgłoszenie niż związane — dyscypliny z X, status na Y. Reguła:
+
+> gdy `session.zgloszenie` jest ustawione, prefill używa go wprost;
+> heurystyka (z tytułem włącznie) zostaje wyłącznie jako fallback.
+
+## 7. Zapis zwrotny
 
 W `create_publication_task` (`src/importer_publikacji/tasks.py:217-239`),
-w tej samej transakcji, która tworzy rekord, tuż po `status = COMPLETED`:
+w **tym samym bloku, co zapis `status = COMPLETED`** (`:226-231`) — czyli po
+powrocie z `_create_publication`, którego własna transakcja
+(`publikacja.py:327`) już się zamknęła (D10):
 
 ```
-jeżeli session.zgloszenie istnieje i jego status != ZAIMPORTOWANY:
-    status            ← Statusy.ZAIMPORTOWANY
-    zaimportowano     ← timezone.now()
-    zaimportowal      ← session.created_by
-    odpowiednik_w_bpp ← utworzony rekord
+with transaction.atomic():
+    session.status = COMPLETED; session.created_record = record; …
+    session.save(...)
+    oznacz_jako_zaimportowane(session, record)
 ```
 
 Własności:
 
 - **idempotentny** — ponowienie zadania nie przesuwa daty ani nie zmienia
-  autora,
-- **odporny na wyścig** — zgłoszenie skasowane w międzyczasie nie wywala
-  importu; brak wiersza jest logowany, nie podnoszony,
-- `zaimportowal` z `created_by`, nie `modified_by` — „kto to zrobił" znaczy
-  kto uruchomił import, nie kto ostatnio dotknął wiersza,
+  autora (guard `status == ZAIMPORTOWANY`),
+- **odporny na soft-delete** — guard `deleted_at is None`; przypadek jest
+  logowany, nie podnoszony,
 - **niepowodzenie importu nie zmienia statusu zgłoszenia** — zapis siedzi
   w gałęzi sukcesu, przed blokiem `except` (`tasks.py:232-239`).
 
-### Efekt uboczny, którego nie trzeba kodować
+### Efekt uboczny w szablonie
 
-Przyciski „Zwróć do autora", „Dodaj wyd. ciągłe", „Dodaj wyd. zwarte" mają
-warunki `status in (NOWY, PO_ZMIANACH)` (`models.py:275, 281, 288` oraz
-`templates/.../change_form.html`). Po zmianie statusu **znikają same** —
-zgłoszenie przestaje wyglądać na wymagające obsługi.
+Gate statusowy dla „Dodaj wyd. ciągłe/zwarte" siedzi **w szablonie**
+(`change_form.html:10`: `{% if original.status == 0 or original.status == 3 %}`),
+a nie w metodach modelu — `pokazuj_przycisk_wydawnictwo_*`
+(`models.py:281-290`) sprawdzają rodzaj publikacji, nie status. Status
+sprawdza tylko `moze_zostac_zwrocony` (`models.py:275-279`).
 
-## 7. Informacja zwrotna
+Skutek: po zmianie statusu przyciski „Zwróć do autora" i „Dodaj wyd. …"
+**znikają same**. Ale przycisk **„Użyj importera" nie ma żadnego gate'u
+statusu** (`change_form.html:4-6`) — trzeba go jawnie ukryć dla
+`ZAIMPORTOWANY`, inaczej operator zaimportuje to samo drugi raz.
+
+## 8. Informacja zwrotna
 
 | Miejsce | Co pokazuje | Gdzie w kodzie |
 |---|---|---|
 | Strona zgłoszenia w adminie | panel readonly: „📥 Zaimportowane 22.07.2026 16:40 przez jkowalski · rekord ↗ · sesja importu ↗" | `admin/zgloszenie_publikacji.py` + `change_form.html` |
-| Strona wyników importera | baner „Domknięto zgłoszenie #402 ↗" | `DoneView` (`views/wizard.py:1069-1084`) |
-| Flash message | `messages.success(...)` przy wejściu na `DoneView` | tamże |
+| Strona wyników importera | baner „Domknięto zgłoszenie #402 ↗" | `DoneView` (`views/wizard.py:1069-1083`) |
+| Flash message | `messages.success(...)` przy pierwszym wejściu na `DoneView` | tamże |
 
 Flash **musi** powstawać w cyklu żądania, **nie w zadaniu Celery** — worker
 jawnie wyrzuca wiadomości do kosza (`_NoopMessageStorage`,
 `tasks.py:254-265`), więc flash postawiony w tasku przepadłby bez śladu.
 
+`DoneView.get` jest odświeżalny (F5), więc flash musi być stawiany **raz** —
+flaga w sesji HTTP kluczowana id-em sesji importu.
+
 Panel w adminie jest wyłącznie prezentacją: admin ma
 `has_change_permission → False` (`admin/zgloszenie_publikacji.py:144`), więc
 nowe pola i tak nie są edytowalne przez formularz.
 
-## 8. Lista zgłoszeń w adminie
+## 9. Lista zgłoszeń w adminie
 
 `ZAIMPORTOWANY` wchodzi automatycznie do istniejącego filtra `"status"`
 (`admin/zgloszenie_publikacji.py:96-107`).
@@ -214,25 +324,37 @@ wszystko łącznie z odrzuconymi i spamem.
 
 Kolumny listy zyskują `zaimportowano`; `list_filter` — `zaimportowal`.
 
-## 9. Testy
+## 10. Testy
 
 `src/zglos_publikacje/tests/` i `src/importer_publikacji/tests/`; pytest bez
 klas, `@pytest.mark.django_db`, `model_bakery.baker.make`.
 
-**Wiązanie**
+**Wiązanie — ścieżka A**
 
 - przycisk „Użyj importera" zawiera `zgloszenie=<pk>` w URL
-- `IndexView` z `?zgloszenie=N` zapisuje FK na sesji
-- `?zgloszenie=` niepoprawne / nieistniejące / usunięte → import startuje bez wiązania, bez błędu
-- auto-wiązanie przy dokładnie jednym zgłoszeniu z tym DOI
-- brak auto-wiązania przy dwóch zgłoszeniach z tym samym DOI + oba na liście kandydatów
+- `?zgloszenie=N` przeżywa rundę GET → render → POST i ląduje na sesji
+- `?zgloszenie=` niepoprawne / nieistniejące / soft-usunięte → import startuje
+  bez wiązania, bez błędu
+- gałąź idempotency: sesja in-flight bez wiązania dostaje FK; z wiązaniem — nie
+  jest nadpisywana
+
+**Wiązanie — ścieżki B i C**
+
+- auto-wiązanie przy dokładnie jednym kandydacie
+- brak auto-wiązania przy dwóch kandydatach + oba na liście
 - brak wiązania po samym tytule (dwa zgłoszenia o identycznym tytule, różne DOI)
-- kandydaci pomijają zgłoszenia `ODRZUCONO`, `SPAM`, `ZAIMPORTOWANY`, soft-deleted
+- kandydaci pomijają `ODRZUCONO`, `SPAM`, `ZAIMPORTOWANY`, `ZAAKCEPTOWANY`,
+  `WYMAGA_ZMIAN` i soft-usunięte
+- **kandydaci nie przekraczają granicy uczelni** (D8) — zgłoszenie autora z
+  innej uczelni nie trafia na listę
+- prefill dyscyplin używa `session.zgloszenie`, gdy jest ustawione
 
 **Wybór operatora**
 
 - `POST` z id kandydata ustawia FK
 - `POST` z id **spoza** listy kandydatów jest odrzucany (regresja IDOR)
+- `POST` bez uprawnień importera → 403
+- `POST` na sesję innej uczelni → 404
 - „żadne z nich" wycisza baner
 
 **Zapis zwrotny**
@@ -240,15 +362,16 @@ klas, `@pytest.mark.django_db`, `model_bakery.baker.make`.
 - po `COMPLETED` zgłoszenie ma status, datę, autora i `odpowiednik_w_bpp`
 - ponowienie zadania nie przesuwa `zaimportowano` (idempotencja)
 - import zakończony błędem nie zmienia statusu zgłoszenia
-- zgłoszenie skasowane w trakcie importu nie wywala zadania
-- po imporcie znikają przyciski „Zwróć do autora" i „Dodaj wyd. …"
+- zgłoszenie soft-usunięte w trakcie importu **nie** zostaje oznaczone
+- po imporcie znikają przyciski „Zwróć do autora", „Dodaj wyd. …" **oraz
+  „Użyj importera"**
 
 **Prezentacja**
 
 - panel w adminie pokazuje datę, użytkownika i link do rekordu
-- `DoneView` renderuje baner i flash message
+- `DoneView` renderuje baner; flash pojawia się raz, nie dubluje po F5
 
-## 10. Poza zakresem
+## 11. Poza zakresem
 
 - **Ścieżka ręczna „Dodaj wyd. ciągłe/zwarte"** (`?numer_zgloszenia=`,
   `bpp/const.py:131`) nadal nie oznacza zgłoszenia — numer trafia wyłącznie do
@@ -260,12 +383,20 @@ klas, `@pytest.mark.django_db`, `model_bakery.baker.make`.
   używa dziś żadnego z trzech mechanizmów powiadomień obecnych w projekcie.
   Osobna decyzja produktowa.
 - **Soft-delete zgłoszenia po imporcie** — świadomie odrzucone (D7).
+- **Pole `uczelnia` na `Zgloszenie_Publikacji`** — właściwe rozwiązanie
+  problemu z D8, ale to migracja danych na modelu z ruchem produkcyjnym.
+  Tu obchodzimy je zawężeniem przez autorów; docelowo osobne zgłoszenie.
 
-## 11. Ryzyka
+## 12. Ryzyka
 
 | Ryzyko | Mitygacja |
 |---|---|
-| Oznaczenie cudzego zgłoszenia | wiązanie tylko jawne albo po DOI przy jednym trafieniu; tytuł wykluczony (D5) |
-| IDOR przy wyborze kandydata | walidacja id względem wyliczonej listy kandydatów (§5C) |
+| Oznaczenie cudzego zgłoszenia (inny autor) | wiązanie tylko jawne albo po DOI przy jednym kandydacie; tytuł wykluczony (D5) |
+| Oznaczenie cudzego zgłoszenia (inna uczelnia) | zawężenie kandydatów przez autorów do `session.uczelnia` (D8) |
+| IDOR przy wyborze kandydata | walidacja id względem wyliczonej listy kandydatów + `ImporterPermissionMixin` + scoping sesji (§6C) |
+| Utrata wiązania na gałęzi idempotency | jawna reguła „dopisz, gdy puste; nie nadpisuj" (§6A) |
+| Oznaczenie soft-usuniętego zgłoszenia | guard `deleted_at is None` (§5.2) |
+| Podwójny import tego samego zgłoszenia | ukrycie przycisku „Użyj importera" dla `ZAIMPORTOWANY` (§7) |
+| Rozjazd paska postępu | reużycie etapu `prefill_zgl`, zero nowych nazw (§6B) |
+| Kolizja numerów migracji importera | numer `0020` podany jawnie (§4.2) |
 | Dwie migracje w jednej gałęzi | `make baseline-update` raz, przy scalaniu — nie w gałęzi |
-| Rozjazd `zaimportowano` z sesją importu | pole zapisywane wyłącznie w jednym miejscu, w transakcji tworzącej rekord |

--- a/docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md
+++ b/docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md
@@ -107,6 +107,18 @@ zastępują.
 | **D17** | **Filtr „Stan obsługi" przepuszcza queryset, gdy jawnie wybrano `status`** | oba filtry składały się koniunkcją, więc kliknięcie „status → spam" dawało pustą listę bez wyjaśnienia. `choices()` nie zaznacza wtedy „Do obsługi", żeby UI nie kłamał o zawężeniu |
 | **D18** | **Informację zwrotną niesie callout, nie flash** | `base.html` renderuje ramkę komunikatów **dwukrotnie** (`:184`, `:210`), więc flash pokazywałby się 2×, a z calloutem 3×. Callout jest idempotentny i trwały (przeżywa F5); znika ~25 linii maszynerii „pokaż dokładnie raz" |
 
+### Decyzje z drugiej rundy recenzji
+
+Druga runda potwierdziła D11–D18 jako poprawnie wdrożone, ale wykazała, że
+**naprawa D17 wyhodowała swoje rodzeństwo**.
+
+| # | Decyzja | Uzasadnienie |
+|---|---|---|
+| **D19** | **Przezroczystość filtra obejmuje `status`, `zaimportowal` i `zaimportowano`** — nie samo `status` | `zaimportowal` jest niepuste **wyłącznie** na zgłoszeniach `ZAIMPORTOWANY`, czyli spoza grupy „Do obsługi". Koniunkcja z domyślnym zawężeniem była więc **sprzeczna z definicji**: kliknięcie dowolnej osoby w filtrze „zaimportował" zawsze dawało zero wyników. Lista pól zamiast pojedynczej stałej, żeby kolejny filtr skorelowany ze statusem nie powtórzył tego błędu |
+| **D20** | **Tryb DjangoQL liczy się dopiero z niepustym `q`** | samo przełączenie trybu bez wpisanego zapytania nie jest wyborem operatora — domyślny widok „Do obsługi" ma zostać |
+| **D21** | **`zwiaz_automatycznie` też przez warunkowy `UPDATE`** | sprawdzenie `zgloszenie_id` na obiekcie w pamięci + bezwarunkowy zapis zostawiało okno: gałąź idempotency `FetchView` zapisuje **równolegle**, więc auto-match po DOI mógł przestemplować jawny wybór operatora i oznaczyć inne zgłoszenie. Reguła „tylko gdy puste" należy do klauzuli `WHERE`, nie do kodu Pythona — symetrycznie do widoku |
+| **D22** | **Zapis zwrotny ustawia `ostatnio_zmieniony` jawnie** | `.update()` omija `auto_now`, a `Meta.ordering` sortuje po tym polu — bez tego świeżo zaimportowane zgłoszenie zostawałoby ze starą datą na dole listy |
+
 ## 4. Zmiany w modelach
 
 ### 4.1 `zglos_publikacje` — migracja `0027` (ostatnia istniejąca: `0026`)
@@ -525,7 +537,9 @@ klas, `@pytest.mark.django_db`, `model_bakery.baker.make`.
 | Podwójny import tego samego zgłoszenia | ukrycie przycisku „Użyj importera" dla `ZAIMPORTOWANY` (§7) + D15 |
 | Wyjątek w zapisie zwrotnym → duplikat po „Ponów" | zapis zwrotny poza `atomic`, w wąskim `try/except` z `logger.exception` + Rollbar, bez re-raise: sesja zostaje `COMPLETED` |
 | Watchdog uzna żywe sesje za martwe | `update_fields` w zadaniach **zawsze** zawiera `modified` — `auto_now` odpala się tylko dla pól z listy, a `is_stalled()` czyta to pole |
-| Dane nieosiągalne z UI po dodaniu filtra | przezroczystość filtra przy jawnym wyborze statusu (D17) + `WYMAGA_ZMIAN` w „Do obsługi" (D16) |
+| Dane nieosiągalne z UI po dodaniu filtra | przezroczystość przy jawnym wyborze statusu (D17), przy `zaimportowal`/`zaimportowano` (D19) i przy zapytaniu DjangoQL (D20) + `WYMAGA_ZMIAN` w „Do obsługi" (D16). Grupy **partycjonują** wszystkie statusy, więc żaden nie może wypaść niezauważony |
+| Auto-match przestemplowuje jawny wybór operatora | `zwiaz_automatycznie` przez warunkowy `UPDATE … WHERE zgloszenie IS NULL` (D21) |
+| Zaimportowane zgłoszenie ginie na dole listy | `ostatnio_zmieniony` ustawiany jawnie, bo `.update()` omija `auto_now` (D22) |
 | Rozjazd paska postępu | reużycie etapu `prefill_zgl`, zero nowych nazw (§6B) |
 | Kolizja numerów migracji importera | numer `0020` podany jawnie (§4.2) |
 | Dwie migracje w jednej gałęzi | `make baseline-update` raz, przy scalaniu — nie w gałęzi |

--- a/src/bpp/newsfragments/+fd443.feature.md
+++ b/src/bpp/newsfragments/+fd443.feature.md
@@ -1,0 +1,7 @@
+Zgłoszenie publikacji domknięte importerem prac oznacza się teraz samo.
+Po zakończeniu importu uruchomionego przyciskiem „Użyj importera" zgłoszenie
+dostaje status „zaimportowany przez importer prac", a przy zgłoszeniu widać,
+kto i o której je zaimportował oraz jaki rekord powstał. Lista zgłoszeń
+w panelu administracyjnym ma nowy filtr „Stan obsługi", domyślnie pokazujący
+tylko zgłoszenia wymagające uwagi. Gdy na to samo DOI czeka kilka zgłoszeń,
+importer pyta operatora, które domknąć, zamiast wybierać samodzielnie (FD#443).

--- a/src/importer_publikacji/forms.py
+++ b/src/importer_publikacji/forms.py
@@ -53,6 +53,21 @@ class FetchForm(forms.Form):
         widget=forms.Textarea(attrs={"rows": 12, "cols": 80}),
         required=False,
     )
+    # Przenosi ``?zgloszenie=<pk>`` z linku „Użyj importera" przez rundę
+    # GET → render → POST: sesję importu tworzy dopiero ``FetchView.post``,
+    # więc parametr GET nieprzeniesiony ukrytym polem ginie bezpowrotnie.
+    # Walidacja (istnienie, soft-delete) jest po stronie widoku — tu
+    # sprawdzamy wyłącznie, czy to liczba; wartość niepoprawna nie może
+    # blokować importu, więc widok ignoruje ją po cichu.
+    # Zakres = zakres AutoField-a (DEFAULT_AUTO_FIELD = AutoField, int4):
+    # bez tego liczba spoza zakresu poszłaby do zapytania jako pk i mogłaby
+    # wywrócić request zamiast po cichu nie znaleźć zgłoszenia.
+    zgloszenie = forms.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=2147483647,
+        widget=forms.HiddenInput,
+    )
 
     def __init__(self, *args, **kwargs):
         last_provider = kwargs.pop("last_provider", None)
@@ -70,6 +85,14 @@ class FetchForm(forms.Form):
 
     def clean(self):
         cleaned = super().clean()
+
+        # Śmieć w ukrytym polu (ręcznie podrasowany URL, stary link) nie może
+        # zablokować importu — kasujemy błąd i traktujemy jak brak wiązania.
+        # Właściwą walidację (istnienie, soft-delete) robi FetchView.post.
+        if "zgloszenie" in self.errors:
+            del self.errors["zgloszenie"]
+            cleaned["zgloszenie"] = None
+
         provider_name = cleaned.get("provider")
         if not provider_name:
             return cleaned

--- a/src/importer_publikacji/migrations/0020_importsession_zgloszenie.py
+++ b/src/importer_publikacji/migrations/0020_importsession_zgloszenie.py
@@ -1,0 +1,49 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # 0019 jest jedynym liściem grafu tej aplikacji (historia ma zdublowane
+    # numery 0005/0006/0007/0012 pościnane merge'ami 0006/0007/0011/0013,
+    # ale od 0014 gałąź jest już liniowa). Numer 0020 podany jawnie, żeby
+    # równoległa gałąź nie dorobiła kolejnego duba.
+    dependencies = [
+        ("importer_publikacji", "0019_multipleworksimport_uczelnia"),
+        # FK celuje w Zgloszenie_Publikacji; migracja 0027 dokłada tam status
+        # ZAIMPORTOWANY + pola audytowe (druga połowa tej samej zmiany).
+        ("zglos_publikacje", "0027_zgloszenie_zaimportowane"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="importsession",
+            name="zgloszenie",
+            field=models.ForeignKey(
+                blank=True,
+                help_text=(
+                    "Zgłoszenie publikacji, które ten import domyka. "
+                    "Ustawiane jawnie (przycisk „Użyj importera”) albo "
+                    "automatycznie po DOI. Zadanie Celery dostaje wyłącznie "
+                    "id sesji — bez tego pola nie miałoby jak ustalić, "
+                    "które zgłoszenie oznaczyć."
+                ),
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="sesje_importu",
+                to="zglos_publikacje.zgloszenie_publikacji",
+                verbose_name="Zgłoszenie publikacji",
+            ),
+        ),
+        migrations.AddField(
+            model_name="importsession",
+            name="zgloszenie_odrzucone_przez_operatora",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "Operator kliknął „żadne z nich” na banerze kandydatów "
+                    "— baner nie pokazuje się już dla tej sesji."
+                ),
+                verbose_name="Operator odrzucił propozycje zgłoszeń",
+            ),
+        ),
+    ]

--- a/src/importer_publikacji/models.py
+++ b/src/importer_publikacji/models.py
@@ -252,12 +252,22 @@ class ImportSession(models.Model):
 
         Wyliczane przy każdym odczycie (nie cache'owane w polu) — DOI jest
         stabilne, a dzięki temu lista nie starzeje się względem stanu bazy.
-        Pusta, gdy operator odrzucił propozycje („żadne z nich”).
+
+        Pusty queryset (nigdy ``None``) w dwóch przypadkach, w których i tak
+        nie ma czego wybierać, a zbudowanie właściwego zapytania kosztowałoby
+        ``Uczelnia.objects.count()`` przy KAŻDYM renderze kroku Verify
+        (``kandydaci_dla_sesji`` → ``tylko_jedna_uczelnia``, wywoływane
+        natychmiast, nie leniwie):
+
+        * operator odrzucił propozycje („żadne z nich”),
+        * sesja ma już wiązanie — baner pokazuje wtedy wersję potwierdzającą
+          (gałąź ``session.zgloszenie_id`` w ``_baner_zgloszenia.html``),
+          a listy kandydatów nawet nie dotyka.
 
         Importy lokalne: ``zgloszenia`` importuje modele, więc import na
         poziomie modułu zamknąłby cykl.
         """
-        if self.zgloszenie_odrzucone_przez_operatora:
+        if self.zgloszenie_odrzucone_przez_operatora or self.zgloszenie_id:
             from zglos_publikacje.models import Zgloszenie_Publikacji
 
             return Zgloszenie_Publikacji.objects.none()

--- a/src/importer_publikacji/models.py
+++ b/src/importer_publikacji/models.py
@@ -184,6 +184,29 @@ class ImportSession(models.Model):
         "created_record_id",
     )
 
+    zgloszenie = models.ForeignKey(
+        "zglos_publikacje.Zgloszenie_Publikacji",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="sesje_importu",
+        verbose_name="Zgłoszenie publikacji",
+        help_text=(
+            "Zgłoszenie publikacji, które ten import domyka. Ustawiane "
+            "jawnie (przycisk „Użyj importera”) albo automatycznie po DOI. "
+            "Zadanie Celery dostaje wyłącznie id sesji — bez tego pola nie "
+            "miałoby jak ustalić, które zgłoszenie oznaczyć."
+        ),
+    )
+    zgloszenie_odrzucone_przez_operatora = models.BooleanField(
+        "Operator odrzucił propozycje zgłoszeń",
+        default=False,
+        help_text=(
+            "Operator kliknął „żadne z nich” na banerze kandydatów — "
+            "baner nie pokazuje się już dla tej sesji."
+        ),
+    )
+
     created = models.DateTimeField("utworzono", auto_now_add=True)
     modified = models.DateTimeField("zmodyfikowano", auto_now=True)
 
@@ -222,6 +245,26 @@ class ImportSession(models.Model):
 
     def __str__(self):
         return f"{self.provider_name}: {self.identifier} ({self.get_status_display()})"
+
+    @property
+    def kandydaci_zgloszen(self):
+        """Zgłoszenia publikacji, które ta sesja importu mogłaby domknąć.
+
+        Wyliczane przy każdym odczycie (nie cache'owane w polu) — DOI jest
+        stabilne, a dzięki temu lista nie starzeje się względem stanu bazy.
+        Pusta, gdy operator odrzucił propozycje („żadne z nich”).
+
+        Importy lokalne: ``zgloszenia`` importuje modele, więc import na
+        poziomie modułu zamknąłby cykl.
+        """
+        if self.zgloszenie_odrzucone_przez_operatora:
+            from zglos_publikacje.models import Zgloszenie_Publikacji
+
+            return Zgloszenie_Publikacji.objects.none()
+
+        from .zgloszenia import kandydaci_dla_sesji
+
+        return kandydaci_dla_sesji(self)
 
     def get_continue_url(self):
         from django.urls import reverse

--- a/src/importer_publikacji/tasks.py
+++ b/src/importer_publikacji/tasks.py
@@ -3,10 +3,19 @@
 Globalny @task_failure.connect w src/django_bpp/celery_tasks.py:40-42
 automatycznie raportuje wyjątki do Rollbar — task body wystarczy raise
 po zapisaniu user-safe message w sesji.
+
+**Wszystkie zapisy sesji idą przez ``update_fields``** (z ``modified``,
+żeby ``auto_now`` zadziałał i watchdog ``ImportSession.is_stalled()`` nie
+uznał sesji za martwą). Pełne ``session.save()`` z instancji wczytanej na
+starcie taska nadpisywało kolumny zmienione W MIĘDZYCZASIE przez widok —
+konkretnie ``zgloszenie`` dopisywane gałęzią idempotency w ``FetchView``
+(lost update: FK wracał do NULL, wiązanie ze zgłoszeniem przepadało).
 """
 
+import logging
 import traceback
 
+import rollbar
 from celery import shared_task
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
@@ -20,6 +29,20 @@ from .progress import (
     user_safe_message,
 )
 from .providers import get_provider
+
+logger = logging.getLogger(__name__)
+
+# Kolumny zapisywane przez terminalne ścieżki błędu (obie gałęzie ``except``
+# oraz „dostawca nic nie zwrócił"). ``modified`` jest tu jawnie, bo
+# ``auto_now`` odpala się WYŁĄCZNIE dla pól wymienionych w ``update_fields``.
+_POLA_BLEDU = [
+    "status",
+    "last_failed_stage",
+    "last_error_message",
+    "last_error_traceback",
+    "celery_task_id",
+    "modified",
+]
 
 
 @shared_task(bind=True)
@@ -55,16 +78,24 @@ def fetch_session_task(self, session_id, request_user_id):
                 ProviderReturnedNothing(), task_kind="fetch"
             )[:255]
             session.celery_task_id = ""
-            session.save()
+            session.save(update_fields=_POLA_BLEDU)
             return
 
         report_progress(self, "create_session", stages=FETCH_STAGES)
         _store_normalized_data(session, result)
-        session.save()
+        session.save(update_fields=["raw_data", "normalized_data", "modified"])
 
         report_progress(self, "match_type_lang", stages=FETCH_STAGES)
         _auto_match_type_and_language(session, result)
-        session.save()
+        session.save(
+            update_fields=[
+                "rodzaj_rekordu",
+                "charakter_formalny",
+                "jest_wydawnictwem_zwartym",
+                "jezyk",
+                "modified",
+            ]
+        )
 
         report_progress(
             self,
@@ -96,6 +127,13 @@ def fetch_session_task(self, session_id, request_user_id):
         # Kolejność: najpierw wiązanie, potem prefill — dzięki temu
         # prefill dyscyplin korzysta z jawnie związanego zgłoszenia,
         # zamiast z heurystyki po tytule.
+        #
+        # ``zgloszenie`` czytamy ŚWIEŻO z bazy: jawne wiązanie (ścieżka A)
+        # mógł dopisać widok JUŻ PO wczytaniu sesji przez ten task —
+        # ``FetchView`` robi to gałęzią idempotency (double-click), nie
+        # startując nowej sesji. Bez tego odczytu auto-wiązanie po DOI
+        # przestemplowałoby jawny wybór operatora.
+        session.refresh_from_db(fields=["zgloszenie"])
         if not session.zgloszenie_id:
             zwiaz_automatycznie(session)
 
@@ -103,14 +141,14 @@ def fetch_session_task(self, session_id, request_user_id):
 
         session.status = ImportSession.Status.FETCHED
         session.celery_task_id = ""
-        session.save()
+        session.save(update_fields=["status", "celery_task_id", "modified"])
     except Exception as exc:
         session.status = ImportSession.Status.IMPORT_FAILED
         session.last_failed_stage = "fetch"
         session.last_error_message = user_safe_message(exc, task_kind="fetch")[:255]
         session.last_error_traceback = traceback.format_exc()
         session.celery_task_id = ""
-        session.save()
+        session.save(update_fields=_POLA_BLEDU)
         raise
 
 
@@ -235,13 +273,6 @@ def create_publication_task(self, session_id, request_user_id, also_pbn):
             report_progress(self, "link_pbn", stages=CREATE_STAGES)
             _enqueue_pbn_export(request_user, record, session.uczelnia)
 
-        # Zapis zwrotny na zgłoszeniu (FD#443, D10) idzie w TYM SAMYM
-        # bloku, co przejście sesji w COMPLETED — nie w
-        # ``_create_publication``, którego własna transakcja już się
-        # zamknęła. Blok siedzi w gałęzi sukcesu, PRZED ``except``, więc
-        # nieudany import nie zmienia statusu zgłoszenia.
-        from .zgloszenia import oznacz_jako_zaimportowane
-
         with transaction.atomic():
             session.status = ImportSession.Status.COMPLETED
             session.created_record_content_type = ContentType.objects.get_for_model(
@@ -250,17 +281,66 @@ def create_publication_task(self, session_id, request_user_id, also_pbn):
             session.created_record_id = record.pk
             session.modified_by = request_user
             session.celery_task_id = ""
-            session.save()
+            session.save(
+                update_fields=[
+                    "status",
+                    "created_record_content_type",
+                    "created_record_id",
+                    "modified_by",
+                    "celery_task_id",
+                    "modified",
+                ]
+            )
 
-            oznacz_jako_zaimportowane(session, record)
+        # Zapis zwrotny na zgłoszeniu (FD#443, D10) idzie PO domknięciu
+        # transakcji sesji i w gałęzi sukcesu, PRZED ``except`` — nieudany
+        # import nie zmienia statusu zgłoszenia. Poza ``atomic`` dlatego, że
+        # błąd bazy WEWNĄTRZ bloku psuje całą transakcję: nie dałoby się go
+        # połknąć bez wywrócenia COMPLETED (patrz helper niżej).
+        _oznacz_zgloszenie_nie_wywracajac_importu(session, record)
     except Exception as exc:
         session.status = ImportSession.Status.IMPORT_FAILED
         session.last_failed_stage = "create"
         session.last_error_message = user_safe_message(exc, task_kind="create")[:255]
         session.last_error_traceback = traceback.format_exc()
         session.celery_task_id = ""
-        session.save()
+        session.save(update_fields=_POLA_BLEDU)
         raise
+
+
+def _oznacz_zgloszenie_nie_wywracajac_importu(session, record):
+    """Zapis zwrotny na zgłoszeniu, który NIGDY nie wywraca importu.
+
+    W chwili wywołania rekord publikacji już istnieje, a sesja jest
+    ``COMPLETED``. Gdyby wyjątek stąd poleciał wyżej, ``except`` w
+    :func:`create_publication_task` cofnąłby sesję do ``IMPORT_FAILED``,
+    operator kliknąłby „Ponów" i powstałby DRUGI rekord tej samej pracy.
+    Dlatego łapiemy szeroko, ale **nie po cichu**: pełny traceback do logu
+    + zgłoszenie do Rollbara (globalny ``@task_failure.connect`` już go tu
+    nie zobaczy, bo nie ma re-raise'a).
+
+    Gorszym scenariuszem jest zgłoszenie nieoznaczone (do ręcznego
+    domknięcia przez operatora), nie duplikat rekordu w bazie.
+
+    ``zgloszenie`` odczytujemy świeżo: operator mógł w trakcie tworzenia
+    rekordu zmienić wiązanie albo je odpiąć („Odepnij" / „Żadne z nich")
+    — jego decyzja jest nowsza niż stan wczytany na starcie taska.
+    """
+    from .zgloszenia import oznacz_jako_zaimportowane
+
+    try:
+        session.refresh_from_db(fields=["zgloszenie"])
+        oznacz_jako_zaimportowane(session, record)
+    except Exception:
+        logger.exception(
+            "Nie udało się oznaczyć zgłoszenia %s jako zaimportowanego "
+            "(sesja importu %s, rekord %s). Rekord publikacji POWSTAŁ, sesja "
+            "zostaje COMPLETED — zgłoszenie wymaga ręcznego domknięcia.",
+            session.zgloszenie_id,
+            session.pk,
+            record.pk,
+        )
+        rollbar.report_exc_info()
 
 
 def _create_publication(session):

--- a/src/importer_publikacji/tasks.py
+++ b/src/importer_publikacji/tasks.py
@@ -9,6 +9,7 @@ import traceback
 
 from celery import shared_task
 from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
 
 from .models import ImportSession
 from .progress import (
@@ -86,6 +87,17 @@ def fetch_session_task(self, session_id, request_user_id):
 
         report_progress(self, "prefill_zgl", stages=FETCH_STAGES)
         from .views.authors import _prefill_dyscypliny_z_zgloszen
+        from .zgloszenia import zwiaz_automatycznie
+
+        # Ścieżka B (FD#443): auto-wiązanie po DOI, gdy kandydat jest
+        # dokładnie jeden. Świadomie reużywamy istniejący etap paska
+        # postępu — ``report_progress`` rzuca ValueError na nieznanej
+        # nazwie etapu, a wagi FETCH_STAGES sumują się do 100.
+        # Kolejność: najpierw wiązanie, potem prefill — dzięki temu
+        # prefill dyscyplin korzysta z jawnie związanego zgłoszenia,
+        # zamiast z heurystyki po tytule.
+        if not session.zgloszenie_id:
+            zwiaz_automatycznie(session)
 
         _prefill_dyscypliny_z_zgloszen(session)
 
@@ -223,12 +235,24 @@ def create_publication_task(self, session_id, request_user_id, also_pbn):
             report_progress(self, "link_pbn", stages=CREATE_STAGES)
             _enqueue_pbn_export(request_user, record, session.uczelnia)
 
-        session.status = ImportSession.Status.COMPLETED
-        session.created_record_content_type = ContentType.objects.get_for_model(record)
-        session.created_record_id = record.pk
-        session.modified_by = request_user
-        session.celery_task_id = ""
-        session.save()
+        # Zapis zwrotny na zgłoszeniu (FD#443, D10) idzie w TYM SAMYM
+        # bloku, co przejście sesji w COMPLETED — nie w
+        # ``_create_publication``, którego własna transakcja już się
+        # zamknęła. Blok siedzi w gałęzi sukcesu, PRZED ``except``, więc
+        # nieudany import nie zmienia statusu zgłoszenia.
+        from .zgloszenia import oznacz_jako_zaimportowane
+
+        with transaction.atomic():
+            session.status = ImportSession.Status.COMPLETED
+            session.created_record_content_type = ContentType.objects.get_for_model(
+                record
+            )
+            session.created_record_id = record.pk
+            session.modified_by = request_user
+            session.celery_task_id = ""
+            session.save()
+
+            oznacz_jako_zaimportowane(session, record)
     except Exception as exc:
         session.status = ImportSession.Status.IMPORT_FAILED
         session.last_failed_stage = "create"

--- a/src/importer_publikacji/templates/importer_publikacji/_baner_zgloszenia.html
+++ b/src/importer_publikacji/templates/importer_publikacji/_baner_zgloszenia.html
@@ -72,12 +72,15 @@
                                 <span class="fi-check"></span>
                                 #{{ zgl.pk }}
                                 &mdash;
+                                {# BEZ e-maila zgłaszającego: zgłoszenie ze #}
+                                {# współautorami z dwóch uczelni jest kandydatem #}
+                                {# dla OBU (semantyka OR po jednostkach autorów), #}
+                                {# więc operator obcej uczelni zobaczyłby cudzy #}
+                                {# adres. Numer zgłoszenia, pierwszy autor, #}
+                                {# tytuł i rok w zupełności wystarczą, żeby #}
+                                {# rozpoznać właściwego kandydata. #}
                                 {% with autor=zgl.zgloszenie_publikacji_autor_set.first %}
-                                    {% if autor %}
-                                        {{ autor.zapisany_jako }},
-                                    {% else %}
-                                        {{ zgl.email }},
-                                    {% endif %}
+                                    {% if autor %}{{ autor.zapisany_jako }},{% endif %}
                                 {% endwith %}
                                 „{{ zgl.tytul_oryginalny|truncatechars:80 }}"
                                 {% if zgl.rok %}, {{ zgl.rok }}{% endif %}

--- a/src/importer_publikacji/templates/importer_publikacji/_baner_zgloszenia.html
+++ b/src/importer_publikacji/templates/importer_publikacji/_baner_zgloszenia.html
@@ -1,0 +1,123 @@
+{% load importer_tags %}
+{# Baner wiązania sesji importu ze zgłoszeniem publikacji (FD#443). #}
+{# Kontekst: #}
+{#   * `session`   — ImportSession, #}
+{#   * `kandydaci` — iterowalne Zgloszenie_Publikacji, zwrócone przez #}
+{#                   zgloszenia.kandydaci_dla_sesji() (np. przez własność #}
+{#                   ImportSession.kandydaci_zgloszen). #}
+{# Operator, który kliknął „Żadne z nich", nie dostaje już nic. #}
+{% if not session.zgloszenie_odrzucone_przez_operatora %}
+    {% if session.zgloszenie_id %}
+        {# Wersja potwierdzająca: wiązanie już istnieje (jawne z modułu #}
+        {# redagowania albo automatyczne po DOI). Operator może #}
+        {# zaprotestować, ZANIM import się wykona. #}
+        <div class="callout primary" id="baner-zgloszenia">
+            <span class="fi-info"></span>
+            Ten import domknie zgłoszenie publikacji
+            <strong>#{{ session.zgloszenie.pk }}</strong>
+            &mdash;
+            „{{ session.zgloszenie.tytul_oryginalny|truncatechars:120 }}"
+            {% if session.zgloszenie.rok %}({{ session.zgloszenie.rok }}){% endif %}
+            .
+            {% with url=session.zgloszenie|admin_change_url %}
+                {% if url %}
+                    <a href="{{ url }}"
+                       target="_blank"
+                       rel="noopener">
+                        <span class="fi-eye"></span>
+                        zobacz
+                    </a>
+                {% endif %}
+            {% endwith %}
+            <form method="post"
+                  action="{% url 'importer_publikacji:zgloszenie-wybierz' session_id=session.pk %}"
+                  style="display:inline; margin:0;">
+                {% csrf_token %}
+                <input type="hidden"
+                       name="odepnij"
+                       value="1">
+                <button type="submit"
+                        class="button small hollow secondary"
+                        style="margin-bottom: 0;">
+                    <span class="fi-x"></span>
+                    Odepnij
+                </button>
+            </form>
+        </div>
+    {% elif kandydaci %}
+        {# Wersja rozstrzygająca: system nie zgaduje, pyta operatora. #}
+        <div class="callout warning" id="baner-zgloszenia">
+            <h5>
+                <span class="fi-info"></span>
+                Zgłoszenia publikacji pasujące do tego DOI
+                {% if session.normalized_data.doi %}
+                    ({{ session.normalized_data.doi }})
+                {% endif %}
+                : {{ kandydaci|length }}
+            </h5>
+            <p>Które z nich domknąć tym importem?</p>
+            <ul class="no-bullet">
+                {% for zgl in kandydaci %}
+                    <li style="margin-bottom: 0.5rem;">
+                        <form method="post"
+                              action="{% url 'importer_publikacji:zgloszenie-wybierz' session_id=session.pk %}"
+                              style="display:inline; margin:0;">
+                            {% csrf_token %}
+                            <input type="hidden"
+                                   name="zgloszenie"
+                                   value="{{ zgl.pk }}">
+                            <button type="submit"
+                                    class="button small"
+                                    style="margin-bottom: 0;">
+                                <span class="fi-check"></span>
+                                #{{ zgl.pk }}
+                                &mdash;
+                                {% with autor=zgl.zgloszenie_publikacji_autor_set.first %}
+                                    {% if autor %}
+                                        {{ autor.zapisany_jako }},
+                                    {% else %}
+                                        {{ zgl.email }},
+                                    {% endif %}
+                                {% endwith %}
+                                „{{ zgl.tytul_oryginalny|truncatechars:80 }}"
+                                {% if zgl.rok %}, {{ zgl.rok }}{% endif %}
+                            </button>
+                        </form>
+                        {% with url=zgl|admin_change_url %}
+                            {% if url %}
+                                <a href="{{ url }}"
+                                   target="_blank"
+                                   rel="noopener">
+                                    <span class="fi-eye"></span>
+                                    zobacz
+                                </a>
+                            {% endif %}
+                        {% endwith %}
+                    </li>
+                {% endfor %}
+            </ul>
+            <a href="{% url 'admin:zglos_publikacje_zgloszenie_publikacji_changelist' %}"
+               class="button small hollow"
+               target="_blank"
+               rel="noopener"
+               style="margin-bottom: 0;">
+                <span class="fi-link"></span>
+                Pokaż wszystkie w module redagowania
+            </a>
+            <form method="post"
+                  action="{% url 'importer_publikacji:zgloszenie-wybierz' session_id=session.pk %}"
+                  style="display:inline; margin:0;">
+                {% csrf_token %}
+                <input type="hidden"
+                       name="zadne"
+                       value="1">
+                <button type="submit"
+                        class="button small hollow secondary"
+                        style="margin-bottom: 0;">
+                    <span class="fi-x"></span>
+                    Żadne z nich
+                </button>
+            </form>
+        </div>
+    {% endif %}
+{% endif %}

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_done.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_done.html
@@ -34,6 +34,23 @@
         </p>
     </div>
 
+    {# Baner domknięcia zgłoszenia: widoczny tylko gdy sesja była związana #}
+    {# ze zgłoszeniem i zapis zwrotny faktycznie ustawił status. #}
+    {% if domkniete_zgloszenie %}
+        <div class="callout primary">
+            <span class="fi-check"></span>
+            Domknięto zgłoszenie publikacji
+            <strong>#{{ domkniete_zgloszenie.pk }}</strong>
+            &mdash; jest teraz oznaczone jako zaimportowane.
+            <a href="{{ domkniete_zgloszenie_url }}"
+               target="_blank"
+               rel="noopener">
+                <span class="fi-eye"></span>
+                Pokaż zgłoszenie
+            </a>
+        </div>
+    {% endif %}
+
     {% if record %}
         <div class="grid-x grid-margin-x grid-margin-y">
             <div class="cell medium-6 large-3">

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_fetch.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_fetch.html
@@ -7,14 +7,21 @@
 
     <p class="importer-chosen-source">
         Źródło danych: <strong>{{ provider_meta.choice_label }}</strong>
-        <a class="importer-change-source"
-           href="{% url 'importer_publikacji:index' %}"
-           hx-get="{% url 'importer_publikacji:index' %}"
-           hx-target="#importer-wizard"
-           hx-push-url="true">
-            <span class="fi-arrow-left"></span>
-            Wybierz inne źródło
-        </a>
+        {# Zmiana dostawcy nie może gubić kontekstu: ?zgloszenie= (wiązanie #}
+        {# ze zgłoszeniem publikacji, FD#443) oraz ?identifier= jadą dalej #}
+        {# w URL-u, a kafelki na stronie wyboru przekazują je do formularza #}
+        {# nowego dostawcy. Bez tego realny scenariusz „CrossRef nie zna DOI #}
+        {# → przełącz na Pozostałe strony WWW" kasował wiązanie po cichu. #}
+        {% with zgl=form.zgloszenie.value ident=form.identifier.value %}
+            <a class="importer-change-source"
+               href="{% url 'importer_publikacji:index' %}{% if zgl %}?zgloszenie={{ zgl|urlencode }}{% if ident %}&amp;identifier={{ ident|urlencode }}{% endif %}{% elif ident %}?identifier={{ ident|urlencode }}{% endif %}"
+               hx-get="{% url 'importer_publikacji:index' %}{% if zgl %}?zgloszenie={{ zgl|urlencode }}{% if ident %}&amp;identifier={{ ident|urlencode }}{% endif %}{% elif ident %}?identifier={{ ident|urlencode }}{% endif %}"
+               hx-target="#importer-wizard"
+               hx-push-url="true">
+                <span class="fi-arrow-left"></span>
+                Wybierz inne źródło
+            </a>
+        {% endwith %}
     </p>
 
     <div class="formdefaults-wrap">{% bpp_formdefaults_button form %}</div>

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_fetch.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_fetch.html
@@ -23,6 +23,10 @@
           hx-indicator="#fetch-spinner">
         {% csrf_token %}
         <input type="hidden" name="provider" value="{{ provider_name }}">
+        {# Przenosi ?zgloszenie=<pk> z przycisku „Użyj importera” do POST-a. #}
+        {# Sesję importu tworzy dopiero FetchView.post, więc bez tego pola #}
+        {# kontekst zgłoszenia ginie na rundzie GET → render → POST. #}
+        {{ form.zgloszenie }}
 
         {% if form.provider.errors %}
             {% for error in form.provider.errors %}

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_landing.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_landing.html
@@ -17,20 +17,26 @@
         Wybierz źródło danych, z którego chcesz zaimportować publikację.
     </p>
 
-    <div class="tile-grid tile-grid--providers" id="provider-tile-grid">
-        {% for p in providers %}
-            <a class="tile-card"
-               data-provider="{{ p.name }}"
-               href="{% url 'importer_publikacji:index' %}?provider={{ p.name|urlencode }}"
-               hx-get="{% url 'importer_publikacji:index' %}?provider={{ p.name|urlencode }}"
-               hx-target="#importer-wizard"
-               hx-push-url="true">
-                <span class="tile-icon {{ p.icon }}"></span>
-                <span class="tile-title">{{ p.choice_label }}</span>
-                <span class="tile-desc">{{ p.landing_caption }}</span>
-            </a>
-        {% endfor %}
-    </div>
+    {# Kafelki przekazują dalej kontekst, z którym operator tu przyszedł: #}
+    {# ?zgloszenie= (wiązanie ze zgłoszeniem publikacji, FD#443) oraz #}
+    {# ?identifier=. Wprost z request.GET, bo ta strona to czysty przelot #}
+    {# — sesji importu jeszcze nie ma, tworzy ją dopiero FetchView.post. #}
+    {% with zgl=request.GET.zgloszenie ident=request.GET.identifier %}
+        <div class="tile-grid tile-grid--providers" id="provider-tile-grid">
+            {% for p in providers %}
+                <a class="tile-card"
+                   data-provider="{{ p.name }}"
+                   href="{% url 'importer_publikacji:index' %}?provider={{ p.name|urlencode }}{% if zgl %}&amp;zgloszenie={{ zgl|urlencode }}{% endif %}{% if ident %}&amp;identifier={{ ident|urlencode }}{% endif %}"
+                   hx-get="{% url 'importer_publikacji:index' %}?provider={{ p.name|urlencode }}{% if zgl %}&amp;zgloszenie={{ zgl|urlencode }}{% endif %}{% if ident %}&amp;identifier={{ ident|urlencode }}{% endif %}"
+                   hx-target="#importer-wizard"
+                   hx-push-url="true">
+                    <span class="tile-icon {{ p.icon }}"></span>
+                    <span class="tile-title">{{ p.choice_label }}</span>
+                    <span class="tile-desc">{{ p.landing_caption }}</span>
+                </a>
+            {% endfor %}
+        </div>
+    {% endwith %}
 </div>
 
 <div class="callout secondary" id="import-progress-bar">

--- a/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
+++ b/src/importer_publikacji/templates/importer_publikacji/partials/step_verify.html
@@ -5,6 +5,13 @@
         Weryfikacja danych publikacji
     </h4>
 
+    {# Pierwszy ekran po pobraniu danych — tu operator decyduje, które #}
+    {# zgłoszenie publikacji ten import domknie (albo widzi potwierdzenie #}
+    {# wiązania jawnego z przycisku „Użyj importera”). Kandydaci wyliczani #}
+    {# przy renderowaniu, nie cache'owani w polu — lista nie starzeje się #}
+    {# względem stanu bazy. #}
+    {% include "importer_publikacji/_baner_zgloszenia.html" with kandydaci=session.kandydaci_zgloszen %}
+
     {% if existing %}
         <div class="callout alert">
             <span class="fi-alert"></span>

--- a/src/importer_publikacji/tests/test_fd443_regresje.py
+++ b/src/importer_publikacji/tests/test_fd443_regresje.py
@@ -625,6 +625,66 @@ def test_zapis_zwrotny_przy_zero_zaktualizowanych_wierszy_loguje(importer_user, 
     assert any(str(int(STATUSY.SPAM)) in m for m in komunikaty), komunikaty
 
 
+@pytest.mark.django_db
+def test_zapis_zwrotny_odswieza_ostatnio_zmieniony(importer_user):
+    """``.update()`` omija ``auto_now`` — datę trzeba wpisać jawnie.
+
+    ``ostatnio_zmieniony`` ma ``auto_now=True``, ale bulk ``UPDATE`` nie
+    woła ``Model.save()``, więc pole zostawało z datą sprzed importu.
+    Zapis zwrotny jest realną zmianą zgłoszenia (status, rekord, kod do
+    edycji) — musi być po niej widoczny w polu „ostatnio zmieniony".
+    """
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    stara_data = timezone.now() - datetime.timedelta(days=3)
+    Zgloszenie_Publikacji.objects.filter(pk=zgl.pk).update(
+        ostatnio_zmieniony=stara_data
+    )
+    przed = Zgloszenie_Publikacji.objects.values_list(
+        "ostatnio_zmieniony", flat=True
+    ).get(pk=zgl.pk)
+    assert przed == stara_data
+
+    assert oznacz_jako_zaimportowane(session, _rekord()) is True
+
+    po, zaimportowano = Zgloszenie_Publikacji.objects.values_list(
+        "ostatnio_zmieniony", "zaimportowano"
+    ).get(pk=zgl.pk)
+
+    assert po > przed, "``ostatnio_zmieniony`` zamarło na dacie sprzed importu"
+    # Jeden ``timezone.now()`` na cały UPDATE — obie kolumny opisują to samo
+    # zdarzenie, więc rozjazd znaczyłby dwa niezależne odczyty zegara.
+    assert po == zaimportowano
+
+
+@pytest.mark.django_db
+def test_zaimportowane_zgloszenie_laduje_na_gorze_domyslnej_listy(importer_user):
+    """``Meta.ordering = ("-ostatnio_zmieniony", …)`` — to nie jest kosmetyka.
+
+    Zamrożona data spychała świeżo domknięte zgłoszenie na DÓŁ listy
+    w module redagowania: operator kończył import i nie widział efektu
+    tam, gdzie go szukał.
+    """
+    assert Zgloszenie_Publikacji._meta.ordering[0] == "-ostatnio_zmieniony"
+
+    zgl = _zgl(tytul="Zgłoszenie domykane importem")
+    Zgloszenie_Publikacji.objects.filter(pk=zgl.pk).update(
+        ostatnio_zmieniony=timezone.now() - datetime.timedelta(days=7)
+    )
+    for numer in range(3):
+        _zgl(tytul=f"Inne zgłoszenie {numer}")
+
+    kolejnosc = list(Zgloszenie_Publikacji.objects.values_list("pk", flat=True))
+    assert kolejnosc[-1] == zgl.pk, "stan wyjściowy: zgłoszenie jest na dole"
+
+    session = _sesja(importer_user, zgloszenie=zgl)
+    assert oznacz_jako_zaimportowane(session, _rekord()) is True
+
+    kolejnosc = list(Zgloszenie_Publikacji.objects.values_list("pk", flat=True))
+    assert kolejnosc[0] == zgl.pk
+
+
 # ==========================================================================
 # D. Lost update + ``modified`` w ``update_fields``
 # ==========================================================================
@@ -687,6 +747,77 @@ def test_task_fetch_nie_przestemplowuje_jawnego_wiazania_auto_matchem(importer_u
     assert session.zgloszenie_id == jawne.pk
     po_doi.refresh_from_db()
     assert po_doi.status == STATUSY.NOWY
+
+
+@pytest.mark.django_db
+def test_zwiaz_automatycznie_nie_przestemplowuje_wiazania_zapisanego_po_odczycie(
+    importer_user, caplog
+):
+    """Okno wyścigu PO ``refresh_from_db`` w zadaniu.
+
+    ``test_task_fetch_nie_przestemplowuje_jawnego_wiazania_auto_matchem``
+    pokrywa zapis widoku, który zdążył PRZED odświeżeniem instancji w tasku.
+    Tu symulujemy drugą połowę okna: instancja w pamięci ma
+    ``zgloszenie_id = None``, ale w bazie jawne wiązanie JUŻ jest.
+
+    Dopóki reguła „tylko gdy puste" siedziała w sprawdzeniu na obiekcie
+    w pamięci, a zapis był bezwarunkowym ``save(update_fields=…)``,
+    auto-match po DOI przestemplowywał jawny wybór operatora — i domknięte
+    zostawało INNE zgłoszenie niż to, które operator wskazał.
+    """
+    session = _sesja(importer_user, doi=DOI)
+    jawne = _zgl(strona_www="https://doi.org/10.9999/jawne")
+    po_doi = _zgl(strona_www=f"https://doi.org/{DOI}", tytul="Kandydat po DOI")
+
+    # Ścieżka A (widok) zapisuje wiązanie już po tym, jak zadanie wczytało
+    # swój wiersz — instancja w pamięci nadal go nie widzi.
+    ImportSession.objects.filter(pk=session.pk).update(zgloszenie=jawne)
+    assert session.zgloszenie_id is None, "obiekt w pamięci nie widzi zapisu"
+
+    # Kontrola pozytywna założeń: auto-match MA jednego kandydata, więc
+    # gdyby nie warunek w ``WHERE``, zapis by się wykonał.
+    assert list(kandydaci_dla_sesji(session)) == [po_doi]
+
+    with caplog.at_level(logging.INFO, logger="importer_publikacji.zgloszenia"):
+        assert zwiaz_automatycznie(session) is False
+
+    w_bazie = ImportSession.objects.values_list("zgloszenie", flat=True).get(
+        pk=session.pk
+    )
+    assert w_bazie == jawne.pk, "auto-match przestemplował jawny wybór"
+
+    # ``refresh_from_db`` w gałęzi przegranej: instancja w pamięci przestaje
+    # kłamać, więc dalszy ciąg zadania (zapis zwrotny) oznacza właściwe
+    # zgłoszenie, a nie żadne.
+    assert session.zgloszenie_id == jawne.pk
+
+    assert any("w międzyczasie" in r.getMessage() for r in caplog.records), [
+        r.getMessage() for r in caplog.records
+    ]
+
+
+@pytest.mark.django_db
+def test_zwiaz_automatycznie_wiaze_gdy_w_bazie_nadal_pusto(importer_user):
+    """Kontrola pozytywna do testu wyżej: bez wyścigu wiązanie powstaje.
+
+    Bez tego warunkowy ``UPDATE`` mógłby nie wiązać NIGDY i test wyścigu
+    i tak byłby zielony.
+    """
+    session = _sesja(importer_user, doi=DOI)
+    kandydat = _zgl(strona_www=f"https://doi.org/{DOI}")
+
+    assert (
+        ImportSession.objects.values_list("zgloszenie", flat=True).get(pk=session.pk)
+        is None
+    )
+
+    assert zwiaz_automatycznie(session) is True
+
+    assert (
+        ImportSession.objects.values_list("zgloszenie", flat=True).get(pk=session.pk)
+        == kandydat.pk
+    )
+    assert session.zgloszenie_id == kandydat.pk
 
 
 @pytest.mark.django_db

--- a/src/importer_publikacji/tests/test_fd443_regresje.py
+++ b/src/importer_publikacji/tests/test_fd443_regresje.py
@@ -1,0 +1,1041 @@
+"""FD#443 — regresje z adwersarialnej recenzji PR-a.
+
+Każdy test w tym pliku pilnuje konkretnej naprawy, której poprzednia suita
+NIE złapała. Grupy odpowiadają lukom z recenzji:
+
+* **A** — dopasowanie po DOI wyłuskanym ze ``strona_www`` (pole ``doi`` jest
+  produkcyjnie ZAWSZE puste: publiczny formularz go nie ma). Testy oparte na
+  ``baker.make(doi=...)`` sprawdzały stan nieosiągalny produkcyjnie, więc
+  przepuściły martwy kod.
+* **B** — ścieżka jawna (``?zgloszenie=<pk>`` → ukryte pole ``FetchForm``)
+  omijała walidację uczelni i statusów (gołe ``objects.filter(pk=...)``).
+* **C** — zapis zwrotny rewaliduje status w chwili ZAPISU, nie w chwili
+  związania, i kasuje ``kod_do_edycji``.
+* **D** — lost update: pełne ``session.save()`` w tasku kasowało wiązanie
+  dopisane w międzyczasie przez widok; ``update_fields`` musi zawierać
+  ``modified``, inaczej watchdog uzna żywą sesję za martwą.
+* **E** — wyjątek w zapisie zwrotnym nie może wywrócić importu (sesja zostaje
+  ``COMPLETED``, inaczej „Ponów" tworzy drugi rekord tej samej pracy).
+* **F** — charakteryzacja świadomych ograniczeń zawężania do uczelni.
+* **G** — renderowanie banera i strony „Gotowe" (wcześniej zero pokrycia).
+"""
+
+import datetime
+import logging
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.models import Site
+from django.urls import reverse
+from django.utils import timezone
+from model_bakery import baker
+
+from bpp.models import Wydawnictwo_Ciagle
+from importer_publikacji.models import ImportSession
+from importer_publikacji.tasks import create_publication_task, fetch_session_task
+from importer_publikacji.zgloszenia import (
+    kandydaci_dla_sesji,
+    oznacz_jako_zaimportowane,
+    zgloszenie_dozwolone,
+    zwiaz_automatycznie,
+)
+from zglos_publikacje.models import Zgloszenie_Publikacji
+
+DOI = "10.1234/fd443.regresja"
+TYTUL = "Praca zgłoszona przez publiczny formularz zgłoszeniowy"
+
+STATUSY = Zgloszenie_Publikacji.Statusy
+
+
+# --------------------------------------------------------------------------
+# Pomocnicze
+# --------------------------------------------------------------------------
+
+
+def _zgl(doi=None, strona_www="", status=STATUSY.NOWY, tytul=TYTUL, **kwargs):
+    """Zgłoszenie publikacji.
+
+    Domyślnie z ``doi=None`` — dokładnie tak, jak wygląda zgłoszenie złożone
+    przez publiczny formularz (ten pola ``doi`` w ogóle nie ma, a kolumna jest
+    ``null=True``, więc produkcyjnie siedzi tam NULL, nie pusty string).
+    """
+    return baker.make(
+        "zglos_publikacje.Zgloszenie_Publikacji",
+        doi=doi,
+        strona_www=strona_www,
+        tytul_oryginalny=tytul,
+        status=status,
+        rok=2024,
+        rodzaj_zglaszanej_publikacji=1,
+        **kwargs,
+    )
+
+
+def _zpa(zgloszenie, jednostka):
+    """Autor zgłoszenia — jedyny nośnik atrybucji zgłoszenia do uczelni."""
+    return baker.make(
+        "zglos_publikacje.Zgloszenie_Publikacji_Autor",
+        rekord=zgloszenie,
+        autor=baker.make("bpp.Autor"),
+        jednostka=jednostka,
+        rok=2024,
+    )
+
+
+def _sesja(user, doi=DOI, uczelnia=None, **kwargs):
+    return ImportSession.objects.create(
+        created_by=user,
+        uczelnia=uczelnia,
+        provider_name="CrossRef",
+        identifier=doi or "brak-doi",
+        raw_data={},
+        normalized_data={
+            "title": TYTUL,
+            "doi": doi,
+            "year": 2024,
+            "authors": [],
+        },
+        **kwargs,
+    )
+
+
+def _rekord():
+    return baker.make(Wydawnictwo_Ciagle, rok=2024)
+
+
+def _jednostka_obcej_uczelni(skrot):
+    """Jednostka nowo utworzonej uczelni (≠ ta spod hosta ``testserver``)."""
+    from bpp.models import Jednostka, Uczelnia, Wydzial
+    from bpp.models.struktura_konwersja import znajdz_lub_utworz_wezel_wydzialu
+
+    site = Site.objects.create(
+        domain=f"{skrot.lower()}.example.com", name=f"Site {skrot}"
+    )
+    uczelnia = Uczelnia.objects.create(
+        nazwa=f"Uczelnia {skrot}", skrot=skrot, site=site
+    )
+    wydzial = Wydzial.objects.create(
+        uczelnia=uczelnia, skrot=f"W-{skrot}", nazwa=f"Wydział {skrot}"
+    )
+    wezel, _ = znajdz_lub_utworz_wezel_wydzialu(wydzial)
+    return Jednostka.objects.create(
+        uczelnia=uczelnia,
+        parent=wezel,
+        skrot=f"J-{skrot}",
+        nazwa=f"Jednostka {skrot}",
+    )
+
+
+@pytest.fixture
+def jednostka_obca(db, uczelnia):
+    """Jednostka DRUGIEJ uczelni — włącza zawężanie (>1 uczelnia)."""
+    return _jednostka_obcej_uczelni("OBC")
+
+
+def _post_fetch(client, **extra):
+    """POST na ``FetchView`` z zamockowanym providerem i taskiem Celery."""
+    dane = {"provider": "CrossRef", "identifier": "10.1234/x"}
+    dane.update(extra)
+
+    with (
+        patch("importer_publikacji.views.wizard.fetch_session_task") as mock_task,
+        patch("importer_publikacji.views.wizard.get_provider") as mock_provider,
+    ):
+        from importer_publikacji.providers import InputMode
+
+        mock_provider.return_value.input_mode = InputMode.IDENTIFIER
+        mock_provider.return_value.validate_identifier.return_value = "10.1234/x"
+        mock_task.delay.return_value.id = "task-uuid"
+
+        return client.post(reverse("importer_publikacji:fetch"), dane)
+
+
+def _uruchom_create_task(session, rekord=None):
+    rekord = rekord or _rekord()
+    with patch("importer_publikacji.tasks._create_publication") as mock_create:
+        mock_create.return_value = rekord
+        create_publication_task.apply(
+            args=[session.pk, session.created_by_id, False]
+        ).get()
+    return rekord
+
+
+def _fake_fetch_result(doi=DOI):
+    """Minimalny wynik dostawcy — komplet atrybutów czytanych przez task."""
+    return MagicMock(
+        raw_data={"k": "v"},
+        title=TYTUL,
+        doi=doi,
+        year=2024,
+        authors=[],
+        source_title="",
+        source_abbreviation="",
+        issn="",
+        e_issn="",
+        isbn="",
+        e_isbn="",
+        publisher="",
+        publication_type="article",
+        language="en",
+        abstract="",
+        volume="",
+        issue="",
+        pages="",
+        url="",
+        license_url="",
+        keywords=[],
+        extra={},
+        patent_number=None,
+        patent_grant_number=None,
+        filing_date=None,
+        grant_date=None,
+        patent_type=None,
+        patent_holder=None,
+        jurisdiction=None,
+    )
+
+
+# ==========================================================================
+# A. Dopasowanie po DOI wyłuskanym ze ``strona_www``
+# ==========================================================================
+
+
+@pytest.mark.django_db
+def test_kandydat_gdy_doi_jest_wylacznie_w_strona_www(importer_user):
+    """NAJWAŻNIEJSZY test grupy A: pole ``doi`` puste, DOI w ``strona_www``.
+
+    Produkcyjnie to JEDYNY osiągalny kształt zgłoszenia — publiczny
+    formularz nie ma pola ``doi``, a help-text każe wkleić DOI właśnie do
+    ``strona_www``. Dopóki match szedł po ``doi__iexact``, ścieżki B i C
+    były martwym kodem.
+    """
+    session = _sesja(importer_user)
+    zgl = _zgl(strona_www=f"https://dx.doi.org/{DOI}")
+
+    assert zgl.doi is None
+    assert list(kandydaci_dla_sesji(session)) == [zgl]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "strona_www",
+    [
+        f"https://doi.org/{DOI}",
+        f"https://dx.doi.org/{DOI}",
+        f"http://dx.doi.org/{DOI}",
+        f"http://doi.org/{DOI}",
+        f"https://doi.org/{DOI}?utm_source=newsletter&rel=cite-as",
+        f"https://wydawca.example.com/artykuly/{DOI}",
+        f"https://doi.org/{DOI.upper()}",
+    ],
+)
+def test_kandydat_dla_roznych_form_zapisu_doi_w_strona_www(importer_user, strona_www):
+    session = _sesja(importer_user)
+    zgl = _zgl(strona_www=strona_www)
+
+    assert list(kandydaci_dla_sesji(session)) == [zgl], strona_www
+
+
+@pytest.mark.django_db
+def test_doi_bedace_prefiksem_innego_nie_daje_trafienia(importer_user):
+    """Prefiltr SQL to ``icontains`` — precyzję daje dopiero Python.
+
+    Zgłoszenie o DOI ``10.1234/x.suffix`` przechodzi przez ``LIKE
+    '%10.1234/x%'``, więc bez dokładnego porównania w Pythonie stałoby się
+    kandydatem sesji o DOI ``10.1234/x`` i zostałoby cicho oznaczone jako
+    zaimportowane.
+    """
+    session = _sesja(importer_user)
+    dluzsze = _zgl(strona_www=f"https://doi.org/{DOI}.suffix")
+
+    # Kontrola negatywna prefiltru: SQL SAM w sobie by to wpuścił.
+    assert Zgloszenie_Publikacji.objects.filter(strona_www__icontains=DOI).exists()
+
+    assert list(kandydaci_dla_sesji(session)) == []
+    assert zwiaz_automatycznie(session) is False
+
+    session.refresh_from_db()
+    assert session.zgloszenie_id is None
+    dluzsze.refresh_from_db()
+    assert dluzsze.status == STATUSY.NOWY
+
+
+@pytest.mark.django_db
+def test_doi_sesji_bedace_dluzsze_od_zgloszenia_nie_daje_trafienia(importer_user):
+    """Symetrycznie: DOI sesji dłuższe niż DOI zgłoszenia też nie pasuje."""
+    session = _sesja(importer_user, doi=f"{DOI}.suffix")
+    _zgl(strona_www=f"https://doi.org/{DOI}")
+
+    assert list(kandydaci_dla_sesji(session)) == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "strona_www",
+    [
+        "https://example.com/papers/123",
+        "https://repozytorium.example.com/handle/11089/12345",
+        "",
+    ],
+)
+def test_strona_www_niebedaca_doi_nie_daje_trafienia(importer_user, strona_www):
+    session = _sesja(importer_user)
+    _zgl(strona_www=strona_www)
+
+    assert list(kandydaci_dla_sesji(session)) == []
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "wartosc_pola_doi",
+    [
+        DOI,
+        DOI.upper(),
+        f"https://doi.org/{DOI}",
+        f"http://dx.doi.org/{DOI}",
+        f"  {DOI}  ",
+    ],
+)
+def test_doi_w_polu_doi_takze_trafia(importer_user, wartosc_pola_doi):
+    """Ścieżka historyczna (dane wgrane skryptem/migracją) nadal działa."""
+    session = _sesja(importer_user)
+    zgl = _zgl(doi=wartosc_pola_doi)
+
+    assert list(kandydaci_dla_sesji(session)) == [zgl], wartosc_pola_doi
+
+
+@pytest.mark.django_db
+def test_auto_wiazanie_na_zgloszeniu_z_doi_tylko_w_strona_www(importer_user):
+    """Ścieżka B end-to-end na produkcyjnym kształcie zgłoszenia."""
+    session = _sesja(importer_user)
+    zgl = _zgl(strona_www=f"https://dx.doi.org/{DOI}")
+
+    assert zwiaz_automatycznie(session) is True
+
+    session.refresh_from_db()
+    assert session.zgloszenie_id == zgl.pk
+
+
+@pytest.mark.django_db
+def test_zgloszenie_z_publicznego_formularza_jest_kandydatem(importer_user, uczelnia):
+    """Zgłoszenie utworzone REALNĄ ścieżką (publiczny formularz), nie bakerem.
+
+    Formularz kroku „dane o publikacji" w ogóle nie ma pola ``doi`` — DOI
+    zgłaszający wkleja do ``strona_www``. Ten test pilnuje, żeby suita nie
+    zieleniła się wyłącznie na stanie nieosiągalnym produkcyjnie.
+    """
+    from zglos_publikacje.forms import Zgloszenie_Publikacji_DaneForm
+
+    form = Zgloszenie_Publikacji_DaneForm(
+        data={
+            "tytul_oryginalny": TYTUL,
+            "rok": 2024,
+            "email": "zglaszajacy@example.com",
+            "strona_www": f"https://dx.doi.org/{DOI}",
+            "zgoda_na_publikacje_pelnego_tekstu": "True",
+        },
+        rodzaj="ARTYKUL",
+        forma_dostepu="OTWARTY",
+        uczelnia=uczelnia,
+    )
+
+    assert "doi" not in form.fields, "publiczny formularz nie ma pola DOI"
+    assert form.is_valid(), form.errors
+
+    # Tak samo jak ``Zgloszenie_PublikacjiWizard.done()``: rodzaj i status
+    # dokłada widok, reszta idzie z formularza.
+    zgl = form.save(commit=False)
+    zgl.status = STATUSY.NOWY
+    zgl.rodzaj_zglaszanej_publikacji = 1
+    zgl.save()
+
+    z_bazy = Zgloszenie_Publikacji.objects.get(pk=zgl.pk)
+    assert z_bazy.doi is None, "produkcyjnie kolumna DOI zostaje pusta"
+    assert DOI in z_bazy.strona_www
+
+    session = _sesja(importer_user, uczelnia=uczelnia)
+    assert list(kandydaci_dla_sesji(session)) == [z_bazy]
+
+
+# ==========================================================================
+# B. Ścieżka jawna (``?zgloszenie=``) przechodzi przez pełną walidację
+# ==========================================================================
+
+
+@pytest.mark.django_db
+def test_fetch_jawne_zgloszenie_obcej_uczelni_bez_wiazania(
+    importer_client, uczelnia, jednostka_obca
+):
+    """Dziura bezpieczeństwa: ukryte pole to input pod kontrolą klienta."""
+    obce = _zgl(strona_www=f"https://doi.org/{DOI}")
+    _zpa(obce, jednostka=jednostka_obca)
+
+    response = _post_fetch(importer_client, zgloszenie=obce.pk)
+
+    assert response.status_code == 302
+    session = ImportSession.objects.get()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_fetch_jawne_zgloszenie_wlasnej_uczelni_wiaze(
+    importer_client, uczelnia, jednostka, jednostka_obca
+):
+    """Kontrola pozytywna: przy dwóch uczelniach SWOJE zgłoszenie przechodzi."""
+    moje = _zgl(strona_www=f"https://doi.org/{DOI}")
+    _zpa(moje, jednostka=jednostka)
+
+    response = _post_fetch(importer_client, zgloszenie=moje.pk)
+
+    assert response.status_code == 302
+    session = ImportSession.objects.get()
+    assert session.zgloszenie_id == moje.pk
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status",
+    [
+        STATUSY.SPAM,
+        STATUSY.ODRZUCONO,
+        STATUSY.WYMAGA_ZMIAN,
+        STATUSY.ZAAKCEPTOWANY,
+        STATUSY.ZAIMPORTOWANY,
+    ],
+)
+def test_fetch_jawne_zgloszenie_w_wykluczonym_statusie_bez_wiazania(
+    importer_client, status
+):
+    """D9 obowiązuje także ścieżkę jawną — i to bez błędu dla operatora."""
+    zgl = _zgl(strona_www=f"https://doi.org/{DOI}", status=status)
+
+    response = _post_fetch(importer_client, zgloszenie=zgl.pk)
+
+    assert response.status_code == 302, status
+    session = ImportSession.objects.get()
+    assert session.zgloszenie_id is None, status
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("status", [STATUSY.NOWY, STATUSY.PO_ZMIANACH])
+def test_fetch_jawne_zgloszenie_w_dozwolonym_statusie_wiaze(importer_client, status):
+    """Kontrola pozytywna do testu wykluczeń — te statusy przechodzą."""
+    zgl = _zgl(strona_www=f"https://doi.org/{DOI}", status=status)
+
+    _post_fetch(importer_client, zgloszenie=zgl.pk)
+
+    session = ImportSession.objects.get()
+    assert session.zgloszenie_id == zgl.pk, status
+
+
+@pytest.mark.django_db
+def test_fetch_jawne_zgloszenie_soft_usuniete_bez_wiazania(importer_client):
+    zgl = _zgl(strona_www=f"https://doi.org/{DOI}")
+    Zgloszenie_Publikacji.global_objects.filter(pk=zgl.pk).update(
+        deleted_at=timezone.now()
+    )
+
+    response = _post_fetch(importer_client, zgloszenie=zgl.pk)
+
+    assert response.status_code == 302
+    session = ImportSession.objects.get()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_sciezka_jawna_do_zapisu_zwrotnego_wykluczony_status_nic_nie_oznacza(
+    importer_client,
+):
+    """End-to-end ścieżki jawnej: co REALNIE zostało oznaczone po imporcie.
+
+    Poprzednia suita sprawdzała wyłącznie, że FK się ustawia — dlatego
+    dziura przeszła. Tu jedziemy aż do rekordu w bazie zgłoszenia.
+    """
+    zgl = _zgl(strona_www=f"https://doi.org/{DOI}", status=STATUSY.WYMAGA_ZMIAN)
+
+    _post_fetch(importer_client, zgloszenie=zgl.pk)
+    session = ImportSession.objects.get()
+    assert session.zgloszenie_id is None
+
+    _uruchom_create_task(session)
+
+    session.refresh_from_db()
+    assert session.status == ImportSession.Status.COMPLETED
+
+    zgl.refresh_from_db()
+    assert zgl.status == STATUSY.WYMAGA_ZMIAN
+    assert zgl.zaimportowano is None
+    assert zgl.zaimportowal_id is None
+    assert zgl.object_id is None
+
+
+@pytest.mark.django_db
+def test_sciezka_jawna_do_zapisu_zwrotnego_oznacza_dozwolone_zgloszenie(
+    importer_client, importer_user
+):
+    """Kontrola pozytywna end-to-end: cała pętla domyka się w bazie."""
+    zgl = _zgl(strona_www=f"https://doi.org/{DOI}")
+
+    _post_fetch(importer_client, zgloszenie=zgl.pk)
+    session = ImportSession.objects.get()
+
+    rekord = _uruchom_create_task(session)
+
+    zgl.refresh_from_db()
+    assert zgl.status == STATUSY.ZAIMPORTOWANY
+    assert zgl.object_id == rekord.pk
+    assert zgl.content_type == ContentType.objects.get_for_model(rekord)
+    assert zgl.zaimportowal_id == importer_user.pk
+    assert zgl.kod_do_edycji is None
+
+
+# --------------------------------------------------------------------------
+# zgloszenie_dozwolone — jednostkowo
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_zgloszenie_dozwolone_przyjmuje_instancje_i_pk_uczelni(uczelnia, jednostka):
+    """Wołający mają raz instancję ``Uczelnia``, raz samo ``uczelnia_id``."""
+    _jednostka_obcej_uczelni("DWA")  # >1 uczelnia → zawężanie aktywne
+    zgl = _zgl()
+    _zpa(zgl, jednostka=jednostka)
+
+    assert zgloszenie_dozwolone(zgl.pk, uczelnia) == zgl
+    assert zgloszenie_dozwolone(zgl.pk, uczelnia.pk) == zgl
+
+
+@pytest.mark.django_db
+def test_zgloszenie_dozwolone_bez_uczelni_nie_zaweza(uczelnia, jednostka_obca):
+    """``uczelnia=None`` (brak mapowania Site→Uczelnia) → filtr jest no-opem."""
+    obce = _zgl()
+    _zpa(obce, jednostka=jednostka_obca)
+
+    assert zgloszenie_dozwolone(obce.pk, None) == obce
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "pk",
+    [None, "", 0, "abc", "12abc", [], {}, 10**30, -1, 3.5],
+)
+def test_zgloszenie_dozwolone_smieciowe_pk_nigdy_nie_rzuca(db, pk):
+    """Wiązanie jest opcjonalne — nie może wywrócić requestu."""
+    assert zgloszenie_dozwolone(pk, None) is None
+
+
+# ==========================================================================
+# C. Zapis zwrotny rewaliduje status W CHWILI ZAPISU
+# ==========================================================================
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status_w_miedzyczasie",
+    [
+        STATUSY.WYMAGA_ZMIAN,
+        STATUSY.ZAAKCEPTOWANY,
+        STATUSY.ODRZUCONO,
+        STATUSY.SPAM,
+    ],
+)
+def test_zapis_zwrotny_nie_oznacza_gdy_status_zmienil_sie_w_miedzyczasie(
+    importer_user, status_w_miedzyczasie
+):
+    """Między związaniem (fetch) a zapisem (create) mija praca operatora.
+
+    Wczytana instancja ``session.zgloszenie`` niesie stan sprzed tego czasu
+    — warunek musi siedzieć w ``WHERE``, nie w Pythonie.
+    """
+    zgl = _zgl(status=STATUSY.NOWY)
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    # Operator (albo inny wątek) zmienia status już po związaniu.
+    Zgloszenie_Publikacji.objects.filter(pk=zgl.pk).update(status=status_w_miedzyczasie)
+
+    assert oznacz_jako_zaimportowane(session, _rekord()) is False
+
+    zgl.refresh_from_db()
+    assert zgl.status == status_w_miedzyczasie
+    assert zgl.zaimportowano is None
+    assert zgl.zaimportowal_id is None
+    assert zgl.object_id is None
+
+
+@pytest.mark.django_db
+def test_zapis_zwrotny_kasuje_kod_do_edycji(importer_user):
+    """Żywy kod na ZAIMPORTOWANYM zgłoszeniu = prosta droga do duplikatu.
+
+    Widok edycji autoryzuje autora SAMYM kodem (nie patrzy na status), więc
+    autor mógłby cofnąć zgłoszenie do PO_ZMIANACH i znów zobaczyć przycisk
+    „Użyj importera" mimo istniejącego już rekordu.
+    """
+    kod = uuid.uuid4()
+    zgl = _zgl(kod_do_edycji=kod)
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    assert oznacz_jako_zaimportowane(session, _rekord()) is True
+
+    zgl.refresh_from_db()
+    assert zgl.status == STATUSY.ZAIMPORTOWANY
+    assert zgl.kod_do_edycji is None
+    assert not Zgloszenie_Publikacji.objects.filter(kod_do_edycji=kod).exists()
+
+
+@pytest.mark.django_db
+def test_zapis_zwrotny_kasuje_kod_do_edycji_przez_task(importer_user):
+    """To samo, ale całą ścieżką zadania — kod nie może przeżyć importu."""
+    zgl = _zgl(kod_do_edycji=uuid.uuid4())
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    _uruchom_create_task(session)
+
+    zgl.refresh_from_db()
+    assert zgl.kod_do_edycji is None
+
+
+@pytest.mark.django_db
+def test_wiele_zgloszen_bez_kodu_do_edycji_wspolistnieje(importer_user):
+    """``kod_do_edycji`` jest ``unique``, ale ``null=True`` — NULL-e nie kolidują."""
+    for _ in range(3):
+        zgl = _zgl(kod_do_edycji=uuid.uuid4())
+        session = _sesja(importer_user, zgloszenie=zgl)
+        assert oznacz_jako_zaimportowane(session, _rekord()) is True
+
+    assert Zgloszenie_Publikacji.objects.filter(kod_do_edycji__isnull=True).count() == 3
+
+
+@pytest.mark.django_db
+def test_zapis_zwrotny_przy_zero_zaktualizowanych_wierszy_loguje(importer_user, caplog):
+    """Warunkowy UPDATE zwrócił 0 → ``False`` + wpis w logu z powodem."""
+    zgl = _zgl(status=STATUSY.NOWY)
+    session = _sesja(importer_user, zgloszenie=zgl)
+    Zgloszenie_Publikacji.objects.filter(pk=zgl.pk).update(status=STATUSY.SPAM)
+
+    with caplog.at_level(logging.INFO, logger="importer_publikacji.zgloszenia"):
+        assert oznacz_jako_zaimportowane(session, _rekord()) is False
+
+    komunikaty = [r.getMessage() for r in caplog.records]
+    assert any("nie kwalifikuje się" in m and str(zgl.pk) in m for m in komunikaty), (
+        komunikaty
+    )
+    # Powód (status w chwili zapisu) MUSI być w logu — inaczej trzeba zgadywać.
+    assert any(str(int(STATUSY.SPAM)) in m for m in komunikaty), komunikaty
+
+
+# ==========================================================================
+# D. Lost update + ``modified`` w ``update_fields``
+# ==========================================================================
+
+
+@pytest.mark.django_db
+def test_task_fetch_nie_kasuje_wiazania_dopisanego_w_locie(importer_user):
+    """Regresja lost update.
+
+    Sesja jest in-flight (FETCHING), więc task trzyma własną, starszą
+    instancję wiersza. W trakcie jego pracy widok (gałąź idempotency
+    ``FetchView``) dopisuje ``zgloszenie`` warunkowym UPDATE-em. Pełne
+    ``session.save()`` taska wpisywało z powrotem ``zgloszenie_id = NULL``.
+    """
+    session = _sesja(importer_user, doi=DOI, status=ImportSession.Status.FETCHING)
+    # DOI zgłoszenia ≠ DOI sesji — auto-match po DOI go NIE odtworzy, więc
+    # jedynym powodem, dla którego FK może przeżyć, jest brak nadpisania.
+    zgl = _zgl(strona_www="https://doi.org/10.9999/inne")
+
+    def _fetch_i_rownolegly_zapis_widoku(identifier):
+        # Dokładnie to, co robi FetchView w gałęzi idempotency.
+        ImportSession.objects.filter(pk=session.pk, zgloszenie__isnull=True).update(
+            zgloszenie=zgl
+        )
+        return _fake_fetch_result()
+
+    with patch("importer_publikacji.tasks.get_provider") as mock_get_provider:
+        provider = MagicMock()
+        provider.fetch.side_effect = _fetch_i_rownolegly_zapis_widoku
+        mock_get_provider.return_value = provider
+
+        fetch_session_task.apply(args=[session.pk, session.created_by_id]).get()
+
+    session.refresh_from_db()
+    assert session.status == ImportSession.Status.FETCHED
+    assert session.zgloszenie_id == zgl.pk, "wiązanie skasowane przez zapis taska"
+
+
+@pytest.mark.django_db
+def test_task_fetch_nie_przestemplowuje_jawnego_wiazania_auto_matchem(importer_user):
+    """Jawny wybór dopisany w locie bije auto-wiązanie po DOI (ścieżka A > B)."""
+    session = _sesja(importer_user, doi=DOI, status=ImportSession.Status.FETCHING)
+    jawne = _zgl(strona_www="https://doi.org/10.9999/jawne")
+    po_doi = _zgl(strona_www=f"https://doi.org/{DOI}", tytul="Kandydat po DOI")
+
+    def _fetch(identifier):
+        ImportSession.objects.filter(pk=session.pk, zgloszenie__isnull=True).update(
+            zgloszenie=jawne
+        )
+        return _fake_fetch_result()
+
+    with patch("importer_publikacji.tasks.get_provider") as mock_get_provider:
+        provider = MagicMock()
+        provider.fetch.side_effect = _fetch
+        mock_get_provider.return_value = provider
+
+        fetch_session_task.apply(args=[session.pk, session.created_by_id]).get()
+
+    session.refresh_from_db()
+    assert session.zgloszenie_id == jawne.pk
+    po_doi.refresh_from_db()
+    assert po_doi.status == STATUSY.NOWY
+
+
+@pytest.mark.django_db
+def test_task_fetch_przesuwa_modified(importer_user):
+    """``update_fields`` MUSI zawierać ``modified``.
+
+    ``auto_now`` odpala się WYŁĄCZNIE dla pól wymienionych w
+    ``update_fields`` — bez tego ``modified`` zamarza i ``is_stalled()``
+    uznaje żywą sesję za martwą (watchdog ubija działający import).
+    """
+    session = _sesja(importer_user, doi=DOI, status=ImportSession.Status.FETCHING)
+    stara_data = timezone.now() - datetime.timedelta(hours=1)
+    ImportSession.objects.filter(pk=session.pk).update(modified=stara_data)
+
+    # Stan wyjściowy: watchdog uznałby tę sesję za martwą.
+    assert ImportSession.objects.get(pk=session.pk).is_stalled() is True
+
+    with patch("importer_publikacji.tasks.get_provider") as mock_get_provider:
+        provider = MagicMock()
+        provider.fetch.return_value = _fake_fetch_result()
+        mock_get_provider.return_value = provider
+
+        fetch_session_task.apply(args=[session.pk, session.created_by_id]).get()
+
+    session.refresh_from_db()
+    assert session.modified > stara_data
+
+    # Gdyby ``modified`` zamarzło, sesja nadal in-flight (kolejny etap
+    # przetwarzania) zostałaby ubita przez watchdog jako zawieszona.
+    session.status = ImportSession.Status.FETCHING
+    assert session.is_stalled() is False
+
+
+@pytest.mark.django_db
+def test_task_fetch_bledny_przesuwa_modified(importer_user):
+    """Gałąź ``except`` też zapisuje ``modified`` (``_POLA_BLEDU``)."""
+    session = _sesja(importer_user, doi=DOI, status=ImportSession.Status.FETCHING)
+    stara_data = timezone.now() - datetime.timedelta(hours=1)
+    ImportSession.objects.filter(pk=session.pk).update(modified=stara_data)
+
+    with patch("importer_publikacji.tasks.get_provider") as mock_get_provider:
+        provider = MagicMock()
+        provider.fetch.side_effect = RuntimeError("boom")
+        mock_get_provider.return_value = provider
+
+        with pytest.raises(RuntimeError, match="boom"):
+            fetch_session_task.apply(args=[session.pk, session.created_by_id]).get()
+
+    session.refresh_from_db()
+    assert session.status == ImportSession.Status.IMPORT_FAILED
+    assert session.modified > stara_data
+
+
+@pytest.mark.django_db
+def test_task_create_przesuwa_modified(importer_user):
+    session = _sesja(importer_user, status=ImportSession.Status.CREATING)
+    stara_data = timezone.now() - datetime.timedelta(hours=1)
+    ImportSession.objects.filter(pk=session.pk).update(modified=stara_data)
+
+    _uruchom_create_task(session)
+
+    session.refresh_from_db()
+    assert session.status == ImportSession.Status.COMPLETED
+    assert session.modified > stara_data
+
+
+@pytest.mark.django_db
+def test_task_create_nie_kasuje_odpiecia_zrobionego_w_locie(importer_user):
+    """Operator odpiął zgłoszenie w trakcie tworzenia rekordu — jego decyzja
+    jest nowsza niż stan wczytany na starcie zadania."""
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    def _create(sess):
+        ImportSession.objects.filter(pk=sess.pk).update(zgloszenie=None)
+        return _rekord()
+
+    with patch("importer_publikacji.tasks._create_publication") as mock_create:
+        mock_create.side_effect = _create
+        create_publication_task.apply(
+            args=[session.pk, session.created_by_id, False]
+        ).get()
+
+    session.refresh_from_db()
+    assert session.status == ImportSession.Status.COMPLETED
+    zgl.refresh_from_db()
+    assert zgl.status == STATUSY.NOWY
+    assert zgl.zaimportowano is None
+
+
+# ==========================================================================
+# E. Wyjątek w zapisie zwrotnym nie wywraca importu
+# ==========================================================================
+
+
+@pytest.mark.django_db
+def test_wyjatek_w_zapisie_zwrotnym_zostawia_sesje_completed(importer_user):
+    """Inaczej operator klika „Ponów" i powstaje DRUGI rekord tej pracy."""
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+    rekord = _rekord()
+
+    with (
+        patch("importer_publikacji.tasks._create_publication") as mock_create,
+        patch(
+            "importer_publikacji.zgloszenia.oznacz_jako_zaimportowane"
+        ) as mock_oznacz,
+        patch("importer_publikacji.tasks.rollbar") as mock_rollbar,
+    ):
+        mock_create.return_value = rekord
+        mock_oznacz.side_effect = RuntimeError("zapis zwrotny wybuchł")
+
+        # Bez ``pytest.raises``: wyjątek NIE może wypłynąć z zadania.
+        create_publication_task.apply(
+            args=[session.pk, session.created_by_id, False]
+        ).get()
+
+        assert mock_rollbar.report_exc_info.called
+
+    session.refresh_from_db()
+    assert session.status == ImportSession.Status.COMPLETED
+    assert session.created_record_id == rekord.pk
+    assert session.last_failed_stage == ""
+
+    # Rekord publikacji istnieje, zgłoszenie zostaje do ręcznego domknięcia.
+    assert Wydawnictwo_Ciagle.objects.filter(pk=rekord.pk).exists()
+    zgl.refresh_from_db()
+    assert zgl.status == STATUSY.NOWY
+
+
+@pytest.mark.django_db
+def test_wyjatek_w_zapisie_zwrotnym_loguje_traceback(importer_user, caplog):
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    with (
+        patch("importer_publikacji.tasks._create_publication") as mock_create,
+        patch(
+            "importer_publikacji.zgloszenia.oznacz_jako_zaimportowane"
+        ) as mock_oznacz,
+        patch("importer_publikacji.tasks.rollbar"),
+        caplog.at_level(logging.ERROR, logger="importer_publikacji.tasks"),
+    ):
+        mock_create.return_value = _rekord()
+        mock_oznacz.side_effect = RuntimeError("zapis zwrotny wybuchł")
+
+        create_publication_task.apply(
+            args=[session.pk, session.created_by_id, False]
+        ).get()
+
+    wpisy = [r for r in caplog.records if "ręcznego domknięcia" in r.getMessage()]
+    assert wpisy, [r.getMessage() for r in caplog.records]
+    # ``logger.exception`` — bez tracebacku nie da się dojść, co wybuchło.
+    assert wpisy[0].exc_info is not None
+    assert "zapis zwrotny wybuchł" in (wpisy[0].exc_text or "")
+
+
+# ==========================================================================
+# F. Zawężenie do uczelni — udokumentowane ograniczenia (charakteryzacja)
+# ==========================================================================
+
+
+@pytest.mark.django_db
+def test_zgloszenie_wspolautorskie_jest_kandydatem_dla_obu_uczelni(
+    importer_user, uczelnia1, uczelnia2, jednostka_uczelnia1, jednostka_uczelnia2
+):
+    """ŚWIADOMY przeciek D8: JOIN po autorach daje semantykę OR.
+
+    Test charakteryzujący — praca współautorska naprawdę „należy" do obu
+    uczelni, a wariant restrykcyjny („wszyscy autorzy z jednej") ukrywałby
+    ją przed obiema. Gdyby ktoś to zmienił, ten test ma zapalić się na
+    czerwono, żeby zmiana była decyzją, a nie efektem ubocznym.
+    """
+    zgl = _zgl(strona_www=f"https://doi.org/{DOI}")
+    _zpa(zgl, jednostka=jednostka_uczelnia1)
+    _zpa(zgl, jednostka=jednostka_uczelnia2)
+
+    sesja_1 = _sesja(importer_user, uczelnia=uczelnia1)
+    sesja_2 = _sesja(importer_user, uczelnia=uczelnia2)
+
+    assert list(kandydaci_dla_sesji(sesja_1)) == [zgl]
+    assert list(kandydaci_dla_sesji(sesja_2)) == [zgl]
+
+
+@pytest.mark.django_db
+def test_zgloszenie_bez_autorow_wypada_w_instalacji_wielouczelnianej(
+    importer_user, uczelnia1, uczelnia2
+):
+    """ŚWIADOME fail-closed: bez autorów nie da się przypisać do uczelni.
+
+    Lepiej nie pokazać nikomu niż pokazać wszystkim — operator dojdzie do
+    zgłoszenia przez moduł redagowania i zwiąże je jawnie.
+    """
+    _zgl(strona_www=f"https://doi.org/{DOI}")
+    session = _sesja(importer_user, uczelnia=uczelnia1)
+
+    assert list(kandydaci_dla_sesji(session)) == []
+
+
+@pytest.mark.django_db
+def test_zgloszenie_bez_autorow_widoczne_w_instalacji_jednouczelnianej(
+    importer_user, uczelnia
+):
+    """Kontrola pozytywna: przy jednej uczelni filtr jest no-opem."""
+    zgl = _zgl(strona_www=f"https://doi.org/{DOI}")
+    session = _sesja(importer_user, uczelnia=uczelnia)
+
+    assert list(kandydaci_dla_sesji(session)) == [zgl]
+
+
+# ==========================================================================
+# G. Renderowanie — baner kandydatów i strona „Gotowe"
+# ==========================================================================
+
+
+def _url_verify(session):
+    return reverse("importer_publikacji:verify", kwargs={"session_id": session.pk})
+
+
+@pytest.mark.django_db
+def test_baner_wersja_rozstrzygajaca_przy_dwoch_kandydatach(
+    importer_client, importer_user
+):
+    session = _sesja(importer_user, status=ImportSession.Status.FETCHED)
+    a = _zgl(strona_www=f"https://doi.org/{DOI}", tytul="Pierwszy kandydat")
+    b = _zgl(strona_www=f"https://doi.org/{DOI}", tytul="Drugi kandydat")
+
+    response = importer_client.get(_url_verify(session))
+    html = response.content.decode()
+
+    assert response.status_code == 200
+    assert 'id="baner-zgloszenia"' in html
+    assert f"#{a.pk}" in html
+    assert f"#{b.pk}" in html
+    assert "Które z nich domknąć tym importem?" in html
+    assert "Żadne z nich" in html
+
+
+@pytest.mark.django_db
+def test_baner_wersja_potwierdzajaca_dla_sesji_zwiazanej(
+    importer_client, importer_user
+):
+    zgl = _zgl(strona_www=f"https://doi.org/{DOI}")
+    session = _sesja(importer_user, status=ImportSession.Status.FETCHED, zgloszenie=zgl)
+
+    response = importer_client.get(_url_verify(session))
+    html = response.content.decode()
+
+    assert 'id="baner-zgloszenia"' in html
+    assert "Ten import domknie zgłoszenie publikacji" in html
+    assert f"#{zgl.pk}" in html
+    assert "Odepnij" in html
+    # Wersja potwierdzająca NIE pyta o wybór.
+    assert "Które z nich domknąć tym importem?" not in html
+
+
+@pytest.mark.django_db
+def test_baner_wyciszony_po_zadne_z_nich(importer_client, importer_user):
+    session = _sesja(
+        importer_user,
+        status=ImportSession.Status.FETCHED,
+        zgloszenie_odrzucone_przez_operatora=True,
+    )
+    _zgl(strona_www=f"https://doi.org/{DOI}")
+    _zgl(strona_www=f"https://doi.org/{DOI}", tytul="Drugi kandydat")
+
+    response = importer_client.get(_url_verify(session))
+    html = response.content.decode()
+
+    assert response.status_code == 200
+    assert 'id="baner-zgloszenia"' not in html
+
+
+@pytest.mark.django_db
+def test_baner_nie_pokazuje_emaila_zglaszajacego(importer_client, importer_user):
+    """Regresja przecieku przez granicę uczelni.
+
+    Zgłoszenie współautorskie jest kandydatem dla OBU uczelni, więc e-mail
+    zgłaszającego zobaczyłby operator obcej uczelni. Numer, autor, tytuł
+    i rok wystarczą do rozpoznania kandydata.
+    """
+    email = "prywatny.adres@example.com"
+    session = _sesja(importer_user, status=ImportSession.Status.FETCHED)
+    _zgl(strona_www=f"https://doi.org/{DOI}", email=email)
+    _zgl(
+        strona_www=f"https://doi.org/{DOI}",
+        email="drugi.adres@example.com",
+        tytul="Drugi kandydat",
+    )
+
+    response = importer_client.get(_url_verify(session))
+    html = response.content.decode()
+
+    assert 'id="baner-zgloszenia"' in html, "baner musi się wyrenderować"
+    assert email not in html
+    assert "drugi.adres@example.com" not in html
+
+
+@pytest.mark.django_db
+def test_done_callout_o_domknieciu_dokladnie_raz(importer_client, importer_user):
+    """Wcześniej komunikat szedł 3× (flash × 2 ramki + callout).
+
+    Flash został usunięty; callout jest wyliczany z bazy przy każdym GET,
+    więc nie znika też po F5.
+    """
+    rekord = _rekord()
+    zgl = _zgl(
+        status=STATUSY.ZAIMPORTOWANY,
+        zaimportowano=timezone.now(),
+        zaimportowal=importer_user,
+        content_type=ContentType.objects.get_for_model(rekord),
+        object_id=rekord.pk,
+    )
+    session = _sesja(
+        importer_user,
+        status=ImportSession.Status.COMPLETED,
+        zgloszenie=zgl,
+        created_record_content_type=ContentType.objects.get_for_model(rekord),
+        created_record_id=rekord.pk,
+    )
+    url = reverse("importer_publikacji:done", kwargs={"session_id": session.pk})
+
+    response = importer_client.get(url)
+    html = response.content.decode()
+
+    assert response.status_code == 200
+    assert html.count("omknięto zgłoszenie publikacji") == 1
+
+    # Idempotencja: F5 nie gasi calloutu (flash by zniknął).
+    html_po_odswiezeniu = importer_client.get(url).content.decode()
+    assert html_po_odswiezeniu.count("omknięto zgłoszenie publikacji") == 1
+
+
+@pytest.mark.django_db
+def test_done_bez_domknietego_zgloszenia_bez_calloutu(importer_client, importer_user):
+    """Kontrola negatywna: sesja związana, ale zgłoszenie NIE oznaczone."""
+    rekord = _rekord()
+    zgl = _zgl(status=STATUSY.NOWY)
+    session = _sesja(
+        importer_user,
+        status=ImportSession.Status.COMPLETED,
+        zgloszenie=zgl,
+        created_record_content_type=ContentType.objects.get_for_model(rekord),
+        created_record_id=rekord.pk,
+    )
+
+    response = importer_client.get(
+        reverse("importer_publikacji:done", kwargs={"session_id": session.pk})
+    )
+
+    assert response.status_code == 200
+    assert "omknięto zgłoszenie publikacji" not in response.content.decode()

--- a/src/importer_publikacji/tests/test_fd443_wiazanie.py
+++ b/src/importer_publikacji/tests/test_fd443_wiazanie.py
@@ -1,0 +1,643 @@
+"""FD#443 — wiązanie sesji importu ze zgłoszeniem publikacji.
+
+Pokrywa trzy ścieżki wiązania ze specu
+``docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-\
+importer-design.md``:
+
+* **A** — jawna, z przycisku „Użyj importera" (``?zgloszenie=<pk>``
+  przeżywa rundę GET → render → POST),
+* **B** — automatyczna po DOI, gdy kandydat jest dokładnie jeden,
+* **C** — wybór operatora, gdy kandydatów jest ≥2 (plus regresja IDOR).
+
+Plus reguły doboru kandydatów (``kandydaci_dla_sesji``) i wpływ wiązania
+na prefill dyscyplin.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.sites.models import Site
+from django.urls import reverse
+from model_bakery import baker
+
+from importer_publikacji.models import ImportedAuthor, ImportSession
+from importer_publikacji.views.authors import (
+    _prefill_dyscypliny_z_zgloszen,
+    _zgloszenie_dla_prefilla,
+)
+from importer_publikacji.zgloszenia import kandydaci_dla_sesji, zwiaz_automatycznie
+
+DOI = "10.1234/fd443.test"
+INNE_DOI = "10.9999/fd443.inne"
+TYTUL = "Wpływ czegoś na coś innego w badaniach modelowych"
+
+
+# --------------------------------------------------------------------------
+# Pomocnicze
+# --------------------------------------------------------------------------
+
+
+def _zgl(doi=DOI, tytul=TYTUL, status=0, **kwargs):
+    """Zgłoszenie publikacji (domyślnie NOWY, z DOI sesji testowej)."""
+    return baker.make(
+        "zglos_publikacje.Zgloszenie_Publikacji",
+        doi=doi,
+        tytul_oryginalny=tytul,
+        status=status,
+        rok=2024,
+        rodzaj_zglaszanej_publikacji=1,
+        **kwargs,
+    )
+
+
+def _zpa(zgloszenie, jednostka=None, autor=None, dyscyplina=None):
+    """Autor w zgłoszeniu — nośnik atrybucji zgłoszenia do uczelni (D8)."""
+    return baker.make(
+        "zglos_publikacje.Zgloszenie_Publikacji_Autor",
+        rekord=zgloszenie,
+        autor=autor or baker.make("bpp.Autor"),
+        jednostka=jednostka or baker.make("bpp.Jednostka"),
+        dyscyplina_naukowa=dyscyplina,
+        rok=2024,
+    )
+
+
+def _sesja(user, doi=DOI, tytul=TYTUL, uczelnia=None, **kwargs):
+    return ImportSession.objects.create(
+        created_by=user,
+        uczelnia=uczelnia,
+        provider_name="CrossRef",
+        identifier=doi or "brak-doi",
+        raw_data={},
+        normalized_data={
+            "title": tytul,
+            "doi": doi,
+            "year": 2024,
+            "authors": [],
+        },
+        **kwargs,
+    )
+
+
+def _url_wyboru(session):
+    return reverse(
+        "importer_publikacji:zgloszenie-wybierz",
+        kwargs={"session_id": session.pk},
+    )
+
+
+@pytest.fixture
+def uczelnia_b(db):
+    """Druga uczelnia — włącza zawężanie (``tylko_jedna_uczelnia`` → False)."""
+    from bpp.models import Uczelnia
+
+    site = Site.objects.create(domain="uczelnia-b.example.com", name="B")
+    return Uczelnia.objects.create(nazwa="Uczelnia B", skrot="BB", site=site)
+
+
+# --------------------------------------------------------------------------
+# kandydaci_dla_sesji
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_kandydaci_brak_doi_pusty_queryset(importer_user):
+    """Bez DOI nie ma czym wiązać — pusty queryset, nie None."""
+    session = _sesja(importer_user, doi=None)
+    _zgl(doi=None)
+
+    assert list(kandydaci_dla_sesji(session)) == []
+
+
+@pytest.mark.django_db
+def test_kandydaci_jedno_pasujace_zgloszenie(importer_user):
+    session = _sesja(importer_user)
+    zgl = _zgl()
+
+    assert list(kandydaci_dla_sesji(session)) == [zgl]
+
+
+@pytest.mark.django_db
+def test_kandydaci_dwa_zgloszenia_tego_samego_doi(importer_user):
+    session = _sesja(importer_user)
+    a = _zgl()
+    b = _zgl(tytul="Zupełnie inny tytuł, to samo DOI")
+
+    assert set(kandydaci_dla_sesji(session)) == {a, b}
+
+
+@pytest.mark.django_db
+def test_kandydaci_doi_znormalizowane(importer_user):
+    """DOI z sesji jest normalizowane (URL, wielkość liter) przed matchem."""
+    session = _sesja(importer_user, doi=f"https://doi.org/{DOI.upper()}")
+    zgl = _zgl()
+
+    assert list(kandydaci_dla_sesji(session)) == [zgl]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status,nazwa",
+    [
+        (4, "ODRZUCONO"),
+        (5, "SPAM"),
+        (6, "ZAIMPORTOWANY"),
+        (1, "ZAAKCEPTOWANY"),
+        (2, "WYMAGA_ZMIAN"),
+    ],
+)
+def test_kandydaci_wykluczone_statusy(importer_user, status, nazwa):
+    session = _sesja(importer_user)
+    _zgl(status=status)
+
+    assert list(kandydaci_dla_sesji(session)) == [], nazwa
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("status,nazwa", [(0, "NOWY"), (3, "PO_ZMIANACH")])
+def test_kandydaci_dopuszczone_statusy(importer_user, status, nazwa):
+    """Kontrola pozytywna do testu wykluczeń — te statusy przechodzą."""
+    session = _sesja(importer_user)
+    zgl = _zgl(status=status)
+
+    assert list(kandydaci_dla_sesji(session)) == [zgl], nazwa
+
+
+@pytest.mark.django_db
+def test_kandydaci_pomijaja_soft_usuniete(importer_user):
+    """``objects`` to SoftDeleteManager — skasowane zgłoszenie wypada."""
+    session = _sesja(importer_user)
+    zgl = _zgl()
+    zgl.delete()
+
+    assert list(kandydaci_dla_sesji(session)) == []
+
+
+@pytest.mark.django_db
+def test_kandydaci_nie_wiaza_po_tytule(importer_user):
+    """D5: identyczny tytuł, inne DOI → NIE jest kandydatem.
+
+    Regresja: dopasowanie po tytule jest wykluczone z wiązania, bo dwa
+    zgłoszenia o tym samym tytule oznaczyłyby przypadkowe.
+    """
+    session = _sesja(importer_user)
+    pasujace_doi = _zgl(doi=DOI, tytul=TYTUL)
+    _zgl(doi=INNE_DOI, tytul=TYTUL)
+
+    assert list(kandydaci_dla_sesji(session)) == [pasujace_doi]
+
+
+@pytest.mark.django_db
+def test_kandydaci_nie_przekraczaja_granicy_uczelni(
+    importer_user, uczelnia1, uczelnia2, jednostka_uczelnia1, jednostka_uczelnia2
+):
+    """D8: zgłoszenie autora z cudzej uczelni nie trafia na listę."""
+    session = _sesja(importer_user, uczelnia=uczelnia1)
+
+    moje = _zgl()
+    _zpa(moje, jednostka=jednostka_uczelnia1)
+
+    cudze = _zgl(tytul="Praca z drugiej uczelni")
+    _zpa(cudze, jednostka=jednostka_uczelnia2)
+
+    kandydaci = list(kandydaci_dla_sesji(session))
+    assert kandydaci == [moje]
+    assert cudze not in kandydaci
+
+
+@pytest.mark.django_db
+def test_kandydaci_bez_uczelni_sesji_bez_zawezenia(
+    importer_user, uczelnia1, uczelnia2, jednostka_uczelnia2
+):
+    """Sesja bez uczelni (brak mapowania Site→Uczelnia) → filtr no-op."""
+    session = _sesja(importer_user, uczelnia=None)
+    cudze = _zgl()
+    _zpa(cudze, jednostka=jednostka_uczelnia2)
+
+    assert list(kandydaci_dla_sesji(session)) == [cudze]
+
+
+@pytest.mark.django_db
+def test_kandydaci_jedna_uczelnia_bez_zawezenia(importer_user, uczelnia, jednostka):
+    """Single-install: filtr per-uczelnia jest no-opem (i kosztowałby JOIN)."""
+    session = _sesja(importer_user, uczelnia=uczelnia)
+    zgl = _zgl()
+    # Zgłoszenie BEZ żadnego autora — przy aktywnym zawężeniu wypadłoby
+    # (JOIN po autorach), w single-install ma pozostać widoczne.
+    assert list(kandydaci_dla_sesji(session)) == [zgl]
+
+
+@pytest.mark.django_db
+def test_kandydaci_bez_duplikatow_przy_wielu_autorach(
+    importer_user, uczelnia1, uczelnia2, jednostka_uczelnia1
+):
+    """JOIN przez autorów mnoży wiersze — ``.distinct()` musi to sklejać."""
+    session = _sesja(importer_user, uczelnia=uczelnia1)
+    zgl = _zgl()
+    for _ in range(3):
+        _zpa(zgl, jednostka=jednostka_uczelnia1)
+
+    assert kandydaci_dla_sesji(session).count() == 1
+    assert list(kandydaci_dla_sesji(session)) == [zgl]
+
+
+# --------------------------------------------------------------------------
+# zwiaz_automatycznie (ścieżka B)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_zwiaz_automatycznie_jeden_kandydat(importer_user):
+    session = _sesja(importer_user)
+    zgl = _zgl()
+
+    assert zwiaz_automatycznie(session) is True
+
+    session.refresh_from_db()
+    assert session.zgloszenie_id == zgl.pk
+
+
+@pytest.mark.django_db
+def test_zwiaz_automatycznie_dwaj_kandydaci_nie_zgaduje(importer_user):
+    """D6: przy ≥2 kandydatach decyduje operator, nie system."""
+    session = _sesja(importer_user)
+    _zgl()
+    _zgl(tytul="Drugi kandydat na to samo DOI")
+
+    assert zwiaz_automatycznie(session) is False
+
+    session.refresh_from_db()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_zwiaz_automatycznie_zero_kandydatow(importer_user):
+    session = _sesja(importer_user)
+
+    assert zwiaz_automatycznie(session) is False
+
+    session.refresh_from_db()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_zwiaz_automatycznie_nie_nadpisuje_istniejacego(importer_user):
+    """Jawny wybór (ścieżka A) jest mocniejszy od heurystyki po DOI."""
+    jawne = _zgl(doi=INNE_DOI, tytul="Jawnie wskazane zgłoszenie")
+    session = _sesja(importer_user, zgloszenie=jawne)
+    _zgl()  # jedyny kandydat po DOI — a jednak nie wygrywa
+
+    assert zwiaz_automatycznie(session) is False
+
+    session.refresh_from_db()
+    assert session.zgloszenie_id == jawne.pk
+
+
+@pytest.mark.django_db
+def test_kandydaci_zgloszen_wyciszone_po_odrzuceniu(importer_user):
+    """``ImportSession.kandydaci_zgloszen`` milknie po „żadne z nich"."""
+    session = _sesja(importer_user, zgloszenie_odrzucone_przez_operatora=True)
+    _zgl()
+
+    assert list(session.kandydaci_zgloszen) == []
+
+
+# --------------------------------------------------------------------------
+# Wybór operatora (ścieżka C) — widok ZgloszenieWyborView
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_wybor_ustawia_fk(importer_client, importer_user):
+    session = _sesja(importer_user)
+    a = _zgl()
+    _zgl(tytul="Drugi kandydat")
+
+    response = importer_client.post(_url_wyboru(session), {"zgloszenie": a.pk})
+
+    assert response.status_code == 302
+    session.refresh_from_db()
+    assert session.zgloszenie_id == a.pk
+    assert session.zgloszenie_odrzucone_przez_operatora is False
+
+
+@pytest.mark.django_db
+def test_wybor_spoza_listy_kandydatow_odrzucony(importer_client, importer_user):
+    """Regresja IDOR: id spoza listy kandydatów NIE może związać sesji."""
+    session = _sesja(importer_user)
+    _zgl()
+    obce = _zgl(doi=INNE_DOI, tytul="Cudze zgłoszenie, inne DOI")
+
+    response = importer_client.post(_url_wyboru(session), {"zgloszenie": obce.pk})
+
+    assert response.status_code == 400
+    session.refresh_from_db()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_wybor_zgloszenia_o_wykluczonym_statusie_odrzucony(
+    importer_client, importer_user
+):
+    """Status wykluczony ⇒ poza listą kandydatów ⇒ nie da się go wybrać."""
+    session = _sesja(importer_user)
+    spam = _zgl(status=5)
+
+    response = importer_client.post(_url_wyboru(session), {"zgloszenie": spam.pk})
+
+    assert response.status_code == 400
+    session.refresh_from_db()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_wybor_smiec_zamiast_id_odrzucony(importer_client, importer_user):
+    session = _sesja(importer_user)
+    _zgl()
+
+    response = importer_client.post(_url_wyboru(session), {"zgloszenie": "abc"})
+
+    assert response.status_code == 400
+    session.refresh_from_db()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_wybor_bez_uprawnien_importera(client, django_user_model, importer_user):
+    """Zalogowany bez GR_WPROWADZANIE_DANYCH → 403 (anonim → redirect)."""
+    session = _sesja(importer_user)
+    zgl = _zgl()
+
+    obcy = baker.make(django_user_model, is_staff=True, is_superuser=False)
+    client.force_login(obcy)
+
+    response = client.post(_url_wyboru(session), {"zgloszenie": zgl.pk})
+
+    assert response.status_code == 403
+    session.refresh_from_db()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_wybor_anonim_przekierowany(client, importer_user):
+    session = _sesja(importer_user)
+    zgl = _zgl()
+
+    response = client.post(_url_wyboru(session), {"zgloszenie": zgl.pk})
+
+    assert response.status_code in (302, 403)
+    session.refresh_from_db()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_wybor_na_sesje_innej_uczelni_404(
+    importer_client, importer_user, uczelnia, uczelnia_b
+):
+    """Sesja spoza uczelni redaktora nie istnieje dla niego (404)."""
+    session = _sesja(importer_user, uczelnia=uczelnia_b)
+    zgl = _zgl()
+
+    response = importer_client.post(_url_wyboru(session), {"zgloszenie": zgl.pk})
+
+    assert response.status_code == 404
+    session.refresh_from_db()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_wybor_zadne_wycisza_baner(importer_client, importer_user):
+    session = _sesja(importer_user)
+    _zgl()
+    _zgl(tytul="Drugi kandydat")
+
+    response = importer_client.post(_url_wyboru(session), {"zadne": "1"})
+
+    assert response.status_code == 302
+    session.refresh_from_db()
+    assert session.zgloszenie_odrzucone_przez_operatora is True
+    assert session.zgloszenie_id is None
+    assert list(session.kandydaci_zgloszen) == []
+
+
+@pytest.mark.django_db
+def test_wybor_odepnij_kasuje_automatyczne_wiazanie(importer_client, importer_user):
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    response = importer_client.post(_url_wyboru(session), {"odepnij": "1"})
+
+    assert response.status_code == 302
+    session.refresh_from_db()
+    assert session.zgloszenie_id is None
+    assert session.zgloszenie_odrzucone_przez_operatora is True
+
+
+@pytest.mark.django_db
+def test_wybor_hx_request_zwraca_hx_redirect(importer_client, importer_user):
+    session = _sesja(importer_user)
+    zgl = _zgl()
+
+    response = importer_client.post(
+        _url_wyboru(session),
+        {"zgloszenie": zgl.pk},
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    assert response["HX-Redirect"]
+
+
+# --------------------------------------------------------------------------
+# Ścieżka A — parametr ?zgloszenie= przeżywa rundę GET → render → POST
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_index_renderuje_ukryte_pole_zgloszenia(importer_client):
+    zgl = _zgl()
+    url = reverse("importer_publikacji:index")
+
+    response = importer_client.get(f"{url}?provider=CrossRef&zgloszenie={zgl.pk}")
+
+    content = response.content.decode()
+    assert response.status_code == 200
+    assert 'name="zgloszenie"' in content
+    assert f'value="{zgl.pk}"' in content
+
+
+@pytest.mark.django_db
+def test_index_bez_parametru_nie_wypelnia_pola(importer_client):
+    url = reverse("importer_publikacji:index")
+
+    response = importer_client.get(f"{url}?provider=CrossRef")
+
+    content = response.content.decode()
+    assert 'name="zgloszenie"' in content
+    # Puste ukryte pole nie renderuje atrybutu ``value``.
+    assert 'name="zgloszenie" value=' not in content.replace("\n", " ")
+
+
+def _post_fetch(client, **extra):
+    """POST na FetchView z zamockowanym providerem i taskiem Celery."""
+    dane = {"provider": "CrossRef", "identifier": "10.1234/x"}
+    dane.update(extra)
+
+    with (
+        patch("importer_publikacji.views.wizard.fetch_session_task") as mock_task,
+        patch("importer_publikacji.views.wizard.get_provider") as mock_provider,
+    ):
+        from importer_publikacji.providers import InputMode
+
+        mock_provider.return_value.input_mode = InputMode.IDENTIFIER
+        mock_provider.return_value.validate_identifier.return_value = "10.1234/x"
+        mock_task.delay.return_value.id = "task-uuid"
+
+        return client.post(reverse("importer_publikacji:fetch"), dane)
+
+
+@pytest.mark.django_db
+def test_fetch_wiaze_sesje_ze_zgloszeniem(importer_client):
+    zgl = _zgl()
+
+    response = _post_fetch(importer_client, zgloszenie=zgl.pk)
+
+    assert response.status_code == 302
+    session = ImportSession.objects.get()
+    assert session.zgloszenie_id == zgl.pk
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("wartosc", ["abc", "0", "-5", "999999999999999999999"])
+def test_fetch_niepoprawna_wartosc_bez_bledu_i_bez_wiazania(importer_client, wartosc):
+    """Śmieć w ukrytym polu nie może zablokować importu ani go związać."""
+    response = _post_fetch(importer_client, zgloszenie=wartosc)
+
+    assert response.status_code == 302
+    session = ImportSession.objects.get()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_fetch_nieistniejacy_pk_bez_wiazania(importer_client):
+    response = _post_fetch(importer_client, zgloszenie=123456)
+
+    assert response.status_code == 302
+    session = ImportSession.objects.get()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_fetch_soft_usuniety_pk_bez_wiazania(importer_client):
+    zgl = _zgl()
+    zgl.delete()
+
+    response = _post_fetch(importer_client, zgloszenie=zgl.pk)
+
+    assert response.status_code == 302
+    session = ImportSession.objects.get()
+    assert session.zgloszenie_id is None
+
+
+@pytest.mark.django_db
+def test_fetch_idempotency_dopisuje_wiazanie_do_sesji_in_flight(
+    importer_client, importer_user
+):
+    """Gałąź double-click omija ``_start_import_session`` — FK dopisujemy."""
+    istniejaca = baker.make(
+        ImportSession,
+        created_by=importer_user,
+        provider_name="CrossRef",
+        identifier="10.1234/x",
+        status=ImportSession.Status.FETCHING,
+        zgloszenie=None,
+    )
+    zgl = _zgl()
+
+    response = _post_fetch(importer_client, zgloszenie=zgl.pk)
+
+    assert response.status_code == 302
+    assert ImportSession.objects.count() == 1
+    istniejaca.refresh_from_db()
+    assert istniejaca.zgloszenie_id == zgl.pk
+
+
+@pytest.mark.django_db
+def test_fetch_idempotency_nie_nadpisuje_istniejacego_wiazania(
+    importer_client, importer_user
+):
+    """Pierwsze wiązanie wygrywa — re-submit nie przestemplowuje sesji."""
+    pierwsze = _zgl(tytul="Pierwsze wiązanie")
+    drugie = _zgl(doi=INNE_DOI, tytul="Drugie wiązanie")
+    istniejaca = baker.make(
+        ImportSession,
+        created_by=importer_user,
+        provider_name="CrossRef",
+        identifier="10.1234/x",
+        status=ImportSession.Status.FETCHING,
+        zgloszenie=pierwsze,
+    )
+
+    _post_fetch(importer_client, zgloszenie=drugie.pk)
+
+    istniejaca.refresh_from_db()
+    assert istniejaca.zgloszenie_id == pierwsze.pk
+
+
+# --------------------------------------------------------------------------
+# Prefill dyscyplin korzysta z jawnego wiązania
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_prefill_uzywa_zwiazanego_zgloszenia(importer_user):
+    """Wiązanie bije heurystykę: dyscyplina z ``session.zgloszenie``."""
+    from bpp.models import Autor_Dyscyplina
+
+    autor = baker.make("bpp.Autor")
+    dysc_zwiazana = baker.make("bpp.Dyscyplina_Naukowa")
+    dysc_heurystyczna = baker.make("bpp.Dyscyplina_Naukowa")
+
+    # ``Zgloszenie_Publikacji_Autor.clean()`` wymaga przypisania autora do
+    # dyscypliny na dany rok — obie muszą być legalne dla tego autora.
+    Autor_Dyscyplina.objects.create(
+        autor=autor,
+        rok=2024,
+        dyscyplina_naukowa=dysc_zwiazana,
+        subdyscyplina_naukowa=dysc_heurystyczna,
+    )
+
+    # Zgłoszenie związane — inne DOI i inny tytuł niż sesja, więc
+    # heurystyka nigdy by go nie wybrała.
+    zwiazane = _zgl(doi=INNE_DOI, tytul="Zupełnie inny tytuł niż w sesji")
+    _zpa(zwiazane, autor=autor, dyscyplina=dysc_zwiazana)
+
+    # Zgłoszenie, które wygrałoby heurystycznie (to samo DOI co sesja).
+    heurystyczne = _zgl()
+    _zpa(heurystyczne, autor=autor, dyscyplina=dysc_heurystyczna)
+
+    session = _sesja(importer_user, zgloszenie=zwiazane)
+    imported = ImportedAuthor.objects.create(
+        session=session,
+        order=0,
+        family_name="Test",
+        given_name="Autor",
+        matched_autor=autor,
+        match_status=ImportedAuthor.MatchStatus.AUTO_EXACT,
+    )
+
+    assert _zgloszenie_dla_prefilla(session).pk == zwiazane.pk
+
+    _prefill_dyscypliny_z_zgloszen(session)
+
+    imported.refresh_from_db()
+    assert imported.matched_dyscyplina == dysc_zwiazana
+
+
+@pytest.mark.django_db
+def test_prefill_bez_wiazania_uzywa_heurystyki(importer_user):
+    """Sesje niezwiązane zachowują się jak dotąd (fallback po DOI/tytule)."""
+    session = _sesja(importer_user)
+    heurystyczne = _zgl()
+
+    assert _zgloszenie_dla_prefilla(session).pk == heurystyczne.pk

--- a/src/importer_publikacji/tests/test_fd443_zapis_zwrotny.py
+++ b/src/importer_publikacji/tests/test_fd443_zapis_zwrotny.py
@@ -1,0 +1,314 @@
+"""FD#443 — zapis zwrotny na zgłoszeniu po udanym imporcie.
+
+Po ``COMPLETED`` zgłoszenie ma dostać status ``ZAIMPORTOWANY``, znacznik
+czasu, operatora (``session.created_by``, nie ``modified_by``) oraz
+GenericFK do utworzonego rekordu.
+
+Testy sprawdzają dwie warstwy:
+
+* jednostkowo ``zgloszenia.oznacz_jako_zaimportowane`` (idempotencja,
+  soft-delete, brak wiązania, faktyczny zapis GenericFK do bazy),
+* integracyjnie ``tasks.create_publication_task`` (gałąź sukcesu vs
+  gałąź błędu, ponowienie zadania).
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from model_bakery import baker
+
+from bpp.models import Wydawnictwo_Ciagle
+from importer_publikacji.models import ImportSession
+from importer_publikacji.tasks import create_publication_task
+from importer_publikacji.zgloszenia import oznacz_jako_zaimportowane
+
+STATUS_NOWY = 0
+STATUS_ZAIMPORTOWANY = 6
+
+
+def _zgl(status=STATUS_NOWY, **kwargs):
+    return baker.make(
+        "zglos_publikacje.Zgloszenie_Publikacji",
+        doi="10.1234/fd443.zapis",
+        tytul_oryginalny="Praca zgłoszona przez formularz zgłoszeniowy",
+        status=status,
+        rok=2024,
+        rodzaj_zglaszanej_publikacji=1,
+        **kwargs,
+    )
+
+
+def _sesja(user, zgloszenie=None, status=ImportSession.Status.REVIEW, **kwargs):
+    return ImportSession.objects.create(
+        created_by=user,
+        provider_name="CrossRef",
+        identifier="10.1234/fd443.zapis",
+        status=status,
+        raw_data={},
+        normalized_data={
+            "title": "Praca zgłoszona przez formularz zgłoszeniowy",
+            "doi": "10.1234/fd443.zapis",
+            "year": 2024,
+            "authors": [],
+        },
+        zgloszenie=zgloszenie,
+        **kwargs,
+    )
+
+
+def _rekord():
+    return baker.make(Wydawnictwo_Ciagle, rok=2024)
+
+
+@pytest.fixture
+def rekord(db):
+    return _rekord()
+
+
+# --------------------------------------------------------------------------
+# oznacz_jako_zaimportowane — jednostkowo
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_oznacza_status_date_i_operatora(importer_user, rekord):
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    assert oznacz_jako_zaimportowane(session, rekord) is True
+
+    zgl.refresh_from_db()
+    assert zgl.status == STATUS_ZAIMPORTOWANY
+    assert zgl.zaimportowano is not None
+    assert zgl.zaimportowal_id == importer_user.pk
+
+
+@pytest.mark.django_db
+def test_zaimportowal_z_created_by_nie_modified_by(
+    importer_user, django_user_model, rekord
+):
+    """„Kto to zrobił" = kto uruchomił import, nie kto ostatnio dotknął."""
+    inny = baker.make(django_user_model)
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+    session.modified_by = inny
+    session.save(update_fields=["modified_by"])
+
+    oznacz_jako_zaimportowane(session, rekord)
+
+    zgl.refresh_from_db()
+    assert zgl.zaimportowal_id == importer_user.pk
+    assert zgl.zaimportowal_id != inny.pk
+
+
+@pytest.mark.django_db
+def test_generic_fk_faktycznie_zapisany_w_bazie(importer_user, rekord):
+    """``update_fields`` MUSI zawierać ``content_type`` i ``object_id``.
+
+    Sam atrybut ``odpowiednik_w_bpp`` w pamięci nic nie dowodzi — GenericFK
+    zapisuje się przez dwie kolumny; pominięcie ich w ``update_fields``
+    zostawiłoby w bazie NULL-e.
+    """
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    oznacz_jako_zaimportowane(session, rekord)
+
+    z_bazy = type(zgl).objects.get(pk=zgl.pk)
+    assert z_bazy.object_id == rekord.pk
+    assert z_bazy.content_type == ContentType.objects.get_for_model(rekord)
+    assert z_bazy.odpowiednik_w_bpp == rekord
+
+
+@pytest.mark.django_db
+def test_idempotencja_drugie_wywolanie_nic_nie_zmienia(
+    importer_user, django_user_model, rekord
+):
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    assert oznacz_jako_zaimportowane(session, rekord) is True
+    zgl.refresh_from_db()
+    data_pierwsza = zgl.zaimportowano
+    operator_pierwszy = zgl.zaimportowal_id
+
+    # Ponowienie zadania pod innym userem i z innym rekordem — guard
+    # statusu ma zablokować przestemplowanie audytu.
+    session.created_by = baker.make(django_user_model)
+    session.save(update_fields=["created_by"])
+    session = ImportSession.objects.get(pk=session.pk)
+
+    assert oznacz_jako_zaimportowane(session, _rekord()) is False
+
+    zgl.refresh_from_db()
+    assert zgl.zaimportowano == data_pierwsza
+    assert zgl.zaimportowal_id == operator_pierwszy
+    assert zgl.object_id == rekord.pk
+
+
+def _soft_usun_bez_kaskady(zgl):
+    """Ustaw ``deleted_at`` z pominięciem ``instance.delete()``.
+
+    ``django_softdelete`` w ``delete()`` emuluje ``on_delete`` relacji
+    odwrotnych — dla ``ImportSession.zgloszenie`` (``SET_NULL``) zeruje
+    FK, więc zwykłe ``zgl.delete()`` NIE ustawia sceny dla guardu
+    ``deleted_at``. Wiersz z ``deleted_at`` i żywym FK powstaje na
+    ścieżkach omijających ``delete()``: ``UPDATE`` z migracji danych,
+    surowy SQL, wyścig między dwoma transakcjami. Guard jest dokładnie
+    dla nich — i to sprawdza ten helper.
+    """
+    from django.utils import timezone
+
+    type(zgl).global_objects.filter(pk=zgl.pk).update(deleted_at=timezone.now())
+
+
+@pytest.mark.django_db
+def test_soft_usuniete_zgloszenie_nie_zostaje_oznaczone(importer_user, rekord):
+    """Dostęp przez FK idzie ``_base_manager`` — nie filtruje usuniętych."""
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+    _soft_usun_bez_kaskady(zgl)
+
+    # Świeży odczyt: FK i tak zwróci soft-usunięty wiersz.
+    session = ImportSession.objects.get(pk=session.pk)
+    assert session.zgloszenie is not None
+    assert session.zgloszenie.deleted_at is not None
+
+    assert oznacz_jako_zaimportowane(session, rekord) is False
+
+    z_bazy = type(zgl).global_objects.get(pk=zgl.pk)
+    assert z_bazy.status == STATUS_NOWY
+    assert z_bazy.zaimportowano is None
+    assert z_bazy.object_id is None
+
+
+@pytest.mark.django_db
+def test_skasowanie_zgloszenia_zeruje_wiazanie_sesji(importer_user, rekord):
+    """Charakteryzacja: ``zgl.delete()`` zeruje ``ImportSession.zgloszenie``.
+
+    ``django_softdelete`` emuluje ``on_delete=SET_NULL`` przy soft-delete,
+    więc typowa ścieżka (operator kasuje zgłoszenie w module redagowania)
+    rozbraja wiązanie jeszcze przed guardem ``deleted_at``. Efekt netto
+    jest ten sam — zgłoszenie nie zostaje oznaczone.
+    """
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    zgl.delete()
+
+    session = ImportSession.objects.get(pk=session.pk)
+    assert session.zgloszenie_id is None
+    assert oznacz_jako_zaimportowane(session, rekord) is False
+
+    z_bazy = type(zgl).global_objects.get(pk=zgl.pk)
+    assert z_bazy.status == STATUS_NOWY
+
+
+@pytest.mark.django_db
+def test_brak_wiazania_to_no_op(importer_user, rekord):
+    session = _sesja(importer_user, zgloszenie=None)
+
+    assert oznacz_jako_zaimportowane(session, rekord) is False
+
+
+# --------------------------------------------------------------------------
+# create_publication_task — integracyjnie
+# --------------------------------------------------------------------------
+
+
+def _uruchom_task(session):
+    rekord = _rekord()
+    with patch("importer_publikacji.tasks._create_publication") as mock_create:
+        mock_create.return_value = rekord
+        create_publication_task.apply(
+            args=[session.pk, session.created_by_id, False]
+        ).get()
+    return rekord
+
+
+@pytest.mark.django_db
+def test_task_oznacza_zgloszenie_po_completed(importer_user):
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    rekord = _uruchom_task(session)
+
+    session.refresh_from_db()
+    assert session.status == ImportSession.Status.COMPLETED
+
+    zgl.refresh_from_db()
+    assert zgl.status == STATUS_ZAIMPORTOWANY
+    assert zgl.zaimportowano is not None
+    assert zgl.zaimportowal_id == importer_user.pk
+    assert zgl.odpowiednik_w_bpp == rekord
+
+
+@pytest.mark.django_db
+def test_task_bez_wiazania_nie_rusza_zadnego_zgloszenia(importer_user):
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=None)
+
+    _uruchom_task(session)
+
+    zgl.refresh_from_db()
+    assert zgl.status == STATUS_NOWY
+    assert zgl.zaimportowano is None
+
+
+@pytest.mark.django_db
+def test_task_zakonczony_bledem_nie_zmienia_statusu_zgloszenia(importer_user):
+    """Zapis zwrotny siedzi w gałęzi sukcesu, przed blokiem ``except``."""
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    with patch("importer_publikacji.tasks._create_publication") as mock_create:
+        mock_create.side_effect = RuntimeError("create exploded")
+        with pytest.raises(RuntimeError, match="create exploded"):
+            create_publication_task.apply(
+                args=[session.pk, session.created_by_id, False]
+            ).get()
+
+    session.refresh_from_db()
+    assert session.status == ImportSession.Status.IMPORT_FAILED
+
+    zgl.refresh_from_db()
+    assert zgl.status == STATUS_NOWY
+    assert zgl.zaimportowano is None
+    assert zgl.zaimportowal_id is None
+    assert zgl.object_id is None
+
+
+@pytest.mark.django_db
+def test_ponowienie_taska_nie_przesuwa_daty(importer_user):
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+
+    pierwszy_rekord = _uruchom_task(session)
+    zgl.refresh_from_db()
+    data_pierwsza = zgl.zaimportowano
+
+    session.status = ImportSession.Status.REVIEW
+    session.save(update_fields=["status"])
+    _uruchom_task(session)
+
+    zgl.refresh_from_db()
+    assert zgl.zaimportowano == data_pierwsza
+    assert zgl.odpowiednik_w_bpp == pierwszy_rekord
+
+
+@pytest.mark.django_db
+def test_task_pomija_soft_usuniete_zgloszenie(importer_user):
+    """Soft-delete w trakcie importu → rekord powstaje, zgłoszenie nietknięte."""
+    zgl = _zgl()
+    session = _sesja(importer_user, zgloszenie=zgl)
+    _soft_usun_bez_kaskady(zgl)
+
+    _uruchom_task(session)
+
+    session.refresh_from_db()
+    assert session.status == ImportSession.Status.COMPLETED
+
+    z_bazy = type(zgl).global_objects.get(pk=zgl.pk)
+    assert z_bazy.status == STATUS_NOWY
+    assert z_bazy.zaimportowano is None

--- a/src/importer_publikacji/urls.py
+++ b/src/importer_publikacji/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import views
 from .views.retry import ImportTaskRetryView
 from .views.task_status import ImportTaskStatusView
+from .views.zgloszenie import ZgloszenieWyborView
 
 app_name = "importer_publikacji"
 
@@ -121,6 +122,11 @@ urlpatterns = [
         "<int:session_id>/cancel/",
         views.CancelView.as_view(),
         name="cancel",
+    ),
+    path(
+        "<int:session_id>/zgloszenie/wybierz/",
+        ZgloszenieWyborView.as_view(),
+        name="zgloszenie-wybierz",
     ),
     path(
         "batch/<int:batch_id>/",

--- a/src/importer_publikacji/views/authors.py
+++ b/src/importer_publikacji/views/authors.py
@@ -188,16 +188,34 @@ def _find_matching_zgloszenie(session):
     return None
 
 
+def _zgloszenie_dla_prefilla(session):
+    """Zgłoszenie, z którego prefill ma brać dyscypliny.
+
+    Gdy sesja jest **związana** ze zgłoszeniem (FD#443: jawny wybór
+    operatora albo auto-wiązanie po DOI), prefill używa go wprost —
+    inaczej dyscypliny mogłyby przyjść z innego zgłoszenia niż to, które
+    import domknie (heurystyka ``_find_matching_zgloszenie`` dopasowuje
+    też po tytule).
+
+    Heurystyka zostaje wyłącznie jako fallback dla sesji niezwiązanych —
+    ich zachowanie jest bez zmian.
+    """
+    if session.zgloszenie_id:
+        return session.zgloszenie
+    return _find_matching_zgloszenie(session)
+
+
 def _prefill_dyscypliny_z_zgloszen(session):
     """Uzupełnij brakujące dyscypliny z danych zgłoszeń publikacji.
 
-    Szuka pasującego Zgloszenie_Publikacji (po DOI/tytule)
-    i kopiuje dyscypliny dla autorów, którym brakuje.
-    Nigdy nie nadpisuje istniejących wartości.
+    Bierze zgłoszenie związane z sesją, a gdy takiego nie ma — szuka
+    pasującego ``Zgloszenie_Publikacji`` heurystycznie (po DOI/tytule).
+    Kopiuje dyscypliny dla autorów, którym brakuje. Nigdy nie nadpisuje
+    istniejących wartości.
     """
     from zglos_publikacje.models import Zgloszenie_Publikacji_Autor
 
-    zgloszenie = _find_matching_zgloszenie(session)
+    zgloszenie = _zgloszenie_dla_prefilla(session)
     if not zgloszenie:
         return
 

--- a/src/importer_publikacji/views/wizard.py
+++ b/src/importer_publikacji/views/wizard.py
@@ -5,6 +5,7 @@ Authors → Review → Create → Done) plus boczne akcje na autorach i
 anulowanie sesji.
 """
 
+from django.contrib import messages
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
@@ -110,6 +111,14 @@ class IndexView(ImporterPermissionMixin, View):
         initial = {"provider": provider_name}
         if request.GET.get("identifier"):
             initial["identifier"] = request.GET["identifier"]
+        # ``?zgloszenie=<pk>`` z przycisku „Użyj importera" w adminie
+        # Zgłoszeń Publikacji. Ten widok NIE tworzy sesji importu (robi to
+        # dopiero FetchView.post), więc parametr musi przejechać rundę
+        # GET → render → POST w ukrytym polu formularza — inaczej ginie.
+        # Bez walidacji: wartość nieprawidłowa i tak zostanie odrzucona
+        # przy odczycie w FetchView.post.
+        if request.GET.get("zgloszenie"):
+            initial["zgloszenie"] = request.GET["zgloszenie"]
         form = FetchForm(initial=initial)
 
         ctx = _fetch_context(form, request=request, provider_name=provider_name)
@@ -180,12 +189,32 @@ def _create_batch(request, provider_name, normalized, records):
     return batch
 
 
-def _start_import_session(request, provider_name, identifier):
+def _zgloszenie_z_pola(value):
+    """Zwaliduj wartość ukrytego pola ``zgloszenie`` z ``FetchForm``.
+
+    Zwraca instancję ``Zgloszenie_Publikacji`` albo ``None``. ``objects`` to
+    ``SoftDeleteManager``, więc zgłoszenia soft-usunięte wypadają tą samą
+    gałęzią co nieistniejące. Wartość niepoprawna jest ignorowana po cichu —
+    import startuje bez wiązania i operator nie dostaje błędu.
+    """
+    if not value:
+        return None
+
+    from zglos_publikacje.models import Zgloszenie_Publikacji
+
+    return Zgloszenie_Publikacji.objects.filter(pk=value).first()
+
+
+def _start_import_session(request, provider_name, identifier, zgloszenie=None):
     """Utwórz sesję importu (FETCHING) + wystartuj task fetch.
 
     BEZ guardu double-click po ``identifier`` — używane też przez import
     pojedynczego wpisu paczki, gdzie duplikaty wpisów są dozwolone, a przed
     podwójnym startem chroni ``entry.session`` po stronie wołającego.
+
+    ``zgloszenie`` (opcjonalne) wiąże sesję ze zgłoszeniem publikacji, które
+    ten import ma domknąć — musi być zapisane już przy tworzeniu, bo zadanie
+    Celery dostaje wyłącznie id sesji.
     """
     session = ImportSession.objects.create(
         created_by=request.user,
@@ -195,6 +224,7 @@ def _start_import_session(request, provider_name, identifier):
         status=ImportSession.Status.FETCHING,
         raw_data={},
         normalized_data={},
+        zgloszenie=zgloszenie,
     )
     task = fetch_session_task.delay(session.pk, request.user.pk)
     session.celery_task_id = task.id
@@ -217,6 +247,7 @@ class FetchView(ImporterPermissionMixin, View):
         provider_name = form.cleaned_data["provider"]
         request.session["importer_last_provider"] = provider_name
         provider = get_provider(provider_name)
+        zgloszenie = _zgloszenie_z_pola(form.cleaned_data.get("zgloszenie"))
 
         if provider.input_mode == InputMode.TEXT:
             raw_input = form.cleaned_data["text_input"]
@@ -270,9 +301,19 @@ class FetchView(ImporterPermissionMixin, View):
             .first()
         )
         if recent_in_flight is not None:
+            # Ta gałąź omija _start_import_session, więc wiązanie ze
+            # zgłoszeniem zginęłoby po cichu. Dopisz je, gdy sesja jeszcze
+            # żadnego nie ma; NIE nadpisuj, gdy ma już inne — pierwsze
+            # wiązanie wygrywa, inaczej przypadkowy re-submit przestemplowałby
+            # sesję na cudze zgłoszenie.
+            if zgloszenie is not None and recent_in_flight.zgloszenie_id is None:
+                recent_in_flight.zgloszenie = zgloszenie
+                recent_in_flight.save(update_fields=["zgloszenie"])
             return _hx_or_redirect(request, recent_in_flight.get_continue_url())
 
-        session = _start_import_session(request, provider_name, normalized)
+        session = _start_import_session(
+            request, provider_name, normalized, zgloszenie=zgloszenie
+        )
 
         url = reverse(
             "importer_publikacji:task-status",
@@ -1066,6 +1107,56 @@ class CreateView(ImporterPermissionMixin, View):
         return HttpResponseRedirect(url)
 
 
+# Klucz w sesji HTTP: lista id sesji importu, dla których flash o domknięciu
+# zgłoszenia już poszedł. ``DoneView.get`` jest odświeżalny (F5), a wiadomość
+# ma się pokazać dokładnie raz.
+FLASH_ZGLOSZENIA_KEY = "importer_zgloszenie_flash"
+
+# Ile ostatnich id trzymać. Bez limitu lista rosłaby przez całe życie sesji
+# HTTP operatora; przy przekroczeniu wypadają najstarsze — a ich strony Done
+# i tak dawno nie są odświeżane.
+FLASH_ZGLOSZENIA_LIMIT = 50
+
+
+def _domkniete_zgloszenie(session):
+    """Zgłoszenie faktycznie domknięte przez tę sesję albo ``None``.
+
+    Trzy warunki: sesja ma wiązanie, zgłoszenie nie jest soft-usunięte (dostęp
+    przez FK idzie ``_base_manager``, który usuniętych NIE filtruje) i ma
+    status ``ZAIMPORTOWANY`` — czyli zapis zwrotny naprawdę się wykonał.
+    """
+    from zglos_publikacje.models import Zgloszenie_Publikacji
+
+    zgloszenie = session.zgloszenie
+    if zgloszenie is None or zgloszenie.is_deleted:
+        return None
+    if zgloszenie.status != Zgloszenie_Publikacji.Statusy.ZAIMPORTOWANY:
+        return None
+    return zgloszenie
+
+
+def _flash_domkniete_zgloszenie(request, session, zgloszenie):
+    """Postaw flash o domknięciu zgłoszenia — dokładnie raz na sesję importu.
+
+    Wiadomość MUSI powstawać tutaj, w cyklu żądania: worker Celery wyrzuca
+    wiadomości do kosza (``_NoopMessageStorage`` w ``tasks.py``), więc flash
+    postawiony w zadaniu przepadłby bez śladu.
+    """
+    pokazane = request.session.setdefault(FLASH_ZGLOSZENIA_KEY, [])
+    if session.pk in pokazane:
+        return
+    messages.success(
+        request,
+        f"Domknięto zgłoszenie publikacji #{zgloszenie.pk} — "
+        "jest teraz oznaczone jako zaimportowane.",
+    )
+    pokazane.append(session.pk)
+    # Przypisanie (nie mutacja w miejscu) — SessionBase wykrywa modyfikację
+    # przez __setitem__; sama .append() nie ustawiłaby flagi ``modified``,
+    # sesja nie zostałaby zapisana i flash wróciłby po F5.
+    request.session[FLASH_ZGLOSZENIA_KEY] = pokazane[-FLASH_ZGLOSZENIA_LIMIT:]
+
+
 class DoneView(ImporterPermissionMixin, View):
     """Strona potwierdzenia utworzenia rekordu (GET)."""
 
@@ -1080,6 +1171,16 @@ class DoneView(ImporterPermissionMixin, View):
         if batch_entry is not None:
             ctx["batch"] = batch_entry.parent
             ctx["batch_progress"] = batch_entry.parent.progress
+
+        zgloszenie = _domkniete_zgloszenie(session)
+        if zgloszenie is not None:
+            ctx["domkniete_zgloszenie"] = zgloszenie
+            ctx["domkniete_zgloszenie_url"] = reverse(
+                "admin:zglos_publikacje_zgloszenie_publikacji_change",
+                args=[zgloszenie.pk],
+            )
+            _flash_domkniete_zgloszenie(request, session, zgloszenie)
+
         return _render_full_page(request, STEP_DONE, ctx)
 
 

--- a/src/importer_publikacji/views/wizard.py
+++ b/src/importer_publikacji/views/wizard.py
@@ -5,7 +5,6 @@ Authors → Review → Create → Done) plus boczne akcje na autorach i
 anulowanie sesji.
 """
 
-from django.contrib import messages
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
@@ -189,20 +188,30 @@ def _create_batch(request, provider_name, normalized, records):
     return batch
 
 
-def _zgloszenie_z_pola(value):
+def _zgloszenie_z_pola(request, value):
     """Zwaliduj wartość ukrytego pola ``zgloszenie`` z ``FetchForm``.
 
-    Zwraca instancję ``Zgloszenie_Publikacji`` albo ``None``. ``objects`` to
-    ``SoftDeleteManager``, więc zgłoszenia soft-usunięte wypadają tą samą
-    gałęzią co nieistniejące. Wartość niepoprawna jest ignorowana po cichu —
-    import startuje bez wiązania i operator nie dostaje błędu.
+    Zwraca instancję ``Zgloszenie_Publikacji`` albo ``None``.
+
+    Ukryte pole to zwykły ``<input type=hidden>`` — jego wartość jest w pełni
+    pod kontrolą klienta (wystarczy jeden POST z podmienionym pk). Dlatego
+    ścieżka jawna („Użyj importera") MUSI przejść przez tę samą bramkę, co
+    ścieżki automatyczna i operatorska: :func:`zgloszenia.zgloszenie_dozwolone`
+    egzekwuje granicę uczelni (D8) i wykluczone statusy (D9), a
+    ``SoftDeleteManager`` odsiewa zgłoszenia soft-usunięte. Bez tego redaktor
+    jednej uczelni mógłby przestemplować zgłoszenie innej (albo zgłoszenie
+    w statusie SPAM/ODRZUCONO/WYMAGA_ZMIAN) na ZAIMPORTOWANY.
+
+    Wartość niepoprawna (nieistniejąca, spoza uczelni, w wykluczonym statusie)
+    jest ignorowana po cichu — import startuje bez wiązania i operator nie
+    dostaje błędu.
     """
     if not value:
         return None
 
-    from zglos_publikacje.models import Zgloszenie_Publikacji
+    from ..zgloszenia import zgloszenie_dozwolone
 
-    return Zgloszenie_Publikacji.objects.filter(pk=value).first()
+    return zgloszenie_dozwolone(value, Uczelnia.objects.get_for_request(request))
 
 
 def _start_import_session(request, provider_name, identifier, zgloszenie=None):
@@ -247,7 +256,7 @@ class FetchView(ImporterPermissionMixin, View):
         provider_name = form.cleaned_data["provider"]
         request.session["importer_last_provider"] = provider_name
         provider = get_provider(provider_name)
-        zgloszenie = _zgloszenie_z_pola(form.cleaned_data.get("zgloszenie"))
+        zgloszenie = _zgloszenie_z_pola(request, form.cleaned_data.get("zgloszenie"))
 
         if provider.input_mode == InputMode.TEXT:
             raw_input = form.cleaned_data["text_input"]
@@ -306,9 +315,17 @@ class FetchView(ImporterPermissionMixin, View):
             # żadnego nie ma; NIE nadpisuj, gdy ma już inne — pierwsze
             # wiązanie wygrywa, inaczej przypadkowy re-submit przestemplowałby
             # sesję na cudze zgłoszenie.
-            if zgloszenie is not None and recent_in_flight.zgloszenie_id is None:
-                recent_in_flight.zgloszenie = zgloszenie
-                recent_in_flight.save(update_fields=["zgloszenie"])
+            #
+            # Warunkowy UPDATE, nie load-modify-save: sesja jest z definicji
+            # in-flight, więc ``fetch_session_task`` trzyma RÓWNOLEGLE własną,
+            # starszą instancję tego wiersza. Zapis przez ``.save()`` przegrałby
+            # z pełnym ``session.save()`` workera (lost update — worker wpisałby
+            # z powrotem ``zgloszenie_id = NULL``). „Dopisz gdy puste" siedzi tu
+            # w klauzuli WHERE, więc rozstrzyga baza, nie kolejność zapisów.
+            if zgloszenie is not None:
+                ImportSession.objects.filter(
+                    pk=recent_in_flight.pk, zgloszenie__isnull=True
+                ).update(zgloszenie=zgloszenie)
             return _hx_or_redirect(request, recent_in_flight.get_continue_url())
 
         session = _start_import_session(
@@ -1107,17 +1124,6 @@ class CreateView(ImporterPermissionMixin, View):
         return HttpResponseRedirect(url)
 
 
-# Klucz w sesji HTTP: lista id sesji importu, dla których flash o domknięciu
-# zgłoszenia już poszedł. ``DoneView.get`` jest odświeżalny (F5), a wiadomość
-# ma się pokazać dokładnie raz.
-FLASH_ZGLOSZENIA_KEY = "importer_zgloszenie_flash"
-
-# Ile ostatnich id trzymać. Bez limitu lista rosłaby przez całe życie sesji
-# HTTP operatora; przy przekroczeniu wypadają najstarsze — a ich strony Done
-# i tak dawno nie są odświeżane.
-FLASH_ZGLOSZENIA_LIMIT = 50
-
-
 def _domkniete_zgloszenie(session):
     """Zgłoszenie faktycznie domknięte przez tę sesję albo ``None``.
 
@@ -1135,30 +1141,17 @@ def _domkniete_zgloszenie(session):
     return zgloszenie
 
 
-def _flash_domkniete_zgloszenie(request, session, zgloszenie):
-    """Postaw flash o domknięciu zgłoszenia — dokładnie raz na sesję importu.
-
-    Wiadomość MUSI powstawać tutaj, w cyklu żądania: worker Celery wyrzuca
-    wiadomości do kosza (``_NoopMessageStorage`` w ``tasks.py``), więc flash
-    postawiony w zadaniu przepadłby bez śladu.
-    """
-    pokazane = request.session.setdefault(FLASH_ZGLOSZENIA_KEY, [])
-    if session.pk in pokazane:
-        return
-    messages.success(
-        request,
-        f"Domknięto zgłoszenie publikacji #{zgloszenie.pk} — "
-        "jest teraz oznaczone jako zaimportowane.",
-    )
-    pokazane.append(session.pk)
-    # Przypisanie (nie mutacja w miejscu) — SessionBase wykrywa modyfikację
-    # przez __setitem__; sama .append() nie ustawiłaby flagi ``modified``,
-    # sesja nie zostałaby zapisana i flash wróciłby po F5.
-    request.session[FLASH_ZGLOSZENIA_KEY] = pokazane[-FLASH_ZGLOSZENIA_LIMIT:]
-
-
 class DoneView(ImporterPermissionMixin, View):
-    """Strona potwierdzenia utworzenia rekordu (GET)."""
+    """Strona potwierdzenia utworzenia rekordu (GET).
+
+    O domknięciu zgłoszenia informuje callout w ``partials/step_done.html``
+    (kontekst ``domkniete_zgloszenie``) — NIE flash z ``django.contrib
+    .messages``. Ramka komunikatów renderuje się w ``base.html`` dwukrotnie,
+    a partial dokładał trzecie wystąpienie tej samej treści. Callout jest
+    z natury idempotentny (stan wyliczony z bazy przy każdym GET), więc nie
+    potrzebuje buchalterii „pokaż dokładnie raz" i — inaczej niż flash —
+    nie znika po F5.
+    """
 
     def get(self, request, session_id):
         session = self.get_scoped_or_404(
@@ -1179,7 +1172,6 @@ class DoneView(ImporterPermissionMixin, View):
                 "admin:zglos_publikacje_zgloszenie_publikacji_change",
                 args=[zgloszenie.pk],
             )
-            _flash_domkniete_zgloszenie(request, session, zgloszenie)
 
         return _render_full_page(request, STEP_DONE, ctx)
 

--- a/src/importer_publikacji/views/zgloszenie.py
+++ b/src/importer_publikacji/views/zgloszenie.py
@@ -1,0 +1,121 @@
+"""Widok wyboru zgłoszenia publikacji domykanego przez sesję importu.
+
+Ścieżka C ze specu FD#443: gdy na to samo DOI istnieje więcej niż jedno
+zgłoszenie, system **nie zgaduje** — operator wskazuje, które domknąć
+(albo deklaruje „żadne z nich", co wycisza baner).
+"""
+
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
+from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.views import View
+
+from ..models import ImportSession
+from ..permissions import ImporterPermissionMixin
+from ..zgloszenia import kandydaci_dla_sesji
+
+
+class ZgloszenieWyborView(ImporterPermissionMixin, View):
+    """Zwiąż sesję importu ze wskazanym zgłoszeniem (albo z żadnym).
+
+    Bezpieczeństwo — trzy niezależne warstwy:
+
+    * ``ImporterPermissionMixin`` — superuser albo grupa
+      ``GR_WPROWADZANIE_DANYCH``,
+    * ``get_scoped_or_404`` — sesja spoza uczelni redaktora daje 404,
+    * walidacja wskazanego id **względem wyliczonej listy kandydatów** —
+      bez niej byłby to IDOR: operator mógłby oznaczyć jako zaimportowane
+      dowolne zgłoszenie w systemie (także z cudzej uczelni).
+    """
+
+    def post(self, request, session_id):
+        session = self.get_scoped_or_404(ImportSession, pk=session_id)
+
+        if request.POST.get("zadne"):
+            return self._zadne(request, session)
+
+        if request.POST.get("odepnij"):
+            return self._odepnij(request, session)
+
+        return self._wybierz(request, session)
+
+    def _wybierz(self, request, session):
+        raw = (request.POST.get("zgloszenie") or "").strip()
+        if not raw.isdigit():
+            return HttpResponseBadRequest(
+                "Nieprawidłowy identyfikator zgłoszenia publikacji."
+            )
+
+        # IDOR guard: id MUSI pochodzić z listy kandydatów tej sesji.
+        # ``kandydaci_dla_sesji`` niesie już zawężenie do uczelni (D8)
+        # oraz wykluczenie statusów, których nie wolno przestemplować.
+        zgloszenie = kandydaci_dla_sesji(session).filter(pk=int(raw)).first()
+        if zgloszenie is None:
+            return HttpResponseBadRequest(
+                "Wskazane zgłoszenie nie znajduje się na liście kandydatów "
+                "dla tej sesji importu."
+            )
+
+        session.zgloszenie = zgloszenie
+        session.zgloszenie_odrzucone_przez_operatora = False
+        session.save(
+            update_fields=[
+                "zgloszenie",
+                "zgloszenie_odrzucone_przez_operatora",
+            ]
+        )
+        return self._powrot(request, session)
+
+    def _zadne(self, request, session):
+        """„Żadne z nich" — wycisz baner, nie wiąż niczego."""
+        session.zgloszenie = None
+        session.zgloszenie_odrzucone_przez_operatora = True
+        session.save(
+            update_fields=[
+                "zgloszenie",
+                "zgloszenie_odrzucone_przez_operatora",
+            ]
+        )
+        return self._powrot(request, session)
+
+    def _odepnij(self, request, session):
+        """„Odepnij" — operator protestuje przeciw auto-wiązaniu.
+
+        Wiązanie znika, a baner milknie: przy jednym kandydacie nie ma
+        czego innego wybrać, więc ponowne pytanie byłoby natrętne.
+        """
+        return self._zadne(request, session)
+
+    def _powrot(self, request, session):
+        """Wróć na ekran, z którego przyszedł POST.
+
+        ``next`` z POST-a, w drugiej kolejności ``Referer`` — oba
+        walidowane (żadnych otwartych przekierowań). Ostatecznie krok
+        weryfikacji danej sesji.
+        """
+        url = self._bezpieczny_url(request, request.POST.get("next"))
+        if url is None:
+            url = self._bezpieczny_url(request, request.headers.get("Referer"))
+        if url is None:
+            url = reverse(
+                "importer_publikacji:verify",
+                kwargs={"session_id": session.pk},
+            )
+
+        if request.headers.get("HX-Request"):
+            response = HttpResponse(status=200)
+            response["HX-Redirect"] = url
+            return response
+        return HttpResponseRedirect(url)
+
+    @staticmethod
+    def _bezpieczny_url(request, url):
+        if not url:
+            return None
+        if url_has_allowed_host_and_scheme(
+            url,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        ):
+            return url
+        return None

--- a/src/importer_publikacji/zgloszenia.py
+++ b/src/importer_publikacji/zgloszenia.py
@@ -244,8 +244,14 @@ def zwiaz_automatycznie(session):
     (ścieżka C, ``views.zgloszenie.ZgloszenieWyborView``).
 
     Nie nadpisuje istniejącego wiązania — jawny wybór (ścieżka A) jest
-    zawsze mocniejszy od heurystyki po DOI.
+    zawsze mocniejszy od heurystyki po DOI. Reguła „tylko gdy puste" siedzi
+    w klauzuli ``WHERE``, nie w sprawdzeniu na obiekcie w pamięci: gałąź
+    idempotency ``FetchView`` zapisuje wiązanie **równolegle**, więc między
+    odczytem a zapisem jest okno, w którym auto-match po DOI przestemplowałby
+    jawny wybór operatora — i oznaczone zostałoby inne zgłoszenie.
     """
+    from .models import ImportSession
+
     if session.zgloszenie_id:
         return False
 
@@ -254,8 +260,21 @@ def zwiaz_automatycznie(session):
     if len(kandydaci) != 1:
         return False
 
+    zwiazane = ImportSession.objects.filter(
+        pk=session.pk, zgloszenie__isnull=True
+    ).update(zgloszenie=kandydaci[0])
+
+    if not zwiazane:
+        # Ktoś (ścieżka A) zdążył w międzyczasie — jego wybór wygrywa.
+        session.refresh_from_db(fields=["zgloszenie"])
+        logger.info(
+            "Sesja importu %s została w międzyczasie związana jawnie — "
+            "pomijam auto-wiązanie po DOI.",
+            session.pk,
+        )
+        return False
+
     session.zgloszenie = kandydaci[0]
-    session.save(update_fields=["zgloszenie"])
     return True
 
 
@@ -316,16 +335,21 @@ def oznacz_jako_zaimportowane(session, record):
         )
         return False
 
+    teraz = timezone.now()
     zaktualizowane = (
         Zgloszenie_Publikacji.objects.filter(pk=session.zgloszenie_id)
         .exclude(status__in=_wykluczone_statusy())
         .update(
             status=Zgloszenie_Publikacji.Statusy.ZAIMPORTOWANY,
-            zaimportowano=timezone.now(),
+            zaimportowano=teraz,
             zaimportowal_id=session.created_by_id,
             content_type=ContentType.objects.get_for_model(record),
             object_id=record.pk,
             kod_do_edycji=None,
+            # ``.update()`` omija ``auto_now``, a ``Meta.ordering`` sortuje po
+            # tym polu — bez jawnego ustawienia świeżo zaimportowane
+            # zgłoszenie zostawałoby ze starą datą na dole listy.
+            ostatnio_zmieniony=teraz,
         )
     )
 

--- a/src/importer_publikacji/zgloszenia.py
+++ b/src/importer_publikacji/zgloszenia.py
@@ -1,0 +1,194 @@
+"""Wiązanie sesji importu ze zgłoszeniem publikacji (FD#443).
+
+Jedno miejsce z regułami „które zgłoszenie domyka ta sesja importu" —
+używane przez zadanie Celery (auto-wiązanie + zapis zwrotny), przez widok
+wyboru kandydata oraz przez prefill dyscyplin. Reguły siedzą tutaj, żeby
+``tasks.py``, ``wizard.py`` i widoki ich nie powielały.
+
+Zasady (spec ``docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-\
+przez-importer-design.md``):
+
+* wiązanie **wyłącznie po DOI** — dopasowanie po tytule jest wykluczone
+  (D5: dwa zgłoszenia o identycznym tytule oznaczyłyby przypadkowe),
+* kandydaci nie przekraczają granicy uczelni (D8) — ``Zgloszenie_Publikacji``
+  nie ma pola ``uczelnia``, więc atrybucja idzie przez jednostki autorów,
+* ``WYMAGA_ZMIAN`` jest wykluczony (D9) — zgłoszenie jest wtedy w rękach
+  autora (aktywny ``kod_do_edycji``); przestemplowanie zabrałoby mu pracę,
+* zapis zwrotny jest idempotentny i odporny na soft-delete (dostęp przez FK
+  idzie ``_base_manager``, który **nie** filtruje usuniętych).
+
+``SoftDeleteModel.delete()`` emuluje ``on_delete``, więc skasowanie zgłoszenia
+zwykłą ścieżką samo wyzeruje ``ImportSession.zgloszenie``. Guard na
+``deleted_at`` w :func:`oznacz_jako_zaimportowane` pilnuje ścieżek, które
+``delete()`` omijają — bulk ``UPDATE deleted_at``, surowy SQL, migracje danych,
+wyścig transakcji.
+"""
+
+import logging
+
+from django.db import transaction
+from django.utils import timezone
+
+from import_common.normalization import normalize_doi
+
+logger = logging.getLogger(__name__)
+
+
+def _wykluczone_statusy():
+    """Statusy, w których zgłoszenia nie ma już czym domykać.
+
+    ``ZAAKCEPTOWANY`` i ``ZAIMPORTOWANY`` — praca jest już w BPP.
+    ``ODRZUCONO``/``SPAM`` — zgłoszenie zamknięte.
+    ``WYMAGA_ZMIAN`` — zgłoszenie jest po stronie zgłaszającego (D9).
+    """
+    from zglos_publikacje.models import Zgloszenie_Publikacji
+
+    statusy = Zgloszenie_Publikacji.Statusy
+    return (
+        statusy.ODRZUCONO,
+        statusy.SPAM,
+        statusy.ZAIMPORTOWANY,
+        statusy.ZAAKCEPTOWANY,
+        statusy.WYMAGA_ZMIAN,
+    )
+
+
+def _doi_sesji(session):
+    """Znormalizowane DOI sesji importu albo ``None``.
+
+    Ta sama normalizacja, co w ``views.authors._find_matching_zgloszenie``
+    — wspólny ``import_common.normalization.normalize_doi``.
+    """
+    return normalize_doi((session.normalized_data or {}).get("doi"))
+
+
+def _zawez_do_uczelni(qs, session):
+    """Zawęź kandydatów do uczelni sesji importu (D8).
+
+    ``Zgloszenie_Publikacji`` nie ma FK do uczelni — jedyna droga w ORM
+    prowadzi przez jednostki autorów zgłoszenia. JOIN przez autorów mnoży
+    wiersze, więc wołający **musi** dołożyć ``.distinct()``.
+
+    No-op (jak w :func:`bpp.util.uczelnia_scope.scope_rekord_do_uczelni`
+    i ``permissions.scope_import_do_uczelni``), gdy:
+
+    * sesja nie ma uczelni (brak mapowania Site→Uczelnia) — nie chcemy
+      nagle ukryć wszystkiego,
+    * w instalacji jest dokładnie jedna uczelnia — filtr byłby no-opem,
+      a kosztowałby JOIN + DISTINCT.
+    """
+    from bpp.util.uczelnia_scope import tylko_jedna_uczelnia
+
+    if not session.uczelnia_id or tylko_jedna_uczelnia():
+        return qs
+    return qs.filter(
+        zgloszenie_publikacji_autor__jednostka__uczelnia_id=session.uczelnia_id
+    )
+
+
+def kandydaci_dla_sesji(session):
+    """Zgłoszenia, które ta sesja importu mogłaby domknąć.
+
+    Zwraca ``QuerySet`` (możliwie pusty — nigdy ``None``), żeby wołający
+    mógł go bezpiecznie filtrować (walidacja wyboru operatora) i liczyć.
+    """
+    from zglos_publikacje.models import Zgloszenie_Publikacji
+
+    doi = _doi_sesji(session)
+    if not doi:
+        return Zgloszenie_Publikacji.objects.none()
+
+    qs = Zgloszenie_Publikacji.objects.filter(doi__iexact=doi).exclude(
+        status__in=_wykluczone_statusy()
+    )
+    return _zawez_do_uczelni(qs, session).distinct()
+
+
+def zwiaz_automatycznie(session):
+    """Ustaw ``session.zgloszenie``, gdy kandydat jest dokładnie jeden.
+
+    Zwraca ``True`` tylko wtedy, gdy wiązanie faktycznie powstało. Zero
+    kandydatów → nie ma czego wiązać; dwa lub więcej → decyduje operator
+    (ścieżka C, ``views.zgloszenie.ZgloszenieWyborView``).
+
+    Nie nadpisuje istniejącego wiązania — jawny wybór (ścieżka A) jest
+    zawsze mocniejszy od heurystyki po DOI.
+    """
+    if session.zgloszenie_id:
+        return False
+
+    # LIMIT 2 wystarczy do rozstrzygnięcia „dokładnie jeden".
+    kandydaci = list(kandydaci_dla_sesji(session)[:2])
+    if len(kandydaci) != 1:
+        return False
+
+    session.zgloszenie = kandydaci[0]
+    session.save(update_fields=["zgloszenie"])
+    return True
+
+
+def oznacz_jako_zaimportowane(session, record):
+    """Zapis zwrotny na zgłoszeniu po udanym imporcie. Idempotentny.
+
+    Zwraca ``True``, gdy zgłoszenie zostało oznaczone; ``False``, gdy
+    pominięto (brak wiązania, zgłoszenie soft-usunięte, albo już
+    oznaczone — ponowienie zadania nie przesuwa daty ani nie zmienia
+    autora).
+
+    ``zaimportowal`` bierzemy z ``session.created_by``, nie
+    ``modified_by`` — „kto to zrobił" znaczy kto uruchomił import, nie kto
+    ostatnio dotknął wiersza.
+    """
+    from zglos_publikacje.models import Zgloszenie_Publikacji
+
+    if not session.zgloszenie_id:
+        return False
+
+    # Dostęp przez FK idzie ``_base_manager``, który NIE filtruje
+    # soft-usuniętych. Zwykłe ``zgl.delete()`` samo wyzeruje to FK (biblioteka
+    # emuluje ``on_delete``), ale bulk UPDATE, surowy SQL czy migracja danych
+    # już nie — stąd jawny guard na ``deleted_at`` niżej.
+    zgl = session.zgloszenie
+
+    if zgl.deleted_at is not None:
+        logger.warning(
+            "Sesja importu %s wskazuje na soft-usunięte zgłoszenie %s — "
+            "pomijam oznaczanie jako zaimportowane.",
+            session.pk,
+            zgl.pk,
+        )
+        return False
+
+    if zgl.status == Zgloszenie_Publikacji.Statusy.ZAIMPORTOWANY:
+        logger.info(
+            "Zgłoszenie %s jest już oznaczone jako zaimportowane — "
+            "pomijam (sesja importu %s).",
+            zgl.pk,
+            session.pk,
+        )
+        return False
+
+    with transaction.atomic():
+        zgl.status = Zgloszenie_Publikacji.Statusy.ZAIMPORTOWANY
+        zgl.zaimportowano = timezone.now()
+        zgl.zaimportowal = session.created_by
+        # GenericForeignKey — zapisuje się przez content_type + object_id.
+        zgl.odpowiednik_w_bpp = record
+        zgl.save(
+            update_fields=[
+                "status",
+                "zaimportowano",
+                "zaimportowal",
+                "content_type",
+                "object_id",
+            ]
+        )
+
+    logger.info(
+        "Zgłoszenie %s oznaczone jako zaimportowane przez sesję importu %s "
+        "(rekord %s).",
+        zgl.pk,
+        session.pk,
+        record.pk,
+    )
+    return True

--- a/src/importer_publikacji/zgloszenia.py
+++ b/src/importer_publikacji/zgloszenia.py
@@ -2,20 +2,25 @@
 
 Jedno miejsce z regułami „które zgłoszenie domyka ta sesja importu" —
 używane przez zadanie Celery (auto-wiązanie + zapis zwrotny), przez widok
-wyboru kandydata oraz przez prefill dyscyplin. Reguły siedzą tutaj, żeby
-``tasks.py``, ``wizard.py`` i widoki ich nie powielały.
+wyboru kandydata, przez walidację jawnego wyboru (ukryte pole ``zgloszenie``
+w ``FetchForm``) oraz przez prefill dyscyplin. Reguły siedzą tutaj, żeby
+``views/wizard.py``, ``tasks.py`` i pozostałe widoki ich nie powielały.
 
 Zasady (spec ``docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-\
 przez-importer-design.md``):
 
 * wiązanie **wyłącznie po DOI** — dopasowanie po tytule jest wykluczone
   (D5: dwa zgłoszenia o identycznym tytule oznaczyłyby przypadkowe),
+* DOI zgłoszenia czytamy z DWÓCH pól: ``doi`` **oraz** ``strona_www``
+  (patrz :func:`_pk_pasujacych_po_doi` — publiczny formularz nie ma pola
+  ``doi``, więc produkcyjnie DOI ląduje w ``strona_www``),
 * kandydaci nie przekraczają granicy uczelni (D8) — ``Zgloszenie_Publikacji``
   nie ma pola ``uczelnia``, więc atrybucja idzie przez jednostki autorów,
 * ``WYMAGA_ZMIAN`` jest wykluczony (D9) — zgłoszenie jest wtedy w rękach
   autora (aktywny ``kod_do_edycji``); przestemplowanie zabrałoby mu pracę,
-* zapis zwrotny jest idempotentny i odporny na soft-delete (dostęp przez FK
-  idzie ``_base_manager``, który **nie** filtruje usuniętych).
+* zapis zwrotny jest idempotentny, odporny na soft-delete (dostęp przez FK
+  idzie ``_base_manager``, który **nie** filtruje usuniętych) i rewaliduje
+  status w chwili zapisu, a nie w chwili związania.
 
 ``SoftDeleteModel.delete()`` emuluje ``on_delete``, więc skasowanie zgłoszenia
 zwykłą ścieżką samo wyzeruje ``ImportSession.zgloszenie``. Guard na
@@ -26,10 +31,10 @@ wyścig transakcji.
 
 import logging
 
-from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone
 
-from import_common.normalization import normalize_doi
+from import_common.normalization import extract_doi_from_url, normalize_doi
 
 logger = logging.getLogger(__name__)
 
@@ -62,35 +67,131 @@ def _doi_sesji(session):
     return normalize_doi((session.normalized_data or {}).get("doi"))
 
 
-def _zawez_do_uczelni(qs, session):
-    """Zawęź kandydatów do uczelni sesji importu (D8).
+def _uczelnia_pk(uczelnia):
+    """Klucz główny uczelni — z instancji, z gołego pk albo ``None``.
+
+    Wołający mają raz instancję (``Uczelnia.get_for_request``), raz samo
+    ``session.uczelnia_id`` (tańsze — bez dociągania wiersza uczelni).
+    """
+    if uczelnia is None:
+        return None
+    return getattr(uczelnia, "pk", uczelnia)
+
+
+def _zawez_do_uczelni(qs, uczelnia):
+    """Zawęź zgłoszenia do uczelni sesji importu / redaktora (D8).
+
+    ``uczelnia`` to instancja ``bpp.Uczelnia``, jej pk albo ``None``.
 
     ``Zgloszenie_Publikacji`` nie ma FK do uczelni — jedyna droga w ORM
     prowadzi przez jednostki autorów zgłoszenia. JOIN przez autorów mnoży
-    wiersze, więc wołający **musi** dołożyć ``.distinct()``.
+    wiersze, więc dokładamy tu ``.distinct()`` (wołający nie musi pamiętać).
 
     No-op (jak w :func:`bpp.util.uczelnia_scope.scope_rekord_do_uczelni`
     i ``permissions.scope_import_do_uczelni``), gdy:
 
-    * sesja nie ma uczelni (brak mapowania Site→Uczelnia) — nie chcemy
-      nagle ukryć wszystkiego,
+    * nie znamy uczelni (brak mapowania Site→Uczelnia) — nie chcemy nagle
+      ukryć wszystkiego,
     * w instalacji jest dokładnie jedna uczelnia — filtr byłby no-opem,
       a kosztowałby JOIN + DISTINCT.
+
+    **Znane ograniczenia semantyki (świadome, udokumentowane):**
+
+    * *przeciek D8 przy autorach z dwóch uczelni* — JOIN daje semantykę OR:
+      zgłoszenie, którego autorzy siedzą w jednostkach DWÓCH uczelni, jest
+      kandydatem dla OBU. Bez pola ``uczelnia`` na samym zgłoszeniu nie da
+      się tego rozstrzygnąć czysto (praca współautorska naprawdę „należy"
+      do obu), a wariant restrykcyjny (``wszyscy`` autorzy z jednej
+      uczelni) ukrywałby zgłoszenia współautorskie przed obiema.
+    * *zgłoszenia BEZ autorów wypadają* — INNER JOIN nie ma czego dopasować.
+      To decyzja **fail-closed**: w instalacji wielouczelnianej zgłoszenie
+      bez ani jednego autora nie daje się przypisać do uczelni, więc lepiej
+      nie pokazać go nikomu, niż pokazać wszystkim. Operator i tak dojdzie
+      do niego przez moduł redagowania i zwiąże jawnie (ścieżka A →
+      :func:`zgloszenie_dozwolone`, która tę samą regułę egzekwuje —
+      jawny wybór też nie przekracza granicy uczelni).
+
+    UWAGA: ``tylko_jedna_uczelnia()`` odpala ``COUNT`` **natychmiast**, przy
+    budowie querysetu — funkcja nie jest leniwa. Dlatego wołający wychodzą
+    wcześniej (brak DOI, brak pk), zanim tu w ogóle wejdą.
     """
     from bpp.util.uczelnia_scope import tylko_jedna_uczelnia
 
-    if not session.uczelnia_id or tylko_jedna_uczelnia():
+    uczelnia_pk = _uczelnia_pk(uczelnia)
+    if uczelnia_pk is None or tylko_jedna_uczelnia():
         return qs
     return qs.filter(
-        zgloszenie_publikacji_autor__jednostka__uczelnia_id=session.uczelnia_id
+        zgloszenie_publikacji_autor__jednostka__uczelnia_id=uczelnia_pk
+    ).distinct()
+
+
+def _dozwolone_zgloszenia(uczelnia):
+    """Baza kandydatów: statusy (D9) + granica uczelni (D8), bez DOI.
+
+    Jedno źródło obu reguł dla :func:`kandydaci_dla_sesji` (dopasowanie
+    po DOI) i :func:`zgloszenie_dozwolone` (wybór jawny).
+    """
+    from zglos_publikacje.models import Zgloszenie_Publikacji
+
+    return _zawez_do_uczelni(
+        Zgloszenie_Publikacji.objects.exclude(status__in=_wykluczone_statusy()),
+        uczelnia,
     )
+
+
+def _pk_pasujacych_po_doi(qs, doi):
+    """PK zgłoszeń, których DOI **równa się** ``doi`` (już znormalizowanemu).
+
+    Dlaczego dwa pola i dokładne dofiltrowanie w Pythonie:
+
+    * publiczny formularz zgłoszenia (``zglos_publikacje.forms``) nie ma
+      pola ``doi``, a help-text każe wkleić DOI do ``strona_www``
+      (``https://dx.doi.org/…``). Admin ma zgłoszenia read-only. Produkcyjnie
+      ``Zgloszenie_Publikacji.doi`` jest więc PUSTE — samo ``doi__iexact``
+      nie dopasowałoby niczego, a ścieżki B i C byłyby martwym kodem. Tę
+      samą kolejność (``strona_www`` przed ``doi``) stosuje już
+      ``admin.zgloszenie_publikacji.importer_url``.
+    * SQL zawęża tylko zgrubnie (``icontains`` po obu polach), bo LIKE nie
+      umie rozpoznać, gdzie w URL-u kończy się DOI. Dokładne porównanie
+      robimy w Pythonie przez ``extract_doi_from_url``/``normalize_doi``:
+      inaczej DOI będące PREFIKSEM innego (``10.1/abc`` vs ``10.1/abc.2``)
+      wpuściłoby fałszywe trafienie i zamieniło ścieżkę B (auto-wiązanie)
+      w ciche oznaczenie cudzego zgłoszenia.
+
+    ``order_by()`` kasuje domyślne ``Meta.ordering`` — inaczej
+    ``SELECT DISTINCT`` + ``ORDER BY`` po kolumnie spoza listy pól wywala
+    się na PostgreSQL-u.
+    """
+    return {
+        pk
+        for pk, zgl_doi, strona_www in qs.order_by().values_list(
+            "pk", "doi", "strona_www"
+        )
+        if normalize_doi(zgl_doi) == doi or extract_doi_from_url(strona_www) == doi
+    }
 
 
 def kandydaci_dla_sesji(session):
     """Zgłoszenia, które ta sesja importu mogłaby domknąć.
 
     Zwraca ``QuerySet`` (możliwie pusty — nigdy ``None``), żeby wołający
-    mógł go bezpiecznie filtrować (walidacja wyboru operatora) i liczyć.
+    mógł go bezpiecznie filtrować (walidacja wyboru operatora,
+    ``views.zgloszenie.ZgloszenieWyborView``), liczyć i iterować.
+
+    Dopasowanie po DOI wymaga materializacji pośredniego zapytania (patrz
+    :func:`_pk_pasujacych_po_doi`), więc wynikowy queryset jest zawężony
+    przez ``pk__in`` — dzięki temu jest znowu „płaski" (bez JOIN-a po
+    autorach i bez ``DISTINCT``) i da się go dalej filtrować.
+
+    ``prefetch_related`` na autorach: baner (``_baner_zgloszenia.html``)
+    woła ``zgl.zgloszenie_publikacji_autor_set.first`` dla każdego
+    kandydata — bez tego mamy N+1.
+
+    Działa tak samo dla importu pojedynczego, jak i dla wpisu z paczki
+    (``MultipleWorksImport`` idzie tą samą drogą: ``_start_import_session``
+    → ``fetch_session_task`` → :func:`zwiaz_automatycznie`). Spec §11
+    nazywa paczkę „poza zakresem", ale wyłączanie tego byłoby regresją —
+    zgłoszenie domknięte importem z paczki jest domknięte tak samo.
     """
     from zglos_publikacje.models import Zgloszenie_Publikacji
 
@@ -98,10 +199,41 @@ def kandydaci_dla_sesji(session):
     if not doi:
         return Zgloszenie_Publikacji.objects.none()
 
-    qs = Zgloszenie_Publikacji.objects.filter(doi__iexact=doi).exclude(
-        status__in=_wykluczone_statusy()
+    zgrubne = _dozwolone_zgloszenia(session.uczelnia_id).filter(
+        Q(doi__icontains=doi) | Q(strona_www__icontains=doi)
     )
-    return _zawez_do_uczelni(qs, session).distinct()
+    return Zgloszenie_Publikacji.objects.filter(
+        pk__in=_pk_pasujacych_po_doi(zgrubne, doi)
+    ).prefetch_related("zgloszenie_publikacji_autor_set")
+
+
+def zgloszenie_dozwolone(pk, uczelnia):
+    """Zgłoszenie, które wolno związać z sesją importu tej uczelni.
+
+    Zwraca obiekt albo ``None``. Egzekwuje te same reguły co
+    :func:`kandydaci_dla_sesji` (statusy D9 + granica uczelni D8), ale bez
+    dopasowania po DOI — wybór jest tu jawny (ścieżka A: przycisk „Użyj
+    importera" w module redagowania, ukryte pole ``zgloszenie``
+    w ``FetchForm``).
+
+    ``uczelnia`` to instancja ``bpp.Uczelnia``, jej pk albo ``None``
+    (brak mapowania Site→Uczelnia — wtedy filtr per-uczelnia jest no-opem,
+    dokładnie jak w :func:`kandydaci_dla_sesji`).
+
+    Wartość niepoprawna (śmieć w ukrytym polu, ręcznie podrasowany URL)
+    daje ``None``, nie wyjątek: wiązanie jest opcjonalne, więc nie może
+    zablokować importu.
+    """
+    if not pk:
+        return None
+
+    try:
+        return _dozwolone_zgloszenia(uczelnia).filter(pk=pk).first()
+    except (TypeError, ValueError):
+        logger.info(
+            "Odrzucono niepoprawny identyfikator zgłoszenia publikacji: %r.", pk
+        )
+        return None
 
 
 def zwiaz_automatycznie(session):
@@ -131,14 +263,37 @@ def oznacz_jako_zaimportowane(session, record):
     """Zapis zwrotny na zgłoszeniu po udanym imporcie. Idempotentny.
 
     Zwraca ``True``, gdy zgłoszenie zostało oznaczone; ``False``, gdy
-    pominięto (brak wiązania, zgłoszenie soft-usunięte, albo już
-    oznaczone — ponowienie zadania nie przesuwa daty ani nie zmienia
-    autora).
+    pominięto (brak wiązania, zgłoszenie soft-usunięte, albo jego status
+    zdążył wejść w :func:`_wykluczone_statusy` — w tym „już oznaczone",
+    więc ponowienie zadania nie przesuwa daty ani nie zmienia autora).
+
+    **Jeden warunkowy ``UPDATE``**, nie „przeczytaj → sprawdź → zapisz".
+    Między związaniem sesji (etap fetch) a tym zapisem (etap create) mija
+    cała praca operatora w kreatorze, a wczytany wcześniej ``session
+    .zgloszenie`` niesie stan sprzed tego czasu. Warunek w ``WHERE``
+    rewaliduje status w chwili zapisu i przy okazji domyka wyścig (bez
+    ``SELECT ... FOR UPDATE``): zgłoszenie zwrócone w międzyczasie autorowi
+    (``WYMAGA_ZMIAN``) nie zostanie przestemplowane.
 
     ``zaimportowal`` bierzemy z ``session.created_by``, nie
     ``modified_by`` — „kto to zrobił" znaczy kto uruchomił import, nie kto
     ostatnio dotknął wiersza.
+
+    ``kod_do_edycji`` kasujemy razem z oznaczeniem. Widok edycji
+    (``zglos_publikacje.views``) autoryzuje autora **samym kodem**, nie
+    patrząc na status — żywy kod na zgłoszeniu ZAIMPORTOWANYM pozwoliłby
+    autorowi cofnąć je do ``PO_ZMIANACH``, co zgasiłoby panel audytu
+    i przywróciło przycisk „Użyj importera" mimo istniejącego już rekordu
+    (prosta droga do duplikatu). Pole jest ``unique``, ale ``null=True``,
+    więc wiele ``NULL``-i współistnieje bez konfliktu.
+
+    Bez własnego ``transaction.atomic()``: pojedynczy ``UPDATE`` jest
+    atomowy sam z siebie, a wołający (``tasks.create_publication_task``)
+    i tak dokłada swój blok — zagnieżdżenie tworzyłoby tylko zbędny
+    savepoint.
     """
+    from django.contrib.contenttypes.models import ContentType
+
     from zglos_publikacje.models import Zgloszenie_Publikacji
 
     if not session.zgloszenie_id:
@@ -147,7 +302,9 @@ def oznacz_jako_zaimportowane(session, record):
     # Dostęp przez FK idzie ``_base_manager``, który NIE filtruje
     # soft-usuniętych. Zwykłe ``zgl.delete()`` samo wyzeruje to FK (biblioteka
     # emuluje ``on_delete``), ale bulk UPDATE, surowy SQL czy migracja danych
-    # już nie — stąd jawny guard na ``deleted_at`` niżej.
+    # już nie. ``objects`` (SoftDeleteManager) i tak by je odsiał w UPDATE
+    # niżej — jawny guard jest po to, żeby przypadek dało się rozpoznać
+    # w logach zamiast zgadywać, czemu UPDATE zwrócił zero.
     zgl = session.zgloszenie
 
     if zgl.deleted_at is not None:
@@ -159,30 +316,36 @@ def oznacz_jako_zaimportowane(session, record):
         )
         return False
 
-    if zgl.status == Zgloszenie_Publikacji.Statusy.ZAIMPORTOWANY:
+    zaktualizowane = (
+        Zgloszenie_Publikacji.objects.filter(pk=session.zgloszenie_id)
+        .exclude(status__in=_wykluczone_statusy())
+        .update(
+            status=Zgloszenie_Publikacji.Statusy.ZAIMPORTOWANY,
+            zaimportowano=timezone.now(),
+            zaimportowal_id=session.created_by_id,
+            content_type=ContentType.objects.get_for_model(record),
+            object_id=record.pk,
+            kod_do_edycji=None,
+        )
+    )
+
+    if not zaktualizowane:
+        # Status czytamy ŚWIEŻO — ``zgl.status`` niesie stan sprzed pracy
+        # operatora, a w logu chcemy zobaczyć powód odrzucenia UPDATE-u.
+        aktualny_status = (
+            Zgloszenie_Publikacji.global_objects.filter(pk=session.zgloszenie_id)
+            .values_list("status", flat=True)
+            .first()
+        )
         logger.info(
-            "Zgłoszenie %s jest już oznaczone jako zaimportowane — "
-            "pomijam (sesja importu %s).",
+            "Zgłoszenie %s nie kwalifikuje się już do oznaczenia jako "
+            "zaimportowane (status w chwili zapisu: %s) — pomijam "
+            "(sesja importu %s).",
             zgl.pk,
+            aktualny_status,
             session.pk,
         )
         return False
-
-    with transaction.atomic():
-        zgl.status = Zgloszenie_Publikacji.Statusy.ZAIMPORTOWANY
-        zgl.zaimportowano = timezone.now()
-        zgl.zaimportowal = session.created_by
-        # GenericForeignKey — zapisuje się przez content_type + object_id.
-        zgl.odpowiednik_w_bpp = record
-        zgl.save(
-            update_fields=[
-                "status",
-                "zaimportowano",
-                "zaimportowal",
-                "content_type",
-                "object_id",
-            ]
-        )
 
     logger.info(
         "Zgłoszenie %s oznaczone jako zaimportowane przez sesję importu %s "

--- a/src/zglos_publikacje/admin/filters.py
+++ b/src/zglos_publikacje/admin/filters.py
@@ -95,9 +95,19 @@ class StanObslugiFilter(SimpleListFilter):
     title = "stan obsługi"
     parameter_name = "stan_obslugi"
 
-    #: Nazwa pola, po którym filtruje sąsiedni filtr ``"status"`` z
-    #: ``list_filter``. Parametry w URL-u to ``status`` / ``status__<lookup>``.
-    POLE_STATUSU = "status"
+    #: Pola sąsiednich filtrów z ``list_filter``, których jawny wybór ma
+    #: wyłączyć domyślne zawężenie. Parametry w URL-u to ``<pole>`` albo
+    #: ``<pole>__<lookup>``.
+    #:
+    #: ``status`` — bo inaczej „status → spam" wpadałby w koniunkcję
+    #: z ``status__in=(0, 2, 3)`` i dawał pustą listę.
+    #:
+    #: ``zaimportowal``/``zaimportowano`` — bo te pola są niepuste
+    #: **wyłącznie** na zgłoszeniach ZAIMPORTOWANYCH, czyli spoza grupy
+    #: „Do obsługi". Bez nich koniunkcja jest sprzeczna z definicji
+    #: i kliknięcie osoby w filtrze „zaimportował" ZAWSZE dawało zero
+    #: wyników — dokładnie ta klasa błędu, którą naprawia ``status``.
+    POLA_WYLACZAJACE_ZAWEZENIE = ("status", "zaimportowal", "zaimportowano")
 
     DO_OBSLUGI = "do_obslugi"
     ZALATWIONE = "zalatwione"
@@ -119,10 +129,18 @@ class StanObslugiFilter(SimpleListFilter):
         super().__init__(request, params, model, model_admin)
         # ``request.GET``, nie ``params``: Django zdejmuje z ``params`` klucze
         # skonsumowane przez kolejne filtry, a nas interesuje surowy URL.
-        self.status_wybrany_recznie = any(
-            klucz == self.POLE_STATUSU or klucz.startswith(f"{self.POLE_STATUSU}__")
-            for klucz in request.GET
+        self.status_wybrany_recznie = self._inny_filtr_wybrany(
+            request
         ) or self._djangoql_aktywne(request)
+
+    @classmethod
+    def _inny_filtr_wybrany(cls, request) -> bool:
+        """Czy operator wybrał ręcznie któryś z sąsiednich filtrów?"""
+        return any(
+            klucz == pole or klucz.startswith(f"{pole}__")
+            for klucz in request.GET
+            for pole in cls.POLA_WYLACZAJACE_ZAWEZENIE
+        )
 
     @staticmethod
     def _djangoql_aktywne(request) -> bool:
@@ -136,8 +154,14 @@ class StanObslugiFilter(SimpleListFilter):
 
         Skoro operator pisze zapytanie ręcznie, domyślne zawężenie ma zejść
         mu z drogi — tak samo jak przy jawnym wyborze w filtrze „status".
+
+        Sam przełączony tryb bez treści zapytania (``q`` puste) nie liczy się
+        jako wybór: operator jeszcze nic nie napisał, więc domyślny widok
+        „Do obsługi" ma zostać.
         """
-        return request.GET.get(DJANGOQL_SEARCH_MARKER) == "on"
+        return request.GET.get(DJANGOQL_SEARCH_MARKER) == "on" and bool(
+            request.GET.get("q", "").strip()
+        )
 
     def lookups(self, request, model_admin):
         return [

--- a/src/zglos_publikacje/admin/filters.py
+++ b/src/zglos_publikacje/admin/filters.py
@@ -4,7 +4,7 @@ from django.db.models import Q, Window
 from django.db.models.functions import ExtractWeekDay, FirstValue
 
 from bpp.models import Jednostka
-from zglos_publikacje.models import Zgloszenie_Publikacji_Autor
+from zglos_publikacje.models import Zgloszenie_Publikacji, Zgloszenie_Publikacji_Autor
 
 
 class WydzialJednostkiPierwszegoAutora(SimpleListFilter):
@@ -69,6 +69,72 @@ class WydzialJednostkiPierwszegoAutora(SimpleListFilter):
         ]
 
         return queryset.filter(pk__in=rekordy)
+
+
+class StanObslugiFilter(SimpleListFilter):
+    """Filtr „Do obsługi / Załatwione / Wszystkie" (FD#443).
+
+    Domyślnie (brak parametru w URL-u) lista pokazuje wyłącznie zgłoszenia
+    wymagające reakcji operatora — bez odrzuconych, spamu i tych domkniętych
+    importerem. „Wszystkie" trzeba wybrać jawnie.
+
+    ``WYMAGA_ZMIAN`` świadomie nie należy do żadnej z dwóch grup: zgłoszenie
+    jest wtedy w rękach autora (aktywny ``kod_do_edycji``), więc ani nie
+    czeka na operatora, ani nie jest załatwione.
+    """
+
+    title = "stan obsługi"
+    parameter_name = "stan_obslugi"
+
+    DO_OBSLUGI = "do_obslugi"
+    ZALATWIONE = "zalatwione"
+    WSZYSTKIE = "wszystkie"
+
+    STATUSY_DO_OBSLUGI = (
+        Zgloszenie_Publikacji.Statusy.NOWY,
+        Zgloszenie_Publikacji.Statusy.PO_ZMIANACH,
+    )
+    STATUSY_ZALATWIONE = (
+        Zgloszenie_Publikacji.Statusy.ZAIMPORTOWANY,
+        Zgloszenie_Publikacji.Statusy.ZAAKCEPTOWANY,
+        Zgloszenie_Publikacji.Statusy.ODRZUCONO,
+        Zgloszenie_Publikacji.Statusy.SPAM,
+    )
+
+    def lookups(self, request, model_admin):
+        return [
+            (self.DO_OBSLUGI, "Do obsługi"),
+            (self.ZALATWIONE, "Załatwione"),
+            (self.WSZYSTKIE, "Wszystkie"),
+        ]
+
+    def choices(self, changelist):
+        # Nadpisujemy domyślne zachowanie ``SimpleListFilter``: tam brak
+        # parametru = „Wszystkie" i dodatkowa pozycja z ``value=None``. U nas
+        # brak parametru = „Do obsługi", a „Wszystkie" jest jawną wartością —
+        # inaczej nie dałoby się jej wybrać z poziomu interfejsu.
+        value = self.value()
+        for lookup, title in self.lookup_choices:
+            yield {
+                "selected": value == lookup
+                or (value is None and lookup == self.DO_OBSLUGI),
+                "query_string": changelist.get_query_string(
+                    {self.parameter_name: lookup}
+                ),
+                "display": title,
+            }
+
+    def queryset(self, request, queryset):
+        value = self.value()
+
+        if value == self.WSZYSTKIE:
+            return queryset
+
+        if value == self.ZALATWIONE:
+            return queryset.filter(status__in=self.STATUSY_ZALATWIONE)
+
+        # Domyślnie (brak parametru) oraz jawne „Do obsługi".
+        return queryset.filter(status__in=self.STATUSY_DO_OBSLUGI)
 
 
 class DzienTygodniaFilter(SimpleListFilter):

--- a/src/zglos_publikacje/admin/filters.py
+++ b/src/zglos_publikacje/admin/filters.py
@@ -2,6 +2,7 @@
 from django.contrib.admin import SimpleListFilter
 from django.db.models import Q, Window
 from django.db.models.functions import ExtractWeekDay, FirstValue
+from djangoql.admin import DJANGOQL_SEARCH_MARKER
 
 from bpp.models import Jednostka
 from zglos_publikacje.models import Zgloszenie_Publikacji, Zgloszenie_Publikacji_Autor
@@ -75,16 +76,28 @@ class StanObslugiFilter(SimpleListFilter):
     """Filtr „Do obsługi / Załatwione / Wszystkie" (FD#443).
 
     Domyślnie (brak parametru w URL-u) lista pokazuje wyłącznie zgłoszenia
-    wymagające reakcji operatora — bez odrzuconych, spamu i tych domkniętych
-    importerem. „Wszystkie" trzeba wybrać jawnie.
+    będące w toku — bez zaakceptowanych, odrzuconych, spamu i tych
+    domkniętych importerem. „Wszystkie" trzeba wybrać jawnie.
 
-    ``WYMAGA_ZMIAN`` świadomie nie należy do żadnej z dwóch grup: zgłoszenie
-    jest wtedy w rękach autora (aktywny ``kod_do_edycji``), więc ani nie
-    czeka na operatora, ani nie jest załatwione.
+    ``WYMAGA_ZMIAN`` należy do „Do obsługi": zgłoszenie siedzi wprawdzie u
+    autora (aktywny ``kod_do_edycji``), ale wciąż jest na biurku operatora —
+    trzeba je pilnować, przypomnieć, po czasie odrzucić. Do „Załatwionych"
+    nie należy na pewno, a wyrzucenie go poza obie grupy chowało zgłoszenia
+    czekające na autora wszędzie poza „Wszystkie" — regres widoczności
+    danych wobec stanu sprzed FD#443.
+
+    Filtr jest **przezroczysty**, gdy stan obsługi nie został wybrany
+    ręcznie, a w URL-u siedzi jawny wybór z sąsiedniego filtra „status"
+    (``status__exact`` itp.). Bez tego oba filtry składałyby się koniunkcją
+    i kliknięcie „status → spam" dawało pustą listę bez wyjaśnienia.
     """
 
     title = "stan obsługi"
     parameter_name = "stan_obslugi"
+
+    #: Nazwa pola, po którym filtruje sąsiedni filtr ``"status"`` z
+    #: ``list_filter``. Parametry w URL-u to ``status`` / ``status__<lookup>``.
+    POLE_STATUSU = "status"
 
     DO_OBSLUGI = "do_obslugi"
     ZALATWIONE = "zalatwione"
@@ -92,6 +105,7 @@ class StanObslugiFilter(SimpleListFilter):
 
     STATUSY_DO_OBSLUGI = (
         Zgloszenie_Publikacji.Statusy.NOWY,
+        Zgloszenie_Publikacji.Statusy.WYMAGA_ZMIAN,
         Zgloszenie_Publikacji.Statusy.PO_ZMIANACH,
     )
     STATUSY_ZALATWIONE = (
@@ -101,6 +115,30 @@ class StanObslugiFilter(SimpleListFilter):
         Zgloszenie_Publikacji.Statusy.SPAM,
     )
 
+    def __init__(self, request, params, model, model_admin):
+        super().__init__(request, params, model, model_admin)
+        # ``request.GET``, nie ``params``: Django zdejmuje z ``params`` klucze
+        # skonsumowane przez kolejne filtry, a nas interesuje surowy URL.
+        self.status_wybrany_recznie = any(
+            klucz == self.POLE_STATUSU or klucz.startswith(f"{self.POLE_STATUSU}__")
+            for klucz in request.GET
+        ) or self._djangoql_aktywne(request)
+
+    @staticmethod
+    def _djangoql_aktywne(request) -> bool:
+        """Czy operator pisze własne zapytanie DjangoQL?
+
+        Ten admin ma ``DjangoQLSearchMixin``, a zapytanie ląduje w ``q``
+        (marker trybu to ``q-l=on``) — czyli poza polem ``status``, którego
+        pilnuje detekcja wyżej. Bez tego ``status = 5`` wpisane w DjangoQL
+        wpadałoby w koniunkcję z domyślnym ``status__in=(0, 2, 3)`` i zawsze
+        zwracało pustą listę: operator szukający spamu dostawał zero wyników.
+
+        Skoro operator pisze zapytanie ręcznie, domyślne zawężenie ma zejść
+        mu z drogi — tak samo jak przy jawnym wyborze w filtrze „status".
+        """
+        return request.GET.get(DJANGOQL_SEARCH_MARKER) == "on"
+
     def lookups(self, request, model_admin):
         return [
             (self.DO_OBSLUGI, "Do obsługi"),
@@ -108,16 +146,24 @@ class StanObslugiFilter(SimpleListFilter):
             (self.WSZYSTKIE, "Wszystkie"),
         ]
 
+    def czy_domyslne_zawezenie(self) -> bool:
+        """Czy filtr działa „z automatu" (brak wyboru użytkownika)?"""
+        return self.value() is None and not self.status_wybrany_recznie
+
     def choices(self, changelist):
         # Nadpisujemy domyślne zachowanie ``SimpleListFilter``: tam brak
         # parametru = „Wszystkie" i dodatkowa pozycja z ``value=None``. U nas
         # brak parametru = „Do obsługi", a „Wszystkie" jest jawną wartością —
         # inaczej nie dałoby się jej wybrać z poziomu interfejsu.
+        #
+        # Gdy filtr jest przezroczysty (wybór w filtrze „status"), nie
+        # zaznaczamy nic — inaczej podświetlone „Do obsługi" kłamałoby o tym,
+        # co realnie zawęża listę.
         value = self.value()
+        domyslne = self.czy_domyslne_zawezenie()
         for lookup, title in self.lookup_choices:
             yield {
-                "selected": value == lookup
-                or (value is None and lookup == self.DO_OBSLUGI),
+                "selected": value == lookup or (domyslne and lookup == self.DO_OBSLUGI),
                 "query_string": changelist.get_query_string(
                     {self.parameter_name: lookup}
                 ),
@@ -132,6 +178,11 @@ class StanObslugiFilter(SimpleListFilter):
 
         if value == self.ZALATWIONE:
             return queryset.filter(status__in=self.STATUSY_ZALATWIONE)
+
+        if value is None and self.status_wybrany_recznie:
+            # Jawny wybór w filtrze „status" wygrywa z domyślnym zawężeniem —
+            # inaczej „status → spam" dawałoby pustą listę bez wyjaśnienia.
+            return queryset
 
         # Domyślnie (brak parametru) oraz jawne „Do obsługi".
         return queryset.filter(status__in=self.STATUSY_DO_OBSLUGI)

--- a/src/zglos_publikacje/admin/zgloszenie_publikacji.py
+++ b/src/zglos_publikacje/admin/zgloszenie_publikacji.py
@@ -98,7 +98,10 @@ class Zgloszenie_PublikacjiAdmin(
     list_filter = [
         StanObslugiFilter,
         "status",
-        "zaimportowal",
+        # ``RelatedOnlyFieldListFilter``, nie gołe pole: inaczej sidebar
+        # dostaje ``<li>`` dla KAŻDEGO użytkownika w bazie (plus HTMX-owy
+        # licznik z ``DynamicAdminFilterMixin`` do każdej pozycji).
+        ("zaimportowal", admin.RelatedOnlyFieldListFilter),
         WydzialJednostkiPierwszegoAutora,
         DzienTygodniaFilter,
         "rodzaj_zglaszanej_publikacji",
@@ -135,22 +138,13 @@ class Zgloszenie_PublikacjiAdmin(
         )
     )
 
-    # Audyt domknięcia zgłoszenia importerem prac (FD#443). Pola dokładane
-    # do formularza wyłącznie dla zgłoszeń faktycznie zaimportowanych — patrz
-    # ``get_fields`` — żeby nie zaśmiecać czterema pustymi wierszami reszty.
-    POLA_AUDYTU_IMPORTU = (
-        "zaimportowano",
-        "zaimportowal",
-        "zaimportowany_rekord",
-        "sesje_importu_linki",
-    )
-
+    # Audyt domknięcia zgłoszenia importerem prac (FD#443) NIE jest polami
+    # formularza — całość pokazuje panel „📥 Zaimportowane …" nad formularzem
+    # (patrz ``change_view`` + ``change_form.html``). Jedno źródło prawdy:
+    # dublowanie tego w ``readonly_fields`` dawało dwa linki do tego samego
+    # rekordu i dwa komplety zapytań na każdy render strony.
     readonly_fields = [
         "pliki_do_pobrania",
-        "zaimportowano",
-        "zaimportowal",
-        "zaimportowany_rekord",
-        "sesje_importu_linki",
     ]
 
     inlines = [
@@ -158,11 +152,11 @@ class Zgloszenie_PublikacjiAdmin(
         Zgloszenie_Publikacji_ZalacznikInline,
     ]
 
-    def get_fields(self, request, obj=None):
-        fields = list(super().get_fields(request, obj))
-        if obj is not None and obj.czy_zaimportowane:
-            fields += [f for f in self.POLA_AUDYTU_IMPORTU if f not in fields]
-        return fields
+    def get_queryset(self, request):
+        # ``zaimportowal`` czyta panel audytu (strona zgłoszenia) — bez
+        # ``select_related`` to dodatkowy SELECT na użytkownika przy każdym
+        # renderze; na liście oszczędza zapytanie na wiersz przy filtrze.
+        return super().get_queryset(request).select_related("zaimportowal")
 
     def has_add_permission(self, request):
         return False
@@ -216,9 +210,9 @@ class Zgloszenie_PublikacjiAdmin(
                 url, nazwa = self._rekord_url_i_nazwa(obj)
                 extra_context["zaimportowany_rekord_url"] = url
                 extra_context["zaimportowany_rekord_nazwa"] = nazwa
-                sesje = self._sesje_importu(obj)
+                sesja = self._ostatnia_sesja_importu(obj)
                 extra_context["sesja_importu_url"] = (
-                    self._sesja_importu_url(sesje[0]) if sesje else None
+                    self._sesja_importu_url(sesja) if sesja is not None else None
                 )
         return super().change_view(request, object_id, form_url, extra_context)
 
@@ -262,8 +256,12 @@ class Zgloszenie_PublikacjiAdmin(
         )
 
     @staticmethod
-    def _sesje_importu(obj) -> list:
-        """Sesje importu związane ze zgłoszeniem.
+    def _ostatnia_sesja_importu(obj):
+        """Najnowsza sesja importu związana ze zgłoszeniem albo ``None``.
+
+        ``ImportSession.Meta.ordering`` to ``["-created"]``, więc ``first()``
+        zwraca **najnowszą** sesję — i o to chodzi: gdy import był ponawiany,
+        operatora interesuje ostatnie podejście, nie pierwsze.
 
         ``sesje_importu`` to relacja odwrotna z ``importer_publikacji``.
         ``getattr`` z wartością domyślną — relacja jest dokładana osobną
@@ -272,27 +270,8 @@ class Zgloszenie_PublikacjiAdmin(
         """
         manager = getattr(obj, "sesje_importu", None)
         if manager is None:
-            return []
-        return list(manager.all())
-
-    @admin.display(description="Utworzony rekord")
-    def zaimportowany_rekord(self, obj):
-        url, nazwa = self._rekord_url_i_nazwa(obj)
-        if url is None:
-            return "-"
-        return format_html('<a href="{}">📗 {}</a>', url, nazwa)
-
-    @admin.display(description="Sesje importu")
-    def sesje_importu_linki(self, obj):
-        sesje = self._sesje_importu(obj)
-        if not sesje:
-            return "-"
-
-        return format_html_join(
-            "<br/>",
-            '<a href="{}">📥 sesja importu #{}</a>',
-            ((self._sesja_importu_url(sesja), sesja.pk) for sesja in sesje),
-        )
+            return None
+        return manager.first()
 
     zwroc_view_template = (
         "admin/zglos_publikacje/zgloszenie_publikacji/zwroc_zgloszenie.html"

--- a/src/zglos_publikacje/admin/zgloszenie_publikacji.py
+++ b/src/zglos_publikacje/admin/zgloszenie_publikacji.py
@@ -32,6 +32,7 @@ from .filters import (
     DzienTygodniaFilter,
     MaPlikFilter,
     MaPrzyczyneZwrotuFilter,
+    StanObslugiFilter,
     WydzialJednostkiPierwszegoAutora,
 )
 from .forms import ZwrocEmailForm
@@ -91,10 +92,13 @@ class Zgloszenie_PublikacjiAdmin(
         "wydzial_pierwszego_autora",
         "email",
         "status",
+        "zaimportowano",
         "zgoda_na_publikacje_pelnego_tekstu",
     ]
     list_filter = [
+        StanObslugiFilter,
         "status",
+        "zaimportowal",
         WydzialJednostkiPierwszegoAutora,
         DzienTygodniaFilter,
         "rodzaj_zglaszanej_publikacji",
@@ -131,12 +135,34 @@ class Zgloszenie_PublikacjiAdmin(
         )
     )
 
-    readonly_fields = ["pliki_do_pobrania"]
+    # Audyt domknięcia zgłoszenia importerem prac (FD#443). Pola dokładane
+    # do formularza wyłącznie dla zgłoszeń faktycznie zaimportowanych — patrz
+    # ``get_fields`` — żeby nie zaśmiecać czterema pustymi wierszami reszty.
+    POLA_AUDYTU_IMPORTU = (
+        "zaimportowano",
+        "zaimportowal",
+        "zaimportowany_rekord",
+        "sesje_importu_linki",
+    )
+
+    readonly_fields = [
+        "pliki_do_pobrania",
+        "zaimportowano",
+        "zaimportowal",
+        "zaimportowany_rekord",
+        "sesje_importu_linki",
+    ]
 
     inlines = [
         Zgloszenie_Publikacji_AutorInline,
         Zgloszenie_Publikacji_ZalacznikInline,
     ]
+
+    def get_fields(self, request, obj=None):
+        fields = list(super().get_fields(request, obj))
+        if obj is not None and obj.czy_zaimportowane:
+            fields += [f for f in self.POLA_AUDYTU_IMPORTU if f not in fields]
+        return fields
 
     def has_add_permission(self, request):
         return False
@@ -185,7 +211,88 @@ class Zgloszenie_PublikacjiAdmin(
         obj = self.get_object(request, object_id)
         if obj is not None:
             extra_context["importer_url"] = self.importer_url(obj)
+            if obj.czy_zaimportowane:
+                # Panel „📥 Zaimportowane …" nad formularzem (FD#443, §8).
+                url, nazwa = self._rekord_url_i_nazwa(obj)
+                extra_context["zaimportowany_rekord_url"] = url
+                extra_context["zaimportowany_rekord_nazwa"] = nazwa
+                sesje = self._sesje_importu(obj)
+                extra_context["sesja_importu_url"] = (
+                    self._sesja_importu_url(sesje[0]) if sesje else None
+                )
         return super().change_view(request, object_id, form_url, extra_context)
+
+    def _rekord_url_i_nazwa(self, obj):
+        """``(url_admina, etykieta)`` rekordu powstałego ze zgłoszenia.
+
+        Zwraca ``(None, None)``, gdy ``odpowiednik_w_bpp`` nie jest ustawiony
+        albo wskazuje na rekord, którego nie da się już załadować (skasowany
+        model / nieistniejący wiersz — GenericFK nie ma integralności).
+        """
+        if obj is None or obj.content_type_id is None or not obj.object_id:
+            return None, None
+
+        try:
+            rekord = obj.odpowiednik_w_bpp
+            if rekord is None:
+                return None, None
+
+            opts = rekord._meta
+            return (
+                reverse(
+                    f"admin:{opts.app_label}_{opts.model_name}_change",
+                    args=[rekord.pk],
+                ),
+                str(rekord),
+            )
+        except Exception:
+            # Zerwany GenericFK to w adminie brak danych do pokazania, nie
+            # awaria — logujemy traceback, bez alarmu Rollbara.
+            zaloguj_polkniety_wyjatek(
+                f"Budowanie linku do odpowiednika w BPP (zgłoszenie pk={obj.pk})",
+                logger=logger,
+                do_rollbar=False,
+            )
+            return None, None
+
+    @staticmethod
+    def _sesja_importu_url(sesja) -> str:
+        return reverse(
+            "admin:importer_publikacji_importsession_change", args=[sesja.pk]
+        )
+
+    @staticmethod
+    def _sesje_importu(obj) -> list:
+        """Sesje importu związane ze zgłoszeniem.
+
+        ``sesje_importu`` to relacja odwrotna z ``importer_publikacji``.
+        ``getattr`` z wartością domyślną — relacja jest dokładana osobną
+        migracją tej samej gałęzi, a admin zgłoszeń nie może się wywalić,
+        gdy jej jeszcze nie ma.
+        """
+        manager = getattr(obj, "sesje_importu", None)
+        if manager is None:
+            return []
+        return list(manager.all())
+
+    @admin.display(description="Utworzony rekord")
+    def zaimportowany_rekord(self, obj):
+        url, nazwa = self._rekord_url_i_nazwa(obj)
+        if url is None:
+            return "-"
+        return format_html('<a href="{}">📗 {}</a>', url, nazwa)
+
+    @admin.display(description="Sesje importu")
+    def sesje_importu_linki(self, obj):
+        sesje = self._sesje_importu(obj)
+        if not sesje:
+            return "-"
+
+        return format_html_join(
+            "<br/>",
+            '<a href="{}">📥 sesja importu #{}</a>',
+            ((self._sesja_importu_url(sesja), sesja.pk) for sesja in sesje),
+        )
 
     zwroc_view_template = (
         "admin/zglos_publikacje/zgloszenie_publikacji/zwroc_zgloszenie.html"
@@ -395,7 +502,14 @@ class Zgloszenie_PublikacjiAdmin(
         ogóle jest — importer z providerem „Pozostałe strony WWW" (import z
         ogólnej strony), z adresem w polu identyfikatora. Gdy adresu nie ma
         — ``None`` (przycisku importera nie pokazujemy).
+
+        Zgłoszenie już domknięte importerem także zwraca ``None``: przycisk
+        znika, żeby operator nie zaimportował tej samej pracy drugi raz
+        (FD#443, §7 specyfikacji).
         """
+        if obj.status == Zgloszenie_Publikacji.Statusy.ZAIMPORTOWANY:
+            return None
+
         doi = extract_doi_from_url(obj.strona_www) or extract_doi_from_url(
             getattr(obj, "doi", None)
         )
@@ -410,6 +524,10 @@ class Zgloszenie_PublikacjiAdmin(
             }
         else:
             return None
+
+        # Kontekst zgłoszenia musi przeżyć skok do importera — bez niego
+        # sesja importu nie ma jak domknąć zgłoszenia (FD#443, §6 ścieżka A).
+        params["zgloszenie"] = obj.pk
 
         return "{}?{}".format(
             reverse("importer_publikacji:index"),

--- a/src/zglos_publikacje/migrations/0027_zgloszenie_zaimportowane.py
+++ b/src/zglos_publikacje/migrations/0027_zgloszenie_zaimportowane.py
@@ -1,0 +1,51 @@
+# Audyt domknięcia zgłoszenia przez importer prac (FD#443).
+# Migracja napisana ręcznie — patrz docs/superpowers/specs/
+# 2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md §4.1
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zglos_publikacje", "0026_faza_b_ii2_repoint_wydzial"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="zgloszenie_publikacji",
+            name="zaimportowano",
+            field=models.DateTimeField(
+                blank=True, db_index=True, null=True, verbose_name="Zaimportowano"
+            ),
+        ),
+        migrations.AddField(
+            model_name="zgloszenie_publikacji",
+            name="zaimportowal",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to=settings.AUTH_USER_MODEL,
+                verbose_name="Zaimportował",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="zgloszenie_publikacji",
+            name="status",
+            field=models.PositiveSmallIntegerField(
+                choices=[
+                    (0, "nowe zgłoszenie"),
+                    (1, "zaakceptowany - dodany do bazy BPP"),
+                    (2, "wymaga zmian - odesłano do zgłaszającego"),
+                    (3, "zmiany naniesione przez zgłaszającego"),
+                    (4, "odrzucono w całości"),
+                    (5, "spam"),
+                    (6, "zaimportowany przez importer prac"),
+                ],
+                default=0,
+            ),
+        ),
+    ]

--- a/src/zglos_publikacje/models.py
+++ b/src/zglos_publikacje/models.py
@@ -95,9 +95,26 @@ class Zgloszenie_Publikacji(
         PO_ZMIANACH = 3, "zmiany naniesione przez zgłaszającego"
         ODRZUCONO = 4, "odrzucono w całości"
         SPAM = 5, "spam"
+        ZAIMPORTOWANY = 6, "zaimportowany przez importer prac"
 
     status = models.PositiveSmallIntegerField(
         default=Statusy.NOWY, choices=Statusy.choices
+    )
+
+    # Audyt domknięcia zgłoszenia importerem prac (FD#443). Denormalizowany
+    # na zgłoszeniu — filtrowalny i sortowalny na liście, przeżywa skasowanie
+    # sesji importu. Jawne pole czasu, nie ``auto_now``: ``ostatnio_zmieniony``
+    # przesuwa każda edycja i nie jest wiarygodnym znacznikiem importu.
+    zaimportowano = models.DateTimeField(
+        "Zaimportowano", null=True, blank=True, db_index=True
+    )
+    zaimportowal = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="+",
+        verbose_name="Zaimportował",
     )
 
     class Rodzaje(models.IntegerChoices):
@@ -288,6 +305,11 @@ class Zgloszenie_Publikacji(
     @property
     def pokazuj_przycisk_wydawnictwo_ciagle(self) -> bool:
         return self.rodzaj_zglaszanej_publikacji == self.Rodzaje.ARTYKUL
+
+    @property
+    def czy_zaimportowane(self) -> bool:
+        """Czy zgłoszenie zostało domknięte przez importer prac (FD#443)."""
+        return self.status == Zgloszenie_Publikacji.Statusy.ZAIMPORTOWANY
 
 
 class Zgloszenie_Publikacji_Autor(BazaModeluOdpowiedzialnosciAutorow):

--- a/src/zglos_publikacje/templates/admin/zglos_publikacje/zgloszenie_publikacji/change_form.html
+++ b/src/zglos_publikacje/templates/admin/zglos_publikacje/zgloszenie_publikacji/change_form.html
@@ -1,6 +1,8 @@
 {% extends "admin/change_form.html" %}
 
 {% block object-tools-items %}
+    {# „Użyj importera" nie pokazuje się dla zgłoszeń już zaimportowanych — #}
+    {# ``importer_url`` zwraca wtedy ``None`` (FD#443, §7 specyfikacji). #}
     {% if importer_url %}
         <li><a href="{{ importer_url }}" target="_blank" rel="noopener">📥 Użyj importera</a></li>
     {% endif %}
@@ -16,6 +18,27 @@
             <li><a href="{% url "admin:bpp_wydawnictwo_ciagle_add" %}?numer_zgloszenia={{ original.pk }}">Dodaj wyd. ciągłe</a></li>
             <li><a href="{% url "admin:bpp_wydawnictwo_zwarte_add" %}?numer_zgloszenia={{ original.pk }}">Dodaj wyd. zwarte</a></li>
         {% endif %}
+    {% endif %}
+    {{ block.super }}
+{% endblock %}
+
+{% block content %}
+    {# Informacja zwrotna po domknięciu zgłoszenia importerem (FD#443, §8). #}
+    {# Wyłącznie prezentacja: admin ma ``has_change_permission`` → False. #}
+    {% if original.czy_zaimportowane %}
+        <div class="module aligned" id="panel-zgloszenie-zaimportowane">
+            <p style="padding: 8px 12px; margin: 0;">
+                📥 <strong>Zaimportowane</strong>
+                {% if original.zaimportowano %}{{ original.zaimportowano|date:"d.m.Y H:i" }}{% endif %}
+                {% if original.zaimportowal %}przez {{ original.zaimportowal }}{% endif %}
+                {% if zaimportowany_rekord_url %}
+                    &middot; <a href="{{ zaimportowany_rekord_url }}">{{ zaimportowany_rekord_nazwa }} &#8599;</a>
+                {% endif %}
+                {% if sesja_importu_url %}
+                    &middot; <a href="{{ sesja_importu_url }}">sesja importu &#8599;</a>
+                {% endif %}
+            </p>
+        </div>
     {% endif %}
     {{ block.super }}
 {% endblock %}

--- a/src/zglos_publikacje/tests/test_fd443_zgloszenie_zaimportowane.py
+++ b/src/zglos_publikacje/tests/test_fd443_zgloszenie_zaimportowane.py
@@ -11,20 +11,31 @@ Zakres tego pliku (spec §10, grupy „Prezentacja" oraz część „Wiązanie �
 * nowy status ``ZAIMPORTOWANY = 6`` i ``czy_zaimportowane`` (§4.1).
 """
 
+import logging
 import re
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 from django.contrib import admin as django_admin
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateformat import format as format_date
 from model_bakery import baker
 
+from importer_publikacji.models import ImportSession
 from zglos_publikacje.admin.filters import StanObslugiFilter
-from zglos_publikacje.models import Zgloszenie_Publikacji
+from zglos_publikacje.models import (
+    Zgloszenie_Publikacji,
+    Zgloszenie_Publikacji_Zalacznik,
+)
 
 Statusy = Zgloszenie_Publikacji.Statusy
+
+CHANGELIST = "admin:zglos_publikacje_zgloszenie_publikacji_changelist"
+
+#: Logger, na który admin zgłoszeń wypuszcza połknięte wyjątki.
+LOGGER_ADMINA = "zglos_publikacje.admin.zgloszenie_publikacji"
 
 
 def _admin():
@@ -58,13 +69,112 @@ def _object_tools_fragment(html):
     return match.group(1)
 
 
+def _panel_fragment(html):
+    """Zawartość panelu „📥 Zaimportowane …" nad formularzem (FD#443, §8)."""
+    match = re.search(
+        r'<div[^>]*id="panel-zgloszenie-zaimportowane"[^>]*>(.*?)</div>',
+        html,
+        flags=re.DOTALL,
+    )
+    assert match, "Brak panelu id=panel-zgloszenie-zaimportowane na stronie edycji"
+    return match.group(1)
+
+
+def _changelist(admin_client, **params):
+    response = admin_client.get(reverse(CHANGELIST), params)
+    assert response.status_code == 200
+    return response
+
+
+def _spec(response, warunek, opis):
+    """Pojedynczy ``FieldListFilter`` changelisty spełniający ``warunek``."""
+    znalezione = [spec for spec in response.context["cl"].filter_specs if warunek(spec)]
+    assert len(znalezione) == 1, f"Oczekiwano dokładnie jednego filtra: {opis}"
+    return znalezione[0]
+
+
+def _spec_stanu_obslugi(response):
+    return _spec(
+        response,
+        lambda spec: isinstance(spec, StanObslugiFilter),
+        "StanObslugiFilter",
+    )
+
+
+def _spec_statusu(response):
+    return _spec(
+        response,
+        lambda spec: getattr(spec, "field_path", None) == "status",
+        "filtr po polu „status”",
+    )
+
+
+def _spec_zaimportowal(response):
+    return _spec(
+        response,
+        lambda spec: getattr(spec, "field_path", None) == "zaimportowal",
+        "filtr po polu „zaimportował”",
+    )
+
+
+def _zaznaczone(spec, changelist):
+    """Etykiety pozycji filtra oznaczonych w interfejsie jako wybrane."""
+    return [wybor["display"] for wybor in spec.choices(changelist) if wybor["selected"]]
+
+
+def _sesja_importu(zgloszenie, **kwargs):
+    """Realna ``ImportSession`` związana ze zgłoszeniem (FD#443, ścieżka A)."""
+    kwargs.setdefault("identifier", "10.1234/abc.def")
+    return baker.make(
+        ImportSession,
+        zgloszenie=zgloszenie,
+        provider_name="CrossRef",
+        raw_data={},
+        normalized_data={},
+        **kwargs,
+    )
+
+
+def _zaimportowane_zgloszenie(**kwargs):
+    kwargs.setdefault("tytul_oryginalny", "Praca domknięta importerem")
+    kwargs.setdefault("zaimportowano", timezone.now())
+    return baker.make(
+        Zgloszenie_Publikacji,
+        status=Statusy.ZAIMPORTOWANY,
+        **kwargs,
+    )
+
+
+def _zgloszenia_wszystkich_statusow(**kwargs):
+    """Po jednym zgłoszeniu w każdym statusie, indeksowane statusem."""
+    return {
+        status: baker.make(
+            Zgloszenie_Publikacji,
+            tytul_oryginalny=f"Zgłoszenie o statusie {status.label}",
+            status=status,
+            **kwargs,
+        )
+        for status in Statusy
+    }
+
+
 # --------------------------------------------------------------------------
 # Model: nowy status i ``czy_zaimportowane``
 # --------------------------------------------------------------------------
 
 
-def test_fd443_status_zaimportowany_ma_wartosc_6():
-    assert Statusy.ZAIMPORTOWANY == 6
+@pytest.mark.django_db
+def test_fd443_status_zaimportowany_zapisuje_w_bazie_wartosc_6():
+    """Liczba, nie nazwa, jedzie do bazy — a dane produkcyjne trzymają liczby.
+
+    Test asertuje na wartości ODCZYTANEJ Z BAZY (nie na literale enuma), więc
+    broni zgodności kolumny ``status`` między kodem a istniejącymi wierszami.
+    """
+    zgloszenie = _zaimportowane_zgloszenie()
+
+    z_bazy = Zgloszenie_Publikacji.objects.filter(pk=zgloszenie.pk)
+    assert list(z_bazy.values_list("status", flat=True)) == [6]
+    assert z_bazy.get().czy_zaimportowane is True
 
 
 def test_fd443_wartosc_6_nie_koliduje_z_istniejacymi_statusami():
@@ -84,10 +194,30 @@ def test_fd443_wartosc_6_nie_koliduje_z_istniejacymi_statusami():
     assert Statusy.SPAM == 5
 
 
-@pytest.mark.parametrize("status", list(Statusy))
-def test_fd443_czy_zaimportowane_tylko_dla_statusu_6(status):
-    zgloszenie = Zgloszenie_Publikacji(status=status)
-    assert zgloszenie.czy_zaimportowane == (status == Statusy.ZAIMPORTOWANY)
+@pytest.mark.django_db
+def test_fd443_czy_zaimportowane_zgadza_sie_z_gate_em_przycisku_importera():
+    """Dokładnie jeden status znaczy „domknięte importerem" — i ten sam status
+    (i tylko on) chowa przycisk „Użyj importera".
+
+    Cross-check dwóch niezależnych implementacji tej samej reguły
+    (``Zgloszenie_Publikacji.czy_zaimportowane`` vs gate w ``importer_url``),
+    zamiast powtarzania literału ``status == 6`` po stronie testu.
+    """
+    zgloszenia = _zgloszenia_wszystkich_statusow(
+        strona_www="https://doi.org/10.1234/abc.def"
+    )
+    z_bazy = {
+        status: Zgloszenie_Publikacji.objects.get(pk=zgloszenie.pk)
+        for status, zgloszenie in zgloszenia.items()
+    }
+
+    zaimportowane = {status for status, obj in z_bazy.items() if obj.czy_zaimportowane}
+    assert len(zaimportowane) == 1
+
+    bez_przycisku = {
+        status for status, obj in z_bazy.items() if _admin().importer_url(obj) is None
+    }
+    assert bez_przycisku == zaimportowane
 
 
 # --------------------------------------------------------------------------
@@ -184,15 +314,15 @@ def test_fd443_importer_url_dla_zaimportowanego_ze_strona_www_to_none():
 # --------------------------------------------------------------------------
 
 
-def _zgloszenia_wszystkich_statusow():
-    return {
-        status: baker.make(
-            Zgloszenie_Publikacji,
-            tytul_oryginalny=f"Zgłoszenie o statusie {status.label}",
-            status=status,
-        )
-        for status in Statusy
-    }
+#: Zgłoszenia „w toku" — te, które operator ma na biurku. ``WYMAGA_ZMIAN``
+#: należy do tej grupy: praca siedzi wprawdzie u autora, ale to nadal sprawa
+#: otwarta (trzeba przypomnieć, po czasie odrzucić). Wyrzucenie jej poza obie
+#: grupy chowało takie zgłoszenia wszędzie poza „Wszystkie".
+STATUSY_DO_OBSLUGI = {
+    Statusy.NOWY,
+    Statusy.WYMAGA_ZMIAN,
+    Statusy.PO_ZMIANACH,
+}
 
 
 def _statusy_po_filtrze(rf, wartosc):
@@ -225,17 +355,31 @@ def test_fd443_filtr_stan_obslugi_ma_trzy_pozycje(rf):
 def test_fd443_filtr_stan_obslugi_domyslnie_tylko_do_obslugi(rf):
     _zgloszenia_wszystkich_statusow()
 
-    assert _statusy_po_filtrze(rf, None) == {Statusy.NOWY, Statusy.PO_ZMIANACH}
+    assert _statusy_po_filtrze(rf, None) == STATUSY_DO_OBSLUGI
 
 
 @pytest.mark.django_db
 def test_fd443_filtr_stan_obslugi_do_obslugi_jawnie(rf):
     _zgloszenia_wszystkich_statusow()
 
-    assert _statusy_po_filtrze(rf, StanObslugiFilter.DO_OBSLUGI) == {
-        Statusy.NOWY,
-        Statusy.PO_ZMIANACH,
-    }
+    assert _statusy_po_filtrze(rf, StanObslugiFilter.DO_OBSLUGI) == STATUSY_DO_OBSLUGI
+
+
+@pytest.mark.django_db
+def test_fd443_filtr_stan_obslugi_grupy_dziela_statusy_bez_reszty(rf):
+    """Każdy status należy do dokładnie jednej grupy — żaden nie wypada poza.
+
+    To jest test, który złapałby regres widoczności: gdy status nie należy do
+    żadnej grupy, zgłoszenia w nim znikają wszędzie poza „Wszystkie".
+    """
+    _zgloszenia_wszystkich_statusow()
+
+    do_obslugi = _statusy_po_filtrze(rf, StanObslugiFilter.DO_OBSLUGI)
+    zalatwione = _statusy_po_filtrze(rf, StanObslugiFilter.ZALATWIONE)
+    wszystkie = _statusy_po_filtrze(rf, StanObslugiFilter.WSZYSTKIE)
+
+    assert do_obslugi & zalatwione == set()
+    assert do_obslugi | zalatwione == wszystkie == {status.value for status in Statusy}
 
 
 @pytest.mark.django_db
@@ -278,20 +422,15 @@ def test_fd443_filtr_stan_obslugi_domyslnie_zaznacza_do_obslugi(rf):
 def test_fd443_filtr_stan_obslugi_dziala_na_liscie_w_adminie(admin_client):
     """Domyślna lista w adminie nie pokazuje zgłoszeń załatwionych."""
     zgloszenia = _zgloszenia_wszystkich_statusow()
-    url = reverse("admin:zglos_publikacje_zgloszenie_publikacji_changelist")
 
-    response = admin_client.get(url)
-    assert response.status_code == 200
+    response = _changelist(admin_client)
     widoczne = {obj.pk for obj in response.context["cl"].result_list}
-    assert widoczne == {
-        zgloszenia[Statusy.NOWY].pk,
-        zgloszenia[Statusy.PO_ZMIANACH].pk,
-    }
+    assert widoczne == {zgloszenia[status].pk for status in STATUSY_DO_OBSLUGI}
 
-    response = admin_client.get(
-        url, {StanObslugiFilter.parameter_name: StanObslugiFilter.ZALATWIONE}
+    response = _changelist(
+        admin_client,
+        **{StanObslugiFilter.parameter_name: StanObslugiFilter.ZALATWIONE},
     )
-    assert response.status_code == 200
     widoczne = {obj.pk for obj in response.context["cl"].result_list}
     assert widoczne == {
         zgloszenia[Statusy.ZAIMPORTOWANY].pk,
@@ -300,12 +439,164 @@ def test_fd443_filtr_stan_obslugi_dziala_na_liscie_w_adminie(admin_client):
         zgloszenia[Statusy.SPAM].pk,
     }
 
-    response = admin_client.get(
-        url, {StanObslugiFilter.parameter_name: StanObslugiFilter.WSZYSTKIE}
+    response = _changelist(
+        admin_client,
+        **{StanObslugiFilter.parameter_name: StanObslugiFilter.WSZYSTKIE},
     )
-    assert response.status_code == 200
     widoczne = {obj.pk for obj in response.context["cl"].result_list}
     assert widoczne == {z.pk for z in zgloszenia.values()}
+
+
+# --------------------------------------------------------------------------
+# Konflikt „stan obsługi" × „status" — dane nieosiągalne z interfejsu
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("status", list(Statusy), ids=lambda s: s.name)
+def test_fd443_wybor_statusu_na_liscie_pokazuje_zgloszenie_w_tym_statusie(
+    admin_client, status
+):
+    """Kliknięcie „status → X" w sidebarze MUSI pokazać zgłoszenia w statusie X.
+
+    Regres: ``StanObslugiFilter`` przy braku własnego parametru dokładał twarde
+    ``status__in=(…)``, które składało się koniunkcją z sąsiednim filtrem
+    „status". Kliknięcie „spam" / „odrzucono" / „zaimportowany" dawało pustą
+    listę bez żadnego wyjaśnienia — dane były nieosiągalne z interfejsu.
+    """
+    zgloszenia = _zgloszenia_wszystkich_statusow()
+
+    response = _changelist(admin_client, status__exact=status.value)
+
+    widoczne = {obj.pk for obj in response.context["cl"].result_list}
+    assert widoczne == {zgloszenia[status].pk}
+
+
+@pytest.mark.django_db
+def test_fd443_wybor_statusu_nie_zaznacza_stanu_obslugi(admin_client):
+    """Skoro „Do obsługi" nie zawęża listy, to nie może być podświetlone.
+
+    Inaczej interfejs kłamie o tym, co realnie ogranicza wyniki.
+    """
+    _zgloszenia_wszystkich_statusow()
+
+    response = _changelist(admin_client, status__exact=Statusy.SPAM.value)
+    changelist = response.context["cl"]
+
+    assert _zaznaczone(_spec_stanu_obslugi(response), changelist) == []
+
+
+@pytest.mark.django_db
+def test_fd443_jawny_stan_obslugi_i_status_daja_koniunkcje(admin_client):
+    """Gdy OBA filtry wybrano ręcznie, zawężenia się składają — i widać to.
+
+    Pusty wynik jest wtedy wyjaśniony: w sidebarze świecą obie wybrane
+    pozycje, więc operator widzi, dlaczego nic nie ma.
+    """
+    _zgloszenia_wszystkich_statusow()
+
+    response = _changelist(
+        admin_client,
+        **{
+            StanObslugiFilter.parameter_name: StanObslugiFilter.DO_OBSLUGI,
+            "status__exact": Statusy.SPAM.value,
+        },
+    )
+    changelist = response.context["cl"]
+
+    assert list(changelist.result_list) == []
+    assert _zaznaczone(_spec_stanu_obslugi(response), changelist) == ["Do obsługi"]
+    assert _zaznaczone(_spec_statusu(response), changelist) == [Statusy.SPAM.label]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "parametr", ["status", "status__exact", "status__in", "status__gte"]
+)
+def test_fd443_kazdy_lookup_statusu_wylacza_domyslne_zawezenie(rf, parametr):
+    """Detekcja obejmuje ``status`` ORAZ ``status__<lookup>``, nie tylko
+    ``status__exact`` (DjangoQL i ręcznie sklejane adresy używają innych)."""
+    _zgloszenia_wszystkich_statusow()
+
+    request = rf.get("/", {parametr: str(Statusy.WYMAGA_ZMIAN.value)})
+    filtr = StanObslugiFilter(request, {}, Zgloszenie_Publikacji, _admin())
+
+    assert filtr.czy_domyslne_zawezenie() is False
+
+    qs = filtr.queryset(request, Zgloszenie_Publikacji.objects.all())
+    assert set(qs.values_list("status", flat=True)) == {
+        status.value for status in Statusy
+    }
+
+
+@pytest.mark.django_db
+def test_fd443_zapytanie_djangoql_wylacza_domyslne_zawezenie(rf):
+    """Zapytanie DjangoQL ląduje w ``q``, poza detekcją po polu ``status``.
+
+    Bez tego ``status = 5`` wpisane w DjangoQL wpadało w koniunkcję
+    z domyślnym ``status__in=(0, 2, 3)`` i ZAWSZE zwracało pustą listę —
+    operator szukający spamu dostawał zero wyników bez wyjaśnienia.
+    """
+    _zgloszenia_wszystkich_statusow()
+
+    request = rf.get("/", {"q": f"status = {Statusy.SPAM.value}", "q-l": "on"})
+    filtr = StanObslugiFilter(request, {}, Zgloszenie_Publikacji, _admin())
+
+    assert filtr.czy_domyslne_zawezenie() is False
+
+    qs = filtr.queryset(request, Zgloszenie_Publikacji.objects.all())
+    assert set(qs.values_list("status", flat=True)) == {
+        status.value for status in Statusy
+    }
+
+
+@pytest.mark.django_db
+def test_fd443_zwykle_wyszukiwanie_nie_wylacza_zawezenia(rf):
+    """Bez markera ``q-l=on`` to zwykłe wyszukiwanie — zawężenie zostaje."""
+    _zgloszenia_wszystkich_statusow()
+
+    request = rf.get("/", {"q": "cokolwiek"})
+    filtr = StanObslugiFilter(request, {}, Zgloszenie_Publikacji, _admin())
+
+    assert filtr.czy_domyslne_zawezenie() is True
+
+
+@pytest.mark.django_db
+def test_fd443_parametr_tylko_podobny_do_statusu_nie_wylacza_zawezenia(rf):
+    """``status_wewnetrzny=…`` to nie jest lookup po ``status`` — filtr działa."""
+    _zgloszenia_wszystkich_statusow()
+
+    request = rf.get("/", {"status_wewnetrzny": "2"})
+    filtr = StanObslugiFilter(request, {}, Zgloszenie_Publikacji, _admin())
+
+    assert filtr.czy_domyslne_zawezenie() is True
+
+    qs = filtr.queryset(request, Zgloszenie_Publikacji.objects.all())
+    assert set(qs.values_list("status", flat=True)) == STATUSY_DO_OBSLUGI
+
+
+# --------------------------------------------------------------------------
+# Filtr „zaimportował" — tylko użytkownicy obecni w danych
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_fd443_filtr_zaimportowal_listuje_tylko_uzytkownikow_z_danych(admin_client):
+    """``RelatedOnlyFieldListFilter``, nie gołe pole.
+
+    Bez tego sidebar dostaje ``<li>`` dla KAŻDEGO użytkownika w bazie (plus
+    HTMX-owy licznik do każdej pozycji) — na produkcji to setki wierszy i
+    setek zapytań na render listy.
+    """
+    importujacy = baker.make("bpp.BppUser", username="fd443_importujacy")
+    baker.make("bpp.BppUser", username="fd443_postronny")
+    _zaimportowane_zgloszenie(zaimportowal=importujacy)
+
+    response = _changelist(admin_client)
+    spec = _spec_zaimportowal(response)
+
+    assert isinstance(spec, django_admin.RelatedOnlyFieldListFilter)
+    assert {pk for pk, _etykieta in spec.lookup_choices} == {importujacy.pk}
 
 
 # --------------------------------------------------------------------------
@@ -320,11 +611,8 @@ def test_fd443_panel_audytu_pokazuje_date_uzytkownika_i_link_do_rekordu(
     operator = baker.make("bpp.BppUser", username="operator_fd443")
     kiedy = timezone.now()
 
-    zgloszenie = baker.make(
-        Zgloszenie_Publikacji,
-        tytul_oryginalny="Praca domknięta importerem",
+    zgloszenie = _zaimportowane_zgloszenie(
         strona_www="https://doi.org/10.1234/abc.def",
-        status=Statusy.ZAIMPORTOWANY,
         zaimportowano=kiedy,
         zaimportowal=operator,
     )
@@ -332,20 +620,153 @@ def test_fd443_panel_audytu_pokazuje_date_uzytkownika_i_link_do_rekordu(
     zgloszenie.save()
 
     html = _change_html(admin_client, zgloszenie)
+    panel = _panel_fragment(html)
 
-    assert 'id="panel-zgloszenie-zaimportowane"' in html
-    assert "Zaimportowane" in html
+    assert "Zaimportowane" in panel
 
     oczekiwana_data = format_date(timezone.localtime(kiedy), "d.m.Y H:i")
-    assert oczekiwana_data in html
+    assert oczekiwana_data in panel
 
-    assert "operator_fd443" in html
+    assert "operator_fd443" in panel
 
     url_rekordu = reverse(
         "admin:bpp_wydawnictwo_ciagle_change", args=[wydawnictwo_ciagle.pk]
     )
-    assert url_rekordu in html
-    assert str(wydawnictwo_ciagle) in html
+    assert url_rekordu in panel
+    assert str(wydawnictwo_ciagle) in panel
+
+
+@pytest.mark.django_db
+def test_fd443_link_do_utworzonego_rekordu_dokladnie_raz_na_stronie(
+    admin_client, wydawnictwo_ciagle
+):
+    """Jedno źródło prawdy: link do rekordu jest WYŁĄCZNIE w panelu.
+
+    Wcześniej to samo dublowało się w ``readonly_fields`` — dwa identyczne
+    linki na stronie i dwa komplety zapytań na render.
+    """
+    zgloszenie = _zaimportowane_zgloszenie()
+    zgloszenie.odpowiednik_w_bpp = wydawnictwo_ciagle
+    zgloszenie.save()
+
+    html = _change_html(admin_client, zgloszenie)
+    url_rekordu = reverse(
+        "admin:bpp_wydawnictwo_ciagle_change", args=[wydawnictwo_ciagle.pk]
+    )
+
+    assert html.count(f'href="{url_rekordu}"') == 1
+    assert html.count(url_rekordu) == 1
+
+
+@pytest.mark.django_db
+def test_fd443_panel_linkuje_do_realnej_sesji_importu(admin_client):
+    """Link „sesja importu" liczony z REALNEJ ``ImportSession``.
+
+    Poprzednia wersja testu nie tworzyła żadnej sesji, więc gałąź budująca
+    ``admin:importer_publikacji_importsession_change`` nie była wykonywana
+    ani razu — działała przez przypadek.
+    """
+    zgloszenie = _zaimportowane_zgloszenie()
+    sesja = _sesja_importu(zgloszenie)
+
+    # Stan z bazy, nie z atrybutu w pamięci.
+    assert list(
+        Zgloszenie_Publikacji.objects.get(pk=zgloszenie.pk).sesje_importu.values_list(
+            "pk", flat=True
+        )
+    ) == [sesja.pk]
+
+    panel = _panel_fragment(_change_html(admin_client, zgloszenie))
+
+    url_sesji = reverse(
+        "admin:importer_publikacji_importsession_change", args=[sesja.pk]
+    )
+    assert f'href="{url_sesji}"' in panel
+    assert "sesja importu" in panel
+
+
+@pytest.mark.django_db
+def test_fd443_panel_bez_sesji_importu_nie_pokazuje_linku_do_sesji(admin_client):
+    zgloszenie = _zaimportowane_zgloszenie()
+
+    panel = _panel_fragment(_change_html(admin_client, zgloszenie))
+
+    assert "sesja importu" not in panel
+
+
+@pytest.mark.django_db
+def test_fd443_panel_przy_wielu_sesjach_importu_linkuje_dokladnie_jedna(admin_client):
+    """Wiele sesji na jednym zgłoszeniu (ponowiony import) nie mnoży linków."""
+    zgloszenie = _zaimportowane_zgloszenie()
+    sesje = [
+        _sesja_importu(zgloszenie, identifier=f"10.1234/abc.{numer}")
+        for numer in range(3)
+    ]
+
+    assert (
+        Zgloszenie_Publikacji.objects.get(pk=zgloszenie.pk).sesje_importu.count() == 3
+    )
+
+    panel = _panel_fragment(_change_html(admin_client, zgloszenie))
+
+    trafione = [
+        sesja
+        for sesja in sesje
+        if reverse("admin:importer_publikacji_importsession_change", args=[sesja.pk])
+        in panel
+    ]
+    assert len(trafione) == 1
+    assert panel.count("sesja importu") == 1
+
+
+@pytest.mark.django_db
+def test_fd443_panel_przezywa_wskazanie_na_nieistniejacy_rekord(
+    admin_client, wydawnictwo_ciagle
+):
+    """Zerwany GenericFK (rekord skasowany) to brak danych, nie HTTP 500."""
+    zgloszenie = _zaimportowane_zgloszenie()
+    zgloszenie.odpowiednik_w_bpp = wydawnictwo_ciagle
+    zgloszenie.save()
+
+    Zgloszenie_Publikacji.objects.filter(pk=zgloszenie.pk).update(
+        object_id=wydawnictwo_ciagle.pk + 10**7
+    )
+
+    panel = _panel_fragment(_change_html(admin_client, zgloszenie))
+
+    assert "Zaimportowane" in panel
+    url_rekordu = reverse(
+        "admin:bpp_wydawnictwo_ciagle_change", args=[wydawnictwo_ciagle.pk]
+    )
+    assert url_rekordu not in panel
+
+
+@pytest.mark.django_db
+def test_fd443_panel_przezywa_rekord_bez_zarejestrowanego_admina(admin_client, caplog):
+    """GenericFK wskazuje na model bez admina → ``NoReverseMatch``, nie 500."""
+    zgloszenie = _zaimportowane_zgloszenie()
+    zalacznik = baker.make(Zgloszenie_Publikacji_Zalacznik, zgloszenie=zgloszenie)
+
+    assert Zgloszenie_Publikacji_Zalacznik not in django_admin.site._registry, (
+        "Test zakłada model bez zarejestrowanego ModelAdmin-a"
+    )
+
+    Zgloszenie_Publikacji.objects.filter(pk=zgloszenie.pk).update(
+        content_type=ContentType.objects.get_for_model(Zgloszenie_Publikacji_Zalacznik),
+        object_id=zalacznik.pk,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_ADMINA):
+        panel = _panel_fragment(_change_html(admin_client, zgloszenie))
+
+    assert "Zaimportowane" in panel
+    assert "&#8599;" not in panel
+
+    # Wyjątek został połknięty ŚWIADOMIE — z tracebackiem w logach, nie po cichu.
+    polkniete = [rekord for rekord in caplog.records if rekord.name == LOGGER_ADMINA]
+    assert len(polkniete) == 1
+    assert polkniete[0].exc_info is not None
+    assert str(zgloszenie.pk) in polkniete[0].getMessage()
 
 
 @pytest.mark.django_db
@@ -353,12 +774,9 @@ def test_fd443_zaimportowane_nie_pokazuje_przycisku_uzyj_importera(
     admin_client,
 ):
     """Ochrona przed podwójnym importem — przycisku nie ma w HTML-u (§7)."""
-    zgloszenie = baker.make(
-        Zgloszenie_Publikacji,
+    zgloszenie = _zaimportowane_zgloszenie(
         tytul_oryginalny="Praca już zaimportowana",
         strona_www="https://doi.org/10.1234/abc.def",
-        status=Statusy.ZAIMPORTOWANY,
-        zaimportowano=timezone.now(),
     )
 
     html = _change_html(admin_client, zgloszenie)
@@ -383,8 +801,10 @@ def test_fd443_niezaimportowane_bez_panelu_ale_z_przyciskiem_importera(
 
     html = _change_html(admin_client, zgloszenie)
 
+    # Asercja na stabilnym identyfikatorze panelu, nie na słowie
+    # „Zaimportowane" — to ostatnie pojawia się też np. w etykiecie kolumny
+    # „Zaimportowano" czy w nazwie filtra i dawało fałszywe alarmy.
     assert 'id="panel-zgloszenie-zaimportowane"' not in html
-    assert "Zaimportowane" not in html
 
     tools = _object_tools_fragment(html)
     assert "Użyj importera" in tools

--- a/src/zglos_publikacje/tests/test_fd443_zgloszenie_zaimportowane.py
+++ b/src/zglos_publikacje/tests/test_fd443_zgloszenie_zaimportowane.py
@@ -562,6 +562,42 @@ def test_fd443_zwykle_wyszukiwanie_nie_wylacza_zawezenia(rf):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("puste_q", ["", " ", "   \t  ", "\n"], ids=repr)
+def test_fd443_djangoql_bez_tresci_zapytania_nie_wylacza_zawezenia(rf, puste_q):
+    """Sam przełączony tryb DjangoQL to jeszcze nie jest wybór operatora.
+
+    Regresja: detekcja patrzyła WYŁĄCZNIE na marker ``q-l=on``, a ten siedzi
+    w URL-u także wtedy, gdy operator tylko przełączył tryb i nic nie napisał
+    (formularz wyszukiwania wysyła marker razem z pustym ``q``). Domyślny
+    widok „Do obsługi" gasł wtedy sam z siebie i lista bez ostrzeżenia
+    pokazywała komplet zgłoszeń — łącznie ze spamem i odrzuconymi.
+    """
+    _zgloszenia_wszystkich_statusow()
+
+    request = rf.get("/", {"q": puste_q, "q-l": "on"})
+    filtr = StanObslugiFilter(request, {}, Zgloszenie_Publikacji, _admin())
+
+    assert filtr.czy_domyslne_zawezenie() is True
+
+    qs = filtr.queryset(request, Zgloszenie_Publikacji.objects.all())
+    assert set(qs.values_list("status", flat=True)) == STATUSY_DO_OBSLUGI
+
+
+@pytest.mark.django_db
+def test_fd443_djangoql_bez_parametru_q_nie_wylacza_zawezenia(rf):
+    """Marker bez pola ``q`` w ogóle (ręcznie sklejony adres) — tak samo."""
+    _zgloszenia_wszystkich_statusow()
+
+    request = rf.get("/", {"q-l": "on"})
+    filtr = StanObslugiFilter(request, {}, Zgloszenie_Publikacji, _admin())
+
+    assert filtr.czy_domyslne_zawezenie() is True
+
+    qs = filtr.queryset(request, Zgloszenie_Publikacji.objects.all())
+    assert set(qs.values_list("status", flat=True)) == STATUSY_DO_OBSLUGI
+
+
+@pytest.mark.django_db
 def test_fd443_parametr_tylko_podobny_do_statusu_nie_wylacza_zawezenia(rf):
     """``status_wewnetrzny=…`` to nie jest lookup po ``status`` — filtr działa."""
     _zgloszenia_wszystkich_statusow()
@@ -597,6 +633,161 @@ def test_fd443_filtr_zaimportowal_listuje_tylko_uzytkownikow_z_danych(admin_clie
 
     assert isinstance(spec, django_admin.RelatedOnlyFieldListFilter)
     assert {pk for pk, _etykieta in spec.lookup_choices} == {importujacy.pk}
+
+
+def _lookup_zaimportowal(admin_client):
+    """Nazwa parametru URL-a, którą admin generuje dla filtra „zaimportował".
+
+    Czytana z samego ``FieldListFilter``, a nie wpisana literałem — gdyby
+    Django zmieniło kształt parametru dla ``ForeignKey``, test detekcji
+    w ``StanObslugiFilter`` ma się posypać, a nie zzielenieć na parametrze,
+    którego interfejs już nie produkuje.
+    """
+    lookup = _spec_zaimportowal(_changelist(admin_client)).lookup_kwarg
+    assert lookup == "zaimportowal__id__exact"
+    return lookup
+
+
+@pytest.mark.django_db
+def test_fd443_wybor_zaimportowal_pokazuje_zgloszenia_tej_osoby(admin_client):
+    """NAJWAŻNIEJSZY test tej grupy: kliknięcie osoby w filtrze COŚ pokazuje.
+
+    Regresja: ``zaimportowal`` jest niepuste WYŁĄCZNIE na zgłoszeniach
+    o statusie ZAIMPORTOWANY, czyli spoza grupy „Do obsługi". Dopóki
+    przezroczystość ``StanObslugiFilter`` obejmowała tylko pole ``status``,
+    domyślne ``status__in=(NOWY, WYMAGA_ZMIAN, PO_ZMIANACH)`` składało się
+    koniunkcją z wyborem osoby — sprzecznie z definicji. Kliknięcie
+    DOWOLNEJ pozycji filtra „zaimportował" dawało ZERO wyników, zawsze.
+
+    Poprzedni test tej grupy sprawdzał wyłącznie LISTĘ pozycji filtra, więc
+    tego nie łapał — trzeba było sprawdzić WYNIK kliknięcia.
+    """
+    importujacy = baker.make("bpp.BppUser", username="fd443_klikany")
+    inny = baker.make("bpp.BppUser", username="fd443_inny_operator")
+
+    moje = _zaimportowane_zgloszenie(zaimportowal=importujacy)
+    _zaimportowane_zgloszenie(
+        tytul_oryginalny="Praca zaimportowana przez kogoś innego",
+        zaimportowal=inny,
+    )
+    _zgloszenia_wszystkich_statusow()
+
+    response = _changelist(
+        admin_client, **{_lookup_zaimportowal(admin_client): importujacy.pk}
+    )
+
+    widoczne = {obj.pk for obj in response.context["cl"].result_list}
+    assert widoczne == {moje.pk}
+
+
+@pytest.mark.django_db
+def test_fd443_wybor_zaimportowal_nie_zaznacza_stanu_obslugi(admin_client):
+    """Skoro „Do obsługi" nie zawęża listy, to nie może być podświetlone."""
+    importujacy = baker.make("bpp.BppUser", username="fd443_klikany_2")
+    _zaimportowane_zgloszenie(zaimportowal=importujacy)
+
+    response = _changelist(
+        admin_client, **{_lookup_zaimportowal(admin_client): importujacy.pk}
+    )
+    changelist = response.context["cl"]
+
+    assert _zaznaczone(_spec_stanu_obslugi(response), changelist) == []
+
+
+@pytest.mark.django_db
+def test_fd443_jawny_stan_obslugi_i_zaimportowal_daja_koniunkcje(admin_client):
+    """Gdy OBA filtry wybrano ręcznie, zawężenia się składają — i widać to.
+
+    Wynik jest pusty z definicji (``zaimportowal`` niepuste tylko poza „Do
+    obsługi"), ale operator widzi w sidebarze obie zaznaczone pozycje, więc
+    wie, dlaczego nic nie ma. To jest różnica między pustką wyjaśnioną
+    a pustką bez powodu.
+    """
+    importujacy = baker.make("bpp.BppUser", username="fd443_klikany_3")
+    _zaimportowane_zgloszenie(zaimportowal=importujacy)
+
+    response = _changelist(
+        admin_client,
+        **{
+            StanObslugiFilter.parameter_name: StanObslugiFilter.DO_OBSLUGI,
+            _lookup_zaimportowal(admin_client): importujacy.pk,
+        },
+    )
+    changelist = response.context["cl"]
+
+    assert list(changelist.result_list) == []
+    assert _zaznaczone(_spec_stanu_obslugi(response), changelist) == ["Do obsługi"]
+    assert _zaznaczone(_spec_zaimportowal(response), changelist) == [str(importujacy)]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "parametr",
+    [
+        "zaimportowal",
+        "zaimportowal__id__exact",
+        "zaimportowal__isnull",
+        "zaimportowano",
+        "zaimportowano__gte",
+        "zaimportowano__year",
+        "zaimportowano__isnull",
+    ],
+)
+def test_fd443_lookupy_pol_importu_wylaczaja_domyslne_zawezenie(rf, parametr):
+    """Detekcja obejmuje oba pola audytu importu i KAŻDY ich lookup.
+
+    ``zaimportowano`` nie siedzi dziś w ``list_filter`` (patrz asercja
+    niżej), więc adres z takim parametrem powstaje ręcznie albo z linku
+    w panelu — ale klasa błędu jest ta sama co przy ``zaimportowal``:
+    pole jest niepuste wyłącznie poza grupą „Do obsługi", więc koniunkcja
+    z domyślnym zawężeniem daje pustkę z definicji. Detekcja pilnuje tego
+    z wyprzedzeniem, żeby dołożenie pola do ``list_filter`` nie wróciło
+    z tym samym błędem.
+    """
+    _zgloszenia_wszystkich_statusow()
+
+    request = rf.get("/", {parametr: "1"})
+    filtr = StanObslugiFilter(request, {}, Zgloszenie_Publikacji, _admin())
+
+    assert filtr.czy_domyslne_zawezenie() is False
+
+    qs = filtr.queryset(request, Zgloszenie_Publikacji.objects.all())
+    assert set(qs.values_list("status", flat=True)) == {
+        status.value for status in Statusy
+    }
+
+
+def test_fd443_zaimportowano_nie_jest_dzis_w_list_filter():
+    """Charakteryzacja: test wyżej testuje samą detekcję, nie klikalny filtr.
+
+    Gdyby ``zaimportowano`` trafiło do ``list_filter``, ten test zapali się
+    na czerwono — i będzie sygnałem, żeby dorobić do niego test end-to-end
+    przez changelistę (tak jak dla ``zaimportowal``).
+    """
+    assert "zaimportowano" not in _admin().list_filter
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "parametr", ["zaimportowal_kiedys", "zaimportowano_recznie", "zaimportowalem"]
+)
+def test_fd443_parametr_tylko_podobny_do_pol_importu_nie_wylacza_zawezenia(
+    rf, parametr
+):
+    """Detekcja idzie po pełnej nazwie pola albo po prefiksie ``<pole>__``.
+
+    ``startswith(pole)`` bez separatora wpuściłoby dowolny parametr
+    zaczynający się od tych liter i cicho gasiło domyślny widok.
+    """
+    _zgloszenia_wszystkich_statusow()
+
+    request = rf.get("/", {parametr: "1"})
+    filtr = StanObslugiFilter(request, {}, Zgloszenie_Publikacji, _admin())
+
+    assert filtr.czy_domyslne_zawezenie() is True
+
+    qs = filtr.queryset(request, Zgloszenie_Publikacji.objects.all())
+    assert set(qs.values_list("status", flat=True)) == STATUSY_DO_OBSLUGI
 
 
 # --------------------------------------------------------------------------

--- a/src/zglos_publikacje/tests/test_fd443_zgloszenie_zaimportowane.py
+++ b/src/zglos_publikacje/tests/test_fd443_zgloszenie_zaimportowane.py
@@ -1,0 +1,391 @@
+"""FD#443 — domknięcie pętli zgłoszenie publikacji ↔ importer prac.
+
+Zakres tego pliku (spec §10, grupy „Prezentacja" oraz część „Wiązanie —
+ścieżka A" dotycząca URL-a przycisku):
+
+* ``importer_url`` — kontekst zgłoszenia (``zgloszenie=<pk>``) w adresie
+  przycisku „Użyj importera" oraz brak przycisku dla zgłoszeń już
+  zaimportowanych (ochrona przed podwójnym importem, §7);
+* filtr „Do obsługi / Załatwione / Wszystkie" (§9);
+* panel audytu „📥 Zaimportowane …" na stronie zgłoszenia (§8);
+* nowy status ``ZAIMPORTOWANY = 6`` i ``czy_zaimportowane`` (§4.1).
+"""
+
+import re
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from django.contrib import admin as django_admin
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.dateformat import format as format_date
+from model_bakery import baker
+
+from zglos_publikacje.admin.filters import StanObslugiFilter
+from zglos_publikacje.models import Zgloszenie_Publikacji
+
+Statusy = Zgloszenie_Publikacji.Statusy
+
+
+def _admin():
+    """Zarejestrowana instancja ``ModelAdmin`` dla zgłoszeń."""
+    return django_admin.site._registry[Zgloszenie_Publikacji]
+
+
+def _params(importer_url):
+    """Rozbierz query string adresu importera na słownik list."""
+    assert importer_url is not None
+    return parse_qs(urlparse(importer_url).query)
+
+
+def _change_html(admin_client, zgloszenie):
+    response = admin_client.get(
+        reverse(
+            "admin:zglos_publikacje_zgloszenie_publikacji_change",
+            args=[zgloszenie.pk],
+        )
+    )
+    assert response.status_code == 200
+    return response.content.decode()
+
+
+def _object_tools_fragment(html):
+    """Zawartość paska akcji ``<ul class="…object-tools">…</ul>``."""
+    match = re.search(
+        r'<ul class="[^"]*object-tools">(.*?)</ul>', html, flags=re.DOTALL
+    )
+    assert match, "Brak paska object-tools na stronie edycji"
+    return match.group(1)
+
+
+# --------------------------------------------------------------------------
+# Model: nowy status i ``czy_zaimportowane``
+# --------------------------------------------------------------------------
+
+
+def test_fd443_status_zaimportowany_ma_wartosc_6():
+    assert Statusy.ZAIMPORTOWANY == 6
+
+
+def test_fd443_wartosc_6_nie_koliduje_z_istniejacymi_statusami():
+    """Wartość 6 była wolna (poprzednio ``Statusy`` kończyło się na SPAM=5)."""
+    wartosci = [s.value for s in Statusy]
+    assert len(wartosci) == len(set(wartosci)), "Zdublowane wartości w Statusy"
+
+    o_wartosci_6 = [s for s in Statusy if s.value == 6]
+    assert o_wartosci_6 == [Statusy.ZAIMPORTOWANY]
+
+    # Stare wartości nie zmieniły znaczenia (dane produkcyjne trzymają liczby).
+    assert Statusy.NOWY == 0
+    assert Statusy.ZAAKCEPTOWANY == 1
+    assert Statusy.WYMAGA_ZMIAN == 2
+    assert Statusy.PO_ZMIANACH == 3
+    assert Statusy.ODRZUCONO == 4
+    assert Statusy.SPAM == 5
+
+
+@pytest.mark.parametrize("status", list(Statusy))
+def test_fd443_czy_zaimportowane_tylko_dla_statusu_6(status):
+    zgloszenie = Zgloszenie_Publikacji(status=status)
+    assert zgloszenie.czy_zaimportowane == (status == Statusy.ZAIMPORTOWANY)
+
+
+# --------------------------------------------------------------------------
+# Ścieżka A — URL przycisku „Użyj importera"
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_fd443_importer_url_z_doi_niesie_kontekst_zgloszenia():
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca z DOI",
+        strona_www="https://doi.org/10.1234/abc.def",
+    )
+
+    params = _params(_admin().importer_url(zgloszenie))
+
+    assert params["zgloszenie"] == [str(zgloszenie.pk)]
+    assert params["provider"] == ["CrossRef"]
+    assert params["identifier"] == ["10.1234/abc.def"]
+
+
+@pytest.mark.django_db
+def test_fd443_importer_url_z_pola_doi_niesie_kontekst_zgloszenia():
+    """DOI bywa w polu ``doi``, nie w ``strona_www`` — kontekst też ma być."""
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca z DOI w polu doi",
+        strona_www="",
+        doi="10.5555/xyz.987",
+    )
+
+    params = _params(_admin().importer_url(zgloszenie))
+
+    assert params["zgloszenie"] == [str(zgloszenie.pk)]
+    assert params["provider"] == ["CrossRef"]
+    assert params["identifier"] == ["10.5555/xyz.987"]
+
+
+@pytest.mark.django_db
+def test_fd443_importer_url_bez_doi_ze_strona_www_niesie_kontekst_zgloszenia():
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca bez DOI, ze stroną WWW",
+        strona_www="https://example.com/papers/123",
+    )
+
+    params = _params(_admin().importer_url(zgloszenie))
+
+    assert params["zgloszenie"] == [str(zgloszenie.pk)]
+    assert params["provider"] == ["Pozostałe strony WWW"]
+    assert params["identifier"] == ["https://example.com/papers/123"]
+
+
+@pytest.mark.django_db
+def test_fd443_importer_url_bez_doi_i_bez_strony_www_to_none():
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca bez adresu",
+        strona_www="",
+    )
+
+    assert _admin().importer_url(zgloszenie) is None
+
+
+@pytest.mark.django_db
+def test_fd443_importer_url_dla_zaimportowanego_to_none_mimo_doi():
+    """Ochrona przed podwójnym importem (§7): przycisk znika, choć DOI jest."""
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca już zaimportowana",
+        strona_www="https://doi.org/10.1234/abc.def",
+        doi="10.1234/abc.def",
+        status=Statusy.ZAIMPORTOWANY,
+    )
+
+    assert _admin().importer_url(zgloszenie) is None
+
+
+@pytest.mark.django_db
+def test_fd443_importer_url_dla_zaimportowanego_ze_strona_www_to_none():
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca już zaimportowana, bez DOI",
+        strona_www="https://example.com/papers/123",
+        status=Statusy.ZAIMPORTOWANY,
+    )
+
+    assert _admin().importer_url(zgloszenie) is None
+
+
+# --------------------------------------------------------------------------
+# Filtr „Do obsługi / Załatwione / Wszystkie"
+# --------------------------------------------------------------------------
+
+
+def _zgloszenia_wszystkich_statusow():
+    return {
+        status: baker.make(
+            Zgloszenie_Publikacji,
+            tytul_oryginalny=f"Zgłoszenie o statusie {status.label}",
+            status=status,
+        )
+        for status in Statusy
+    }
+
+
+def _statusy_po_filtrze(rf, wartosc):
+    """Statusy widoczne po zastosowaniu filtra o zadanej wartości."""
+    if wartosc is None:
+        request = rf.get("/")
+        params = {}
+    else:
+        request = rf.get("/", {StanObslugiFilter.parameter_name: wartosc})
+        params = {StanObslugiFilter.parameter_name: [wartosc]}
+
+    filtr = StanObslugiFilter(request, params, Zgloszenie_Publikacji, _admin())
+    qs = filtr.queryset(request, Zgloszenie_Publikacji.objects.all())
+    return set(qs.values_list("status", flat=True))
+
+
+@pytest.mark.django_db
+def test_fd443_filtr_stan_obslugi_ma_trzy_pozycje(rf):
+    request = rf.get("/")
+    filtr = StanObslugiFilter(request, {}, Zgloszenie_Publikacji, _admin())
+
+    assert filtr.lookup_choices == [
+        ("do_obslugi", "Do obsługi"),
+        ("zalatwione", "Załatwione"),
+        ("wszystkie", "Wszystkie"),
+    ]
+
+
+@pytest.mark.django_db
+def test_fd443_filtr_stan_obslugi_domyslnie_tylko_do_obslugi(rf):
+    _zgloszenia_wszystkich_statusow()
+
+    assert _statusy_po_filtrze(rf, None) == {Statusy.NOWY, Statusy.PO_ZMIANACH}
+
+
+@pytest.mark.django_db
+def test_fd443_filtr_stan_obslugi_do_obslugi_jawnie(rf):
+    _zgloszenia_wszystkich_statusow()
+
+    assert _statusy_po_filtrze(rf, StanObslugiFilter.DO_OBSLUGI) == {
+        Statusy.NOWY,
+        Statusy.PO_ZMIANACH,
+    }
+
+
+@pytest.mark.django_db
+def test_fd443_filtr_stan_obslugi_zalatwione(rf):
+    _zgloszenia_wszystkich_statusow()
+
+    assert _statusy_po_filtrze(rf, StanObslugiFilter.ZALATWIONE) == {
+        Statusy.ZAIMPORTOWANY,
+        Statusy.ZAAKCEPTOWANY,
+        Statusy.ODRZUCONO,
+        Statusy.SPAM,
+    }
+
+
+@pytest.mark.django_db
+def test_fd443_filtr_stan_obslugi_wszystkie(rf):
+    _zgloszenia_wszystkich_statusow()
+
+    assert _statusy_po_filtrze(rf, StanObslugiFilter.WSZYSTKIE) == {
+        status.value for status in Statusy
+    }
+
+
+@pytest.mark.django_db
+def test_fd443_filtr_stan_obslugi_domyslnie_zaznacza_do_obslugi(rf):
+    """Brak parametru w URL-u = zaznaczona pozycja „Do obsługi"."""
+
+    class _Changelist:
+        def get_query_string(self, params):
+            return "?" + "&".join(f"{k}={v}" for k, v in params.items())
+
+    request = rf.get("/")
+    filtr = StanObslugiFilter(request, {}, Zgloszenie_Publikacji, _admin())
+
+    zaznaczone = [c["display"] for c in filtr.choices(_Changelist()) if c["selected"]]
+    assert zaznaczone == ["Do obsługi"]
+
+
+@pytest.mark.django_db
+def test_fd443_filtr_stan_obslugi_dziala_na_liscie_w_adminie(admin_client):
+    """Domyślna lista w adminie nie pokazuje zgłoszeń załatwionych."""
+    zgloszenia = _zgloszenia_wszystkich_statusow()
+    url = reverse("admin:zglos_publikacje_zgloszenie_publikacji_changelist")
+
+    response = admin_client.get(url)
+    assert response.status_code == 200
+    widoczne = {obj.pk for obj in response.context["cl"].result_list}
+    assert widoczne == {
+        zgloszenia[Statusy.NOWY].pk,
+        zgloszenia[Statusy.PO_ZMIANACH].pk,
+    }
+
+    response = admin_client.get(
+        url, {StanObslugiFilter.parameter_name: StanObslugiFilter.ZALATWIONE}
+    )
+    assert response.status_code == 200
+    widoczne = {obj.pk for obj in response.context["cl"].result_list}
+    assert widoczne == {
+        zgloszenia[Statusy.ZAIMPORTOWANY].pk,
+        zgloszenia[Statusy.ZAAKCEPTOWANY].pk,
+        zgloszenia[Statusy.ODRZUCONO].pk,
+        zgloszenia[Statusy.SPAM].pk,
+    }
+
+    response = admin_client.get(
+        url, {StanObslugiFilter.parameter_name: StanObslugiFilter.WSZYSTKIE}
+    )
+    assert response.status_code == 200
+    widoczne = {obj.pk for obj in response.context["cl"].result_list}
+    assert widoczne == {z.pk for z in zgloszenia.values()}
+
+
+# --------------------------------------------------------------------------
+# Panel audytu na formularzu zgłoszenia
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_fd443_panel_audytu_pokazuje_date_uzytkownika_i_link_do_rekordu(
+    admin_client, wydawnictwo_ciagle
+):
+    operator = baker.make("bpp.BppUser", username="operator_fd443")
+    kiedy = timezone.now()
+
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca domknięta importerem",
+        strona_www="https://doi.org/10.1234/abc.def",
+        status=Statusy.ZAIMPORTOWANY,
+        zaimportowano=kiedy,
+        zaimportowal=operator,
+    )
+    zgloszenie.odpowiednik_w_bpp = wydawnictwo_ciagle
+    zgloszenie.save()
+
+    html = _change_html(admin_client, zgloszenie)
+
+    assert 'id="panel-zgloszenie-zaimportowane"' in html
+    assert "Zaimportowane" in html
+
+    oczekiwana_data = format_date(timezone.localtime(kiedy), "d.m.Y H:i")
+    assert oczekiwana_data in html
+
+    assert "operator_fd443" in html
+
+    url_rekordu = reverse(
+        "admin:bpp_wydawnictwo_ciagle_change", args=[wydawnictwo_ciagle.pk]
+    )
+    assert url_rekordu in html
+    assert str(wydawnictwo_ciagle) in html
+
+
+@pytest.mark.django_db
+def test_fd443_zaimportowane_nie_pokazuje_przycisku_uzyj_importera(
+    admin_client,
+):
+    """Ochrona przed podwójnym importem — przycisku nie ma w HTML-u (§7)."""
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca już zaimportowana",
+        strona_www="https://doi.org/10.1234/abc.def",
+        status=Statusy.ZAIMPORTOWANY,
+        zaimportowano=timezone.now(),
+    )
+
+    html = _change_html(admin_client, zgloszenie)
+
+    assert "Użyj importera" not in html
+    # Przy okazji: gate statusowy chowa też pozostałe przyciski akcji.
+    tools = _object_tools_fragment(html)
+    assert "Zwróć do autora" not in tools
+    assert "Dodaj wyd." not in tools
+
+
+@pytest.mark.django_db
+def test_fd443_niezaimportowane_bez_panelu_ale_z_przyciskiem_importera(
+    admin_client,
+):
+    zgloszenie = baker.make(
+        Zgloszenie_Publikacji,
+        tytul_oryginalny="Praca do zaimportowania",
+        strona_www="https://doi.org/10.1234/abc.def",
+        status=Statusy.NOWY,
+    )
+
+    html = _change_html(admin_client, zgloszenie)
+
+    assert 'id="panel-zgloszenie-zaimportowane"' not in html
+    assert "Zaimportowane" not in html
+
+    tools = _object_tools_fragment(html)
+    assert "Użyj importera" in tools
+    assert f"zgloszenie={zgloszenie.pk}" in tools

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "bpp-iplweb"
-version = "202607.1397"
+version = "202607.1398"
 source = { editable = "." }
 dependencies = [
     { name = "arrow", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
Fixes Freshdesk **FD#443** — <https://iplweb.freshdesk.com/a/tickets/443>
(zgłaszający: Jan Bichałowicz, klient `bpp.apoz.edu.pl`)

> „Chodzi o to żeby jakoś oznaczyć (miękko usunąć) to zgłoszenie automatycznie
> po tym jeśli importer przejdzie i skończy się publikacją/rekordem."

## Problem

Operator otwierał zgłoszenie publikacji, klikał „Użyj importera", tworzył
rekord — a zgłoszenie zostawało w stanie `NOWY`, jakby nikt się nim nie zajął.

Luka była **jedna, nie trzy**: `ImportSession` nie wiedziała, że uruchomiono ją
ze zgłoszenia. Link „Użyj importera" był bezstanowy — przekazywał wyłącznie
`?provider=&identifier=`. Co ciekawe, pola po stronie zgłoszenia istniały
od dawna, tylko martwe:

| Element | Stan przed zmianą |
|---|---|
| `Zgloszenie_Publikacji.odpowiednik_w_bpp` (GenericFK do rekordu) | pole istniało, **nic w `src/` go nie zapisywało** |
| `Statusy.ZAAKCEPTOWANY` („dodany do bazy BPP") | **nigdy nie ustawiany programowo** |

## Co się zmienia

Po udanym imporcie zgłoszenie samo dostaje status **`ZAIMPORTOWANY`**, datę,
operatora i wskazanie na powstały rekord. Informacja zwrotna w trzech
miejscach: panel na stronie zgłoszenia, baner na wynikach importera, flash.

### Wiązanie sesji ze zgłoszeniem

1. **Jawne, z przycisku** — `?zgloszenie=N`. Uwaga na niuans: `IndexView`
   tylko renderuje formularz, sesję zakłada dopiero `FetchView.post`, więc
   parametr musi przeżyć rundę GET → render → POST ukrytym polem `FetchForm`.
   Obsłużona też gałąź idempotency (sesja in-flight): dopisz gdy puste,
   nie nadpisuj gdy zajęte.
2. **Automatyczne po DOI** — gdy kandydat jest dokładnie jeden.
3. **Wybór operatora** — przy kilku kandydatach baner na ekranie weryfikacji
   pyta, które zgłoszenie domknąć, zamiast zgadywać.

### Decyzje warte uwagi recenzenta

- **Dopasowanie po tytule nie bierze udziału w wiązaniu.** Istniejąca
  heurystyka `_find_matching_zgloszenie` dopasowuje po DOI, a w razie braku po
  tytule — ale do zmiany statusu to za słabe: dwa zgłoszenia o identycznym
  tytule oznaczyłyby przypadkowe. Heurystyka zostaje tam, gdzie była (prefill
  dyscyplin), gdzie pomyłka jest nieszkodliwa.
- **Kandydaci nie przekraczają granicy uczelni.** `Zgloszenie_Publikacji` nie
  ma pola `uczelnia`, więc atrybucja idzie przez jednostki autorów. Bez tego
  na instalacji multi-hosted baner pokazywałby tytuł i e-mail zgłaszającego
  z cudzej uczelni.
- **Widok wyboru waliduje id względem wyliczonej listy kandydatów**, a nie
  `objects.get(pk=…)` — inaczej byłby to IDOR. Ponad tym `ImporterPermissionMixin`
  i scoping sesji po uczelni.
- **`WYMAGA_ZMIAN` wykluczony z auto-wiązania** — zgłoszenie jest wtedy
  w rękach autora (aktywny `kod_do_edycji`); przestemplowanie zabrałoby mu pracę.
- **Zapis zwrotny idempotentny**, w gałęzi sukcesu przed `except`, więc
  nieudany import nie rusza statusu zgłoszenia.

### Dwie pułapki, które kosztowały poprawkę projektu

- `odpowiednik_w_bpp` to **GenericForeignKey**, więc `save(update_fields=…)`
  musi wymieniać `content_type` i `object_id` — inaczej zapis po cichu przepada.
- Flash **musi** powstawać w cyklu żądania, nie w zadaniu Celery — worker
  jawnie wyrzuca wiadomości do kosza (`_NoopMessageStorage`).

## Lista zgłoszeń w adminie

Nowy filtr **„Stan obsługi"**, domyślnie *Do obsługi* (`NOWY`, `PO_ZMIANACH`).
Dotąd takiego filtra nie było w ogóle — lista pokazywała wszystko łącznie
z odrzuconymi i spamem.

## Testy

**82 nowe testy** (25 + 57), pełne suity obu aplikacji: **866 passed, 1 skipped**
(z Playwrightem). Pokrycie obejmuje regresje bezpieczeństwa: POST z id spoza
listy kandydatów → 400, sesja innej uczelni → 404, brak uprawnień → 403.

Testy przypinają też zachowanie `django-softdelete`, które okazało się inne, niż
zakładał projekt: `SoftDeleteModel.delete()` **emuluje `on_delete`**, więc
kasowanie zgłoszenia samo zeruje FK. Guard na `deleted_at` pozostaje potrzebny
dla ścieżek omijających `delete()` (bulk `UPDATE`, surowy SQL, migracje danych).

## Uwagi wdrożeniowe

- **Migracje: `zglos_publikacje` 0027, `importer_publikacji` 0020.**
  Baseline do odświeżenia **przy scalaniu**, nie w tej gałęzi.
- Przy okazji zsynchronizowany `uv.lock` — na `dev` został na `202607.1397`
  przy `version.py` = `202607.1398`. Jedna linia, ale to ta klasa rozjazdu,
  która wcześniej wywalała check `uv.lock` na PR-ach.

## Świadomie poza zakresem

Ścieżka ręczna „Dodaj wyd. ciągłe/zwarte" (`?numer_zgloszenia=`) nadal nie
oznacza zgłoszenia — numer trafia wyłącznie do pola tekstowego `adnotacje`.
Ta sama luka, innym korytarzem; nadaje się na osobne zgłoszenie.

Projekt: `docs/superpowers/specs/2026-07-22-zgloszenie-zaimportowane-przez-importer-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP3jjsrGnyeCy9RAoosBos
