### PR TITLE
Speed up GitHub Actions builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,13 +17,16 @@ src/django_bpp/staticroot/
 .gitattributes
 .github/
 
-# Test-runner contract tests inspect this workflow. Keep every other GitHub
-# metadata file outside the Docker context.
+# Test-runner contract tests inspect the CI/release workflows below. Keep every
+# other GitHub metadata file outside the Docker context.
 !.github/
 .github/*
 !.github/workflows/
 .github/workflows/*
 !.github/workflows/build-docker-images.yml
+!.github/workflows/refresh-baseline.yml
+!.github/workflows/release-candidate.yml
+!.github/workflows/tests.yml
 
 # Python cache files
 __pycache__/
@@ -112,6 +115,7 @@ azure-pipelines.yml
 docker-compose*.yml
 Dockerfile*
 .dockerignore
+!docker/bpp_base/Dockerfile
 
 # Node modules if rebuilt during Docker build
 node_modules/

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -11,7 +11,7 @@ name: Docker - oficjalne obrazy
 #   moga go pullnac, zanim zobaczymy raport.
 #
 # Jak dzialamy:
-#   Faza 1 — Build → push do STAGING TAGU (np. ":sha-abc1234")
+#   Faza 1A — Build → push do STAGING TAGU (np. ":sha-abc1234")
 #     Bake pushuje obrazy do Docker Hub, ale pod tagiem *niekanonicznym*,
 #     unikalnym per-build (SHA commitu). Zaden deployment ani dokumentacja
 #     nie odwoluje sie do tych tagow — sa technicznie publiczne, ale w
@@ -19,7 +19,11 @@ name: Docker - oficjalne obrazy
 #     bo nikt tego tagu nie zna). Staging tag umozliwia Trivy skanowanie
 #     obrazu tak, jak bylby po release.
 #
-#   Faza 2 — Trivy gate (release-candidate przez workflow_call)
+#   Faza 1B — Równolegle: skan zależności projektu
+#     Skan SBOM nie potrzebuje gotowych obrazów, więc biegnie od początku
+#     równolegle z najdłuższym krokiem builda. Jego wynik jest bramką promocji.
+#
+#   Faza 2 — Trivy gate obrazów (release-candidate przez workflow_call)
 #     Skan staging tagu. Polityka:
 #       • CRITICAL (z dostepnym fix-em) → HARD FAIL. Promocja sie nie
 #         wykona, wiec kanoniczny tag nigdy nie powstanie w rejestrze.
@@ -85,6 +89,10 @@ on:
         description: Uruchom bramę Trivy CRITICAL przed promocją
         type: boolean
         default: true
+      run_dependency_scan:
+        description: Uruchom bramę CVE zależności równolegle z buildem
+        type: boolean
+        default: false
     secrets:
       DOCKER_PAT:
         required: true
@@ -236,7 +244,70 @@ jobs:
             --allow=fs.write=/tmp
 
   # ===================================================================
-  # JOB 2: scan — brama Trivy w ODDZIELNYM jobie, CELOWO BEZ DOCKER_PAT.
+  # JOB 2: dependency_scan — brama zależności równoległa z buildem.
+  # ===================================================================
+  # Nie ma `needs: build`, bo skanuje uv.lock/SBOM, a nie gotowe obrazy.
+  # Dzięki temu jego koszt chowa się pod dłuższym Docker buildem. Job ma tylko
+  # contents:read i nie dostaje DOCKER_PAT ani uprawnień do pushowania tagów.
+  dependency_scan:
+    name: Skan CVE zależności — równolegle z buildem
+    if: ${{ inputs.run_dependency_scan }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.29"
+          enable-cache: false
+
+      - name: Install pinned CVE scanners
+        env:
+          # BUMP: podnieś wersję i wklej SHA256 z pliku checksums release'u.
+          OSV_SCANNER_VERSION: "2.4.0"
+          OSV_SCANNER_SHA256: "15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0"
+          GRYPE_VERSION: "0.115.0"
+          GRYPE_SHA256: "3fad92940650e514c0aa2dad83526942a055e210cec09a8a59d9c024adc2b90e"
+          TRIVY_VERSION: "0.72.0"
+          TRIVY_SHA256: "bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea"
+        run: |
+          set -euo pipefail
+          TMP="$(mktemp -d)"
+          trap 'rm -rf "$TMP"' EXIT
+
+          curl -sSL -o "${TMP}/osv-scanner" \
+            "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          echo "${OSV_SCANNER_SHA256}  ${TMP}/osv-scanner" | sha256sum -c -
+          install -m 0755 "${TMP}/osv-scanner" /usr/local/bin/osv-scanner
+
+          curl -sSL -o "${TMP}/grype.tar.gz" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
+          echo "${GRYPE_SHA256}  ${TMP}/grype.tar.gz" | sha256sum -c -
+          tar -xzf "${TMP}/grype.tar.gz" -C "${TMP}" grype
+          install -m 0755 "${TMP}/grype" /usr/local/bin/grype
+
+          curl -sSL -o "${TMP}/trivy.tar.gz" \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          echo "${TRIVY_SHA256}  ${TMP}/trivy.tar.gz" | sha256sum -c -
+          tar -xzf "${TMP}/trivy.tar.gz" -C "${TMP}" trivy
+          install -m 0755 "${TMP}/trivy" /usr/local/bin/trivy
+
+          osv-scanner --version
+          grype version
+          trivy --version
+
+      - name: Scan dependency SBOM (gate)
+        run: ./bin/scan-deps.sh
+
+  # ===================================================================
+  # JOB 3: scan — brama Trivy w ODDZIELNYM jobie, CELOWO BEZ DOCKER_PAT.
   # ===================================================================
   # Dlaczego osobny job: Trivy to zewnętrzne narzędzie odpalane z docker
   # socketem. Gdyby dzieliło job z krokiem `docker login` (DOCKER_PAT),
@@ -262,7 +333,7 @@ jobs:
       # Trivy PRZYPIĘTY do wersji + digestu (multi-arch index), NIE ruchomego
       # :latest — rejestr nie może podmienić zawartości pod niezmiennym
       # digestem. Wersja 0.72.0 = ta sama co binarka trivy w
-      # release-candidate.yml (skan deps) — jeden trivy w całym pipeline.
+      # jobie dependency_scan — jeden Trivy w całym pipeline.
       # BUMP: podnieś wersję i digest z
       #   docker buildx imagetools inspect aquasec/trivy:<wersja>
       # (weź „Digest:" indeksu multi-arch, nie per-platform manifest).
@@ -395,7 +466,7 @@ jobs:
           done
 
   # ===================================================================
-  # JOB 3: promote — kopiuje manifest staging → kanoniczny tag.
+  # JOB 4: promote — kopiuje manifest staging → kanoniczny tag.
   # ===================================================================
   # Ma DOCKER_PAT: `imagetools create` PUSHUJE manifest do rejestru, więc
   # wymaga loginu. Oddzielony od skanu — PAT nie jest w środowisku Trivy.
@@ -407,16 +478,16 @@ jobs:
   #   Koszt: 1-2 sek per tag. (Nie potrzebuje cloud drivera — to operacja
   #   na rejestrze; domyślny builder w zupełności wystarcza.)
   #
-  # BRAMKA `if`: buduj kanoniczny tag tylko gdy build OK ORAZ skan zielony
-  # LUB pominięty. scan='skipped' = run_trivy=false (ręczny feature branch)
-  # → promocja tymczasowego tagu może iść od razu. scan='failure'/'cancelled'
-  # (CRITICAL CVE) → promocja się NIE wykona, kanoniczny tag nie powstanie.
+  # BRAMKA `if`: buduj kanoniczny tag tylko gdy build OK ORAZ oba skany zielone
+  # LUB jawnie pominięte. Failure/cancelled któregokolwiek skanu blokuje
+  # kanoniczne tagi; staging SHA pozostaje wyłącznie do diagnostyki.
   promote:
     name: Promote staging → kanoniczny tag
-    needs: [build, scan]
+    needs: [build, dependency_scan, scan]
     if: |
       always()
       && needs.build.result == 'success'
+      && (needs.dependency_scan.result == 'success' || needs.dependency_scan.result == 'skipped')
       && (needs.scan.result == 'success' || needs.scan.result == 'skipped')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -2,8 +2,9 @@ name: Refresh baseline pg_dump
 
 # Regenerates baseline-sql/baseline.sql + baseline.meta.json after
 # any push to dev that touches a migration file. The workflow uses the
-# django_pg_baseline management commands, which spin up an isolated
-# Postgres via testcontainers (iplweb/bpp_dbserver:psql-16.13).
+# canonical Make target, which loads the existing baseline, applies only
+# pending migrations and spins up an isolated Postgres via testcontainers
+# (iplweb/bpp_dbserver:psql-16.13).
 #
 # Manual trigger via the Actions tab is also enabled.
 
@@ -62,10 +63,10 @@ jobs:
       - name: Pre-pull dbserver image
         run: docker pull iplweb/bpp_dbserver:psql-16.13 || true
 
-      - name: Rebuild baseline
-        env:
-          DJANGO_BPP_SKIP_DOTENV: "1"
-        run: uv run python src/manage.py baseline_rebuild
+      - name: Update baseline in place
+        # The Make target also repairs pg_dump's empty search_path. Calling
+        # the management command directly would omit that required post-step.
+        run: make baseline-update
 
       - name: Commit refreshed baseline
         run: |

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -15,11 +15,11 @@ name: Release candidate (kandydat → staging)
 # najwolniejszy shard zamiast całości seryjnie.
 #
 # Kolejność (patrz `needs`/`if` niżej):
-#   prepare → bump RC (commit lokalny) + skan CVE + build&push obrazu +
+#   prepare → bump RC (commit lokalny) + opcjonalny build&push test-runnera +
 #             PUSH gałęzi release/* (od razu, żeby `build` mógł ją checkoutować)
 #   tests   → matrix shard 0..11, pull obrazu, pytest-split (needs: prepare)
-#   build   → obrazy :staging (needs: [prepare, tests], BRAMKA: tylko gdy testy
-#             zielone LUB pominięte)
+#   build   → obrazy :staging + równoległy skan zależności; promocja czeka na
+#             zielone testy, skan zależności i Trivy obrazów
 #
 # UWAGA SEMANTYKA: gałąź release/* jest pushowana w `prepare`, ZANIM testy
 # przejdą — więc nieudany run zostawia ją wypchniętą. To świadomy trade-off za
@@ -53,7 +53,7 @@ permissions:
 
 jobs:
   prepare:
-    name: Zbuduj kandydata (bump RC + scan + push obrazu)
+    name: Zbuduj kandydata (bump RC + opcjonalny obraz testowy)
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
@@ -246,63 +246,6 @@ jobs:
           # wskazywać ten commit, nie github.sha (= dev tip, przed bumpem).
           echo "rc_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Zainstaluj skanery CVE
-        if: ${{ !inputs.skip_scan }}
-        env:
-          # Skanery CVE PRZYPIĘTE do konkretnych wersji + weryfikowane po SHA256.
-          # Wcześniej ten krok pobierał ruchomy `latest` (osv-scanner) i wykony-
-          # wał `curl | sh` z gałęzi `main` (grype, trivy) — czyli URUCHAMIAŁ
-          # NIEPRZYPIĘTY kod z Internetu w jobie z `packages: write` (push obrazu
-          # do GHCR) i `contents: write` (push gałęzi release/*). Klasyczny wektor
-          # supply-chain: ktokolwiek z write-em na tych repo/gałęziach (albo ich
-          # przejęcie) wstrzykuje kod, który leci z sekretami tego joba.
-          #
-          # BUMP: podnieś wersję i wklej SHA256 z pliku *checksums* danego release
-          #   (osv:   osv-scanner_SHA256SUMS → osv-scanner_linux_amd64)
-          #   (grype: grype_<ver>_checksums.txt → grype_<ver>_linux_amd64.tar.gz)
-          #   (trivy: trivy_<ver>_checksums.txt → trivy_<ver>_Linux-64bit.tar.gz)
-          # NIE zgaduj sumy — pobierz realną z assetów release-u, inaczej gate CVE
-          # padnie na `sha256sum -c` i zablokuje całe wydanie.
-          OSV_SCANNER_VERSION: "2.4.0"
-          OSV_SCANNER_SHA256: "15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0"
-          GRYPE_VERSION: "0.115.0"
-          GRYPE_SHA256: "3fad92940650e514c0aa2dad83526942a055e210cec09a8a59d9c024adc2b90e"
-          TRIVY_VERSION: "0.72.0"
-          TRIVY_SHA256: "bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea"
-        run: |
-          set -euo pipefail
-          TMP="$(mktemp -d)"
-          trap 'rm -rf "$TMP"' EXIT
-
-          # --- osv-scanner: przypięty binarny release + weryfikacja SHA256 ---
-          curl -sSL -o "${TMP}/osv-scanner" \
-            "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
-          echo "${OSV_SCANNER_SHA256}  ${TMP}/osv-scanner" | sha256sum -c -
-          install -m 0755 "${TMP}/osv-scanner" /usr/local/bin/osv-scanner
-
-          # --- grype: przypięty tarball + weryfikacja SHA256 (BEZ curl|sh) ---
-          curl -sSL -o "${TMP}/grype.tar.gz" \
-            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
-          echo "${GRYPE_SHA256}  ${TMP}/grype.tar.gz" | sha256sum -c -
-          tar -xzf "${TMP}/grype.tar.gz" -C "${TMP}" grype
-          install -m 0755 "${TMP}/grype" /usr/local/bin/grype
-
-          # --- trivy: przypięty tarball + weryfikacja SHA256 (BEZ curl|sh) ---
-          curl -sSL -o "${TMP}/trivy.tar.gz" \
-            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-          echo "${TRIVY_SHA256}  ${TMP}/trivy.tar.gz" | sha256sum -c -
-          tar -xzf "${TMP}/trivy.tar.gz" -C "${TMP}" trivy
-          install -m 0755 "${TMP}/trivy" /usr/local/bin/trivy
-
-          # Smoke-check: binarki są na PATH (scan-deps.sh woła je przez command -v).
-          osv-scanner --version
-          grype version
-          trivy --version
-
-      - name: Skan CVE (bramka)
-        if: ${{ !inputs.skip_scan }}
-        run: ./bin/scan-deps.sh
-
       # --- Build & push obrazu test-runner do GHCR (dla sharded `tests`) ---
       # Wcześniej `prepare` budował obraz lokalnie (`docker compose build`) i
       # sam odpalał całą suitę. Teraz obraz idzie do rejestru, żeby 12 runnerów
@@ -337,7 +280,9 @@ jobs:
           context: .
           file: docker/bpp_base/Dockerfile
           target: test-runner
-          push: true
+          # Zstd zmniejsza transfer obrazu pullowanego rownolegle przez 12
+          # shardow. `outputs: type=registry` jest odpowiednikiem push=true.
+          outputs: type=registry,compression=zstd,compression-level=3,force-compression=true
           tags: |
             ${{ steps.tag.outputs.image }}
           build-args: |
@@ -353,7 +298,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.IMAGE_REPO }}:cache,mode=max
 
       - name: Push gałęzi wydania
-        # Bez `if:` → biegnie gdy poprzednie kroki OK (bump + scan + build).
+        # Bez `if:` → biegnie gdy poprzednie kroki OK (bump + opcjonalny build).
         # Pushujemy TU (przed testami), bo job `build` checkoutuje release_ref;
         # bramka „tylko na zielonych testach" jest na `build` (needs: tests),
         # nie na samym istnieniu gałęzi. Patrz nota SEMANTYKA na górze pliku.
@@ -509,5 +454,6 @@ jobs:
       version_tag: ${{ needs.prepare.outputs.version_tag }}
       channel: staging
       run_trivy: ${{ !inputs.skip_scan }}
+      run_dependency_scan: ${{ !inputs.skip_scan }}
     secrets:
       DOCKER_PAT: ${{ secrets.DOCKER_PAT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -255,7 +255,9 @@ jobs:
         context: .
         file: docker/bpp_base/Dockerfile
         target: test-runner
-        push: true
+        # Zstd zmniejsza transfer obrazu pullowanego rownolegle przez 12
+        # shardow. `outputs: type=registry` jest odpowiednikiem push=true.
+        outputs: type=registry,compression=zstd,compression-level=3,force-compression=true
         # Two tags: immutable sha-pinned (consumed by tests jobs) and
         # the registry-cache helper used to seed `cache-from` next time.
         tags: |

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -58,7 +58,9 @@ services:
     build:
       context: .
       dockerfile: docker/bpp_base/Dockerfile
-      target: test-runner
+      # Local bind-mount needs Node/Yarn so conftest.py can rebuild changed
+      # assets. CI pulls the slimmer `test-runner` target instead.
+      target: test-runner-local
       args:
         PYTHON_VERSION: ${PYTHON_VERSION:-3.12}
         DEBIAN_VERSION: ${DEBIAN_VERSION:-trixie}

--- a/docker/bpp_base/Dockerfile
+++ b/docker/bpp_base/Dockerfile
@@ -224,12 +224,12 @@ RUN find /app/.venv -type d -name __pycache__ -exec rm -rf {} + \
 ##############################################################################
 # TEST-RUNNER: test environment (source mounted at runtime via volume)
 ##############################################################################
-# TEST-VENV-BUILDER: kompiluje testowy venv (--all-extras --all-groups) i
-# pobiera przegladarki Playwright NA PELNYM python:trixie (z toolchainem),
-# bo wheelsy z C-rozszerzeniami wymagajacymi kompilacji ze zrodel
+# TEST-VENV-BUILDER: kompiluje testowy venv (--all-extras --all-groups) NA
+# PELNYM python:trixie (z toolchainem), bo wheelsy z C-rozszerzeniami
+# wymagajacymi kompilacji ze zrodel
 # (python-ldap z extras `ldap`) potrzebuja gcc + naglowkow z build.txt.
-# Artefakty (/opt/venv, /opt/playwright) sa COPY-owane do slim test-runnera
-# nizej — to wzorzec identyczny jak produkcyjny stage `runtime`, dzieki
+# Venv i browser sa COPY-owane z osobnych stage'y do slim test-runnera nizej —
+# to wzorzec identyczny jak produkcyjny stage `runtime`, dzieki
 # ktoremu ~1.1 GB toolchainu (buildpack python:trixie + build.txt) NIE laduje
 # w obrazie testowym.
 FROM base AS test-venv-builder
@@ -242,82 +242,24 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache \
     uv sync --frozen --all-extras \
         --all-groups --no-install-project --no-editable
 
-# Przegladarki Playwright raz, do /opt/playwright (kopiowane do slim nizej).
+# Browser i assety sa osobnymi galeziami od venv-buildera, zeby BuildKit mogl
+# pobierac Playwrighta i kompilowac frontend rownolegle.
+FROM test-venv-builder AS test-browser-builder
+
+# Playwright w CI zawsze dziala headless. `--only-shell` nie pobiera pelnego
+# Chromium (~setki MB), tylko Chromium Headless Shell uzywany przez pytest.
 RUN PLAYWRIGHT_BROWSERS_PATH=/opt/playwright \
-    /opt/venv/bin/playwright install chromium chromium-headless-shell
+    /opt/venv/bin/playwright install --only-shell chromium
 
 
 ##############################################################################
-# TEST-RUNNER: srodowisko testowe NA python:slim. Skompilowany venv +
-# przegladarki przychodza gotowe z `test-venv-builder` (COPY --from), wiec slim
-# nie potrzebuje toolchainu. Tnie to obraz o ~1.1 GB build-only deps (buildpack
-# pelnego python:trixie: gcc/g++/dpkg-dev/autoconf + git/mercurial/svn, plus
-# nasz build.txt), ktore byly martwym balastem w obrazie testowym. Wzorzec
-# identyczny jak produkcyjny stage `runtime` (compiled venv na slim + runtime
-# liby). Slim NIE dziedziczy z `base`, wiec ENV/uv/node trzeba odtworzyc.
+# TEST-ASSETS-BUILDER: kompiluje CSS/JS poza finalnym obrazem test-runner.
+# Dziedziczy Node z `base` i venv z `test-venv-builder`, bo Gruntfile tworzy
+# symlink do site-packages dla bundle-entry.js. Do finalnego obrazu kopiujemy
+# tylko gotowe pliki z /src/src — bez Node, Yarn, Grunta i node_modules.
 ##############################################################################
-ARG PYTHON_VERSION
-ARG DEBIAN_VERSION
-FROM python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION} AS test-runner
+FROM test-venv-builder AS test-assets-builder
 
-ARG NODEJS_VERSION
-
-ENV DEBIAN_FRONTEND=noninteractive
-# MALLOC_ARENA_MAX: patrz komentarz w stage `base` (slim nie dziedziczy).
-ENV MALLOC_ARENA_MAX=2
-ENV UV_COMPILE_BYTECODE=1 \
-    UV_LINK_MODE=copy \
-    UV_PROJECT_ENVIRONMENT=/opt/venv \
-    PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
-ENV PATH="/opt/venv/bin:${PATH}"
-
-# uv potrzebne w runtime — CI wola `uv run pytest` (jak na pelnym obrazie).
-COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
-
-RUN sed -i s/http/https/g /etc/apt/sources.list.d/debian.sources
-
-# Runtime liby wspoldzielone, ktorych potrzebuja skompilowane wheelsy +
-# narzedzia. runtime.txt: pango/cairo (weasyprint), libpq, gmp/lua (pandoc).
-# test.txt: make, redis-tools. Dodatkowo wzgledem `base`/produkcji:
-#  - libldap2/libsasl2-2: python-ldap (z extras `ldap`) linkuje sie z nimi;
-#    na pelnym trixie dawal je libldap2-dev/libsasl2-dev (build.txt), tu nie ma,
-#  - ca-certificates/curl/gnupg: repo NodeSource,
-#  - git: `yarn install` ma zaleznosci po URL-u git (pelny trixie mial git
-#    w buildpacku; slim nie ma) — bez tego `yarn install` pada.
-# UWAGA: `gettext` (msgfmt) NIE jest tu potrzebny — projektowy override
-# `compilemessages` (src/bpp/management/commands/) kompiluje .po→.mo Babelem
-# w czystym Pythonie. xgettext/makemessages to operacja dev-only, nieobecna
-# w buildzie/CI.
-COPY docker/bpp_base/runtime.txt docker/bpp_base/test.txt /tmp/packages/
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=apt-lists \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg git libldap2 libsasl2-2 && \
-    cat /tmp/packages/*.txt | xargs apt-get install -y
-
-# Node (grunt build + yarn install dla `make assets`) + yarn/grunt globalnie.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=apt-lists \
-    curl -fsSL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash - && \
-    apt-get install -y nodejs && \
-    npm install -g --force yarn grunt-cli
-
-# Skompilowany venv + przegladarki z buildera (bez toolchainu).
-COPY --from=test-venv-builder /opt/venv /opt/venv
-COPY --from=test-venv-builder /opt/playwright /opt/playwright
-
-# Playwright system deps. Na slim — w odroznieniu od pelnego trixie — tych
-# bibliotek nie ma, wiec instalacja jest konieczna (uzywamy playwrighta z venv).
-RUN /opt/venv/bin/playwright install-deps chromium
-
-# Pandoc z oficjalnego obrazu (patrz komentarz R7 przy runtime stage).
-# libgmp10/liblua5.4-0 juz sa w runtime.txt instalowanym wyzej.
-COPY --from=pandoc-src /usr/local/bin/pandoc /usr/local/bin/pandoc
-
-# Yarn deps + grunt CLI (needed for `make assets`). Mirrors the
-# testserver stage so CI gets a pre-built test-runner image with the
-# same toolchain available offline.
 WORKDIR /src
 COPY package.json yarn.lock Gruntfile.js ./
 RUN --mount=type=cache,target=/root/.npm,id=npm-cache \
@@ -325,28 +267,14 @@ RUN --mount=type=cache,target=/root/.npm,id=npm-cache \
     npx yarn install --dev --ignore-optional && \
     npx yarn add grunt
 
-# Snapshot the source tree and bake the frontend assets + .mo
-# translations into the image. CI consumes this through the
-# docker-compose.test.ci.yml override (no bind mount), so each test
-# job pulls a ready-to-run image instead of running `make assets`
-# (~1 min × N jobs) on every invocation. Local dev keeps the bind
-# mount and rebuilds assets on demand.
-#
-# Asset-source COPYs PRZED `grunt build` — dokladnie jak w stage `builder`
-# (patrz komentarz tam) — zeby warstwa grunta (~60s) byla CACHE-HIT, gdy
-# zmienil sie TYLKO kod Pythona, a nie scss/js. Wczesniej test-runner robil
-# `COPY src/` (cale drzewo) przed gruntem, wiec grunt przebudowywal sie na
-# KAZDYM commicie (a wiec i prepare-image gejtujacy wszystkie shardy). Teraz
-# grunt odpala sie tylko gdy faktycznie ruszysz scss/js. Gruntfile.js juz jest
-# w /src (skopiowany z package.json/yarn.lock wyzej). Dodajac nowy task
-# SCSS/JS do Gruntfile.js — dopisz tu COPY (jak w builderze). Pominiecie
-# zrodla taska esbuild = "Could not resolve <entry>" i grunt build pada.
+# Asset-source COPYs przed Gruntem utrzymuja cache-hit, gdy zmienia sie tylko
+# Python. Dodajac nowy task SCSS/JS do Gruntfile.js, dopisz jego zrodla tutaj.
 # Theme and admin SCSS
 COPY src/bpp/static/scss/ src/bpp/static/scss/
 COPY src/bpp/static/bpp/scss/ src/bpp/static/bpp/scss/
 # JS for esbuild bundle
 COPY src/bpp/static/bpp/js/ src/bpp/static/bpp/js/
-# JS for esbuild bundle eksploratora powiązań (cytoscape-entry + moduły ES)
+# JS for esbuild bundle eksploratora powiazan (cytoscape-entry + moduly ES)
 COPY src/powiazania_autorow/static/powiazania_autorow/js/ \
      src/powiazania_autorow/static/powiazania_autorow/js/
 # App-specific SCSS (keep alphabetical, mirror `builder`)
@@ -379,16 +307,96 @@ COPY src/przemapuj_zrodla_pbn/static/przemapuj_zrodla_pbn/scss/ \
 
 RUN npx grunt build-non-interactive
 
-# Reszta zrodla PO gruncie: zmiany w kodzie Pythona nie unieważniaja warstwy
-# grunta powyzej. Skompilowane assety (gitignored, nieobecne w kontekscie
-# build) przezyja ten COPY — COPY nie kasuje plikow, ktorych nie ma w zrodle.
+
+##############################################################################
+# TEST-RUNNER: srodowisko testowe NA python:slim. Skompilowany venv +
+# przegladarki przychodza gotowe z `test-venv-builder` (COPY --from), wiec slim
+# nie potrzebuje toolchainu. Tnie to obraz o ~1.1 GB build-only deps (buildpack
+# pelnego python:trixie: gcc/g++/dpkg-dev/autoconf + git/mercurial/svn, plus
+# nasz build.txt), ktore byly martwym balastem w obrazie testowym. Wzorzec
+# identyczny jak produkcyjny stage `runtime` (compiled venv na slim + runtime
+# liby). Slim NIE dziedziczy z `base`, wiec ENV i uv trzeba odtworzyc.
+##############################################################################
+ARG PYTHON_VERSION
+ARG DEBIAN_VERSION
+FROM python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION} AS test-runner
+
+ENV DEBIAN_FRONTEND=noninteractive
+# MALLOC_ARENA_MAX: patrz komentarz w stage `base` (slim nie dziedziczy).
+ENV MALLOC_ARENA_MAX=2
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/opt/venv \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# uv potrzebne w runtime — CI wola `uv run pytest` (jak na pelnym obrazie).
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
+
+RUN sed -i s/http/https/g /etc/apt/sources.list.d/debian.sources
+
+# Runtime liby wspoldzielone, ktorych potrzebuja skompilowane wheelsy +
+# narzedzia. runtime.txt: pango/cairo (weasyprint), libpq, gmp/lua (pandoc).
+# test.txt: make, redis-tools. Dodatkowo wzgledem `base`/produkcji:
+#  - libldap2/libsasl2-2: python-ldap (z extras `ldap`) linkuje sie z nimi;
+#    na pelnym trixie dawal je libldap2-dev/libsasl2-dev (build.txt), tu nie ma,
+#  - git: test_no_deklinacja uruchamia `git grep`.
+# UWAGA: `gettext` (msgfmt) NIE jest tu potrzebny — projektowy override
+# `compilemessages` (src/bpp/management/commands/) kompiluje .po→.mo Babelem
+# w czystym Pythonie. xgettext/makemessages to operacja dev-only, nieobecna
+# w buildzie/CI.
+COPY docker/bpp_base/runtime.txt docker/bpp_base/test.txt /tmp/packages/
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=apt-lists \
+    apt-get update && \
+    apt-get install -y --no-install-recommends git libldap2 libsasl2-2 && \
+    cat /tmp/packages/*.txt | xargs apt-get install -y
+
+# Skompilowany venv + przegladarki z buildera (bez toolchainu).
+COPY --from=test-venv-builder /opt/venv /opt/venv
+COPY --from=test-browser-builder /opt/playwright /opt/playwright
+
+# Playwright system deps. Na slim — w odroznieniu od pelnego trixie — tych
+# bibliotek nie ma, wiec instalacja jest konieczna (uzywamy playwrighta z venv).
+RUN /opt/venv/bin/playwright install-deps chromium
+
+# Pandoc z oficjalnego obrazu (patrz komentarz R7 przy runtime stage).
+# libgmp10/liblua5.4-0 juz sa w runtime.txt instalowanym wyzej.
+COPY --from=pandoc-src /usr/local/bin/pandoc /usr/local/bin/pandoc
+
+WORKDIR /src
+# Pelne zrodlo oraz gotowe CSS/JS z osobnego buildera. Drugi COPY nadpisuje
+# tylko poddrzewa assetow i dodaje gitignored wyniki Grunta.
 COPY src/ /src/src/
+COPY --from=test-assets-builder /src/src/ /src/src/
 COPY baseline-sql/ /src/baseline-sql/
 COPY conftest.py pytest.ini Makefile pyproject.toml uv.lock /src/
+COPY docker/bpp_base/Dockerfile /src/docker/bpp_base/Dockerfile
 COPY .github/workflows/build-docker-images.yml \
-     /src/.github/workflows/build-docker-images.yml
+     .github/workflows/refresh-baseline.yml \
+     .github/workflows/release-candidate.yml \
+     .github/workflows/tests.yml \
+     /src/.github/workflows/
 
 RUN /opt/venv/bin/python src/manage.py compilemessages -v0 -l pl --traceback
+
+
+##############################################################################
+# TEST-RUNNER-LOCAL: narzedzia frontendowe tylko dla lokalnego bind-mounta.
+# CI targetuje `test-runner` powyzej. Lokalny docker-compose montuje repo na
+# /src i pozwala conftest.py wykonac `make assets`, wiec potrzebuje Node/Yarn.
+##############################################################################
+FROM test-runner AS test-runner-local
+
+ARG NODEJS_VERSION
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=apt-lists \
+    apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates gnupg && \
+    curl -fsSL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g --force yarn grunt-cli
 
 ##############################################################################
 # TESTSERVER: lokalny obraz developerski (NIE jest publikowany do registry)

--- a/src/bpp/newsfragments/ci-workflows-speed.feature.rst
+++ b/src/bpp/newsfragments/ci-workflows-speed.feature.rst
@@ -1,0 +1,3 @@
+Przyspieszono workflowy GitHub Actions przez odchudzenie obrazu testowego,
+równoległe skanowanie zależności i aktualizowanie baseline bez pełnego
+odtwarzania migracji.

--- a/src/django_bpp/tests/test_docker_workflow.py
+++ b/src/django_bpp/tests/test_docker_workflow.py
@@ -8,6 +8,24 @@ WORKFLOW_PATH = (
     / "workflows"
     / "build-docker-images.yml"
 )
+REFRESH_BASELINE_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[3]
+    / ".github"
+    / "workflows"
+    / "refresh-baseline.yml"
+)
+TESTS_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "tests.yml"
+)
+RELEASE_CANDIDATE_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[3]
+    / ".github"
+    / "workflows"
+    / "release-candidate.yml"
+)
+DOCKERFILE_PATH = (
+    Path(__file__).resolve().parents[3] / "docker" / "bpp_base" / "Dockerfile"
+)
 
 
 def test_docker_workflow_uruchamia_sie_tylko_jawnie():
@@ -27,6 +45,48 @@ def test_docker_workflow_nie_ma_pustego_jobu_guard():
     jobs = workflow.split("\njobs:\n", maxsplit=1)[1]
 
     assert "\n  build:\n" in jobs
+    assert "\n  dependency_scan:\n" in jobs
     assert "\n  scan:\n" in jobs
     assert "\n  promote:\n" in jobs
     assert "\n  check-flag:" not in jobs
+
+
+def test_docker_workflow_promocja_czeka_na_oba_skany():
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    promote = workflow.split("\n  promote:\n", maxsplit=1)[1]
+
+    assert "needs: [build, dependency_scan, scan]" in promote
+    assert "needs.dependency_scan.result == 'success'" in promote
+    assert "needs.scan.result == 'success'" in promote
+
+
+def test_release_candidate_wlacza_oba_skany_w_reusable_workflow():
+    workflow = RELEASE_CANDIDATE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "run_trivy: ${{ !inputs.skip_scan }}" in workflow
+    assert "run_dependency_scan: ${{ !inputs.skip_scan }}" in workflow
+
+
+def test_refresh_baseline_uzywa_kanonicznego_targetu_make():
+    workflow = REFRESH_BASELINE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "run: make baseline-update" in workflow
+    assert "run: uv run python src/manage.py baseline_rebuild" not in workflow
+
+
+def test_ci_test_runner_nie_zawiera_node_ani_pelnego_chromium():
+    dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
+    test_runner = dockerfile.split(" AS test-runner\n", maxsplit=1)[1].split(
+        " AS test-runner-local\n", maxsplit=1
+    )[0]
+
+    assert "playwright install --only-shell chromium" in dockerfile
+    assert "node_modules" not in test_runner
+    assert "npm install" not in test_runner
+    assert "apt-get install -y nodejs" not in test_runner
+
+
+def test_ci_test_runner_jest_pushowany_z_kompresja_zstd():
+    workflow = TESTS_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "type=registry,compression=zstd,compression-level=3" in workflow


### PR DESCRIPTION
## Co się zmienia

- odświeżanie baseline korzysta z `make baseline-update`, razem z wymaganym post-processingiem `search_path`
- obraz `test-runner` używany w CI jest odchudzony: nie zawiera Node/Yarn/Grunt ani pełnego Chromium; assety powstają w osobnym etapie, a Playwright instaluje tylko Chromium headless shell
- lokalny `test-runner-local` zachowuje narzędzia frontendowe potrzebne przy bind-mountach
- obrazy testowe są wypychane z kompresją zstd
- skan zależności release candidate biegnie równolegle z budowaniem oficjalnych obrazów; promocja nadal czeka na oba skany
- dodane są testy kontraktowe workflowów i Dockerfile

## Dlaczego

Celem jest skrócenie czasu przygotowania obrazu testowego i ścieżki release candidate bez osłabiania gejtów bezpieczeństwa ani zmiany akceptowalnego, około pięciominutowego czasu samych testów.

## Weryfikacja lokalna

- `pre-commit`
- `actionlint` i `zizmor` dla zmienionych workflowów
- 7 testów kontraktowych workflowów
- rzeczywisty build `test-runner` i sprawdzenie jego zawartości
- test Playwright globalnego wyszukiwania w nowym obrazie
- build i kontrola `test-runner-local`
- walidacja `docker compose config` oraz `docker buildx bake --print`

## Poza zakresem

Oficjalne obrazy nadal budują się z `no-cache`; ten punkt pozostaje bez zmian zgodnie z ustaleniem.