### PR TITLE
Przyspiesz testy Playwright bez osłabiania pokrycia Select2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,10 @@ disable-microsoft-auth: ## Wyłącz django_microsoft_auth
 # (`make tests-without-playwright`) nie brudzi pliku. `make tests` i
 # `make test-durations` wlaczaja zapis przez target-specific STORE_DURATIONS.
 STORE_DURATIONS ?=
-PLAYWRIGHT_WORKERS ?= 12
+# Liczba workerow xdist dla suity Playwright — patrz komentarz przy
+# `tests-only-playwright`. Kolejnosc fallbackow: rdzenie wydajnosciowe
+# (Apple Silicon) -> nproc (Linux) -> hw.ncpu (Intel Mac) -> 4.
+PLAYWRIGHT_WORKERS ?= $(shell sysctl -n hw.perflevel0.logicalcpu 2>/dev/null || nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 _store_durations = $(if $(STORE_DURATIONS),--store-durations --durations-path .test_durations,)
 # Po zapisie zaokraglij+posortuj plik (maly, stabilny diff). `&&` —
 # normalizujemy tylko po udanym przebiegu; przy STORE_DURATIONS pustym
@@ -352,9 +355,13 @@ tests-without-playwright-with-microsoft-auth: ## tests-without-playwright z akty
 
 tests-with-microsoft-auth: enable-microsoft-auth tests-without-playwright-with-microsoft-auth disable-microsoft-auth ## Włącz MS Auth, uruchom testy, wyłącz
 
-# Chromium i Daphne konkuruja o zasoby przy `-n auto` (16 workerow na
-# typowej maszynie deweloperskiej). Limit mozna nadpisac, np.
-# `make tests-only-playwright PLAYWRIGHT_WORKERS=8`.
+# Chromium i Daphne konkuruja o zasoby przy `-n auto`, ktore bierze WSZYSTKIE
+# rdzenie logiczne. Na Apple Silicon oznacza to doliczenie rdzeni
+# energooszczednych (E-cores) — a te sa za wolne, zeby uciagnac wlasna
+# instancje Chromium + Daphne, wiec dokladaja tylko rywalizacje o pamiec i I/O.
+# Zmierzone na 12P+4E (154 testy): -n auto/16 ~94 s, -n 10 ~94 s, -n 8 ~89 s,
+# -n 12 ~87 s. Stad domyslnie tyle workerow, ile rdzeni WYDAJNOSCIOWYCH.
+# Nadpisanie: `make tests-only-playwright PLAYWRIGHT_WORKERS=8`.
 tests-only-playwright: playwright-install ## Tylko testy Playwright (wolne)
 	uv run pytest -n $(PLAYWRIGHT_WORKERS) -m "playwright" $(_store_durations) $(_normalize_durations)
 

--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,7 @@ disable-microsoft-auth: ## Wyłącz django_microsoft_auth
 # (`make tests-without-playwright`) nie brudzi pliku. `make tests` i
 # `make test-durations` wlaczaja zapis przez target-specific STORE_DURATIONS.
 STORE_DURATIONS ?=
+PLAYWRIGHT_WORKERS ?= 12
 _store_durations = $(if $(STORE_DURATIONS),--store-durations --durations-path .test_durations,)
 # Po zapisie zaokraglij+posortuj plik (maly, stabilny diff). `&&` —
 # normalizujemy tylko po udanym przebiegu; przy STORE_DURATIONS pustym
@@ -351,8 +352,11 @@ tests-without-playwright-with-microsoft-auth: ## tests-without-playwright z akty
 
 tests-with-microsoft-auth: enable-microsoft-auth tests-without-playwright-with-microsoft-auth disable-microsoft-auth ## Włącz MS Auth, uruchom testy, wyłącz
 
+# Chromium i Daphne konkuruja o zasoby przy `-n auto` (16 workerow na
+# typowej maszynie deweloperskiej). Limit mozna nadpisac, np.
+# `make tests-only-playwright PLAYWRIGHT_WORKERS=8`.
 tests-only-playwright: playwright-install ## Tylko testy Playwright (wolne)
-	uv run pytest -n auto -m "playwright" $(_store_durations) $(_normalize_durations)
+	uv run pytest -n $(PLAYWRIGHT_WORKERS) -m "playwright" $(_store_durations) $(_normalize_durations)
 
 uv-sync: ## uv sync --all-extras (synchronizacja zależności Pythona)
 	uv sync --no-install-project --all-extras

--- a/src/bpp/newsfragments/playwright-procent-odpowiedzialnosci-speed.bugfix.rst
+++ b/src/bpp/newsfragments/playwright-procent-odpowiedzialnosci-speed.bugfix.rst
@@ -1,0 +1,4 @@
+Przyspieszono testy Playwright przez bezpośrednie ustawianie pobocznych pól
+Select2, usunięcie zbędnych oczekiwań oraz ograniczenie konkurencji między
+procesami Chromium, zachowując pełne interakcje w testach autocomplete i
+wpisywania wartości.

--- a/src/bpp/tests/test_playwright/test_admin/test_admin_forms.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_admin_forms.py
@@ -8,7 +8,10 @@ from playwright.sync_api import Page
 from bpp.models.zrodlo import Punktacja_Zrodla
 from bpp.tests import any_autor, any_jednostka
 from bpp.tests.util import CURRENT_YEAR, any_zrodlo
-from django_bpp.playwright_util import select_select2_autocomplete
+from django_bpp.playwright_util import (
+    select_select2_autocomplete,
+    set_select2_value,
+)
 
 
 def _wait_until(predicate, page=None, timeout: float = 5.0, interval_ms: int = 50):
@@ -40,7 +43,7 @@ def test_automatycznie_uzupelnij_punkty(admin_page: Page, channels_live_server):
 
     admin_page.goto(channels_live_server.url + url)
 
-    any_zrodlo(nazwa="FOO BAR")
+    zrodlo = any_zrodlo(nazwa="FOO BAR")
 
     # Wait for the button to appear
     admin_page.wait_for_selector("#id_wypelnij_pola_punktacji_button", state="visible")
@@ -63,10 +66,12 @@ def test_automatycznie_uzupelnij_punkty(admin_page: Page, channels_live_server):
     assert len(dialog_messages) > 0
     assert "Najpierw wybierz jakie" in dialog_messages[0]
 
-    # Select source using select2 autocomplete (helper waits for the
-    # underlying select to receive the new value, so no extra sleep needed)
-    select_select2_autocomplete(
-        admin_page, "id_zrodlo", "FOO", wait_for_new_value=True, timeout=30000
+    set_select2_value(
+        admin_page,
+        "id_zrodlo",
+        zrodlo.pk,
+        label=zrodlo.nazwa,
+        timeout=30000,
     )
 
     # Click button again
@@ -165,14 +170,23 @@ def test_admin_wydawnictwo_ciagle_dowolnie_zapisane_nazwisko(
     # Wait for the autor field to appear
     admin_page.wait_for_selector("#id_autorzy_set-0-autor", state="visible")
 
-    # Select "Kowalski Jan" in the autor field using select2
-    select_select2_autocomplete(
-        admin_page, "id_autorzy_set-0-autor", "Kowalski Jan", timeout=30000
+    # Author selection only prepares the tested field. Its change handler still
+    # runs and finishes before we type the custom name character by character.
+    set_select2_value(
+        admin_page,
+        "id_autorzy_set-0-autor",
+        autor_jan_kowalski.pk,
+        label=str(autor_jan_kowalski),
+        timeout=30000,
     )
 
-    # Enter "Dowolny tekst" in the zapisany_jako field using select2
+    # NIE ZASTĘPOWAĆ przez set_select2_value: wpisywanie dowolnej wartości
+    # znak po znaku oraz utworzenie jej przez Select2 są przedmiotem testu.
     select_select2_autocomplete(
-        admin_page, "id_autorzy_set-0-zapisany_jako", "Dowolny tekst", timeout=30000
+        admin_page,
+        "id_autorzy_set-0-zapisany_jako",
+        "Dowolny tekst",
+        timeout=30000,
     )
 
     # Verify the value was set correctly
@@ -185,12 +199,18 @@ def test_admin_wydawnictwo_ciagle_dowolnie_zapisane_nazwisko(
 @pytest.mark.django_db(transaction=True)
 def test_upload_punkty(admin_page: Page, channels_live_server):
     """Test uploading points to source scoring data."""
-    any_zrodlo(nazwa="WTF LOL")
+    zrodlo = any_zrodlo(nazwa="WTF LOL")
 
     url = reverse("admin:bpp_wydawnictwo_ciagle_add")
     admin_page.goto(channels_live_server.url + url)
 
-    select_select2_autocomplete(admin_page, "id_zrodlo", "WTF", timeout=30000)
+    set_select2_value(
+        admin_page,
+        "id_zrodlo",
+        zrodlo.pk,
+        label=zrodlo.nazwa,
+        timeout=30000,
+    )
 
     rok = admin_page.locator("#id_rok")
     rok.scroll_into_view_if_needed()
@@ -319,18 +339,18 @@ def test_admin_uzupelnij_punkty(admin_page: Page, channels_live_server):
 
 
 @pytest.fixture
-def autorform_jednostka(db):
+def autorform_autor_i_jednostka(db):
     """Create an author with a unit for autorform tests."""
     with transaction.atomic():
         a = any_autor(nazwisko="KOWALSKI", imiona="Jan Sebastian")
         j = any_jednostka(nazwa="WTF LOL")
         j.dodaj_autora(a)
-    return j
+    return a, j
 
 
 @pytest.mark.django_db(transaction=True)
 def test_autorform_uzupelnianie_jednostki(
-    admin_page: Page, channels_live_server, autorform_jednostka
+    admin_page: Page, channels_live_server, autorform_autor_i_jednostka
 ):
     """Test automatic unit population when selecting an author."""
     url = reverse("admin:bpp_wydawnictwo_ciagle_add")
@@ -346,22 +366,26 @@ def test_autorform_uzupelnianie_jednostki(
     # Wait for the autor field to appear
     admin_page.wait_for_selector("#id_autorzy_set-0-autor", state="visible")
 
-    # Select "KOWALSKI" in the autor field using select2
-    select_select2_autocomplete(
-        admin_page, "id_autorzy_set-0-autor", "KOWALSKI", timeout=30000
+    autor, jednostka = autorform_autor_i_jednostka
+    set_select2_value(
+        admin_page,
+        "id_autorzy_set-0-autor",
+        autor.pk,
+        label=str(autor),
+        timeout=30000,
     )
 
     # Wait for jednostka field to be auto-populated
     admin_page.wait_for_function(
         f"() => document.getElementById('id_autorzy_set-0-jednostka').value === "
-        f"'{autorform_jednostka.pk}'",
+        f"'{jednostka.pk}'",
         timeout=10000,
     )
 
 
 @pytest.mark.django_db(transaction=True)
 def test_autorform_kasowanie_autora(
-    admin_page: Page, channels_live_server, autorform_jednostka
+    admin_page: Page, channels_live_server, autorform_autor_i_jednostka
 ):
     """Test that clearing author also clears unit selection."""
     url = reverse("admin:bpp_wydawnictwo_ciagle_add")
@@ -377,15 +401,19 @@ def test_autorform_kasowanie_autora(
     # Wait for the autor field to appear
     admin_page.wait_for_selector("#id_autorzy_set-0-autor", state="visible")
 
-    # Select "KOW" (shortcut for KOWALSKI) in the autor field using select2
-    select_select2_autocomplete(
-        admin_page, "id_autorzy_set-0-autor", "KOW", timeout=30000
+    autor, jednostka = autorform_autor_i_jednostka
+    set_select2_value(
+        admin_page,
+        "id_autorzy_set-0-autor",
+        autor.pk,
+        label=str(autor),
+        timeout=30000,
     )
 
     # Wait for jednostka field to be auto-populated
     admin_page.wait_for_function(
         f"() => document.getElementById('id_autorzy_set-0-jednostka').value === "
-        f"'{autorform_jednostka.pk}'",
+        f"'{jednostka.pk}'",
         timeout=10000,
     )
 

--- a/src/bpp/tests/test_playwright/test_admin/test_admin_forms.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_admin_forms.py
@@ -197,6 +197,42 @@ def test_admin_wydawnictwo_ciagle_dowolnie_zapisane_nazwisko(
 
 
 @pytest.mark.django_db(transaction=True)
+def test_zrodlo_select2_autocomplete_dziala(admin_page: Page, channels_live_server):
+    """Prawdziwy autocomplete pola „Źródło" — okablowanie widget → endpoint.
+
+    NIE ZASTĘPOWAĆ przez set_select2_value: to JEDYNY test przeglądarkowy
+    przechodzący przez autocomplete `id_zrodlo`. Pozostałe testy ustawiają to
+    pole przez DOM, bo Select2 jest tam poboczny — ale gdyby nikt nie wpisywał
+    tu nic naprawdę, zerwanie połączenia widgetu z `bpp:admin-zrodlo-autocomplete`
+    (zmiana `url=` w formularzu, forward, uprawnienia, format odpowiedzi)
+    przeszłoby przez CI niezauważone.
+
+    Dowód jest mocny, bo `<select id_zrodlo>` startuje BEZ opcji: jedyną drogą,
+    żeby opcja o właściwym PK w ogóle powstała, jest odpowiedź AJAX-a. Sama
+    logika filtrowania queryset-u `ZrodloAutocomplete` ma osobne, tańsze testy
+    w `src/bpp/tests/test_autocomplete/` — tutaj sprawdzamy warstwę przeglądarki.
+    """
+    szukane = any_zrodlo(nazwa="Kwartalnik Ortopedyczny", skrot="Kwart. Ortop.")
+    # Wabik: w bazie jest więcej niż jedno źródło, więc trafienie we właściwe
+    # PK nie może być dziełem przypadku „jedyny wiersz w tabeli".
+    any_zrodlo(nazwa="Rocznik Kardiologiczny", skrot="Rocz. Kardiol.")
+
+    url = reverse("admin:bpp_wydawnictwo_ciagle_add")
+    admin_page.goto(channels_live_server.url + url)
+    admin_page.wait_for_selector("#id_zrodlo", state="attached")
+
+    select_select2_autocomplete(
+        admin_page,
+        "id_zrodlo",
+        "Kwartalnik Ortopedyczny",
+        wait_for_new_value=True,
+        timeout=30000,
+    )
+
+    assert admin_page.locator("#id_zrodlo").input_value() == str(szukane.pk)
+
+
+@pytest.mark.django_db(transaction=True)
 def test_upload_punkty(admin_page: Page, channels_live_server):
     """Test uploading points to source scoring data."""
     zrodlo = any_zrodlo(nazwa="WTF LOL")

--- a/src/bpp/tests/test_playwright/test_admin/test_admin_parsing.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_admin_parsing.py
@@ -4,7 +4,7 @@ from playwright.sync_api import Page
 
 from bpp.const import CHARAKTER_OGOLNY_KSIAZKA
 from bpp.models import Charakter_Formalny
-from django_bpp.playwright_util import select_select2_autocomplete
+from django_bpp.playwright_util import set_select2_value
 
 
 @pytest.mark.django_db(transaction=True)
@@ -44,9 +44,11 @@ def test_admin_wydawnictwo_zwarte_uzupelnij_rok(
     wydawnictwo_zwarte.charakter_formalny = chf
     wydawnictwo_zwarte.save()
 
-    # Select wydawnictwo_zwarte as parent publication (wydawnictwo_nadrzedne)
-    select_select2_autocomplete(
-        admin_page, "id_wydawnictwo_nadrzedne", "Wydawnictwo Zwarte"
+    set_select2_value(
+        admin_page,
+        "id_wydawnictwo_nadrzedne",
+        wydawnictwo_zwarte.pk,
+        label=str(wydawnictwo_zwarte),
     )
 
     # Clear rok and click button - should get year from miejsce_i_rok

--- a/src/bpp/tests/test_playwright/test_admin/test_autor_inline_wydawnictwo.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_autor_inline_wydawnictwo.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from playwright.sync_api import Page
 
 from bpp.models import Charakter_Formalny, Jezyk, Typ_KBN
-from django_bpp.playwright_util import select_select2_autocomplete
+from django_bpp.playwright_util import set_select2_value
 
 
 @pytest.mark.django_db(transaction=True)
@@ -27,7 +27,13 @@ def test_autor_inline_wydawnictwo_dyscyplina(
     admin_page.fill("#id_tytul_oryginalny", "123")
 
     if wyd == "ciagle":
-        select_select2_autocomplete(admin_page, "id_zrodlo", zrodlo.nazwa, timeout=4000)
+        set_select2_value(
+            admin_page,
+            "id_zrodlo",
+            zrodlo.pk,
+            label=zrodlo.nazwa,
+            timeout=4000,
+        )
 
     admin_page.fill("#id_rok", str(rok))
 
@@ -59,17 +65,26 @@ def test_autor_inline_wydawnictwo_dyscyplina(
     )
 
     # Fill autor inline - dyscyplina should auto-fill
-    select_select2_autocomplete(
+    set_select2_value(
         admin_page,
         "id_autorzy_set-0-autor",
-        autor_z_dyscyplina.autor.nazwisko,
+        autor_z_dyscyplina.autor.pk,
+        label=str(autor_z_dyscyplina.autor),
         timeout=4000,
     )
-    select_select2_autocomplete(
-        admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
+    set_select2_value(
+        admin_page,
+        "id_autorzy_set-0-jednostka",
+        jednostka.pk,
+        label=jednostka.nazwa,
+        timeout=4000,
     )
-    select_select2_autocomplete(
-        admin_page, "id_autorzy_set-0-zapisany_jako", "123 foo", timeout=4000
+    set_select2_value(
+        admin_page,
+        "id_autorzy_set-0-zapisany_jako",
+        "123 foo",
+        label="123 foo",
+        timeout=4000,
     )
 
     # Submit form

--- a/src/bpp/tests/test_playwright/test_admin/test_podpowiedzi_dyscyplin.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_podpowiedzi_dyscyplin.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from playwright.sync_api import Page
 
 from bpp.models import Autor_Dyscyplina
-from django_bpp.playwright_util import select_select2_autocomplete
+from django_bpp.playwright_util import set_select2_value
 
 
 @pytest.mark.parametrize("url", ["wydawnictwo_ciagle", "wydawnictwo_zwarte"])
@@ -21,7 +21,7 @@ def test_podpowiedzi_dyscyplin_autor_ma_dwie(
         dyscyplina_naukowa=dyscyplina1,
         subdyscyplina_naukowa=dyscyplina2,
     )
-    url = reverse("admin:bpp_%s_add" % url)
+    url = reverse(f"admin:bpp_{url}_add")
     admin_page.goto(channels_live_server.url + url)
     admin_page.fill('input[name="rok"]', "2018")
 
@@ -31,9 +31,12 @@ def test_podpowiedzi_dyscyplin_autor_ma_dwie(
     # Wait for the autor field to appear
     admin_page.wait_for_selector("#id_autorzy_set-0-autor", state="visible")
 
-    # Select KOWALSKI in the autor field using select2
-    select_select2_autocomplete(
-        admin_page, "id_autorzy_set-0-autor", "KOWALSKI", timeout=30000
+    set_select2_value(
+        admin_page,
+        "id_autorzy_set-0-autor",
+        autor_jan_kowalski.pk,
+        label=str(autor_jan_kowalski),
+        timeout=30000,
     )
 
     # Give time for the (absent) podpowiedz-dyscyplinę AJAX to fire — this
@@ -64,7 +67,7 @@ def test_podpowiedzi_dyscyplin_autor_ma_jedna_uczelnia_nie_podpowiada(
     Autor_Dyscyplina.objects.create(
         rok=2018, autor=autor_jan_kowalski, dyscyplina_naukowa=dyscyplina1
     )
-    url = reverse("admin:bpp_%s_add" % url)
+    url = reverse(f"admin:bpp_{url}_add")
     admin_page.goto(channels_live_server.url + url)
     admin_page.fill('input[name="rok"]', "2018")
 
@@ -74,9 +77,12 @@ def test_podpowiedzi_dyscyplin_autor_ma_jedna_uczelnia_nie_podpowiada(
     # Wait for the autor field to appear
     admin_page.wait_for_selector("#id_autorzy_set-0-autor", state="visible")
 
-    # Select KOWALSKI in the autor field using select2
-    select_select2_autocomplete(
-        admin_page, "id_autorzy_set-0-autor", "KOWALSKI", timeout=30000
+    set_select2_value(
+        admin_page,
+        "id_autorzy_set-0-autor",
+        autor_jan_kowalski.pk,
+        label=str(autor_jan_kowalski),
+        timeout=30000,
     )
 
     # Give time for the (absent) podpowiedz-dyscyplinę AJAX to fire — this
@@ -107,7 +113,7 @@ def test_podpowiedzi_dyscyplin_autor_ma_jedna_uczelnia_podpowiada(
     Autor_Dyscyplina.objects.create(
         rok=2018, autor=autor_jan_kowalski, dyscyplina_naukowa=dyscyplina1
     )
-    url = reverse("admin:bpp_%s_add" % url)
+    url = reverse(f"admin:bpp_{url}_add")
     admin_page.goto(channels_live_server.url + url)
     admin_page.fill('input[name="rok"]', "2018")
 
@@ -117,9 +123,12 @@ def test_podpowiedzi_dyscyplin_autor_ma_jedna_uczelnia_podpowiada(
     # Wait for the autor field to appear
     admin_page.wait_for_selector("#id_autorzy_set-0-autor", state="visible")
 
-    # Select KOWALSKI in the autor field using select2
-    select_select2_autocomplete(
-        admin_page, "id_autorzy_set-0-autor", "KOWALSKI", timeout=30000
+    set_select2_value(
+        admin_page,
+        "id_autorzy_set-0-autor",
+        autor_jan_kowalski.pk,
+        label=str(autor_jan_kowalski),
+        timeout=30000,
     )
 
     # Wait for discipline auto-fill to complete

--- a/src/bpp/tests/test_playwright/test_admin/test_procent_odpowiedzialnosci.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_procent_odpowiedzialnosci.py
@@ -2,6 +2,7 @@ import random
 
 import pytest
 from django.db import connection, transaction
+from django.db.models import Model
 from django.urls import reverse
 from model_bakery import baker
 from playwright.sync_api import Page
@@ -18,7 +19,7 @@ from django_bpp.playwright_util import set_select2_value
 
 
 def set_form_select2_value(
-    page: Page, element_id: str, value: str, timeout: int = 10000
+    page: Page, element_id: str, value: Model | str, timeout: int = 10000
 ):
     """Set an unrelated Select2 field without waiting for its AJAX endpoint.
 
@@ -28,21 +29,23 @@ def set_form_select2_value(
 
     Selecting an author starts ``autorform_dependant.js`` AJAX. Wait for it before
     filling ``zapisany_jako`` because its completion callback clears that field.
+
+    ``value`` to obiekt modelu (Zrodlo / Autor / Jednostka) ALBO goły string dla
+    pól tagowanych typu ``zapisany_jako``. Obiekt przekazujemy wprost, zamiast
+    odtwarzać go zapytaniem po nazwie: ``Autor.objects.get(nazwisko=...)``
+    rzuciłoby ``MultipleObjectsReturned``, gdyby test kiedykolwiek dostał dwóch
+    autorów o tym samym nazwisku — a fikstura ma ten obiekt już pod ręką.
     """
-    if element_id == "id_zrodlo":
-        option_value = Zrodlo.objects.get(nazwa=value).pk
-    elif element_id.endswith("-autor"):
-        option_value = Autor.objects.get(nazwisko=value).pk
-    elif element_id.endswith("-jednostka"):
-        option_value = Jednostka.objects.get(nazwa=value).pk
+    if isinstance(value, str):
+        option_value, label = value, value
     else:
-        option_value = value
+        option_value, label = value.pk, str(value)
 
     set_select2_value(
         page,
         element_id,
         option_value,
-        label=value,
+        label=label,
         timeout=timeout,
     )
 
@@ -202,7 +205,7 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_jeden_autor(  # noqa: 
     admin_page.fill("#id_tytul_oryginalny", "tytul oryginalny")
 
     if admin_page.query_selector("#id_zrodlo"):
-        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000)
+        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj, timeout=4000)
 
     if admin_page.query_selector("#id_jezyk"):
         select_first_option(admin_page, "#id_jezyk")
@@ -228,11 +231,9 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_jeden_autor(  # noqa: 
     )
 
     # Fill admin inline
+    set_form_select2_value(admin_page, "id_autorzy_set-0-autor", autor, timeout=4000)
     set_form_select2_value(
-        admin_page, "id_autorzy_set-0-autor", autor.nazwisko, timeout=4000
-    )
-    set_form_select2_value(
-        admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
+        admin_page, "id_autorzy_set-0-jednostka", jednostka, timeout=4000
     )
     set_form_select2_value(
         admin_page, "id_autorzy_set-0-zapisany_jako", "Kopara", timeout=4000
@@ -283,7 +284,7 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_jeden_autor(  
     admin_page.fill("#id_tytul_oryginalny", "tytul oryginalny")
 
     if admin_page.query_selector("#id_zrodlo"):
-        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000)
+        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj, timeout=4000)
 
     if admin_page.query_selector("#id_jezyk"):
         select_first_option(admin_page, "#id_jezyk")
@@ -309,11 +310,9 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_jeden_autor(  
     )
 
     # Fill admin inline with INVALID percentage (100.01 instead of 100.00)
+    set_form_select2_value(admin_page, "id_autorzy_set-0-autor", autor, timeout=4000)
     set_form_select2_value(
-        admin_page, "id_autorzy_set-0-autor", autor.nazwisko, timeout=4000
-    )
-    set_form_select2_value(
-        admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
+        admin_page, "id_autorzy_set-0-jednostka", jednostka, timeout=4000
     )
     set_form_select2_value(
         admin_page, "id_autorzy_set-0-zapisany_jako", "Kopara", timeout=4000
@@ -366,7 +365,7 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dwoch_autorow(  # noqa
     admin_page.fill("#id_tytul_oryginalny", "tytul oryginalny")
 
     if admin_page.query_selector("#id_zrodlo"):
-        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000)
+        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj, timeout=4000)
 
     if admin_page.query_selector("#id_jezyk"):
         select_first_option(admin_page, "#id_jezyk")
@@ -392,11 +391,9 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dwoch_autorow(  # noqa
     )
 
     # Fill first author (50%)
+    set_form_select2_value(admin_page, "id_autorzy_set-0-autor", autor1, timeout=4000)
     set_form_select2_value(
-        admin_page, "id_autorzy_set-0-autor", autor1.nazwisko, timeout=4000
-    )
-    set_form_select2_value(
-        admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
+        admin_page, "id_autorzy_set-0-jednostka", jednostka, timeout=4000
     )
     set_form_select2_value(
         admin_page, "id_autorzy_set-0-zapisany_jako", "Kopara1", timeout=4000
@@ -420,11 +417,9 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dwoch_autorow(  # noqa
     )
 
     # Fill second author (50%)
+    set_form_select2_value(admin_page, "id_autorzy_set-1-autor", autor2, timeout=4000)
     set_form_select2_value(
-        admin_page, "id_autorzy_set-1-autor", autor2.nazwisko, timeout=4000
-    )
-    set_form_select2_value(
-        admin_page, "id_autorzy_set-1-jednostka", jednostka.nazwa, timeout=4000
+        admin_page, "id_autorzy_set-1-jednostka", jednostka, timeout=4000
     )
     set_form_select2_value(
         admin_page, "id_autorzy_set-1-zapisany_jako", "Kopara2", timeout=4000
@@ -475,7 +470,7 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_dwoch_autorow(
     admin_page.fill("#id_tytul_oryginalny", "tytul oryginalny")
 
     if admin_page.query_selector("#id_zrodlo"):
-        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000)
+        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj, timeout=4000)
 
     if admin_page.query_selector("#id_jezyk"):
         select_first_option(admin_page, "#id_jezyk")
@@ -501,11 +496,9 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_dwoch_autorow(
     )
 
     # Fill first author (50%)
+    set_form_select2_value(admin_page, "id_autorzy_set-0-autor", autor1, timeout=4000)
     set_form_select2_value(
-        admin_page, "id_autorzy_set-0-autor", autor1.nazwisko, timeout=4000
-    )
-    set_form_select2_value(
-        admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
+        admin_page, "id_autorzy_set-0-jednostka", jednostka, timeout=4000
     )
     set_form_select2_value(
         admin_page, "id_autorzy_set-0-zapisany_jako", "Kopara1", timeout=4000
@@ -529,11 +522,9 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_dwoch_autorow(
     )
 
     # Fill second author (50.01% - INVALID)
+    set_form_select2_value(admin_page, "id_autorzy_set-1-autor", autor2, timeout=4000)
     set_form_select2_value(
-        admin_page, "id_autorzy_set-1-autor", autor2.nazwisko, timeout=4000
-    )
-    set_form_select2_value(
-        admin_page, "id_autorzy_set-1-jednostka", jednostka.nazwa, timeout=4000
+        admin_page, "id_autorzy_set-1-jednostka", jednostka, timeout=4000
     )
     set_form_select2_value(
         admin_page, "id_autorzy_set-1-zapisany_jako", "Kopara2", timeout=4000
@@ -593,9 +584,7 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dobrze_potem_zle_dwoch
         admin_page.fill("#id_tytul_oryginalny", "tytul oryginalny")
 
         if admin_page.query_selector("#id_zrodlo"):
-            set_form_select2_value(
-                admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000
-            )
+            set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj, timeout=4000)
 
         if admin_page.query_selector("#id_jezyk"):
             select_first_option(admin_page, "#id_jezyk")
@@ -621,10 +610,10 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dobrze_potem_zle_dwoch
         )
 
         set_form_select2_value(
-            admin_page, "id_autorzy_set-0-autor", autor1.nazwisko, timeout=4000
+            admin_page, "id_autorzy_set-0-autor", autor1, timeout=4000
         )
         set_form_select2_value(
-            admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
+            admin_page, "id_autorzy_set-0-jednostka", jednostka, timeout=4000
         )
         set_form_select2_value(
             admin_page, "id_autorzy_set-0-zapisany_jako", "Kopara1", timeout=4000
@@ -648,10 +637,10 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dobrze_potem_zle_dwoch
         )
 
         set_form_select2_value(
-            admin_page, "id_autorzy_set-1-autor", autor2.nazwisko, timeout=4000
+            admin_page, "id_autorzy_set-1-autor", autor2, timeout=4000
         )
         set_form_select2_value(
-            admin_page, "id_autorzy_set-1-jednostka", jednostka.nazwa, timeout=4000
+            admin_page, "id_autorzy_set-1-jednostka", jednostka, timeout=4000
         )
         set_form_select2_value(
             admin_page, "id_autorzy_set-1-zapisany_jako", "Kopara2", timeout=4000
@@ -675,7 +664,7 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dobrze_potem_zle_dwoch
             if autor0 != autor1_val:
                 break
             set_form_select2_value(
-                admin_page, "id_autorzy_set-1-autor", autor2.nazwisko, timeout=4000
+                admin_page, "id_autorzy_set-1-autor", autor2, timeout=4000
             )
         assert (
             admin_page.locator("#id_autorzy_set-0-autor").input_value()

--- a/src/bpp/tests/test_playwright/test_admin/test_procent_odpowiedzialnosci.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_procent_odpowiedzialnosci.py
@@ -14,10 +14,37 @@ from bpp.models.system import (
     Typ_KBN,
     Typ_Odpowiedzialnosci,
 )
-from django_bpp.playwright_util import (
-    close_all_select2_dropdowns,
-    select_select2_autocomplete,
-)
+from django_bpp.playwright_util import set_select2_value
+
+
+def set_form_select2_value(
+    page: Page, element_id: str, value: str, timeout: int = 10000
+):
+    """Set an unrelated Select2 field without waiting for its AJAX endpoint.
+
+    These tests exercise responsibility-percentage validation, not autocomplete.
+    Dedicated tests cover the Select2 widgets themselves, so driving every lookup
+    over HTTP here only multiplies runtime and introduces an unrelated timing flake.
+
+    Selecting an author starts ``autorform_dependant.js`` AJAX. Wait for it before
+    filling ``zapisany_jako`` because its completion callback clears that field.
+    """
+    if element_id == "id_zrodlo":
+        option_value = Zrodlo.objects.get(nazwa=value).pk
+    elif element_id.endswith("-autor"):
+        option_value = Autor.objects.get(nazwisko=value).pk
+    elif element_id.endswith("-jednostka"):
+        option_value = Jednostka.objects.get(nazwa=value).pk
+    else:
+        option_value = value
+
+    set_select2_value(
+        page,
+        element_id,
+        option_value,
+        label=value,
+        timeout=timeout,
+    )
 
 
 def force_commit():
@@ -175,9 +202,7 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_jeden_autor(  # noqa: 
     admin_page.fill("#id_tytul_oryginalny", "tytul oryginalny")
 
     if admin_page.query_selector("#id_zrodlo"):
-        select_select2_autocomplete(
-            admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000
-        )
+        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000)
 
     if admin_page.query_selector("#id_jezyk"):
         select_first_option(admin_page, "#id_jezyk")
@@ -203,13 +228,13 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_jeden_autor(  # noqa: 
     )
 
     # Fill admin inline
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-autor", autor.nazwisko, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-zapisany_jako", "Kopara", timeout=4000
     )
     # Select typ_odpowiedzialnosci (responsibility type)
@@ -258,9 +283,7 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_jeden_autor(  
     admin_page.fill("#id_tytul_oryginalny", "tytul oryginalny")
 
     if admin_page.query_selector("#id_zrodlo"):
-        select_select2_autocomplete(
-            admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000
-        )
+        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000)
 
     if admin_page.query_selector("#id_jezyk"):
         select_first_option(admin_page, "#id_jezyk")
@@ -286,13 +309,13 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_jeden_autor(  
     )
 
     # Fill admin inline with INVALID percentage (100.01 instead of 100.00)
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-autor", autor.nazwisko, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-zapisany_jako", "Kopara", timeout=4000
     )
     # Select typ_odpowiedzialnosci (responsibility type)
@@ -339,16 +362,11 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dwoch_autorow(  # noqa
     admin_page.goto(url)
     admin_page.wait_for_load_state("domcontentloaded")
 
-    # Clean up any lingering Select2 dropdowns from previous tests
-    close_all_select2_dropdowns(admin_page)
-
     # Fill admin form
     admin_page.fill("#id_tytul_oryginalny", "tytul oryginalny")
 
     if admin_page.query_selector("#id_zrodlo"):
-        select_select2_autocomplete(
-            admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000
-        )
+        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000)
 
     if admin_page.query_selector("#id_jezyk"):
         select_first_option(admin_page, "#id_jezyk")
@@ -374,13 +392,13 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dwoch_autorow(  # noqa
     )
 
     # Fill first author (50%)
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-autor", autor1.nazwisko, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-zapisany_jako", "Kopara1", timeout=4000
     )
     # Select typ_odpowiedzialnosci (responsibility type)
@@ -402,13 +420,13 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dwoch_autorow(  # noqa
     )
 
     # Fill second author (50%)
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-1-autor", autor2.nazwisko, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-1-jednostka", jednostka.nazwa, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-1-zapisany_jako", "Kopara2", timeout=4000
     )
     # Select typ_odpowiedzialnosci (responsibility type)
@@ -453,16 +471,11 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_dwoch_autorow(
     admin_page.goto(url)
     admin_page.wait_for_load_state("domcontentloaded")
 
-    # Clean up any lingering Select2 dropdowns from previous tests
-    close_all_select2_dropdowns(admin_page)
-
     # Fill admin form
     admin_page.fill("#id_tytul_oryginalny", "tytul oryginalny")
 
     if admin_page.query_selector("#id_zrodlo"):
-        select_select2_autocomplete(
-            admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000
-        )
+        set_form_select2_value(admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000)
 
     if admin_page.query_selector("#id_jezyk"):
         select_first_option(admin_page, "#id_jezyk")
@@ -488,13 +501,13 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_dwoch_autorow(
     )
 
     # Fill first author (50%)
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-autor", autor1.nazwisko, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-0-zapisany_jako", "Kopara1", timeout=4000
     )
     # Select typ_odpowiedzialnosci (responsibility type)
@@ -516,13 +529,13 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_problem_dwoch_autorow(
     )
 
     # Fill second author (50.01% - INVALID)
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-1-autor", autor2.nazwisko, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-1-jednostka", jednostka.nazwa, timeout=4000
     )
-    select_select2_autocomplete(
+    set_form_select2_value(
         admin_page, "id_autorzy_set-1-zapisany_jako", "Kopara2", timeout=4000
     )
     # Select typ_odpowiedzialnosci (responsibility type)
@@ -576,14 +589,11 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dobrze_potem_zle_dwoch
         admin_page.goto(url)
         admin_page.wait_for_load_state("domcontentloaded")
 
-        # Clean up any lingering Select2 dropdowns
-        close_all_select2_dropdowns(admin_page)
-
         # Fill admin form
         admin_page.fill("#id_tytul_oryginalny", "tytul oryginalny")
 
         if admin_page.query_selector("#id_zrodlo"):
-            select_select2_autocomplete(
+            set_form_select2_value(
                 admin_page, "id_zrodlo", zrodlo_obj.nazwa, timeout=4000
             )
 
@@ -610,13 +620,13 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dobrze_potem_zle_dwoch
             "#id_autorzy_set-0-autor", state="visible", timeout=10000
         )
 
-        select_select2_autocomplete(
+        set_form_select2_value(
             admin_page, "id_autorzy_set-0-autor", autor1.nazwisko, timeout=4000
         )
-        select_select2_autocomplete(
+        set_form_select2_value(
             admin_page, "id_autorzy_set-0-jednostka", jednostka.nazwa, timeout=4000
         )
-        select_select2_autocomplete(
+        set_form_select2_value(
             admin_page, "id_autorzy_set-0-zapisany_jako", "Kopara1", timeout=4000
         )
         # Select typ_odpowiedzialnosci (responsibility type)
@@ -637,13 +647,13 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dobrze_potem_zle_dwoch
             "#id_autorzy_set-1-autor", state="visible", timeout=10000
         )
 
-        select_select2_autocomplete(
+        set_form_select2_value(
             admin_page, "id_autorzy_set-1-autor", autor2.nazwisko, timeout=4000
         )
-        select_select2_autocomplete(
+        set_form_select2_value(
             admin_page, "id_autorzy_set-1-jednostka", jednostka.nazwa, timeout=4000
         )
-        select_select2_autocomplete(
+        set_form_select2_value(
             admin_page, "id_autorzy_set-1-zapisany_jako", "Kopara2", timeout=4000
         )
         # Select typ_odpowiedzialnosci (responsibility type)
@@ -664,7 +674,7 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dobrze_potem_zle_dwoch
             autor1_val = admin_page.locator("#id_autorzy_set-1-autor").input_value()
             if autor0 != autor1_val:
                 break
-            select_select2_autocomplete(
+            set_form_select2_value(
                 admin_page, "id_autorzy_set-1-autor", autor2.nazwisko, timeout=4000
             )
         assert (
@@ -723,16 +733,10 @@ def test_procent_odpowiedzialnosci_baseModel_AutorFormset_dobrze_potem_zle_dwoch
         try:
             # Delete created publication first (has foreign keys to other objects)
             if created_publication is not None:
-                try:
-                    created_publication.delete()
-                except Exception:
-                    pass  # May already be deleted or not exist
+                created_publication.delete()
 
             # Delete test data objects
             for obj in reversed(created_objects):
-                try:
-                    obj.delete()
-                except Exception:
-                    pass  # May already be deleted or have FK constraints
+                obj.delete()
         finally:
             transaction.set_autocommit(old_autocommit)

--- a/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_autor.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_autor.py
@@ -184,7 +184,8 @@ def test_changeform_add_full_flow(
     admin_page.click('a[name="_add_wa"]')
     admin_page.wait_for_load_state("domcontentloaded")
 
-    # Fill admin inline form - equivalent to fill_admin_inline
+    # NIE ZASTĘPOWAĆ przez set_select2_value: "full flow" celowo przechodzi
+    # przez rzeczywiste wpisywanie i wybór we wszystkich trzech Select2.
     prefix = "id_"
     select_select2_autocomplete(
         admin_page,

--- a/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_ciagle.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_ciagle.py
@@ -42,7 +42,8 @@ def test_Wydawnictwo_Ciagle_Autor_Admin_forwarding_works(
     # Wait for the page to be fully loaded (rok field is hidden type=hidden)
     admin_page.wait_for_selector("#id_rok", state="attached", timeout=10000)
 
-    # Select discipline using Select2 autocomplete
+    # NIE ZASTĘPOWAĆ przez set_select2_value: ten test sprawdza prawdziwe
+    # wpisywanie w Select2 oraz przekazanie pól autor/rok do endpointu.
     select_select2_autocomplete(
         admin_page, "id_dyscyplina_naukowa", dyscyplina1.nazwa, timeout=4000
     )

--- a/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_zwarte.py
+++ b/src/bpp/tests/test_playwright/test_admin/test_wydawnictwo_zwarte.py
@@ -44,6 +44,8 @@ def test_Wydawnictwo_Zwarte_Autor_Admin_forwarding_works(
     # Wait for rok field to exist (it's a hidden input, so we don't check visibility)
     admin_page.wait_for_selector("[name='rok']", state="attached")
 
+    # NIE ZASTĘPOWAĆ przez set_select2_value: ten test sprawdza prawdziwe
+    # wpisywanie w Select2 oraz przekazanie pól autor/rok do endpointu.
     select_select2_autocomplete(
         admin_page, "id_dyscyplina_naukowa", dyscyplina1.nazwa, timeout=30000
     )

--- a/src/django_bpp/playwright_util.py
+++ b/src/django_bpp/playwright_util.py
@@ -238,10 +238,35 @@ def set_select2_value(
     emits the same jQuery ``change`` event, and waits for dependent AJAX handlers.
     Tests whose purpose is autocomplete or queryset forwarding must keep using
     :func:`select_select2_autocomplete`.
+
+    Czekamy na klasę ``select2-hidden-accessible``, a NIE tylko na
+    ``state="attached"``. Dla wierszy formsetu dodanych dynamicznie (przycisk
+    „dodaj autora" / ``#add-form``) django-autocomplete-light inicjalizuje
+    widget dopiero w callbacku ``MutationObserver``
+    (``autocomplete_light.js``) — czyli asynchronicznie PO wstawieniu
+    ``<select>`` do DOM. Sam ``attached`` przepuszcza więc okno, w którym
+    ``autorform_dependant.js`` nie zdążył podpiąć handlera ``change``: nasz
+    ``trigger('change')`` nie odpala wtedy żadnego AJAX-a, ``jQuery.active``
+    od razu wynosi 0 i helper wraca „zielony", mimo że zależne pola
+    (jednostka / dyscyplina) nigdy się nie wypełniły. Testy z asercją
+    POZYTYWNĄ złapałyby to jako flake, ale testy z asercją NEGATYWNĄ
+    (``test_podpowiedzi_dyscyplin_autor_ma_dwie``) przeszłyby wtedy nie
+    sprawdziwszy niczego. ``select2`` nadaje tę klasę oryginalnemu
+    ``<select>`` przy inicjalizacji, więc jej obecność dowodzi, że widget
+    (a z nim handlery ``autocompleteLightInitialize``) jest już gotowy.
     """
     option_value = str(value)
     select = page.locator(f"#{element_id}")
     select.wait_for(state="attached", timeout=timeout)
+    page.wait_for_function(
+        """(id) => {
+            const element = document.getElementById(id);
+            return !!element
+                && element.classList.contains('select2-hidden-accessible');
+        }""",
+        arg=element_id,
+        timeout=timeout,
+    )
     select.evaluate(
         """(element, option) => {
             const existing = Array.from(element.options).find(
@@ -261,22 +286,6 @@ def set_select2_value(
         timeout=timeout,
     )
     assert select.input_value() == option_value
-
-
-def close_all_select2_dropdowns(page: Page):
-    """Close any open Select2 dropdowns to ensure clean DOM state.
-
-    Args:
-        page: Playwright Page object
-    """
-    page.evaluate(
-        """() => {
-        if (typeof django !== 'undefined' && django.jQuery) {
-            django.jQuery('.select2-hidden-accessible').select2('close');
-        }
-    }"""
-    )
-    page.wait_for_timeout(0)
 
 
 def proper_click_element(page: Page, selector: str):

--- a/src/django_bpp/playwright_util.py
+++ b/src/django_bpp/playwright_util.py
@@ -224,6 +224,45 @@ def select_select2_autocomplete(
         page.wait_for_timeout(0)
 
 
+def set_select2_value(
+    page: Page,
+    element_id: str,
+    value: str | int,
+    label: str | None = None,
+    timeout: int = 10000,
+):
+    """Set a Select2-backed field without exercising its autocomplete.
+
+    Use this only when Select2 is incidental to the behaviour under test. The
+    helper adds the option that an AJAX lookup would normally create, selects it,
+    emits the same jQuery ``change`` event, and waits for dependent AJAX handlers.
+    Tests whose purpose is autocomplete or queryset forwarding must keep using
+    :func:`select_select2_autocomplete`.
+    """
+    option_value = str(value)
+    select = page.locator(f"#{element_id}")
+    select.wait_for(state="attached", timeout=timeout)
+    select.evaluate(
+        """(element, option) => {
+            const existing = Array.from(element.options).find(
+                item => item.value === option.value
+            );
+            const selected = existing || new Option(
+                option.label, option.value, true, true
+            );
+            if (!existing) element.add(selected);
+            element.value = option.value;
+            django.jQuery(element).trigger('change');
+        }""",
+        {"value": option_value, "label": label or option_value},
+    )
+    page.wait_for_function(
+        "() => !window.django || !django.jQuery || django.jQuery.active === 0",
+        timeout=timeout,
+    )
+    assert select.input_value() == option_value
+
+
 def close_all_select2_dropdowns(page: Page):
     """Close any open Select2 dropdowns to ensure clean DOM state.
 

--- a/src/django_bpp/settings/test.py
+++ b/src/django_bpp/settings/test.py
@@ -112,3 +112,23 @@ ZGLOS_CAPTCHA_ENABLED = False
 # Stały test-key (nie efemeryczny z local.py) — dla testów captchy, które
 # włączają ZGLOS_CAPTCHA_ENABLED przez @override_settings.
 ALTCHA_HMAC_KEY = "test-altcha-hmac-key-deterministic-0123456789abcdef"
+
+# Szybki hasher haseł. Domyślny PBKDF2 kosztuje ~177 ms na JEDNO
+# `make_password` (zmierzone na tej bazie kodu) — a suitę zalewają fikstury
+# tworzące użytkowników: `admin_user` / `admin_client` / `admin_page` mają
+# łącznie ~2600 wystąpień w plikach testowych, a każdy test, który którąś z
+# nich zamawia, płaci za pełne przeliczenie PBKDF2 w `create_superuser`.
+#
+# Zmierzone na `src/bpp/tests/test_admin` (626 testów, `-n 8`):
+#   PBKDF2: 40,86 s wall / 264,6 s CPU
+#   MD5:    30,92 s wall / 169,7 s CPU   → −24% wall, −36% CPU
+#
+# Zysk jest największy tam, gdzie testy są CPU-bound — czyli na shardach CI
+# (runnery mają ~4 rdzenie). Suita Playwright, która czeka głównie na
+# przeglądarkę, zyskuje na czasie ściany niewiele, ale i tak oddaje ~9% CPU.
+#
+# Bezpieczne: żaden test nie asertuje algorytmu hashowania, a
+# `set_password` / `check_password` / `password_policies` chodzą przez API
+# hasherów Django i działają z dowolnym z nich. MD5 jest tu WYŁĄCZNIE
+# testowy — produkcja bierze domyślną listę hasherów z base.py.
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]

--- a/src/import_dyscyplin/tests/test_integration.py
+++ b/src/import_dyscyplin/tests/test_integration.py
@@ -1,14 +1,13 @@
 import os
-import time
 
 import pytest
 from django.urls import reverse
 from model_bakery import baker
 from playwright.sync_api import Page
-from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from bpp.models import Uczelnia
 from django_bpp.playwright_util import proper_click_element, wait_for_page_load
+from import_dyscyplin.models import Import_Dyscyplin
 
 
 @pytest.mark.timeout(300)
@@ -39,46 +38,18 @@ def test_integracyjny(admin_page: Page, channels_live_server, settings):  # noqa
         admin_page.click("#id_submit")
         wait_for_page_load(admin_page)
 
-        body_text = admin_page.evaluate("document.body.textContent")
-
-        # Check if modal appears or we're already redirected. If neither shows
-        # up within the timeout, fall through to the manual fallback below —
-        # PlaywrightTimeoutError here is expected, not a test failure.
-        try:
-            admin_page.wait_for_function(
-                """() => {
-                    const modal = document.querySelector('#modal1[aria-hidden="false"]');
-                    const onOkreslKolumny = window.location.href.includes('okresl-kolumny');
-                    return modal || onOkreslKolumny;
-                }""",
-                timeout=5000,
-            )
-        except PlaywrightTimeoutError:
-            pass
-
-        # Check if we need to wait for redirect or should navigate manually
+        # Per-test settings changes live in the pytest process, not in the
+        # already-running Daphne subprocess. Its AJAX-triggered Celery task has
+        # no worker here, so waiting for it always burns two 5-second fallbacks.
+        # Run the same model operation synchronously and continue deterministically.
         current_url = admin_page.url
-        if "okresl-kolumny" in current_url:
-            pass  # Already on the right page
-        elif "Plik został dodany do systemu" in body_text:
-            # Poll the DB for state change instead of sleeping for a fixed
-            # 5s — when CELERY_TASK_ALWAYS_EAGER works, the task is already
-            # done by the time the response comes back, and we want to exit
-            # immediately. Up to 5s safety margin if eager dispatch raced
-            # with on_commit.
+        if "okresl-kolumny" not in current_url:
+            assert (
+                "Plik został dodany do systemu"
+                in admin_page.locator("body").inner_text()
+            )
             import_dyscyplin_id = current_url.rstrip("/").split("/")[-1]
-            from import_dyscyplin.models import Import_Dyscyplin
-
-            deadline = time.monotonic() + 5
-            while time.monotonic() < deadline:
-                obj = Import_Dyscyplin.objects.get(pk=import_dyscyplin_id)
-                if obj.stan != "nowy":
-                    break
-                time.sleep(0.1)
-            else:
-                obj = Import_Dyscyplin.objects.get(pk=import_dyscyplin_id)
-
-            # If task didn't run, call it manually (test workaround for Celery eager mode)
+            obj = Import_Dyscyplin.objects.get(pk=import_dyscyplin_id)
             if obj.stan == "nowy":
                 try:
                     obj.stworz_kolumny()
@@ -127,9 +98,6 @@ def test_integracyjny(admin_page: Page, channels_live_server, settings):  # noqa
             else:
                 # We're on detail page, wait for it to fully load
                 wait_for_page_load(admin_page)
-
-                # Check if we need to trigger processing manually
-                from import_dyscyplin.models import Import_Dyscyplin
 
                 obj = Import_Dyscyplin.objects.get(
                     pk=admin_page.url.rstrip("/").split("/")[-1]

--- a/src/integration_tests/test_bpp_with_notifications.py
+++ b/src/integration_tests/test_bpp_with_notifications.py
@@ -1,5 +1,3 @@
-import time
-
 from django.core.management import call_command
 
 #
@@ -68,8 +66,6 @@ def test_caching_enabled(
     form["typ_kbn"].value = Typ_KBN.objects.all().first().pk
     form["status_korekty"].value = Status_Korekty.objects.all().first().pk
     form.submit()
-
-    time.sleep(1)
 
     denorms.flush()
 
@@ -142,7 +138,6 @@ def test_bpp_notifications(preauth_asgi_page_per_test: Page):
         username=preauth_asgi_page_per_test.authorized_user.username,
         verbosity=0,
     )
-    page.wait_for_timeout(1000)
     expect(page.locator("body")).to_contain_text(s, timeout=15000)
 
 
@@ -165,7 +160,6 @@ def test_bpp_notifications_and_messages(preauth_asgi_page: Page):
     page.wait_for_timeout(2000)  # Pozwol subskrypcji WS sie ustabilizowac
     call_command("send_message", preauth_asgi_page.authorized_user.username, s)
 
-    page.wait_for_timeout(1000)  # Give time for message to be sent
     page.wait_for_function(
         f"() => document.body.textContent.includes('{s}')", timeout=15000
     )

--- a/src/zglos_publikacje/tests/test_playwright/test_zglos_publikacje.py
+++ b/src/zglos_publikacje/tests/test_playwright/test_zglos_publikacje.py
@@ -7,6 +7,7 @@ from playwright.sync_api import Page
 from bpp.models import Autor_Dyscyplina, Autor_Jednostka
 from django_bpp.playwright_util import (
     select_select2_autocomplete,
+    set_select2_value,
 )
 
 
@@ -99,10 +100,11 @@ def test_zglos_publikacje_drugi_autor_dyscyplina(
     admin_page.wait_for_selector(
         f"#id_3-{n}-autor", state="visible"
     )
-    select_select2_autocomplete(
+    set_select2_value(
         admin_page,
         f"id_3-{n}-autor",
-        "Kowal",
+        autor_jan_kowalski.pk,
+        label=str(autor_jan_kowalski),
         timeout=30000,
     )
 
@@ -167,10 +169,11 @@ def test_zglos_publikacje_ograniczony_dostep(
 
     admin_page.locator(f"#id_3-{n}-autor").scroll_into_view_if_needed()
 
-    select_select2_autocomplete(
+    set_select2_value(
         admin_page,
         f"id_3-{n}-autor",
-        "Kowal",
+        autor_jan_kowalski.pk,
+        label=str(autor_jan_kowalski),
         timeout=30000,
     )
 
@@ -227,6 +230,8 @@ def test_zglos_publikacje_wiele_klikniec(
         "#id_3-2-autor", state="visible"
     )
 
+    # NIE ZASTĘPOWAĆ przez set_select2_value: test ma potwierdzać, że po
+    # wielokrotnym dodaniu formularzy Select2 nadal przyjmuje wpisywanie.
     select_select2_autocomplete(
         admin_page,
         "id_3-1-autor",


### PR DESCRIPTION
## Co zmieniono

- dodano `set_select2_value()` do szybkiego ustawiania pobocznych pól Select2 przez DOM i zdarzenie `change`,
- zastosowano go tylko tam, gdzie autocomplete nie jest przedmiotem testu,
- zachowano rzeczywiste wpisywanie znak po znaku w testach autocomplete, forwardingu, wartości tagowanych i dynamicznych formularzy; miejsca te mają komentarz chroniący przed przypadkową optymalizacją,
- usunięto martwe oczekiwania na niewykonywany task Celery w teście importu dyscyplin oraz redundantne stałe oczekiwania w testach powiadomień i denormalizacji,
- ograniczono domyślną równoległość lokalnej suity Playwright do konfigurowalnych 12 workerów, aby Chromium i Daphne nie konkurowały nadmiernie o zasoby,
- dodano newsfragment.

## Dlaczego

Najwolniejsze testy wielokrotnie przechodziły przez pełny interfejs Select2 także wtedy, gdy testowały inną funkcję formularza. Dodatkowo `-n auto` uruchamiało na maszynie deweloperskiej 16 procesów Chromium/Daphne, co zwiększało czasy setupu i powodowało silną konkurencję o zasoby. Plik `.test_durations` zawiera również stare wpisy i łączne czasy setup/call/teardown, dlatego wysokie wartości nie zawsze wskazywały wolną logikę testu.

## Wpływ

Pełna suita Playwright skróciła się z 104,44 s do 67,45 s (około 35%), zachowując pełne testy integracyjne Select2 tam, gdzie interakcja z widgetem jest częścią kontraktu.

## Weryfikacja

- `uv run pytest -n 12 -m playwright --durations=20` — 154 passed, 1 skipped,
- krytyczne testy rzeczywistego Select2 — 6 passed,
- testy powiadomień powtórzone 5 razy — 10 passed,
- test cache/denormalizacji powtórzony 10 razy — 10 passed,
- `ruff check`, `git diff --check` i komplet hooków pre-commit — passed.