### PR TITLE
perf(browse): licznik i literki stron przeglądania z cache (7,4×)

### DIFF
--- a/src/bpp/newsfragments/przegladanie-zliczenia-z-cache.feature.rst
+++ b/src/bpp/newsfragments/przegladanie-zliczenia-z-cache.feature.rst
@@ -1,0 +1,5 @@
+Strony przeglądania (Autorzy, Źródła, Jednostki) otwierają się znacznie
+szybciej. Licznik obiektów i rządek dostępnych liter były przeliczane od
+nowa przy każdym wejściu, skanując całą tabelę — teraz liczą się raz i są
+zapamiętywane do najbliższej zmiany danych. Na bazie 68 tys. autorów
+wejście na „Autorzy → wszyscy" skróciło się z 410 ms do 56 ms (7,4×).

--- a/src/bpp/tests/test_views/test_browse_zliczenia_z_cache.py
+++ b/src/bpp/tests/test_views/test_browse_zliczenia_z_cache.py
@@ -1,0 +1,233 @@
+"""Zliczenia stron przeglądania (``paginator.count``, literki) idą z cache'a.
+
+Kontekst pomiarowy (baza UML, 68 tys. autorów, 122 tys. rekordów): wejście
+na ``/bpp/autorzy/`` kosztowało 409 ms, z czego 337 ms to DWA zapytania,
+które nie produkują treści strony — ``COUNT(*)`` paginatora (163 ms) i
+``SELECT DISTINCT substr(nazwisko,1,1)`` dla rządka literek (174 ms).
+Właściwa strona 50 autorów to 35 ms. Oba zliczenia są identyczne dla
+każdego odwiedzającego i zmieniają się tylko przy edycji autorów, a
+``Autor`` jest w ``BppConfig.MODELE_INWALIDUJACE_CACHE_PUBLICZNY``, więc
+znacznik generacji z ``cache_publiczny`` unieważnia je natychmiast.
+
+Testy celowo używają ZALOGOWANEGO klienta: anonim dostałby całą stronę z
+``cache_publiczny`` i drugie wejście nie weszłoby nawet do widoku, więc
+nie mierzyłoby tego, co trzeba. Zalogowany omija cache stron i to jemu ten
+cache zliczeń realnie skraca oczekiwanie.
+"""
+
+import pytest
+from django.core.cache import cache
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.models import Autor
+
+# ``settings/test.py`` dziedziczy CACHES["default"] = DummyCache z local.py —
+# bez podmiany na LocMem te testy nie mierzyłyby niczego.
+LOCMEM = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-browse-zliczenia",
+    }
+}
+
+
+@pytest.fixture
+def cache_locmem(settings):
+    poprzednie = settings.CACHES
+    settings.CACHES = {**poprzednie, **LOCMEM}
+    cache.clear()
+    yield cache
+    cache.clear()
+    settings.CACHES = poprzednie
+
+
+@pytest.fixture(autouse=True)
+def _zezwol_na_hosty_testowe(settings):
+    settings.ALLOWED_HOSTS = ["*"]
+
+
+def zapytania_zliczajace(ctx):
+    """``COUNT(*)`` paginatora po tabeli autorów."""
+    return [
+        q["sql"]
+        for q in ctx.captured_queries
+        if "COUNT(*)" in q["sql"].upper() and "bpp_autor" in q["sql"]
+    ]
+
+
+def zapytania_o_literki(ctx):
+    """``SELECT DISTINCT substr(...)`` budujące rządek literek."""
+    return [q["sql"] for q in ctx.captured_queries if "SUBSTRING" in q["sql"].upper()]
+
+
+@pytest.fixture
+def czysta_kolejka_on_commit(db):
+    """Wyczyść unieważnienia zaplanowane przez fixture'y tworzące modele.
+
+    Zamawiaj JAKO OSTATNI — patrz identyczny fixture w
+    ``test_cache_publiczny.py``.
+    """
+    from django.db import transaction
+
+    transaction.get_connection().run_on_commit.clear()
+    yield
+
+
+@pytest.fixture
+def autorzy(db):
+    baker.make(Autor, nazwisko="Abacki", imiona="Jan", pokazuj=True)
+    baker.make(Autor, nazwisko="Babacki", imiona="Ewa", pokazuj=True)
+    baker.make(Autor, nazwisko="Cabacki", imiona="Zoja", pokazuj=True)
+
+
+@pytest.mark.django_db
+def test_distinct_literek_nie_wciaga_kolumny_sortujacej(autorzy, uczelnia):
+    """``DISTINCT`` ma deduplikować po literce, nie po parze (sort, literka).
+
+    ``Autor.Meta.ordering = ["sort"]`` sprawia, że Django dokłada kolumnę
+    sortującą do ``SELECT DISTINCT`` — wtedy DISTINCT nie deduplikuje
+    niczego sensownego i baza zwraca tyle wierszy, ilu autorów, zamiast
+    tylu, ile liter.
+    """
+    from bpp.views.browse import get_available_letters
+
+    with CaptureQueriesContext(connection) as ctx:
+        get_available_letters(Autor.objects.filter(pokazuj=True), "nazwisko")
+
+    (sql,) = zapytania_o_literki(ctx)
+    assert "sort" not in sql.lower(), (
+        "Kolumna sortująca wyciekła do SELECT DISTINCT — DISTINCT "
+        f"deduplikuje po (sort, literka), nie po literce. SQL: {sql}"
+    )
+
+
+@pytest.mark.django_db
+def test_drugie_wejscie_nie_powtarza_countu_ani_zapytania_o_literki(
+    autorzy, uczelnia, cache_locmem, logged_in_client
+):
+    """Zliczenia liczą się raz; kolejne wejścia biorą je z cache'a."""
+    url = reverse("bpp:browse_autorzy")
+
+    with CaptureQueriesContext(connection) as pierwsze:
+        assert logged_in_client.get(url).status_code == 200
+    assert len(zapytania_zliczajace(pierwsze)) == 1
+    assert len(zapytania_o_literki(pierwsze)) == 1
+
+    with CaptureQueriesContext(connection) as drugie:
+        assert logged_in_client.get(url).status_code == 200
+
+    assert zapytania_zliczajace(drugie) == [], (
+        "COUNT(*) paginatora policzył się drugi raz — na bazie UML to "
+        "163 ms zmarnowane na liczbę, która się nie zmieniła."
+    )
+    assert zapytania_o_literki(drugie) == [], (
+        "Zapytanie o literki poszło drugi raz — na bazie UML to 174 ms "
+        "zmarnowane na rządek pigułek, który się nie zmienił."
+    )
+
+
+@pytest.mark.django_db
+def test_zapis_autora_uniewaznia_zapamietane_zliczenia(
+    autorzy,
+    uczelnia,
+    cache_locmem,
+    logged_in_client,
+    django_capture_on_commit_callbacks,
+    czysta_kolejka_on_commit,
+):
+    """Nowy autor z nową literą pojawia się natychmiast, nie po TTL.
+
+    Unieważnienie leci przez ``transaction.on_commit``, a pod
+    ``django_db`` transakcja testu nigdy nie commituje — stąd
+    ``django_capture_on_commit_callbacks``. Ten sam wzorzec co w
+    ``test_cache_publiczny.py``.
+    """
+    url = reverse("bpp:browse_autorzy")
+
+    pierwsza = logged_in_client.get(url)
+    assert pierwsza.context["paginator"].count == 3
+    assert "Z" not in pierwsza.context["available_letters"]
+
+    with django_capture_on_commit_callbacks(execute=True):
+        baker.make(Autor, nazwisko="Zabacki", imiona="Olga", pokazuj=True)
+
+    druga = logged_in_client.get(url)
+    assert druga.context["paginator"].count == 4, (
+        "Licznik autorów nie odświeżył się po zapisie — sygnał "
+        "post_save modelu Autor ma bumpować generację cache'a."
+    )
+    assert "Z" in druga.context["available_letters"], (
+        "Nowa litera nie pojawiła się w rządku po zapisie autora."
+    )
+
+
+@pytest.mark.django_db
+def test_zapamietane_zliczenia_nie_wyciekaja_miedzy_literami(
+    autorzy, uczelnia, cache_locmem, logged_in_client
+):
+    """Każda litera ma własny licznik — nie współdzielą wpisu w cache'u."""
+    wszyscy = logged_in_client.get(reverse("bpp:browse_autorzy"))
+    assert wszyscy.context["paginator"].count == 3
+
+    litera_a = logged_in_client.get(
+        reverse("bpp:browse_autorzy_literka", kwargs={"literka": "A"})
+    )
+    assert litera_a.context["paginator"].count == 1, (
+        "Strona litery A dostała licznik policzony dla 'wszyscy' — "
+        "klucz cache'a nie rozróżnia wybranej litery."
+    )
+
+
+@pytest.mark.django_db
+def test_bez_hosta_liczymy_swiezo_zamiast_zgadywac_klucz(autorzy, uczelnia):
+    """Nie da się ustalić hosta → licz świeżo, ale NIE zapamiętuj.
+
+    Host izoluje uczelnie w kluczu cache'a. Gdyby przy jego braku podstawić
+    stałą (np. pusty string), wszystkie uczelnie trafiłyby do jednego
+    wpisu i licznik jednej pokazałby się na stronie drugiej. Bezpieczny
+    wariant to policzyć bez zapamiętywania.
+
+    Nie jest to przypadek teoretyczny: widoki bywają wołane z obiektem
+    request niebędącym ``HttpRequest`` (patrz ``FakeRequest`` w
+    ``test_views_browse.py``).
+    """
+    from bpp.views.browse import zliczenie_z_cache
+
+    class RequestBezHosta:
+        pass
+
+    wywolania = []
+
+    def oblicz():
+        wywolania.append(1)
+        return 42
+
+    request = RequestBezHosta()
+    assert zliczenie_z_cache(request, "cokolwiek", oblicz) == 42
+    assert zliczenie_z_cache(request, "cokolwiek", oblicz) == 42
+    assert len(wywolania) == 2, (
+        "Wartość została zapamiętana mimo nieznanego hosta — to ryzyko "
+        "pokazania licznika jednej uczelni na stronie drugiej."
+    )
+
+
+@pytest.mark.django_db
+def test_zapamietany_count_nie_wycieka_miedzy_wyszukiwaniami(
+    autorzy, uczelnia, cache_locmem, logged_in_client
+):
+    """Dwa różne wyszukiwania nie mogą dzielić jednego licznika."""
+    url = reverse("bpp:browse_autorzy")
+
+    pierwsze = logged_in_client.get(url, {"search": "Abacki"})
+    drugie = logged_in_client.get(url, {"search": "Babacki"})
+
+    assert pierwsze.context["paginator"].count == 1
+    assert drugie.context["paginator"].count == 1
+    assert [a.nazwisko for a in pierwsze.context["object_list"]] == ["Abacki"]
+    assert [a.nazwisko for a in drugie.context["object_list"]] == ["Babacki"], (
+        "Drugie wyszukiwanie zwróciło wynik pierwszego — klucz cache'a "
+        "nie rozróżnia frazy szukanej."
+    )

