### PR TITLE
perf(docker): cache unchanged image layers

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -151,9 +151,11 @@ jobs:
           # przy workflow_call budujemy dokładnie gałąź wydania.
           ref: ${{ inputs.ref }}
 
-      - name: Resolve checked-out commit
+      - name: Resolve build inputs
         id: source
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "cache_epoch=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
 
       - name: Compute Docker tags (staging + final)
         id: tag
@@ -213,6 +215,7 @@ jobs:
       - name: Build and push to staging tag
         env:
           GIT_SHA: ${{ steps.source.outputs.sha }}
+          BUILD_CACHE_EPOCH: ${{ steps.source.outputs.cache_epoch }}
           DOCKER_VERSION: ${{ steps.tag.outputs.staging_tag }}
           TAG_LATEST: "false"
           PUSH: "true"
@@ -237,6 +240,7 @@ jobs:
             beatserver authserver denorm-queue \
             --file docker-bake.hcl \
             --set "base.args.GIT_SHA=${GIT_SHA}" \
+            --set "base.args.BUILD_CACHE_EPOCH=${BUILD_CACHE_EPOCH}" \
             --set "base.args.BPP_BUILD_FLAVOR=${BPP_BUILD_FLAVOR}" \
             --set "base.args.BPP_IMAGE_TAG=${BPP_IMAGE_TAG}" \
             --set '*.platform=linux/amd64' \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -28,6 +28,13 @@ variable "GIT_SHA" {
   default = "unknown"
 }
 
+# Kontrolowany salt cache dla pakietów systemowych i zależności. Oficjalny
+# workflow ustawia tydzień ISO, więc cache pozostaje szybki między buildami,
+# ale co najmniej raz w tygodniu pobieramy świeże pakiety z repozytoriów.
+variable "BUILD_CACHE_EPOCH" {
+  default = "manual"
+}
+
 # Rozróżnienie release vs developer build. Master release -> "release"
 # (stopka pokazuje tylko numer wersji); PR/feature/lokalne -> "dev"
 # (stopka dokleja `(<image_tag>, commit XXXXXXX)` po wersji, dla łatwego
@@ -87,10 +94,11 @@ target "base" {
   dockerfile = "docker/bpp_base/Dockerfile"
   context    = "."
   args = {
-    GIT_SHA          = GIT_SHA
-    BPP_BUILD_FLAVOR = BPP_BUILD_FLAVOR
-    BPP_IMAGE_TAG    = BPP_IMAGE_TAG
-    BPP_BRANCH_TAG   = BPP_BRANCH_TAG
+    GIT_SHA           = GIT_SHA
+    BUILD_CACHE_EPOCH = BUILD_CACHE_EPOCH
+    BPP_BUILD_FLAVOR  = BPP_BUILD_FLAVOR
+    BPP_IMAGE_TAG     = BPP_IMAGE_TAG
+    BPP_BRANCH_TAG    = BPP_BRANCH_TAG
   }
   tags = TAG_LATEST == "true" ? [
     "iplweb/bpp_base:${DOCKER_VERSION}",
@@ -98,12 +106,8 @@ target "base" {
   ] : [
     "iplweb/bpp_base:${DOCKER_VERSION}"
   ]
-  # Always rebuild base from scratch — Docker Build Cloud's layer cache has
-  # produced stale bpp_base images (missing files added in fresh COPY lines).
-  # Package downloads remain fast thanks to cache mounts inside
-  # docker/bpp_base/Dockerfile (apt-cache, apt-lists, uv-cache, npm-cache,
-  # yarn-cache) which persist across --no-cache builds.
-  no-cache  = true
+  # Cache jest celowo włączony. GIT_SHA unieważnia snapshot kodu na każdy
+  # commit, a BUILD_CACHE_EPOCH okresowo odświeża wcześniejsze warstwy pakietów.
   platforms = [PLATFORM]
   output    = PUSH ? ["type=registry,compression=${COMPRESSION},compression-level=${COMPRESSION_LEVEL},force-compression=true"] : ["type=docker"]
 }

--- a/docker/bpp_base/Dockerfile
+++ b/docker/bpp_base/Dockerfile
@@ -372,7 +372,7 @@ WORKDIR /src
 COPY src/ /src/src/
 COPY --from=test-assets-builder /src/src/ /src/src/
 COPY baseline-sql/ /src/baseline-sql/
-COPY conftest.py pytest.ini Makefile pyproject.toml uv.lock /src/
+COPY conftest.py pytest.ini Makefile pyproject.toml uv.lock docker-bake.hcl /src/
 COPY docker/bpp_base/Dockerfile /src/docker/bpp_base/Dockerfile
 COPY .github/workflows/build-docker-images.yml \
      .github/workflows/refresh-baseline.yml \

--- a/docker/bpp_base/Dockerfile
+++ b/docker/bpp_base/Dockerfile
@@ -22,6 +22,7 @@ FROM pandoc/core:${PANDOC_VERSION}-ubuntu AS pandoc-src
 FROM python:${PYTHON_VERSION}-${DEBIAN_VERSION} AS base
 
 ARG NODEJS_VERSION
+ARG BUILD_CACHE_EPOCH=manual
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -40,7 +41,8 @@ COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
 
-RUN sed -i s/http/https/g /etc/apt/sources.list.d/debian.sources
+RUN echo "Dependency cache epoch: ${BUILD_CACHE_EPOCH}" && \
+    sed -i s/http/https/g /etc/apt/sources.list.d/debian.sources
 
 COPY docker/bpp_base/build.txt /tmp/
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache \
@@ -498,19 +500,10 @@ ARG PYTHON_VERSION
 ARG DEBIAN_VERSION
 FROM python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION} AS runtime
 
