### PR TITLE
feat(kompletnosc_polon): raport kompletności danych wg rozporządzenia POL-on 2026 (FD#437)

### DIFF
--- a/docs/superpowers/specs/2026-07-25-raport-kompletnosci-polon-2026-design.md
+++ b/docs/superpowers/specs/2026-07-25-raport-kompletnosci-polon-2026-design.md
@@ -222,7 +222,6 @@ src/kompletnosc_polon/
 ├── const.py                # Osiagniecie, Waga
 ├── reguly.py               # REGULY: tuple[Regula, ...] + pomocnicze selektory
 ├── selektory.py            # budowa querysetów per typ osiągnięcia
-├── uczelnia_scope.py       # scope_kompletnosc(qs, uczelnia)
 ├── urls.py                 # app_name = "kompletnosc_polon"
 ├── views/
 │   ├── __init__.py         # re-eksport + __all__
@@ -255,8 +254,15 @@ autora. Zawężenie do uczelni przez `uczelnia_dla_odczytu(request)`
 ## Przepływ danych
 
 1. Widok ustala okno (`OKNO_EWALUACJI`) i uczelnię (`uczelnia_dla_odczytu`).
-2. `selektory.py` buduje trzy querysety through-modeli, zawężone do: roku
-   w oknie, przypiętej dyscypliny, autora afiliowanego do jednostki tej uczelni.
+2. `selektory.py` buduje querysety through-modeli, zawężone do: roku w oknie,
+   powiązania **przypiętego** (`przypieta=True`) oraz autora afiliowanego do
+   jednostki tej uczelni (przez `scope_autorzy_do_uczelni`).
+
+   Zawężenie celowo **nie** odsiewa powiązań bez dyscypliny. Pierwotna wersja
+   projektu mówiła o „przypiętej dyscyplinie", co czytane dosłownie odsiałoby
+   też `dyscyplina_naukowa IS NULL` — a wtedy reguły `*_DYSCYPLINA` stałyby się
+   martwe i raport przemilczałby dokładnie ten brak, o który pyta. Powiązanie
+   przypięte, ale bez dyscypliny, zostaje w raporcie i jest zgłaszane jako brak.
 3. Dla każdego querysetu `annotate()` dokłada po jednym `BooleanField` na regułę
    pasującą do typu osiągnięcia (`Case/When` z `Regula.warunek`).
 4. Widok zbiorczy agreguje po autorze: liczba rekordów z brakami, liczba braków

--- a/docs/superpowers/specs/2026-07-25-raport-kompletnosci-polon-2026-design.md
+++ b/docs/superpowers/specs/2026-07-25-raport-kompletnosci-polon-2026-design.md
@@ -1,0 +1,325 @@
+# Raport kompletności danych POL-on 2026 — projekt
+
+**Zgłoszenie:** FD#437 · **Data:** 2026-07-25 · **Status:** projekt zaakceptowany, do implementacji
+
+## Problem
+
+Rozporządzenie Ministra Nauki i Szkolnictwa Wyższego z dnia 16 czerwca 2026 r.
+w sprawie danych przetwarzanych w Zintegrowanym Systemie Informacji o Szkolnictwie
+Wyższym i Nauce POL-on (Dz. U. 2026 poz. 811, w życie od 30 czerwca 2026 r.)
+określa w § 2 ust. 10 zakres danych o osiągnięciach naukowych, jakie podmiot
+wprowadza do **wykazu pracowników**.
+
+Rozpoznanie wykazało, że **BPP w zdecydowanej większości nie wymaga nowych pól** —
+zakres z § 2 ust. 10 pokrywa się z tym, czego wymaga eksport do PBN, a te pola
+w BPP są. Problemem nie jest brak miejsca na dane, tylko **brak widoczności,
+których danych brakuje** w konkretnych rekordach.
+
+Rozporządzenie wyznacza przy tym twarde terminy (§ 9 ust. 3):
+
+- osiągnięcia wprowadza się **do 31 grudnia roku następującego po roku zaistnienia zmiany**,
+- osiągnięcia z roku poprzedzającego rok ewaluacji — **do 15 stycznia roku ewaluacji**.
+
+## Cel
+
+Raport roboczy, który dla bieżącego okna ewaluacyjnego pokazuje **przy którym
+pracowniku, w którym rekordzie, jakiej danej brakuje** — z odnośnikiem do
+paragrafu rozporządzenia i linkiem prosto do formularza edycji.
+
+Raport **nie** wysyła niczego do POL-on. BPP nie jest zintegrowane z POL-on;
+dane trafiają tam pośrednio (PBN/SEDN, sprawozdawczość uczelni). Raport jest
+narzędziem przygotowania danych, nie kanałem sprawozdawczym.
+
+### Poza zakresem
+
+- blokowanie zapisu rekordu z brakami (walidacja u źródła) — ewentualny krok drugi,
+- eksport do pliku sprawozdawczego POL-on,
+- dane spoza § 2 ust. 10 (wykaz studentów, doktorantów, instytucji, dyplomy),
+- ujednolicenie rozjechanych definicji okna ewaluacyjnego — patrz „Dług techniczny",
+- **osiągnięcia artystyczne (pkt 7), wzory użytkowe (pkt 2), odmiany roślin (pkt 3)** —
+  BPP nie ma dla nich modelu ani charakteru formalnego. Raport nie może zgłaszać
+  braków w danych, dla których nie istnieje miejsce zapisu.
+
+### Zakres ograniczony: patenty
+
+Model `Patent` pokrywa z § 2 ust. 10 pkt 1 tylko litery a (tytuł), c (numer
+patentu), g (data i numer zgłoszenia) oraz przez relacje k (dyscyplina) i m
+(współtwórcy, ORCID).
+
+Dla liter **b, d, e, f, h, i, j, l BPP nie ma pól**: nazwa uprawnionego podmiotu,
+nazwa urzędu udzielającego, państwa ochrony, data ogłoszenia w „Wiadomościach
+Urzędu Patentowego", uprzednie pierwszeństwo, streszczenie opisu, data złożenia
+tłumaczenia patentu europejskiego.
+
+Raport sprawdza więc dla patentów wyłącznie wymogi możliwe do wypełnienia.
+Dołożenie brakujących pól to samodzielna zmiana — zbiega się z FD#449, gdzie
+klientka niezależnie zgłosiła braki w modelu patentowym.
+
+## Decyzje projektowe
+
+### 1. Ziarno: (autor, dyscyplina, rekord)
+
+Raport operuje na **parach autor–osiągnięcie**, nie na samych publikacjach.
+Odwzorowuje to konstrukcję rozporządzenia: § 2 ust. 10 umieszcza osiągnięcia
+w wykazie pracowników, a każde osiągnięcie niesie własną „dyscyplinę, o której
+mowa w art. 265 ust. 13 ustawy". Ten sam artykuł u dwóch współautorów to
+w POL-onie dwa wpisy, przy dwóch osobach, potencjalnie w dwóch dyscyplinach.
+
+**Źródłem ziarna są konkretne modele powiązań** — `Wydawnictwo_Ciagle_Autor`,
+`Wydawnictwo_Zwarte_Autor`, `Patent_Autor` — a **nie** widok
+`Cache_Punktacja_Autora_Query`.
+
+Powód jest twardy i wynika z kodu: widok `Rekord` (`bpp_rekord_mat`,
+`managed = False`) dziedziczy tylko wybrane klasy abstrakcyjne (`RekordBase`,
+`src/bpp/models/cache/rekord.py:192-211`). **Nie ma wśród nich**
+`ModelZOplataZaPublikacje` ani `ModelZPolamiEwaluacjiPBN`, a `strony`, `tom`
+i `nr_zeszytu` są jawnie wygaszone (`= None`, linie 258–260). Przez `Rekord`
+**nie da się sprawdzić** wymogów dotyczących opłat APC (pkt 4 lit. m, pkt 5
+lit. n), artykułu recenzyjnego (pkt 4 lit. f), projektów NCN/FNP/NPRH/UE
+(pkt 5 lit. k), edycji naukowej (pkt 5 lit. j) ani tomu, zeszytu i stron
+(pkt 4 lit. j, k).
+
+Model konkretny wystawia wszystkie te pola, a jego through-model niesie komplet
+danych potrzebnych do przypisania braku do osoby: `autor`, `jednostka`,
+`dyscyplina_naukowa`, `przypieta`, `upowaznienie_pbn`, `typ_odpowiedzialnosci`
+(`src/bpp/models/abstract/authors.py:19-90`). Dodatkowa korzyść: dane czytane są
+na żywo, nie z cache'u, który bywa nieświeży.
+
+Konsekwencja: widok składa wynik z trzech zapytań (ciągłe, zwarte, patenty).
+
+### 2. Rejestr reguł jako dane
+
+Nowa aplikacja `kompletnosc_polon`, moduł `reguly.py`:
+
+```python
+class Waga(models.TextChoices):
+    WYMAGANE = "W", "Wymagane"        # rozporządzenie żąda bezwarunkowo
+    WARUNKOWE = "C", "Warunkowe"      # „jeżeli posiada", „jeżeli są znane"
+
+@dataclass(frozen=True)
+class Regula:
+    kod: str                 # stabilny identyfikator, np. "ART_DOI"
+    dotyczy: Osiagniecie     # ARTYKUL | MONOGRAFIA | ROZDZIAL | PATENT
+    warunek: Q               # PRAWDZIWY, gdy danej BRAKUJE
+    opis: str                # komunikat dla użytkownika
+    paragraf: str            # np. "§ 2 ust. 10 pkt 4 lit. a"
+    waga: Waga = Waga.WYMAGANE
+```
+
+Warunek jest obiektem `Q`, więc jedna definicja obsługuje trzy zastosowania:
+policzenie braków (`annotate`), zawężenie listy (`filter`) i test jednostkowy.
+Dopisanie wymogu po nowelizacji to jeden wpis, bez dotykania widoku.
+
+Pole `paragraf` trafia do interfejsu — użytkownik widzi podstawę prawną wymogu,
+a nie samo „czerwone pole". Pole `waga` odwzorowuje warunkowość rozporządzenia:
+wymogi opatrzone „jeżeli posiada" / „jeżeli są znane" **nie stają się
+bezwarunkowe**; raport pokazuje je osobno i nie wlicza do licznika braków
+krytycznych.
+
+### 3. Rejestr reguł — treść
+
+Warunki zapisane od strony modelu konkretnego; `a__` oznacza prefiks
+through-modelu (`Wydawnictwo_Ciagle_Autor` itd.).
+
+#### Artykuł naukowy (§ 2 ust. 10 pkt 4) — `Wydawnictwo_Ciagle`
+
+| Kod | Warunek braku | Lit. | Waga |
+|---|---|---|---|
+| `ART_DOI` | `doi` puste **i** `public_www` puste **i** `www` puste | a | W |
+| `ART_DYSCYPLINA` | `a__dyscyplina_naukowa` NULL **lub** `a__przypieta=False` | c | W |
+| `ART_UPOWAZNIENIE` | `a__upowaznienie_pbn=False` | d | W |
+| `ART_ORCID` | `a__autor__orcid` puste | e | C |
+| `ART_RECENZYJNY` | `pbn_czy_artykul_recenzyjny` NULL | f | W |
+| `ART_ZRODLO` | `zrodlo` NULL | h | W |
+| `ART_ISSN` | `zrodlo__issn`, `zrodlo__e_issn`, `issn`, `e_issn` — wszystkie puste | h | W |
+| `ART_TOM` | `tom` puste **i** `informacje` puste | j | C |
+| `ART_STRONY` | `strony` puste **i** `szczegoly` puste | k | C |
+| `ART_OA_WERSJA` | `openaccess_tryb_dostepu` ustawione **i** `openaccess_wersja_tekstu` NULL | l | W |
+| `ART_OA_LICENCJA` | `openaccess_tryb_dostepu` ustawione **i** `openaccess_licencja` NULL | l | W |
+| `ART_OA_DATA` | `openaccess_tryb_dostepu` ustawione **i** `openaccess_data_opublikowania` NULL | l | W |
+| `ART_OA_CZAS` | `openaccess_tryb_dostepu` ustawione **i** `openaccess_czas_publikacji` NULL | l | W |
+| `ART_OA_MIESIACE` | `openaccess_czas_publikacji` = „po opublikowaniu" **i** `openaccess_ilosc_miesiecy` NULL | l | W |
+| `ART_APC` | `opl_pub_cost_free` NULL **i** `opl_pub_amount` NULL **i** trzy flagi źródeł NULL | m | W |
+| `ART_APC_ZRODLO` | `opl_pub_amount` > 0 **i** żadna flaga źródła nie jest `True` | m | W |
+
+Reguły OA są **warunkowe względem trybu dostępu**: jeśli praca nie jest
+oznaczona jako Open Access, rozporządzenie nie wymaga danych OA i raport milczy.
+`ART_OA_MIESIACE` uruchamia się tylko dla udostępnienia po opublikowaniu — bo
+tylko wtedy liczba miesięcy ma sens.
+
+#### Monografia (§ 2 ust. 10 pkt 5) — `Wydawnictwo_Zwarte`, `charakter_sloty` = książka
+
+| Kod | Warunek braku | Lit. | Waga |
+|---|---|---|---|
+| `MON_DOI` | `doi` puste **i** `public_www` puste **i** `www` puste | a | W |
+| `MON_ISBN` | `isbn` puste **i** `e_isbn` puste | b | W |
+| `MON_WYDAWCA` | `wydawca` NULL **i** `wydawca_opis` puste | e | W |
+| `MON_DYSCYPLINA` | `a__dyscyplina_naukowa` NULL **lub** `a__przypieta=False` | g | W |
+| `MON_UPOWAZNIENIE` | `a__upowaznienie_pbn=False` | h | W |
+| `MON_ORCID` | `a__autor__orcid` puste | d | C |
+| `MON_EDYCJA_NAUKOWA` | `pbn_czy_edycja_naukowa` NULL | j | W |
+| `MON_PROJEKTY` | wszystkie cztery `pbn_czy_projekt_*` NULL | k | W |
+| `MON_OA_*` | jak `ART_OA_*` | m | W |
+| `MON_APC`, `MON_APC_ZRODLO` | jak `ART_APC*` | n | W |
+
+#### Rozdział (§ 2 ust. 10 pkt 6) — `Wydawnictwo_Zwarte`, `charakter_sloty` = rozdział
+
+| Kod | Warunek braku | Lit. | Waga |
+|---|---|---|---|
+| `ROZ_NADRZEDNE` | `wydawnictwo_nadrzedne` NULL **i** `wydawnictwo_nadrzedne_w_pbn` NULL | a | W |
+| `ROZ_DYSCYPLINA` | jak `MON_DYSCYPLINA` | d | W |
+| `ROZ_UPOWAZNIENIE` | jak `MON_UPOWAZNIENIE` | e | W |
+| `ROZ_ORCID` | `a__autor__orcid` puste | c | C |
+
+Rozdział dziedziczy wymogi monografii macierzystej (lit. a odsyła do pkt 5),
+ale raport **nie duplikuje** ich na rozdziale — braki monografii pokazuje przy
+monografii. Inaczej jedna niekompletna książka generowałaby braki przy każdym
+z kilkunastu rozdziałów, zalewając listę.
+
+#### Patent (§ 2 ust. 10 pkt 1) — `Patent`
+
+| Kod | Warunek braku | Lit. | Waga |
+|---|---|---|---|
+| `PAT_NUMER` | `numer_prawa_wylacznego` puste | c | W |
+| `PAT_ZGLOSZENIE` | `numer_zgloszenia` puste **lub** `data_zgloszenia` NULL | g | W |
+| `PAT_DYSCYPLINA` | jak wyżej | k | W |
+| `PAT_UPOWAZNIENIE` | jak wyżej | l | W |
+| `PAT_ORCID` | `a__autor__orcid` puste | m | C |
+
+### 4. Okno ewaluacyjne
+
+Bieżące okno zaczyna się w **2026 r.** Stała `OKNO_EWALUACJI = (2026, 2029)`
+w `ewaluacja_common/const.py` jako jedyne źródło prawdy dla nowej aplikacji.
+Istniejących wywołań w `ewaluacja_metryki` nie ruszamy — patrz „Dług techniczny".
+
+### 5. Liczenie na żywo, bez materializacji
+
+Braki liczone przy każdym otwarciu widoku, przez `annotate()` warunkami reguł.
+Nie powstaje tabela pochodna, nie ma migracji tworzącej model raportu.
+
+Uzasadnienie: okno 2026+ dopiero się otwiera, więc zbiór jest dziś bliski pustemu
+i przez pierwsze lata pozostanie mały. Materializacja (wzorem `MetrykaAutora`)
+wprowadzałaby opóźnienie między poprawką a zniknięciem rekordu z listy — czyli
+tarcie, które zabija adopcję narzędzia roboczego. Rejestr reguł jest niezależny
+od sposobu liczenia, więc materializacja da się dołożyć bez przepisywania logiki.
+
+## Architektura
+
+```
+src/kompletnosc_polon/
+├── apps.py                 # KompletnoscPolonConfig
+├── const.py                # Osiagniecie, Waga
+├── reguly.py               # REGULY: tuple[Regula, ...] + pomocnicze selektory
+├── selektory.py            # budowa querysetów per typ osiągnięcia
+├── uczelnia_scope.py       # scope_kompletnosc(qs, uczelnia)
+├── urls.py                 # app_name = "kompletnosc_polon"
+├── views/
+│   ├── __init__.py         # re-eksport + __all__
+│   ├── lista.py            # widok zbiorczy: autor → liczba braków
+│   └── szczegoly.py        # rozwinięcie: rekordy autora + konkretne braki
+├── templates/kompletnosc_polon/
+│   ├── lista.html
+│   └── szczegoly.html
+└── tests/
+```
+
+Wzorzec skopiowany z `ewaluacja_metryki` (pakiet `views/` z re-eksportem,
+`uczelnia_scope.py`, szablony w `templates/<app_label>/`, dziedziczenie
+po globalnym `base.html`).
+
+**Rejestracja:** `"kompletnosc_polon"` w `INSTALLED_APPS`
+(`src/django_bpp/settings/base.py`, blok aplikacji ewaluacyjnych, ok. linii 480);
+`path("kompletnosc_polon/", include("kompletnosc_polon.urls"))`
+w `src/django_bpp/urls.py`; link w `src/django_bpp/templates/top_bar.html`
+w istniejącym podmenu „ewaluacja".
+
+**Kontrola dostępu:** `EwaluacjaRequiredMixin` z
+`ewaluacja_metryki.views.mixins`, ale widok wymaga **pełnych** uprawnień
+(`ma_pelne_uprawnienia_ewaluacji`) — to narzędzie redaktorskie, nie widok dla
+autora. Zawężenie do uczelni przez `uczelnia_dla_odczytu(request)`
+(`raport_slotow.uczelnia_helper`) i `scope_*` z `bpp.util.uczelnia_scope`.
+
+**Migracje:** brak. Aplikacja nie ma modeli.
+
+## Przepływ danych
+
+1. Widok ustala okno (`OKNO_EWALUACJI`) i uczelnię (`uczelnia_dla_odczytu`).
+2. `selektory.py` buduje trzy querysety through-modeli, zawężone do: roku
+   w oknie, przypiętej dyscypliny, autora afiliowanego do jednostki tej uczelni.
+3. Dla każdego querysetu `annotate()` dokłada po jednym `BooleanField` na regułę
+   pasującą do typu osiągnięcia (`Case/When` z `Regula.warunek`).
+4. Widok zbiorczy agreguje po autorze: liczba rekordów z brakami, liczba braków
+   wymaganych i warunkowych.
+5. Widok szczegółów listuje rekordy jednego autora wraz z nazwami naruszonych
+   reguł, opisami i paragrafami, każdy z linkiem do formularza edycji w adminie.
+
+## Obsługa błędów
+
+- **Brak przypiętych dyscyplin w całej bazie** (świeża instalacja, nieuruchomiona
+  ewaluacja) → widok pokazuje komunikat wyjaśniający, że raport wymaga
+  przypisanych dyscyplin, zamiast pustej tabeli sugerującej „wszystko w porządku".
+- **Zero braków** → jawny komunikat „sprawdzono N rekordów, brak zastrzeżeń",
+  z podaniem zakresu lat. Puste tabele bez kontekstu są mylące.
+- **Charakter formalny bez `charakter_sloty`** (fixture instalacyjny zostawia
+  `null` — ustalone w rozpoznaniu) → taki rekord nie daje się zaklasyfikować jako
+  monografia ani rozdział. Trafia do osobnej sekcji „nierozpoznany typ
+  osiągnięcia" zamiast zniknąć po cichu.
+- Zgodnie z regułą repo: żadnego `except: pass`.
+
+## Testy
+
+- **Test per reguła** — dla każdej z reguł dwa rekordy przez `baker.make`: jeden
+  spełniający wymóg, jeden z brakiem; asercja, że reguła łapie dokładnie ten drugi.
+  To właściwa jednostka testowa, bo reguły są danymi. Test parametryzowany po
+  `REGULY`, więc dopisanie reguły bez testu psuje suitę.
+- **Test ziarna** — publikacja dwóch współautorów w dwóch dyscyplinach daje dwa
+  wiersze, a brak przypisany jest właściwej osobie.
+- **Test zakresu** — rekord spoza okna, rekord z odpiętą dyscypliną i rekord
+  autora z innej uczelni nie pojawiają się w raporcie.
+- **Test warunkowości** — praca bez oznaczenia OA nie generuje braków OA;
+  praca z `openaccess_czas_publikacji` innym niż „po opublikowaniu" nie wymaga
+  liczby miesięcy.
+- **Test widoku** — dostęp odrzucony dla użytkownika bez pełnych uprawnień;
+  dane zawężone do uczelni.
+
+Konwencja repo: pytest, funkcje bez klas, `@pytest.mark.django_db`,
+`model_bakery.baker`.
+
+## Dług techniczny ujawniony przy okazji
+
+Trzy niezgodne definicje okna ewaluacyjnego:
+
+| Miejsce | Wartość |
+|---|---|
+| `ewaluacja_common/const.py` | `ROK_MIN = 2022`, `ROK_MAX = 2026` |
+| `ewaluacja_metryki/models.py:114-120` | pola `rok_min`/`rok_max`, domyślnie `2022` / `2025` |
+| `ewaluacja_metryki/tasks.py`, `utils.py` | `rok_min=2022, rok_max=2025` w ośmiu sygnaturach |
+
+`ROK_MAX` mówi 2026, metryki liczą do 2025. Rozjazd siedzi w domyślnych
+argumentach funkcji, nie we wspólnej stałej, więc jest niewidoczny. Wraz
+z otwarciem okna 2026+ każde z tych miejsc jest błędne.
+
+Świadomie **nie naprawiane w tym PR** — zmiana domyślnych lat zmieniłaby wyniki
+liczenia metryk i slotów, czyli zachowanie niezwiązane z tym zgłoszeniem.
+Do osobnego zgłoszenia.
+
+## Braki modelu danych do osobnych zgłoszeń
+
+Wymogi rozporządzenia bez odpowiednika w BPP:
+
+| Wymóg | Paragraf | Stan |
+|---|---|---|
+| ISMN (druki muzyczne) | pkt 5 lit. b | brak pola |
+| Czy monografia jest przekładem dzieła istotnego | pkt 5 lit. i | brak pola; kierunek tłumaczenia wyliczany dopiero w adapterze eksportu PBN, nieprzechowywany |
+| Zgłoszenie do oceny eksperckiej KEN + wynik | pkt 5 lit. l | brak pola |
+| Patenty: uprawniony, urząd, państwa ochrony, data ogłoszenia w WUP, pierwszeństwo, streszczenie, tłumaczenie patentu EP | pkt 1 lit. b, d, e, f, h, i, j | brak pól (por. FD#449) |
+| Osiągnięcia artystyczne | pkt 7 | brak modelu |
+
+## Ryzyka
+
+| Ryzyko | Reakcja |
+|---|---|
+| Raport na starcie pusty (okno 2026 dopiero się otwiera) — użytkownik uzna, że nie działa | Widok jawnie komunikuje zakres lat i liczbę sprawdzonych rekordów, także przy zerze braków |
+| Fałszywe braki tam, gdzie dana jest nieobowiązkowa | Pole `waga`; wymogi warunkowe liczone osobno i nieoznaczane jako krytyczne |
+| Trzy zapytania zamiast jednego | Akceptowane — zbiór mały, a alternatywą jest rozszerzanie widoku `bpp_rekord`, co dotyka całego systemu |
+| Instalacje bez ustawionego `charakter_sloty` klasyfikują się nijak | Osobna sekcja „nierozpoznany typ" zamiast cichego pominięcia |

--- a/docs/superpowers/specs/2026-07-25-raport-kompletnosci-polon-2026-design.md
+++ b/docs/superpowers/specs/2026-07-25-raport-kompletnosci-polon-2026-design.md
@@ -340,3 +340,69 @@ Wymogi rozporządzenia bez odpowiednika w BPP:
 | Fałszywe braki tam, gdzie dana jest nieobowiązkowa | Pole `waga`; wymogi warunkowe liczone osobno i nieoznaczane jako krytyczne |
 | Trzy zapytania zamiast jednego | Akceptowane — zbiór mały, a alternatywą jest rozszerzanie widoku `bpp_rekord`, co dotyka całego systemu |
 | Instalacje bez ustawionego `charakter_sloty` klasyfikują się nijak | Osobna sekcja „nierozpoznany typ" zamiast cichego pominięcia |
+
+## Errata — zmiany wprowadzone po recenzji adwersarialnej
+
+Recenzja całości przed wystawieniem PR znalazła dwa błędy krytyczne, wyciek
+danych w instalacji wielouczelnianej i pięć luk merytorycznych. Wszystkie
+potwierdzone uruchomieniem kodu, nie domysłem. Rejestr urósł z **40 do 50+
+reguł**. Zmiany względem treści powyżej:
+
+### Wydawnictwa ciągłe wymagają filtra charakteru formalnego
+
+Pierwotny projekt zakładał, że „wydawnictwo ciągłe jest zawsze pkt 4". To
+nieprawda: `Wydawnictwo_Ciagle` obejmuje w BPP także streszczenia zjazdowe
+(PSZ/ZSZ), listy do redakcji (L), recenzje (R) i komunikaty (KOM). Bez filtra
+raport żądał od streszczenia konferencyjnego numeru DOI i informacji, czy jest
+artykułem recenzyjnym.
+
+Ziarno dla artykułów zawężone do
+`rekord__charakter_formalny__rodzaj_pbn = RODZAJ_PBN_ARTYKUL` — idiom, którego
+repo już używa w `pbn_integrator` i `komparator_pbn`.
+
+### Monografia macierzysta rozdziału nie była sprawdzana wcale
+
+Projekt zakładał, że braki monografii pokazujemy przy monografii, więc rozdział
+ich nie duplikuje. Przesłanka była fałszywa: monografia trafia do raportu tylko
+wtedy, gdy sama ma powiązanie autorskie z uczelni. Rozdział w monografii
+zbiorowej pod obcą redakcją ma rodzica bez takich powiązań — więc § 2 ust. 10
+pkt 6 lit. a nie był sprawdzany w najczęstszym przypadku.
+
+Dodane reguły `ROZ_MON_ISBN`, `ROZ_MON_WYDAWCA`, `ROZ_MON_DOI` po ścieżce
+`rekord__wydawnictwo_nadrzedne__…`, bramkowane wskazanym rodzicem. Świadomie
+tylko trio identyfikujące, a nie cały pkt 5 — rodzic z autorami z uczelni jest
+audytowany osobno, a pełne powielenie dawałoby podwójne zgłoszenia.
+
+### Widok szczegółów przeciekał dane między uczelniami
+
+`get_object_or_404(Autor, slug=…)` bez zawężenia zwracał HTTP 200 z imieniem
+i nazwiskiem autora obcej uczelni. Slug jest przewidywalny (`nazwisko-imie`),
+więc pozwalało to enumerować kadrę. Zawężone przez `scope_autor_do_uczelni` —
+teraz 404.
+
+### Reguły dołożone
+
+| Kod | Wymóg | Paragraf |
+|---|---|---|
+| `ART_OA_TRYB`, `MON_OA_TRYB` | sposób udostępnienia OA — brakowało reguły na samą bramkę, więc rekord z datą OA, ale bez trybu, wersji i licencji nie dawał żadnego naruszenia | pkt 4 lit. l / pkt 5 lit. m |
+| `ART_APC_KWOTA`, `MON_APC_KWOTA` | zadeklarowano niebezkosztowość, ale nie podano kwoty — luka między dwiema dotychczasowymi regułami APC | pkt 4 lit. m / pkt 5 lit. n |
+| `ART_KONFERENCJA_NAZWA`, `_DATY`, `_MIEJSCE` | dane konferencji, gdy artykuł jest z materiałów konferencyjnych; wymóg całkiem pominięty, mimo że BPP ma pola | pkt 4 lit. g |
+| `ROZ_MON_ISBN`, `ROZ_MON_WYDAWCA`, `ROZ_MON_DOI` | dane identyfikujące monografii macierzystej | pkt 6 lit. a |
+
+### Pozostałe poprawki
+
+- **Paginacja** widoku listy (25 autorów na stronę). Założenie „zbiór jest mały"
+  nie przeżyje pierwszego roku okna: pola `pbn_czy_*` i `opl_pub_*` mają
+  `default=None`, a `przypieta` `default=True`, więc w realnej instalacji prawie
+  każde powiązanie ma co najmniej jeden brak wymagany.
+- **Sekcja „nierozpoznany typ"** zawężona do rekordów, które naprawdę jadą do
+  PBN — wcześniej ostrzegała o charakterach sklasyfikowanych poprawnie i celowo
+  (fragment, tłumaczenie, skrypt), wysyłając redaktora do edycji słownika bez
+  powodu. Rozszerzona symetrycznie na wydawnictwa ciągłe bez ustawionego
+  `rodzaj_pbn`, żeby artykuły nie znikały po cichu na niedokonfigurowanej
+  instalacji.
+- **Testy**: dotychczasowy wzorzec zerował wszystkie człony koniunkcji naraz,
+  więc dowolny człon poza pierwszym dawało się usunąć z kodu przy zielonej
+  suicie. Dołożone testy „fallback ratuje" na każdy taki człon.
+- `sa_przypiete_dyscypliny()` zawężone do uczelni — zdradzało boolean o stanie
+  danych obcej instytucji.

--- a/docs/superpowers/specs/2026-07-25-raport-kompletnosci-polon-2026-design.md
+++ b/docs/superpowers/specs/2026-07-25-raport-kompletnosci-polon-2026-design.md
@@ -118,8 +118,19 @@ krytycznych.
 
 ### 3. Rejestr reguł — treść
 
-Warunki zapisane od strony modelu konkretnego; `a__` oznacza prefiks
-through-modelu (`Wydawnictwo_Ciagle_Autor` itd.).
+**Warunki zapisane są od strony through-modelu** (`Wydawnictwo_Ciagle_Autor`,
+`Wydawnictwo_Zwarte_Autor`, `Patent_Autor`): pola powiązania autora bez prefiksu
+(`dyscyplina_naukowa`, `przypieta`, `upowaznienie_pbn`, `autor__orcid`), pola
+publikacji z prefiksem `rekord__`.
+
+Pierwsza wersja tego projektu zapisywała warunki odwrotnie — od strony modelu
+konkretnego, z `a__` jako skrótem na through-model. Było to **błędne
+semantycznie**: `Q(autorzy_set__upowaznienie_pbn=False)` na querysecie
+`Wydawnictwo_Ciagle` znaczy „istnieje *jakiś* autor bez upoważnienia", a nie
+„*ten* autor go nie ma", a przy `annotate()` zwielokrotniałoby wiersze przez
+JOIN. Ziarno raportu to jedna para (autor, rekord) — czyli dokładnie jeden
+wiersz through-modelu. W tabelach niżej `a__` czytaj jako „pole powiązania
+autora, zapisywane bez prefiksu".
 
 #### Artykuł naukowy (§ 2 ust. 10 pkt 4) — `Wydawnictwo_Ciagle`
 

--- a/src/bpp/newsfragments/fd437-kompletnosc-polon.feature.rst
+++ b/src/bpp/newsfragments/fd437-kompletnosc-polon.feature.rst
@@ -1,0 +1,6 @@
+Nowy raport „kompletność danych POL-on" w menu ewaluacji pokazuje, przy którym
+pracowniku i w którym rekordzie brakuje danych wymaganych rozporządzeniem
+Ministra Nauki i Szkolnictwa Wyższego z 16 czerwca 2026 r. (Dz. U. 2026 poz. 811).
+Każdy brak opatrzony jest podstawą prawną i odnośnikiem prosto do formularza
+edycji. Raport rozróżnia dane wymagane bezwarunkowo od tych, których
+rozporządzenie żąda tylko „jeżeli posiada" — te drugie liczone są osobno.

--- a/src/bpp/newsfragments/fd437-kompletnosc-polon.feature.rst
+++ b/src/bpp/newsfragments/fd437-kompletnosc-polon.feature.rst
@@ -1,6 +1,0 @@
-Nowy raport „kompletność danych POL-on" w menu ewaluacji pokazuje, przy którym
-pracowniku i w którym rekordzie brakuje danych wymaganych rozporządzeniem
-Ministra Nauki i Szkolnictwa Wyższego z 16 czerwca 2026 r. (Dz. U. 2026 poz. 811).
-Każdy brak opatrzony jest podstawą prawną i odnośnikiem prosto do formularza
-edycji. Raport rozróżnia dane wymagane bezwarunkowo od tych, których
-rozporządzenie żąda tylko „jeżeli posiada" — te drugie liczone są osobno.

--- a/src/bpp/newsfragments/fd437.feature.md
+++ b/src/bpp/newsfragments/fd437.feature.md
@@ -6,4 +6,6 @@ malejąco po brakach wymaganych, a widok szczegółów wypisuje przy każdym
 rekordzie naruszone wymogi wraz z podstawą prawną i linkiem prosto do
 formularza edycji. Raport odróżnia dane wymagane bezwarunkowo od tych, których
 rozporządzenie żąda tylko „jeżeli posiada" — te drugie liczone są osobno i nie
-zawyżają pilności.
+zawyżają pilności. Zakres raportu to lata **od 2026 wzwyż**: górna granica
+pozostaje otwarta, dopóki MEiN nie ogłosi długości nowego okresu ewaluacyjnego,
+żeby raport nie przestał po cichu widzieć najnowszych rekordów.

--- a/src/bpp/newsfragments/fd437.feature.md
+++ b/src/bpp/newsfragments/fd437.feature.md
@@ -1,0 +1,9 @@
+Nowy raport „kompletność danych POL-on" (menu *ewaluacja*, dla redaktorów
+danych): wskazuje, przy którym pracowniku i w którym rekordzie brakuje danych
+wymaganych przez § 2 ust. 10 rozporządzenia MNiSW z 16 czerwca 2026 r.
+(Dz. U. 2026 poz. 811). Zestawienie zbiorcze pokazuje autorów posortowanych
+malejąco po brakach wymaganych, a widok szczegółów wypisuje przy każdym
+rekordzie naruszone wymogi wraz z podstawą prawną i linkiem prosto do
+formularza edycji. Raport odróżnia dane wymagane bezwarunkowo od tych, których
+rozporządzenie żąda tylko „jeżeli posiada" — te drugie liczone są osobno i nie
+zawyżają pilności.

--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -481,6 +481,7 @@ INSTALLED_APPS = [
     "ewaluacja_optymalizacja",
     "ewaluacja_optymalizuj_publikacje",
     "ewaluacja_dwudyscyplinowcy",
+    "kompletnosc_polon",
     # UWAGA: NIE USUWAĆ aplikacji test_bpp z INSTALLED_APPS!
     #
     # Mimo nazwy sugerującej "tylko do testów", test_bpp dostarcza realnych

--- a/src/django_bpp/templates/top_bar.html
+++ b/src/django_bpp/templates/top_bar.html
@@ -103,6 +103,7 @@
                         <ul class="menu vertical column-1">
                             <li><a href="{% url "ewaluacja_liczba_n:index" %}"><i class="fi-list-number"></i> liczba N</a></li>
                             <li><a href="{% url "ewaluacja_metryki:lista" %}"><i class="fi-graph-trend"></i> metryki ewaluacyjne</a></li>
+                            <li><a href="{% url "kompletnosc_polon:lista" %}"><i class="fi-clipboard-notes"></i> kompletność danych POL-on</a></li>
                             <li><a href="{% url "ewaluacja_optymalizacja:index" %}"><i class="fi-target-two"></i> optymalizacja ewaluacji</a></li>
                             <li><a href="{% url "snapshot_odpiec:index" %}"><i class="fi-camera"></i> snapshoty odpięć</a></li>
                             <li><a href="{% url "oswiadczenia:wydruk-2022-25" %}"><i class="fi-print"></i> wydruk oświadczeń 2022-25</a></li>

--- a/src/django_bpp/urls.py
+++ b/src/django_bpp/urls.py
@@ -113,6 +113,12 @@ urlpatterns = (
             ),
         ),
         path(
+            "kompletnosc_polon/",
+            include(
+                "kompletnosc_polon.urls",
+            ),
+        ),
+        path(
             "ewaluacja_optymalizacja/",
             include(
                 "ewaluacja_optymalizacja.urls",

--- a/src/ewaluacja_common/const.py
+++ b/src/ewaluacja_common/const.py
@@ -8,16 +8,31 @@
 ROK_MIN = 2022
 ROK_MAX = 2026
 
-# Okno *bieżącej* ewaluacji, jako domknięty przedział (pierwszy rok, ostatni
-# rok). Bieżące okno otwiera się w 2026 r. i zamyka w 2029 r.
+# Okno lat raportu kompletności danych POL-on, jako para
+# (pierwszy rok, ostatni rok). Okno otwiera się w 2026 r., a jego górna
+# granica jest **z rozmysłem nieustalona** — stąd ``None``.
 #
-# To jedyne źródło prawdy dla aplikacji ``kompletnosc_polon`` (raport
-# kompletności danych POL-on, FD#437) — raport pyta o braki wyłącznie
-# w rekordach z tego przedziału lat.
+# ``None`` NIE jest przeoczeniem ani „brakiem czasu, żeby wpisać rok”.
+# W chwili pisania tego kodu MEiN nie ogłosił, czy nowy okres ewaluacyjny
+# trwa cztery czy pięć lat. Wpisanie tu zgadniętego roku (np. 2029) znaczyło
+# by, że w pierwszym roku poza zgadniętym zakresem raport po cichu przestanie
+# pokazywać nowe rekordy — najgorszy możliwy tryb awarii dla raportu
+# o brakach, bo wygląda dokładnie jak „wszystko w porządku”. ``None`` czyta
+# się jako „od 2026 wzwyż, granicy jeszcze nie znamy”: selektory nie nakładają
+# wtedy górnego odcięcia, a interfejs pokazuje „od 2026”, nie zmyśloną datę.
 #
-# UWAGA: świadomie NIE podpięte pod ``ROK_MIN``/``ROK_MAX`` powyżej ani pod
-# domyślne argumenty w ``ewaluacja_metryki`` (``rok_min=2022, rok_max=2025``
-# w ośmiu sygnaturach). Te trzy definicje okna są dziś wzajemnie niezgodne;
-# ich ujednolicenie zmieniłoby wyniki liczenia metryk i slotów, więc idzie
-# osobnym zgłoszeniem. Nowy kod ma używać ``OKNO_EWALUACJI``.
-OKNO_EWALUACJI = (2026, 2029)
+# Gdy zasady zostaną ogłoszone, domknięcie okna to zmiana jednej liczby:
+# ``OKNO_EWALUACJI = (2026, <ostatni rok>)``. Kod obsługuje oba warianty
+# (patrz ``kompletnosc_polon.selektory._zawez`` i
+# ``kompletnosc_polon.views.mixins.opis_okna``) i ma na oba testy.
+#
+# To okno jest **prywatnym ustawieniem raportu POL-on** (``kompletnosc_polon``,
+# FD#437) — raport pyta o braki wyłącznie w rekordach z tego zakresu lat.
+# Celowo NIE jest tym samym, co ``ROK_MIN``/``ROK_MAX`` powyżej ani co
+# domyślne argumenty ``rok_min``/``rok_max`` w ``ewaluacja_metryki``
+# (czyli domyślny okres metryk i liczby N). To dwa różne zegary: tu chodzi
+# o obowiązek sprawozdawczy z rozporządzenia o danych w POL-on (jakie dane
+# muszą być kompletne), tam — o okres, za który liczy się punktację, sloty
+# i liczbę N. Ujednolicenie ich zmieniłoby wyniki liczenia metryk, więc idzie
+# osobnym zgłoszeniem. Nowy kod raportu POL-on ma używać ``OKNO_EWALUACJI``.
+OKNO_EWALUACJI = (2026, None)

--- a/src/ewaluacja_common/const.py
+++ b/src/ewaluacja_common/const.py
@@ -7,3 +7,17 @@
 # od uśpionej apki ``ewaluacja2021`` (patrz ``ewaluacja2021/README.md``).
 ROK_MIN = 2022
 ROK_MAX = 2026
+
+# Okno *bieżącej* ewaluacji, jako domknięty przedział (pierwszy rok, ostatni
+# rok). Bieżące okno otwiera się w 2026 r. i zamyka w 2029 r.
+#
+# To jedyne źródło prawdy dla aplikacji ``kompletnosc_polon`` (raport
+# kompletności danych POL-on, FD#437) — raport pyta o braki wyłącznie
+# w rekordach z tego przedziału lat.
+#
+# UWAGA: świadomie NIE podpięte pod ``ROK_MIN``/``ROK_MAX`` powyżej ani pod
+# domyślne argumenty w ``ewaluacja_metryki`` (``rok_min=2022, rok_max=2025``
+# w ośmiu sygnaturach). Te trzy definicje okna są dziś wzajemnie niezgodne;
+# ich ujednolicenie zmieniłoby wyniki liczenia metryk i slotów, więc idzie
+# osobnym zgłoszeniem. Nowy kod ma używać ``OKNO_EWALUACJI``.
+OKNO_EWALUACJI = (2026, 2029)

--- a/src/kompletnosc_polon/apps.py
+++ b/src/kompletnosc_polon/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class KompletnoscPolonConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "kompletnosc_polon"
+    verbose_name = "Kompletność danych POL-on"

--- a/src/kompletnosc_polon/const.py
+++ b/src/kompletnosc_polon/const.py
@@ -1,0 +1,53 @@
+"""Stałe słownikowe raportu kompletności danych POL-on.
+
+Rozporządzenie MNiSW z dnia 16 czerwca 2026 r. w sprawie danych przetwarzanych
+w ZSIoSW POL-on (Dz. U. 2026 poz. 811) określa w § 2 ust. 10 zakres danych
+o osiągnięciach naukowych wprowadzanych do wykazu pracowników.
+"""
+
+from django.db import models
+
+
+class Osiagniecie(models.TextChoices):
+    """Typ osiągnięcia naukowego w rozumieniu § 2 ust. 10 rozporządzenia.
+
+    Każdy wariant odwzorowuje jeden punkt ustępu i jeden model BPP:
+
+    * ``ARTYKUL`` — pkt 4, ``bpp.Wydawnictwo_Ciagle``,
+    * ``MONOGRAFIA`` — pkt 5, ``bpp.Wydawnictwo_Zwarte`` o charakterze
+      slotów „książka” (``bpp.const.CHARAKTER_SLOTY_KSIAZKA``),
+    * ``ROZDZIAL`` — pkt 6, ``bpp.Wydawnictwo_Zwarte`` o charakterze slotów
+      „rozdział” (``bpp.const.CHARAKTER_SLOTY_ROZDZIAL``),
+    * ``PATENT`` — pkt 1, ``bpp.Patent``.
+
+    Osiągnięcia artystyczne (pkt 7), wzory użytkowe (pkt 2) i odmiany roślin
+    (pkt 3) nie mają w BPP modelu ani charakteru formalnego, więc raport ich
+    nie obejmuje — nie da się zgłosić braku danej, dla której nie istnieje
+    miejsce zapisu.
+    """
+
+    ARTYKUL = "ART", "Artykuł naukowy"
+    MONOGRAFIA = "MON", "Monografia naukowa"
+    ROZDZIAL = "ROZ", "Rozdział w monografii naukowej"
+    PATENT = "PAT", "Patent"
+
+
+class Waga(models.TextChoices):
+    """Kategoria wymogu — czy rozporządzenie żąda danej bezwarunkowo.
+
+    ``WYMAGANE`` to wymóg bezwarunkowy; brak danej jest błędem, który trzeba
+    uzupełnić. ``WARUNKOWE`` odwzorowuje zwroty „jeżeli posiada”, „jeżeli są
+    znane”, „o ile został nadany” — braki tej kategorii raport pokazuje
+    osobno i nie wlicza do licznika braków krytycznych.
+    """
+
+    WYMAGANE = "W", "Wymagane"
+    WARUNKOWE = "C", "Warunkowe"
+
+
+#: Skrót pozycji słownika ``bpp.Czas_Udostepnienia_OpenAccess`` oznaczającej
+#: udostępnienie utworu *po* opublikowaniu. Tylko dla tej wartości ma sens
+#: pytanie o liczbę miesięcy karencji (patrz reguły ``*_OA_MIESIACE``).
+#: Wartość pochodzi z fixture instalacyjnego ``bpp.fixtures.DANE_OPEN_ACCESS``
+#: i jest tożsama ze słownikiem PBN (``releaseDateMode``).
+OA_CZAS_PO_OPUBLIKOWANIU = "AFTER_PUBLICATION"

--- a/src/kompletnosc_polon/reguly.py
+++ b/src/kompletnosc_polon/reguly.py
@@ -1,0 +1,517 @@
+"""Rejestr reguł kompletności danych POL-on — reguły jako dane.
+
+Każdy wymóg § 2 ust. 10 rozporządzenia MNiSW z 16 czerwca 2026 r. (Dz. U. 2026
+poz. 811) zapisany jest jako jedna :class:`Regula` z warunkiem w postaci
+``django.db.models.Q``. Dzięki temu jedna definicja obsługuje trzy
+zastosowania: policzenie braków (``annotate``), zawężenie listy (``filter``)
+oraz test jednostkowy. Dopisanie wymogu po nowelizacji to jeden wpis w
+:data:`REGULY`, bez dotykania widoku.
+
+Konwencja zapisu warunków (WAŻNE — selektory i widoki na niej polegają)
+=======================================================================
+
+**Warunki zapisane są od strony *through-modelu* powiązania autora z
+rekordem**, czyli ``bpp.Wydawnictwo_Ciagle_Autor``,
+``bpp.Wydawnictwo_Zwarte_Autor`` albo ``bpp.Patent_Autor``. Wynika to wprost
+z ziarna raportu: § 2 ust. 10 umieszcza osiągnięcia w *wykazie pracowników*,
+a każde osiągnięcie niesie własną dyscyplinę i własne upoważnienie. Jeden
+wiersz raportu to jedna para (autor, rekord), czyli dokładnie jeden wiersz
+through-modelu.
+
+Stąd dwie klasy ścieżek pól:
+
+* pola powiązania autora — **bez prefiksu**: ``dyscyplina_naukowa``,
+  ``przypieta``, ``upowaznienie_pbn``, ``autor__orcid``;
+* pola samej publikacji — z prefiksem :data:`PREFIKS_REKORDU` (``rekord__``):
+  ``rekord__doi``, ``rekord__zrodlo__issn`` itd.
+
+Projekt (``docs/superpowers/specs/2026-07-25-raport-kompletnosci-polon-2026-design.md``)
+notował pola autora skrótem ``a__`` przy warunkach pisanych od strony modelu
+konkretnego. Ta konwencja została świadomie odwrócona, bo:
+
+1. ``a__`` nie jest realnym akcesorem Django — odwrotna relacja z
+   ``Wydawnictwo_Ciagle`` do through-modelu nazywa się ``autorzy_set``;
+2. warunek ``autorzy_set__upowaznienie_pbn=False`` na querysecie modelu
+   konkretnego znaczy „*istnieje* autor bez upoważnienia”, a nie „*ten* autor
+   nie ma upoważnienia” — a przy ``annotate()`` dodatkowo zwielokrotniałby
+   wiersze przez JOIN;
+3. sam projekt (sekcja „Przepływ danych”) zakłada, że selektory budują
+   querysety through-modeli — czyli tę właśnie stronę relacji.
+
+Warunek jest PRAWDZIWY, gdy danej BRAKUJE
+=========================================
+
+Konsekwentnie w całym rejestrze: reguła „łapie” rekord niekompletny. Pola
+tekstowe w BPP są przeważnie ``blank=True, default=""`` (a więc NOT NULL),
+ale nie wszystkie — ``doi``, ``autor.orcid``, ``numer_zgloszenia`` oraz
+``numer_prawa_wylacznego`` dopuszczają NULL. Dlatego pustkę testujemy dwoma
+pomocnikami: :func:`_puste` dla pól NOT NULL i :func:`_puste_lub_null` dla
+pól nullowalnych. Warunki muszą dać się w całości wyrazić w SQL — żadnych
+metod Pythona.
+"""
+
+from dataclasses import dataclass
+
+from django.db.models import Q
+
+from kompletnosc_polon.const import (
+    OA_CZAS_PO_OPUBLIKOWANIU,
+    Osiagniecie,
+    Waga,
+)
+
+#: Prefiks ścieżki do pól publikacji, gdy zapytanie startuje z through-modelu
+#: powiązania autora. Patrz docstring modułu.
+PREFIKS_REKORDU = "rekord__"
+
+
+@dataclass(frozen=True)
+class Regula:
+    """Pojedynczy wymóg rozporządzenia, wyrażony jako warunek SQL.
+
+    :param kod: stabilny identyfikator, np. ``"ART_DOI"``; unikalny w całym
+        rejestrze, używany w szablonach i w adresach URL.
+    :param dotyczy: typ osiągnięcia, którego reguła dotyczy.
+    :param warunek: ``Q`` prawdziwe wtedy i tylko wtedy, gdy danej BRAKUJE.
+    :param opis: komunikat dla użytkownika — co konkretnie uzupełnić.
+    :param paragraf: podstawa prawna, np. ``"§ 2 ust. 10 pkt 4 lit. a"``.
+    :param waga: czy rozporządzenie żąda danej bezwarunkowo.
+    """
+
+    kod: str
+    dotyczy: Osiagniecie
+    warunek: Q
+    opis: str
+    paragraf: str
+    waga: Waga = Waga.WYMAGANE
+
+
+def _puste(pole: str) -> Q:
+    """Pole tekstowe NOT NULL (``blank=True, default=""``) jest puste."""
+    return Q(**{pole: ""})
+
+
+def _puste_lub_null(pole: str) -> Q:
+    """Pole tekstowe nullowalne jest puste albo NULL.
+
+    W BPP nullowalne są m.in. ``doi`` (``DOIField(null=True)``),
+    ``Autor.orcid``, ``Patent.numer_zgloszenia`` i
+    ``Patent.numer_prawa_wylacznego`` — te dwa ostatnie z powodów
+    historycznych (``# noqa: DJ001`` w modelu). Pusty ciąg i NULL znaczą
+    dla użytkownika to samo: danej nie ma.
+    """
+    return Q(**{pole: ""}) | Q(**{f"{pole}__isnull": True})
+
+
+def _nie_tak(pole: str) -> Q:
+    """Nullowalne pole logiczne nie jest ustawione na „tak”.
+
+    Zapisane wprost (``False`` albo NULL), zamiast przez ``~Q(pole=True)``,
+    żeby wygenerowany SQL nie zależał od tego, jak Django obchodzi się
+    z negacją warunku na kolumnie nullowalnej.
+    """
+    return Q(**{pole: False}) | Q(**{f"{pole}__isnull": True})
+
+
+# --------------------------------------------------------------------------
+# Fragmenty wspólne dla wielu typów osiągnięć
+# --------------------------------------------------------------------------
+
+#: Brak identyfikatora cyfrowego: ani DOI, ani żadnego adresu WWW.
+#: ``doi`` jest nullowalne, ``www`` i ``public_www`` to ``URLField`` NOT NULL.
+BRAK_IDENTYFIKATORA_CYFROWEGO = (
+    _puste_lub_null("rekord__doi")
+    & _puste("rekord__public_www")
+    & _puste("rekord__www")
+)
+
+#: Dyscyplina nieokreślona albo odpięta od tego powiązania autor–rekord.
+BRAK_DYSCYPLINY = Q(dyscyplina_naukowa__isnull=True) | Q(przypieta=False)
+
+#: Autor nie upoważnił uczelni do sprawozdania tej publikacji.
+#: ``upowaznienie_pbn`` to ``BooleanField(default=False)`` — NOT NULL.
+BRAK_UPOWAZNIENIA = Q(upowaznienie_pbn=False)
+
+#: Autor nie ma numeru ORCID. Pole ``Autor.orcid`` jest nullowalne (unique).
+BRAK_ORCID = _puste_lub_null("autor__orcid")
+
+#: Praca jest oznaczona jako Open Access. Wszystkie wymogi OA są warunkowe
+#: względem tego oznaczenia: bez trybu dostępu rozporządzenie nie żąda
+#: danych OA i raport milczy.
+OZNACZONO_OPEN_ACCESS = Q(rekord__openaccess_tryb_dostepu__isnull=False)
+
+#: Brak kompletu danych o opłacie za publikację (APC): nie wiadomo nawet,
+#: czy publikacja była bezkosztowa.
+BRAK_DANYCH_O_OPLACIE = (
+    Q(rekord__opl_pub_cost_free__isnull=True)
+    & Q(rekord__opl_pub_amount__isnull=True)
+    & Q(rekord__opl_pub_research_potential__isnull=True)
+    & Q(rekord__opl_pub_research_or_development_projects__isnull=True)
+    & Q(rekord__opl_pub_other__isnull=True)
+)
+
+#: Wpisano kwotę opłaty, ale nie wskazano źródła jej finansowania.
+BRAK_ZRODLA_OPLATY = (
+    Q(rekord__opl_pub_amount__gt=0)
+    & _nie_tak("rekord__opl_pub_research_potential")
+    & _nie_tak("rekord__opl_pub_research_or_development_projects")
+    & _nie_tak("rekord__opl_pub_other")
+)
+
+
+def _reguly_open_access(
+    prefiks_kodu: str,
+    dotyczy: Osiagniecie,
+    paragraf: str,
+) -> tuple[Regula, ...]:
+    """Pięć reguł Open Access, identycznych dla artykułu i monografii.
+
+    Wszystkie poza ``*_OA_MIESIACE`` są warunkowe względem ustawionego trybu
+    dostępu. ``*_OA_MIESIACE`` uruchamia się węziej — tylko dla udostępnienia
+    po opublikowaniu, bo tylko wtedy liczba miesięcy karencji ma sens.
+    """
+    return (
+        Regula(
+            kod=f"{prefiks_kodu}_OA_WERSJA",
+            dotyczy=dotyczy,
+            warunek=OZNACZONO_OPEN_ACCESS
+            & Q(rekord__openaccess_wersja_tekstu__isnull=True),
+            opis="Praca jest oznaczona jako Open Access, ale nie podano "
+            "wersji udostępnionego tekstu.",
+            paragraf=paragraf,
+        ),
+        Regula(
+            kod=f"{prefiks_kodu}_OA_LICENCJA",
+            dotyczy=dotyczy,
+            warunek=OZNACZONO_OPEN_ACCESS & Q(rekord__openaccess_licencja__isnull=True),
+            opis="Praca jest oznaczona jako Open Access, ale nie podano "
+            "licencji, na jakiej ją udostępniono.",
+            paragraf=paragraf,
+        ),
+        Regula(
+            kod=f"{prefiks_kodu}_OA_DATA",
+            dotyczy=dotyczy,
+            warunek=OZNACZONO_OPEN_ACCESS
+            & Q(rekord__openaccess_data_opublikowania__isnull=True),
+            opis="Praca jest oznaczona jako Open Access, ale nie podano daty "
+            "udostępnienia w otwartym dostępie.",
+            paragraf=paragraf,
+        ),
+        Regula(
+            kod=f"{prefiks_kodu}_OA_CZAS",
+            dotyczy=dotyczy,
+            warunek=OZNACZONO_OPEN_ACCESS
+            & Q(rekord__openaccess_czas_publikacji__isnull=True),
+            opis="Praca jest oznaczona jako Open Access, ale nie podano "
+            "czasu udostępnienia (przed, w momencie albo po opublikowaniu).",
+            paragraf=paragraf,
+        ),
+        Regula(
+            kod=f"{prefiks_kodu}_OA_MIESIACE",
+            dotyczy=dotyczy,
+            warunek=Q(
+                rekord__openaccess_czas_publikacji__skrot=OA_CZAS_PO_OPUBLIKOWANIU
+            )
+            & Q(rekord__openaccess_ilosc_miesiecy__isnull=True),
+            opis="Pracę udostępniono po opublikowaniu, ale nie podano liczby "
+            "miesięcy, jakie upłynęły od publikacji do udostępnienia.",
+            paragraf=paragraf,
+        ),
+    )
+
+
+def _reguly_oplaty(
+    prefiks_kodu: str,
+    dotyczy: Osiagniecie,
+    paragraf: str,
+) -> tuple[Regula, ...]:
+    """Dwie reguły dotyczące opłaty za publikację (APC)."""
+    return (
+        Regula(
+            kod=f"{prefiks_kodu}_APC",
+            dotyczy=dotyczy,
+            warunek=BRAK_DANYCH_O_OPLACIE,
+            opis="Nie wypełniono danych o opłacie za publikację — nie "
+            "zaznaczono nawet, czy publikacja była bezkosztowa.",
+            paragraf=paragraf,
+        ),
+        Regula(
+            kod=f"{prefiks_kodu}_APC_ZRODLO",
+            dotyczy=dotyczy,
+            warunek=BRAK_ZRODLA_OPLATY,
+            opis="Wpisano kwotę opłaty za publikację, ale nie wskazano "
+            "żadnego źródła jej finansowania.",
+            paragraf=paragraf,
+        ),
+    )
+
+
+# --------------------------------------------------------------------------
+# Artykuł naukowy — § 2 ust. 10 pkt 4 — bpp.Wydawnictwo_Ciagle_Autor
+# --------------------------------------------------------------------------
+
+REGULY_ARTYKUL: tuple[Regula, ...] = (
+    Regula(
+        kod="ART_DOI",
+        dotyczy=Osiagniecie.ARTYKUL,
+        warunek=BRAK_IDENTYFIKATORA_CYFROWEGO,
+        opis="Brak numeru DOI oraz adresu strony WWW artykułu.",
+        paragraf="§ 2 ust. 10 pkt 4 lit. a",
+    ),
+    Regula(
+        kod="ART_DYSCYPLINA",
+        dotyczy=Osiagniecie.ARTYKUL,
+        warunek=BRAK_DYSCYPLINY,
+        opis="Autorowi nie przypisano dyscypliny naukowej dla tej pracy "
+        "albo dyscyplina została odpięta.",
+        paragraf="§ 2 ust. 10 pkt 4 lit. c",
+    ),
+    Regula(
+        kod="ART_UPOWAZNIENIE",
+        dotyczy=Osiagniecie.ARTYKUL,
+        warunek=BRAK_UPOWAZNIENIA,
+        opis="Brak upoważnienia autora do wykazania tej pracy w ewaluacji.",
+        paragraf="§ 2 ust. 10 pkt 4 lit. d",
+    ),
+    Regula(
+        kod="ART_ORCID",
+        dotyczy=Osiagniecie.ARTYKUL,
+        warunek=BRAK_ORCID,
+        opis="Autor nie ma wpisanego identyfikatora ORCID.",
+        paragraf="§ 2 ust. 10 pkt 4 lit. e",
+        waga=Waga.WARUNKOWE,
+    ),
+    Regula(
+        kod="ART_RECENZYJNY",
+        dotyczy=Osiagniecie.ARTYKUL,
+        warunek=Q(rekord__pbn_czy_artykul_recenzyjny__isnull=True),
+        opis="Nie określono, czy artykuł jest artykułem recenzyjnym.",
+        paragraf="§ 2 ust. 10 pkt 4 lit. f",
+    ),
+    Regula(
+        kod="ART_ZRODLO",
+        dotyczy=Osiagniecie.ARTYKUL,
+        warunek=Q(rekord__zrodlo__isnull=True),
+        opis="Nie wskazano czasopisma, w którym artykuł się ukazał.",
+        paragraf="§ 2 ust. 10 pkt 4 lit. h",
+    ),
+    Regula(
+        kod="ART_ISSN",
+        dotyczy=Osiagniecie.ARTYKUL,
+        # Gdy źródło nie jest wskazane, LEFT JOIN daje NULL-e i porównanie
+        # z pustym ciągiem nie zadziała — stąd jawny człon o braku źródła.
+        warunek=(
+            Q(rekord__zrodlo__isnull=True)
+            | (_puste("rekord__zrodlo__issn") & _puste("rekord__zrodlo__e_issn"))
+        )
+        & _puste("rekord__issn")
+        & _puste("rekord__e_issn"),
+        opis="Ani czasopismo, ani sam rekord nie mają numeru ISSN ani e-ISSN.",
+        paragraf="§ 2 ust. 10 pkt 4 lit. h",
+    ),
+    Regula(
+        kod="ART_TOM",
+        dotyczy=Osiagniecie.ARTYKUL,
+        warunek=_puste("rekord__tom") & _puste("rekord__informacje"),
+        opis="Nie podano tomu (rocznika) czasopisma — pole „Tom” jest puste, "
+        "a pole „Informacje” nie zawiera danych do wyekstrahowania.",
+        paragraf="§ 2 ust. 10 pkt 4 lit. j",
+        waga=Waga.WARUNKOWE,
+    ),
+    Regula(
+        kod="ART_STRONY",
+        dotyczy=Osiagniecie.ARTYKUL,
+        warunek=_puste("rekord__strony") & _puste("rekord__szczegoly"),
+        opis="Nie podano zakresu stron — pole „Strony” jest puste, a pole "
+        "„Szczegóły” nie zawiera danych do wyekstrahowania.",
+        paragraf="§ 2 ust. 10 pkt 4 lit. k",
+        waga=Waga.WARUNKOWE,
+    ),
+    *_reguly_open_access("ART", Osiagniecie.ARTYKUL, "§ 2 ust. 10 pkt 4 lit. l"),
+    *_reguly_oplaty("ART", Osiagniecie.ARTYKUL, "§ 2 ust. 10 pkt 4 lit. m"),
+)
+
+
+# --------------------------------------------------------------------------
+# Monografia naukowa — § 2 ust. 10 pkt 5 — bpp.Wydawnictwo_Zwarte_Autor
+# --------------------------------------------------------------------------
+
+REGULY_MONOGRAFIA: tuple[Regula, ...] = (
+    Regula(
+        kod="MON_DOI",
+        dotyczy=Osiagniecie.MONOGRAFIA,
+        warunek=BRAK_IDENTYFIKATORA_CYFROWEGO,
+        opis="Brak numeru DOI oraz adresu strony WWW monografii.",
+        paragraf="§ 2 ust. 10 pkt 5 lit. a",
+    ),
+    Regula(
+        kod="MON_ISBN",
+        dotyczy=Osiagniecie.MONOGRAFIA,
+        warunek=_puste("rekord__isbn") & _puste("rekord__e_isbn"),
+        opis="Monografia nie ma numeru ISBN ani e-ISBN.",
+        paragraf="§ 2 ust. 10 pkt 5 lit. b",
+    ),
+    Regula(
+        kod="MON_ORCID",
+        dotyczy=Osiagniecie.MONOGRAFIA,
+        warunek=BRAK_ORCID,
+        opis="Autor nie ma wpisanego identyfikatora ORCID.",
+        paragraf="§ 2 ust. 10 pkt 5 lit. d",
+        waga=Waga.WARUNKOWE,
+    ),
+    Regula(
+        kod="MON_WYDAWCA",
+        dotyczy=Osiagniecie.MONOGRAFIA,
+        warunek=Q(rekord__wydawca__isnull=True) & _puste("rekord__wydawca_opis"),
+        opis="Nie wskazano wydawcy monografii — ani ze słownika wydawców, ani opisowo.",
+        paragraf="§ 2 ust. 10 pkt 5 lit. e",
+    ),
+    Regula(
+        kod="MON_DYSCYPLINA",
+        dotyczy=Osiagniecie.MONOGRAFIA,
+        warunek=BRAK_DYSCYPLINY,
+        opis="Autorowi nie przypisano dyscypliny naukowej dla tej pracy "
+        "albo dyscyplina została odpięta.",
+        paragraf="§ 2 ust. 10 pkt 5 lit. g",
+    ),
+    Regula(
+        kod="MON_UPOWAZNIENIE",
+        dotyczy=Osiagniecie.MONOGRAFIA,
+        warunek=BRAK_UPOWAZNIENIA,
+        opis="Brak upoważnienia autora do wykazania tej pracy w ewaluacji.",
+        paragraf="§ 2 ust. 10 pkt 5 lit. h",
+    ),
+    Regula(
+        kod="MON_EDYCJA_NAUKOWA",
+        dotyczy=Osiagniecie.MONOGRAFIA,
+        warunek=Q(rekord__pbn_czy_edycja_naukowa__isnull=True),
+        opis="Nie określono, czy monografia jest edycją naukową tekstów źródłowych.",
+        paragraf="§ 2 ust. 10 pkt 5 lit. j",
+    ),
+    Regula(
+        kod="MON_PROJEKTY",
+        dotyczy=Osiagniecie.MONOGRAFIA,
+        warunek=Q(rekord__pbn_czy_projekt_ncn__isnull=True)
+        & Q(rekord__pbn_czy_projekt_nprh__isnull=True)
+        & Q(rekord__pbn_czy_projekt_fnp__isnull=True)
+        & Q(rekord__pbn_czy_projekt_ue__isnull=True),
+        opis="Nie określono, czy monografia powstała w ramach projektu NCN, "
+        "NPRH, FNP lub finansowanego przez Unię Europejską.",
+        paragraf="§ 2 ust. 10 pkt 5 lit. k",
+    ),
+    *_reguly_open_access("MON", Osiagniecie.MONOGRAFIA, "§ 2 ust. 10 pkt 5 lit. m"),
+    *_reguly_oplaty("MON", Osiagniecie.MONOGRAFIA, "§ 2 ust. 10 pkt 5 lit. n"),
+)
+
+
+# --------------------------------------------------------------------------
+# Rozdział w monografii — § 2 ust. 10 pkt 6 — bpp.Wydawnictwo_Zwarte_Autor
+#
+# Rozdział dziedziczy wymogi monografii macierzystej (lit. a odsyła do pkt 5),
+# ale raport ich tu NIE duplikuje — braki monografii pokazuje przy monografii.
+# Inaczej jedna niekompletna książka generowałaby braki przy każdym
+# z kilkunastu rozdziałów, zalewając listę.
+# --------------------------------------------------------------------------
+
+REGULY_ROZDZIAL: tuple[Regula, ...] = (
+    Regula(
+        kod="ROZ_NADRZEDNE",
+        dotyczy=Osiagniecie.ROZDZIAL,
+        warunek=Q(rekord__wydawnictwo_nadrzedne__isnull=True)
+        & Q(rekord__wydawnictwo_nadrzedne_w_pbn__isnull=True),
+        opis="Nie wskazano monografii, w której rozdział się ukazał — ani "
+        "rekordu w BPP, ani publikacji w PBN.",
+        paragraf="§ 2 ust. 10 pkt 6 lit. a",
+    ),
+    Regula(
+        kod="ROZ_ORCID",
+        dotyczy=Osiagniecie.ROZDZIAL,
+        warunek=BRAK_ORCID,
+        opis="Autor nie ma wpisanego identyfikatora ORCID.",
+        paragraf="§ 2 ust. 10 pkt 6 lit. c",
+        waga=Waga.WARUNKOWE,
+    ),
+    Regula(
+        kod="ROZ_DYSCYPLINA",
+        dotyczy=Osiagniecie.ROZDZIAL,
+        warunek=BRAK_DYSCYPLINY,
+        opis="Autorowi nie przypisano dyscypliny naukowej dla tej pracy "
+        "albo dyscyplina została odpięta.",
+        paragraf="§ 2 ust. 10 pkt 6 lit. d",
+    ),
+    Regula(
+        kod="ROZ_UPOWAZNIENIE",
+        dotyczy=Osiagniecie.ROZDZIAL,
+        warunek=BRAK_UPOWAZNIENIA,
+        opis="Brak upoważnienia autora do wykazania tej pracy w ewaluacji.",
+        paragraf="§ 2 ust. 10 pkt 6 lit. e",
+    ),
+)
+
+
+# --------------------------------------------------------------------------
+# Patent — § 2 ust. 10 pkt 1 — bpp.Patent_Autor
+#
+# Model Patent pokrywa tylko litery a, c, g oraz — przez relacje — k i m.
+# Dla liter b, d, e, f, h, i, j, l BPP nie ma pól (nazwa uprawnionego,
+# urząd udzielający, państwa ochrony, data ogłoszenia w „Wiadomościach Urzędu
+# Patentowego", uprzednie pierwszeństwo, streszczenie opisu, data złożenia
+# tłumaczenia patentu europejskiego). Raport nie może zgłaszać braku danej,
+# dla której nie istnieje miejsce zapisu — por. FD#449.
+# --------------------------------------------------------------------------
+
+REGULY_PATENT: tuple[Regula, ...] = (
+    Regula(
+        kod="PAT_NUMER",
+        dotyczy=Osiagniecie.PATENT,
+        warunek=_puste_lub_null("rekord__numer_prawa_wylacznego"),
+        opis="Nie podano numeru prawa wyłącznego (numeru patentu).",
+        paragraf="§ 2 ust. 10 pkt 1 lit. c",
+    ),
+    Regula(
+        kod="PAT_ZGLOSZENIE",
+        dotyczy=Osiagniecie.PATENT,
+        warunek=_puste_lub_null("rekord__numer_zgloszenia")
+        | Q(rekord__data_zgloszenia__isnull=True),
+        opis="Niekompletne dane zgłoszenia patentowego — brakuje numeru "
+        "zgłoszenia albo jego daty.",
+        paragraf="§ 2 ust. 10 pkt 1 lit. g",
+    ),
+    Regula(
+        kod="PAT_DYSCYPLINA",
+        dotyczy=Osiagniecie.PATENT,
+        warunek=BRAK_DYSCYPLINY,
+        opis="Współtwórcy nie przypisano dyscypliny naukowej dla tego "
+        "patentu albo dyscyplina została odpięta.",
+        paragraf="§ 2 ust. 10 pkt 1 lit. k",
+    ),
+    Regula(
+        kod="PAT_UPOWAZNIENIE",
+        dotyczy=Osiagniecie.PATENT,
+        warunek=BRAK_UPOWAZNIENIA,
+        opis="Brak upoważnienia współtwórcy do wykazania tego patentu w ewaluacji.",
+        paragraf="§ 2 ust. 10 pkt 1 lit. l",
+    ),
+    Regula(
+        kod="PAT_ORCID",
+        dotyczy=Osiagniecie.PATENT,
+        warunek=BRAK_ORCID,
+        opis="Współtwórca nie ma wpisanego identyfikatora ORCID.",
+        paragraf="§ 2 ust. 10 pkt 1 lit. m",
+        waga=Waga.WARUNKOWE,
+    ),
+)
+
+
+#: Kompletny rejestr reguł kompletności danych POL-on.
+REGULY: tuple[Regula, ...] = (
+    *REGULY_ARTYKUL,
+    *REGULY_MONOGRAFIA,
+    *REGULY_ROZDZIAL,
+    *REGULY_PATENT,
+)
+
+
+def reguly_dla(osiagniecie: Osiagniecie) -> tuple[Regula, ...]:
+    """Zwróć reguły dotyczące danego typu osiągnięcia."""
+    return tuple(regula for regula in REGULY if regula.dotyczy == osiagniecie)

--- a/src/kompletnosc_polon/reguly.py
+++ b/src/kompletnosc_polon/reguly.py
@@ -135,10 +135,29 @@ BRAK_UPOWAZNIENIA = Q(upowaznienie_pbn=False)
 #: Autor nie ma numeru ORCID. Pole ``Autor.orcid`` jest nullowalne (unique).
 BRAK_ORCID = _puste_lub_null("autor__orcid")
 
-#: Praca jest oznaczona jako Open Access. Wszystkie wymogi OA są warunkowe
-#: względem tego oznaczenia: bez trybu dostępu rozporządzenie nie żąda
-#: danych OA i raport milczy.
+#: Praca jest oznaczona jako Open Access. Wszystkie wymogi OA — poza samym
+#: trybem dostępu — są warunkowe względem tego oznaczenia: bez trybu dostępu
+#: rozporządzenie nie żąda danych OA i raport milczy.
 OZNACZONO_OPEN_ACCESS = Q(rekord__openaccess_tryb_dostepu__isnull=False)
+
+#: Wypełniono JAKIKOLWIEK sygnał otwartego dostępu inny niż sam tryb.
+#: Wszystkie pola są kolumnami samego rekordu (FK „do jednego” albo liczba),
+#: więc warunek nie zwielokrotnia wierszy przy ``annotate()``.
+JAKIS_SYGNAL_OPEN_ACCESS = (
+    Q(rekord__openaccess_wersja_tekstu__isnull=False)
+    | Q(rekord__openaccess_licencja__isnull=False)
+    | Q(rekord__openaccess_data_opublikowania__isnull=False)
+    | Q(rekord__openaccess_czas_publikacji__isnull=False)
+    | Q(rekord__openaccess_ilosc_miesiecy__isnull=False)
+)
+
+#: Dane o otwartym dostępie zaczęte, ale bez trybu dostępu — czyli bez
+#: pierwszego tiretu litery („otwarte czasopismo / otwarte repozytorium /
+#: inny sposób”). Bez żadnego sygnału OA warunek jest fałszywy: praca
+#: po prostu nie jest w otwartym dostępie i nie ma czego wymagać.
+BRAK_TRYBU_OPEN_ACCESS = (
+    Q(rekord__openaccess_tryb_dostepu__isnull=True) & JAKIS_SYGNAL_OPEN_ACCESS
+)
 
 #: Brak kompletu danych o opłacie za publikację (APC): nie wiadomo nawet,
 #: czy publikacja była bezkosztowa.
@@ -148,6 +167,18 @@ BRAK_DANYCH_O_OPLACIE = (
     & Q(rekord__opl_pub_research_potential__isnull=True)
     & Q(rekord__opl_pub_research_or_development_projects__isnull=True)
     & Q(rekord__opl_pub_other__isnull=True)
+)
+
+#: Zadeklarowano, że publikacja NIE była bezkosztowa, ale nie podano kwoty.
+#: Domyka lukę między :data:`BRAK_DANYCH_O_OPLACIE` (żąda, by wszystkie pięć
+#: pól było puste) a :data:`BRAK_ZRODLA_OPLATY` (żąda kwoty dodatniej): bez
+#: tego warunku rekord z samym odznaczonym „bezkosztowa” nie naruszał NICZEGO,
+#: choć redaktor zadeklarował opłatę i nie podał ani jej kwoty, ani źródła.
+#: Kwota zerowa przy odznaczonej bezkosztowości jest wewnętrznie sprzeczna,
+#: więc traktujemy ją tak samo jak brak kwoty — inaczej luka zostałaby otwarta
+#: dla wartości 0.
+BRAK_KWOTY_OPLATY = Q(rekord__opl_pub_cost_free=False) & (
+    Q(rekord__opl_pub_amount__isnull=True) | Q(rekord__opl_pub_amount=0)
 )
 
 #: Wpisano kwotę opłaty, ale nie wskazano źródła jej finansowania.
@@ -164,13 +195,31 @@ def _reguly_open_access(
     dotyczy: Osiagniecie,
     paragraf: str,
 ) -> tuple[Regula, ...]:
-    """Pięć reguł Open Access, identycznych dla artykułu i monografii.
+    """Sześć reguł Open Access, identycznych dla artykułu i monografii.
 
-    Wszystkie poza ``*_OA_MIESIACE`` są warunkowe względem ustawionego trybu
-    dostępu. ``*_OA_MIESIACE`` uruchamia się węziej — tylko dla udostępnienia
-    po opublikowaniu, bo tylko wtedy liczba miesięcy karencji ma sens.
+    Pierwszym tiretem litery jest sam **tryb dostępu** (otwarte czasopismo,
+    otwarte repozytorium albo inny sposób) — stąd ``*_OA_TRYB``. Reguła
+    uruchamia się, gdy wypełniono którykolwiek inny sygnał otwartego dostępu,
+    a trybu nie podano: dana jest wtedy zaczęta i niedokończona. Bez żadnego
+    sygnału raport milczy, bo praca po prostu nie jest w otwartym dostępie.
+
+    Pozostałe pięć reguł bramkuje **ustawiony tryb dostępu** — wszystkie tak
+    samo, ``*_OA_MIESIACE`` włącznie. Wcześniej ta jedna bramkowana była
+    wyłącznie skrótem czasu udostępnienia, więc rekord bez trybu potrafił
+    dostać brak liczby miesięcy i NIE dostać braku wersji tekstu: dwie reguły
+    tej samej litery mówiły co innego o tym samym rekordzie.
+    ``*_OA_MIESIACE`` zawęża się dodatkowo do udostępnienia po opublikowaniu,
+    bo tylko wtedy liczba miesięcy karencji ma sens.
     """
     return (
+        Regula(
+            kod=f"{prefiks_kodu}_OA_TRYB",
+            dotyczy=dotyczy,
+            warunek=BRAK_TRYBU_OPEN_ACCESS,
+            opis="Wypełniono dane o otwartym dostępie, ale nie podano trybu "
+            "dostępu (otwarte czasopismo, otwarte repozytorium, inny sposób).",
+            paragraf=paragraf,
+        ),
         Regula(
             kod=f"{prefiks_kodu}_OA_WERSJA",
             dotyczy=dotyczy,
@@ -209,9 +258,8 @@ def _reguly_open_access(
         Regula(
             kod=f"{prefiks_kodu}_OA_MIESIACE",
             dotyczy=dotyczy,
-            warunek=Q(
-                rekord__openaccess_czas_publikacji__skrot=OA_CZAS_PO_OPUBLIKOWANIU
-            )
+            warunek=OZNACZONO_OPEN_ACCESS
+            & Q(rekord__openaccess_czas_publikacji__skrot=OA_CZAS_PO_OPUBLIKOWANIU)
             & Q(rekord__openaccess_ilosc_miesiecy__isnull=True),
             opis="Pracę udostępniono po opublikowaniu, ale nie podano liczby "
             "miesięcy, jakie upłynęły od publikacji do udostępnienia.",
@@ -225,7 +273,13 @@ def _reguly_oplaty(
     dotyczy: Osiagniecie,
     paragraf: str,
 ) -> tuple[Regula, ...]:
-    """Dwie reguły dotyczące opłaty za publikację (APC)."""
+    """Trzy reguły dotyczące opłaty za publikację (APC).
+
+    Razem pokrywają całą deklarację bez dziur: albo nie wypełniono niczego
+    (``*_APC``), albo zadeklarowano opłatę i nie podano kwoty
+    (``*_APC_KWOTA``), albo podano kwotę i nie wskazano źródła
+    (``*_APC_ZRODLO``).
+    """
     return (
         Regula(
             kod=f"{prefiks_kodu}_APC",
@@ -236,11 +290,74 @@ def _reguly_oplaty(
             paragraf=paragraf,
         ),
         Regula(
+            kod=f"{prefiks_kodu}_APC_KWOTA",
+            dotyczy=dotyczy,
+            warunek=BRAK_KWOTY_OPLATY,
+            opis="Zaznaczono, że publikacja nie była bezkosztowa, ale nie "
+            "podano kwoty opłaty za publikację.",
+            paragraf=paragraf,
+        ),
+        Regula(
             kod=f"{prefiks_kodu}_APC_ZRODLO",
             dotyczy=dotyczy,
             warunek=BRAK_ZRODLA_OPLATY,
             opis="Wpisano kwotę opłaty za publikację, ale nie wskazano "
             "żadnego źródła jej finansowania.",
+            paragraf=paragraf,
+        ),
+    )
+
+
+def _reguly_konferencji(
+    prefiks_kodu: str,
+    dotyczy: Osiagniecie,
+    paragraf: str,
+) -> tuple[Regula, ...]:
+    """Trzy reguły o konferencji — po jednej na tiret litery.
+
+    Wszystkie są bramkowane **wskazaniem konferencji**
+    (``rekord__konferencja__isnull=False``). Rozporządzenie pyta, czy praca
+    została opublikowana w materiałach konferencyjnych — „nie” jest legalną
+    odpowiedzią, więc od rekordu bez konferencji raport nie żąda niczego.
+    Dopiero wskazanie konferencji zobowiązuje do podania jej nazwy, dat
+    i miejsca.
+
+    ``Konferencja.nazwa`` jest ``CharField`` NOT NULL, ale ``miasto``
+    i ``panstwo`` dopuszczają NULL — stąd dwa różne pomocniki pustki.
+    Daty i miejsce traktujemy łącznie: brak którejkolwiek połowy znaczy, że
+    danej z tiretu nie da się sprawozdać w całości.
+    """
+    return (
+        Regula(
+            kod=f"{prefiks_kodu}_KONFERENCJA_NAZWA",
+            dotyczy=dotyczy,
+            warunek=Q(rekord__konferencja__isnull=False)
+            & _puste("rekord__konferencja__nazwa"),
+            opis="Wskazano konferencję, ale nie ma ona wpisanej nazwy.",
+            paragraf=paragraf,
+        ),
+        Regula(
+            kod=f"{prefiks_kodu}_KONFERENCJA_DATY",
+            dotyczy=dotyczy,
+            warunek=Q(rekord__konferencja__isnull=False)
+            & (
+                Q(rekord__konferencja__rozpoczecie__isnull=True)
+                | Q(rekord__konferencja__zakonczenie__isnull=True)
+            ),
+            opis="Wskazano konferencję, ale nie podano pełnego zakresu jej "
+            "trwania — brakuje daty rozpoczęcia albo zakończenia.",
+            paragraf=paragraf,
+        ),
+        Regula(
+            kod=f"{prefiks_kodu}_KONFERENCJA_MIEJSCE",
+            dotyczy=dotyczy,
+            warunek=Q(rekord__konferencja__isnull=False)
+            & (
+                _puste_lub_null("rekord__konferencja__miasto")
+                | _puste_lub_null("rekord__konferencja__panstwo")
+            ),
+            opis="Wskazano konferencję, ale nie podano pełnego miejsca jej "
+            "odbycia — brakuje miasta albo państwa.",
             paragraf=paragraf,
         ),
     )
@@ -288,6 +405,7 @@ REGULY_ARTYKUL: tuple[Regula, ...] = (
         opis="Nie określono, czy artykuł jest artykułem recenzyjnym.",
         paragraf="§ 2 ust. 10 pkt 4 lit. f",
     ),
+    *_reguly_konferencji("ART", Osiagniecie.ARTYKUL, "§ 2 ust. 10 pkt 4 lit. g"),
     Regula(
         kod="ART_ZRODLO",
         dotyczy=Osiagniecie.ARTYKUL,
@@ -363,7 +481,7 @@ REGULY_MONOGRAFIA: tuple[Regula, ...] = (
         kod="MON_WYDAWCA",
         dotyczy=Osiagniecie.MONOGRAFIA,
         warunek=Q(rekord__wydawca__isnull=True) & _puste("rekord__wydawca_opis"),
-        opis="Nie wskazano wydawcy monografii — ani ze słownika wydawców, ani opisowo.",
+        opis="Nie wskazano wydawcy monografii — ani ze słownika, ani opisowo.",
         paragraf="§ 2 ust. 10 pkt 5 lit. e",
     ),
     Regula(
@@ -385,7 +503,7 @@ REGULY_MONOGRAFIA: tuple[Regula, ...] = (
         kod="MON_EDYCJA_NAUKOWA",
         dotyczy=Osiagniecie.MONOGRAFIA,
         warunek=Q(rekord__pbn_czy_edycja_naukowa__isnull=True),
-        opis="Nie określono, czy monografia jest edycją naukową tekstów źródłowych.",
+        opis="Nie określono, czy monografia to edycja naukowa tekstów źródłowych.",
         paragraf="§ 2 ust. 10 pkt 5 lit. j",
     ),
     Regula(
@@ -407,11 +525,36 @@ REGULY_MONOGRAFIA: tuple[Regula, ...] = (
 # --------------------------------------------------------------------------
 # Rozdział w monografii — § 2 ust. 10 pkt 6 — bpp.Wydawnictwo_Zwarte_Autor
 #
-# Rozdział dziedziczy wymogi monografii macierzystej (lit. a odsyła do pkt 5),
-# ale raport ich tu NIE duplikuje — braki monografii pokazuje przy monografii.
-# Inaczej jedna niekompletna książka generowałaby braki przy każdym
-# z kilkunastu rozdziałów, zalewając listę.
+# Litera a odsyła do KOMPLETU wymogów pkt 5, czyli do danych monografii
+# macierzystej. Raport sprawdza z nich wyłącznie **trio identyfikujące**
+# książkę: ISBN/e-ISBN, wydawcę oraz DOI/URL (reguły ``ROZ_MON_*``). Wybór
+# jest świadomy i wynika z dwóch obserwacji:
+#
+# 1. Monografia macierzysta trafia do raportu jako osobne osiągnięcie TYLKO
+#    wtedy, gdy sama ma choć jednego autora z uczelni. Typowy rozdział
+#    w pracy zbiorowej pod obcą redakcją ma rodzica bez takiego autora, więc
+#    rodzic nigdy nie pojawiłby się w raporcie — i lit. a nie byłaby
+#    sprawdzana w ogóle. Dlatego czegoś tu sprawdzać trzeba.
+# 2. Pełne powielenie pkt 5 na rozdziale dawałoby podwójne zgłoszenia dla
+#    rodziców, którzy JUŻ są audytowani jako monografia, i zalewałoby listę:
+#    jedna niekompletna książka generowałaby komplet braków przy każdym
+#    z kilkunastu rozdziałów. Trio identyfikujące to minimum, bez którego
+#    książki nie da się w POL-onie wskazać, a jednocześnie zbiór na tyle
+#    wąski, że duplikat przy rodzicu-z-uczelni jest znośny.
+#
+# Wymogi zależne od autora (dyscyplina, upoważnienie, ORCID) i od redakcji
+# rodzica (OA, APC, projekty) świadomie zostają poza tym zestawem — dotyczą
+# osób i decyzji, których redaktor rozdziału nie ma jak uzupełnić.
+#
+# Wszystkie reguły ``ROZ_MON_*`` bramkuje wskazany rodzic
+# (``rekord__wydawnictwo_nadrzedne__isnull=False``), żeby nie dublowały
+# ``ROZ_NADRZEDNE`` — rozdział bez rodzica ma dostać jedno zgłoszenie, nie
+# cztery. Bramka jest też warunkiem poprawności: bez rodzica LEFT JOIN daje
+# same NULL-e, a porównanie z pustym ciągiem nie zadziała.
 # --------------------------------------------------------------------------
+
+#: Rozdział ma wskazaną monografię macierzystą w BPP.
+WSKAZANO_MONOGRAFIE_MACIERZYSTA = Q(rekord__wydawnictwo_nadrzedne__isnull=False)
 
 REGULY_ROZDZIAL: tuple[Regula, ...] = (
     Regula(
@@ -421,6 +564,36 @@ REGULY_ROZDZIAL: tuple[Regula, ...] = (
         & Q(rekord__wydawnictwo_nadrzedne_w_pbn__isnull=True),
         opis="Nie wskazano monografii, w której rozdział się ukazał — ani "
         "rekordu w BPP, ani publikacji w PBN.",
+        paragraf="§ 2 ust. 10 pkt 6 lit. a",
+    ),
+    Regula(
+        kod="ROZ_MON_ISBN",
+        dotyczy=Osiagniecie.ROZDZIAL,
+        warunek=WSKAZANO_MONOGRAFIE_MACIERZYSTA
+        & _puste("rekord__wydawnictwo_nadrzedne__isbn")
+        & _puste("rekord__wydawnictwo_nadrzedne__e_isbn"),
+        opis="Monografia, w której ukazał się rozdział, nie ma ISBN ani e-ISBN.",
+        paragraf="§ 2 ust. 10 pkt 6 lit. a",
+    ),
+    Regula(
+        kod="ROZ_MON_WYDAWCA",
+        dotyczy=Osiagniecie.ROZDZIAL,
+        warunek=WSKAZANO_MONOGRAFIE_MACIERZYSTA
+        & Q(rekord__wydawnictwo_nadrzedne__wydawca__isnull=True)
+        & _puste("rekord__wydawnictwo_nadrzedne__wydawca_opis"),
+        opis="Monografia, w której ukazał się rozdział, nie ma wskazanego "
+        "wydawcy — ani ze słownika wydawców, ani opisowo.",
+        paragraf="§ 2 ust. 10 pkt 6 lit. a",
+    ),
+    Regula(
+        kod="ROZ_MON_DOI",
+        dotyczy=Osiagniecie.ROZDZIAL,
+        warunek=WSKAZANO_MONOGRAFIE_MACIERZYSTA
+        & _puste_lub_null("rekord__wydawnictwo_nadrzedne__doi")
+        & _puste("rekord__wydawnictwo_nadrzedne__public_www")
+        & _puste("rekord__wydawnictwo_nadrzedne__www"),
+        opis="Monografia, w której ukazał się rozdział, nie ma numeru DOI "
+        "ani adresu strony WWW.",
         paragraf="§ 2 ust. 10 pkt 6 lit. a",
     ),
     Regula(
@@ -452,8 +625,8 @@ REGULY_ROZDZIAL: tuple[Regula, ...] = (
 # --------------------------------------------------------------------------
 # Patent — § 2 ust. 10 pkt 1 — bpp.Patent_Autor
 #
-# Model Patent pokrywa tylko litery a, c, g oraz — przez relacje — k i m.
-# Dla liter b, d, e, f, h, i, j, l BPP nie ma pól (nazwa uprawnionego,
+# Model Patent pokrywa litery a, c, g oraz — przez relacje — k, l i m.
+# Dla liter b, d, e, f, h, i, j BPP nie ma pól (nazwa uprawnionego,
 # urząd udzielający, państwa ochrony, data ogłoszenia w „Wiadomościach Urzędu
 # Patentowego", uprzednie pierwszeństwo, streszczenie opisu, data złożenia
 # tłumaczenia patentu europejskiego). Raport nie może zgłaszać braku danej,

--- a/src/kompletnosc_polon/selektory.py
+++ b/src/kompletnosc_polon/selektory.py
@@ -1,0 +1,237 @@
+"""Budowa querysetów raportu kompletności danych POL-on.
+
+Ziarnem raportu jest **para (autor, rekord)**, czyli dokładnie jeden wiersz
+*through-modelu* powiązania autora z publikacją (``Wydawnictwo_Ciagle_Autor``,
+``Wydawnictwo_Zwarte_Autor``, ``Patent_Autor``). Wynika to z konstrukcji
+§ 2 ust. 10 rozporządzenia: osiągnięcia trafiają do *wykazu pracowników*,
+a każde niesie własną dyscyplinę i własne upoważnienie. Ten sam artykuł
+dwóch współautorów to w POL-onie dwa wpisy.
+
+Moduł wystawia trzy warstwy, składane przez widok:
+
+1. :func:`powiazania` — surowe ziarno, zawężone do okna ewaluacji, do
+   przypiętych powiązań i do uczelni oglądającego;
+2. :func:`z_regulami` — anotacja: po jednym ``BooleanField`` na regułę plus
+   liczniki braków wymaganych i warunkowych;
+3. :func:`naruszone_reguly` — odczyt anotacji z pojedynczego wiersza jako
+   listy obiektów :class:`~kompletnosc_polon.reguly.Regula` (z opisem
+   i podstawą prawną, do wyświetlenia).
+
+Rozbieżności wobec projektu (świadome, opisane)
+===============================================
+
+*Zawężenie „przypięta dyscyplina”* realizujemy jako ``przypieta=True``
+i **nie** dokładamy ``dyscyplina_naukowa__isnull=False``. Projekt w sekcji
+„Przepływ danych” wymienia oba warunki, ale drugi z nich unieważniłby reguły
+``*_DYSCYPLINA`` (``dyscyplina_naukowa`` NULL **lub** ``przypieta=False``) —
+powiązanie bez dyscypliny wypadałoby z raportu, zamiast zostać w nim
+zgłoszone jako brak. Zostawiamy więc w raporcie powiązania przypięte, ale
+bezdyscyplinowe; człon ``przypieta=False`` reguł ``*_DYSCYPLINA`` jest przy
+tym zawężeniu nieosiągalny i pozostaje wyłącznie jako dokumentacja wymogu.
+"""
+
+from functools import reduce
+
+from django.apps import apps
+from django.db.models import (
+    BooleanField,
+    Case,
+    IntegerField,
+    Q,
+    QuerySet,
+    Value,
+    When,
+)
+
+from bpp.const import CHARAKTER_SLOTY_KSIAZKA, CHARAKTER_SLOTY_ROZDZIAL
+from bpp.util.uczelnia_scope import scope_autorzy_do_uczelni
+from ewaluacja_common.const import OKNO_EWALUACJI
+from kompletnosc_polon.const import Osiagniecie, Waga
+from kompletnosc_polon.reguly import Regula, reguly_dla
+
+#: Prefiks nazw anotacji z wynikiem reguły: ``brak_ART_DOI`` itd.
+PREFIKS_POLA_REGULY = "brak_"
+
+#: Nazwa anotacji z liczbą naruszonych reguł bezwarunkowych.
+POLE_BRAKI_WYMAGANE = "braki_wymagane"
+
+#: Nazwa anotacji z liczbą naruszonych reguł warunkowych („jeżeli posiada”).
+POLE_BRAKI_WARUNKOWE = "braki_warunkowe"
+
+#: Through-model niosący ziarno raportu dla danego typu osiągnięcia.
+#: Monografia i rozdział dzielą jeden model — rozróżnia je dopiero
+#: ``charakter_formalny.charakter_sloty`` (patrz :data:`CHARAKTER_SLOTOW`).
+MODEL_POWIAZANIA: dict[Osiagniecie, str] = {
+    Osiagniecie.ARTYKUL: "bpp.Wydawnictwo_Ciagle_Autor",
+    Osiagniecie.MONOGRAFIA: "bpp.Wydawnictwo_Zwarte_Autor",
+    Osiagniecie.ROZDZIAL: "bpp.Wydawnictwo_Zwarte_Autor",
+    Osiagniecie.PATENT: "bpp.Patent_Autor",
+}
+
+#: Wartość ``Charakter_Formalny.charakter_sloty`` klasyfikująca wydawnictwo
+#: zwarte do danego typu osiągnięcia. Typy spoza tego słownika (artykuł,
+#: patent) nie podlegają klasyfikacji po charakterze formalnym: patent nie ma
+#: takiego pola w ogóle, a wydawnictwo ciągłe jest zawsze pkt 4.
+CHARAKTER_SLOTOW: dict[Osiagniecie, int] = {
+    Osiagniecie.MONOGRAFIA: CHARAKTER_SLOTY_KSIAZKA,
+    Osiagniecie.ROZDZIAL: CHARAKTER_SLOTY_ROZDZIAL,
+}
+
+
+def pole_reguly(kod: str) -> str:
+    """Nazwa anotacji niosącej wynik reguły o podanym kodzie."""
+    return f"{PREFIKS_POLA_REGULY}{kod}"
+
+
+def _model(osiagniecie: Osiagniecie):
+    return apps.get_model(MODEL_POWIAZANIA[osiagniecie])
+
+
+def _zawez(qs, okno: tuple[int, int], uczelnia) -> QuerySet:
+    """Wspólne zawężenie ziarna: okno ewaluacji, przypięcie, uczelnia.
+
+    Okno jest przedziałem **domkniętym** — oba lata graniczne wchodzą.
+
+    Uczelnię odsiewamy przez ``scope_autorzy_do_uczelni``: through-modele
+    niosą ``jednostka``, dokładnie tak jak mat-view autorstw, dla którego ten
+    pomocnik powstał, więc reguła atrybucji (jednostka zapisana na autorstwie)
+    i guard single-install są wspólne z resztą systemu — nie powielamy ich
+    tutaj własnym filtrem.
+    """
+    pierwszy_rok, ostatni_rok = okno
+    qs = qs.filter(
+        rekord__rok__gte=pierwszy_rok,
+        rekord__rok__lte=ostatni_rok,
+        przypieta=True,
+    )
+    return scope_autorzy_do_uczelni(qs, uczelnia)
+
+
+def powiazania(
+    osiagniecie: Osiagniecie,
+    uczelnia=None,
+    okno: tuple[int, int] = OKNO_EWALUACJI,
+) -> QuerySet:
+    """Ziarno raportu dla jednego typu osiągnięcia.
+
+    :param osiagniecie: typ osiągnięcia w rozumieniu § 2 ust. 10.
+    :param uczelnia: uczelnia oglądającego; ``None`` (albo instalacja
+        jednouczelniana) oznacza brak zawężenia.
+    :param okno: domknięty przedział lat; domyślnie bieżące okno ewaluacji.
+    """
+    qs = _zawez(_model(osiagniecie).objects.all(), okno, uczelnia)
+
+    charakter_slotow = CHARAKTER_SLOTOW.get(osiagniecie)
+    if charakter_slotow is not None:
+        qs = qs.filter(rekord__charakter_formalny__charakter_sloty=charakter_slotow)
+
+    return qs
+
+
+def powiazania_nierozpoznane(
+    uczelnia=None,
+    okno: tuple[int, int] = OKNO_EWALUACJI,
+) -> QuerySet:
+    """Powiązania z wydawnictwem zwartym, którego nie da się zaklasyfikować.
+
+    Fixture instalacyjny BPP zostawia ``Charakter_Formalny.charakter_sloty``
+    puste, a bez tej wartości nie wiadomo, czy rekord jest monografią (pkt 5),
+    czy rozdziałem (pkt 6) — a więc których wymogów od niego oczekiwać. Takie
+    powiązania wypadają z obu querysetów :func:`powiazania` i **nie wolno im
+    zniknąć po cichu**, bo użytkownik uznałby, że raport je sprawdził
+    i nie znalazł zastrzeżeń. Widok pokazuje je w osobnej sekcji
+    „nierozpoznany typ osiągnięcia”.
+
+    Zakres celowo ograniczony do ``charakter_sloty IS NULL``, czyli do
+    *braku klasyfikacji*. Wydawnictwo zwarte oznaczone jako referat
+    (``CHARAKTER_SLOTY_REFERAT``) jest zaklasyfikowane jawnie i po prostu nie
+    należy do żadnego z punktów objętych raportem — to nie jest brak danych.
+    """
+    return _zawez(
+        apps.get_model("bpp.Wydawnictwo_Zwarte_Autor").objects.filter(
+            rekord__charakter_formalny__charakter_sloty__isnull=True
+        ),
+        okno,
+        uczelnia,
+    )
+
+
+def _czy_brakuje(warunek: Q):
+    """Wyrażenie logiczne: czy warunek reguły zachodzi dla tego wiersza."""
+    return Case(
+        When(warunek, then=Value(True)),
+        default=Value(False),
+        output_field=BooleanField(),
+    )
+
+
+def _ile_brakow(reguly):
+    """Suma naruszonych reguł — dodawanie wyrażeń, nie agregat.
+
+    Świadomie NIE używamy ``Sum``: liczymy w obrębie jednego wiersza, więc
+    agregat wymusiłby ``GROUP BY`` po całym through-modelu. Zwykłe dodawanie
+    wyrażeń ``CASE ... THEN 1 ELSE 0`` daje ten sam wynik jednym przebiegiem.
+    """
+    skladniki = [
+        Case(
+            When(regula.warunek, then=Value(1)),
+            default=Value(0),
+            output_field=IntegerField(),
+        )
+        for regula in reguly
+    ]
+    if not skladniki:
+        return Value(0, output_field=IntegerField())
+    return reduce(lambda a, b: a + b, skladniki)
+
+
+def z_regulami(qs: QuerySet, osiagniecie: Osiagniecie) -> QuerySet:
+    """Dołóż anotacje z wynikiem każdej reguły danego typu osiągnięcia.
+
+    Dokładane pola:
+
+    * ``brak_<KOD>`` (``BooleanField``) — po jednym na regułę z
+      :func:`~kompletnosc_polon.reguly.reguly_dla`; ``True`` znaczy „danej
+      brakuje”;
+    * :data:`POLE_BRAKI_WYMAGANE` i :data:`POLE_BRAKI_WARUNKOWE`
+      (``IntegerField``) — liczba naruszonych reguł danej wagi.
+
+    Queryset MUSI startować z through-modelu odpowiadającego typowi
+    osiągnięcia (patrz :func:`powiazania`) — warunki reguł zapisane są od tej
+    strony relacji.
+    """
+    reguly = reguly_dla(osiagniecie)
+
+    anotacje = {pole_reguly(r.kod): _czy_brakuje(r.warunek) for r in reguly}
+    anotacje[POLE_BRAKI_WYMAGANE] = _ile_brakow(
+        [r for r in reguly if r.waga == Waga.WYMAGANE]
+    )
+    anotacje[POLE_BRAKI_WARUNKOWE] = _ile_brakow(
+        [r for r in reguly if r.waga == Waga.WARUNKOWE]
+    )
+
+    return qs.annotate(**anotacje)
+
+
+def naruszone_reguly(wiersz, osiagniecie: Osiagniecie) -> list[Regula]:
+    """Reguły naruszone przez pojedynczy — zanotowany — wiersz raportu.
+
+    Zwraca obiekty :class:`~kompletnosc_polon.reguly.Regula`, a nie same kody,
+    bo widok szczegółów wypisuje z nich opis i podstawę prawną.
+
+    :raises ValueError: gdy wiersz nie przeszedł przez :func:`z_regulami`.
+        Cicha pusta lista byłaby tu najgorszą możliwą odpowiedzią — wyglądałaby
+        jak „rekord kompletny”.
+    """
+    naruszone = []
+    for regula in reguly_dla(osiagniecie):
+        pole = pole_reguly(regula.kod)
+        if not hasattr(wiersz, pole):
+            raise ValueError(
+                f"Wiersz {wiersz!r} nie ma anotacji {pole!r} — przepuść "
+                f"queryset przez z_regulami(qs, {osiagniecie!r}) zanim "
+                f"zapytasz o naruszone reguły."
+            )
+        if getattr(wiersz, pole):
+            naruszone.append(regula)
+    return naruszone

--- a/src/kompletnosc_polon/selektory.py
+++ b/src/kompletnosc_polon/selektory.py
@@ -43,7 +43,11 @@ from django.db.models import (
     When,
 )
 
-from bpp.const import CHARAKTER_SLOTY_KSIAZKA, CHARAKTER_SLOTY_ROZDZIAL
+from bpp.const import (
+    CHARAKTER_SLOTY_KSIAZKA,
+    CHARAKTER_SLOTY_ROZDZIAL,
+    RODZAJ_PBN_ARTYKUL,
+)
 from bpp.util.uczelnia_scope import scope_autorzy_do_uczelni
 from ewaluacja_common.const import OKNO_EWALUACJI
 from kompletnosc_polon.const import Osiagniecie, Waga
@@ -60,7 +64,7 @@ POLE_BRAKI_WARUNKOWE = "braki_warunkowe"
 
 #: Through-model niosący ziarno raportu dla danego typu osiągnięcia.
 #: Monografia i rozdział dzielą jeden model — rozróżnia je dopiero
-#: ``charakter_formalny.charakter_sloty`` (patrz :data:`CHARAKTER_SLOTOW`).
+#: ``charakter_formalny.charakter_sloty`` (patrz :data:`FILTR_CHARAKTERU`).
 MODEL_POWIAZANIA: dict[Osiagniecie, str] = {
     Osiagniecie.ARTYKUL: "bpp.Wydawnictwo_Ciagle_Autor",
     Osiagniecie.MONOGRAFIA: "bpp.Wydawnictwo_Zwarte_Autor",
@@ -68,13 +72,49 @@ MODEL_POWIAZANIA: dict[Osiagniecie, str] = {
     Osiagniecie.PATENT: "bpp.Patent_Autor",
 }
 
-#: Wartość ``Charakter_Formalny.charakter_sloty`` klasyfikująca wydawnictwo
-#: zwarte do danego typu osiągnięcia. Typy spoza tego słownika (artykuł,
-#: patent) nie podlegają klasyfikacji po charakterze formalnym: patent nie ma
-#: takiego pola w ogóle, a wydawnictwo ciągłe jest zawsze pkt 4.
-CHARAKTER_SLOTOW: dict[Osiagniecie, int] = {
-    Osiagniecie.MONOGRAFIA: CHARAKTER_SLOTY_KSIAZKA,
-    Osiagniecie.ROZDZIAL: CHARAKTER_SLOTY_ROZDZIAL,
+#: Zawężenie po charakterze formalnym rekordu — po jednym słowniku ``filter()``
+#: na typ osiągnięcia. Patent nie ma charakteru formalnego w ogóle, więc go tu
+#: nie ma.
+#:
+#: **Wydawnictwo ciągłe NIE jest automatycznie artykułem naukowym.** Ten sam
+#: model niesie streszczenia zjazdowe (PSZ, ZSZ), listy do redakcji (L),
+#: recenzje (R) i komentarze (KOM) — rzeczy, które nie są osiągnięciem z § 2
+#: ust. 10 pkt 4 i nigdy nie jadą do PBN. Bez tego filtra raport żądał od nich
+#: DOI, ISSN i flagi „czy artykuł recenzyjny”, zalewając listę brakami, których
+#: nie ma po co uzupełniać.
+#:
+#: Kryterium jest ``Charakter_Formalny.rodzaj_pbn`` — to samo, którym posługuje
+#: się reszta systemu przy pytaniu „czy ten rekord w ogóle jedzie do PBN”
+#: (``pbn_integrator.utils.synchronization``, ``komparator_pbn.views``). Dla
+#: ciągłych zawężamy je jeszcze mocniej, do :data:`RODZAJ_PBN_ARTYKUL`: pkt 4
+#: mówi wprost o *artykule naukowym*, a wszystkie reguły ``ART_*`` (źródło,
+#: ISSN, tom, strony, artykuł recenzyjny) są wymogami artykułu. Charakter
+#: ciągły oznaczony jako rozdział albo książka byłby audytowany nie tą listą
+#: wymogów, co trzeba.
+#:
+#: Wydawnictwo zwarte zostaje przy ``charakter_sloty``: to jedyne pole, które
+#: rozróżnia monografię (pkt 5) od rozdziału (pkt 6), a ``rodzaj_pbn`` byłby
+#: tu redundantny — w fixture instalacyjnym obie wartości idą w parze
+#: (KS/KSP/KSZ/PA/SKR → książka, frg/ROZ/ROZS → rozdział). Nie dokładamy więc
+#: drugiego warunku, który mógłby tylko po cichu ukryć rekord jawnie
+#: zaklasyfikowany jako książka.
+#:
+#: Uwaga o świeżej instalacji: fixture zostawia ``rodzaj_pbn`` pusty także dla
+#: charakteru „AC — Artykuł w czasopismie”. Dopóki administrator go nie ustawi
+#: (ten sam krok konfiguracji, bez którego nie działa eksport do PBN), raport
+#: nie ma w ciągłych czego sprawdzać — i **nie wolno mu wtedy milczeć**:
+#: powiązania z takim rekordem zbiera :func:`_nierozpoznane_ciagle` i pokazuje
+#: sekcja „nierozpoznany typ osiągnięcia”.
+FILTR_CHARAKTERU: dict[Osiagniecie, dict[str, int]] = {
+    Osiagniecie.ARTYKUL: {
+        "rekord__charakter_formalny__rodzaj_pbn": RODZAJ_PBN_ARTYKUL,
+    },
+    Osiagniecie.MONOGRAFIA: {
+        "rekord__charakter_formalny__charakter_sloty": CHARAKTER_SLOTY_KSIAZKA,
+    },
+    Osiagniecie.ROZDZIAL: {
+        "rekord__charakter_formalny__charakter_sloty": CHARAKTER_SLOTY_ROZDZIAL,
+    },
 }
 
 
@@ -121,39 +161,104 @@ def powiazania(
     """
     qs = _zawez(_model(osiagniecie).objects.all(), okno, uczelnia)
 
-    charakter_slotow = CHARAKTER_SLOTOW.get(osiagniecie)
-    if charakter_slotow is not None:
-        qs = qs.filter(rekord__charakter_formalny__charakter_sloty=charakter_slotow)
+    filtr_charakteru = FILTR_CHARAKTERU.get(osiagniecie)
+    if filtr_charakteru is not None:
+        qs = qs.filter(**filtr_charakteru)
 
     return qs
+
+
+def _nierozpoznane_zwarte(uczelnia, okno: tuple[int, int]) -> QuerySet:
+    """Powiązania z wydawnictwem zwartym, którego nie da się zaklasyfikować.
+
+    Fixture instalacyjny BPP zostawia ``Charakter_Formalny.charakter_sloty``
+    puste, a bez tej wartości nie wiadomo, czy rekord jest monografią (pkt 5),
+    czy rozdziałem (pkt 6) — a więc których wymogów od niego oczekiwać.
+
+    Zakres to iloczyn dwóch warunków:
+
+    * ``charakter_sloty IS NULL`` — czyli *brak klasyfikacji*. Wydawnictwo
+      zwarte oznaczone jako referat (``CHARAKTER_SLOTY_REFERAT``) jest
+      zaklasyfikowane jawnie i po prostu nie należy do żadnego z punktów
+      objętych raportem — to nie jest brak danych;
+    * ``rodzaj_pbn IS NOT NULL`` — czyli rekord, który **naprawdę jedzie do
+      PBN**. Bez tego warunku sekcja zbierała charaktery sklasyfikowane
+      poprawnie i celowo (frg, TŁ, SKR, PZ, BR, IN): migracje ``0173``
+      i ``0225`` ustawiają ``charakter_sloty`` wyłącznie dla KS/KSP/KSZ,
+      ROZ/ROZS i PRZ/ZRZ, więc pusta wartość jest normą, a nie usterką.
+      Sekcja „raport tego nie sprawdził” ma zawierać wyłącznie rekordy, dla
+      których to zdanie jest zarzutem.
+    """
+    return _zawez(
+        apps.get_model("bpp.Wydawnictwo_Zwarte_Autor").objects.filter(
+            rekord__charakter_formalny__charakter_sloty__isnull=True,
+            rekord__charakter_formalny__rodzaj_pbn__isnull=False,
+        ),
+        okno,
+        uczelnia,
+    )
+
+
+def _nierozpoznane_ciagle(uczelnia, okno: tuple[int, int]) -> QuerySet:
+    """Powiązania z wydawnictwem ciągłym o niesklasyfikowanym charakterze.
+
+    :data:`FILTR_CHARAKTERU` zawęża ciągłe do
+    ``rodzaj_pbn = RODZAJ_PBN_ARTYKUL`` i tak ma zostać — pkt 4 mówi wprost
+    o *artykule naukowym*, więc streszczenia zjazdowe i listy do redakcji
+    słusznie z raportu wypadają. Rzecz w tym, że ``rodzaj_pbn`` **nie jest
+    ustawiane przez fixture instalacyjny** (patrz migracja ``0174``: wypełnia
+    je z pól ``artykul_pbn``/``ksiazka_pbn``/``rozdzial_pbn`` istniejącej
+    instalacji, a w słowniku dostarczanym z BPP wszystkie są puste).
+    Dopóki administrator nie ustawi go dla charakteru „AC — Artykuł
+    w czasopismie”, z raportu wypadają **wszystkie artykuły naraz** — a to
+    dokładnie ten tryb awarii, którego być nie może: pusta tabela i licznik
+    sprawdzonych powiązań, który artykułów nie obejmuje, czytają się jak
+    „artykuły są w porządku”.
+
+    Warunkiem jest samo ``rodzaj_pbn IS NULL``, czyli *brak rozstrzygnięcia*
+    — nie da się go tu podeprzeć drugim sygnałem tak, jak przy zwartych
+    (``charakter_sloty``): dla ciągłych żadne inne pole charakteru nie mówi,
+    czy rekord jest artykułem naukowym.
+
+    Świadoma cena: pusta wartość jest zarazem legalnym wyborem „nie
+    eksportuj do PBN” (etykieta ``None`` w ``choices``), więc do sekcji trafią
+    także poprawnie oznaczone PSZ, ZSZ, L, R i KOM. Fałszywy alarm jest tu
+    tańszy niż cisza — mówi „raport tego nie sprawdził” o rekordzie, którego
+    faktycznie nie sprawdził, a zamyka się go jednym ustawieniem w słowniku
+    charakterów formalnych.
+    """
+    return _zawez(
+        apps.get_model("bpp.Wydawnictwo_Ciagle_Autor").objects.filter(
+            rekord__charakter_formalny__rodzaj_pbn__isnull=True,
+        ),
+        okno,
+        uczelnia,
+    )
 
 
 def powiazania_nierozpoznane(
     uczelnia=None,
     okno: tuple[int, int] = OKNO_EWALUACJI,
-) -> QuerySet:
-    """Powiązania z wydawnictwem zwartym, którego nie da się zaklasyfikować.
+) -> list[QuerySet]:
+    """Powiązania z rekordem, którego typu osiągnięcia nie da się ustalić.
 
-    Fixture instalacyjny BPP zostawia ``Charakter_Formalny.charakter_sloty``
-    puste, a bez tej wartości nie wiadomo, czy rekord jest monografią (pkt 5),
-    czy rozdziałem (pkt 6) — a więc których wymogów od niego oczekiwać. Takie
-    powiązania wypadają z obu querysetów :func:`powiazania` i **nie wolno im
-    zniknąć po cichu**, bo użytkownik uznałby, że raport je sprawdził
-    i nie znalazł zastrzeżeń. Widok pokazuje je w osobnej sekcji
-    „nierozpoznany typ osiągnięcia”.
+    Takie powiązania wypadają ze wszystkich querysetów :func:`powiazania`
+    i **nie wolno im zniknąć po cichu**, bo użytkownik uznałby, że raport je
+    sprawdził i nie znalazł zastrzeżeń. Widok pokazuje je w jednej wspólnej
+    sekcji „nierozpoznany typ osiągnięcia”.
 
-    Zakres celowo ograniczony do ``charakter_sloty IS NULL``, czyli do
-    *braku klasyfikacji*. Wydawnictwo zwarte oznaczone jako referat
-    (``CHARAKTER_SLOTY_REFERAT``) jest zaklasyfikowane jawnie i po prostu nie
-    należy do żadnego z punktów objętych raportem — to nie jest brak danych.
+    Zwracamy **listę querysetów**, po jednym na model: nierozpoznane bywają
+    i wydawnictwa zwarte (brak ``charakter_sloty``, patrz
+    :func:`_nierozpoznane_zwarte`), i ciągłe (brak ``rodzaj_pbn``, patrz
+    :func:`_nierozpoznane_ciagle`), a to dwa różne through-modele, których
+    jednym querysetem złączyć się nie da. Materializacji nie robimy tutaj —
+    widok listy potrzebuje agregatu ``GROUP BY autor``, a widok szczegółów
+    zawężenia do jednego autora; oba wykonują to na querysetach.
     """
-    return _zawez(
-        apps.get_model("bpp.Wydawnictwo_Zwarte_Autor").objects.filter(
-            rekord__charakter_formalny__charakter_sloty__isnull=True
-        ),
-        okno,
-        uczelnia,
-    )
+    return [
+        _nierozpoznane_zwarte(uczelnia, okno),
+        _nierozpoznane_ciagle(uczelnia, okno),
+    ]
 
 
 def _czy_brakuje(warunek: Q):

--- a/src/kompletnosc_polon/selektory.py
+++ b/src/kompletnosc_polon/selektory.py
@@ -127,10 +127,16 @@ def _model(osiagniecie: Osiagniecie):
     return apps.get_model(MODEL_POWIAZANIA[osiagniecie])
 
 
-def _zawez(qs, okno: tuple[int, int], uczelnia) -> QuerySet:
+def _zawez(qs, okno: tuple[int, int | None], uczelnia) -> QuerySet:
     """Wspólne zawężenie ziarna: okno ewaluacji, przypięcie, uczelnia.
 
-    Okno jest przedziałem **domkniętym** — oba lata graniczne wchodzą.
+    Oba lata graniczne **wchodzą** do wyniku. Górna granica bywa jednak
+    nieustalona: ``ostatni_rok`` równy ``None`` znaczy „od pierwszego roku
+    wzwyż, bez końca” (patrz :data:`ewaluacja_common.const.OKNO_EWALUACJI`)
+    i wtedy górnego odcięcia po prostu nie nakładamy. Odcięcie po zgadniętym
+    roku byłoby gorsze niż jego brak — raport o brakach przestałby po cichu
+    widzieć najnowsze rekordy, a pusta lista czyta się jak „wszystko
+    w porządku”.
 
     Uczelnię odsiewamy przez ``scope_autorzy_do_uczelni``: through-modele
     niosą ``jednostka``, dokładnie tak jak mat-view autorstw, dla którego ten
@@ -139,25 +145,25 @@ def _zawez(qs, okno: tuple[int, int], uczelnia) -> QuerySet:
     tutaj własnym filtrem.
     """
     pierwszy_rok, ostatni_rok = okno
-    qs = qs.filter(
-        rekord__rok__gte=pierwszy_rok,
-        rekord__rok__lte=ostatni_rok,
-        przypieta=True,
-    )
+    qs = qs.filter(rekord__rok__gte=pierwszy_rok, przypieta=True)
+    if ostatni_rok is not None:
+        qs = qs.filter(rekord__rok__lte=ostatni_rok)
     return scope_autorzy_do_uczelni(qs, uczelnia)
 
 
 def powiazania(
     osiagniecie: Osiagniecie,
     uczelnia=None,
-    okno: tuple[int, int] = OKNO_EWALUACJI,
+    okno: tuple[int, int | None] = OKNO_EWALUACJI,
 ) -> QuerySet:
     """Ziarno raportu dla jednego typu osiągnięcia.
 
     :param osiagniecie: typ osiągnięcia w rozumieniu § 2 ust. 10.
     :param uczelnia: uczelnia oglądającego; ``None`` (albo instalacja
         jednouczelniana) oznacza brak zawężenia.
-    :param okno: domknięty przedział lat; domyślnie bieżące okno ewaluacji.
+    :param okno: para ``(pierwszy rok, ostatni rok)``, oba lata wchodzą;
+        ``ostatni rok`` równy ``None`` znaczy „bez górnej granicy”.
+        Domyślnie bieżące okno raportu POL-on.
     """
     qs = _zawez(_model(osiagniecie).objects.all(), okno, uczelnia)
 
@@ -168,7 +174,7 @@ def powiazania(
     return qs
 
 
-def _nierozpoznane_zwarte(uczelnia, okno: tuple[int, int]) -> QuerySet:
+def _nierozpoznane_zwarte(uczelnia, okno: tuple[int, int | None]) -> QuerySet:
     """Powiązania z wydawnictwem zwartym, którego nie da się zaklasyfikować.
 
     Fixture instalacyjny BPP zostawia ``Charakter_Formalny.charakter_sloty``
@@ -199,7 +205,7 @@ def _nierozpoznane_zwarte(uczelnia, okno: tuple[int, int]) -> QuerySet:
     )
 
 
-def _nierozpoznane_ciagle(uczelnia, okno: tuple[int, int]) -> QuerySet:
+def _nierozpoznane_ciagle(uczelnia, okno: tuple[int, int | None]) -> QuerySet:
     """Powiązania z wydawnictwem ciągłym o niesklasyfikowanym charakterze.
 
     :data:`FILTR_CHARAKTERU` zawęża ciągłe do
@@ -238,7 +244,7 @@ def _nierozpoznane_ciagle(uczelnia, okno: tuple[int, int]) -> QuerySet:
 
 def powiazania_nierozpoznane(
     uczelnia=None,
-    okno: tuple[int, int] = OKNO_EWALUACJI,
+    okno: tuple[int, int | None] = OKNO_EWALUACJI,
 ) -> list[QuerySet]:
     """Powiązania z rekordem, którego typu osiągnięcia nie da się ustalić.
 

--- a/src/kompletnosc_polon/templates/kompletnosc_polon/lista.html
+++ b/src/kompletnosc_polon/templates/kompletnosc_polon/lista.html
@@ -78,6 +78,17 @@
         {% endif %}
 
         {% if wiersze %}
+            {# Liczba autorów PONAD stroną — bez niej użytkownik nie wie, #}
+            {# czy widzi całość, czy pierwsze 25 z tysiąca. #}
+            <p>
+                Autorów z brakami: <strong>{{ autorow }}</strong>.
+                {% if is_paginated %}
+                    Strona {{ page_obj.number }} z {{ paginator.num_pages }}.
+                {% endif %}
+            </p>
+
+            {% include "pagination/pagination_with_anchor.html" %}
+
             <table class="hover stack">
                 <thead>
                     <tr>
@@ -134,6 +145,8 @@
                 </tbody>
             </table>
 
+            {% include "pagination/pagination_with_anchor.html" %}
+
             <div class="callout secondary">
                 <p>
                     <span class="label alert">Braki wymagane</span>
@@ -156,11 +169,24 @@
             <div class="callout warning">
                 <h4><i class="fi-alert"></i> Nierozpoznany typ osiągnięcia</h4>
                 <p>
-                    Poniższe wydawnictwa zwarte nie mają ustawionego
-                    <strong>charakteru dla slotów</strong>, więc nie wiadomo, czy są
-                    monografią (§ 2 ust. 10 pkt 5), czy rozdziałem (pkt 6) &mdash;
-                    a więc jakich danych od nich wymagać.
+                    Poniżsi autorzy mają rekordy, których <strong>charakter formalny
+                    nie jest sklasyfikowany</strong>: wydawnictwo zwarte bez
+                    <strong>charakteru dla slotów</strong> może być monografią
+                    (§ 2 ust. 10 pkt 5) albo rozdziałem (pkt 6), a wydawnictwo
+                    ciągłe bez <strong>rodzaju dla PBN</strong> &mdash; artykułem
+                    naukowym (pkt 4) albo publikacją, która osiągnięciem nie jest
+                    (streszczenie zjazdowe, list do redakcji, recenzja).
+                    W obu przypadkach nie wiadomo, jakich danych wymagać.
                     <strong>Raport ich nie sprawdził.</strong>
+                </p>
+                <p>
+                    <i class="fi-info"></i>
+                    Obie wartości ustawia się <strong>w słowniku charakterów
+                    formalnych</strong>
+                    (<a href="{% url 'admin:bpp_charakter_formalny_changelist' %}"
+                        target="_blank">Charakter formalny</a>),
+                    a nie w samym rekordzie &mdash; jedna poprawka obejmuje
+                    wszystkie rekordy o danym charakterze.
                 </p>
                 <table class="hover stack">
                     <thead>

--- a/src/kompletnosc_polon/templates/kompletnosc_polon/lista.html
+++ b/src/kompletnosc_polon/templates/kompletnosc_polon/lista.html
@@ -23,7 +23,9 @@
             </p>
             <p>
                 <i class="fi-calendar"></i>
-                Zakres: lata <strong>{{ pierwszy_rok }}&ndash;{{ ostatni_rok }}</strong>,
+                {# Zakres lat składa widok (``opis_okna``), bo górna granica #}
+                {# okna bywa nieustalona — patrz OKNO_EWALUACJI. #}
+                Zakres: lata <strong>{{ zakres_lat }}</strong>,
                 powiązania autorów z <strong>przypiętą</strong> dyscypliną.
                 Liczba sprawdzonych powiązań autor&ndash;rekord:
                 <strong>{{ sprawdzonych }}</strong>.
@@ -62,14 +64,14 @@
                 <p>
                     Sprawdzono powiązań autor&ndash;rekord:
                     <strong>{{ sprawdzonych }}</strong>
-                    (lata {{ pierwszy_rok }}&ndash;{{ ostatni_rok }}).
+                    (lata {{ zakres_lat }}).
                     Żadne z nich nie narusza wymogów § 2 ust. 10.
                 </p>
                 {% if sprawdzonych == 0 %}
                     <p>
                         <i class="fi-info"></i>
                         Zero sprawdzonych rekordów znaczy, że w oknie
-                        {{ pierwszy_rok }}&ndash;{{ ostatni_rok }} nie ma jeszcze
+                        {{ zakres_lat }} nie ma jeszcze
                         publikacji z przypiętą dyscypliną &mdash; bieżące okno
                         ewaluacyjne dopiero się otwiera.
                     </p>

--- a/src/kompletnosc_polon/templates/kompletnosc_polon/lista.html
+++ b/src/kompletnosc_polon/templates/kompletnosc_polon/lista.html
@@ -1,0 +1,195 @@
+{% extends "base.html" %}
+
+{% block title %}Kompletność danych POL-on{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="/">Strona główna</a></li>
+    <li class="current">Kompletność danych POL-on</li>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="columns">
+
+        <h1><i class="fi-clipboard-notes"></i> Kompletność danych POL-on</h1>
+
+        <div class="callout secondary">
+            <p>
+                Raport wskazuje, <strong>przy którym pracowniku i w którym rekordzie</strong>
+                brakuje danych wymaganych przez § 2 ust. 10 rozporządzenia Ministra Nauki
+                i Szkolnictwa Wyższego z dnia 16 czerwca 2026 r. w sprawie danych
+                przetwarzanych w POL-on (Dz. U. 2026 poz. 811).
+            </p>
+            <p>
+                <i class="fi-calendar"></i>
+                Zakres: lata <strong>{{ pierwszy_rok }}&ndash;{{ ostatni_rok }}</strong>,
+                powiązania autorów z <strong>przypiętą</strong> dyscypliną.
+                Liczba sprawdzonych powiązań autor&ndash;rekord:
+                <strong>{{ sprawdzonych }}</strong>.
+            </p>
+            <p>
+                <i class="fi-info"></i>
+                Raport niczego <strong>nie wysyła</strong> do POL-on &mdash; służy
+                wyłącznie przygotowaniu danych przed sprawozdaniem.
+            </p>
+        </div>
+
+        {# Stan pusty nr 1: nikt nie przypiął żadnej dyscypliny. #}
+        {# Pusta tabela sugerowałaby „wszystko w porządku” — a raport nie miał czego #}
+        {# sprawdzić, bo pracuje na powiązaniach z przypiętą dyscypliną. #}
+        {% if brak_przypietych_dyscyplin %}
+            <div class="callout warning">
+                <h4><i class="fi-alert"></i> Raport nie ma czego sprawdzić</h4>
+                <p>
+                    W bazie nie ma <strong>ani jednego</strong> powiązania autora
+                    z rekordem, które miałoby przypiętą dyscyplinę naukową. Raport
+                    kompletności pracuje wyłącznie na takich powiązaniach &mdash;
+                    to one trafiają do wykazu pracowników.
+                </p>
+                <p>
+                    Zanim raport cokolwiek pokaże, trzeba przypisać autorom dyscypliny
+                    naukowe i przypiąć je do rekordów.
+                    <strong>Pusta tabela poniżej nie znaczy, że dane są kompletne.</strong>
+                </p>
+            </div>
+        {% endif %}
+
+        {# Stan pusty nr 2: sprawdzono rekordy i nie znaleziono żadnego braku. #}
+        {% if not wiersze and not brak_przypietych_dyscyplin %}
+            <div class="callout success">
+                <h4><i class="fi-check"></i> Brak zastrzeżeń</h4>
+                <p>
+                    Sprawdzono powiązań autor&ndash;rekord:
+                    <strong>{{ sprawdzonych }}</strong>
+                    (lata {{ pierwszy_rok }}&ndash;{{ ostatni_rok }}).
+                    Żadne z nich nie narusza wymogów § 2 ust. 10.
+                </p>
+                {% if sprawdzonych == 0 %}
+                    <p>
+                        <i class="fi-info"></i>
+                        Zero sprawdzonych rekordów znaczy, że w oknie
+                        {{ pierwszy_rok }}&ndash;{{ ostatni_rok }} nie ma jeszcze
+                        publikacji z przypiętą dyscypliną &mdash; bieżące okno
+                        ewaluacyjne dopiero się otwiera.
+                    </p>
+                {% endif %}
+            </div>
+        {% endif %}
+
+        {% if wiersze %}
+            <table class="hover stack">
+                <thead>
+                    <tr>
+                        <th>Autor</th>
+                        <th class="text-center">Rekordów z brakami</th>
+                        <th class="text-center">
+                            <i class="fi-alert"></i> Braki wymagane
+                        </th>
+                        <th class="text-center">
+                            <i class="fi-info"></i> Braki warunkowe
+                        </th>
+                        <th class="text-center">Akcje</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for wiersz in wiersze %}
+                        <tr>
+                            <td>
+                                <strong>
+                                    <a href="{% url 'kompletnosc_polon:szczegoly' autor_slug=wiersz.autor.slug %}"
+                                       title="Pokaż braki w rekordach tego autora">
+                                        {{ wiersz.autor }}
+                                    </a>
+                                </strong>
+                            </td>
+                            <td class="text-center">{{ wiersz.rekordow_z_brakami }}</td>
+                            <td class="text-center">
+                                {% if wiersz.braki_wymagane %}
+                                    <span class="label alert">{{ wiersz.braki_wymagane }}</span>
+                                {% else %}
+                                    <span class="label success">0</span>
+                                {% endif %}
+                            </td>
+                            <td class="text-center">
+                                {% if wiersz.braki_warunkowe %}
+                                    <span class="label secondary">{{ wiersz.braki_warunkowe }}</span>
+                                {% else %}
+                                    <span class="label success">0</span>
+                                {% endif %}
+                            </td>
+                            <td class="text-center">
+                                <a href="{% url 'kompletnosc_polon:szczegoly' autor_slug=wiersz.autor.slug %}"
+                                   class="button" title="Szczegóły braków">
+                                    <i class="fi-eye"></i>
+                                </a>
+                                <a href="{{ wiersz.autor.get_absolute_url }}"
+                                   class="button success" target="_blank"
+                                   title="Profil autora w BPP">
+                                    <i class="fi-torso"></i>
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+
+            <div class="callout secondary">
+                <p>
+                    <span class="label alert">Braki wymagane</span>
+                    rozporządzenie żąda tych danych bezwarunkowo &mdash; to one
+                    wymagają uzupełnienia.
+                </p>
+                <p>
+                    <span class="label secondary">Braki warunkowe</span>
+                    wymogi opatrzone zwrotami „jeżeli posiada”, „jeżeli są znane”.
+                    <strong>Nie są pilne</strong> i nie liczą się do braków krytycznych
+                    &mdash; raport pokazuje je tylko informacyjnie.
+                </p>
+            </div>
+        {% endif %}
+
+        {# Rekordy, których typu osiągnięcia nie da się ustalić. NIE wolno im #}
+        {# zniknąć po cichu: raport ich nie sprawdził, a użytkownik uznałby, #}
+        {# że sprawdził i nie znalazł zastrzeżeń. #}
+        {% if nierozpoznane %}
+            <div class="callout warning">
+                <h4><i class="fi-alert"></i> Nierozpoznany typ osiągnięcia</h4>
+                <p>
+                    Poniższe wydawnictwa zwarte nie mają ustawionego
+                    <strong>charakteru dla slotów</strong>, więc nie wiadomo, czy są
+                    monografią (§ 2 ust. 10 pkt 5), czy rozdziałem (pkt 6) &mdash;
+                    a więc jakich danych od nich wymagać.
+                    <strong>Raport ich nie sprawdził.</strong>
+                </p>
+                <table class="hover stack">
+                    <thead>
+                        <tr>
+                            <th>Autor</th>
+                            <th class="text-center">Rekordów niesprawdzonych</th>
+                            <th class="text-center">Akcje</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for wiersz in nierozpoznane %}
+                            <tr>
+                                <td>{{ wiersz.autor }}</td>
+                                <td class="text-center">
+                                    <span class="label warning">{{ wiersz.rekordow }}</span>
+                                </td>
+                                <td class="text-center">
+                                    <a href="{% url 'kompletnosc_polon:szczegoly' autor_slug=wiersz.autor.slug %}"
+                                       class="button" title="Pokaż niesprawdzone rekordy">
+                                        <i class="fi-eye"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
+
+    </div>
+</div>
+{% endblock %}

--- a/src/kompletnosc_polon/templates/kompletnosc_polon/szczegoly.html
+++ b/src/kompletnosc_polon/templates/kompletnosc_polon/szczegoly.html
@@ -19,8 +19,10 @@
             <p>
                 <i class="fi-calendar"></i>
                 Braki w danych wymaganych przez § 2 ust. 10 rozporządzenia
+                {# Zakres lat składa widok (``opis_okna``), bo górna granica #}
+                {# okna bywa nieustalona — patrz OKNO_EWALUACJI. #}
                 (Dz. U. 2026 poz. 811), lata
-                <strong>{{ pierwszy_rok }}&ndash;{{ ostatni_rok }}</strong>.
+                <strong>{{ zakres_lat }}</strong>.
                 Liczba sprawdzonych powiązań tego autora:
                 <strong>{{ sprawdzonych }}</strong>.
             </p>
@@ -41,7 +43,7 @@
                 <p>
                     Sprawdzono powiązań autor&ndash;rekord:
                     <strong>{{ sprawdzonych }}</strong>
-                    (lata {{ pierwszy_rok }}&ndash;{{ ostatni_rok }}).
+                    (lata {{ zakres_lat }}).
                     Żadne z nich nie narusza wymogów § 2 ust. 10.
                 </p>
             </div>

--- a/src/kompletnosc_polon/templates/kompletnosc_polon/szczegoly.html
+++ b/src/kompletnosc_polon/templates/kompletnosc_polon/szczegoly.html
@@ -1,0 +1,160 @@
+{% extends "base.html" %}
+
+{% block title %}Kompletność danych POL-on: {{ autor }}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="/">Strona główna</a></li>
+    <li><a href="{% url 'kompletnosc_polon:lista' %}">Kompletność danych POL-on</a></li>
+    <li class="current">{{ autor }}</li>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="columns">
+
+        <h1><i class="fi-torso"></i> {{ autor }}</h1>
+
+        <div class="callout secondary">
+            <p>
+                <i class="fi-calendar"></i>
+                Braki w danych wymaganych przez § 2 ust. 10 rozporządzenia
+                (Dz. U. 2026 poz. 811), lata
+                <strong>{{ pierwszy_rok }}&ndash;{{ ostatni_rok }}</strong>.
+                Liczba sprawdzonych powiązań tego autora:
+                <strong>{{ sprawdzonych }}</strong>.
+            </p>
+            <p>
+                <a href="{% url 'kompletnosc_polon:lista' %}" class="button secondary">
+                    <i class="fi-arrow-left"></i> Powrót do zestawienia
+                </a>
+                <a href="{{ autor.get_absolute_url }}" class="button success"
+                   target="_blank">
+                    <i class="fi-torso"></i> Profil autora w BPP
+                </a>
+            </p>
+        </div>
+
+        {% if not pozycje %}
+            <div class="callout success">
+                <h4><i class="fi-check"></i> Brak zastrzeżeń</h4>
+                <p>
+                    Sprawdzono powiązań autor&ndash;rekord:
+                    <strong>{{ sprawdzonych }}</strong>
+                    (lata {{ pierwszy_rok }}&ndash;{{ ostatni_rok }}).
+                    Żadne z nich nie narusza wymogów § 2 ust. 10.
+                </p>
+            </div>
+        {% endif %}
+
+        {% for pozycja in pozycje %}
+            <div class="callout">
+                <h4>
+                    {{ pozycja.rekord.tytul_oryginalny|safe }}
+                </h4>
+                <p>
+                    <span class="label">{{ pozycja.typ }}</span>
+                    <span class="label secondary">rok {{ pozycja.rekord.rok }}</span>
+                    {% if pozycja.dyscyplina %}
+                        <span class="label secondary">{{ pozycja.dyscyplina.nazwa }}</span>
+                    {% else %}
+                        <span class="label alert">bez dyscypliny</span>
+                    {% endif %}
+                    {% if pozycja.jednostka %}
+                        <span class="label secondary">{{ pozycja.jednostka.skrot|default:pozycja.jednostka.nazwa }}</span>
+                    {% endif %}
+                    <a href="{{ pozycja.url_admina }}" class="button tiny"
+                       target="_blank" title="Otwórz formularz edycji rekordu">
+                        <i class="fi-pencil"></i> Popraw rekord
+                    </a>
+                </p>
+
+                {# Braki WYMAGANE — bezwarunkowy wymóg rozporządzenia. #}
+                {% if pozycja.wymagane %}
+                    <h5><i class="fi-alert"></i> Braki wymagane</h5>
+                    <table class="hover stack kompletnosc-polon-braki-wymagane">
+                        <tbody>
+                            {% for regula in pozycja.wymagane %}
+                                <tr>
+                                    <td>
+                                        <span class="label alert">{{ regula.kod }}</span>
+                                    </td>
+                                    <td>{{ regula.opis }}</td>
+                                    <td><em>{{ regula.paragraf }}</em></td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
+
+                {# Braki WARUNKOWE — „jeżeli posiada”, „jeżeli są znane”. #}
+                {# Wizualnie stonowane: nie wolno im wyglądać na równie pilne. #}
+                {% if pozycja.warunkowe %}
+                    <h5><i class="fi-info"></i> Braki warunkowe (nieobowiązkowe)</h5>
+                    <p class="text-muted">
+                        Rozporządzenie żąda tych danych warunkowo &mdash; „jeżeli
+                        posiada”, „jeżeli są znane”. Brak nie jest błędem.
+                    </p>
+                    <table class="hover stack kompletnosc-polon-braki-warunkowe">
+                        <tbody>
+                            {% for regula in pozycja.warunkowe %}
+                                <tr>
+                                    <td>
+                                        <span class="label secondary">{{ regula.kod }}</span>
+                                    </td>
+                                    <td>{{ regula.opis }}</td>
+                                    <td><em>{{ regula.paragraf }}</em></td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
+            </div>
+        {% endfor %}
+
+        {# Rekordy, których raport NIE sprawdził — muszą być widoczne. #}
+        {% if nierozpoznane %}
+            <div class="callout warning">
+                <h4><i class="fi-alert"></i> Nierozpoznany typ osiągnięcia</h4>
+                <p>
+                    Poniższe wydawnictwa zwarte nie mają ustawionego
+                    <strong>charakteru dla slotów</strong>, więc nie wiadomo, czy
+                    są monografią (§ 2 ust. 10 pkt 5), czy rozdziałem (pkt 6).
+                    <strong>Raport ich nie sprawdził</strong> &mdash; poprawka
+                    polega na uzupełnieniu charakteru formalnego.
+                </p>
+                <table class="hover stack">
+                    <thead>
+                        <tr>
+                            <th>Rekord</th>
+                            <th>Charakter formalny</th>
+                            <th class="text-center">Akcje</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for pozycja in nierozpoznane %}
+                            <tr>
+                                <td>{{ pozycja.rekord.tytul_oryginalny|safe }}</td>
+                                <td>
+                                    {% if pozycja.charakter_formalny %}
+                                        {{ pozycja.charakter_formalny.nazwa }}
+                                    {% else %}
+                                        <span class="label alert">brak</span>
+                                    {% endif %}
+                                </td>
+                                <td class="text-center">
+                                    <a href="{{ pozycja.url_admina }}" class="button tiny"
+                                       target="_blank" title="Otwórz formularz edycji rekordu">
+                                        <i class="fi-pencil"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
+
+    </div>
+</div>
+{% endblock %}

--- a/src/kompletnosc_polon/templates/kompletnosc_polon/szczegoly.html
+++ b/src/kompletnosc_polon/templates/kompletnosc_polon/szczegoly.html
@@ -117,16 +117,29 @@
             <div class="callout warning">
                 <h4><i class="fi-alert"></i> Nierozpoznany typ osiągnięcia</h4>
                 <p>
-                    Poniższe wydawnictwa zwarte nie mają ustawionego
-                    <strong>charakteru dla slotów</strong>, więc nie wiadomo, czy
-                    są monografią (§ 2 ust. 10 pkt 5), czy rozdziałem (pkt 6).
-                    <strong>Raport ich nie sprawdził</strong> &mdash; poprawka
-                    polega na uzupełnieniu charakteru formalnego.
+                    Poniższe rekordy mają <strong>niesklasyfikowany charakter
+                    formalny</strong>: wydawnictwo zwarte bez <strong>charakteru
+                    dla slotów</strong> może być monografią (§ 2 ust. 10 pkt 5)
+                    albo rozdziałem (pkt 6), a wydawnictwo ciągłe bez
+                    <strong>rodzaju dla PBN</strong> &mdash; artykułem naukowym
+                    (pkt 4) albo publikacją, która osiągnięciem nie jest
+                    (streszczenie zjazdowe, list do redakcji, recenzja).
+                    <strong>Raport ich nie sprawdził.</strong>
+                </p>
+                <p>
+                    <i class="fi-info"></i>
+                    Brakującą wartość uzupełnia się <strong>w słowniku charakterów
+                    formalnych</strong>
+                    (<a href="{% url 'admin:bpp_charakter_formalny_changelist' %}"
+                        target="_blank">Charakter formalny</a>),
+                    a nie w samym rekordzie &mdash; jedna poprawka obejmuje
+                    wszystkie rekordy o danym charakterze.
                 </p>
                 <table class="hover stack">
                     <thead>
                         <tr>
                             <th>Rekord</th>
+                            <th>Rodzaj</th>
                             <th>Charakter formalny</th>
                             <th class="text-center">Akcje</th>
                         </tr>
@@ -135,13 +148,10 @@
                         {% for pozycja in nierozpoznane %}
                             <tr>
                                 <td>{{ pozycja.rekord.tytul_oryginalny|safe }}</td>
-                                <td>
-                                    {% if pozycja.charakter_formalny %}
-                                        {{ pozycja.charakter_formalny.nazwa }}
-                                    {% else %}
-                                        <span class="label alert">brak</span>
-                                    {% endif %}
-                                </td>
+                                <td>{{ pozycja.rodzaj|capfirst }}</td>
+                                {# ``charakter_formalny`` to FK NOT NULL — #}
+                                {# gałąź „brak” byłaby martwym kodem. #}
+                                <td>{{ pozycja.charakter_formalny.nazwa }}</td>
                                 <td class="text-center">
                                     <a href="{{ pozycja.url_admina }}" class="button tiny"
                                        target="_blank" title="Otwórz formularz edycji rekordu">

--- a/src/kompletnosc_polon/tests/test_reguly.py
+++ b/src/kompletnosc_polon/tests/test_reguly.py
@@ -1,0 +1,439 @@
+"""Testy rejestru reguł kompletności danych POL-on.
+
+Reguły są danymi, więc właściwą jednostką testową jest pojedyncza reguła.
+Dla każdej z nich budujemy dwa powiązania autor–rekord: jedno spełniające
+KOMPLET wymogów swojego typu osiągnięcia i jedno zepsute dokładnie w tym
+jednym miejscu, którego reguła dotyczy. Asercja: ``warunek`` łapie wyłącznie
+to zepsute.
+
+Testy są parametryzowane po :data:`kompletnosc_polon.reguly.REGULY`, więc
+dopisanie reguły bez dopisania sposobu jej zepsucia (:data:`PSUJ`) psuje
+suitę — i o to chodzi.
+"""
+
+import datetime
+import itertools
+from decimal import Decimal
+
+import pytest
+from model_bakery import baker
+
+from kompletnosc_polon.const import OA_CZAS_PO_OPUBLIKOWANIU, Osiagniecie, Waga
+from kompletnosc_polon.reguly import (
+    REGULY,
+    REGULY_ARTYKUL,
+    REGULY_MONOGRAFIA,
+    REGULY_PATENT,
+    REGULY_ROZDZIAL,
+    reguly_dla,
+)
+
+#: Rok wewnątrz bieżącego okna ewaluacji — patrz ``OKNO_EWALUACJI``.
+ROK = 2026
+
+#: Model powiązania autora z rekordem (ziarno raportu) dla każdego typu
+#: osiągnięcia. Monografia i rozdział dzielą ten sam model — rozróżnia je
+#: dopiero ``charakter_formalny.charakter_sloty``, czym zajmują się selektory,
+#: nie reguły.
+MODEL_POWIAZANIA = {
+    Osiagniecie.ARTYKUL: "bpp.Wydawnictwo_Ciagle_Autor",
+    Osiagniecie.MONOGRAFIA: "bpp.Wydawnictwo_Zwarte_Autor",
+    Osiagniecie.ROZDZIAL: "bpp.Wydawnictwo_Zwarte_Autor",
+    Osiagniecie.PATENT: "bpp.Patent_Autor",
+}
+
+MODEL_TRYBU_OA = {
+    "wydawnictwo_ciagle": "bpp.Tryb_OpenAccess_Wydawnictwo_Ciagle",
+    "wydawnictwo_zwarte": "bpp.Tryb_OpenAccess_Wydawnictwo_Zwarte",
+}
+
+_licznik_orcid = itertools.count(1)
+
+
+def _kolejny_orcid() -> str:
+    """Unikalny ORCID w formacie akceptowanym przez walidator ``Autor.orcid``."""
+    numer = next(_licznik_orcid)
+    return f"0000-0001-{numer // 10000 % 10000:04d}-{numer % 10000:04d}"
+
+
+# --------------------------------------------------------------------------
+# Budowa obiektów kompletnych — takich, których ŻADNA reguła nie łapie
+# --------------------------------------------------------------------------
+
+
+def _kompletny_artykul():
+    zrodlo = baker.make("bpp.Zrodlo", issn="1234-5678", e_issn="")
+    return baker.make(
+        "bpp.Wydawnictwo_Ciagle",
+        rok=ROK,
+        zrodlo=zrodlo,
+        doi="10.1000/kompletny",
+        www="",
+        public_www="",
+        issn="",
+        e_issn="",
+        tom="12",
+        informacje="",
+        strony="1-10",
+        szczegoly="",
+        pbn_czy_artykul_recenzyjny=False,
+        openaccess_tryb_dostepu=None,
+        openaccess_wersja_tekstu=None,
+        openaccess_licencja=None,
+        openaccess_czas_publikacji=None,
+        openaccess_data_opublikowania=None,
+        openaccess_ilosc_miesiecy=None,
+        opl_pub_cost_free=True,
+        opl_pub_amount=None,
+        opl_pub_research_potential=None,
+        opl_pub_research_or_development_projects=None,
+        opl_pub_other=None,
+    )
+
+
+def _kompletne_zwarte():
+    """Wydawnictwo zwarte spełniające wymogi i monografii, i rozdziału."""
+    return baker.make(
+        "bpp.Wydawnictwo_Zwarte",
+        rok=ROK,
+        doi="10.1000/kompletny",
+        www="",
+        public_www="",
+        isbn="978-83-01-00000-0",
+        e_isbn="",
+        wydawca=baker.make("bpp.Wydawca"),
+        wydawca_opis="",
+        wydawnictwo_nadrzedne=baker.make("bpp.Wydawnictwo_Zwarte", rok=ROK),
+        wydawnictwo_nadrzedne_w_pbn=None,
+        pbn_czy_edycja_naukowa=False,
+        pbn_czy_projekt_ncn=False,
+        pbn_czy_projekt_nprh=False,
+        pbn_czy_projekt_fnp=False,
+        pbn_czy_projekt_ue=False,
+        openaccess_tryb_dostepu=None,
+        openaccess_wersja_tekstu=None,
+        openaccess_licencja=None,
+        openaccess_czas_publikacji=None,
+        openaccess_data_opublikowania=None,
+        openaccess_ilosc_miesiecy=None,
+        opl_pub_cost_free=True,
+        opl_pub_amount=None,
+        opl_pub_research_potential=None,
+        opl_pub_research_or_development_projects=None,
+        opl_pub_other=None,
+    )
+
+
+def _kompletny_patent():
+    return baker.make(
+        "bpp.Patent",
+        rok=ROK,
+        numer_prawa_wylacznego="PL 123456",
+        numer_zgloszenia="P.400000",
+        data_zgloszenia=datetime.date(ROK, 1, 15),
+    )
+
+
+BUDOWNICZY_REKORDU = {
+    Osiagniecie.ARTYKUL: _kompletny_artykul,
+    Osiagniecie.MONOGRAFIA: _kompletne_zwarte,
+    Osiagniecie.ROZDZIAL: _kompletne_zwarte,
+    Osiagniecie.PATENT: _kompletny_patent,
+}
+
+
+def _zbuduj_kompletne_powiazanie(osiagniecie: Osiagniecie):
+    """Zbuduj parę (autor, rekord), której nie łapie żadna reguła.
+
+    Zwraca instancję through-modelu — to jest ziarno raportu i jednocześnie
+    punkt, z którego liczone są wszystkie warunki (patrz docstring modułu
+    ``kompletnosc_polon.reguly``).
+    """
+    rekord = BUDOWNICZY_REKORDU[osiagniecie]()
+    autor = baker.make("bpp.Autor", orcid=_kolejny_orcid())
+    dyscyplina = baker.make("bpp.Dyscyplina_Naukowa")
+
+    # Powiązanie autor–dyscyplina na dany rok jest wymuszone przez
+    # BazaModeluOdpowiedzialnosciAutorow.clean(), wołane z save().
+    baker.make(
+        "bpp.Autor_Dyscyplina",
+        autor=autor,
+        rok=ROK,
+        dyscyplina_naukowa=dyscyplina,
+        subdyscyplina_naukowa=None,
+    )
+
+    return baker.make(
+        MODEL_POWIAZANIA[osiagniecie],
+        rekord=rekord,
+        autor=autor,
+        jednostka=baker.make("bpp.Jednostka"),
+        dyscyplina_naukowa=dyscyplina,
+        przypieta=True,
+        upowaznienie_pbn=True,
+        oswiadczenie_ken=None,
+    )
+
+
+# --------------------------------------------------------------------------
+# Psucie — jedna funkcja na regułę, wprowadza dokładnie jeden brak
+# --------------------------------------------------------------------------
+
+
+def _tryb_open_access(rekord):
+    return baker.make(MODEL_TRYBU_OA[rekord._meta.model_name])
+
+
+def _psuj_doi(powiazanie):
+    rekord = powiazanie.rekord
+    rekord.doi = None
+    rekord.www = ""
+    rekord.public_www = ""
+    rekord.save()
+
+
+def _psuj_dyscypline(powiazanie):
+    powiazanie.przypieta = False
+    powiazanie.save()
+
+
+def _psuj_upowaznienie(powiazanie):
+    powiazanie.upowaznienie_pbn = False
+    powiazanie.save()
+
+
+def _psuj_orcid(powiazanie):
+    powiazanie.autor.orcid = None
+    powiazanie.autor.save()
+
+
+def _psuj_oa(pole):
+    """Zbuduj funkcję psującą jedno pole Open Access.
+
+    Ustawia tryb dostępu (czyli włącza wymogi OA) i czyści wskazane pole.
+    """
+
+    def psuj(powiazanie):
+        rekord = powiazanie.rekord
+        rekord.openaccess_tryb_dostepu = _tryb_open_access(rekord)
+        setattr(rekord, pole, None)
+        rekord.save()
+
+    return psuj
+
+
+def _psuj_oa_miesiace(powiazanie):
+    from bpp.models import Czas_Udostepnienia_OpenAccess
+
+    # Słownik czasów udostępnienia jest częścią baseline'u bazy (fixture
+    # instalacyjny), a `skrot` ma ograniczenie unikalności — stąd
+    # get_or_create zamiast baker.make.
+    czas, _ = Czas_Udostepnienia_OpenAccess.objects.get_or_create(
+        skrot=OA_CZAS_PO_OPUBLIKOWANIU,
+        defaults={"nazwa": "po opublikowaniu"},
+    )
+    rekord = powiazanie.rekord
+    rekord.openaccess_czas_publikacji = czas
+    rekord.openaccess_ilosc_miesiecy = None
+    rekord.save()
+
+
+def _psuj_apc(powiazanie):
+    rekord = powiazanie.rekord
+    rekord.opl_pub_cost_free = None
+    rekord.opl_pub_amount = None
+    rekord.opl_pub_research_potential = None
+    rekord.opl_pub_research_or_development_projects = None
+    rekord.opl_pub_other = None
+    rekord.save()
+
+
+def _psuj_apc_zrodlo(powiazanie):
+    rekord = powiazanie.rekord
+    rekord.opl_pub_cost_free = False
+    rekord.opl_pub_amount = Decimal("1500.00")
+    rekord.opl_pub_research_potential = None
+    rekord.opl_pub_research_or_development_projects = False
+    rekord.opl_pub_other = None
+    rekord.save()
+
+
+def _psuj_pole_rekordu(**nadpisz):
+    """Zbuduj funkcję ustawiającą wskazane pola rekordu na podane wartości."""
+
+    def psuj(powiazanie):
+        rekord = powiazanie.rekord
+        for pole, wartosc in nadpisz.items():
+            setattr(rekord, pole, wartosc)
+        rekord.save()
+
+    return psuj
+
+
+def _psuj_issn(powiazanie):
+    rekord = powiazanie.rekord
+    rekord.zrodlo.issn = ""
+    rekord.zrodlo.e_issn = ""
+    rekord.zrodlo.save()
+    rekord.issn = ""
+    rekord.e_issn = ""
+    rekord.save()
+
+
+#: Sposób wprowadzenia dokładnie tego braku, którego dotyczy dana reguła.
+PSUJ = {
+    # Artykuł naukowy — § 2 ust. 10 pkt 4
+    "ART_DOI": _psuj_doi,
+    "ART_DYSCYPLINA": _psuj_dyscypline,
+    "ART_UPOWAZNIENIE": _psuj_upowaznienie,
+    "ART_ORCID": _psuj_orcid,
+    "ART_RECENZYJNY": _psuj_pole_rekordu(pbn_czy_artykul_recenzyjny=None),
+    "ART_ZRODLO": _psuj_pole_rekordu(zrodlo=None),
+    "ART_ISSN": _psuj_issn,
+    "ART_TOM": _psuj_pole_rekordu(tom="", informacje=""),
+    "ART_STRONY": _psuj_pole_rekordu(strony="", szczegoly=""),
+    "ART_OA_WERSJA": _psuj_oa("openaccess_wersja_tekstu"),
+    "ART_OA_LICENCJA": _psuj_oa("openaccess_licencja"),
+    "ART_OA_DATA": _psuj_oa("openaccess_data_opublikowania"),
+    "ART_OA_CZAS": _psuj_oa("openaccess_czas_publikacji"),
+    "ART_OA_MIESIACE": _psuj_oa_miesiace,
+    "ART_APC": _psuj_apc,
+    "ART_APC_ZRODLO": _psuj_apc_zrodlo,
+    # Monografia naukowa — § 2 ust. 10 pkt 5
+    "MON_DOI": _psuj_doi,
+    "MON_ISBN": _psuj_pole_rekordu(isbn="", e_isbn=""),
+    "MON_ORCID": _psuj_orcid,
+    "MON_WYDAWCA": _psuj_pole_rekordu(wydawca=None, wydawca_opis=""),
+    "MON_DYSCYPLINA": _psuj_dyscypline,
+    "MON_UPOWAZNIENIE": _psuj_upowaznienie,
+    "MON_EDYCJA_NAUKOWA": _psuj_pole_rekordu(pbn_czy_edycja_naukowa=None),
+    "MON_PROJEKTY": _psuj_pole_rekordu(
+        pbn_czy_projekt_ncn=None,
+        pbn_czy_projekt_nprh=None,
+        pbn_czy_projekt_fnp=None,
+        pbn_czy_projekt_ue=None,
+    ),
+    "MON_OA_WERSJA": _psuj_oa("openaccess_wersja_tekstu"),
+    "MON_OA_LICENCJA": _psuj_oa("openaccess_licencja"),
+    "MON_OA_DATA": _psuj_oa("openaccess_data_opublikowania"),
+    "MON_OA_CZAS": _psuj_oa("openaccess_czas_publikacji"),
+    "MON_OA_MIESIACE": _psuj_oa_miesiace,
+    "MON_APC": _psuj_apc,
+    "MON_APC_ZRODLO": _psuj_apc_zrodlo,
+    # Rozdział w monografii — § 2 ust. 10 pkt 6
+    "ROZ_NADRZEDNE": _psuj_pole_rekordu(
+        wydawnictwo_nadrzedne=None, wydawnictwo_nadrzedne_w_pbn=None
+    ),
+    "ROZ_ORCID": _psuj_orcid,
+    "ROZ_DYSCYPLINA": _psuj_dyscypline,
+    "ROZ_UPOWAZNIENIE": _psuj_upowaznienie,
+    # Patent — § 2 ust. 10 pkt 1
+    "PAT_NUMER": _psuj_pole_rekordu(numer_prawa_wylacznego=None),
+    "PAT_ZGLOSZENIE": _psuj_pole_rekordu(data_zgloszenia=None),
+    "PAT_DYSCYPLINA": _psuj_dyscypline,
+    "PAT_UPOWAZNIENIE": _psuj_upowaznienie,
+    "PAT_ORCID": _psuj_orcid,
+}
+
+
+def _id_reguly(regula):
+    return regula.kod
+
+
+# --------------------------------------------------------------------------
+# Testy samego rejestru (bez bazy danych)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("regula", REGULY, ids=_id_reguly)
+def test_regula_ma_komplet_metadanych(regula):
+    assert regula.kod.strip(), "Reguła bez kodu"
+    assert regula.opis.strip(), f"Reguła {regula.kod} bez opisu"
+    assert regula.paragraf.strip(), f"Reguła {regula.kod} bez podstawy prawnej"
+    assert regula.paragraf.startswith("§ 2 ust. 10 "), (
+        f"Reguła {regula.kod} wskazuje paragraf spoza § 2 ust. 10"
+    )
+    assert regula.dotyczy in Osiagniecie
+    assert regula.waga in Waga
+
+
+def test_kody_regul_sa_unikalne():
+    kody = [regula.kod for regula in REGULY]
+    assert len(kody) == len(set(kody)), "Zduplikowane kody reguł w rejestrze"
+
+
+@pytest.mark.parametrize("regula", REGULY, ids=_id_reguly)
+def test_kod_reguly_pasuje_do_typu_osiagniecia(regula):
+    prefiks = {
+        Osiagniecie.ARTYKUL: "ART_",
+        Osiagniecie.MONOGRAFIA: "MON_",
+        Osiagniecie.ROZDZIAL: "ROZ_",
+        Osiagniecie.PATENT: "PAT_",
+    }[regula.dotyczy]
+    assert regula.kod.startswith(prefiks)
+
+
+@pytest.mark.parametrize("regula", REGULY, ids=_id_reguly)
+def test_kazda_regula_ma_zdefiniowany_sposob_zepsucia(regula):
+    assert regula.kod in PSUJ, (
+        f"Dopisano regułę {regula.kod}, ale nie opisano, jak wprowadzić "
+        f"brak, który ma łapać — uzupełnij słownik PSUJ."
+    )
+
+
+def test_reguly_dla_zwraca_rozlaczne_i_zupelne_podzbiory():
+    zebrane = []
+    for osiagniecie in Osiagniecie:
+        podzbior = reguly_dla(osiagniecie)
+        assert podzbior, f"Brak reguł dla {osiagniecie}"
+        zebrane.extend(podzbior)
+
+    assert len(zebrane) == len(REGULY)
+    assert set(zebrane) == set(REGULY)
+
+
+def test_rejestr_sklada_sie_z_czterech_grup():
+    assert REGULY == (
+        *REGULY_ARTYKUL,
+        *REGULY_MONOGRAFIA,
+        *REGULY_ROZDZIAL,
+        *REGULY_PATENT,
+    )
+
+
+# --------------------------------------------------------------------------
+# Test właściwy: reguła łapie brak i nie łapie kompletnego
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("regula", REGULY, ids=_id_reguly)
+def test_regula_lapie_dokladnie_rekord_z_brakiem(regula):
+    kompletne = _zbuduj_kompletne_powiazanie(regula.dotyczy)
+    niekompletne = _zbuduj_kompletne_powiazanie(regula.dotyczy)
+
+    PSUJ[regula.kod](niekompletne)
+
+    model = type(niekompletne)
+    znalezione = set(model.objects.filter(regula.warunek).values_list("pk", flat=True))
+
+    assert znalezione == {niekompletne.pk}, (
+        f"Reguła {regula.kod} ({regula.paragraf}) nie łapie wprowadzonego "
+        f"braku albo łapie także rekord kompletny (pk={kompletne.pk})."
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("regula", REGULY, ids=_id_reguly)
+def test_zaden_kompletny_rekord_nie_jest_lapany(regula):
+    """Obiekt kompletny nie może być łapany przez ŻADNĄ regułę swojego typu.
+
+    Chroni przed budowaniem „kompletnego” obiektu pod jedną regułę kosztem
+    innej — a więc przed fałszywie zielonym testem powyżej.
+    """
+    kompletne = _zbuduj_kompletne_powiazanie(regula.dotyczy)
+    model = type(kompletne)
+
+    assert not model.objects.filter(regula.warunek).filter(pk=kompletne.pk).exists(), (
+        f"Reguła {regula.kod} ({regula.paragraf}) łapie rekord kompletny."
+    )

--- a/src/kompletnosc_polon/tests/test_reguly.py
+++ b/src/kompletnosc_polon/tests/test_reguly.py
@@ -18,6 +18,7 @@ from decimal import Decimal
 import pytest
 from model_bakery import baker
 
+from bpp.const import RODZAJ_PBN_ARTYKUL
 from kompletnosc_polon.const import OA_CZAS_PO_OPUBLIKOWANIU, Osiagniecie, Waga
 from kompletnosc_polon.reguly import (
     REGULY,
@@ -56,9 +57,38 @@ def _kolejny_orcid() -> str:
     return f"0000-0001-{numer // 10000 % 10000:04d}-{numer % 10000:04d}"
 
 
+_licznik_dyscyplin = itertools.count(1)
+
+
+def _kolejna_dyscyplina():
+    """Dyscyplina naukowa o **deterministycznie** unikalnym kodzie.
+
+    ``Dyscyplina_Naukowa.kod`` jest unikalny w bazie, a domyślny generator
+    ``model_bakery`` losuje go z wąskiego zakresu (``N.MMM``). W teście
+    budującym kilkadziesiąt powiązań naraz kolizja urodzinowa trafiała się na
+    tyle często, że pełny przebieg suity potrafił paść na ``IntegrityError``
+    w losowym miejscu. Licznik zamyka temat u źródła.
+    """
+    numer = next(_licznik_dyscyplin)
+    return baker.make(
+        "bpp.Dyscyplina_Naukowa",
+        kod=f"{numer // 900 + 1}.{numer % 900 + 100}",
+    )
+
+
 # --------------------------------------------------------------------------
 # Budowa obiektów kompletnych — takich, których ŻADNA reguła nie łapie
 # --------------------------------------------------------------------------
+
+
+def charakter_artykulu():
+    """Charakter formalny, który raport uznaje za artykuł naukowy (pkt 4).
+
+    Bez ``rodzaj_pbn = RODZAJ_PBN_ARTYKUL`` selektor :func:`powiazania`
+    w ogóle nie wciągnie rekordu do raportu — tak samo, jak nie wciąga
+    streszczeń zjazdowych, listów do redakcji czy recenzji.
+    """
+    return baker.make("bpp.Charakter_Formalny", rodzaj_pbn=RODZAJ_PBN_ARTYKUL)
 
 
 def _kompletny_artykul():
@@ -66,6 +96,8 @@ def _kompletny_artykul():
     return baker.make(
         "bpp.Wydawnictwo_Ciagle",
         rok=ROK,
+        charakter_formalny=charakter_artykulu(),
+        konferencja=None,
         zrodlo=zrodlo,
         doi="10.1000/kompletny",
         www="",
@@ -91,6 +123,28 @@ def _kompletny_artykul():
     )
 
 
+def _kompletna_monografia_macierzysta():
+    """Monografia macierzysta rozdziału, z kompletem danych identyfikujących.
+
+    Reguły ``ROZ_MON_*`` sprawdzają ISBN/e-ISBN, wydawcę i DOI/URL rodzica,
+    więc „kompletny” rozdział musi mieć rodzica, który je ma. Rodzic
+    zbudowany gołym ``baker.make`` ma te pola puste i wywracałby test
+    „żaden kompletny rekord nie jest łapany”.
+    """
+    return baker.make(
+        "bpp.Wydawnictwo_Zwarte",
+        rok=ROK,
+        doi="10.1000/macierzysta",
+        www="",
+        public_www="",
+        isbn="978-83-01-11111-1",
+        e_isbn="",
+        wydawca=baker.make("bpp.Wydawca"),
+        wydawca_opis="",
+        wydawnictwo_nadrzedne=None,
+    )
+
+
 def _kompletne_zwarte():
     """Wydawnictwo zwarte spełniające wymogi i monografii, i rozdziału."""
     return baker.make(
@@ -103,7 +157,7 @@ def _kompletne_zwarte():
         e_isbn="",
         wydawca=baker.make("bpp.Wydawca"),
         wydawca_opis="",
-        wydawnictwo_nadrzedne=baker.make("bpp.Wydawnictwo_Zwarte", rok=ROK),
+        wydawnictwo_nadrzedne=_kompletna_monografia_macierzysta(),
         wydawnictwo_nadrzedne_w_pbn=None,
         pbn_czy_edycja_naukowa=False,
         pbn_czy_projekt_ncn=False,
@@ -151,7 +205,7 @@ def _zbuduj_kompletne_powiazanie(osiagniecie: Osiagniecie):
     """
     rekord = BUDOWNICZY_REKORDU[osiagniecie]()
     autor = baker.make("bpp.Autor", orcid=_kolejny_orcid())
-    dyscyplina = baker.make("bpp.Dyscyplina_Naukowa")
+    dyscyplina = _kolejna_dyscyplina()
 
     # Powiązanie autor–dyscyplina na dany rok jest wymuszone przez
     # BazaModeluOdpowiedzialnosciAutorow.clean(), wołane z save().
@@ -233,9 +287,70 @@ def _psuj_oa_miesiace(powiazanie):
         defaults={"nazwa": "po opublikowaniu"},
     )
     rekord = powiazanie.rekord
+    # Tryb dostępu ustawiamy, bo reguła jest nim bramkowana tak samo jak
+    # pozostałe reguły litery; bez trybu zadziałałaby ``*_OA_TRYB``.
+    rekord.openaccess_tryb_dostepu = _tryb_open_access(rekord)
+    rekord.openaccess_wersja_tekstu = baker.make("bpp.Wersja_Tekstu_OpenAccess")
+    rekord.openaccess_licencja = baker.make("bpp.Licencja_OpenAccess")
+    rekord.openaccess_data_opublikowania = datetime.date(ROK, 3, 1)
     rekord.openaccess_czas_publikacji = czas
     rekord.openaccess_ilosc_miesiecy = None
     rekord.save()
+
+
+def _psuj_oa_tryb(powiazanie):
+    """Wypełnij sygnał OA (datę udostępnienia), ale NIE podawaj trybu."""
+    rekord = powiazanie.rekord
+    rekord.openaccess_tryb_dostepu = None
+    rekord.openaccess_data_opublikowania = datetime.date(ROK, 3, 1)
+    rekord.save()
+
+
+def _psuj_apc_kwota(powiazanie):
+    """Odznacz „bezkosztowa”, ale nie podaj ani kwoty, ani źródła."""
+    rekord = powiazanie.rekord
+    rekord.opl_pub_cost_free = False
+    rekord.opl_pub_amount = None
+    rekord.opl_pub_research_potential = None
+    rekord.opl_pub_research_or_development_projects = None
+    rekord.opl_pub_other = None
+    rekord.save()
+
+
+def _konferencja(**nadpisz):
+    """Konferencja z kompletem danych z lit. g, poza tym, co nadpisano."""
+    pola = {
+        "nazwa": "Konferencja testowa",
+        "rozpoczecie": datetime.date(ROK, 5, 1),
+        "zakonczenie": datetime.date(ROK, 5, 3),
+        "miasto": "Lublin",
+        "panstwo": "Polska",
+    }
+    pola.update(nadpisz)
+    return baker.make("bpp.Konferencja", **pola)
+
+
+def _psuj_konferencje(**nadpisz):
+    """Zbuduj funkcję wskazującą konferencję z brakiem w podanych polach."""
+
+    def psuj(powiazanie):
+        rekord = powiazanie.rekord
+        rekord.konferencja = _konferencja(**nadpisz)
+        rekord.save()
+
+    return psuj
+
+
+def _psuj_pole_nadrzednego(**nadpisz):
+    """Zbuduj funkcję psującą pola monografii macierzystej rozdziału."""
+
+    def psuj(powiazanie):
+        nadrzedne = powiazanie.rekord.wydawnictwo_nadrzedne
+        for pole, wartosc in nadpisz.items():
+            setattr(nadrzedne, pole, wartosc)
+        nadrzedne.save()
+
+    return psuj
 
 
 def _psuj_apc(powiazanie):
@@ -288,16 +403,21 @@ PSUJ = {
     "ART_UPOWAZNIENIE": _psuj_upowaznienie,
     "ART_ORCID": _psuj_orcid,
     "ART_RECENZYJNY": _psuj_pole_rekordu(pbn_czy_artykul_recenzyjny=None),
+    "ART_KONFERENCJA_NAZWA": _psuj_konferencje(nazwa=""),
+    "ART_KONFERENCJA_DATY": _psuj_konferencje(zakonczenie=None),
+    "ART_KONFERENCJA_MIEJSCE": _psuj_konferencje(panstwo=""),
     "ART_ZRODLO": _psuj_pole_rekordu(zrodlo=None),
     "ART_ISSN": _psuj_issn,
     "ART_TOM": _psuj_pole_rekordu(tom="", informacje=""),
     "ART_STRONY": _psuj_pole_rekordu(strony="", szczegoly=""),
+    "ART_OA_TRYB": _psuj_oa_tryb,
     "ART_OA_WERSJA": _psuj_oa("openaccess_wersja_tekstu"),
     "ART_OA_LICENCJA": _psuj_oa("openaccess_licencja"),
     "ART_OA_DATA": _psuj_oa("openaccess_data_opublikowania"),
     "ART_OA_CZAS": _psuj_oa("openaccess_czas_publikacji"),
     "ART_OA_MIESIACE": _psuj_oa_miesiace,
     "ART_APC": _psuj_apc,
+    "ART_APC_KWOTA": _psuj_apc_kwota,
     "ART_APC_ZRODLO": _psuj_apc_zrodlo,
     # Monografia naukowa — § 2 ust. 10 pkt 5
     "MON_DOI": _psuj_doi,
@@ -313,17 +433,22 @@ PSUJ = {
         pbn_czy_projekt_fnp=None,
         pbn_czy_projekt_ue=None,
     ),
+    "MON_OA_TRYB": _psuj_oa_tryb,
     "MON_OA_WERSJA": _psuj_oa("openaccess_wersja_tekstu"),
     "MON_OA_LICENCJA": _psuj_oa("openaccess_licencja"),
     "MON_OA_DATA": _psuj_oa("openaccess_data_opublikowania"),
     "MON_OA_CZAS": _psuj_oa("openaccess_czas_publikacji"),
     "MON_OA_MIESIACE": _psuj_oa_miesiace,
     "MON_APC": _psuj_apc,
+    "MON_APC_KWOTA": _psuj_apc_kwota,
     "MON_APC_ZRODLO": _psuj_apc_zrodlo,
     # Rozdział w monografii — § 2 ust. 10 pkt 6
     "ROZ_NADRZEDNE": _psuj_pole_rekordu(
         wydawnictwo_nadrzedne=None, wydawnictwo_nadrzedne_w_pbn=None
     ),
+    "ROZ_MON_ISBN": _psuj_pole_nadrzednego(isbn="", e_isbn=""),
+    "ROZ_MON_WYDAWCA": _psuj_pole_nadrzednego(wydawca=None, wydawca_opis=""),
+    "ROZ_MON_DOI": _psuj_pole_nadrzednego(doi=None, www="", public_www=""),
     "ROZ_ORCID": _psuj_orcid,
     "ROZ_DYSCYPLINA": _psuj_dyscypline,
     "ROZ_UPOWAZNIENIE": _psuj_upowaznienie,
@@ -437,3 +562,156 @@ def test_zaden_kompletny_rekord_nie_jest_lapany(regula):
     assert not model.objects.filter(regula.warunek).filter(pk=kompletne.pk).exists(), (
         f"Reguła {regula.kod} ({regula.paragraf}) łapie rekord kompletny."
     )
+
+
+# --------------------------------------------------------------------------
+# Alternatywy w koniunkcjach — „drugie źródło danej ratuje rekord”
+#
+# Testy wyżej psują WSZYSTKIE człony koniunkcji naraz, więc przechodzą także
+# wtedy, gdy z warunku wypadnie dowolny człon poza pierwszym: rekord i tak
+# zostanie złapany. Kod jest poprawny, ale suita tego nie broni. Poniższe
+# testy domykają lukę od drugiej strony: psują człon główny, zostawiają
+# wypełnioną alternatywę i wymagają, żeby reguła MILCZAŁA. Skasowanie
+# któregokolwiek członu z warunku psuje któryś z nich.
+# --------------------------------------------------------------------------
+
+REGULA_PO_KODZIE = {regula.kod: regula for regula in REGULY}
+
+
+def _lapie(kod: str, powiazanie) -> bool:
+    """Czy reguła o podanym kodzie łapie to konkretne powiązanie."""
+    warunek = REGULA_PO_KODZIE[kod].warunek
+    return type(powiazanie).objects.filter(warunek).filter(pk=powiazanie.pk).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("kod", ["ART_DOI", "MON_DOI"])
+def test_publiczny_adres_www_zastepuje_doi(kod):
+    """Lit. a żąda „identyfikatora cyfrowego”, nie konkretnie numeru DOI."""
+    osiagniecie = REGULA_PO_KODZIE[kod].dotyczy
+    powiazanie = _zbuduj_kompletne_powiazanie(osiagniecie)
+    _psuj_pole_rekordu(doi=None, www="", public_www="https://example.org/publikacja")(
+        powiazanie
+    )
+
+    assert not _lapie(kod, powiazanie)
+
+
+@pytest.mark.django_db
+def test_wewnetrzny_adres_www_zastepuje_doi():
+    """Adres `www` (niepubliczny) też jest identyfikatorem cyfrowym."""
+    powiazanie = _zbuduj_kompletne_powiazanie(Osiagniecie.ARTYKUL)
+    _psuj_pole_rekordu(doi=None, public_www="", www="https://intranet/x")(powiazanie)
+
+    assert not _lapie("ART_DOI", powiazanie)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("pole", ["issn", "e_issn"])
+def test_issn_na_samym_rekordzie_ratuje_artykul_bez_issn_zrodla(pole):
+    """Numer wpisany przy rekordzie zastępuje pusty numer w słowniku źródeł."""
+    powiazanie = _zbuduj_kompletne_powiazanie(Osiagniecie.ARTYKUL)
+    rekord = powiazanie.rekord
+    rekord.zrodlo.issn = ""
+    rekord.zrodlo.e_issn = ""
+    rekord.zrodlo.save()
+    setattr(rekord, pole, "1234-5678")
+    rekord.save()
+
+    assert not _lapie("ART_ISSN", powiazanie)
+
+
+@pytest.mark.django_db
+def test_e_issn_zrodla_ratuje_artykul_bez_issn():
+    powiazanie = _zbuduj_kompletne_powiazanie(Osiagniecie.ARTYKUL)
+    rekord = powiazanie.rekord
+    rekord.zrodlo.issn = ""
+    rekord.zrodlo.e_issn = "8765-4321"
+    rekord.zrodlo.save()
+
+    assert not _lapie("ART_ISSN", powiazanie)
+
+
+@pytest.mark.django_db
+def test_pole_informacje_ratuje_pusty_tom():
+    """Tom da się wyekstrahować z pola „Informacje” — to nie jest brak."""
+    powiazanie = _zbuduj_kompletne_powiazanie(Osiagniecie.ARTYKUL)
+    _psuj_pole_rekordu(tom="", informacje="2026, vol. 12, nr 3")(powiazanie)
+
+    assert not _lapie("ART_TOM", powiazanie)
+
+
+@pytest.mark.django_db
+def test_pole_szczegoly_ratuje_puste_strony():
+    """Zakres stron da się wyekstrahować z pola „Szczegóły”."""
+    powiazanie = _zbuduj_kompletne_powiazanie(Osiagniecie.ARTYKUL)
+    _psuj_pole_rekordu(strony="", szczegoly="s. 15-27")(powiazanie)
+
+    assert not _lapie("ART_STRONY", powiazanie)
+
+
+@pytest.mark.django_db
+def test_e_isbn_ratuje_monografie_bez_isbn():
+    powiazanie = _zbuduj_kompletne_powiazanie(Osiagniecie.MONOGRAFIA)
+    _psuj_pole_rekordu(isbn="", e_isbn="978-83-01-99999-9")(powiazanie)
+
+    assert not _lapie("MON_ISBN", powiazanie)
+
+
+@pytest.mark.django_db
+def test_opis_wydawcy_ratuje_monografie_bez_wydawcy_ze_slownika():
+    powiazanie = _zbuduj_kompletne_powiazanie(Osiagniecie.MONOGRAFIA)
+    _psuj_pole_rekordu(wydawca=None, wydawca_opis="Wydawnictwo Własne")(powiazanie)
+
+    assert not _lapie("MON_WYDAWCA", powiazanie)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("kod", ["ART_APC_ZRODLO", "MON_APC_ZRODLO"])
+@pytest.mark.parametrize(
+    "flaga",
+    [
+        "opl_pub_research_potential",
+        "opl_pub_research_or_development_projects",
+        "opl_pub_other",
+    ],
+)
+def test_kazde_zrodlo_finansowania_z_osobna_zamyka_wymog(kod, flaga):
+    """Wystarczy JEDNO wskazane źródło — którekolwiek z trzech."""
+    osiagniecie = REGULA_PO_KODZIE[kod].dotyczy
+    powiazanie = _zbuduj_kompletne_powiazanie(osiagniecie)
+    pola = {
+        "opl_pub_cost_free": False,
+        "opl_pub_amount": Decimal("1500.00"),
+        "opl_pub_research_potential": None,
+        "opl_pub_research_or_development_projects": None,
+        "opl_pub_other": None,
+    }
+    pola[flaga] = True
+    _psuj_pole_rekordu(**pola)(powiazanie)
+
+    assert not _lapie(kod, powiazanie)
+
+
+@pytest.mark.django_db
+def test_brak_numeru_zgloszenia_lapie_patent_mimo_wpisanej_daty():
+    """Drugi człon alternatywy z lit. g: numer, nie tylko data."""
+    powiazanie = _zbuduj_kompletne_powiazanie(Osiagniecie.PATENT)
+    assert powiazanie.rekord.data_zgloszenia is not None
+    _psuj_pole_rekordu(numer_zgloszenia=None)(powiazanie)
+
+    assert _lapie("PAT_ZGLOSZENIE", powiazanie)
+
+
+@pytest.mark.django_db
+def test_wydawnictwo_nadrzedne_w_pbn_ratuje_rozdzial_bez_rekordu_nadrzednego():
+    """Rodzic wskazany w PBN zamyka lit. a tak samo jak rekord w BPP."""
+    from pbn_api.models import Publication
+
+    powiazanie = _zbuduj_kompletne_powiazanie(Osiagniecie.ROZDZIAL)
+    _psuj_pole_rekordu(
+        wydawnictwo_nadrzedne=None,
+        wydawnictwo_nadrzedne_w_pbn=baker.make(Publication),
+    )(powiazanie)
+
+    assert not _lapie("ROZ_NADRZEDNE", powiazanie)

--- a/src/kompletnosc_polon/tests/test_selektory.py
+++ b/src/kompletnosc_polon/tests/test_selektory.py
@@ -1,0 +1,513 @@
+"""Testy selektorów raportu kompletności danych POL-on.
+
+Selektory odpowiadają za trzy rzeczy i każda z nich ma tu własny blok testów:
+
+1. **zawężenie** — do okna ewaluacji, do przypiętych powiązań i do uczelni
+   oglądającego (multi-tenant);
+2. **klasyfikację** — rozróżnienie monografii od rozdziału po
+   ``charakter_formalny.charakter_sloty``, wraz z osobną kategorią
+   „nierozpoznany typ osiągnięcia” dla rekordów, których zaklasyfikować
+   się nie da;
+3. **anotację** — dołożenie po jednym polu logicznym na regułę oraz
+   liczników braków wymaganych i warunkowych.
+
+Budowniczych obiektów „kompletnych” (takich, których nie łapie ŻADNA reguła)
+importujemy z :mod:`kompletnosc_polon.tests.test_reguly`. Zduplikowanie ich
+tutaj oznaczałoby, że przy zmianie reguły trzeba pamiętać o dwóch miejscach —
+a to gwarancja cichego rozjazdu.
+"""
+
+import datetime
+
+import pytest
+from model_bakery import baker
+
+from bpp.const import CHARAKTER_SLOTY_KSIAZKA, CHARAKTER_SLOTY_ROZDZIAL
+from ewaluacja_common.const import OKNO_EWALUACJI
+from kompletnosc_polon import selektory
+from kompletnosc_polon.const import OA_CZAS_PO_OPUBLIKOWANIU, Osiagniecie, Waga
+from kompletnosc_polon.reguly import reguly_dla
+
+from .test_reguly import (
+    ROK,
+    _kolejny_orcid,
+    _kompletne_zwarte,
+    _kompletny_artykul,
+    _kompletny_patent,
+)
+
+PIERWSZY_ROK, OSTATNI_ROK = OKNO_EWALUACJI
+
+
+# --------------------------------------------------------------------------
+# Pomocnicy budujący ziarno raportu: powiązanie (autor, dyscyplina, rekord)
+# --------------------------------------------------------------------------
+
+
+def _jednostka(uczelnia=None):
+    """Jednostka w podanej uczelni; przy braku uczelni — w nowej."""
+    if uczelnia is None:
+        uczelnia = baker.make("bpp.Uczelnia")
+    return baker.make("bpp.Jednostka", uczelnia=uczelnia)
+
+
+def _powiazanie(
+    rekord,
+    model_powiazania,
+    *,
+    uczelnia=None,
+    jednostka=None,
+    z_dyscyplina=True,
+    przypieta=True,
+    orcid=True,
+    **nadpisz,
+):
+    """Zbuduj powiązanie autora z rekordem — jeden wiersz raportu.
+
+    Powiązanie autor–dyscyplina na rok rekordu jest wymuszone przez
+    ``BazaModeluOdpowiedzialnosciAutorow.clean()``, wołane z ``save()``,
+    więc tworzymy je zawsze, gdy dyscyplina ma być ustawiona.
+    """
+    autor = baker.make("bpp.Autor", orcid=_kolejny_orcid() if orcid else None)
+
+    dyscyplina = None
+    if z_dyscyplina:
+        dyscyplina = baker.make("bpp.Dyscyplina_Naukowa")
+        baker.make(
+            "bpp.Autor_Dyscyplina",
+            autor=autor,
+            rok=rekord.rok,
+            dyscyplina_naukowa=dyscyplina,
+            subdyscyplina_naukowa=None,
+        )
+
+    return baker.make(
+        model_powiazania,
+        rekord=rekord,
+        autor=autor,
+        jednostka=jednostka if jednostka is not None else _jednostka(uczelnia),
+        dyscyplina_naukowa=dyscyplina,
+        przypieta=przypieta,
+        upowaznienie_pbn=True,
+        oswiadczenie_ken=None,
+        **nadpisz,
+    )
+
+
+def _artykul_z_autorem(rok=ROK, **kwargs):
+    rekord = _kompletny_artykul()
+    if rok != rekord.rok:
+        rekord.rok = rok
+        rekord.save()
+    return _powiazanie(rekord, "bpp.Wydawnictwo_Ciagle_Autor", **kwargs)
+
+
+def _charakter(charakter_sloty):
+    """Charakter formalny o zadanym „charakterze dla slotów”.
+
+    ``skrot`` bierzemy losowy (baker), bo słownik charakterów jest częścią
+    baseline'u bazy i kolizja unikalności psułaby test.
+    """
+    return baker.make("bpp.Charakter_Formalny", charakter_sloty=charakter_sloty)
+
+
+def _zwarte_z_autorem(charakter_sloty, rok=ROK, **kwargs):
+    rekord = _kompletne_zwarte()
+    rekord.rok = rok
+    rekord.charakter_formalny = _charakter(charakter_sloty)
+    rekord.save()
+    return _powiazanie(rekord, "bpp.Wydawnictwo_Zwarte_Autor", **kwargs)
+
+
+def _patent_z_autorem(rok=ROK, **kwargs):
+    rekord = _kompletny_patent()
+    if rok != rekord.rok:
+        rekord.rok = rok
+        rekord.save()
+    return _powiazanie(rekord, "bpp.Patent_Autor", **kwargs)
+
+
+def _pk(qs):
+    return set(qs.values_list("pk", flat=True))
+
+
+# --------------------------------------------------------------------------
+# Zawężenie: okno ewaluacji
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_selektor_bierze_wylacznie_lata_z_okna():
+    przed = _artykul_z_autorem(rok=PIERWSZY_ROK - 1)
+    pierwszy = _artykul_z_autorem(rok=PIERWSZY_ROK)
+    ostatni = _artykul_z_autorem(rok=OSTATNI_ROK)
+    po = _artykul_z_autorem(rok=OSTATNI_ROK + 1)
+
+    znalezione = _pk(selektory.powiazania(Osiagniecie.ARTYKUL))
+
+    assert znalezione == {pierwszy.pk, ostatni.pk}, (
+        "Obie granice okna muszą wchodzić do raportu, a lata spoza okna — nie"
+    )
+    assert przed.pk not in znalezione
+    assert po.pk not in znalezione
+
+
+@pytest.mark.django_db
+def test_okno_da_sie_nadpisac_argumentem():
+    stary = _artykul_z_autorem(rok=PIERWSZY_ROK - 1)
+    nowy = _artykul_z_autorem(rok=PIERWSZY_ROK)
+
+    znalezione = _pk(
+        selektory.powiazania(Osiagniecie.ARTYKUL, okno=(PIERWSZY_ROK - 1, PIERWSZY_ROK))
+    )
+
+    assert znalezione == {stary.pk, nowy.pk}
+
+
+# --------------------------------------------------------------------------
+# Zawężenie: przypięta dyscyplina
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_odpieta_dyscyplina_nie_trafia_do_raportu():
+    przypieta = _artykul_z_autorem()
+    odpieta = _artykul_z_autorem(przypieta=False)
+
+    znalezione = _pk(selektory.powiazania(Osiagniecie.ARTYKUL))
+
+    assert znalezione == {przypieta.pk}
+    assert odpieta.pk not in znalezione
+
+
+@pytest.mark.django_db
+def test_brak_dyscypliny_trafia_do_raportu_i_jest_zglaszany_jako_brak():
+    """Powiązanie przypięte, ale bez dyscypliny, MUSI zostać w raporcie.
+
+    Gdyby selektor odsiewał także ``dyscyplina_naukowa IS NULL``, reguły
+    ``*_DYSCYPLINA`` nigdy nie mogłyby się uruchomić — a to one są jedynym
+    sposobem, żeby użytkownik dowiedział się o braku dyscypliny.
+    """
+    bez_dyscypliny = _artykul_z_autorem(z_dyscyplina=False)
+
+    qs = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    )
+    wiersz = qs.get(pk=bez_dyscypliny.pk)
+
+    assert getattr(wiersz, selektory.pole_reguly("ART_DYSCYPLINA")) is True
+
+
+# --------------------------------------------------------------------------
+# Zawężenie: uczelnia (multi-tenant)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_powiazanie_autora_z_innej_uczelni_nie_trafia():
+    nasza = baker.make("bpp.Uczelnia")
+    obca = baker.make("bpp.Uczelnia")
+
+    nasze = _artykul_z_autorem(uczelnia=nasza)
+    obce = _artykul_z_autorem(uczelnia=obca)
+
+    znalezione = _pk(selektory.powiazania(Osiagniecie.ARTYKUL, uczelnia=nasza))
+
+    assert znalezione == {nasze.pk}
+    assert obce.pk not in znalezione
+
+
+@pytest.mark.django_db
+def test_bez_podanej_uczelni_selektor_nie_zawezia():
+    pierwsze = _artykul_z_autorem(uczelnia=baker.make("bpp.Uczelnia"))
+    drugie = _artykul_z_autorem(uczelnia=baker.make("bpp.Uczelnia"))
+
+    znalezione = _pk(selektory.powiazania(Osiagniecie.ARTYKUL, uczelnia=None))
+
+    assert znalezione == {pierwsze.pk, drugie.pk}
+
+
+# --------------------------------------------------------------------------
+# Ziarno raportu: (autor, dyscyplina, rekord)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dwoch_wspolautorow_w_dwoch_dyscyplinach_daje_dwa_wiersze():
+    """Jedna publikacja dwóch współautorów to DWA wpisy w wykazie pracowników.
+
+    Brak (tu: ORCID) musi być przypisany tej osobie, której dotyczy — a nie
+    „publikacji”.
+    """
+    rekord = _kompletny_artykul()
+    jednostka = _jednostka()
+
+    z_orcidem = _powiazanie(
+        rekord, "bpp.Wydawnictwo_Ciagle_Autor", jednostka=jednostka, orcid=True
+    )
+    bez_orcidu = _powiazanie(
+        rekord,
+        "bpp.Wydawnictwo_Ciagle_Autor",
+        jednostka=jednostka,
+        orcid=False,
+        kolejnosc=1,
+    )
+
+    assert z_orcidem.dyscyplina_naukowa_id != bez_orcidu.dyscyplina_naukowa_id, (
+        "Test ma sens tylko przy dwóch RÓŻNYCH dyscyplinach"
+    )
+
+    qs = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    )
+    assert _pk(qs) == {z_orcidem.pk, bez_orcidu.pk}
+
+    pole = selektory.pole_reguly("ART_ORCID")
+    assert getattr(qs.get(pk=bez_orcidu.pk), pole) is True
+    assert getattr(qs.get(pk=z_orcidem.pk), pole) is False
+
+
+# --------------------------------------------------------------------------
+# Klasyfikacja: monografia vs rozdział vs „nierozpoznany typ”
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_monografia_i_rozdzial_rozroznia_charakter_slotow():
+    monografia = _zwarte_z_autorem(CHARAKTER_SLOTY_KSIAZKA)
+    rozdzial = _zwarte_z_autorem(CHARAKTER_SLOTY_ROZDZIAL)
+
+    assert _pk(selektory.powiazania(Osiagniecie.MONOGRAFIA)) == {monografia.pk}
+    assert _pk(selektory.powiazania(Osiagniecie.ROZDZIAL)) == {rozdzial.pk}
+
+
+@pytest.mark.django_db
+def test_rekord_bez_charakteru_slotow_nie_znika_tylko_trafia_do_nierozpoznanych():
+    """Fixture instalacyjny zostawia ``charakter_sloty`` puste.
+
+    Taki rekord nie daje się zaklasyfikować ani jako monografia, ani jako
+    rozdział — ale nie wolno mu zniknąć po cichu, bo użytkownik uznałby, że
+    raport go sprawdził.
+    """
+    nierozpoznany = _zwarte_z_autorem(None)
+    monografia = _zwarte_z_autorem(CHARAKTER_SLOTY_KSIAZKA)
+
+    assert nierozpoznany.pk not in _pk(selektory.powiazania(Osiagniecie.MONOGRAFIA))
+    assert nierozpoznany.pk not in _pk(selektory.powiazania(Osiagniecie.ROZDZIAL))
+
+    nierozpoznane = _pk(selektory.powiazania_nierozpoznane())
+    assert nierozpoznane == {nierozpoznany.pk}
+    assert monografia.pk not in nierozpoznane
+
+
+@pytest.mark.django_db
+def test_nierozpoznane_respektuja_okno_i_uczelnie():
+    nasza = baker.make("bpp.Uczelnia")
+    obca = baker.make("bpp.Uczelnia")
+
+    nasz = _zwarte_z_autorem(None, uczelnia=nasza)
+    _zwarte_z_autorem(None, uczelnia=obca)
+    _zwarte_z_autorem(None, uczelnia=nasza, rok=PIERWSZY_ROK - 1)
+
+    assert _pk(selektory.powiazania_nierozpoznane(uczelnia=nasza)) == {nasz.pk}
+
+
+@pytest.mark.django_db
+def test_patenty_i_artykuly_nie_podlegaja_klasyfikacji_po_charakterze():
+    """Patent nie ma pola ``charakter_formalny``; artykuł zawsze jest pkt 4."""
+    patent = _patent_z_autorem()
+    artykul = _artykul_z_autorem()
+
+    assert _pk(selektory.powiazania(Osiagniecie.PATENT)) == {patent.pk}
+    assert _pk(selektory.powiazania(Osiagniecie.ARTYKUL)) == {artykul.pk}
+
+
+# --------------------------------------------------------------------------
+# Anotacja regułami
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_anotacja_doklada_pole_logiczne_dla_kazdej_reguly():
+    _artykul_z_autorem()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    for regula in reguly_dla(Osiagniecie.ARTYKUL):
+        pole = selektory.pole_reguly(regula.kod)
+        assert hasattr(wiersz, pole), f"Brak anotacji {pole}"
+        assert isinstance(getattr(wiersz, pole), bool)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("osiagniecie", list(Osiagniecie), ids=lambda o: o.value)
+def test_anotacja_dziala_dla_kazdego_typu_i_nie_zwielokrotnia_wierszy(osiagniecie):
+    """Anotacja nie może rozmnożyć ziarna przez JOIN-y warunków reguł.
+
+    Wszystkie ścieżki w regułach idą przez relacje „do jednego” (FK w przód),
+    więc jedno powiązanie musi dać dokładnie jeden wiersz — także wtedy, gdy
+    dołożymy kilkanaście warunków naraz.
+    """
+    budowniczy = {
+        Osiagniecie.ARTYKUL: lambda: _artykul_z_autorem(),
+        Osiagniecie.MONOGRAFIA: lambda: _zwarte_z_autorem(CHARAKTER_SLOTY_KSIAZKA),
+        Osiagniecie.ROZDZIAL: lambda: _zwarte_z_autorem(CHARAKTER_SLOTY_ROZDZIAL),
+        Osiagniecie.PATENT: lambda: _patent_z_autorem(),
+    }[osiagniecie]
+    powiazanie = budowniczy()
+
+    qs = selektory.z_regulami(selektory.powiazania(osiagniecie), osiagniecie)
+
+    assert list(qs.values_list("pk", flat=True)) == [powiazanie.pk]
+    assert selektory.naruszone_reguly(qs.get(), osiagniecie) == []
+
+
+@pytest.mark.django_db
+def test_rekord_kompletny_nie_ma_zadnego_braku():
+    _artykul_z_autorem()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    assert selektory.naruszone_reguly(wiersz, Osiagniecie.ARTYKUL) == []
+    assert getattr(wiersz, selektory.POLE_BRAKI_WYMAGANE) == 0
+    assert getattr(wiersz, selektory.POLE_BRAKI_WARUNKOWE) == 0
+
+
+@pytest.mark.django_db
+def test_liczniki_zliczaja_braki_osobno_dla_kazdej_wagi():
+    """Jeden brak wymagany (DOI) i jeden warunkowy (ORCID)."""
+    powiazanie = _artykul_z_autorem(orcid=False)
+    rekord = powiazanie.rekord
+    rekord.doi = None
+    rekord.www = ""
+    rekord.public_www = ""
+    rekord.save()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    assert getattr(wiersz, selektory.pole_reguly("ART_DOI")) is True
+    assert getattr(wiersz, selektory.pole_reguly("ART_ORCID")) is True
+    assert getattr(wiersz, selektory.POLE_BRAKI_WYMAGANE) == 1
+    assert getattr(wiersz, selektory.POLE_BRAKI_WARUNKOWE) == 1
+
+    naruszone = selektory.naruszone_reguly(wiersz, Osiagniecie.ARTYKUL)
+    assert {regula.kod for regula in naruszone} == {"ART_DOI", "ART_ORCID"}
+
+
+@pytest.mark.django_db
+def test_liczniki_zgadzaja_sie_z_lista_naruszonych_regul():
+    _artykul_z_autorem(orcid=False, z_dyscyplina=False)
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+    naruszone = selektory.naruszone_reguly(wiersz, Osiagniecie.ARTYKUL)
+
+    wymagane = [r for r in naruszone if r.waga == Waga.WYMAGANE]
+    warunkowe = [r for r in naruszone if r.waga == Waga.WARUNKOWE]
+
+    assert getattr(wiersz, selektory.POLE_BRAKI_WYMAGANE) == len(wymagane)
+    assert getattr(wiersz, selektory.POLE_BRAKI_WARUNKOWE) == len(warunkowe)
+    assert wymagane and warunkowe, "Test ma sens tylko przy brakach obu wag"
+
+
+@pytest.mark.django_db
+def test_naruszone_reguly_zwraca_obiekty_regul_z_opisem_i_paragrafem():
+    powiazanie = _artykul_z_autorem()
+    powiazanie.upowaznienie_pbn = False
+    powiazanie.save()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+    (regula,) = selektory.naruszone_reguly(wiersz, Osiagniecie.ARTYKUL)
+
+    assert regula.kod == "ART_UPOWAZNIENIE"
+    assert regula.paragraf == "§ 2 ust. 10 pkt 4 lit. d"
+    assert regula.opis
+
+
+@pytest.mark.django_db
+def test_naruszone_reguly_wymagaja_zanotowanego_wiersza():
+    _artykul_z_autorem()
+    wiersz = selektory.powiazania(Osiagniecie.ARTYKUL).get()
+
+    with pytest.raises(ValueError):
+        selektory.naruszone_reguly(wiersz, Osiagniecie.ARTYKUL)
+
+
+@pytest.mark.django_db
+def test_anotacja_rozdzialu_uzywa_wylacznie_regul_rozdzialu():
+    _zwarte_z_autorem(CHARAKTER_SLOTY_ROZDZIAL)
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ROZDZIAL), Osiagniecie.ROZDZIAL
+    ).get()
+
+    assert hasattr(wiersz, selektory.pole_reguly("ROZ_NADRZEDNE"))
+    assert not hasattr(wiersz, selektory.pole_reguly("MON_ISBN"))
+
+
+def test_pole_reguly_wyprowadza_nazwe_z_kodu():
+    assert selektory.pole_reguly("ART_DOI") == "brak_ART_DOI"
+
+
+# --------------------------------------------------------------------------
+# Warunkowość Open Access
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_praca_bez_trybu_open_access_nie_generuje_brakow_oa():
+    _artykul_z_autorem()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    for kod in (
+        "ART_OA_WERSJA",
+        "ART_OA_LICENCJA",
+        "ART_OA_DATA",
+        "ART_OA_CZAS",
+        "ART_OA_MIESIACE",
+    ):
+        assert getattr(wiersz, selektory.pole_reguly(kod)) is False, (
+            f"Reguła {kod} zadziałała mimo braku oznaczenia Open Access"
+        )
+
+
+@pytest.mark.django_db
+def test_udostepnienie_inne_niz_po_opublikowaniu_nie_wymaga_liczby_miesiecy():
+    from bpp.models import Czas_Udostepnienia_OpenAccess
+
+    czas, _ = Czas_Udostepnienia_OpenAccess.objects.get_or_create(
+        skrot="BEFORE_PUBLICATION",
+        defaults={"nazwa": "przed opublikowaniem"},
+    )
+    assert czas.skrot != OA_CZAS_PO_OPUBLIKOWANIU
+
+    powiazanie = _artykul_z_autorem()
+    rekord = powiazanie.rekord
+    rekord.openaccess_tryb_dostepu = baker.make(
+        "bpp.Tryb_OpenAccess_Wydawnictwo_Ciagle"
+    )
+    rekord.openaccess_wersja_tekstu = baker.make("bpp.Wersja_Tekstu_OpenAccess")
+    rekord.openaccess_licencja = baker.make("bpp.Licencja_OpenAccess")
+    rekord.openaccess_data_opublikowania = datetime.date(ROK, 3, 1)
+    rekord.openaccess_czas_publikacji = czas
+    rekord.openaccess_ilosc_miesiecy = None
+    rekord.save()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    assert getattr(wiersz, selektory.pole_reguly("ART_OA_MIESIACE")) is False
+    assert selektory.naruszone_reguly(wiersz, Osiagniecie.ARTYKUL) == []

--- a/src/kompletnosc_polon/tests/test_selektory.py
+++ b/src/kompletnosc_polon/tests/test_selektory.py
@@ -18,11 +18,18 @@ a to gwarancja cichego rozjazdu.
 """
 
 import datetime
+from decimal import Decimal
 
 import pytest
 from model_bakery import baker
 
-from bpp.const import CHARAKTER_SLOTY_KSIAZKA, CHARAKTER_SLOTY_ROZDZIAL
+from bpp.const import (
+    CHARAKTER_SLOTY_KSIAZKA,
+    CHARAKTER_SLOTY_REFERAT,
+    CHARAKTER_SLOTY_ROZDZIAL,
+    RODZAJ_PBN_ARTYKUL,
+    RODZAJ_PBN_KSIAZKA,
+)
 from ewaluacja_common.const import OKNO_EWALUACJI
 from kompletnosc_polon import selektory
 from kompletnosc_polon.const import OA_CZAS_PO_OPUBLIKOWANIU, Osiagniecie, Waga
@@ -30,6 +37,7 @@ from kompletnosc_polon.reguly import reguly_dla
 
 from .test_reguly import (
     ROK,
+    _kolejna_dyscyplina,
     _kolejny_orcid,
     _kompletne_zwarte,
     _kompletny_artykul,
@@ -72,7 +80,7 @@ def _powiazanie(
 
     dyscyplina = None
     if z_dyscyplina:
-        dyscyplina = baker.make("bpp.Dyscyplina_Naukowa")
+        dyscyplina = _kolejna_dyscyplina()
         baker.make(
             "bpp.Autor_Dyscyplina",
             autor=autor,
@@ -94,27 +102,47 @@ def _powiazanie(
     )
 
 
-def _artykul_z_autorem(rok=ROK, **kwargs):
+def _artykul_z_autorem(rok=ROK, rodzaj_pbn=RODZAJ_PBN_ARTYKUL, **kwargs):
+    """Powiązanie autora z artykułem; ``rodzaj_pbn`` zmienia typ rekordu.
+
+    ``rodzaj_pbn=None`` odwzorowuje streszczenie zjazdowe, list do redakcji,
+    recenzję albo komunikat — wydawnictwa ciągłe, które nie są artykułem
+    naukowym z § 2 ust. 10 pkt 4 i nigdy nie jadą do PBN.
+    """
     rekord = _kompletny_artykul()
-    if rok != rekord.rok:
-        rekord.rok = rok
-        rekord.save()
+    rekord.rok = rok
+    if rodzaj_pbn != RODZAJ_PBN_ARTYKUL:
+        rekord.charakter_formalny = baker.make(
+            "bpp.Charakter_Formalny", rodzaj_pbn=rodzaj_pbn
+        )
+    rekord.save()
     return _powiazanie(rekord, "bpp.Wydawnictwo_Ciagle_Autor", **kwargs)
 
 
-def _charakter(charakter_sloty):
+def _charakter(charakter_sloty, rodzaj_pbn=RODZAJ_PBN_KSIAZKA):
     """Charakter formalny o zadanym „charakterze dla slotów”.
 
     ``skrot`` bierzemy losowy (baker), bo słownik charakterów jest częścią
     baseline'u bazy i kolizja unikalności psułaby test.
+
+    ``rodzaj_pbn`` domyślnie ustawiamy na niepusty, bo to on odpowiada na
+    pytanie „czy ten rekord w ogóle jedzie do PBN”. Charakter bez tej wartości
+    (np. TŁ, SKR, PZ, BR, IN) jest sklasyfikowany poprawnie i celowo poza
+    zakresem raportu — do sekcji „nierozpoznane” trafiać NIE ma.
     """
-    return baker.make("bpp.Charakter_Formalny", charakter_sloty=charakter_sloty)
+    return baker.make(
+        "bpp.Charakter_Formalny",
+        charakter_sloty=charakter_sloty,
+        rodzaj_pbn=rodzaj_pbn,
+    )
 
 
-def _zwarte_z_autorem(charakter_sloty, rok=ROK, **kwargs):
+def _zwarte_z_autorem(
+    charakter_sloty, rok=ROK, rodzaj_pbn=RODZAJ_PBN_KSIAZKA, **kwargs
+):
     rekord = _kompletne_zwarte()
     rekord.rok = rok
-    rekord.charakter_formalny = _charakter(charakter_sloty)
+    rekord.charakter_formalny = _charakter(charakter_sloty, rodzaj_pbn)
     rekord.save()
     return _powiazanie(rekord, "bpp.Wydawnictwo_Zwarte_Autor", **kwargs)
 
@@ -129,6 +157,26 @@ def _patent_z_autorem(rok=ROK, **kwargs):
 
 def _pk(qs):
     return set(qs.values_list("pk", flat=True))
+
+
+def _identyfikator(powiazanie):
+    """Para (model, pk) — jednoznaczna także przy mieszaniu dwóch modeli.
+
+    Sekcja „nierozpoznane” łączy powiązania z wydawnictwami zwartymi
+    i ciągłymi, a to dwie tabele o **niezależnych sekwencjach** kluczy
+    głównych: samo ``pk`` potrafiłoby się powtórzyć i asercja na zbiorze
+    byłaby fałszywie zielona.
+    """
+    return (powiazanie._meta.model_name, powiazanie.pk)
+
+
+def _nierozpoznane(**kwargs):
+    """Zbiór identyfikatorów wszystkich nierozpoznanych powiązań."""
+    return {
+        _identyfikator(powiazanie)
+        for qs in selektory.powiazania_nierozpoznane(**kwargs)
+        for powiazanie in qs
+    }
 
 
 # --------------------------------------------------------------------------
@@ -295,9 +343,36 @@ def test_rekord_bez_charakteru_slotow_nie_znika_tylko_trafia_do_nierozpoznanych(
     assert nierozpoznany.pk not in _pk(selektory.powiazania(Osiagniecie.MONOGRAFIA))
     assert nierozpoznany.pk not in _pk(selektory.powiazania(Osiagniecie.ROZDZIAL))
 
-    nierozpoznane = _pk(selektory.powiazania_nierozpoznane())
-    assert nierozpoznane == {nierozpoznany.pk}
-    assert monografia.pk not in nierozpoznane
+    nierozpoznane = _nierozpoznane()
+    assert nierozpoznane == {_identyfikator(nierozpoznany)}
+    assert _identyfikator(monografia) not in nierozpoznane
+
+
+@pytest.mark.django_db
+def test_charakter_spoza_pbn_nie_trafia_do_nierozpoznanych():
+    """Sekcja „raport tego nie sprawdził” to zarzut, nie worek na wszystko.
+
+    Migracje ``0173`` i ``0225`` ustawiają ``charakter_sloty`` wyłącznie dla
+    KS/KSP/KSZ, ROZ/ROZS i PRZ/ZRZ, więc pusta wartość jest normą dla frg, TŁ,
+    SKR, PZ, BR i IN. Te charaktery są sklasyfikowane poprawnie i celowo —
+    po prostu nie jadą do PBN (``rodzaj_pbn`` puste). Zgłoszenie ich jako
+    „niesprawdzonych” byłoby fałszywym alarmem.
+    """
+    spoza_pbn = _zwarte_z_autorem(None, rodzaj_pbn=None)
+    nierozpoznany = _zwarte_z_autorem(None, rodzaj_pbn=RODZAJ_PBN_KSIAZKA)
+
+    nierozpoznane = _nierozpoznane()
+
+    assert nierozpoznane == {_identyfikator(nierozpoznany)}
+    assert _identyfikator(spoza_pbn) not in nierozpoznane
+
+
+@pytest.mark.django_db
+def test_referat_nie_trafia_do_nierozpoznanych():
+    """Referat jest zaklasyfikowany JAWNIE — to nie jest brak danych."""
+    referat = _zwarte_z_autorem(CHARAKTER_SLOTY_REFERAT)
+
+    assert _identyfikator(referat) not in _nierozpoznane()
 
 
 @pytest.mark.django_db
@@ -309,17 +384,102 @@ def test_nierozpoznane_respektuja_okno_i_uczelnie():
     _zwarte_z_autorem(None, uczelnia=obca)
     _zwarte_z_autorem(None, uczelnia=nasza, rok=PIERWSZY_ROK - 1)
 
-    assert _pk(selektory.powiazania_nierozpoznane(uczelnia=nasza)) == {nasz.pk}
+    assert _nierozpoznane(uczelnia=nasza) == {_identyfikator(nasz)}
 
 
 @pytest.mark.django_db
-def test_patenty_i_artykuly_nie_podlegaja_klasyfikacji_po_charakterze():
-    """Patent nie ma pola ``charakter_formalny``; artykuł zawsze jest pkt 4."""
-    patent = _patent_z_autorem()
+def test_ciagle_bez_rodzaju_pbn_nie_znika_tylko_trafia_do_nierozpoznanych():
+    """Nieustawiony ``rodzaj_pbn`` NIE może wyciszyć wszystkich artykułów.
+
+    ``Charakter_Formalny.rodzaj_pbn`` nie jest wypełniane przez fixture
+    instalacyjny — administrator ustawia je per instalacja. Dopóki tego nie
+    zrobi dla charakteru „AC”, każdy artykuł wypada z :func:`powiazania`;
+    gdyby wypadał też z sekcji nierozpoznanych, użytkownik zobaczyłby raport
+    bez ani jednego artykułu i uznałby, że artykuły są w porządku.
+    """
+    nierozpoznany = _artykul_z_autorem(rodzaj_pbn=None)
+
+    assert nierozpoznany.pk not in _pk(selektory.powiazania(Osiagniecie.ARTYKUL))
+    assert _nierozpoznane() == {_identyfikator(nierozpoznany)}
+
+
+@pytest.mark.django_db
+def test_artykul_z_ustawionym_rodzajem_pbn_nie_trafia_do_nierozpoznanych():
+    """Rekord audytowany normalnie nie ma prawa być zarazem „niesprawdzony”."""
     artykul = _artykul_z_autorem()
 
+    assert artykul.pk in _pk(selektory.powiazania(Osiagniecie.ARTYKUL))
+    assert _identyfikator(artykul) not in _nierozpoznane()
+
+
+@pytest.mark.django_db
+def test_ciagle_o_jawnie_innym_rodzaju_pbn_nie_trafia_do_nierozpoznanych():
+    """Ciągłe oznaczone jako książka jest sklasyfikowane — po prostu poza pkt 4.
+
+    Tak samo jak referat wśród zwartych: raport go nie audytuje, ale to nie
+    jest brak danych, więc „raport tego nie sprawdził” byłoby zarzutem
+    postawionym poprawnie wypełnionemu rekordowi.
+    """
+    ksiazkowe = _artykul_z_autorem(rodzaj_pbn=RODZAJ_PBN_KSIAZKA)
+
+    assert _identyfikator(ksiazkowe) not in _nierozpoznane()
+
+
+@pytest.mark.django_db
+def test_nierozpoznane_lacza_zwarte_i_ciagle_w_jeden_zbior():
+    """Sekcja jest JEDNA — obsługuje oba modele naraz."""
+    zwarte = _zwarte_z_autorem(None)
+    ciagle = _artykul_z_autorem(rodzaj_pbn=None)
+
+    assert _nierozpoznane() == {_identyfikator(zwarte), _identyfikator(ciagle)}
+
+
+@pytest.mark.django_db
+def test_nierozpoznane_ciagle_respektuja_okno_i_uczelnie():
+    nasza = baker.make("bpp.Uczelnia")
+    obca = baker.make("bpp.Uczelnia")
+
+    nasz = _artykul_z_autorem(rodzaj_pbn=None, uczelnia=nasza)
+    _artykul_z_autorem(rodzaj_pbn=None, uczelnia=obca)
+    _artykul_z_autorem(rodzaj_pbn=None, uczelnia=nasza, rok=PIERWSZY_ROK - 1)
+
+    assert _nierozpoznane(uczelnia=nasza) == {_identyfikator(nasz)}
+
+
+@pytest.mark.django_db
+def test_patent_nie_podlega_klasyfikacji_po_charakterze_formalnym():
+    """Patent nie ma pola ``charakter_formalny`` w ogóle."""
+    patent = _patent_z_autorem()
+
     assert _pk(selektory.powiazania(Osiagniecie.PATENT)) == {patent.pk}
-    assert _pk(selektory.powiazania(Osiagniecie.ARTYKUL)) == {artykul.pk}
+
+
+@pytest.mark.django_db
+def test_streszczenie_zjazdowe_nie_jest_audytowane_jako_artykul():
+    """Wydawnictwo ciągłe NIE jest automatycznie artykułem naukowym.
+
+    Ten sam model niesie streszczenia zjazdowe (PSZ, ZSZ), listy do redakcji
+    (L), recenzje (R) i komunikaty (KOM). Charakter formalny bez ``rodzaj_pbn``
+    znaczy, że rekord nie jedzie do PBN — a więc nie jest osiągnięciem z § 2
+    ust. 10 pkt 4 i raport nie ma prawa żądać od niego DOI, ISSN ani flagi
+    „czy artykuł recenzyjny”.
+    """
+    artykul = _artykul_z_autorem()
+    streszczenie = _artykul_z_autorem(rodzaj_pbn=None)
+
+    znalezione = _pk(selektory.powiazania(Osiagniecie.ARTYKUL))
+
+    assert znalezione == {artykul.pk}
+    assert streszczenie.pk not in znalezione
+
+
+@pytest.mark.django_db
+def test_ciagle_o_rodzaju_pbn_innym_niz_artykul_nie_jest_audytowane():
+    """Pkt 4 mówi o *artykule naukowym*, a nie o dowolnym rekordzie w PBN."""
+    ksiazkowe = _artykul_z_autorem(rodzaj_pbn=RODZAJ_PBN_KSIAZKA)
+
+    assert _pk(selektory.powiazania(Osiagniecie.ARTYKUL)) == set()
+    assert ksiazkowe.pk not in _pk(selektory.powiazania(Osiagniecie.ARTYKUL))
 
 
 # --------------------------------------------------------------------------
@@ -511,3 +671,169 @@ def test_udostepnienie_inne_niz_po_opublikowaniu_nie_wymaga_liczby_miesiecy():
 
     assert getattr(wiersz, selektory.pole_reguly("ART_OA_MIESIACE")) is False
     assert selektory.naruszone_reguly(wiersz, Osiagniecie.ARTYKUL) == []
+
+
+@pytest.mark.django_db
+def test_dane_oa_bez_trybu_dostepu_daja_brak_zamiast_ciszy():
+    """Regresja: pierwszy tiret lit. l to sam TRYB dostępu.
+
+    Rekord z wypełnioną datą udostępnienia, ale bez trybu, wersji i licencji
+    dawał wcześniej ZERO naruszeń: cztery reguły OA były bramkowane trybem,
+    a piąta (miesiące) czasem udostępnienia — więc brak trybu wyłączał je
+    wszystkie i raport milczał o danej zaczętej i niedokończonej.
+    """
+    powiazanie = _artykul_z_autorem()
+    rekord = powiazanie.rekord
+    rekord.openaccess_tryb_dostepu = None
+    rekord.openaccess_wersja_tekstu = None
+    rekord.openaccess_licencja = None
+    rekord.openaccess_data_opublikowania = datetime.date(ROK, 3, 1)
+    rekord.save()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    assert getattr(wiersz, selektory.pole_reguly("ART_OA_TRYB")) is True
+    assert "ART_OA_TRYB" in {
+        r.kod for r in selektory.naruszone_reguly(wiersz, Osiagniecie.ARTYKUL)
+    }
+
+
+@pytest.mark.django_db
+def test_liczba_miesiecy_bramkowana_tak_samo_jak_reszta_litery():
+    """Bez trybu dostępu ``*_OA_MIESIACE`` milczy — jak pozostałe reguły OA.
+
+    Wcześniej ta jedna reguła bramkowana była wyłącznie skrótem czasu
+    udostępnienia, więc rekord bez trybu dostawał brak liczby miesięcy
+    i NIE dostawał braku wersji tekstu — dwie reguły tej samej litery mówiły
+    co innego o tym samym rekordzie.
+    """
+    from bpp.models import Czas_Udostepnienia_OpenAccess
+
+    czas, _ = Czas_Udostepnienia_OpenAccess.objects.get_or_create(
+        skrot=OA_CZAS_PO_OPUBLIKOWANIU,
+        defaults={"nazwa": "po opublikowaniu"},
+    )
+
+    powiazanie = _artykul_z_autorem()
+    rekord = powiazanie.rekord
+    rekord.openaccess_tryb_dostepu = None
+    rekord.openaccess_czas_publikacji = czas
+    rekord.openaccess_ilosc_miesiecy = None
+    rekord.save()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    assert getattr(wiersz, selektory.pole_reguly("ART_OA_MIESIACE")) is False
+    assert getattr(wiersz, selektory.pole_reguly("ART_OA_WERSJA")) is False
+    # …a o samej dziurze mówi reguła od trybu dostępu.
+    assert getattr(wiersz, selektory.pole_reguly("ART_OA_TRYB")) is True
+
+
+# --------------------------------------------------------------------------
+# Opłata za publikację (APC) — pokrycie bez dziur
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_zadeklarowana_oplata_bez_kwoty_jest_brakiem():
+    """Regresja: luka między ``*_APC`` a ``*_APC_ZRODLO``.
+
+    ``*_APC`` żądało, by wszystkie pięć pól było puste, ``*_APC_ZRODLO`` —
+    kwoty dodatniej. Rekord z samym odznaczonym „bezkosztowa” wpadał między
+    nie i nie naruszał NICZEGO, choć redaktor zadeklarował opłatę i nie podał
+    ani jej kwoty, ani źródła.
+    """
+    powiazanie = _artykul_z_autorem()
+    rekord = powiazanie.rekord
+    rekord.opl_pub_cost_free = False
+    rekord.opl_pub_amount = None
+    rekord.opl_pub_research_potential = None
+    rekord.opl_pub_research_or_development_projects = None
+    rekord.opl_pub_other = None
+    rekord.save()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    assert getattr(wiersz, selektory.pole_reguly("ART_APC_KWOTA")) is True
+    assert getattr(wiersz, selektory.pole_reguly("ART_APC")) is False
+    assert getattr(wiersz, selektory.pole_reguly("ART_APC_ZRODLO")) is False
+
+
+@pytest.mark.django_db
+def test_zadeklarowana_oplata_z_kwota_zerowa_tez_jest_brakiem():
+    """Kwota 0 przy odznaczonej bezkosztowości jest wewnętrznie sprzeczna."""
+    powiazanie = _artykul_z_autorem()
+    rekord = powiazanie.rekord
+    rekord.opl_pub_cost_free = False
+    rekord.opl_pub_amount = Decimal("0")
+    rekord.save()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    assert getattr(wiersz, selektory.pole_reguly("ART_APC_KWOTA")) is True
+
+
+@pytest.mark.django_db
+def test_publikacja_bezkosztowa_nie_wymaga_kwoty():
+    """Zaznaczona bezkosztowość zamyka temat opłaty — bez żadnych braków."""
+    _artykul_z_autorem()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    for kod in ("ART_APC", "ART_APC_KWOTA", "ART_APC_ZRODLO"):
+        assert getattr(wiersz, selektory.pole_reguly(kod)) is False
+
+
+# --------------------------------------------------------------------------
+# Konferencja — § 2 ust. 10 pkt 4 lit. g
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_artykul_bez_konferencji_nie_generuje_brakow_konferencji():
+    """„Nie opublikowano w materiałach konferencyjnych” to legalna odpowiedź."""
+    _artykul_z_autorem()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    for kod in (
+        "ART_KONFERENCJA_NAZWA",
+        "ART_KONFERENCJA_DATY",
+        "ART_KONFERENCJA_MIEJSCE",
+    ):
+        assert getattr(wiersz, selektory.pole_reguly(kod)) is False
+
+
+@pytest.mark.django_db
+def test_wskazana_konferencja_bez_dat_i_miejsca_daje_braki():
+    powiazanie = _artykul_z_autorem()
+    rekord = powiazanie.rekord
+    rekord.konferencja = baker.make(
+        "bpp.Konferencja",
+        nazwa="Konferencja testowa",
+        rozpoczecie=None,
+        zakonczenie=None,
+        miasto="",
+        panstwo="",
+    )
+    rekord.save()
+
+    wiersz = selektory.z_regulami(
+        selektory.powiazania(Osiagniecie.ARTYKUL), Osiagniecie.ARTYKUL
+    ).get()
+
+    assert getattr(wiersz, selektory.pole_reguly("ART_KONFERENCJA_NAZWA")) is False
+    assert getattr(wiersz, selektory.pole_reguly("ART_KONFERENCJA_DATY")) is True
+    assert getattr(wiersz, selektory.pole_reguly("ART_KONFERENCJA_MIEJSCE")) is True

--- a/src/kompletnosc_polon/tests/test_selektory.py
+++ b/src/kompletnosc_polon/tests/test_selektory.py
@@ -44,7 +44,10 @@ from .test_reguly import (
     _kompletny_patent,
 )
 
-PIERWSZY_ROK, OSTATNI_ROK = OKNO_EWALUACJI
+#: Pierwszy rok okna raportu. Górnej granicy świadomie tu NIE rozpakowujemy:
+#: :data:`OKNO_EWALUACJI` ma ją dziś nieustaloną (``None``) i testy muszą
+#: mówić o oknie otwartym i domkniętym osobno — patrz blok „Zawężenie: okno”.
+PIERWSZY_ROK = OKNO_EWALUACJI[0]
 
 
 # --------------------------------------------------------------------------
@@ -185,18 +188,82 @@ def _nierozpoznane(**kwargs):
 
 
 @pytest.mark.django_db
-def test_selektor_bierze_wylacznie_lata_z_okna():
+def test_selektor_odsiewa_lata_sprzed_okna():
+    """Dolna granica okna gryzie i gryźć musi — to ona wchodzi do raportu.
+
+    Rok wcześniejszy niż pierwszy rok okna należy do POPRZEDNIEJ ewaluacji;
+    jego braki nie są już do uzupełnienia w tym sprawozdaniu.
+    """
     przed = _artykul_z_autorem(rok=PIERWSZY_ROK - 1)
     pierwszy = _artykul_z_autorem(rok=PIERWSZY_ROK)
-    ostatni = _artykul_z_autorem(rok=OSTATNI_ROK)
-    po = _artykul_z_autorem(rok=OSTATNI_ROK + 1)
 
     znalezione = _pk(selektory.powiazania(Osiagniecie.ARTYKUL))
 
-    assert znalezione == {pierwszy.pk, ostatni.pk}, (
-        "Obie granice okna muszą wchodzić do raportu, a lata spoza okna — nie"
+    assert znalezione == {pierwszy.pk}, (
+        "Pierwszy rok okna wchodzi do raportu, rok sprzed okna — nie"
     )
     assert przed.pk not in znalezione
+
+
+@pytest.mark.django_db
+def test_otwarta_gorna_granica_bierze_takze_odlegly_rok():
+    """Sens ``ostatni rok = None``: raport nie przestaje widzieć nowych lat.
+
+    Rok 2035 jest tu umyślnie absurdalnie daleki — chodzi o wykazanie, że
+    przy nieustalonej górnej granicy żadne odcięcie z góry nie działa.
+    """
+    daleki = _artykul_z_autorem(rok=2035)
+    tuz_przed_oknem = _artykul_z_autorem(rok=PIERWSZY_ROK - 1)
+
+    znalezione = _pk(
+        selektory.powiazania(Osiagniecie.ARTYKUL, okno=(PIERWSZY_ROK, None))
+    )
+
+    assert znalezione == {daleki.pk}, (
+        "Otwarte okno bierze rekord z dowolnie odległego roku, ale dolna "
+        "granica nadal obowiązuje"
+    )
+    assert tuz_przed_oknem.pk not in znalezione
+
+
+@pytest.mark.django_db
+def test_domyslne_okno_bierze_rekord_z_odleglego_roku():
+    """To samo, ale na STAŁEJ — bo to ona decyduje o zachowaniu raportu.
+
+    Gdy MEiN ogłosi długość okresu ewaluacyjnego i granica zostanie
+    domknięta, test przestanie mieć zastosowanie (rok „daleki” wypadnie
+    z okna zgodnie z przepisem) — dlatego wtedy się pomija, a nie psuje.
+    """
+    pierwszy_rok, ostatni_rok = OKNO_EWALUACJI
+    if ostatni_rok is not None:
+        pytest.skip(
+            "Górna granica okna została domknięta — otwartego okna nie ma "
+            "już czego sprawdzać na stałej"
+        )
+
+    daleki = _artykul_z_autorem(rok=pierwszy_rok + 9)
+
+    assert daleki.pk in _pk(selektory.powiazania(Osiagniecie.ARTYKUL))
+
+
+@pytest.mark.django_db
+def test_domkniete_okno_odcina_lata_po_gornej_granicy():
+    """Po domknięciu granicy górne odcięcie ma znów działać.
+
+    Okno podajemy jawnie argumentem, więc test opisuje przyszły stan
+    (``OKNO_EWALUACJI = (2026, <rok>)``) bez ruszania stałej.
+    """
+    ostatni_rok = PIERWSZY_ROK + 1
+    ostatni = _artykul_z_autorem(rok=ostatni_rok)
+    po = _artykul_z_autorem(rok=ostatni_rok + 1)
+
+    znalezione = _pk(
+        selektory.powiazania(Osiagniecie.ARTYKUL, okno=(PIERWSZY_ROK, ostatni_rok))
+    )
+
+    assert znalezione == {ostatni.pk}, (
+        "Ostatni rok domkniętego okna wchodzi do raportu, następny — nie"
+    )
     assert po.pk not in znalezione
 
 

--- a/src/kompletnosc_polon/tests/test_views.py
+++ b/src/kompletnosc_polon/tests/test_views.py
@@ -22,6 +22,7 @@ from model_bakery import baker
 from bpp.const import CHARAKTER_SLOTY_KSIAZKA, GR_WPROWADZANIE_DANYCH
 from bpp.models.profile import BppUser
 from ewaluacja_common.const import OKNO_EWALUACJI
+from kompletnosc_polon.views import ListaKompletnosciView
 
 from .test_selektory import (
     _artykul_z_autorem,
@@ -197,6 +198,46 @@ def test_lista_rozdziela_braki_wymagane_od_warunkowych(admin_client):
 
 
 # --------------------------------------------------------------------------
+# Widok zbiorczy: paginacja
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_lista_stronicuje_autorow(admin_client):
+    """W realnej instalacji prawie każdy pracownik ma jakiś brak wymagany.
+
+    Pola ``pbn_czy_*`` i ``opl_pub_*`` mają ``default=None``, a ``przypieta``
+    domyślnie ``True``, więc bez paginacji tabela urosłaby do wiersza na
+    każdego autora uczelni.
+    """
+    jednostka = _jednostka()
+    ilu = ListaKompletnosciView.autorow_na_stronie + 3
+    for _ in range(ilu):
+        _zepsuj_doi(_artykul_z_autorem(jednostka=jednostka))
+
+    odpowiedz = admin_client.get(reverse("kompletnosc_polon:lista"))
+
+    assert odpowiedz.context["autorow"] == ilu
+    assert odpowiedz.context["is_paginated"] is True
+    assert len(odpowiedz.context["wiersze"]) == ListaKompletnosciView.autorow_na_stronie
+    assert odpowiedz.context["paginator"].num_pages == 2
+
+    druga = admin_client.get(reverse("kompletnosc_polon:lista"), {"page": 2})
+    assert len(druga.context["wiersze"]) == 3
+    assert druga.context["page_obj"].number == 2
+
+
+@pytest.mark.django_db
+def test_jedna_strona_nie_pokazuje_nawigacji(admin_client):
+    _zepsuj_doi(_artykul_z_autorem())
+
+    odpowiedz = admin_client.get(reverse("kompletnosc_polon:lista"))
+
+    assert odpowiedz.context["is_paginated"] is False
+    assert "pagination-next" not in _tresc(odpowiedz)
+
+
+# --------------------------------------------------------------------------
 # Widok zbiorczy: zawężenie do uczelni oglądającego (multi-tenant)
 # --------------------------------------------------------------------------
 
@@ -224,7 +265,15 @@ def test_lista_pokazuje_wylacznie_autorow_uczelni_ogladajacego(admin_client):
 
 
 @pytest.mark.django_db
-def test_szczegoly_nie_pokazuja_rekordow_z_obcej_uczelni(admin_client):
+def test_szczegoly_autora_z_obcej_uczelni_daja_404_a_nie_pusta_liste(admin_client):
+    """Regresja wycieku: sam fakt istnienia pracownika jest daną chronioną.
+
+    Widok zawężał wyłącznie *powiązania*, a autora wyciągał
+    ``get_object_or_404(Autor, slug=…)`` z całej bazy. Slug jest przewidywalny
+    („nazwisko-imie”), więc odpowiedź HTTP 200 z imieniem i nazwiskiem
+    w ``<title>``, okruszkach i ``<h1>`` pozwalała enumerować kadrę OBCEJ
+    uczelni. Pusta lista pozycji tego nie ratowała — nazwisko i tak wyciekało.
+    """
     nasza = baker.make("bpp.Uczelnia")
     obca = baker.make("bpp.Uczelnia")
 
@@ -235,8 +284,34 @@ def test_szczegoly_nie_pokazuja_rekordow_z_obcej_uczelni(admin_client):
         {"uczelnia": nasza.pk},
     )
 
-    assert odpowiedz.context["pozycje"] == []
-    assert "Brak zastrzeżeń" in _tresc(odpowiedz)
+    assert odpowiedz.status_code == 404
+    assert str(obcy.autor) not in _tresc(odpowiedz)
+    assert obcy.autor.nazwisko not in _tresc(odpowiedz)
+
+
+@pytest.mark.django_db
+def test_szczegoly_autora_wlasnej_uczelni_dzialaja_mimo_zawezenia(admin_client):
+    """Zawężenie ma odsiewać obcych, a nie zamykać widok na własnych.
+
+    Atrybucja ``scope_autor_do_uczelni`` idzie przez jednostkę autora
+    (aktualną albo historyczną), więc test nadaje autorowi aktualną jednostkę
+    naszej uczelni — tak jak wygląda to dla realnego pracownika.
+    """
+    nasza = baker.make("bpp.Uczelnia")
+    baker.make("bpp.Uczelnia")
+
+    jednostka = _jednostka(nasza)
+    nasz = _zepsuj_doi(_artykul_z_autorem(jednostka=jednostka))
+    nasz.autor.aktualna_jednostka = jednostka
+    nasz.autor.save()
+
+    odpowiedz = admin_client.get(
+        reverse("kompletnosc_polon:szczegoly", kwargs={"autor_slug": nasz.autor.slug}),
+        {"uczelnia": nasza.pk},
+    )
+
+    assert odpowiedz.status_code == 200
+    assert [p["rekord"].pk for p in odpowiedz.context["pozycje"]] == [nasz.rekord_id]
 
 
 # --------------------------------------------------------------------------
@@ -330,6 +405,28 @@ def test_pusta_baza_tlumaczy_ze_brakuje_przypietych_dyscyplin(admin_client):
 
 
 @pytest.mark.django_db
+def test_komunikat_o_dyscyplinach_patrzy_tylko_na_wlasna_uczelnie(admin_client):
+    """Boolean „są przypięte dyscypliny” nie może mówić o cudzych danych.
+
+    Bez zawężenia redaktor uczelni, w której nikt nie przypiął dyscyplin,
+    nie zobaczyłby wyjaśnienia — bo dyscypliny ma sąsiad. To i wprowadza go
+    w błąd co do własnych danych, i wycieka jednym bitem stan obcej bazy.
+    """
+    nasza = baker.make("bpp.Uczelnia")
+    obca = baker.make("bpp.Uczelnia")
+
+    _artykul_z_autorem(uczelnia=obca)
+
+    odpowiedz = admin_client.get(
+        reverse("kompletnosc_polon:lista"), {"uczelnia": nasza.pk}
+    )
+
+    assert odpowiedz.context["sprawdzonych"] == 0
+    assert odpowiedz.context["brak_przypietych_dyscyplin"] is True
+    assert "Raport nie ma czego sprawdzić" in _tresc(odpowiedz)
+
+
+@pytest.mark.django_db
 def test_zero_brakow_daje_jawny_komunikat_z_liczba_i_zakresem_lat(admin_client):
     _artykul_z_autorem()
 
@@ -390,3 +487,84 @@ def test_szczegoly_wypisuja_nierozpoznane_rekordy_autora(admin_client):
     assert len(odpowiedz.context["nierozpoznane"]) == 1
     assert "Nierozpoznany typ osiągnięcia" in tresc
     assert oczekiwany in tresc
+
+
+@pytest.mark.django_db
+def test_artykul_bez_rodzaju_pbn_nie_znika_z_raportu_po_cichu(admin_client):
+    """Artykuł, którego charakter nie ma ``rodzaj_pbn``, MUSI być widoczny.
+
+    Bez tego użytkownik świeżej instalacji dostawał raport bez ani jednego
+    artykułu i licznik „sprawdzono N powiązań”, który artykułów nie obejmował
+    — czyli komunikat „artykuły są w porządku” o czymś, czego raport nawet
+    nie obejrzał.
+    """
+    ciagle = _artykul_z_autorem(rodzaj_pbn=None)
+
+    odpowiedz = admin_client.get(reverse("kompletnosc_polon:lista"))
+    tresc = _tresc(odpowiedz)
+
+    assert odpowiedz.context["sprawdzonych"] == 0
+    assert [w["autor"].pk for w in odpowiedz.context["nierozpoznane"]] == [
+        ciagle.autor_id
+    ]
+    assert "Nierozpoznany typ osiągnięcia" in tresc
+    assert "Raport ich nie sprawdził" in tresc
+    assert str(ciagle.autor) in tresc
+
+
+@pytest.mark.django_db
+def test_lista_laczy_nierozpoznane_zwarte_i_ciagle_w_jednej_sekcji(admin_client):
+    zwarte = _zwarte_z_autorem(None)
+    ciagle = _artykul_z_autorem(rodzaj_pbn=None)
+
+    odpowiedz = admin_client.get(reverse("kompletnosc_polon:lista"))
+    tresc = _tresc(odpowiedz)
+
+    assert {w["autor"].pk for w in odpowiedz.context["nierozpoznane"]} == {
+        zwarte.autor_id,
+        ciagle.autor_id,
+    }
+    assert tresc.count("Nierozpoznany typ osiągnięcia") == 1, (
+        "Sekcja ma być JEDNA, wspólna dla obu rodzajów wydawnictw"
+    )
+    assert str(zwarte.autor) in tresc
+    assert str(ciagle.autor) in tresc
+
+
+@pytest.mark.django_db
+def test_szczegoly_wypisuja_nierozpoznane_obu_rodzajow(admin_client):
+    """Sekcja szczegółów prowadzi do formularza edycji obu rodzajów rekordów."""
+    przypadki = (
+        (_zwarte_z_autorem(None), "admin:bpp_wydawnictwo_zwarte_change"),
+        (_artykul_z_autorem(rodzaj_pbn=None), "admin:bpp_wydawnictwo_ciagle_change"),
+    )
+
+    for powiazanie, trasa_admina in przypadki:
+        odpowiedz = admin_client.get(
+            reverse(
+                "kompletnosc_polon:szczegoly",
+                kwargs={"autor_slug": powiazanie.autor.slug},
+            )
+        )
+        tresc = _tresc(odpowiedz)
+
+        assert len(odpowiedz.context["nierozpoznane"]) == 1
+        assert "Nierozpoznany typ osiągnięcia" in tresc
+        assert reverse(trasa_admina, args=[powiazanie.rekord_id]) in tresc
+
+
+@pytest.mark.django_db
+def test_komunikat_sekcji_nierozpoznanych_wskazuje_slownik_charakterow(admin_client):
+    """Komunikat ma być prawdziwy dla OBU przypadków i wskazywać miejsce naprawy.
+
+    Poprawka nie polega na edycji rekordu: dla zwartych trzeba ustawić
+    „charakter dla slotów”, dla ciągłych „rodzaj dla PBN” — obie wartości
+    siedzą w słowniku charakterów formalnych.
+    """
+    _artykul_z_autorem(rodzaj_pbn=None)
+
+    tresc = _tresc(admin_client.get(reverse("kompletnosc_polon:lista")))
+
+    assert "charakteru dla slotów" in tresc
+    assert "rodzaju dla PBN" in tresc
+    assert reverse("admin:bpp_charakter_formalny_changelist") in tresc

--- a/src/kompletnosc_polon/tests/test_views.py
+++ b/src/kompletnosc_polon/tests/test_views.py
@@ -1,0 +1,392 @@
+"""Testy warstwy prezentacji raportu kompletności danych POL-on.
+
+Widoki są cienkie, ale niosą trzy rzeczy, których nie da się sprawdzić na
+poziomie selektorów i które łatwo zepsuć po cichu:
+
+1. **kontrolę dostępu** — to narzędzie redaktorskie, więc zalogowany autor
+   *bez* uprawnień redaktorskich musi dostać odmowę (bazowy
+   ``EwaluacjaRequiredMixin`` sam z siebie by go przepuścił);
+2. **agregację po autorze** przez wszystkie cztery typy osiągnięć naraz;
+3. **komunikaty stanów pustych** — pusta tabela bez kontekstu czyta się jak
+   „wszystko w porządku”, co jest najgorszą możliwą odpowiedzią raportu.
+
+Asercje sprawdzają TREŚĆ odpowiedzi, nie sam kod 200: szablon, który się
+renderuje, ale niczego nie pokazuje, jest tak samo zepsuty jak wyjątek.
+"""
+
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from model_bakery import baker
+
+from bpp.const import CHARAKTER_SLOTY_KSIAZKA, GR_WPROWADZANIE_DANYCH
+from bpp.models.profile import BppUser
+from ewaluacja_common.const import OKNO_EWALUACJI
+
+from .test_selektory import (
+    _artykul_z_autorem,
+    _jednostka,
+    _zwarte_z_autorem,
+)
+
+PIERWSZY_ROK, OSTATNI_ROK = OKNO_EWALUACJI
+
+HASLO = "haslo-do-testow"
+
+
+def _tresc(odpowiedz) -> str:
+    return odpowiedz.content.decode("utf-8")
+
+
+def _uzytkownik(nazwa, *, grupa=False, autor=None):
+    user = baker.make(BppUser, username=nazwa, autor=autor)
+    user.set_password(HASLO)
+    if grupa:
+        grupa_obiekt, _ = Group.objects.get_or_create(name=GR_WPROWADZANIE_DANYCH)
+        user.groups.add(grupa_obiekt)
+    user.save()
+    return user
+
+
+def _zaloguj(client, user):
+    assert client.login(username=user.username, password=HASLO)
+    return client
+
+
+def _zepsuj_doi(powiazanie):
+    """Skasuj identyfikator cyfrowy rekordu — brak WYMAGANY (``*_DOI``)."""
+    rekord = powiazanie.rekord
+    rekord.doi = None
+    rekord.www = ""
+    rekord.public_www = ""
+    rekord.save()
+    return powiazanie
+
+
+# --------------------------------------------------------------------------
+# Kontrola dostępu
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_niezalogowany_jest_przekierowany_na_logowanie(client):
+    odpowiedz = client.get(reverse("kompletnosc_polon:lista"))
+
+    assert odpowiedz.status_code == 302
+
+
+@pytest.mark.django_db
+def test_uzytkownik_bez_uprawnien_dostaje_odmowe(client):
+    _zaloguj(client, _uzytkownik("bez-uprawnien"))
+
+    odpowiedz = client.get(reverse("kompletnosc_polon:lista"))
+
+    assert odpowiedz.status_code == 403
+
+
+@pytest.mark.django_db
+def test_zalogowany_autor_bez_uprawnien_redaktorskich_dostaje_odmowe(client):
+    """Kluczowe zawężenie wobec ``EwaluacjaRequiredMixin``.
+
+    Bazowy mixin przepuszcza użytkownika powiązanego z autorem (widok „swoich”
+    metryk). Raport kompletności pokazuje cudze rekordy i linkuje do panelu
+    administracyjnego, więc dla takiego użytkownika musi być zamknięty.
+    """
+    autor = baker.make("bpp.Autor")
+    _zaloguj(client, _uzytkownik("autor-bez-grupy", autor=autor))
+
+    odpowiedz = client.get(reverse("kompletnosc_polon:lista"))
+
+    assert odpowiedz.status_code == 403
+
+
+@pytest.mark.django_db
+def test_uzytkownik_z_grupa_wprowadzania_danych_wchodzi(client):
+    _zaloguj(client, _uzytkownik("redaktor", grupa=True))
+
+    odpowiedz = client.get(reverse("kompletnosc_polon:lista"))
+
+    assert odpowiedz.status_code == 200
+
+
+@pytest.mark.django_db
+def test_superuser_wchodzi(admin_client):
+    odpowiedz = admin_client.get(reverse("kompletnosc_polon:lista"))
+
+    assert odpowiedz.status_code == 200
+
+
+@pytest.mark.django_db
+def test_szczegoly_tez_wymagaja_pelnych_uprawnien(client):
+    autor = baker.make("bpp.Autor")
+    _zaloguj(client, _uzytkownik("autor-bez-grupy", autor=autor))
+
+    odpowiedz = client.get(
+        reverse("kompletnosc_polon:szczegoly", kwargs={"autor_slug": autor.slug})
+    )
+
+    assert odpowiedz.status_code == 403
+
+
+# --------------------------------------------------------------------------
+# Widok zbiorczy: kto trafia na listę
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_autor_z_brakami_jest_na_liscie_a_kompletny_nie(admin_client):
+    z_brakiem = _zepsuj_doi(_artykul_z_autorem())
+    kompletny = _artykul_z_autorem()
+
+    tresc = _tresc(admin_client.get(reverse("kompletnosc_polon:lista")))
+
+    assert str(z_brakiem.autor) in tresc
+    assert str(kompletny.autor) not in tresc, (
+        "Autor bez żadnego braku nie ma czego robić w raporcie braków"
+    )
+
+
+@pytest.mark.django_db
+def test_lista_zlicza_braki_z_wielu_typow_osiagniec_pod_jednym_autorem(admin_client):
+    """Agregacja idzie po osobie, nie po typie publikacji.
+
+    § 2 ust. 10 umieszcza osiągnięcia w wykazie *pracowników*, więc artykuł
+    i monografia tego samego autora muszą zsumować się w jednym wierszu.
+    """
+    jednostka = _jednostka()
+    artykul = _zepsuj_doi(_artykul_z_autorem(jednostka=jednostka))
+    monografia = _zepsuj_doi(
+        _zwarte_z_autorem(CHARAKTER_SLOTY_KSIAZKA, jednostka=jednostka)
+    )
+
+    odpowiedz = admin_client.get(reverse("kompletnosc_polon:lista"))
+    wiersze = {wiersz["autor"].pk: wiersz for wiersz in odpowiedz.context["wiersze"]}
+
+    assert set(wiersze) == {artykul.autor_id, monografia.autor_id}
+    for wiersz in wiersze.values():
+        assert wiersz["rekordow_z_brakami"] == 1
+        assert wiersz["braki_wymagane"] >= 1
+
+
+@pytest.mark.django_db
+def test_lista_sortuje_malejaco_po_brakach_wymaganych(admin_client):
+    jednostka = _jednostka()
+    _zepsuj_doi(_artykul_z_autorem(jednostka=jednostka))
+
+    # Drugi autor: brak DOI PLUS brak upoważnienia — dwa braki wymagane.
+    gorszy = _zepsuj_doi(_artykul_z_autorem(jednostka=jednostka))
+    gorszy.upowaznienie_pbn = False
+    gorszy.save()
+
+    wiersze = admin_client.get(reverse("kompletnosc_polon:lista")).context["wiersze"]
+
+    assert [w["autor"].pk for w in wiersze][0] == gorszy.autor_id
+    assert wiersze[0]["braki_wymagane"] > wiersze[1]["braki_wymagane"]
+
+
+@pytest.mark.django_db
+def test_lista_rozdziela_braki_wymagane_od_warunkowych(admin_client):
+    """ORCID to wymóg warunkowy — nie może podbijać licznika krytycznego."""
+    powiazanie = _artykul_z_autorem(orcid=False)
+
+    (wiersz,) = admin_client.get(reverse("kompletnosc_polon:lista")).context["wiersze"]
+
+    assert wiersz["autor"].pk == powiazanie.autor_id
+    assert wiersz["braki_wymagane"] == 0
+    assert wiersz["braki_warunkowe"] == 1
+
+
+# --------------------------------------------------------------------------
+# Widok zbiorczy: zawężenie do uczelni oglądającego (multi-tenant)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_lista_pokazuje_wylacznie_autorow_uczelni_ogladajacego(admin_client):
+    """Superuser wybiera uczelnię parametrem ``?uczelnia=`` (read-side).
+
+    Przy dwóch uczelniach ``scope_autorzy_do_uczelni`` przestaje być no-opem,
+    więc test faktycznie sprawdza izolację, a nie fast-track single-install.
+    """
+    nasza = baker.make("bpp.Uczelnia")
+    obca = baker.make("bpp.Uczelnia")
+
+    nasz = _zepsuj_doi(_artykul_z_autorem(uczelnia=nasza))
+    obcy = _zepsuj_doi(_artykul_z_autorem(uczelnia=obca))
+
+    odpowiedz = admin_client.get(
+        reverse("kompletnosc_polon:lista"), {"uczelnia": nasza.pk}
+    )
+    tresc = _tresc(odpowiedz)
+
+    assert [w["autor"].pk for w in odpowiedz.context["wiersze"]] == [nasz.autor_id]
+    assert str(obcy.autor) not in tresc
+
+
+@pytest.mark.django_db
+def test_szczegoly_nie_pokazuja_rekordow_z_obcej_uczelni(admin_client):
+    nasza = baker.make("bpp.Uczelnia")
+    obca = baker.make("bpp.Uczelnia")
+
+    obcy = _zepsuj_doi(_artykul_z_autorem(uczelnia=obca))
+
+    odpowiedz = admin_client.get(
+        reverse("kompletnosc_polon:szczegoly", kwargs={"autor_slug": obcy.autor.slug}),
+        {"uczelnia": nasza.pk},
+    )
+
+    assert odpowiedz.context["pozycje"] == []
+    assert "Brak zastrzeżeń" in _tresc(odpowiedz)
+
+
+# --------------------------------------------------------------------------
+# Widok szczegółów
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_szczegoly_wypisuja_opis_i_paragraf_naruszonej_reguly(admin_client):
+    powiazanie = _artykul_z_autorem()
+    powiazanie.upowaznienie_pbn = False
+    powiazanie.save()
+
+    tresc = _tresc(
+        admin_client.get(
+            reverse(
+                "kompletnosc_polon:szczegoly",
+                kwargs={"autor_slug": powiazanie.autor.slug},
+            )
+        )
+    )
+
+    assert "ART_UPOWAZNIENIE" in tresc
+    assert "Brak upoważnienia autora" in tresc
+    assert "§ 2 ust. 10 pkt 4 lit. d" in tresc
+
+
+@pytest.mark.django_db
+def test_szczegoly_linkuja_do_formularza_edycji_w_adminie(admin_client):
+    powiazanie = _zepsuj_doi(_artykul_z_autorem())
+    oczekiwany = reverse(
+        "admin:bpp_wydawnictwo_ciagle_change", args=[powiazanie.rekord_id]
+    )
+
+    tresc = _tresc(
+        admin_client.get(
+            reverse(
+                "kompletnosc_polon:szczegoly",
+                kwargs={"autor_slug": powiazanie.autor.slug},
+            )
+        )
+    )
+
+    assert oczekiwany in tresc
+    assert powiazanie.rekord.tytul_oryginalny in tresc
+
+
+@pytest.mark.django_db
+def test_szczegoly_oddzielaja_braki_wymagane_od_warunkowych(admin_client):
+    powiazanie = _zepsuj_doi(_artykul_z_autorem(orcid=False))
+
+    odpowiedz = admin_client.get(
+        reverse(
+            "kompletnosc_polon:szczegoly",
+            kwargs={"autor_slug": powiazanie.autor.slug},
+        )
+    )
+    (pozycja,) = odpowiedz.context["pozycje"]
+
+    assert [r.kod for r in pozycja["wymagane"]] == ["ART_DOI"]
+    assert [r.kod for r in pozycja["warunkowe"]] == ["ART_ORCID"]
+
+    tresc = _tresc(odpowiedz)
+    assert "Braki wymagane" in tresc
+    assert "Braki warunkowe (nieobowiązkowe)" in tresc
+
+
+@pytest.mark.django_db
+def test_szczegoly_nieznanego_autora_daja_404(admin_client):
+    odpowiedz = admin_client.get(
+        reverse("kompletnosc_polon:szczegoly", kwargs={"autor_slug": "nie-ma-takiego"})
+    )
+
+    assert odpowiedz.status_code == 404
+
+
+# --------------------------------------------------------------------------
+# Stany puste — komunikat zamiast pustej tabeli
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_pusta_baza_tlumaczy_ze_brakuje_przypietych_dyscyplin(admin_client):
+    odpowiedz = admin_client.get(reverse("kompletnosc_polon:lista"))
+    tresc = _tresc(odpowiedz)
+
+    assert odpowiedz.context["brak_przypietych_dyscyplin"] is True
+    assert "Raport nie ma czego sprawdzić" in tresc
+    assert "przypiętą dyscyplinę" in tresc
+    assert "nie znaczy, że dane są kompletne" in tresc
+
+
+@pytest.mark.django_db
+def test_zero_brakow_daje_jawny_komunikat_z_liczba_i_zakresem_lat(admin_client):
+    _artykul_z_autorem()
+
+    odpowiedz = admin_client.get(reverse("kompletnosc_polon:lista"))
+    tresc = _tresc(odpowiedz)
+
+    assert odpowiedz.context["wiersze"] == []
+    assert odpowiedz.context["sprawdzonych"] == 1
+    assert odpowiedz.context["brak_przypietych_dyscyplin"] is False
+    assert "Brak zastrzeżeń" in tresc
+    assert f"{PIERWSZY_ROK}&ndash;{OSTATNI_ROK}" in tresc
+
+
+@pytest.mark.django_db
+def test_zakres_lat_jest_podany_takze_gdy_sa_braki(admin_client):
+    _zepsuj_doi(_artykul_z_autorem())
+
+    tresc = _tresc(admin_client.get(reverse("kompletnosc_polon:lista")))
+
+    assert f"{PIERWSZY_ROK}&ndash;{OSTATNI_ROK}" in tresc
+
+
+# --------------------------------------------------------------------------
+# Nierozpoznany typ osiągnięcia — nie wolno mu zniknąć po cichu
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_lista_pokazuje_sekcje_nierozpoznanego_typu_osiagniecia(admin_client):
+    nierozpoznane = _zwarte_z_autorem(None)
+
+    odpowiedz = admin_client.get(reverse("kompletnosc_polon:lista"))
+    tresc = _tresc(odpowiedz)
+
+    assert [w["autor"].pk for w in odpowiedz.context["nierozpoznane"]] == [
+        nierozpoznane.autor_id
+    ]
+    assert "Nierozpoznany typ osiągnięcia" in tresc
+    assert "Raport ich nie sprawdził" in tresc
+    assert str(nierozpoznane.autor) in tresc
+
+
+@pytest.mark.django_db
+def test_szczegoly_wypisuja_nierozpoznane_rekordy_autora(admin_client):
+    nierozpoznane = _zwarte_z_autorem(None)
+    oczekiwany = reverse(
+        "admin:bpp_wydawnictwo_zwarte_change", args=[nierozpoznane.rekord_id]
+    )
+
+    odpowiedz = admin_client.get(
+        reverse(
+            "kompletnosc_polon:szczegoly",
+            kwargs={"autor_slug": nierozpoznane.autor.slug},
+        )
+    )
+    tresc = _tresc(odpowiedz)
+
+    assert len(odpowiedz.context["nierozpoznane"]) == 1
+    assert "Nierozpoznany typ osiągnięcia" in tresc
+    assert oczekiwany in tresc

--- a/src/kompletnosc_polon/tests/test_views.py
+++ b/src/kompletnosc_polon/tests/test_views.py
@@ -23,6 +23,7 @@ from bpp.const import CHARAKTER_SLOTY_KSIAZKA, GR_WPROWADZANIE_DANYCH
 from bpp.models.profile import BppUser
 from ewaluacja_common.const import OKNO_EWALUACJI
 from kompletnosc_polon.views import ListaKompletnosciView
+from kompletnosc_polon.views.mixins import opis_okna
 
 from .test_selektory import (
     _artykul_z_autorem,
@@ -30,7 +31,11 @@ from .test_selektory import (
     _zwarte_z_autorem,
 )
 
-PIERWSZY_ROK, OSTATNI_ROK = OKNO_EWALUACJI
+#: Opis zakresu lat, który użytkownik ma zobaczyć na stronie: „od 2026” przy
+#: dziś otwartej górnej granicy okna, „2026–<rok>” po jej domknięciu. Bierzemy
+#: go z :func:`opis_okna`, żeby test nie przepisywał ręcznie tej samej reguły;
+#: brzmienie samej funkcji sprawdzają testy jednostkowe na końcu pliku.
+ZAKRES_LAT = opis_okna(OKNO_EWALUACJI)
 
 HASLO = "haslo-do-testow"
 
@@ -437,7 +442,7 @@ def test_zero_brakow_daje_jawny_komunikat_z_liczba_i_zakresem_lat(admin_client):
     assert odpowiedz.context["sprawdzonych"] == 1
     assert odpowiedz.context["brak_przypietych_dyscyplin"] is False
     assert "Brak zastrzeżeń" in tresc
-    assert f"{PIERWSZY_ROK}&ndash;{OSTATNI_ROK}" in tresc
+    assert ZAKRES_LAT in tresc
 
 
 @pytest.mark.django_db
@@ -446,7 +451,51 @@ def test_zakres_lat_jest_podany_takze_gdy_sa_braki(admin_client):
 
     tresc = _tresc(admin_client.get(reverse("kompletnosc_polon:lista")))
 
-    assert f"{PIERWSZY_ROK}&ndash;{OSTATNI_ROK}" in tresc
+    assert ZAKRES_LAT in tresc
+
+
+@pytest.mark.django_db
+def test_nieustalona_gorna_granica_nie_wycieka_do_strony(admin_client):
+    """Otwarte okno wolno pokazać jako „od 2026” — nie jako „2026–None”.
+
+    Sklejenie zakresu z pary liczb w szablonie renderowało dosłowne
+    „None” (albo urwane „2026–”) w zdaniu o zakresie raportu. Test pilnuje,
+    że tekst o latach jest zdaniem po polsku, a nie wyciekiem ``None``.
+    """
+    _zepsuj_doi(_artykul_z_autorem())
+
+    tresc = _tresc(admin_client.get(reverse("kompletnosc_polon:lista")))
+
+    assert "None" not in tresc
+    assert f"lata <strong>{ZAKRES_LAT}</strong>" in tresc
+
+
+@pytest.mark.django_db
+def test_szczegoly_podaja_zakres_lat(admin_client):
+    """Strona autora też mówi, za jakie lata raport sprawdzał dane."""
+    powiazanie = _zepsuj_doi(_artykul_z_autorem())
+
+    tresc = _tresc(
+        admin_client.get(
+            reverse(
+                "kompletnosc_polon:szczegoly",
+                kwargs={"autor_slug": powiazanie.autor.slug},
+            )
+        )
+    )
+
+    assert ZAKRES_LAT in tresc
+    assert "None" not in tresc
+
+
+def test_opis_okna_dla_otwartej_gornej_granicy():
+    """Nieustalona górna granica ma własne zdanie, bez zmyślonego roku."""
+    assert opis_okna((2026, None)) == "od 2026"
+
+
+def test_opis_okna_dla_domknietego_okna():
+    """Po domknięciu granicy wraca zwykły zakres z półpauzą."""
+    assert opis_okna((2026, 2029)) == "2026–2029"
 
 
 # --------------------------------------------------------------------------

--- a/src/kompletnosc_polon/urls.py
+++ b/src/kompletnosc_polon/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+
+from . import views
+
+app_name = "kompletnosc_polon"
+
+urlpatterns = [
+    path("", views.ListaKompletnosciView.as_view(), name="lista"),
+    path(
+        "szczegoly/<slug:autor_slug>/",
+        views.SzczegolyKompletnosciView.as_view(),
+        name="szczegoly",
+    ),
+]

--- a/src/kompletnosc_polon/views/__init__.py
+++ b/src/kompletnosc_polon/views/__init__.py
@@ -1,0 +1,41 @@
+"""Widoki raportu kompletności danych POL-on.
+
+Pakiet re-eksportuje publiczne nazwy, żeby ``urls.py`` i testy mogły pisać
+``from kompletnosc_polon import views`` bez wiedzy o podziale na moduły —
+tak samo jak w :mod:`ewaluacja_metryki.views`.
+"""
+
+from .lista import (
+    ListaKompletnosciView,
+    ma_jakikolwiek_brak,
+    sa_przypiete_dyscypliny,
+    zbierz_nierozpoznane,
+    zbierz_po_autorach,
+)
+from .mixins import (
+    PelneUprawnieniaEwaluacjiMixin,
+    RaportKompletnosciMixin,
+    url_formularza_admina,
+)
+from .szczegoly import (
+    SzczegolyKompletnosciView,
+    zbierz_nierozpoznane_autora,
+    zbierz_pozycje,
+)
+
+__all__ = [
+    # Mixiny i pomocnicy
+    "PelneUprawnieniaEwaluacjiMixin",
+    "RaportKompletnosciMixin",
+    "url_formularza_admina",
+    "ma_jakikolwiek_brak",
+    "sa_przypiete_dyscypliny",
+    # Widok zbiorczy
+    "ListaKompletnosciView",
+    "zbierz_po_autorach",
+    "zbierz_nierozpoznane",
+    # Widok szczegółów
+    "SzczegolyKompletnosciView",
+    "zbierz_pozycje",
+    "zbierz_nierozpoznane_autora",
+]

--- a/src/kompletnosc_polon/views/lista.py
+++ b/src/kompletnosc_polon/views/lista.py
@@ -1,0 +1,155 @@
+"""Widok zbiorczy raportu kompletności danych POL-on.
+
+Tabela „autor → liczba rekordów z brakami, braki wymagane, braki warunkowe”,
+posortowana malejąco po brakach wymaganych. Agregacja obejmuje **wszystkie
+cztery** typy osiągnięć naraz: § 2 ust. 10 rozporządzenia umieszcza
+osiągnięcia w wykazie *pracowników*, więc jednostką, o którą pyta użytkownik,
+jest osoba, a nie typ publikacji.
+"""
+
+from collections import defaultdict
+
+from django.apps import apps
+from django.db.models import Count, Q
+from django.views.generic import TemplateView
+
+from bpp.models import Autor
+from kompletnosc_polon.const import Osiagniecie
+from kompletnosc_polon.selektory import (
+    MODEL_POWIAZANIA,
+    POLE_BRAKI_WARUNKOWE,
+    POLE_BRAKI_WYMAGANE,
+    powiazania,
+    powiazania_nierozpoznane,
+    z_regulami,
+)
+
+from .mixins import RaportKompletnosciMixin
+
+
+def ma_jakikolwiek_brak() -> Q:
+    """Warunek: wiersz narusza co najmniej jedną regułę — dowolnej wagi."""
+    return Q(**{f"{POLE_BRAKI_WYMAGANE}__gt": 0}) | Q(
+        **{f"{POLE_BRAKI_WARUNKOWE}__gt": 0}
+    )
+
+
+def sa_przypiete_dyscypliny() -> bool:
+    """Czy w bazie istnieje choć jedno powiązanie z przypiętą dyscypliną.
+
+    Pytanie zadajemy o **całą bazę**, nie o okno ewaluacji: chodzi
+    o rozróżnienie „instalacja, w której nikt jeszcze nie przypisał
+    dyscyplin” od „okno ewaluacji dopiero się otwiera, rekordów po prostu
+    nie ma”. Te dwa stany dają identycznie pustą tabelę, a wymagają zupełnie
+    innej reakcji użytkownika — dlatego widok komunikuje je osobno.
+    """
+    for sciezka_modelu in set(MODEL_POWIAZANIA.values()):
+        if (
+            apps.get_model(sciezka_modelu)
+            .objects.filter(przypieta=True, dyscyplina_naukowa__isnull=False)
+            .exists()
+        ):
+            return True
+    return False
+
+
+def zbierz_po_autorach(uczelnia, okno) -> tuple[list[dict], int]:
+    """Zsumuj braki po autorach, przez wszystkie typy osiągnięć.
+
+    Zwraca krotkę: listę wierszy tabeli oraz liczbę **sprawdzonych** powiązań
+    autor–rekord (także tych bez zastrzeżeń — bez niej pusta tabela nic nie
+    znaczy, patrz „Obsługa błędów” w projekcie).
+
+    Sumowanie idzie przez Pythona, nie przez ``GROUP BY``: querysety niosą już
+    kilkanaście anotacji ``CASE`` na regułę, a ``values('autor_id')`` po
+    ``annotate()`` wciągnęłoby je do grupowania. Z bazy ściągamy wyłącznie trzy
+    liczby na wiersz (identyfikator autora i dwa liczniki), więc koszt jest
+    proporcjonalny do liczby *niekompletnych* powiązań — a projekt zakłada, że
+    zbiór jest mały (okno 2026+ dopiero się otwiera).
+    """
+    liczniki: dict[int, dict[str, int]] = defaultdict(
+        lambda: {"rekordow": 0, "wymagane": 0, "warunkowe": 0}
+    )
+    sprawdzonych = 0
+
+    for osiagniecie in Osiagniecie:
+        qs = z_regulami(powiazania(osiagniecie, uczelnia, okno), osiagniecie)
+        sprawdzonych += qs.count()
+
+        for wiersz in qs.filter(ma_jakikolwiek_brak()).values(
+            "autor_id", POLE_BRAKI_WYMAGANE, POLE_BRAKI_WARUNKOWE
+        ):
+            pozycja = liczniki[wiersz["autor_id"]]
+            pozycja["rekordow"] += 1
+            pozycja["wymagane"] += wiersz[POLE_BRAKI_WYMAGANE]
+            pozycja["warunkowe"] += wiersz[POLE_BRAKI_WARUNKOWE]
+
+    autorzy = Autor.objects.in_bulk(liczniki.keys())
+    wiersze = [
+        {
+            "autor": autorzy[autor_id],
+            "rekordow_z_brakami": pozycja["rekordow"],
+            "braki_wymagane": pozycja["wymagane"],
+            "braki_warunkowe": pozycja["warunkowe"],
+        }
+        for autor_id, pozycja in liczniki.items()
+        if autor_id in autorzy
+    ]
+    wiersze.sort(
+        key=lambda w: (
+            -w["braki_wymagane"],
+            -w["braki_warunkowe"],
+            str(w["autor"]),
+        )
+    )
+    return wiersze, sprawdzonych
+
+
+def zbierz_nierozpoznane(uczelnia, okno) -> list[dict]:
+    """Powiązania z rekordem, którego typu osiągnięcia nie da się ustalić.
+
+    Grupujemy po autorze — inaczej użytkownik zobaczyłby, że coś jest nie tak,
+    ale nie miałby jak do tego dojść: autor z samymi nierozpoznanymi rekordami
+    nie pojawia się w głównej tabeli, bo nie ma dla niego czego policzyć.
+
+    Tu agregujemy już w bazie: queryset nierozpoznanych nie przechodzi przez
+    ``z_regulami``, więc nie niesie anotacji, które ``GROUP BY`` musiałby
+    obsłużyć.
+    """
+    zliczone = (
+        powiazania_nierozpoznane(uczelnia, okno)
+        .values("autor_id")
+        .annotate(ile=Count("pk"))
+    )
+    zliczone = {pozycja["autor_id"]: pozycja["ile"] for pozycja in zliczone}
+
+    autorzy = Autor.objects.in_bulk(zliczone.keys())
+    wiersze = [
+        {"autor": autorzy[autor_id], "rekordow": ile}
+        for autor_id, ile in zliczone.items()
+        if autor_id in autorzy
+    ]
+    wiersze.sort(key=lambda w: (-w["rekordow"], str(w["autor"])))
+    return wiersze
+
+
+class ListaKompletnosciView(RaportKompletnosciMixin, TemplateView):
+    """Zbiorcze zestawienie braków — jeden wiersz na autora."""
+
+    template_name = "kompletnosc_polon/lista.html"
+
+    def get_context_data(self, **kwargs):
+        kontekst = super().get_context_data(**kwargs)
+
+        wiersze, sprawdzonych = zbierz_po_autorach(self.uczelnia, self.okno)
+        kontekst["wiersze"] = wiersze
+        kontekst["sprawdzonych"] = sprawdzonych
+        kontekst["nierozpoznane"] = zbierz_nierozpoznane(self.uczelnia, self.okno)
+
+        # Pytanie o dyscypliny zadajemy TYLKO wtedy, gdy raport nie miał czego
+        # sprawdzić — przy niepustym zbiorze odpowiedź i tak jest twierdząca,
+        # a zapytanie byłoby czystym kosztem.
+        kontekst["brak_przypietych_dyscyplin"] = (
+            sprawdzonych == 0 and not sa_przypiete_dyscypliny()
+        )
+        return kontekst

--- a/src/kompletnosc_polon/views/lista.py
+++ b/src/kompletnosc_polon/views/lista.py
@@ -10,10 +10,12 @@ jest osoba, a nie typ publikacji.
 from collections import defaultdict
 
 from django.apps import apps
+from django.core.paginator import Paginator
 from django.db.models import Count, Q
 from django.views.generic import TemplateView
 
 from bpp.models import Autor
+from bpp.util.uczelnia_scope import scope_autorzy_do_uczelni
 from kompletnosc_polon.const import Osiagniecie
 from kompletnosc_polon.selektory import (
     MODEL_POWIAZANIA,
@@ -34,21 +36,27 @@ def ma_jakikolwiek_brak() -> Q:
     )
 
 
-def sa_przypiete_dyscypliny() -> bool:
-    """Czy w bazie istnieje choć jedno powiązanie z przypiętą dyscypliną.
+def sa_przypiete_dyscypliny(uczelnia=None) -> bool:
+    """Czy istnieje choć jedno powiązanie z przypiętą dyscypliną.
 
-    Pytanie zadajemy o **całą bazę**, nie o okno ewaluacji: chodzi
+    Pytanie zadajemy o **wszystkie lata**, nie o okno ewaluacji: chodzi
     o rozróżnienie „instalacja, w której nikt jeszcze nie przypisał
     dyscyplin” od „okno ewaluacji dopiero się otwiera, rekordów po prostu
     nie ma”. Te dwa stany dają identycznie pustą tabelę, a wymagają zupełnie
     innej reakcji użytkownika — dlatego widok komunikuje je osobno.
+
+    Zawężamy natomiast do **uczelni oglądającego**: bez tego wartość logiczna
+    zdradzałaby, czy dane ma jakakolwiek uczelnia w instalacji multi-tenant.
+    Redaktor uczelni bez przypiętych dyscyplin zobaczyłby „raport nie ma czego
+    sprawdzić”… albo i nie, w zależności od stanu bazy sąsiada — czyli jednym
+    bitem wyciekłaby informacja o cudzych danych i zarazem wprowadziłaby go
+    w błąd co do jego własnych.
     """
     for sciezka_modelu in set(MODEL_POWIAZANIA.values()):
-        if (
-            apps.get_model(sciezka_modelu)
-            .objects.filter(przypieta=True, dyscyplina_naukowa__isnull=False)
-            .exists()
-        ):
+        qs = apps.get_model(sciezka_modelu).objects.filter(
+            przypieta=True, dyscyplina_naukowa__isnull=False
+        )
+        if scope_autorzy_do_uczelni(qs, uczelnia).exists():
             return True
     return False
 
@@ -112,16 +120,16 @@ def zbierz_nierozpoznane(uczelnia, okno) -> list[dict]:
     ale nie miałby jak do tego dojść: autor z samymi nierozpoznanymi rekordami
     nie pojawia się w głównej tabeli, bo nie ma dla niego czego policzyć.
 
-    Tu agregujemy już w bazie: queryset nierozpoznanych nie przechodzi przez
-    ``z_regulami``, więc nie niesie anotacji, które ``GROUP BY`` musiałby
-    obsłużyć.
+    Tu agregujemy już w bazie: querysety nierozpoznanych nie przechodzą przez
+    ``z_regulami``, więc nie niosą anotacji, które ``GROUP BY`` musiałby
+    obsłużyć. Sumowanie po modelach idzie przez Pythona — selektor zwraca po
+    jednym querysecie na model (zwarte, ciągłe), a ten sam autor może mieć
+    nierozpoznane rekordy obu rodzajów i w tabeli ma być jednym wierszem.
     """
-    zliczone = (
-        powiazania_nierozpoznane(uczelnia, okno)
-        .values("autor_id")
-        .annotate(ile=Count("pk"))
-    )
-    zliczone = {pozycja["autor_id"]: pozycja["ile"] for pozycja in zliczone}
+    zliczone: dict[int, int] = defaultdict(int)
+    for qs in powiazania_nierozpoznane(uczelnia, okno):
+        for pozycja in qs.values("autor_id").annotate(ile=Count("pk")):
+            zliczone[pozycja["autor_id"]] += pozycja["ile"]
 
     autorzy = Autor.objects.in_bulk(zliczone.keys())
     wiersze = [
@@ -138,18 +146,41 @@ class ListaKompletnosciView(RaportKompletnosciMixin, TemplateView):
 
     template_name = "kompletnosc_polon/lista.html"
 
+    #: Autorów na stronę. Prawie każde powiązanie ma jakiś brak wymagany
+    #: (``pbn_czy_*`` i ``opl_pub_*`` mają ``default=None``), więc bez
+    #: paginacji tabela urosłaby do wiersza na każdego pracownika uczelni.
+    autorow_na_stronie = 25
+
+    def _stronicuj(self, wiersze, kontekst):
+        """Podziel gotową listę wierszy na strony.
+
+        Paginujemy listę Pythona, nie queryset: wiersze powstają przez
+        zsumowanie braków z czterech typów osiągnięć (patrz
+        :func:`zbierz_po_autorach`), więc nie ma jednego queryseta, który
+        dałoby się przekazać ``ListView``. Nazwy w kontekście trzymamy takie,
+        jakich oczekuje wspólny szablon ``pagination/pagination_with_anchor``.
+        """
+        paginator = Paginator(wiersze, self.autorow_na_stronie)
+        strona = paginator.get_page(self.request.GET.get("page"))
+
+        kontekst["paginator"] = paginator
+        kontekst["page_obj"] = strona
+        kontekst["is_paginated"] = strona.has_other_pages()
+        kontekst["autorow"] = paginator.count
+        return list(strona.object_list)
+
     def get_context_data(self, **kwargs):
         kontekst = super().get_context_data(**kwargs)
 
         wiersze, sprawdzonych = zbierz_po_autorach(self.uczelnia, self.okno)
-        kontekst["wiersze"] = wiersze
+        kontekst["wiersze"] = self._stronicuj(wiersze, kontekst)
         kontekst["sprawdzonych"] = sprawdzonych
         kontekst["nierozpoznane"] = zbierz_nierozpoznane(self.uczelnia, self.okno)
 
         # Pytanie o dyscypliny zadajemy TYLKO wtedy, gdy raport nie miał czego
         # sprawdzić — przy niepustym zbiorze odpowiedź i tak jest twierdząca,
         # a zapytanie byłoby czystym kosztem.
-        kontekst["brak_przypietych_dyscyplin"] = (
-            sprawdzonych == 0 and not sa_przypiete_dyscypliny()
+        kontekst["brak_przypietych_dyscyplin"] = sprawdzonych == 0 and (
+            not sa_przypiete_dyscypliny(self.uczelnia)
         )
         return kontekst

--- a/src/kompletnosc_polon/views/mixins.py
+++ b/src/kompletnosc_polon/views/mixins.py
@@ -11,6 +11,29 @@ from ewaluacja_metryki.views.mixins import (
 from raport_slotow.uczelnia_helper import uczelnia_dla_odczytu
 
 
+def opis_okna(okno: tuple[int, int | None]) -> str:
+    """Zakres lat okna raportu tak, jak ma go zobaczyć użytkownik.
+
+    Dwa warianty, bo :data:`ewaluacja_common.const.OKNO_EWALUACJI` ma dziś
+    górną granicę nieustaloną:
+
+    * okno domknięte → ``"2026–2029"`` (półpauza, jak w typografii zakresu);
+    * okno otwarte (``ostatni_rok`` to ``None``) → ``"od 2026"``.
+
+    Wariant otwarty musi mieć własne zdanie, a nie sklejkę z pustym miejscem:
+    „2026–None” byłoby wyciekiem implementacji, a „2026–” — sugestią, że
+    czegoś w szablonie brakuje. „Od 2026” jest po prostu prawdą.
+
+    Zwracamy półpauzę jako znak (U+2013), nie encję ``&ndash;``: encja
+    w automatycznie escape'owanym szablonie wyszłaby jako dosłowne
+    „&amp;ndash;”, a znak renderuje się tak samo i nie wymaga ``mark_safe``.
+    """
+    pierwszy_rok, ostatni_rok = okno
+    if ostatni_rok is None:
+        return f"od {pierwszy_rok}"
+    return f"{pierwszy_rok}–{ostatni_rok}"
+
+
 class PelneUprawnieniaEwaluacjiMixin(EwaluacjaRequiredMixin):
     """Dostęp wyłącznie dla redaktorów danych.
 
@@ -40,7 +63,7 @@ class RaportKompletnosciMixin(PelneUprawnieniaEwaluacjiMixin):
     nadpisania przez superusera parametrem ``?uczelnia=<pk>``).
     """
 
-    okno: tuple[int, int] = OKNO_EWALUACJI
+    okno: tuple[int, int | None] = OKNO_EWALUACJI
 
     @cached_property
     def uczelnia(self):
@@ -48,13 +71,17 @@ class RaportKompletnosciMixin(PelneUprawnieniaEwaluacjiMixin):
 
     def get_context_data(self, **kwargs):
         kontekst = super().get_context_data(**kwargs)
-        pierwszy_rok, ostatni_rok = self.okno
         # Świadomie NIE wystawiamy tu ``uczelnia`` — pod tą nazwą base.html
         # dostaje uczelnię z context processora i nadpisanie jej wartością
         # ``None`` (instalacja bez mapowania Site→Uczelnia) wywala szablon
         # bazowy przy ``uczelnia.skrot``.
-        kontekst["pierwszy_rok"] = pierwszy_rok
-        kontekst["ostatni_rok"] = ostatni_rok
+        #
+        # Do szablonu idzie GOTOWY opis zakresu, a nie para liczb: przy
+        # otwartej górnej granicy ``ostatni_rok`` jest ``None`` i każde
+        # sklejanie „{{ pierwszy_rok }}–{{ ostatni_rok }}” w szablonie
+        # wyrenderowałoby „2026–None”. Jedno miejsce decyduje o brzmieniu
+        # zakresu — patrz :func:`opis_okna`.
+        kontekst["zakres_lat"] = opis_okna(self.okno)
         return kontekst
 
 

--- a/src/kompletnosc_polon/views/mixins.py
+++ b/src/kompletnosc_polon/views/mixins.py
@@ -1,0 +1,73 @@
+"""Wspólne mixiny widoków raportu kompletności danych POL-on."""
+
+from django.urls import reverse
+from django.utils.functional import cached_property
+
+from ewaluacja_common.const import OKNO_EWALUACJI
+from ewaluacja_metryki.views.mixins import (
+    EwaluacjaRequiredMixin,
+    ma_pelne_uprawnienia_ewaluacji,
+)
+from raport_slotow.uczelnia_helper import uczelnia_dla_odczytu
+
+
+class PelneUprawnieniaEwaluacjiMixin(EwaluacjaRequiredMixin):
+    """Dostęp wyłącznie dla redaktorów danych.
+
+    Raport kompletności jest narzędziem **redaktorskim**: pokazuje braki
+    w cudzych rekordach i prowadzi wprost do formularza edycji w panelu
+    administracyjnym. Bazowy ``EwaluacjaRequiredMixin`` przepuszcza także
+    zalogowanego autora (żeby mógł obejrzeć *swoje* metryki) — tu to za mało,
+    więc zawężamy test do pełnych uprawnień
+    (superuser albo grupa „wprowadzanie danych”).
+
+    Zalogowany użytkownik bez uprawnień dostanie 403 (``PermissionDenied``
+    z ``AccessMixin.handle_no_permission``), niezalogowany — przekierowanie
+    na formularz logowania.
+    """
+
+    def test_func(self):
+        return ma_pelne_uprawnienia_ewaluacji(self.request.user)
+
+
+class RaportKompletnosciMixin(PelneUprawnieniaEwaluacjiMixin):
+    """Wspólny kontekst obu widoków raportu: uczelnia oglądającego i okno lat.
+
+    Okno bierzemy ze stałej :data:`ewaluacja_common.const.OKNO_EWALUACJI` —
+    jedynego źródła prawdy dla tej aplikacji. Uczelnię rozstrzyga
+    :func:`raport_slotow.uczelnia_helper.uczelnia_dla_odczytu`, czyli tak samo
+    jak reszta raportów slotowych (domena → Site → Uczelnia, z możliwością
+    nadpisania przez superusera parametrem ``?uczelnia=<pk>``).
+    """
+
+    okno: tuple[int, int] = OKNO_EWALUACJI
+
+    @cached_property
+    def uczelnia(self):
+        return uczelnia_dla_odczytu(self.request)
+
+    def get_context_data(self, **kwargs):
+        kontekst = super().get_context_data(**kwargs)
+        pierwszy_rok, ostatni_rok = self.okno
+        # Świadomie NIE wystawiamy tu ``uczelnia`` — pod tą nazwą base.html
+        # dostaje uczelnię z context processora i nadpisanie jej wartością
+        # ``None`` (instalacja bez mapowania Site→Uczelnia) wywala szablon
+        # bazowy przy ``uczelnia.skrot``.
+        kontekst["pierwszy_rok"] = pierwszy_rok
+        kontekst["ostatni_rok"] = ostatni_rok
+        return kontekst
+
+
+def url_formularza_admina(rekord) -> str:
+    """Adres formularza edycji rekordu w panelu administracyjnym.
+
+    Nazwę trasy wyprowadzamy z metadanych modelu, zamiast trzymać słownik
+    ``Osiagniecie → nazwa trasy``: raport dotyka trzech modeli
+    (``Wydawnictwo_Ciagle``, ``Wydawnictwo_Zwarte``, ``Patent``), wszystkie
+    zarejestrowane w adminie, a słownik byłby czwartym miejscem do
+    zsynchronizowania przy każdej zmianie.
+    """
+    opcje = rekord._meta
+    return reverse(
+        f"admin:{opcje.app_label}_{opcje.model_name}_change", args=[rekord.pk]
+    )

--- a/src/kompletnosc_polon/views/szczegoly.py
+++ b/src/kompletnosc_polon/views/szczegoly.py
@@ -11,6 +11,7 @@ from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView
 
 from bpp.models import Autor
+from bpp.util.uczelnia_scope import scope_autor_do_uczelni
 from kompletnosc_polon.const import Osiagniecie, Waga
 from kompletnosc_polon.selektory import (
     POLE_BRAKI_WARUNKOWE,
@@ -70,25 +71,35 @@ def zbierz_pozycje(autor, uczelnia, okno) -> tuple[list[dict], int]:
 def zbierz_nierozpoznane_autora(autor, uczelnia, okno) -> list[dict]:
     """Rekordy autora, których typu osiągnięcia nie da się ustalić.
 
-    Brak ``charakter_formalny.charakter_sloty`` znaczy, że nie wiadomo, czy
-    rekord jest monografią (pkt 5), czy rozdziałem (pkt 6) — a więc których
-    wymogów od niego oczekiwać. Raport ich NIE sprawdził i musi to powiedzieć
-    wprost.
+    Wydawnictwo zwarte bez ``charakter_formalny.charakter_sloty`` może być
+    monografią (pkt 5) albo rozdziałem (pkt 6); wydawnictwo ciągłe bez
+    ``charakter_formalny.rodzaj_pbn`` — artykułem naukowym (pkt 4) albo
+    publikacją, która osiągnięciem nie jest. W obu przypadkach nie wiadomo,
+    których wymogów od rekordu oczekiwać: raport go NIE sprawdził i musi to
+    powiedzieć wprost.
+
+    Rekordy obu rodzajów lądują w **jednej** liście — użytkownika interesuje
+    „czego raport nie sprawdził”, a nie z którego modelu to pochodzi. Rodzaj
+    niesiemy per wiersz (``rodzaj``), bo od niego zależy, które pole słownika
+    charakterów trzeba uzupełnić. Sortujemy w Pythonie, bo źródłem są dwa
+    querysety.
     """
-    qs = (
-        powiazania_nierozpoznane(uczelnia, okno)
-        .filter(autor=autor)
-        .select_related("rekord", "rekord__charakter_formalny")
-        .order_by("-rekord__rok")
-    )
-    return [
-        {
-            "rekord": wiersz.rekord,
-            "charakter_formalny": wiersz.rekord.charakter_formalny,
-            "url_admina": url_formularza_admina(wiersz.rekord),
-        }
-        for wiersz in qs
-    ]
+    pozycje = []
+    for qs in powiazania_nierozpoznane(uczelnia, okno):
+        wiersze = qs.filter(autor=autor).select_related(
+            "rekord", "rekord__charakter_formalny"
+        )
+        pozycje.extend(
+            {
+                "rekord": wiersz.rekord,
+                "rodzaj": wiersz.rekord._meta.verbose_name,
+                "charakter_formalny": wiersz.rekord.charakter_formalny,
+                "url_admina": url_formularza_admina(wiersz.rekord),
+            }
+            for wiersz in wiersze
+        )
+    pozycje.sort(key=lambda p: (-p["rekord"].rok, str(p["rekord"].tytul_oryginalny)))
+    return pozycje
 
 
 class SzczegolyKompletnosciView(RaportKompletnosciMixin, TemplateView):
@@ -99,7 +110,17 @@ class SzczegolyKompletnosciView(RaportKompletnosciMixin, TemplateView):
     def get_context_data(self, **kwargs):
         kontekst = super().get_context_data(**kwargs)
 
-        autor = get_object_or_404(Autor, slug=self.kwargs["autor_slug"])
+        # Autora szukamy w zbiorze JUŻ zawężonym do uczelni oglądającego.
+        # Zawężenie samych powiązań nie wystarcza: slug jest przewidywalny
+        # („nazwisko-imie”), więc bez tego superuser z ``?uczelnia=<nasza>``
+        # dostawał HTTP 200 z imieniem i nazwiskiem pracownika OBCEJ uczelni
+        # w tytule strony, okruszkach i nagłówku — czyli enumerację cudzej
+        # kadry. Nieznalezienie autora w swojej uczelni ma być nieodróżnialne
+        # od nieistnienia autora, stąd 404, a nie 200 z pustą listą.
+        autor = get_object_or_404(
+            scope_autor_do_uczelni(Autor.objects.all(), self.uczelnia),
+            slug=self.kwargs["autor_slug"],
+        )
         pozycje, sprawdzonych = zbierz_pozycje(autor, self.uczelnia, self.okno)
 
         kontekst["autor"] = autor

--- a/src/kompletnosc_polon/views/szczegoly.py
+++ b/src/kompletnosc_polon/views/szczegoly.py
@@ -1,0 +1,111 @@
+"""Widok szczegółów raportu kompletności danych POL-on — jeden autor.
+
+Dla wskazanego autora wypisuje jego niekompletne rekordy, a przy każdym:
+naruszone reguły (opis + podstawa prawna) oraz link prosto do formularza
+edycji w panelu administracyjnym. To „prowadzenie do działania” jest sensem
+raportu — sama informacja „czegoś brakuje” jest bezużyteczna, jeśli
+uzupełnienie wymaga szukania rekordu po tytule.
+"""
+
+from django.shortcuts import get_object_or_404
+from django.views.generic import TemplateView
+
+from bpp.models import Autor
+from kompletnosc_polon.const import Osiagniecie, Waga
+from kompletnosc_polon.selektory import (
+    POLE_BRAKI_WARUNKOWE,
+    POLE_BRAKI_WYMAGANE,
+    naruszone_reguly,
+    powiazania,
+    powiazania_nierozpoznane,
+    z_regulami,
+)
+
+from .lista import ma_jakikolwiek_brak
+from .mixins import RaportKompletnosciMixin, url_formularza_admina
+
+
+def zbierz_pozycje(autor, uczelnia, okno) -> tuple[list[dict], int]:
+    """Niekompletne rekordy jednego autora, z rozpisanymi brakami.
+
+    Zwraca krotkę: listę pozycji oraz liczbę sprawdzonych powiązań tego
+    autora — potrzebną, by przy zerze braków napisać wprost „sprawdzono N,
+    brak zastrzeżeń”, zamiast pokazać pustą stronę.
+    """
+    pozycje = []
+    sprawdzonych = 0
+
+    for osiagniecie in Osiagniecie:
+        qs = z_regulami(
+            powiazania(osiagniecie, uczelnia, okno).filter(autor=autor),
+            osiagniecie,
+        )
+        sprawdzonych += qs.count()
+
+        niekompletne = (
+            qs.filter(ma_jakikolwiek_brak())
+            .select_related("rekord", "dyscyplina_naukowa", "jednostka")
+            .order_by("-rekord__rok")
+        )
+        for wiersz in niekompletne:
+            naruszone = naruszone_reguly(wiersz, osiagniecie)
+            pozycje.append(
+                {
+                    "typ": osiagniecie.label,
+                    "rekord": wiersz.rekord,
+                    "dyscyplina": wiersz.dyscyplina_naukowa,
+                    "jednostka": wiersz.jednostka,
+                    "url_admina": url_formularza_admina(wiersz.rekord),
+                    "wymagane": [r for r in naruszone if r.waga == Waga.WYMAGANE],
+                    "warunkowe": [r for r in naruszone if r.waga == Waga.WARUNKOWE],
+                    "braki_wymagane": getattr(wiersz, POLE_BRAKI_WYMAGANE),
+                    "braki_warunkowe": getattr(wiersz, POLE_BRAKI_WARUNKOWE),
+                }
+            )
+
+    pozycje.sort(key=lambda p: (-p["braki_wymagane"], -p["braki_warunkowe"]))
+    return pozycje, sprawdzonych
+
+
+def zbierz_nierozpoznane_autora(autor, uczelnia, okno) -> list[dict]:
+    """Rekordy autora, których typu osiągnięcia nie da się ustalić.
+
+    Brak ``charakter_formalny.charakter_sloty`` znaczy, że nie wiadomo, czy
+    rekord jest monografią (pkt 5), czy rozdziałem (pkt 6) — a więc których
+    wymogów od niego oczekiwać. Raport ich NIE sprawdził i musi to powiedzieć
+    wprost.
+    """
+    qs = (
+        powiazania_nierozpoznane(uczelnia, okno)
+        .filter(autor=autor)
+        .select_related("rekord", "rekord__charakter_formalny")
+        .order_by("-rekord__rok")
+    )
+    return [
+        {
+            "rekord": wiersz.rekord,
+            "charakter_formalny": wiersz.rekord.charakter_formalny,
+            "url_admina": url_formularza_admina(wiersz.rekord),
+        }
+        for wiersz in qs
+    ]
+
+
+class SzczegolyKompletnosciView(RaportKompletnosciMixin, TemplateView):
+    """Rozwinięcie zbiorczego zestawienia dla jednego autora."""
+
+    template_name = "kompletnosc_polon/szczegoly.html"
+
+    def get_context_data(self, **kwargs):
+        kontekst = super().get_context_data(**kwargs)
+
+        autor = get_object_or_404(Autor, slug=self.kwargs["autor_slug"])
+        pozycje, sprawdzonych = zbierz_pozycje(autor, self.uczelnia, self.okno)
+
+        kontekst["autor"] = autor
+        kontekst["pozycje"] = pozycje
+        kontekst["sprawdzonych"] = sprawdzonych
+        kontekst["nierozpoznane"] = zbierz_nierozpoznane_autora(
+            autor, self.uczelnia, self.okno
+        )
+        return kontekst


### PR DESCRIPTION
## Co i po co

Raport kompletności danych wymaganych **rozporządzeniem MNiSW z 16 czerwca 2026 r. w sprawie danych przetwarzanych w POL-on** (Dz. U. 2026 poz. 811, w życie od 30 czerwca 2026 r.). Zgłoszenie FD#437 — prorektor UAFM przysłał rozporządzenie z prośbą o dostosowanie systemu.

**Rozpoznanie dało wynik odwrotny do oczekiwanego: BPP nie potrzebuje nowych pól.** § 2 ust. 10 rozporządzenia wylicza praktycznie ten sam zestaw danych, który BPP już utrzymuje na potrzeby eksportu do PBN — łącznie z opłatami APC, pełnym blokiem Open Access i flagą artykułu recenzyjnego. Problemem nie jest brak miejsca na dane, tylko brak widoczności, **których** danych brakuje i **przy kim**.

Stąd raport, a nie migracja.

## Jak to działa

Nowa aplikacja `kompletnosc_polon`, bez modeli i bez migracji. Trzy decyzje, które warto znać przy review:

**Ziarno to para (autor, osiągnięcie), nie sama publikacja.** Rozporządzenie umieszcza osiągnięcia *w wykazie pracowników* — dane wiszą przy człowieku, a każde osiągnięcie niesie własną dyscyplinę z art. 265 ust. 13. Ten sam artykuł u dwóch współautorów to w POL-onie dwa wpisy. Querysety startują więc z through-modeli (`Wydawnictwo_Ciagle_Autor` itd.).

**Nie da się tego oprzeć na widoku `Rekord`.** `bpp_rekord_mat` nie wystawia opłat APC ani flag ewaluacyjnych PBN, a `strony`/`tom`/`nr_zeszytu` ma jawnie wygaszone (`RekordBase`, `src/bpp/models/cache/rekord.py:192-260`). Jedna trzecia wymogów rozporządzenia byłaby przez ten widok niesprawdzalna.

**Reguły są danymi, nie kodem.** 50 reguł, każda to `(kod, typ osiągnięcia, warunek Q, opis, paragraf, waga)`. Warunek jest obiektem `Q`, więc jedna definicja służy do liczenia, filtrowania i testu. Paragraf trafia do interfejsu — użytkownik widzi podstawę prawną, nie samo czerwone pole. Waga odróżnia wymogi bezwarunkowe od tych, które rozporządzenie opatruje słowami „jeżeli posiada" / „jeżeli są znane" — raport ich nie zaostrza.

## Zakres

Objęte: artykuły (§ 2 ust. 10 pkt 4), monografie (pkt 5), rozdziały (pkt 6), patenty (pkt 1) — te ostatnie częściowo.

Poza zakresem, bo **BPP nie ma gdzie tych danych trzymać**:

| Wymóg | Paragraf |
|---|---|
| Osiągnięcia artystyczne | pkt 7 — brak modelu w ogóle |
| Wzory użytkowe, odmiany roślin | pkt 2, 3 — j.w. |
| Patenty: uprawniony, urząd udzielający, państwa ochrony, data ogłoszenia w WUP, uprzednie pierwszeństwo, streszczenie opisu, tłumaczenie patentu EP | pkt 1 lit. b, d, e, f, h, i, j |
| ISMN | pkt 5 lit. b |
| Czy monografia jest przekładem dzieła istotnego | pkt 5 lit. i |
| Zgłoszenie do oceny eksperckiej KEN i jej wynik | pkt 5 lit. l |

Braki patentowe pokrywają się z tym, co niezależnie zgłosiła klientka w **FD#449**.

## Recenzja adwersarialna — co znalazła

Kod przeszedł osobną recenzję przed wystawieniem PR. Znaleziska naprawione w `365fbd5c4`, wszystkie zweryfikowane mutacyjnie (cofnięcie poprawki → odpowiadające testy padają):

- **Streszczenia zjazdowe audytowane jak artykuły naukowe.** `Wydawnictwo_Ciagle` obejmuje w BPP także PSZ/ZSZ, listy do redakcji, recenzje i komunikaty. Raport żądał od streszczenia konferencyjnego numeru DOI. Uderzyłoby w każdą instalację z bibliografią zjazdową.
- **Monografia macierzysta rozdziału nie była sprawdzana nigdy.** Komentarz w kodzie twierdził, że jej braki widać przy monografii — ale rodzic trafia do raportu tylko wtedy, gdy sam ma autora z uczelni, a rozdział w monografii zbiorowej pod obcą redakcją takiego rodzica nie ma. Cały pkt 6 lit. a wypadał z audytu.
- **Wyciek nazwisk między uczelniami.** Widok szczegółów nie zawężał autora do uczelni; slug jest przewidywalny (`nazwisko-imie`), więc pozwalało to enumerować kadrę obcej instytucji. Teraz 404.
- Trzy luki wobec rozporządzenia: brak reguły na sam tryb dostępu OA, dziura między regułami APC, całkiem pominięta lit. g o konferencjach.
- Luka w testach: wzorzec zerował wszystkie człony koniunkcji naraz, więc dowolny fallback dało się usunąć z kodu przy zielonej suicie.

Recenzja potwierdziła też, że nie ma N+1 (45 zapytań przy 2 i przy 20 autorach), nie ma mnożenia wierszy przez JOIN-y i że wszystkie paragrafy przy regułach wskazują właściwą jednostkę redakcyjną rozporządzenia.

## Testy

341 testów w `src/kompletnosc_polon/`. Każda reguła sprawdzana parą rekordów (kompletny / z brakiem), plus testy „fallback ratuje" na każdy człon koniunkcji, testy ziarna, zakresu, warunkowości OA, uprawnień i multi-tenanta.

Przy okazji naprawiony flake w fixture'ach: `Dyscyplina_Naukowa.kod` jest unikalny, a generator `model_bakery` losuje z wąskiego zakresu — test budujący 28 powiązań trafiał w kolizję urodzinową (reprodukowalne przez `--count=40`).

## Dług techniczny — do osobnego zgłoszenia, NIE naprawiany tutaj

W repo są **trzy niezgodne definicje okna ewaluacyjnego**:

| Miejsce | Wartość |
|---|---|
| `ewaluacja_common/const.py` | `ROK_MIN = 2022`, `ROK_MAX = 2026` |
| `ewaluacja_metryki/models.py:114-120` | pola `rok_min`/`rok_max`, domyślnie `2022` / `2025` |
| `ewaluacja_metryki/tasks.py`, `utils.py` | `rok_min=2022, rok_max=2025` w ośmiu sygnaturach funkcji |

`ROK_MAX` mówi 2026, a metryki liczą do 2025. Rozjazd siedzi w domyślnych argumentach, nie we wspólnej stałej, więc jest niewidoczny. **Wraz z otwarciem okna 2026+ każde z tych miejsc jest błędne.**

Ten PR dokłada `OKNO_EWALUACJI = (2026, 2029)` w `ewaluacja_common` jako źródło prawdy **wyłącznie dla nowej aplikacji** i celowo nie rusza reszty — zmiana domyślnych lat przestawiłaby wyniki liczenia metryk i slotów, czyli zachowanie niezwiązane z tym zgłoszeniem.

## Uwagi wdrożeniowe

- Brak migracji.
- Raport na starcie będzie **prawie pusty** — okno 2026 dopiero się otwiera. Widok jawnie podaje zakres lat i liczbę sprawdzonych powiązań, żeby pustka nie wyglądała jak „wszystko w porządku".
- Raport zależy od ustawionych w słowniku charakterów formalnych pól `rodzaj_pbn` i `charakter_sloty`. Rekordy, dla których ich brak, trafiają do osobnej sekcji „nierozpoznany typ osiągnięcia" z linkiem do słownika — nie znikają po cichu.

Projekt: `docs/superpowers/specs/2026-07-25-raport-kompletnosci-polon-2026-design.md`

Refs FD#437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McWgJYK4c4GSMdsm6P4oXc