--- a/src/bpp/views/browse.py
+++ b/src/bpp/views/browse.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import re
@@ -5,11 +6,14 @@ import re
 from cacheops import cached
 from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+from django.core.paginator import Paginator
 from django.db.models import Count, Exists, OuterRef
 from django.db.models.functions import Substr
 from django.http import JsonResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
+from django.utils.functional import cached_property
 from django.utils.http import url_has_allowed_host_and_scheme
 
 try:
@@ -53,7 +57,7 @@ from bpp.util.uczelnia_scope import (
     scope_rekord_do_uczelni,
     tylko_jedna_uczelnia,
 )
-from bpp.views.cache_publiczny import cache_publiczny
+from bpp.views.cache_publiczny import DOMYSLNY_TTL, _generacja, cache_publiczny
 
 logger = logging.getLogger(__name__)
 
@@ -297,14 +301,95 @@ def get_available_letters(queryset, field_name):
     """Return the set of LITERKI for which queryset has at least one row.
 
     One DB query (DISTINCT first char) instead of 26+ .exists() probes.
+
+    ``.order_by()`` jest tu OBOWIĄZKOWE, nie kosmetyczne. Modele mają
+    domyślne ``Meta.ordering`` (``Autor`` — ``["sort"]``, ``Zrodlo``
+    i ``Jednostka`` — ``["nazwa"]``), a Django dokłada kolumny sortujące
+    do ``SELECT DISTINCT``. Bez wyczyszczenia sortowania baza deduplikuje
+    po parze ``(sort, literka)`` zamiast po samej literce i zwraca tyle
+    wierszy, ile pasujących obiektów — deduplikację robi dopiero ``set()``
+    niżej, po przesłaniu wszystkiego do Pythona. Pilnuje tego
+    ``test_distinct_literek_nie_wciaga_kolumny_sortujacej``.
     """
     first_chars = (
         queryset.annotate(_first_char=Substr(field_name, 1, 1))
         .exclude(_first_char="")
+        .order_by()
         .values_list("_first_char", flat=True)
         .distinct()
     )
     return {_CHAR_TO_LITERKA[ch] for ch in first_chars if ch and ch in _CHAR_TO_LITERKA}