-# Bake'a przekazuje GIT_SHA z `--set "base.args.GIT_SHA=..."`. Nadpisanie
-# możliwe dla lokalnych buildów; default `unknown` zostaje, kiedy nikt nie
-# poda wartości. BPP_BUILD_FLAVOR rozróżnia release (master) od dev (PR/feature)
-# — pokazujemy SHA w stopce tylko poza release-em. BPP_IMAGE_TAG to kanoniczny
-# tag obrazu (np. "119-merge"), który workflow promuje po skanie Trivy.
-ARG GIT_SHA=unknown
-ARG BPP_BUILD_FLAVOR=dev
-ARG BPP_IMAGE_TAG=unknown
-# Opcjonalny alias nazwy brancha dla starszych obrazów PR lub buildów lokalnych.
-# Bieżący workflow CI pozostawia go pusty.
-ARG BPP_BRANCH_TAG=
+ARG BUILD_CACHE_EPOCH=manual
 
-RUN sed -i s/http/https/g /etc/apt/sources.list.d/debian.sources
+RUN echo "Dependency cache epoch: ${BUILD_CACHE_EPOCH}" && \
+    sed -i s/http/https/g /etc/apt/sources.list.d/debian.sources
 
 COPY docker/bpp_base/runtime.txt /tmp/
 
@@ -533,6 +526,17 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache \
 # oszczednosci + stabilna warstwa cache, niezalezna od rebuildow bpp).
 # Binary linkuje dynamicznie do libgmp10, liblua5.4-0 (w runtime.txt).
 COPY --from=pandoc-src /usr/local/bin/pandoc /usr/local/bin/pandoc
+
+# Argumenty metadanych są celowo deklarowane PO instalacji pakietów. Zmieniają
+# się w każdym buildzie i nie powinny unieważniać cache warstw APT powyżej.
+# Bake przekazuje GIT_SHA z `--set "base.args.GIT_SHA=..."`. BPP_BUILD_FLAVOR
+# rozróżnia release od dev/staging, a BPP_IMAGE_TAG to promowany tag obrazu.
+ARG GIT_SHA=unknown
+ARG BPP_BUILD_FLAVOR=dev
+ARG BPP_IMAGE_TAG=unknown
+# Opcjonalny alias nazwy brancha dla starszych obrazów PR lub buildów lokalnych.
+# Bieżący workflow CI pozostawia go pusty.
+ARG BPP_BRANCH_TAG=
 
 # Uwaga: wcześniej PATH wskazywał na /.venv/bin, a venv jest pod
 # /app/.venv — działało to tylko dlatego, że wszystkie komendy w

--- a/src/bpp/newsfragments/docker-build-cache.feature.rst
+++ b/src/bpp/newsfragments/docker-build-cache.feature.rst
@@ -1,0 +1,2 @@
+Oficjalne obrazy Docker wykorzystują cache niezmienionych warstw zależności,
+odświeżany co tydzień, co skraca kolejne buildy bez utrwalania starych pakietów.

--- a/src/django_bpp/tests/test_docker_workflow.py
+++ b/src/django_bpp/tests/test_docker_workflow.py
@@ -96,6 +96,8 @@ def test_ci_test_runner_jest_pushowany_z_kompresja_zstd():
 def test_oficjalny_build_uzywa_kontrolowanego_cache_warstw():
     workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
     dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
