### PR TITLE
fix(rollbar): scalaj DocxConversionError w jeden item per serwer

### DIFF
--- a/src/bpp/newsfragments/rollbar-docx-fingerprint.bugfix.rst
+++ b/src/bpp/newsfragments/rollbar-docx-fingerprint.bugfix.rst
@@ -1,0 +1,3 @@
+Rollbar: błędy konwersji DOCX (``DocxConversionError``) są teraz grupowane w jedno
+zgłoszenie per serwer, zamiast rozbijać się na dziesiątki osobnych itemów (treść
+raportu z nazwiskiem autora wyciekała do domyślnego fingerprintu Rollbara).

--- a/src/bpp/rollbar_config.py
+++ b/src/bpp/rollbar_config.py
@@ -1,6 +1,14 @@
 import rollbar
 from django.conf import settings
 
+# Wyjątki, które Rollbar domyślnie rozbija na wiele itemów, bo zmienna treść
+# w tracebacku (np. wyrenderowany raport z nazwiskiem autora w zmiennej
+# lokalnej `html`) wycieka do fingerprintu. Dla nich narzucamy własny,
+# stały fingerprint — patrz collapse_noisy_fingerprints.
+NOISY_FINGERPRINT_EXC = {
+    "DocxConversionError",
+}
+
 
 def add_hostname_to_payload(payload, **kw):
     """
@@ -13,6 +21,33 @@ def add_hostname_to_payload(payload, **kw):
         payload["data"]["custom"]["DJANGO_BPP_HOSTNAME"] = getattr(
             settings, "DJANGO_BPP_HOSTNAME", "unknown"
         )
+    return payload
+
+
+def collapse_noisy_fingerprints(payload, **kw):
+    """Narzuć stały fingerprint na zgłośne wyjątki (patrz NOISY_FINGERPRINT_EXC).
+
+    Rollbar domyślnie tworzy osobny item per raport, bo treść HTML z danymi
+    autora trafia do fingerprintu. Jawny ``data["fingerprint"]`` przejmuje
+    grupowanie: jeden serwer z zepsutą konwersją = dokładnie jeden item,
+    niezależnie od liczby autorów. Klucz ``(klasa, host)``, żeby dwa różne
+    serwery pozostały dwoma osobnymi itemami (dwa problemy do naprawy).
+
+    Musi być zarejestrowany PO add_hostname_to_payload — czyta hosta z
+    ``custom`` wypełnionego przez tamten handler.
+    """
+    data = payload.get("data", {})
+    body = data.get("body", {})
+    chain = body.get("trace_chain")
+    # trace_chain[0] to najbardziej zewnętrzny (finalnie podniesiony) wyjątek;
+    # dla niełańcuchowych zgłoszeń bierzemy pojedynczy trace.
+    trace = chain[0] if chain else body.get("trace")
+    if not trace:
+        return payload
+    exc_class = trace.get("exception", {}).get("class")
+    if exc_class in NOISY_FINGERPRINT_EXC:
+        host = data.get("custom", {}).get("DJANGO_BPP_HOSTNAME", "unknown")
+        data["fingerprint"] = f"{exc_class}:{host}"
     return payload
 
 
@@ -30,4 +65,6 @@ def configure_rollbar():
 
     rollbar.init(**settings.ROLLBAR)
     rollbar.events.add_payload_handler(add_hostname_to_payload)
+    # PO hostname: collapse_noisy_fingerprints czyta hosta z custom.
+    rollbar.events.add_payload_handler(collapse_noisy_fingerprints)
     _initialized = True

--- a/src/bpp/tests/test_rollbar_config.py
+++ b/src/bpp/tests/test_rollbar_config.py
@@ -1,0 +1,93 @@
+"""Testy payload-handlerów Rollbara (src/bpp/rollbar_config.py)."""
+
+from bpp.rollbar_config import collapse_noisy_fingerprints
+
+
+def _docx_payload(host="publikacje.up.lublin.pl"):
+    """Payload zbliżony do realnego DocxConversionError (chained exc)."""
+    return {
+        "data": {
+            "custom": {"DJANGO_BPP_HOSTNAME": host},
+            "body": {
+                "trace_chain": [
+                    {
+                        "exception": {
+                            "class": "DocxConversionError",
+                            "message": "DOCX conversion failed using both "
+                            "pandoc and html2docx",
+                        }
+                    },
+                    {
+                        "exception": {
+                            "class": "RuntimeError",
+                            "message": "HTML2DOCX_URL not configured",
+                        }
+                    },
+                ]
+            },
+        }
+    }
+
+
+def test_docx_error_dostaje_staly_fingerprint_per_host():
+    """DocxConversionError scala się do jednego itemu per host."""
+    result = collapse_noisy_fingerprints(_docx_payload())
+
+    assert (
+        result["data"]["fingerprint"] == "DocxConversionError:publikacje.up.lublin.pl"
+    )
+
+
+def test_rozne_hosty_daja_rozne_fingerprinty():
+    """Dwa serwery z zepsutą konwersją = dwa osobne itemy, nie jeden."""
+    a = collapse_noisy_fingerprints(_docx_payload("a.example.pl"))
+    b = collapse_noisy_fingerprints(_docx_payload("b.example.pl"))
+
+    assert a["data"]["fingerprint"] != b["data"]["fingerprint"]
+
+
+def test_niewymieniony_wyjatek_bez_fingerprintu():
+    """Wyjątki spoza allowlisty zachowują domyślne grupowanie Rollbara."""
+    payload = {
+        "data": {
+            "custom": {"DJANGO_BPP_HOSTNAME": "x.pl"},
+            "body": {
+                "trace_chain": [{"exception": {"class": "Http404", "message": "..."}}]
+            },
+        }
+    }
+
+    result = collapse_noisy_fingerprints(payload)
+
+    assert "fingerprint" not in result["data"]
+
+
+def test_brak_hosta_daje_unknown():
+    """Bez DJANGO_BPP_HOSTNAME fingerprint degraduje do :unknown."""
+    payload = {
+        "data": {
+            "body": {
+                "trace_chain": [
+                    {
+                        "exception": {
+                            "class": "DocxConversionError",
+                            "message": "...",
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+    result = collapse_noisy_fingerprints(payload)
+
+    assert result["data"]["fingerprint"] == "DocxConversionError:unknown"
+
+
+def test_payload_bez_body_nie_wybucha():
+    """Payload bez trace/trace_chain przechodzi bez zmian."""
+    payload = {"data": {"custom": {"DJANGO_BPP_HOSTNAME": "x.pl"}}}
+
+    result = collapse_noisy_fingerprints(payload)
+
+    assert "fingerprint" not in result["data"]


### PR DESCRIPTION
## Problem

Rollbar rozbijał błędy konwersji DOCX (`DocxConversionError`) na **osobny item per raport** — w produkcji uzbierało się **~20 aktywnych itemów z jednego serwera** (publikacje.up.lublin.pl, VMWare ESX, gdzie pandoc pada SIGILL-em, a fallback html2docx nie był skonfigurowany).

Przyczyna: wyrenderowana treść raportu **z nazwiskiem autora** — trzymana w zmiennej lokalnej `html` we frame'ie tracebacku — wyciekała do domyślnego fingerprintu Rollbara. Każdy autor → inny hash → nowy item (każdy z 1 occurrence).

## Fix

Payload handler `collapse_noisy_fingerprints` narzuca jawny `data["fingerprint"] = "{klasa}:{host}"` dla wyjątków z allowlisty `NOISY_FINGERPRINT_EXC` (na razie `DocxConversionError`). Grupowanie staje się deterministyczne i niezależne od domyślnego algorytmu Rollbara.

- Klucz per **(klasa, host)** — dwa różne serwery z zepsutą konwersją zostają **dwoma** osobnymi itemami (dwa problemy do naprawy, nie jeden zlepek).
- Zarejestrowany **po** `add_hostname_to_payload` (czyta hosta z `custom`, który tamten wypełnia).
- Rozszerzalne: kolejny „rozmnażający się" wyjątek dopisuje się jedną linijką do `NOISY_FINGERPRINT_EXC`.

## Testy

`src/bpp/tests/test_rollbar_config.py` — 5 przypadków (stały fingerprint per host, różne hosty → różne fingerprinty, wyjątek spoza allowlisty bez zmian, brak hosta → `:unknown`, payload bez body nie wybucha). TDD: RED (ImportError) → GREEN.

## Kontekst

To higiena/ubezpieczenie na przyszłość — właściwa naprawa (włączenie html2docx na tym serwerze) już powódź zatrzymała; 21 istniejących itemów zamknięto ręcznie.

## Uwaga poboczna (poza tym PR)

Ten sam `cleaned_html` z treścią raportu i nazwiskiem autora leci do Rollbara (third-party) jako zmienna lokalna — `scrub_fields` tego nie łapie (działa po nazwach kluczy, nie wartościach locali). Warty osobnego rozważenia wątek prywatnościowy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)