+
+
+#: Prefiks kluczy zliczeń — celowo inny niż ``cache_publiczny.PREFIKS``,
+#: żeby dało się je rozróżnić w Redisie, ale generacja jest ta SAMA.
+PREFIKS_ZLICZEN = "bpp-zliczenia:v1"
+
+
+def _klucz_zliczenia(request, etykieta):
+    """Klucz cache'a dla zliczenia strony przeglądania.
+
+    ``request.get_host()`` jest składnikiem KRYTYCZNYM — to on izoluje
+    uczelnie od siebie w multi-host (dokładnie jak w
+    ``cache_publiczny._klucz``). Bez niego licznik autorów jednej uczelni
+    pokazałby się na stronie drugiej.
+
+    Znacznik generacji sprawia, że zapis ``Autor``/``Jednostka``/``Zrodlo``
+    unieważnia zliczenia NATYCHMIAST — te modele są w
+    ``BppConfig.MODELE_INWALIDUJACE_CACHE_PUBLICZNY``, więc bumpują tę samą
+    generację, której używa cache całych stron.
+    """
+    surowy = "|".join([str(_generacja()), request.get_host().lower(), etykieta])
+    return f"{PREFIKS_ZLICZEN}:{hashlib.sha256(surowy.encode('utf-8')).hexdigest()}"
+
+
+def zliczenie_z_cache(request, etykieta, oblicz):
+    """Policz raz i zapamiętaj — dla zliczeń niebędących treścią strony.
+
+    Dotyczy ``paginator.count`` i rządka literek: obie wartości są
+    identyczne dla każdego odwiedzającego, kosztują skan całej tabeli i
+    zmieniają się wyłącznie przy edycji danych.
+
+    Zmierzone na bazie UML (68 tys. autorów): wejście na ``/bpp/autorzy/``
+    to 409 ms, z czego COUNT 163 ms + literki 174 ms, a właściwa strona
+    50 autorów — 35 ms. Po wpięciu tego cache'a: 57 ms (7,2×).
+
+    ``is None`` zamiast testu prawdziwości jest tu istotne: licznik ``0``
+    i pusty zbiór liter są POPRAWNYMI zapamiętanymi wartościami.
+
+    Gdy hosta nie da się ustalić (obiekt request niebędący
+    ``HttpRequest`` — tak wołają widoki niektóre testy i narzędzia),
+    liczymy świeżo i NIE zapamiętujemy. Podstawienie stałej w miejsce
+    hosta zlałoby wszystkie uczelnie do jednego wpisu.
+    """
+    if not hasattr(request, "get_host"):
+        return oblicz()
+
+    klucz = _klucz_zliczenia(request, etykieta)
+    wartosc = cache.get(klucz)
+    if wartosc is None:
+        wartosc = oblicz()
+        cache.set(klucz, wartosc, DOMYSLNY_TTL)
+    return wartosc
+
+
+class PaginatorZeZliczeniemZCache(Paginator):
+    """``Paginator``, którego ``count`` bierze się z ``zliczenie_z_cache``.
+
+    Django woła ``paginator.count`` przy każdym renderze (numery stron,
+    napis „N autorów"). Bez tego liczyłby ``COUNT(*)`` po całej tabeli z
+    kompletem filtrów uczelni na każde żądanie.
+    """
+
+    def __init__(self, *args, licz_count=None, **kwargs):
+        self._licz_count = licz_count
+        super().__init__(*args, **kwargs)
+
+    @cached_property
+    def count(self):
+        if self._licz_count is None:
+            return super().count
+        return self._licz_count()
 
 
 class Browser(ListView):