+    assert "uv.lock docker-bake.hcl /src/" in dockerfile
+
     bake = BAKE_PATH.read_text(encoding="utf-8")
     base_target = bake.split('target "base" {', maxsplit=1)[1].split(
         'target "appserver" {', maxsplit=1

--- a/src/django_bpp/tests/test_docker_workflow.py
+++ b/src/django_bpp/tests/test_docker_workflow.py
@@ -26,6 +26,7 @@ RELEASE_CANDIDATE_WORKFLOW_PATH = (
 DOCKERFILE_PATH = (
     Path(__file__).resolve().parents[3] / "docker" / "bpp_base" / "Dockerfile"
 )
+BAKE_PATH = Path(__file__).resolve().parents[3] / "docker-bake.hcl"
 
 
 def test_docker_workflow_uruchamia_sie_tylko_jawnie():
@@ -90,3 +91,40 @@ def test_ci_test_runner_jest_pushowany_z_kompresja_zstd():
     workflow = TESTS_WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert "type=registry,compression=zstd,compression-level=3" in workflow
+
+
+def test_oficjalny_build_uzywa_kontrolowanego_cache_warstw():
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
+    bake = BAKE_PATH.read_text(encoding="utf-8")
+    base_target = bake.split('target "base" {', maxsplit=1)[1].split(
+        'target "appserver" {', maxsplit=1
+    )[0]
+
+    assert "no-cache" not in base_target
+    assert "BUILD_CACHE_EPOCH = BUILD_CACHE_EPOCH" in base_target
+    assert "cache_epoch=$(date -u +%G-%V)" in workflow
+    assert "BUILD_CACHE_EPOCH: ${{ steps.source.outputs.cache_epoch }}" in workflow
+    assert '--set "base.args.BUILD_CACHE_EPOCH=${BUILD_CACHE_EPOCH}"' in workflow
+
+    base_stage = dockerfile.split(" AS base\n", maxsplit=1)[1].split(
+        " AS builder\n", maxsplit=1
+    )[0]
+    runtime_stage = dockerfile.split(" AS runtime\n", maxsplit=1)[1]
+    for stage in (base_stage, runtime_stage):
+        assert "ARG BUILD_CACHE_EPOCH=manual" in stage
+        assert "Dependency cache epoch: ${BUILD_CACHE_EPOCH}" in stage
+
+    assert runtime_stage.index("ARG BUILD_CACHE_EPOCH=manual") < (
+        runtime_stage.index("apt-get update")
+    )
+    assert runtime_stage.index("apt-get update") < runtime_stage.index(
+        "ARG GIT_SHA=unknown"
+    )
+
+    builder_stage = dockerfile.split(" AS builder\n", maxsplit=1)[1].split(
+        " AS test-venv-builder\n", maxsplit=1
+    )[0]
+    assert builder_stage.index("\nARG GIT_SHA=unknown\n") < builder_stage.index(
+        "\nCOPY . .\n"
+    )


### PR DESCRIPTION
## Co się zmienia

- oficjalny build `bpp_base` przestaje wymuszać globalne `no-cache`;
- ciężkie, niezmienione warstwy APT, uv, Yarn i Grunt mogą korzystać z cache Docker Build Cloud;
- workflow przekazuje tygodniowy `BUILD_CACHE_EPOCH`, więc pakiety systemowe są okresowo odświeżane;
- argumenty metadanych obrazu są deklarowane po instalacji pakietów runtime, aby nowy SHA nie unieważniał cache APT;
- `GIT_SHA` nadal znajduje się bezpośrednio przed pełnym `COPY . .`, więc kod aplikacji jest przebudowywany dla każdego commitu;
- dodano test kontraktowy i newsfragment.

## Dlaczego

Target `base` miał `no-cache = true` jako obejście historycznego przypadku starego obrazu po rebase. W obecnym Dockerfile snapshot kodu ma już jawny cache-buster oparty o SHA, a zależności mają precyzyjne wejścia w postaci lockfile'ów i źródeł assetów.

W ostatnim zmierzonym RC krok build/push trwał 2 min 53 s. Globalne `no-cache` ponownie wykonywało m.in. APT + Node (27,4 s), `uv sync` (27,7 s), Yarn (22,4 s) i Grunt (29,2 s), nawet gdy ich wejścia się nie zmieniły.

## Pomiar Docker Build Cloud

- historyczny build z globalnym `no-cache`: krok build/push **173 s**;
- pierwszy build po zmianie schematu cache: krok build/push **174 s**, cały job **3 min 3 s**;
- ponowienie tego samego SHA z ciepłym cache: krok build/push **13 s**, cały job **24 s**;
- redukcja czasu samego kroku build/push w ciepłym wariancie: **92,5%**.

Pierwszy przebieg potwierdza brak regresji dla zimnego cache. Drugi jest najlepszym przypadkiem — identyczny SHA. Zwykły nowy commit przebuduje snapshot kodu i warstwy po nim, więc nie należy oczekiwać 13 s za każdym razem; kosztowne warstwy APT, uv, Yarn i Grunt pozostaną jednak w cache, o ile nie zmienią się ich wejścia albo tygodniowy epoch.

Przebiegi:
- zimny: https://github.com/iplweb/bpp/actions/runs/30128884453
- ciepły: https://github.com/iplweb/bpp/actions/runs/30129101110

## Bezpieczeństwo cache

- kod aplikacji: cache-bust per `GIT_SHA`;
- zależności: invalidacja po zmianie Dockerfile, lockfile'ów lub źródeł assetów;
- pakiety repozytoriów: wymuszona invalidacja raz na tydzień ISO;
- ręczny pełny rebuild nadal jest dostępny przez `make build-force`.

## Weryfikacja

- `uv run pytest src/django_bpp/tests/test_docker_workflow.py -q` — 8 passed;
- Ruff check i format — passed;
- `docker buildx bake ... --print` — epoch obecny, brak `no-cache`;
- BuildKit `--check` dla `bpp_base` — bez ostrzeżeń;
- pełny `pre-commit` — passed;
- oba pełne buildy Docker Build Cloud zakończyły się sukcesem dla sześciu obrazów;
- opublikowany `iplweb/bpp_base:sha-2b28a04` zawiera pełne SHA `2b28a041b90770b07a352d83175b609c003a0b9e`.
