### PR TITLE
fix(assets): self-hosting bibliotek JS/CSS zamiast CDN-ów

### DIFF
--- a/docs/superpowers/specs/2026-07-22-import-pracownikow-cdn-i-paginacja-design.md
+++ b/docs/superpowers/specs/2026-07-22-import-pracownikow-cdn-i-paginacja-design.md
@@ -51,7 +51,7 @@ To **3 zapytania na każdy wiersz importu**, namierzone stack-trace'em:
    w PostgreSQL, N razy.
 
 Do tego **9,1 KB HTML na wiersz**, z czego **3830 bajtów to identyczny blok
-`<script>`** powtórzony w każdym wierszu (`_wiersz_preview_kom.html:160-231`).
+`<script>`** powtórzony w każdym wierszu (`partials/_wiersz_preview_kom.html:160-231`).
 Ma guard `window.__bppImportAutorPicker`, więc wykonuje się raz — ale przesyła się
 i parsuje N razy. Przy 1000 wierszy to 3,8 MB czystego duplikatu.
 
@@ -137,7 +137,7 @@ Trzy szablony jadą dziś na htmx **2.0.4** z CDN-a, a cała reszta aplikacji na
 raportuje `version:"1.9.12"`). Self-hosting oznacza więc **zejście o major**
 w tych trzech miejscach — ujednolicenie wersji w całej aplikacji.
 