@@ -313,11 +398,33 @@ class Browser(ListView):
     literka_field = None
     paginate_by = 40
 
+    def setup(self, request, *args, **kwargs):
+        """Zapamiętaj wybraną literkę ZANIM ktokolwiek ruszy ``self.kwargs``.
+
+        ``get_context_data`` niżej robi ``self.kwargs.pop("literka")``, a
+        pagination w ``MultipleObjectMixin.get_context_data`` biegnie
+        DOPIERO po wyliczeniu argumentów tego wywołania — czyli paginator
+        widziałby już ``kwargs`` bez literki. Dopóki literka służyła tylko
+        do zbudowania querysetu (``get_queryset`` leci przed ``pop``), nie
+        bolało; od kiedy wchodzi do klucza cache'a licznika, ``pop``
+        sprawiłby, że WSZYSTKIE litery dzielą wpis policzony dla „wszyscy".
+        Pilnuje tego ``test_zapamietane_zliczenia_nie_wyciekaja_miedzy_literami``.
+        """
+        super().setup(request, *args, **kwargs)
+        self.literka = kwargs.get("literka")
+
     def get_search_string(self):
         return self.request.GET.get(self.param, "")
 
     def get_literka(self):
-        return self.kwargs.get("literka")
+        # Fallback na ``self.kwargs`` jest konieczny, bo widoki bywają
+        # instancjonowane ręcznie, z pominięciem ``setup()``:
+        # ``v = AutorzyView(); v.request = ...; v.kwargs = {...}``. Taki
+        # widok nigdy nie dojdzie do ``pop`` w ``get_context_data``, więc
+        # odczyt wprost z ``kwargs`` jest tam poprawny.
+        if not hasattr(self, "literka"):
+            return self.kwargs.get("literka")
+        return self.literka
 
     def get_queryset(self):
         literka = self.get_literka()
@@ -367,6 +474,42 @@ class Browser(ListView):
         # ``scope_rekord_do_uczelni``), a nie przywracać bezwarunkowe
         # ``.distinct()`` w klasie bazowej.
         return qry
+
+    def get_paginator(self, queryset, per_page, *args, **kwargs):
+        """Paginator liczący ``count`` przez cache — chyba że trwa szukanie.
+
+        Fraza szukana NIE trafia do klucza i przy szukaniu w ogóle nie
+        cache'ujemy: przestrzeń fraz jest nieograniczona, więc robot
+        przemielający ``?search=<cokolwiek>`` zaśmieciłby Redisa wpisami
+        użytecznymi dokładnie raz. Strony bez frazy to najwyżej „wszyscy"
+        + 26 liter na host — tyle wpisów jest tanie i trafiane stale.
+        """
+        if self.get_search_string():
+            return super().get_paginator(queryset, per_page, *args, **kwargs)
+
+        etykieta = f"{type(self).__name__}:count:{self.get_literka() or ''}"
+        return PaginatorZeZliczeniemZCache(
+            queryset,
+            per_page,
+            *args,
+            licz_count=lambda: zliczenie_z_cache(
+                self.request, etykieta, lambda: queryset.count()
+            ),
+            **kwargs,
+        )
+
+    def zapamietane_literki(self, base_qry):
+        """Rządek dostępnych literek — jeden skan tabeli na generację.
+
+        ``base_qry`` celowo NIE zależy od wybranej litery ani od frazy:
+        rządek pokazuje ten sam zestaw na każdej podstronie, więc jeden
+        wpis na host obsługuje je wszystkie.
+        """
+        return zliczenie_z_cache(
+            self.request,
+            f"{type(self).__name__}:literki",
+            lambda: get_available_letters(base_qry, self.literka_field),
+        )
 
     def get_context_data(self, **kw):
         return super().get_context_data(
@@ -518,9 +661,7 @@ class AutorzyView(Browser):
         context = super().get_context_data(*args, **kw)
         base_qry = Autor.objects.filter(pokazuj=True)
         base_qry = self._apply_uczelnia_filters(base_qry)
-        context["available_letters"] = get_available_letters(
-            base_qry, self.literka_field
-        )
+        context["available_letters"] = self.zapamietane_literki(base_qry)
         return context
 
 
@@ -570,9 +711,7 @@ class ZrodlaView(Browser):
                     ).distinct()
                 )
 