-Ocena ryzyka: komentarze w `_wiersz_preview_kom.html:83-87` wprost tłumaczą obejście
+Ocena ryzyka: komentarze w `partials/_wiersz_preview_kom.html:83-87` wprost tłumaczą obejście
 napisane **pod semantykę 1.x** (filtr zdarzenia `change[target.classList…]` zamiast
 `from:`, bo „bare selektor w `from:` w htmx 1.x wiąże na CAŁYM dokumencie"). Kod był
 więc projektowany pod 1.x i na 2.x działa przypadkiem. Użyte API to wyłącznie
@@ -150,10 +150,21 @@ przeklikać ręcznie (lista w „Testowanie" niżej).
 ### Test regresyjny — brak zewnętrznych assetów
 
 Nowy test (`src/django_bpp/tests/test_brak_zewnetrznych_assetow.py`) skanuje
-wszystkie szablony w `src/**/templates/**` oraz wszystkie pliki `*.py` w `src/`
-(klasy `Media` mogą żyć nie tylko w `admin.py`, ale też w `forms.py`/`widgets.py`;
-dziś ich tam nie ma, ale szerszy skan jest odporniejszy na przyszłość) i szuka
-`<script src>` / `<link href>` wskazujących na `http://` lub `https://`.
+dwa rodzaje plików **dwoma różnymi wzorcami** — to jest istotne, bo naiwne
+przeniesienie wzorca tagowego na `.py` przepuściłoby jedną z pięciu naprawianych
+regresji:
+
+- **szablony** (`src/**/templates/**`) — wzorzec tagowy: `<script src=…>` /
+  `<link href=…>` wskazujące na `http://` lub `https://`;
+- **pliki `*.py`** w `src/` — wzorzec **literału URL**, nie tagu. Klasa `Media`
+  w `przemapuj_zrodlo/admin.py:109` nie zawiera żadnego tagu, tylko goły string
+  `"https://cdnjs.cloudflare.com/…"` w tuplecie `css`; tag renderuje dopiero
+  Django. Skanujemy więc literały `https?://` kończące się rozszerzeniem assetu
+  (`.js`, `.css`, `.woff`, `.woff2`, `.svg`, `.png`) — to odsiewa linki
+  dokumentacyjne w docstringach i `href`-y do stron zewnętrznych.
+
+Skan `.py` obejmuje wszystkie moduły, nie tylko `admin.py` — klasy `Media` mogą
+żyć też w `forms.py`/`widgets.py` (dziś ich tam nie ma, sprawdzone).
 
 Test naśladuje istniejący precedens `src/bpp/tests/test_admin_fonts_selfhosted.py`
 (strażnik self-hostowania fontów admina) — łącznie z dwiema jego nieoczywistymi
@@ -240,12 +251,12 @@ ta funkcja (`views.py:107-153`) nie dotyka `_aj_lista` ani `_okres`.
 
 Zmiana pozostaje potrzebna **także po** Zmianie 4: szablon woła
 `row.porownaj_z_baza` bezpośrednio, przy renderze bloku porównań
-(`_wiersz_preview_kom.html:263`), niezależnie od tego, skąd biorą się
+(`partials/_wiersz_preview_kom.html:263`), niezależnie od tego, skąd biorą się
 `data-diff-*`. Materializacja stanów pól usuwa jedno wołanie, nie wszystkie.
 
 ### Zmiana 3 — zdublowany `<script>`
 
-Blok `<script>` z `_wiersz_preview_kom.html:160-231` przenosimy do
+Blok `<script>` z `partials/_wiersz_preview_kom.html:160-231` przenosimy do
 `importpracownikowrow_list.html` (raz na stronę). Kod jest już napisany jako
 delegacja zdarzeń na `document` z guardem `window.__bppImportAutorPicker`, więc
 przeniesienie jest czysto mechaniczne — nie wymaga zmian w samym JS.
@@ -275,16 +286,36 @@ Zamiast tego materializujemy wynik.
 (migracja `0024`). Rozszerzamy jego cykl życia na dwie fazy:
 
 - **przed integracją** — żywy cache: liczony na koniec analizy i odświeżany po
-  każdej mutacji wiersza;
+  każdej mutacji **pól czytanych przez ekstraktory** (nie po każdej mutacji
+  wiersza — patrz „Czego świadomie NIE odświeżamy");
 - **przy integracji** — `integrate.py` zapisuje ostatnią wartość i przestaje
   odświeżać. Po integracji nic wiersza nie mutuje (wszystkie ścieżki mutujące są
   za bramką `edytowalny_podglad`), więc pole zamarza samo.
 
-**`stany_pol()` nie wymaga zmian.** Obecna implementacja (`models.py:1127-1142`)
-już robi dokładnie to, czego potrzebujemy: zwraca snapshot dopełniony neutralnym
-`"brak"` dla kluczy dodanych po jego zapisaniu, a gdy `None` — liczy na żywo.
-Zmienia się nie ta metoda, tylko fakt, że pole jest **zawsze wypełnione** także
-przed integracją.
+**Rozdzielenie „policz" od „przeczytaj" — warunek konieczny.** Obecna
+`stany_pol()` (`models.py:1127-1142`) jest metodą **czytającą**: gdy snapshot jest
+niepusty, **zwraca go** (`{**baza, **self.stany_pol_snapshot}`), a liczy tylko gdy
+pole jest `None`. Po tej zmianie pole jest niepuste od końca analizy, więc każde
+„przeliczenie" napisane jako `self.stany_pol_snapshot = self.stany_pol()` byłoby
+**kopiowaniem pola w samo siebie** — cichym no-opem. Dotyczyłoby to wszystkich
+punktów odświeżania naraz, czyli reaktywowałoby dokładnie ten błąd, któremu ta
+sekcja ma zapobiegać.
+
+Dlatego dokładamy metodę **liczącą**, bez gałęzi snapshotu:
+
+```python
+def stany_pol_live(self):
+    """Stan każdego pola policzony ekstraktorami POLA_ROZNIC — ZAWSZE świeżo,
+    z pominięciem ``stany_pol_snapshot``. Źródło prawdy dla materializacji."""
+    from import_pracownikow.roznice import POLA_ROZNIC
+
+    return {klucz: ekstraktor(self) for klucz, _et, ekstraktor in POLA_ROZNIC}
+```
+
+`stany_pol_live()` używają: `odswiez_stany_pol()`, backfill oraz zamrożenie
+w `integrate.py`. `stany_pol()` — czytana przez szablon i przez kod spoza tej
+zmiany — zachowuje dzisiejsze zachowanie; jej gałąź „policz na żywo" delegujemy
+do `stany_pol_live()`, żeby nie było dwóch kopii tej samej pętli.
 
 Świadomie **nie dodajemy** drugiej kolumny. Rozważona alternatywa (osobne
 `stany_pol_cache` obok `stany_pol_snapshot`) daje czytelniejszy rozdział ról, ale
@@ -300,9 +331,9 @@ czytane przez ekstraktory `POLA_ROZNIC`. Pierwsza wersja tej specyfikacji
 wskazywała tu widoki `Weryfikacja{Jednostek,Tytulow,Stopni,Stanowisk}View` — **to
 było błędne**. Te widoki zapisują wyłącznie obiekty decyzji
 (`dec.save(update_fields=["decyzja", "wybrany_parent", "wybrana_jednostka"])`,
-`views.py:1125`); wierszy nie dotykają. Faktyczne przypisanie pól wierszom dzieje
-się w `pipeline/integrate.py` przy „Zapisz strukturę": `row.jednostka` (:546),
-`row.tytul` (:742), `row.stopien` (:817), `row.stanowisko_dydaktyczne` (:883).
+`views.py:1122`); wierszy nie dotykają. Faktyczne przypisanie pól wierszom dzieje
+się w `pipeline/integrate.py` przy „Zapisz strukturę": `row.jednostka` (:543),
+`row.tytul` (:735), `row.stopien` (:810), `row.stanowisko_dydaktyczne` (:876).
 
 | miejsce | co mutuje |
 |---------|-----------|
@@ -315,11 +346,25 @@ się w `pipeline/integrate.py` przy „Zapisz strukturę": `row.jednostka` (:546
 stanem `STAN_STRUKTURA_ZINTEGROWANA`, który **nadal jest** `edytowalny_podglad`
 (`models.py:214-222`) — to jest Krok 2, faza osób, dokładnie ta, w której operator
 pracuje na widoku rezultatów. Bez odświeżenia w tym miejscu filtr `jednostka`
-(a także `data_od`, `data_do`, `funkcja`, `stanowisko`, których ekstraktory
-bramkują po `jednostka_id` — `roznice.py:56,69,80`) pokazywałby stan sprzed
-przypisania jednostek. Zakres strukturalny bywa uruchamiany **drugi raz** z fazy
-osób (dotworzenie słowników, `views.py:1480-1489`), więc odświeżenie musi być
+pokazywałby stan sprzed przypisania jednostek — a razem z nim `data_od` i `data_do`
+(ekstraktory bramkują po `jednostka_id`, `roznice.py:69,80`) oraz `funkcja`
+i `stanowisko` (zależą od `autor_jednostka`, przeliczanego przy przypisaniu
+jednostki). Zakres strukturalny bywa uruchamiany **drugi raz** z fazy osób
+(dotworzenie słowników, `views.py:1480-1489`), więc odświeżenie musi być
 idempotentne i wołane przy każdym przebiegu, nie tylko pierwszym.
+
+**Dlaczego przebieg PEŁNY nie potrzebuje osobnego punktu.** Reconcilery
+`_podlacz_wiersze_do_jednostek` / `_rozstrzygnij_{tytuly,stopnie,stanowiska}`
+biegną w **każdym** zakresie, także pełnym (`integrate.py:908-931`), a
+early-return dla zakresu strukturalnego (`:934-953`) w przebiegu pełnym się nie
+wykonuje — więc formalnie mutują wiersze poza wymienionymi punktami. Nie tworzy
+to dziury, bo: (a) widoki `Weryfikacja*` pozwalają edytować decyzje **tylko**
+w stanie `przeanalizowany` (`views.py:970`, `:1137` i analogiczne), (b) przebieg
+pełny wymaga wcześniejszego przebiegu strukturalnego, którego końcowy refresh
+zobaczył te same decyzje, a (c) reconcilery są idempotentne, więc ponowne
+przypisanie daje wartościowo tę samą jednostkę/tytuł/stopień/stanowisko. Wiersze
+z worklisty i tak przechodzą przez zamrożenie w `integrate.py:193`. Zapisujemy ten
+argument jawnie, żeby nie trzeba go było odtwarzać przy następnej zmianie w potoku.
 
 **Czego świadomie NIE odświeżamy.** `PrzelaczUtworzNowegoView`,
 `PrzepnijPraceView` i `ZaznaczWszystkiePrzepieciaView` mutują `utworz_nowego`
@@ -336,15 +381,34 @@ zabiegów.
 
 **Zachowanie zamrożonego snapshotu audytu — bez zmian.** Dziś snapshot dla wiersza
 „utwórz nowego" liczy się **po** tym, jak `_przygotuj_nowego_autora` (`integrate.py:983`,
-przed pętlą worklisty w :986) ustawił świeżo utworzonego autora — zamrożone stany
-porównują więc plik z nowym autorem. Gdybyśmy zostawili istniejące guardy
-`if stany_pol_snapshot is None` (`integrate.py:193`, `models.py:1366`), stałyby się
-one martwe (pole byłoby już wypełnione przez odświeżanie przedintegracyjne),
-a audyt pokazałby stan sprzed utworzenia autora (`autor=None` → wszędzie „brak").
-To byłaby cicha zmiana danych audytowych. Dlatego **oba guardy zamieniamy na
-bezwarunkowe przypisanie** w tym samym miejscu potoku: wartość audytowa pozostaje
-bit w bit taka jak dziś. Test asertuje snapshot wiersza „utwórz nowego" po pełnej
-integracji.
+przed pętlą worklisty w :986) ustawił świeżo utworzonego autora, a **przed**
+`_materializuj_diff` — zamrożone stany porównują więc plik z nowym autorem, ale
+z jeszcze niezmaterializowanym `Autor_Jednostka` (odroczone AJ = `None` →
+`funkcja` = „brak"). Tak mówi komentarz w `integrate.py:189-192` i to jest wartość,
+którą trzeba odtworzyć co do joty.
+
+Po tej zmianie pole jest już wypełnione przed integracją, więc guard
+`if stany_pol_snapshot is None` w `integrate.py:193` nigdy by nie strzelił i audyt
+pokazałby stan z końca analizy (`autor=None` → wszędzie „brak"). Dlatego **w tym
+jednym miejscu** zamieniamy guard na bezwarunkowe przeliczenie:
+
+```python
+row.stany_pol_snapshot = row.stany_pol_live()   # integrate.py:193, było: if ... is None
+```
+
+**Drugi guard, w `models.py:1366` (`ImportPracownikowRow.integrate()`), zostaje
+nietknięty.** To nie jest martwy kod, tylko aktywne zabezpieczenie: `integrate()`
+ma dokładnie jednego wywołującego (`_integruj_wiersz`, `integrate.py:219`)
+i wykonuje się **po** `_materializuj_diff`, czyli **po zmianie bazy**. Gdyby
+zamienić i ten guard na bezwarunkowe przeliczenie, nadpisałby świeże zamrożenie
+wartościami policzonymi względem już utworzonego AJ — dla każdego wiersza
+z `diff_do_utworzenia` (w tym każdego „utwórz nowego") `funkcja`, `data_od`
+i `data_do` wyszłyby inaczej niż dziś. To byłaby dokładnie ta korupcja audytu,
+przed którą guard chroni.
+
+Test niezmienności audytu musi asertować **konkretne dzisiejsze wartości**
+(np. `funkcja == "brak"` dla wiersza z odroczonym AJ), a nie samo „policzone
+względem nowego autora" — bo błędny wariant też spełniałby ten słabszy warunek.
 
 **Backfill (samonaprawianie).** Importy sprzed tej zmiany mają `NULL` i filtr SQL
 by ich nie znalazł. Zamiast migracji danych (musiałaby wykonać zapytania per wiersz
@@ -399,7 +463,7 @@ serwerowej byłaby jednoklikowym powrotem do problemu, który naprawiamy.
 
 **Zakres `?q=`.** Musi pokryć to, co dziś pokrywa kliencki filtr tekstowy —
 a ten przeszukuje wszystkie elementy `[data-szukaj]`, czyli **więcej** niż
-oczywiste nazwisko z pliku. Z `_wiersz_preview_kom.html:16-23,33-35,235-241`
+oczywiste nazwisko z pliku. Z `partials/_wiersz_preview_kom.html:16-23,33-35,235-241`
 wynika sześć pól:
 
 ```python
@@ -407,6 +471,7 @@ Q(dane_znormalizowane__nazwisko__icontains=q)
 | Q(**{"dane_znormalizowane__imię__icontains": q})
 | Q(**{"dane_znormalizowane__tytuł_stopień__icontains": q})
 | Q(autor__nazwisko__icontains=q) | Q(autor__imiona__icontains=q)
+| Q(autor__poprzednie_nazwiska__icontains=q) | Q(autor__orcid__icontains=q)
 | Q(jednostka__nazwa__icontains=q)
 | Q(autor__aktualna_jednostka__nazwa__icontains=q)
 ```
@@ -414,8 +479,16 @@ Q(dane_znormalizowane__nazwisko__icontains=q)
 Klucze `imię` i `tytuł_stopień` mają polskie znaki; `imię` jest poprawnym
 identyfikatorem Pythona, ale `tytuł_stopień` w zapisie `Q(a__tytuł_stopień=…)`
 byłby kruchy — dlatego oba przekazujemy przez `Q(**{...})`, jednolicie.
-Pominięcie `autor__imiona` i `autor__aktualna_jednostka__nazwa` byłoby cichym
-zawężeniem wyszukiwania względem stanu dzisiejszego.
+
+`poprzednie_nazwiska` i `orcid` wchodzą, bo `span[data-szukaj]`
+(`partials/_wiersz_preview_kom.html:33-35`) obejmuje **cały** include `_autor_dane.html`,
+a ten renderuje ORCID oraz `Autor.__str__`, doklejający poprzednie nazwiska.
+Operator wklejający ORCID w wyszukiwarkę to realny scenariusz.
+
+**Zaakceptowane zawężenie** (świadome, żeby nie budować wyszukiwania po
+wyrenderowanym tekście): serwerowe `?q=` nie dopasuje po skrócie wydziału
+doklejanym przez `Jednostka.__str__` przy włączonych wydziałach ani po skrócie
+tytułu z `Autor.__str__`. Oba są pochodnymi pól, po których i tak szukamy.
 
 **Stan `"brak"` wymaga osobnego lookupu.** Istnieją zamrożone snapshoty **bez**
 kluczy `data_od`/`data_do` — pochodzą sprzed dodania tych pól i dlatego
@@ -431,6 +504,11 @@ Q(**{f"stany_pol_snapshot__{klucz}": "brak"})
 Pozostałe stany (`zmienione`, `zgodne`) to zwykła równość. Nie „naprawiamy" tych
 snapshotów backfillem — są zamrożonym zapisem audytowym i backfill ich nie dotyka
 (patrz Zmiana 4).
+
+Uwaga na kolejność w `get_queryset()`: `~Q(has_key)` dopasowuje także wiersze
+z `stany_pol_snapshot IS NULL` (Django generuje `NOT (snap ? 'k' AND snap IS NOT
+NULL)`). Poprawność filtra `"brak"` zależy więc od tego, że **backfill biegnie
+przed filtrowaniem** w tym samym `get_queryset()` — po nim NULL-i już nie ma.
 
 `?rodzaj=` zachowuje dzisiejszą walidację i dzisiejszą semantykę deep-linku
 `?rodzaj=do-pominiecia` z ostrzeżenia finalizacji — z tą różnicą, że teraz filtruje

--- a/docs/superpowers/specs/2026-07-22-import-pracownikow-cdn-i-paginacja-design.md
+++ b/docs/superpowers/specs/2026-07-22-import-pracownikow-cdn-i-paginacja-design.md
@@ -1,0 +1,400 @@
+# Self-hosting assetów + wydajność i paginacja widoku rezultatów importu pracowników
+
+Data: 2026-07-22
+Status: zaakceptowany do implementacji
+Gałęzie: `fix/self-hosting-cdn-assets` (PR #1), `perf/import-pracownikow-paginacja-serwerowa` (PR #2)
+
+## Problem
+
+Wejście na `/import_pracownikow/<uuid>/rezultaty/` trwa dramatycznie długo. Diagnoza
+wykazała **dwa niezależne** źródła, a nie jedno.
+
+### Źródło 1 — blokujący skrypt z CDN-a (dominujące)
+
+`src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html:53`
+ładuje htmx z `https://unpkg.com/htmx.org@2.0.4`. Tag leży w `<body>` w linii 53,
+a tabela zaczyna się w linii 144 — jest to więc **parser-blocking script**:
+przeglądarka wstrzymuje parsowanie HTML-a i czeka na odpowiedź unpkg.com. Za
+VPN-em lub firewallem, który tego hosta nie przepuszcza, oznacza to blokadę do
+timeoutu DNS/TCP (typowo 20–75 s białej strony). Dodatkowo `unpkg.com/htmx.org@2.0.4`
+odpowiada `301`, więc to dwa round-tripy zamiast jednego.
+
+Objaw jest **niezależny od liczby wierszy** i nie odtwarza się w sieci, która CDN-a
+widzi — stąd trudność w diagnozie.
+
+htmx jest już w projekcie lokalnie i reszta aplikacji ładuje go poprawnie; trzy
+szablony zostały pominięte przy przejściu na vendoring lokalny.
+
+### Źródło 2 — koszt renderowania po stronie serwera (realny, niezależny)
+
+Zmierzone benchmarkiem (render widoku przez `admin_client`, `CaptureQueriesContext`,
+lokalny PostgreSQL w testcontainerze — czyli **bez** narzutu sieciowego; produkcja
+będzie wolniejsza):
+
+| N wierszy | czas odpowiedzi | zapytań SQL | rozmiar HTML |
+|-----------|-----------------|-------------|--------------|
+| 300       | 1,08 s          | 935         | 2,7 MB       |
+| 1000      | 3,15 s          | 3035        | 9,1 MB       |
+
+To **3 zapytania na każdy wiersz importu**, namierzone stack-trace'em:
+
+1. **2× `bpp_uczelnia` na wiersz** — `Jednostka.__str__`
+   (`src/bpp/models/jednostka.py:249`) czyta `self.uczelnia.uzywaj_wydzialow`.
+   Szablon renderuje dwie różne jednostki na wiersz (`row.jednostka` oraz
+   `row.autor.aktualna_jednostka`), a `select_related` tworzy **osobną instancję**
+   `Jednostka` per wiersz, więc cache FK na instancji nic nie daje. W produkcji
+   cacheops (`bpp.uczelnia` jest w `CACHEOPS`) zamienia to na trafienia do Redisa —
+   tańsze, ale nadal 2×N round-tripów.
+2. **1× `bpp_autor_jednostka` na wiersz** — `ImportPracownikowRow._aj_lista()`
+   (`models.py:995`), wołane przez `porownaj_z_baza()` → `stany_pol()`.
+   `bpp.autor_jednostka` **nie jest** w `CACHEOPS`, więc to prawdziwe uderzenie
+   w PostgreSQL, N razy.
+
+Do tego **9,1 KB HTML na wiersz**, z czego **3830 bajtów to identyczny blok
+`<script>`** powtórzony w każdym wierszu (`_wiersz_preview_kom.html:160-231`).
+Ma guard `window.__bppImportAutorPicker`, więc wykonuje się raz — ale przesyła się
+i parsuje N razy. Przy 1000 wierszy to 3,8 MB czystego duplikatu.
+
+Wreszcie: widok **nie ma paginacji serwerowej**. `paginate_by` nie jest ustawione,
+całość jedzie do DOM-u, a stronicowanie jest udawane w JS przez `hidden` na
+`<tbody>`. Przy realnym imporcie uczelnianym (1500–3000 wierszy) daje to 15–27 MB
+HTML-a niezależnie od tego, ile wierszy użytkownik ogląda.
+
+### Zmierzony efekt poprawek (spike)
+
+Spike (`select_related` na ścieżki `uczelnia`, hurtowy prefetch `Autor_Jednostka`,
+wyniesienie `<script>`), N=1000:
+
+| metryka          | przed  | po        | zysk |
+|------------------|--------|-----------|------|
+| czas odpowiedzi  | 3,15 s | **0,49 s**| 6,4× |
+| czas w SQL       | 1,24 s | **0,08 s**| 15×  |
+| liczba zapytań   | 3035   | **36**    | 84×  |
+| rozmiar HTML     | 9,1 MB | **5,3 MB**| −42% |
+
+Paginacja serwerowa dokłada się do tego ortogonalnie: sprowadza koszt renderu
+z O(liczba wierszy importu) do O(rozmiar strony).
+
+## Cele i nie-cele
+
+**Cele.**
+
+1. Żaden zasób ładowany przez BPP nie pochodzi z zewnętrznego CDN-a.
+2. Widok rezultatów renderuje się w czasie niezależnym od rozmiaru importu.
+3. Filtry działają na **całym** imporcie, nie na bieżącej stronie.
+4. Regresja jest niemożliwa do wprowadzenia po cichu (testy pilnują obu rzeczy).
+
+**Nie-cele.**
+
+- Usuwanie widgetów SaaS (Freshworks, Google Analytics, UserWay). To zdalne
+  **usługi**, nie pliki — nie da się ich self-hostować. Wszystkie są `async` lub
+  wstrzykiwane dynamicznie, więc nie blokują parsera. Zostają bez zmian
+  (świadoma decyzja, zapisana jako allow-lista w teście).
+- Przepisywanie wykresów w `ewaluacja_optymalizacja` na inną bibliotekę.
+  Chart.js zostaje, zmienia się wyłącznie źródło pliku.
+- Zmiana logiki dopasowywania autorów, resolvera okresów ani czegokolwiek
+  w potoku analizy/integracji.
+- Refaktor `views.py` (1713 linii) poza tym, czego wymaga zadanie.
+
+## PR #1 — self-hosting assetów
+
+Gałąź `fix/self-hosting-cdn-assets`, baza `dev`. Mały, niskiego ryzyka,
+mergowalny natychmiast — to on rozwiązuje realny ból użytkownika.
+
+### Zmiany
+
+| plik | dziś | po |
+|------|------|-----|
+| `import_pracownikow/templates/…/importpracownikowrow_list.html:53` | `https://unpkg.com/htmx.org@2.0.4` | `{% static 'liveops/vendor/htmx.min.js' %}` |
+| `import_pracownikow/templates/…/odpiecia.html:25` | j.w. | j.w. |
+| `importer_publikacji/templates/…/index.html:53` | j.w. | j.w. |
+| `ewaluacja_optymalizacja/templates/…/run_detail.html:7` | `https://cdn.jsdelivr.net/npm/chart.js@4.4.0/…` | `{% static 'chart.js/dist/chart.umd.min.js' %}` |
+| `przemapuj_zrodlo/admin.py:109` | `https://cdnjs.cloudflare.com/…/foundation-icons.min.css` | `foundation-datepicker/foundation/fonts/foundation-icons.css` |
+
+Szczegóły, które zostały zweryfikowane w kodzie przed napisaniem specyfikacji:
+
+- `liveops/vendor/htmx.min.js` pochodzi z zainstalowanego pakietu `liveops`
+  (`site-packages/liveops/static/liveops/vendor/htmx.min.js`) i jest już używany
+  przez `import_pracownikow/import_pracownikow.html:33` oraz
+  `import_punktacji_zrodel/…:33`. Nie wymaga żadnej nowej zależności.
+- `foundation-icons.css` jest już lokalnie, dostarczany przez pakiet npm
+  `foundation-datepicker` pod ścieżką
+  `foundation-datepicker/foundation/fonts/foundation-icons.css`, razem z fontami
+  (`.woff`, `.ttf`, `.eot`, `.svg`). Używa go `bare.html:77` i dwa szablony
+  admina. `przemapuj_zrodlo/admin.py` jest jedynym odstępstwem. Nie wymaga
+  nowej zależności — to podmiana jednego stringa w `class Media`.
+- **Chart.js jest jedyną pozycją wymagającą nowej zależności npm.** Do
+  `package.json` (`dependencies`) trafia `"chart.js": "^4.4.0"`; `YarnFinder`
+  zbierze `node_modules/chart.js/dist/chart.umd.min.js` do statików, analogicznie
+  do `htmx.org/dist/htmx.js` używanego przez `admin/base_site.html:16`.
+  Wymaga `yarn install` + `make assets` przy budowaniu obrazu — czyli nic nowego
+  w pipeline, ale `yarn.lock` idzie do commita.
+
+### Zejście htmx 2.0.4 → 1.9.12
+
+Trzy szablony jadą dziś na htmx **2.0.4** z CDN-a, a cała reszta aplikacji na
+**1.9.12** (`package.json`: `"htmx.org": "^1.9.12"`; `liveops/vendor/htmx.min.js`
+raportuje `version:"1.9.12"`). Self-hosting oznacza więc **zejście o major**
+w tych trzech miejscach — ujednolicenie wersji w całej aplikacji.
+
+Ocena ryzyka: komentarze w `_wiersz_preview_kom.html:83-87` wprost tłumaczą obejście
+napisane **pod semantykę 1.x** (filtr zdarzenia `change[target.classList…]` zamiast
+`from:`, bo „bare selektor w `from:` w htmx 1.x wiąże na CAŁYM dokumencie"). Kod był
+więc projektowany pod 1.x i na 2.x działa przypadkiem. Użyte API to wyłącznie
+`hx-post`, `hx-target`, `hx-swap="innerHTML"`, `hx-trigger` z filtrem zdarzenia oraz
+zdarzenie `htmx:afterSettle` — wszystkie obecne i zgodne w 1.9.12.
+
+**Warunek akceptacji:** samo przejście testów nie wystarcza. Trzy ekrany trzeba
+przeklikać ręcznie (lista w „Testowanie" niżej).
+
+### Test regresyjny — brak zewnętrznych assetów
+
+Nowy test (`src/django_bpp/tests/test_brak_zewnetrznych_assetow.py`) skanuje
+wszystkie szablony w `src/**/templates/**` oraz wszystkie klasy `Media` w plikach
+`admin.py` i szuka `<script src>` / `<link href>` wskazujących na `http://`
+lub `https://`.
+
+Allow-lista (jawna, z uzasadnieniem w komentarzu):
+
+- `euc-widget.freshworks.com` — widget zgłoszeń, usługa SaaS, `async defer`
+- `www.googletagmanager.com` — Google Analytics, usługa SaaS, `async`
+- `cdn.userway.org` — widget dostępności WCAG, wstrzykiwany dynamicznie
+
+Wszystko poza allow-listą to błąd testu. Komunikat błędu ma wprost mówić, co
+zrobić: „zvendoruj do `package.json` i użyj `{% static %}`, albo dopisz do
+allow-listy z uzasadnieniem".
+
+Skanowanie ograniczamy do plików źródłowych — `src/django_bpp/staticroot/`
+(artefakt `collectstatic`) i `node_modules/` są wyłączone. Świadomie **poza
+zakresem** skanu zostaje `src/bpp/static/kbw-keypad/dist/index.html`, który ładuje
+jQuery z `ajax.googleapis.com` — to strona demo vendorowanego pluginu, nigdy nie
+renderowana przez aplikację. Test skanuje szablony Django, nie statyczny HTML
+bibliotek, więc plik nie wpada w zakres i nie wymaga wyjątku.
+
+## PR #2 — wydajność i paginacja serwerowa
+
+Gałąź `perf/import-pracownikow-paginacja-serwerowa`, baza **`fix/self-hosting-cdn-assets`**
+(nie `dev`) — oba PR-y dotykają `importpracownikowrow_list.html`, więc stackowanie
+eliminuje konflikt i sprawia, że diff PR #2 pokazuje tylko jego własne zmiany.
+
+### Zmiana 1 — N+1 „uczelnia"
+
+W `ImportPracownikowResultsView.get_queryset()` dokładamy do istniejącego
+`select_related` trzy ścieżki:
+
+```python
+.select_related(
+    "jednostka__uczelnia",
+    "autor__aktualna_jednostka__uczelnia",
+    "autor__aktualna_jednostka__wydzial",
+)
+```
+
+Dwie pierwsze zabijają zmierzone 2×N zapytań o `bpp_uczelnia`. Trzecia jest
+**profilaktyczna**: `Jednostka.__str__` po sprawdzeniu `uzywaj_wydzialow` sięga do
+`self.wydzial`. W benchmarku ta gałąź nie odpaliła (`uzywaj_wydzialow` było
+`False`), ale na instancji z włączonymi wydziałami byłoby to trzecie N+1.
+`jednostka__wydzial` jest już w `get_details_set()`; brakuje odpowiednika dla
+`autor__aktualna_jednostka`.
+
+### Zmiana 2 — N+1 `Autor_Jednostka`
+
+Nowa funkcja modułowa w `views.py`, wołana z `get_context_data()`:
+
+```python
+def wstepnie_zaladuj_okresy(rows):
+    """Zasila memo ``_aj_lista_cache`` wszystkich wierszy JEDNYM zapytaniem."""
+```
+
+Pobiera `Autor_Jednostka` dla zbioru par `(autor_id, jednostka_id)` widocznych
+na stronie i przypisuje listy do `row._aj_lista_cache`. **Logika modelu pozostaje
+nietknięta** — korzystamy z istniejącego kontraktu memo, ten sam, którego używa
+`_okres()`. Wiersze bez pary dostają `[]`, żeby `hasattr` nie odpalił zapytania.
+
+Uwaga na kolejność: funkcja musi być wołana **przed** `oznacz_przepiecie_prac()`
+i przed renderem, na tej samej liście instancji (`list(ctx["object_list"])`),
+inaczej memo trafi w inne obiekty niż te renderowane.
+
+### Zmiana 3 — zdublowany `<script>`
+
+Blok `<script>` z `_wiersz_preview_kom.html:160-231` przenosimy do
+`importpracownikowrow_list.html` (raz na stronę). Kod jest już napisany jako
+delegacja zdarzeń na `document` z guardem `window.__bppImportAutorPicker`, więc
+przeniesienie jest czysto mechaniczne — nie wymaga zmian w samym JS.
+
+Ważne: partial jest też wstrzykiwany przez HTMX przy swapie wiersza. Delegacja na
+`document` + `htmx:afterSettle` (już w kodzie) obsługuje to poprawnie, bo listener
+żyje na stronie, nie w wierszu. Po przeniesieniu guard `__bppImportAutorPicker`
+przestaje być potrzebny, ale **zostaje** — chroni przed podwójną rejestracją,
+gdyby ktoś kiedyś wstawił partial na inną stronę.
+
+### Zmiana 4 — materializacja stanów pól
+
+To jest warunek konieczny paginacji, więc opis zaczyna się od uzasadnienia.
+
+**Dlaczego bez tego się nie da.** Pasek filtrów ma 8 filtrów stanu pola
+(`POLA_ROZNIC`), dziś liczonych w Pythonie przez ekstraktory w `roznice.py`.
+Sześć z nich (`jednostka`, `tytul`, `funkcja`, `email`, `stopien`, `stanowisko`)
+to porównania FK/stringów, które dałoby się zapisać w SQL. Dwa pozostałe
+(`data_od`, `data_do`) wołają `porownaj_z_baza()` → `_okres()` →
+`rozwiaz_okres_zatrudnienia()`, czyli imperatywny resolver okresów zatrudnienia
+operujący na liście `Autor_Jednostka`. **Tego nie da się wyrazić w SQL** bez
+przepisania resolvera, co jest ryzykowną zmianą w logice biznesowej importu.
+
+Zamiast tego materializujemy wynik.
+
+**Model.** Pole `stany_pol_snapshot` (JSONField, `null=True`) już istnieje
+(migracja `0024`). Rozszerzamy jego cykl życia na dwie fazy:
+
+- **przed integracją** — żywy cache: liczony na koniec analizy i odświeżany po
+  każdej mutacji wiersza;
+- **przy integracji** — `integrate.py` zapisuje ostatnią wartość i przestaje
+  odświeżać. Po integracji nic wiersza nie mutuje (wszystkie ścieżki mutujące są
+  za bramką `edytowalny_podglad`), więc pole zamarza samo.
+
+`stany_pol()` upraszcza się do: zwróć `stany_pol_snapshot` (dopełniony neutralnym
+`"brak"` dla kluczy dodanych po zapisaniu snapshotu), a gdy `None` — policz na
+żywo (ścieżka awaryjna, patrz backfill).
+
+Świadomie **nie dodajemy** drugiej kolumny. Rozważona alternatywa (osobne
+`stany_pol_cache` obok `stany_pol_snapshot`) daje czytelniejszy rozdział ról, ale
+kosztem migracji, dodatkowego pola i dwóch miejsc, które mogą się rozjechać.
+Ponieważ post-integracyjne zamrożenie wynika z bramki `edytowalny_podglad`
+(a nie z osobnego pola), jedna kolumna wystarcza.
+
+**Punkty odświeżania.** Metoda `ImportPracownikowRow.odswiez_stany_pol()`
+przelicza i zapisuje pole (`update_fields=["stany_pol_snapshot"]`). Wołana z:
+
+| miejsce | dlaczego |
+|---------|----------|
+| koniec analizy (`pipeline/analyze.py`) | pierwsze wypełnienie, batch |
+| `WybierzKandydataView` | zmienia `autor` |
+| `DopasujAutoraView` | zmienia `autor` |
+| `PrzelaczUtworzNowegoView` | zmienia `utworz_nowego` (wpływa na `do_pominiecia`) |
+| `PrzepnijPraceView` | zmienia `przepnij_prace` |
+| `ZaznaczWszystkiePrzepieciaView` | akcja zbiorcza, batch |
+| `WeryfikacjaJednostekView` | przypisuje `jednostka` wierszom |
+| `WeryfikacjaTytulowView` | przypisuje `tytul` |
+| `WeryfikacjaStopniView` | przypisuje `stopien` |
+| `WeryfikacjaStanowiskView` | przypisuje `stanowisko_dydaktyczne` |
+
+`RestartAnalizaView` czyści wiersze i uruchamia analizę od nowa, więc pokrywa go
+punkt „koniec analizy". `PrzelaczOdpiecieView` i `ZaznaczOdpieciaView` mutują
+`Odpiecie`, nie wiersze — bez wpływu.
+
+**Backfill (samonaprawianie).** Importy sprzed tej zmiany mają `NULL` i filtr
+SQL by ich nie znalazł. Zamiast migracji danych (która musiałaby wykonać zapytania
+per wiersz na całej historii) robimy **leniwy backfill**: w `get_queryset()`, gdy
+`parent.importpracownikowrow_set.filter(stany_pol_snapshot__isnull=True).exists()`,
+przeliczamy cały import jednym batchem (z hurtowym prefetchem `Autor_Jednostka`,
+jak w Zmianie 2) i zapisujemy przez `bulk_update`. Dzieje się to **raz na import**,
+przy pierwszym wejściu na stronę po wdrożeniu.
+
+Backfill jest opakowany w `transaction.atomic()` i **nie zmienia stanu importu** —
+to czysta materializacja tego, co i tak liczyło się na żywo. Dla importu już
+zintegrowanego backfill też jest bezpieczny: `integrate.py` zapisuje snapshot
+przy integracji, więc importy zintegrowane po migracji `0024` mają go wypełnione;
+starsze dostaną wartość policzoną na żywo, czyli dokładnie to, co widok pokazuje
+dziś (`stany_pol()` z gałęzią live).
+
+**Ryzyko i jego kontrola.** Jeśli przegapimy ścieżkę mutującą, filtr skłamie po
+cichu. Kontrola: test parametryzowany po wszystkich endpointach mutujących, który
+dla każdego wykonuje akcję zmieniającą stan pola i asertuje, że
+`row.refresh_from_db().stany_pol_snapshot` odpowiada świeżo policzonemu
+`stany_pol()`. Nowy endpoint mutujący bez odświeżenia = czerwony test.
+
+### Zmiana 5 — paginacja i filtry po stronie serwera
+
+**Paginacja.** `paginate_by = 25`, rozmiar strony z `?per_page=` (dozwolone:
+10, 25, 50, 100; wartość spoza listy degraduje do 25 — tak samo jak dziś
+zachowuje się walidacja `?rodzaj=`). Opcja „wszystkie" **znika**: przy paginacji
+serwerowej byłaby jednoklikowym powrotem do problemu, który naprawiamy.
+
+**Filtry w querysecie:**
+
+| filtr | parametr GET | realizacja |
+|-------|--------------|------------|
+| rodzaj dopasowania | `?rodzaj=` | `confidence=` lub predykat `do-pominiecia` (`autor__isnull=True, utworz_nowego=False`) |
+| szukaj | `?q=` | `Q(dane_znormalizowane__nazwisko__icontains=…) \| Q(dane_znormalizowane__imię__icontains=…) \| Q(autor__nazwisko__icontains=…) \| Q(jednostka__nazwa__icontains=…)` |
+| stan pola (8×) | `?stan_<klucz>=` | `stany_pol_snapshot__<klucz>=` (JSONB) |
+
+`?rodzaj=` zachowuje dzisiejszą walidację i dzisiejszą semantykę deep-linku
+`?rodzaj=do-pominiecia` z ostrzeżenia finalizacji — z tą różnicą, że teraz filtruje
+w SQL, więc trafia w **cały** import, a nie w to, co akurat jest w DOM-ie.
+
+Indeksowanie: queryset jest zawsze zawężony do jednego importu (`parent_id`,
+indeks FK istnieje), więc filtrowanie JSONB działa na najwyżej kilku tysiącach
+wierszy. Indeks GIN na `stany_pol_snapshot` jest zbędny i świadomie go **nie
+dodajemy** — kosztowałby przy każdym zapisie wiersza, a nic realnego nie przyspiesza.
+
+**Szablon.** Formularz filtrów przestaje być sterowany JS-em i staje się zwykłym
+`<form method="get">` z `<button>` „Filtruj”. Znika ~140 linii JS
+(`importpracownikowrow_list.html:174-316`): funkcje `filtruj()`, `stanPola()`,
+`tekstRekordu()`, `okRodzaj()` i cała kliencka paginacja. Zostaje standardowy
+pager Django, a linki pagera **zachowują aktywne filtry** w querystringu
+(tag szablonowy budujący URL z podmienionym `page`).
+
+Atrybuty `data-diff-*`, `data-confidence`, `data-do-pominiecia` i `data-szukaj`
+w `_wiersz_preview_kom.html` **zostają**. Przestają zasilać filtr, ale są
+asertowane przez istniejące testy (`test_filtr_rodzaj.py`, `test_stany_pol.py`)
+i pozostają użyteczne jako czytelny stan w DOM-ie.
+
+**Zmiana zachowania, świadoma:** po akcji HTMX wiersz, który przestał pasować do
+aktywnego filtra, zostaje widoczny do przeładowania strony. Dziś JS chowałby go
+natychmiast. Uznajemy to za akceptowalne — a nawet lepsze: wiersz nie znika
+operatorowi spod kursora zaraz po tym, jak go zmienił.
+
+## Testowanie
+
+**Automatyczne.**
+
+- Test braku zewnętrznych assetów (PR #1, opis wyżej).
+- Test liczby zapytań: render widoku dla N wierszy wykonuje **stałą** liczbę
+  zapytań, niezależną od N. Realizacja: `django_assert_num_queries` dla N=5 i N=25
+  z tym samym oczekiwaniem. To jest właściwy test regresyjny na N+1 — łapie każde
+  z trzech naprawianych N+1 i każde przyszłe.
+- Test paginacji: przy N > `paginate_by` strona zawiera dokładnie `paginate_by`
+  kart, a pager pokazuje właściwą liczbę stron.
+- Testy filtrów: dla każdego z 8 stanów pola oraz dla `?rodzaj=`, `?q=` —
+  filtr zawęża wynik na **całym** imporcie, także gdy pasujący wiersz leży poza
+  pierwszą stroną (to jest istota zmiany, więc test musi to sprawdzać jawnie).
+- Test zachowania filtrów w linkach pagera.
+- Test świeżości snapshotu, parametryzowany po endpointach mutujących (opis wyżej).
+- Test leniwego backfillu: import z `NULL` w `stany_pol_snapshot` po wejściu na
+  stronę ma pole wypełnione, a wartości zgadzają się z liczonymi na żywo.
+- Pełne `make tests` lokalnie (nie tylko na CI), zgodnie z regułą projektu.
+
+**Ręczne (warunek merge'a PR #1 — zejście htmx o major).**
+
+Trzy ekrany, każdy z akcją HTMX:
+
+1. `/import_pracownikow/<uuid>/rezultaty/` — „zmień autora" (Select2 →
+   `dopasuj-autora`), dropdown kandydatów dla wiersza `wielu`, radia
+   Pomiń/Utwórz/Dopasuj dla wiersza `brak`, checkbox przepięcia prac.
+2. `/import_pracownikow/<uuid>/odpiecia/` — przełączanie odpięcia i akcja zbiorcza.
+3. `/importer_publikacji/` — przejście kreatora przez kroki.
+
+Szczególna uwaga na `hx-trigger="change[target.classList.contains('js-brak-radio-post')]"`
+w wierszu `brak`: to jest miejsce, gdzie różnica 1.x/2.x w obsłudze filtrów zdarzeń
+ujawniłaby się najpierw (objaw regresji: jeden klik POST-uje wiele wierszy).
+
+**Weryfikacja pomiaru.** Benchmark z sekcji „Problem" powtarzamy po zmianach
+i wynik trafia do opisu PR #2. Bez liczby „po" nie twierdzimy, że jest szybciej.
+
+## Newsfragmenty
+
+`src/bpp/newsfragments/` (kanoniczny katalog), po polsku:
+
+- PR #1: `self-hosting-assetow.bugfix.rst` — biblioteki JS/CSS ładowane są
+  z serwera uczelni zamiast z zewnętrznych CDN-ów; strony importu działają
+  w sieciach bez dostępu do unpkg.com/jsdelivr.
+- PR #2: `import-pracownikow-paginacja.feature.rst` — lista wyników importu
+  pracowników jest stronicowana po stronie serwera, a filtry działają na całym
+  imporcie.
+
+## Kolejność wdrożenia
+
+1. PR #1 — self-hosting. Merge po ręcznym przeklikaniu trzech ekranów.
+2. PR #2 — stackowany na PR #1: zmiany 1–3 (N+1, skrypt) jako pierwszy commit,
+   zmiana 4 (materializacja) jako drugi, zmiana 5 (paginacja i filtry) jako trzeci.
+   Kolejność jest istotna: paginacja bez materializacji nie miałaby czym filtrować.

--- a/docs/superpowers/specs/2026-07-22-import-pracownikow-cdn-i-paginacja-design.md
+++ b/docs/superpowers/specs/2026-07-22-import-pracownikow-cdn-i-paginacja-design.md
@@ -46,7 +46,7 @@ To **3 zapytania na każdy wiersz importu**, namierzone stack-trace'em:
    cacheops (`bpp.uczelnia` jest w `CACHEOPS`) zamienia to na trafienia do Redisa —
    tańsze, ale nadal 2×N round-tripów.
 2. **1× `bpp_autor_jednostka` na wiersz** — `ImportPracownikowRow._aj_lista()`
-   (`models.py:995`), wołane przez `porownaj_z_baza()` → `stany_pol()`.
+   (`models.py:985`), wołane przez `porownaj_z_baza()` → `stany_pol()`.
    `bpp.autor_jednostka` **nie jest** w `CACHEOPS`, więc to prawdziwe uderzenie
    w PostgreSQL, N razy.
 
@@ -150,15 +150,37 @@ przeklikać ręcznie (lista w „Testowanie" niżej).
 ### Test regresyjny — brak zewnętrznych assetów
 
 Nowy test (`src/django_bpp/tests/test_brak_zewnetrznych_assetow.py`) skanuje
-wszystkie szablony w `src/**/templates/**` oraz wszystkie klasy `Media` w plikach
-`admin.py` i szuka `<script src>` / `<link href>` wskazujących na `http://`
-lub `https://`.
+wszystkie szablony w `src/**/templates/**` oraz wszystkie pliki `*.py` w `src/`
+(klasy `Media` mogą żyć nie tylko w `admin.py`, ale też w `forms.py`/`widgets.py`;
+dziś ich tam nie ma, ale szerszy skan jest odporniejszy na przyszłość) i szuka
+`<script src>` / `<link href>` wskazujących na `http://` lub `https://`.
 
-Allow-lista (jawna, z uzasadnieniem w komentarzu):
+Test naśladuje istniejący precedens `src/bpp/tests/test_admin_fonts_selfhosted.py`
+(strażnik self-hostowania fontów admina) — łącznie z dwiema jego nieoczywistymi
+decyzjami, które trzeba powtórzyć:
 
-- `euc-widget.freshworks.com` — widget zgłoszeń, usługa SaaS, `async defer`
-- `www.googletagmanager.com` — Google Analytics, usługa SaaS, `async`
-- `cdn.userway.org` — widget dostępności WCAG, wstrzykiwany dynamicznie
+1. **Dopasowanie regexem, nie `"host" in text`.** Substringowe sprawdzanie
+   literału-hosta odpala fałszywy alarm CodeQL
+   `py/incomplete-url-substring-sanitization` (heurystyka bierze je za
+   obejściopodatną sanityzację URL-a).
+2. **Lokalizowanie plików względem pliku testu** (`Path(__file__).resolve().parents[…]`),
+   nie przez `import django_bpp`. Przy editable-install `__file__` pakietu
+   wskazuje główny checkout, nie worktree — test sprawdzałby wtedy cudzy kod.
+   Przy tej pracy (worktree obok repo) to nie jest teoretyczne.
+
+Allow-lista (jawna, z uzasadnieniem w komentarzu) — usługi SaaS, których nie da
+się self-hostować:
+
+- `euc-widget.freshworks.com` — widget zgłoszeń; realny tag `<script src>`
+  (`base.html:111`, `admin/base_site.html:157`), `async defer`
+- `www.googletagmanager.com` — Google Analytics; realny tag (`google_analytics.html:1`), `async`
+
+`cdn.userway.org` (widget dostępności WCAG) **nie trafia do allow-listy**, bo skan
+tagów by go i tak nie zobaczył: jest wstrzykiwany inline'owym JS-em przez
+`s.setAttribute("src", …)` (`base.html:368`). Wpis byłby martwy i mylący.
+Zamiast tego docstring testu wymienia go jako znany, świadomie tolerowany
+zewnętrzny zasób poza zasięgiem skanu — żeby nikt nie uznał zielonego testu za
+dowód, że zewnętrznych requestów nie ma w ogóle.
 
 Wszystko poza allow-listą to błąd testu. Komunikat błędu ma wprost mówić, co
 zrobić: „zvendoruj do `package.json` i użyj `{% static %}`, albo dopisz do
@@ -211,9 +233,15 @@ na stronie i przypisuje listy do `row._aj_lista_cache`. **Logika modelu pozostaj
 nietknięta** — korzystamy z istniejącego kontraktu memo, ten sam, którego używa
 `_okres()`. Wiersze bez pary dostają `[]`, żeby `hasattr` nie odpalił zapytania.
 
-Uwaga na kolejność: funkcja musi być wołana **przed** `oznacz_przepiecie_prac()`
-i przed renderem, na tej samej liście instancji (`list(ctx["object_list"])`),
-inaczej memo trafi w inne obiekty niż te renderowane.
+Wymóg jest jeden: funkcja musi dostać **tę samą listę instancji**, która pójdzie
+do renderu (`rows = list(ctx["object_list"])`), inaczej memo trafi w inne obiekty
+niż renderowane. Kolejność względem `oznacz_przepiecie_prac()` jest obojętna —
+ta funkcja (`views.py:107-153`) nie dotyka `_aj_lista` ani `_okres`.
+
+Zmiana pozostaje potrzebna **także po** Zmianie 4: szablon woła
+`row.porownaj_z_baza` bezpośrednio, przy renderze bloku porównań
+(`_wiersz_preview_kom.html:263`), niezależnie od tego, skąd biorą się
+`data-diff-*`. Materializacja stanów pól usuwa jedno wołanie, nie wszystkie.
 
 ### Zmiana 3 — zdublowany `<script>`
 
@@ -252,9 +280,11 @@ Zamiast tego materializujemy wynik.
   odświeżać. Po integracji nic wiersza nie mutuje (wszystkie ścieżki mutujące są
   za bramką `edytowalny_podglad`), więc pole zamarza samo.
 
-`stany_pol()` upraszcza się do: zwróć `stany_pol_snapshot` (dopełniony neutralnym
-`"brak"` dla kluczy dodanych po zapisaniu snapshotu), a gdy `None` — policz na
-żywo (ścieżka awaryjna, patrz backfill).
+**`stany_pol()` nie wymaga zmian.** Obecna implementacja (`models.py:1127-1142`)
+już robi dokładnie to, czego potrzebujemy: zwraca snapshot dopełniony neutralnym
+`"brak"` dla kluczy dodanych po jego zapisaniu, a gdy `None` — liczy na żywo.
+Zmienia się nie ta metoda, tylko fakt, że pole jest **zawsze wypełnione** także
+przed integracją.
 
 Świadomie **nie dodajemy** drugiej kolumny. Rozważona alternatywa (osobne
 `stany_pol_cache` obok `stany_pol_snapshot`) daje czytelniejszy rozdział ról, ale
@@ -263,45 +293,94 @@ Ponieważ post-integracyjne zamrożenie wynika z bramki `edytowalny_podglad`
 (a nie z osobnego pola), jedna kolumna wystarcza.
 
 **Punkty odświeżania.** Metoda `ImportPracownikowRow.odswiez_stany_pol()`
-przelicza i zapisuje pole (`update_fields=["stany_pol_snapshot"]`). Wołana z:
+przelicza i zapisuje pole (`update_fields=["stany_pol_snapshot"]`).
 
-| miejsce | dlaczego |
-|---------|----------|
-| koniec analizy (`pipeline/analyze.py`) | pierwsze wypełnienie, batch |
-| `WybierzKandydataView` | zmienia `autor` |
-| `DopasujAutoraView` | zmienia `autor` |
-| `PrzelaczUtworzNowegoView` | zmienia `utworz_nowego` (wpływa na `do_pominiecia`) |
-| `PrzepnijPraceView` | zmienia `przepnij_prace` |
-| `ZaznaczWszystkiePrzepieciaView` | akcja zbiorcza, batch |
-| `WeryfikacjaJednostekView` | przypisuje `jednostka` wierszom |
-| `WeryfikacjaTytulowView` | przypisuje `tytul` |
-| `WeryfikacjaStopniView` | przypisuje `stopien` |
-| `WeryfikacjaStanowiskView` | przypisuje `stanowisko_dydaktyczne` |
+Ustalenie miejsc odświeżania wymagało prześledzenia, co **naprawdę** mutuje pola
+czytane przez ekstraktory `POLA_ROZNIC`. Pierwsza wersja tej specyfikacji
+wskazywała tu widoki `Weryfikacja{Jednostek,Tytulow,Stopni,Stanowisk}View` — **to
+było błędne**. Te widoki zapisują wyłącznie obiekty decyzji
+(`dec.save(update_fields=["decyzja", "wybrany_parent", "wybrana_jednostka"])`,
+`views.py:1125`); wierszy nie dotykają. Faktyczne przypisanie pól wierszom dzieje
+się w `pipeline/integrate.py` przy „Zapisz strukturę": `row.jednostka` (:546),
+`row.tytul` (:742), `row.stopien` (:817), `row.stanowisko_dydaktyczne` (:883).
 
-`RestartAnalizaView` czyści wiersze i uruchamia analizę od nowa, więc pokrywa go
-punkt „koniec analizy". `PrzelaczOdpiecieView` i `ZaznaczOdpieciaView` mutują
-`Odpiecie`, nie wiersze — bez wpływu.
+| miejsce | co mutuje |
+|---------|-----------|
+| koniec analizy (`pipeline/analyze.py`) | pierwsze wypełnienie, batch po całym imporcie |
+| koniec integracji **strukturalnej** (`pipeline/integrate.py`) | `jednostka`, `tytul`, `stopien`, `stanowisko_dydaktyczne` — batch po całym imporcie |
+| `WybierzKandydataView` | `autor` |
+| `DopasujAutoraView` | `autor` |
 
-**Backfill (samonaprawianie).** Importy sprzed tej zmiany mają `NULL` i filtr
-SQL by ich nie znalazł. Zamiast migracji danych (która musiałaby wykonać zapytania
-per wiersz na całej historii) robimy **leniwy backfill**: w `get_queryset()`, gdy
+**Dlaczego integracja strukturalna jest punktem krytycznym.** Kończy się ona
+stanem `STAN_STRUKTURA_ZINTEGROWANA`, który **nadal jest** `edytowalny_podglad`
+(`models.py:214-222`) — to jest Krok 2, faza osób, dokładnie ta, w której operator
+pracuje na widoku rezultatów. Bez odświeżenia w tym miejscu filtr `jednostka`
+(a także `data_od`, `data_do`, `funkcja`, `stanowisko`, których ekstraktory
+bramkują po `jednostka_id` — `roznice.py:56,69,80`) pokazywałby stan sprzed
+przypisania jednostek. Zakres strukturalny bywa uruchamiany **drugi raz** z fazy
+osób (dotworzenie słowników, `views.py:1480-1489`), więc odświeżenie musi być
+idempotentne i wołane przy każdym przebiegu, nie tylko pierwszym.
+
+**Czego świadomie NIE odświeżamy.** `PrzelaczUtworzNowegoView`,
+`PrzepnijPraceView` i `ZaznaczWszystkiePrzepieciaView` mutują `utworz_nowego`
+i `przepnij_prace`. Żaden ekstraktor `POLA_ROZNIC` ani `porownaj_z_baza()` tych
+pól nie czyta (zweryfikowane gerepem po `roznice.py` i `models.py:1029-1125` —
+zero trafień), więc odświeżanie byłoby no-opem. Filtr `?rodzaj=do-pominiecia`
+czyta `utworz_nowego` **bezpośrednio w SQL** (`autor__isnull=True,
+utworz_nowego=False`), a nie ze snapshotu, więc pozostaje świeży bez żadnych
+zabiegów.
+
+`RestartAnalizaView` kasuje wiersze i uruchamia analizę od nowa → pokrywa go punkt
+„koniec analizy". `PrzelaczOdpiecieView` i `ZaznaczOdpieciaView` mutują
+`Odpiecie.zaznaczone`, nie wiersze — bez wpływu.
+
+**Zachowanie zamrożonego snapshotu audytu — bez zmian.** Dziś snapshot dla wiersza
+„utwórz nowego" liczy się **po** tym, jak `_przygotuj_nowego_autora` (`integrate.py:983`,
+przed pętlą worklisty w :986) ustawił świeżo utworzonego autora — zamrożone stany
+porównują więc plik z nowym autorem. Gdybyśmy zostawili istniejące guardy
+`if stany_pol_snapshot is None` (`integrate.py:193`, `models.py:1366`), stałyby się
+one martwe (pole byłoby już wypełnione przez odświeżanie przedintegracyjne),
+a audyt pokazałby stan sprzed utworzenia autora (`autor=None` → wszędzie „brak").
+To byłaby cicha zmiana danych audytowych. Dlatego **oba guardy zamieniamy na
+bezwarunkowe przypisanie** w tym samym miejscu potoku: wartość audytowa pozostaje
+bit w bit taka jak dziś. Test asertuje snapshot wiersza „utwórz nowego" po pełnej
+integracji.
+
+**Backfill (samonaprawianie).** Importy sprzed tej zmiany mają `NULL` i filtr SQL
+by ich nie znalazł. Zamiast migracji danych (musiałaby wykonać zapytania per wiersz
+na całej historii) robimy **leniwy backfill**: w `get_queryset()`, gdy
 `parent.importpracownikowrow_set.filter(stany_pol_snapshot__isnull=True).exists()`,
-przeliczamy cały import jednym batchem (z hurtowym prefetchem `Autor_Jednostka`,
-jak w Zmianie 2) i zapisujemy przez `bulk_update`. Dzieje się to **raz na import**,
-przy pierwszym wejściu na stronę po wdrożeniu.
+przeliczamy **wyłącznie wiersze z `NULL`** (z hurtowym prefetchem `Autor_Jednostka`,
+jak w Zmianie 2) i zapisujemy przez `bulk_update`. Raz na import, przy pierwszym
+wejściu na stronę po wdrożeniu.
 
-Backfill jest opakowany w `transaction.atomic()` i **nie zmienia stanu importu** —
-to czysta materializacja tego, co i tak liczyło się na żywo. Dla importu już
-zintegrowanego backfill też jest bezpieczny: `integrate.py` zapisuje snapshot
-przy integracji, więc importy zintegrowane po migracji `0024` mają go wypełnione;
-starsze dostaną wartość policzoną na żywo, czyli dokładnie to, co widok pokazuje
-dziś (`stany_pol()` z gałęzią live).
+Zawężenie do `isnull=True` jest **warunkiem poprawności, nie optymalizacją**.
+Snapshot dostają dziś tylko wiersze przechodzące przez worklistę integracji
+(`parent.zmiany_potrzebne_set.all()`, `integrate.py:986`) — wiersze bez zmian,
+pominięte i bez autora mają `NULL` **także w importach zintegrowanych po migracji
+`0024`**. Warunek wejścia backfillu będzie więc prawdziwy dla większości
+historycznych zintegrowanych importów, a przeliczenie „całego importu" nadpisałoby
+zamrożone wartości audytowe („zmienione") wartościami policzonymi po integracji
+(„zgodne"). Backfill jest opakowany w `transaction.atomic()`.
 
-**Ryzyko i jego kontrola.** Jeśli przegapimy ścieżkę mutującą, filtr skłamie po
-cichu. Kontrola: test parametryzowany po wszystkich endpointach mutujących, który
-dla każdego wykonuje akcję zmieniającą stan pola i asertuje, że
-`row.refresh_from_db().stany_pol_snapshot` odpowiada świeżo policzonemu
-`stany_pol()`. Nowy endpoint mutujący bez odświeżenia = czerwony test.
+**Ryzyko rezydualne: mutacje spoza importu.** Ekstraktory zależą od stanu `Autor`
+i `Autor_Jednostka` w bazie. Edycja autora w adminie BPP albo integracja *innego*
+importu między analizą a integracją tego importu unieważnia snapshot po cichu —
+filtr będzie kłamał do najbliższej mutacji wiersza. Dziś, przy liczeniu na żywo,
+tego problemu nie ma; to jest cena, którą płacimy za filtrowanie w SQL.
+Akceptujemy ją świadomie: okno jest wąskie (jedna sesja pracy operatora nad
+importem), skutek jest kosmetyczny (filtr, nie decyzja importu), a operator ma
+przycisk „Restart analizy", który przelicza wszystko od nowa. Alternatywa —
+inwalidacja snapshotów sygnałami z `Autor`/`Autor_Jednostka` — kosztowałaby
+przy każdym zapisie autora w całym systemie, dla korzyści w jednym widoku.
+
+**Kontrola ryzyka głównego.** Jeśli przegapimy ścieżkę mutującą, filtr skłamie po
+cichu. Test parametryzowany po endpointach HTMX tej dziury by **nie** złapał
+(dla widoków Weryfikacja* snapshot trywialnie równa się live, bo nic nie mutują).
+Dlatego test musi obejmować **przebieg integracji strukturalnej**: uruchom
+`integruj()` w zakresie struktury i asertuj, że dla każdego wiersza
+`stany_pol_snapshot == stany_pol()` policzone na żywo. Do tego test per endpoint
+mutujący `autor` (`wybierz-kandydata`, `dopasuj-autora`).
 
 ### Zmiana 5 — paginacja i filtry po stronie serwera
 
@@ -315,8 +394,43 @@ serwerowej byłaby jednoklikowym powrotem do problemu, który naprawiamy.
 | filtr | parametr GET | realizacja |
 |-------|--------------|------------|
 | rodzaj dopasowania | `?rodzaj=` | `confidence=` lub predykat `do-pominiecia` (`autor__isnull=True, utworz_nowego=False`) |
-| szukaj | `?q=` | `Q(dane_znormalizowane__nazwisko__icontains=…) \| Q(dane_znormalizowane__imię__icontains=…) \| Q(autor__nazwisko__icontains=…) \| Q(jednostka__nazwa__icontains=…)` |
-| stan pola (8×) | `?stan_<klucz>=` | `stany_pol_snapshot__<klucz>=` (JSONB) |
+| szukaj | `?q=` | suma `Q(...__icontains=…)` po sześciu polach (niżej) |
+| stan pola (8×) | `?stan_<klucz>=` | `stany_pol_snapshot__<klucz>=` (JSONB), ze specjalnym traktowaniem `"brak"` (niżej) |
+
+**Zakres `?q=`.** Musi pokryć to, co dziś pokrywa kliencki filtr tekstowy —
+a ten przeszukuje wszystkie elementy `[data-szukaj]`, czyli **więcej** niż
+oczywiste nazwisko z pliku. Z `_wiersz_preview_kom.html:16-23,33-35,235-241`
+wynika sześć pól:
+
+```python
+Q(dane_znormalizowane__nazwisko__icontains=q)
+| Q(**{"dane_znormalizowane__imię__icontains": q})
+| Q(**{"dane_znormalizowane__tytuł_stopień__icontains": q})
+| Q(autor__nazwisko__icontains=q) | Q(autor__imiona__icontains=q)
+| Q(jednostka__nazwa__icontains=q)
+| Q(autor__aktualna_jednostka__nazwa__icontains=q)
+```
+
+Klucze `imię` i `tytuł_stopień` mają polskie znaki; `imię` jest poprawnym
+identyfikatorem Pythona, ale `tytuł_stopień` w zapisie `Q(a__tytuł_stopień=…)`
+byłby kruchy — dlatego oba przekazujemy przez `Q(**{...})`, jednolicie.
+Pominięcie `autor__imiona` i `autor__aktualna_jednostka__nazwa` byłoby cichym
+zawężeniem wyszukiwania względem stanu dzisiejszego.
+
+**Stan `"brak"` wymaga osobnego lookupu.** Istnieją zamrożone snapshoty **bez**
+kluczy `data_od`/`data_do` — pochodzą sprzed dodania tych pól i dlatego
+`stany_pol()` dopełnia je w Pythonie (`models.py:1133-1135`). Zapytanie
+`stany_pol_snapshot__data_od="brak"` takich wierszy **nie znajdzie**, bo w JSONB
+klucza po prostu nie ma. Filtr stanu `"brak"` realizujemy więc jako:
+
+```python
+Q(**{f"stany_pol_snapshot__{klucz}": "brak"})
+| ~Q(**{"stany_pol_snapshot__has_key": klucz})
+```
+
+Pozostałe stany (`zmienione`, `zgodne`) to zwykła równość. Nie „naprawiamy" tych
+snapshotów backfillem — są zamrożonym zapisem audytowym i backfill ich nie dotyka
+(patrz Zmiana 4).
 
 `?rodzaj=` zachowuje dzisiejszą walidację i dzisiejszą semantykę deep-linku
 `?rodzaj=do-pominiecia` z ostrzeżenia finalizacji — z tą różnicą, że teraz filtruje
@@ -359,9 +473,24 @@ operatorowi spod kursora zaraz po tym, jak go zmienił.
   filtr zawęża wynik na **całym** imporcie, także gdy pasujący wiersz leży poza
   pierwszą stroną (to jest istota zmiany, więc test musi to sprawdzać jawnie).
 - Test zachowania filtrów w linkach pagera.
-- Test świeżości snapshotu, parametryzowany po endpointach mutujących (opis wyżej).
-- Test leniwego backfillu: import z `NULL` w `stany_pol_snapshot` po wejściu na
-  stronę ma pole wypełnione, a wartości zgadzają się z liczonymi na żywo.
+- Test świeżości snapshotu po **integracji strukturalnej**: po `integruj()`
+  w zakresie struktury każdy wiersz ma `stany_pol_snapshot` równy świeżo
+  policzonemu `stany_pol()`. To jest test, który łapie klasę błędu opisaną
+  w Zmianie 4 — parametryzacja po endpointach HTMX by jej nie złapała.
+- Test świeżości po endpointach mutujących `autor` (`wybierz-kandydata`,
+  `dopasuj-autora`).
+- Test leniwego backfillu, dwa warianty:
+  (a) wiersz z `NULL` po wejściu na stronę ma pole wypełnione wartością zgodną
+  z liczoną na żywo; (b) wiersz z **niepustym** snapshotem, w tym samym imporcie,
+  pozostaje **nietknięty** — to zabezpiecza zamrożony zapis audytowy.
+- Test niezmienności audytu: wiersz „utwórz nowego" po pełnej integracji ma
+  snapshot policzony względem świeżo utworzonego autora (zachowanie identyczne
+  jak przed zmianą).
+- Test filtra stanu `"brak"` na snapshocie **bez** klucza `data_od`/`data_do`
+  (symulacja starego zapisu) — wiersz musi zostać znaleziony.
+- Test zakresu `?q=`: dopasowanie po `autor__imiona` oraz po nazwie aktualnej
+  jednostki autora (pola, które kliencki filtr obejmował, a naiwna wersja
+  serwerowa by pominęła).
 - Pełne `make tests` lokalnie (nie tylko na CI), zgodnie z regułą projektu.
 
 **Ręczne (warunek merge'a PR #1 — zejście htmx o major).**

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dependencies": {
         "3d-force-graph": "^1.80.0",
         "basic-ftp": "5.3.1",
+        "chart.js": "^4.4.0",
         "cytoscape": "^3.34.0",
         "cytoscape-fcose": "^2.2.0",
         "cytoscape-svg": "^0.4.0",

--- a/src/bpp/newsfragments/self-hosting-assetow.bugfix.rst
+++ b/src/bpp/newsfragments/self-hosting-assetow.bugfix.rst
@@ -1,0 +1,6 @@
+Biblioteki JavaScript i CSS są ładowane z serwera uczelni, a nie z zewnętrznych
+CDN-ów (unpkg.com, jsdelivr, cdnjs). Wcześniej lista wyników importu pracowników,
+ekran powiązań spoza pliku, importer publikacji, wykresy optymalizacji ewaluacji
+i ekran przemapowania źródła sięgały po pliki do sieci zewnętrznej — w sieciach
+bez dostępu do tych serwerów (VPN, firewall) strona potrafiła wisieć kilkadziesiąt
+sekund, zanim się wyświetliła.

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -1011,6 +1011,8 @@ YARN_FILE_PATTERNS = {
     "select2-foundation-theme": ["dist/select2-foundation-theme.css"],
     "plotly.js": ["dist/plotly.min.js", "dist/plotly-locale-pl.js"],
     "htmx.org": ["dist/htmx.js"],
+    # Wykresy w ewaluacja_optymalizacja (dawniej ładowane z cdn.jsdelivr.net).
+    "chart.js": ["dist/chart.umd.min.js"],
     "tone": ["build/Tone.js", "build/Tone.js.map"],
     # Do developerki:
     "qunit": ["qunit/qunit.js", "qunit/qunit.css"],

--- a/src/django_bpp/tests/test_brak_zewnetrznych_assetow.py
+++ b/src/django_bpp/tests/test_brak_zewnetrznych_assetow.py
@@ -1,0 +1,131 @@
+"""Strażnik: żaden asset (JS/CSS/font) nie może być ładowany z zewnętrznego CDN-a.
+
+Skrypt z CDN-a wstawiony w ``<body>`` blokuje parser: w sieci bez dostępu do
+tego hosta (VPN, firewall uczelniany) przeglądarka wstrzymuje renderowanie do
+timeoutu DNS/TCP — dziesiątki sekund białej strony. Tak właśnie zachowywała się
+lista wyników importu pracowników, ładująca htmx z ``unpkg.com``. Dochodzi do
+tego wyciek informacji o ruchu do operatora CDN-a i zależność dostępności BPP od
+cudzej infrastruktury.
+
+Reguła: biblioteki wchodzą do ``package.json`` (zbiera je ``YarnFinder``) albo
+przyjeżdżają z pakietu pythonowego, a szablony sięgają po nie przez
+``{% static %}``.
+
+Skanujemy DWOMA wzorcami, bo asset można wpiąć na dwa sposoby:
+
+- w szablonie — jako tag ``<script src>`` / ``<link href>``;
+- w Pythonie — jako goły string w ``class Media`` (tag renderuje dopiero
+  Django). Wzorzec tagowy by tego NIE złapał, a dokładnie tak wyglądał
+  ``przemapuj_zrodlo/admin.py`` przed tą zmianą.
+
+POZA ZASIĘGIEM tego testu (świadomie — zielony wynik NIE oznacza zera
+zewnętrznych requestów):
+
+- ``cdn.userway.org`` (widget dostępności WCAG) — wstrzykiwany inline'owym JS-em
+  przez ``s.setAttribute("src", ...)`` w ``base.html``, więc żaden skan tagów go
+  nie zobaczy;
+- ``src/bpp/static/kbw-keypad/dist/index.html`` — strona demo vendorowanego
+  pluginu, nigdy nierenderowana przez aplikację (nie jest szablonem Django).
+"""
+
+import re
+from pathlib import Path
+
+# Ścieżki liczymy względem TEGO pliku (src/django_bpp/tests/...), a nie przez
+# `import django_bpp` — przy editable-install `__file__` pakietu wskazuje główny
+# checkout, a nie worktree, w którym test faktycznie leży. Test ma sprawdzać
+# checkout, w którym się znajduje. parents[2] == src/.
+SRC = Path(__file__).resolve().parents[2]
+
+# Hosty usług SaaS, których NIE da się self-hostować (to zdalne API, nie pliki).
+# Oba są `async`, więc nie blokują parsera. Dopisanie czegokolwiek tutaj wymaga
+# uzasadnienia w komentarzu — to jest wyjątek od reguły, nie wygodna furtka.
+DOZWOLONE_HOSTY = (
+    # Widget zgłoszeń Freshworks — base.html, admin/base_site.html
+    "euc-widget.freshworks.com",
+    # Google Analytics (gtag) — google_analytics.html, tylko gdy skonfigurowane
+    "www.googletagmanager.com",
+)
+
+# Tag ładujący asset z bezwzględnego URL-a. Nie używamy `"host" in text`, bo
+# substringowe sprawdzanie literału-hosta odpala fałszywy alarm CodeQL
+# `py/incomplete-url-substring-sanitization` (heurystyka bierze je za
+# obejściopodatną sanityzację URL-a) — patrz test_admin_fonts_selfhosted.py.
+_TAG_RE = re.compile(
+    r"""<(?:script|link)\b[^>]*?\b(?:src|href)\s*=\s*["']?(https?://[^"'\s>]+)""",
+    re.IGNORECASE,
+)
+
+# Literał URL-a wskazujący na plik-asset — wzorzec dla plików .py (`class Media`).
+# Zawężenie do rozszerzeń assetów odsiewa linki dokumentacyjne w docstringach
+# i adresy stron zewnętrznych, które z ładowaniem zasobów nie mają nic wspólnego.
+_LITERAL_ASSET_RE = re.compile(
+    r"""["'](https?://[^"'\s]+\.(?:js|css|woff2?|ttf|eot|svg|png|gif|jpe?g))["']""",
+    re.IGNORECASE,
+)
+
+# Komentarze blokowe Django `{# ... #}` wycinamy przed skanem szablonów, żeby
+# wzmianka o CDN-ie w komentarzu (np. „wcześniej był tu unpkg") nie była
+# fałszywym alarmem.
+_KOMENTARZ_DJANGO_RE = re.compile(r"\{#.*?#\}", re.DOTALL)
+
+
+def _dozwolony(url: str) -> bool:
+    return any(host in url for host in DOZWOLONE_HOSTY)
+
+
+def _szablony():
+    """Wszystkie szablony Django w src/ (katalogi `templates/`)."""
+    return sorted(SRC.glob("*/templates/**/*.html"))
+
+
+def _moduly_python():
+    """Wszystkie moduły Pythona w src/, poza migracjami i staticroot.
+
+    Skanujemy nie tylko `admin.py` — `class Media` bywa też w `forms.py`
+    i `widgets.py`.
+    """
+    return sorted(
+        p
+        for p in SRC.glob("*/**/*.py")
+        if "/migrations/" not in str(p) and "/staticroot/" not in str(p)
+    )
+
+
+def test_szablony_nie_laduja_assetow_z_cdn():
+    """Żaden szablon nie ma `<script src>` ani `<link href>` z bezwzględnym URL-em
+    spoza allow-listy."""
+    winowajcy = []
+    for szablon in _szablony():
+        tresc = _KOMENTARZ_DJANGO_RE.sub("", szablon.read_text(encoding="utf-8"))
+        for url in _TAG_RE.findall(tresc):
+            if not _dozwolony(url):
+                winowajcy.append(f"{szablon.relative_to(SRC)}: {url}")
+
+    assert not winowajcy, (
+        "Assety ładowane z zewnętrznego CDN-a w szablonach:\n  "
+        + "\n  ".join(winowajcy)
+        + "\n\nZvendoruj bibliotekę (dodaj do package.json, zbierze ją YarnFinder) "
+        "i użyj {% static '...' %}, albo — jeśli to usługa SaaS, której nie da "
+        "się self-hostować — dopisz host do DOZWOLONE_HOSTY z uzasadnieniem."
+    )
+
+
+def test_klasy_media_nie_laduja_assetow_z_cdn():
+    """Żaden moduł Pythona (m.in. `class Media` w adminie) nie wskazuje na plik
+    assetu pod bezwzględnym URL-em spoza allow-listy."""
+    winowajcy = []
+    for modul in _moduly_python():
+        if modul.resolve() == Path(__file__).resolve():
+            continue  # ten plik z definicji zawiera wzorce URL-i
+        for url in _LITERAL_ASSET_RE.findall(modul.read_text(encoding="utf-8")):
+            if not _dozwolony(url):
+                winowajcy.append(f"{modul.relative_to(SRC)}: {url}")
+
+    assert not winowajcy, (
+        "Assety ładowane z zewnętrznego CDN-a w kodzie Pythona:\n  "
+        + "\n  ".join(winowajcy)
+        + "\n\nW `class Media` podaj ścieżkę WZGLĘDNĄ do statików "
+        "(np. 'foundation-datepicker/foundation/fonts/foundation-icons.css'), "
+        "a bibliotekę zvendoruj przez package.json."
+    )

--- a/src/ewaluacja_optymalizacja/templates/ewaluacja_optymalizacja/run_detail.html
+++ b/src/ewaluacja_optymalizacja/templates/ewaluacja_optymalizacja/run_detail.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
 {% load humanize %}
+{% load static %}
 
 {% block title %}Wyniki optymalizacji - {{ run.dyscyplina_naukowa.nazwa }}{% endblock %}
 
 {% block extrahead %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+{# Chart.js self-hostowany (npm chart.js → YarnFinder), bez CDN-a. #}
+<script src="{% static 'chart.js/dist/chart.umd.min.js' %}"></script>
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
+++ b/src/import_pracownikow/templates/import_pracownikow/importpracownikowrow_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load render_table from django_tables2 %}
+{% extends "base.html" %}{% load render_table from django_tables2 %}{% load static %}
 
 {% block extratitle %}
     Import pracowników i jednostek - szczegóły {{ parent_object.plik_xls.name }}
@@ -49,8 +49,10 @@
     {% endif %}
 
     {# HTMX dla akcji per-wiersz (wybór kandydata / edycja inline) — patrz #}
-    {# wzorzec importer_publikacji/index.html. #}
-    <script src="https://unpkg.com/htmx.org@2.0.4" crossorigin="anonymous"></script>
+    {# wzorzec importer_publikacji/index.html. Self-hostowany: skrypt z CDN-a #}
+    {# w tym miejscu blokował parser (leży PRZED tabelą), więc w sieci bez #}
+    {# dostępu do unpkg.com strona wisiała do timeoutu DNS/TCP. #}
+    <script src="{% static 'liveops/vendor/htmx.min.js' %}"></script>
 
     {% if parent_object.edytowalny_podglad and parent_object.przepnij_wszystkie_prace %}
         {# akcja zbiorcza: zaznacz przepięcie prac dla wierszy z różnicą jednostki #}

--- a/src/import_pracownikow/templates/import_pracownikow/odpiecia.html
+++ b/src/import_pracownikow/templates/import_pracownikow/odpiecia.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base.html" %}{% load static %}
 
 {% block extratitle %}Import pracowników i jednostek — ludzie spoza XLS{% endblock %}
 
@@ -22,7 +22,8 @@
     </p>
 
     {# HTMX dla toggla checkboxa odpięcia (partial _odpiecie_row.html). #}
-    <script src="https://unpkg.com/htmx.org@2.0.4" crossorigin="anonymous"></script>
+    {# Self-hostowany — bez zależności od zewnętrznego CDN-a. #}
+    <script src="{% static 'liveops/vendor/htmx.min.js' %}"></script>
 
     {% if odpiecia %}
         {% if parent_object.edytowalny_podglad %}

--- a/src/importer_publikacji/templates/importer_publikacji/index.html
+++ b/src/importer_publikacji/templates/importer_publikacji/index.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base.html" %}{% load static %}
 
 {% block extratitle %}Importer publikacji{% endblock %}
 
@@ -49,10 +49,8 @@
         animation: wizardFadeIn 0.3s ease-out;
     }
     </style>
-    <script
-      src="https://unpkg.com/htmx.org@2.0.4"
-      crossorigin="anonymous"
-    ></script>
+    {# HTMX self-hostowany — bez zależności od zewnętrznego CDN-a. #}
+    <script src="{% static 'liveops/vendor/htmx.min.js' %}"></script>
     <script>
     function showWizardError(msg) {
         var wizard = document.getElementById(

--- a/src/przemapuj_zrodlo/admin.py
+++ b/src/przemapuj_zrodlo/admin.py
@@ -104,8 +104,8 @@ class PrzemapowaZrodlaAdmin(admin.ModelAdmin):
     akcje.allow_tags = True
 
     class Media:
-        css = {
-            "all": (
-                "https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.min.css",
-            )
-        }
+        # Foundation-Icons z lokalnych statików (pakiet npm foundation-datepicker
+        # dostarcza CSS razem z fontami) — ten sam plik, którego używa `bare.html`
+        # i szablony admina. Wcześniej był tu URL do cdnjs: zewnętrzna zależność
+        # sieciowa przy każdym otwarciu ekranu.
+        css = {"all": ("foundation-datepicker/foundation/fonts/foundation-icons.css",)}

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "bpp-iplweb"
-version = "202607.1397"
+version = "202607.1398"
 source = { editable = "." }
 dependencies = [
     { name = "arrow", marker = "platform_python_implementation != 'PyPy'" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,6 +199,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@mapbox/geojson-rewind@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz#591a5d71a9cd1da1a0bf3420b3bea31b0fc7946a"
@@ -997,6 +1002,13 @@ chalk@^4.1.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chart.js@^4.4.0:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.5.1.tgz#19dd1a9a386a3f6397691672231cb5fc9c052c35"
+  integrity sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 check-error@^2.1.1:
   version "2.1.3"


### PR DESCRIPTION
## Problem

Wejście na `/import_pracownikow/<uuid>/rezultaty/` potrafi trwać kilkadziesiąt sekund — ale **nie z powodu danych**.

`importpracownikowrow_list.html:53` ładował htmx tagiem `<script src>` z `unpkg.com`, umieszczonym w `<body>` w linii 53, podczas gdy tabela zaczyna się w linii 144. To skrypt **blokujący parser**: przeglądarka wstrzymuje renderowanie HTML-a i czeka na CDN. W sieci bez dostępu do unpkg.com (VPN, firewall uczelniany) oznacza to białą stronę do timeoutu DNS/TCP — typowo 20–75 s, **niezależnie od liczby wierszy**. Dodatkowo `unpkg.com/htmx.org@2.0.4` odpowiada `301`, więc to dwa round-tripy.

htmx był już w projekcie lokalnie i reszta aplikacji ładowała go poprawnie — trzy szablony zostały pominięte przy przejściu na vendoring lokalny.

## Zmiany

| plik | dziś | po |
|---|---|---|
| `import_pracownikow/…/importpracownikowrow_list.html` | unpkg htmx 2.0.4 | `{% static 'liveops/vendor/htmx.min.js' %}` |
| `import_pracownikow/…/odpiecia.html` | j.w. | j.w. |
| `importer_publikacji/…/index.html` | j.w. | j.w. |
| `ewaluacja_optymalizacja/…/run_detail.html` | jsdelivr chart.js 4.4.0 | `{% static 'chart.js/dist/chart.umd.min.js' %}` |
| `przemapuj_zrodlo/admin.py` | cdnjs foundation-icons | lokalna ścieżka do statików |

Dwie rzeczy warte uwagi przy review:

- **`YarnFinder` ma jawną listę `YARN_FILE_PATTERNS`** — sam wpis w `package.json` nie wystarcza. `findstatic` wyłapał to od razu; `chart.js` dopisany w obu miejscach.
- **`foundation-icons.css` nie wymagał nowej zależności** — dostarcza go npm-owy `foundation-datepicker` razem z fontami, a `bare.html:77` i szablony admina już z niego korzystają. `przemapuj_zrodlo` był jedynym odstępstwem w repo.

## Zejście htmx 2.0.4 → 1.9.12

Te trzy ekrany jechały na htmx 2.x, a cała reszta aplikacji na 1.9.12 (`package.json`, `liveops/vendor/htmx.min.js`). Self-hosting ujednolica wersję, ale to **zejście o major** — dlatego wymaga ręcznego przeklikania, testy tego nie zwalidują.

Ocena ryzyka: komentarze w `partials/_wiersz_preview_kom.html:83-87` wprost tłumaczą obejście napisane pod semantykę 1.x (filtr zdarzenia zamiast `from:`, bo „bare selektor w `from:` w htmx 1.x wiąże na CAŁYM dokumencie"). Kod był projektowany pod 1.x. Użyte API to wyłącznie `hx-post`, `hx-target`, `hx-swap="innerHTML"`, `hx-trigger` z filtrem zdarzenia i `htmx:afterSettle` — wszystko obecne w 1.9.12.

**Checklist ręczny przed merge:**

- [ ] `/import_pracownikow/<uuid>/rezultaty/` — „zmień autora" (Select2), dropdown kandydatów (`wielu`), radia Pomiń/Utwórz/Dopasuj (`brak`), checkbox przepięcia prac
- [ ] `/import_pracownikow/<uuid>/odpiecia/` — przełączanie odpięcia + akcja zbiorcza
- [ ] `/importer_publikacji/` — przejście kreatora przez kroki

Szczególna uwaga na `hx-trigger="change[target.classList.contains('js-brak-radio-post')]"` w wierszu `brak` — tam różnica 1.x/2.x ujawniłaby się najpierw, a objaw byłby paskudny: jeden klik POST-uje wiele wierszy.

## Test strażnika

`src/django_bpp/tests/test_brak_zewnetrznych_assetow.py` skanuje **dwoma wzorcami**, bo asset można wpiąć na dwa sposoby: tagiem w szablonie albo gołym stringiem w `class Media` (tag renderuje dopiero Django). Wzorzec tagowy przepuściłby `przemapuj_zrodlo/admin.py` — czyli jedną z pięciu naprawianych regresji.

Oba testy zweryfikowane pod kątem **czerwieni**: przywrócenie CDN-a w szablonie i w `class Media` wywala je z komunikatem mówiącym, co zrobić.

Allow-lista zawiera wyłącznie usługi SaaS, których self-hostować się nie da (Freshworks, Google Analytics — oba `async`, nie blokują parsera). Docstring wymienia znane zasoby **poza zasięgiem** skanu (UserWay wstrzykiwany inline-JS-em, demo `kbw-keypad`), żeby zielony test nie był mylony z dowodem na zero zewnętrznych requestów.

## Weryfikacja

- `findstatic` potwierdza rozwiązywanie wszystkich trzech ścieżek statycznych
- 1493 testy dotkniętych aplikacji przechodzą (`import_pracownikow`, `importer_publikacji`, `ewaluacja_optymalizacja`, `przemapuj_zrodlo`, `django_bpp`), w tym test Playwright ekranu z wykresami
- `pre-commit` czysty

Spec: `docs/superpowers/specs/2026-07-22-import-pracownikow-cdn-i-paginacja-design.md`

Kolejny PR (stackowany na tym) zajmie się drugą, niezależną przyczyną wolnego ładowania: 3 zapytania SQL na wiersz importu i brak paginacji serwerowej.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtA9uqEVjojQKqdt38EP4f