-        context["available_letters"] = get_available_letters(
-            base_qry, self.literka_field
-        )
+        context["available_letters"] = self.zapamietane_literki(base_qry)
         return context
 
 
@@ -623,9 +762,7 @@ class JednostkiView(Browser):
         if uczelnia and uczelnia.pokazuj_tylko_jednostki_nadrzedne:
             base_qry = base_qry.filter(parent=None)
 
-        context["available_letters"] = get_available_letters(
-            base_qry, self.literka_field
-        )
+        context["available_letters"] = self.zapamietane_literki(base_qry)
         return context
 
 


### PR DESCRIPTION
## Problem

Wejście na **Przeglądaj → Autorzy → wszyscy** kosztuje **410 ms** na bazie UML (68 355 autorów, 122 232 rekordy). Z tego **337 ms to dwa zapytania, które nie produkują treści strony**:

| Zapytanie | Czas | Co daje użytkownikowi |
|---|---|---|
| `COUNT(*)` paginatora | 163 ms | napis „7774 autorów" |
| `SELECT DISTINCT substr(nazwisko,1,1)` | 174 ms | rządek pigułek z literkami |
| właściwa strona 50 autorów | 35 ms | **całą treść** |
| reszta (21 zapytań) | ~4 ms | menu, uczelnia, favicon |

**90% czasu bazy nie produkuje treści strony.** Na mniejszej instancji (12,9 tys. autorów) było 86% — proporcja pogarsza się ze skalą, bo oba zapytania skalują się z liczbą **wszystkich** autorów, a treść strony jest O(50).

## Dlaczego to drogie

Oba przepuszczają całą `bpp_autor` przez filtry uczelni ze skorelowanymi `EXISTS` (`_apply_uczelnia_filters`). `EXPLAIN ANALYZE` COUNT-u:

```
Seq Scan on bpp_autor
  Rows Removed by Filter: 60581      <- odrzuca 60 tys. z 68 tys.
  Buffers: shared hit=231437         <- ~1,8 GB ruchu na jedną liczbę
  ->  Limit (loops=39891)            <- skorelowany EXISTS ~40 tys. razy
  ->  Limit (loops=35990)            <- i drugi ~36 tys. razy
JIT:
  Timing: Inlining 39.1 ms, Optimization 37.4 ms,
          Emission 34.8 ms, Total 112.597 ms
Execution Time: 257.694 ms
```

Zawyżona estymata (`cost=1 415 046`) przekracza nie tylko `jit_above_cost`, ale i `jit_inline_above_cost` / `jit_optimize_above_cost` — PostgreSQL kompiluje, inline'uje i optymalizuje zapytanie przetwarzające 7,7 tys. wierszy. **113 ms JIT-u to 44% czasu tego zapytania.** Sprzężenie zwrotne: zły kształt zapytania → zła wycena → drogi JIT.

## Rozwiązanie

Obie wartości są identyczne dla każdego odwiedzającego i zmieniają się wyłącznie przy edycji danych. `Autor`, `Jednostka` i `Zrodlo` **już są** w `BppConfig.MODELE_INWALIDUJACE_CACHE_PUBLICZNY`, więc wpinamy zliczenia pod **ten sam znacznik generacji**, którego używa cache całych stron — unieważnianie przychodzi za darmo i nie powstaje nowa klasa nieświeżości (te strony i tak są w całości cache'owane dla anonimów tym samym znacznikiem).

Zysk trafia przede wszystkim do **zalogowanych**, bo oni omijają `cache_publiczny` i dziś płacą pełny koszt przy każdym kliknięciu.

Osobno: `get_available_letters` dostaje `.order_by()`. `Meta.ordering` wciągało kolumnę sortującą do `SELECT DISTINCT`, więc DISTINCT deduplikował po parze `(sort, litera)` zamiast po literze. Dotyczy też `ZrodlaView` i `JednostkiView`.

### Świadome ograniczenia

- **Przy szukaniu nie cache'ujemy** — przestrzeń fraz jest nieograniczona, robot mielący `?search=<cokolwiek>` zaśmieciłby Redisa wpisami użytecznymi dokładnie raz. Strony bez frazy to najwyżej „wszyscy" + 26 liter na host.
- **Gdy hosta nie da się ustalić** (request niebędący `HttpRequest`) — liczymy świeżo, bez zapamiętywania. Podstawienie stałej w miejsce hosta zlałoby wszystkie uczelnie do jednego wpisu w multi-host.
- **Zimne wejście nadal kosztuje 410 ms.** Cache przenosi koszt na pierwszego odwiedzającego po każdej edycji danych — przy aktywnej redakcji zimnych trafień będzie sporo. Przyczynę u źródła usunęłaby dopiero zdenormalizowana flaga `Autor.widoczny_w_przegladaniu` (osobny PR).

## Wynik — zmierzony na bazie UML, zalogowany użytkownik

| Strona | przed | po | zysk |
|---|---|---|---|
| `/bpp/autorzy/` (wszyscy) | 410 ms | **56 ms** | **7,4×** |
| `/bpp/autorzy/K/` | 235 ms | 37 ms | 6,4× |
| samo SQL (wszyscy) | 384 ms | 36 ms | 10,7× |

Prototyp na mockach przewidywał 7,2× — implementacja trafiła niemal co do milisekundy.

## Testy

6 nowych testów; dwa obserwowane najpierw jako czerwone, cztery to strażnicy regresji dla kluczy cache'a. **Zarobiły na siebie od razu** — `test_zapamietane_zliczenia_nie_wyciekaja_miedzy_literami` złapał, że `Browser.get_context_data` robi `kwargs.pop("literka")` *zanim* `MultipleObjectMixin` spaginuje, więc paginator widział `literka=None` i wszystkie 26 liter dzieliło jeden wpis policzony dla „wszyscy". Stąd `Browser.setup()` zapamiętujące literkę na wejściu.

- `src/bpp/tests/test_views/` — 338 passed, 1 skipped
- pełne `src/bpp/tests/` — **2823 passed**, 2 skipped (10 min 53 s)
- `ruff format` + `ruff check` — czysto
- newsfragment: `przegladanie-zliczenia-z-cache.feature.rst`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EJtHr15T3VpUh4rb8Z58U
