### PR TITLE
fix(zglos): podpowiedź jednostki działa też dla niezalogowanych (CSRF/login off)

### DIFF
--- a/src/bpp/newsfragments/+zglos-podpowiedz-jednostki-publiczna.bugfix.rst
+++ b/src/bpp/newsfragments/+zglos-podpowiedz-jednostki-publiczna.bugfix.rst
@@ -1,0 +1,7 @@
+W publicznym formularzu zgłaszania publikacji znów działa automatyczne
+podpowiadanie jednostki i dyscypliny po wybraniu autora. Endpoint
+``/bpp/api/ostatnia-jednostka-i-dyscyplina/`` przestał wymagać uprawnień
+redaktorskich, zalogowania oraz tokenu CSRF — niczego nie zmienia, tylko
+odczytuje dane dostępne publicznie także na stronie autora, a zgłaszać
+publikacje mogą również osoby niezalogowane. Wcześniej podpowiedź znikała
+po cichu (bez komunikatu), bo blokada trafiała w zapytanie AJAX.

--- a/src/bpp/tests/test_authz_views.py
+++ b/src/bpp/tests/test_authz_views.py
@@ -72,15 +72,15 @@ API_ROUTES_REDAKCYJNE = [
 ]
 
 # Wszystkie endpointy API wymagające ZALOGOWANIA (anonim → 302 na login).
-# `api_ostatnia_jednostka_i_dyscyplina` jest tutaj, ale ŚWIADOMIE nie ma go na
-# liście redakcyjnej wyżej: to widok tylko-do-odczytu, konsumowany przez
-# `autorform_dependant.js` w PUBLICZNYM formularzu `zglos_publikacje`, więc
-# zwykły zalogowany użytkownik musi dostać 200, a nie 403. Pilnuje tego
+#
+# `api_ostatnia_jednostka_i_dyscyplina` ŚWIADOMIE tu NIE występuje: to widok
+# tylko-do-odczytu, konsumowany przez `autorform_dependant.js` w PUBLICZNYM
+# formularzu `zglos_publikacje`, który anonimów wpuszcza. Musi więc odpowiadać
+# 200 zarówno anonimowi, jak i zalogowanemu bez uprawnień redaktorskich —
+# pilnują tego `test_ostatnia_jednostka_dostepna_dla_anonima` oraz
 # `test_ostatnia_jednostka_dostepna_bez_uprawnien_redaktorskich`
 # w `src/bpp/tests/test_views/test_api.py`.
-API_ROUTES = API_ROUTES_REDAKCYJNE + [
-    ("bpp:api_ostatnia_jednostka_i_dyscyplina", {}),
-]
+API_ROUTES = API_ROUTES_REDAKCYJNE
 
 
 @pytest.mark.django_db

--- a/src/bpp/tests/test_views/test_api.py
+++ b/src/bpp/tests/test_views/test_api.py
@@ -2,6 +2,7 @@ import json
 from collections import namedtuple
 
 import pytest
+from django.test import Client
 from django.urls import reverse
 from model_bakery import baker
 
@@ -405,7 +406,6 @@ def test_upload_punktacja_zrodla_niepoprawna_liczba():
             {"zrodlo_id": 1, "rok": CURRENT_YEAR},
             {"impact_factor": "50.0"},
         ),
-        ("bpp:api_ostatnia_jednostka_i_dyscyplina", {}, {"autor_id": 1}),
         ("bpp:api_pubmed_id", {}, {"t": "test"}),
     ],
 )
@@ -441,6 +441,43 @@ def test_ostatnia_jednostka_dostepna_bez_uprawnien_redaktorskich(
     assert not moze_wprowadzac_dane(user)
     client.force_login(user)
 
+    url = reverse("bpp:api_ostatnia_jednostka_i_dyscyplina")
+    response = client.post(url, data={"autor_id": autor.pk, "rok": CURRENT_YEAR})
+
+    assert response.status_code == 200
+    assert json.loads(response.content)["jednostka_id"] == jednostka.pk
+
+
+@pytest.mark.django_db
+def test_ostatnia_jednostka_dostepna_dla_anonima(client, autor, jednostka):
+    """Podpowiadanie jednostki działa dla NIEZALOGOWANEGO zgłaszającego.
+
+    Formularz ``zglos_publikacje`` jest publiczny (``Zgloszenie_PublikacjiWizard``
+    nie ma żadnej bramki logowania), więc najliczniejsza grupa jego użytkowników
+    to anonimy. ``LoginRequiredMixin`` odpowiadał im 302 na login — a że to AJAX,
+    ``autorform_dependant.js`` po cichu gubił podpowiedź jednostki i dyscypliny.
+    """
+    jednostka.dodaj_autora(autor)
+
+    url = reverse("bpp:api_ostatnia_jednostka_i_dyscyplina")
+    response = client.post(url, data={"autor_id": autor.pk, "rok": CURRENT_YEAR})
+
+    assert response.status_code == 200
+    assert json.loads(response.content)["jednostka_id"] == jednostka.pk
+
+
+@pytest.mark.django_db
+def test_ostatnia_jednostka_nie_wymaga_tokenu_csrf(autor, jednostka):
+    """POST bez ``csrfmiddlewaretoken`` przechodzi — widok jest ``csrf_exempt``.
+
+    CSRF chroni przed wymuszoną ZMIANĄ STANU; ten widok wyłącznie czyta i zwraca
+    JSON, więc token nie wnosi ochrony, a wymaga od konsumenta dostępu do
+    formularza z tokenem. Anonim na stronie serwowanej z cache'u publicznego
+    świeżego tokenu mieć nie musi.
+    """
+    jednostka.dodaj_autora(autor)
+
+    client = Client(enforce_csrf_checks=True)
     url = reverse("bpp:api_ostatnia_jednostka_i_dyscyplina")
     response = client.post(url, data={"autor_id": autor.pk, "rok": CURRENT_YEAR})
 

--- a/src/bpp/views/api/__init__.py
+++ b/src/bpp/views/api/__init__.py
@@ -1,9 +1,10 @@
 from decimal import Decimal, InvalidOperation
 
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import models, transaction
 from django.http import JsonResponse
 from django.http.response import HttpResponseNotFound
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
 from bpp.models import Autor, Autor_Dyscyplina, Uczelnia, Zrodlo
@@ -155,22 +156,38 @@ def ostatnia_dyscyplina(request, a, rok):
             return ad.dyscyplina_naukowa or ad.subdyscyplina_naukowa
 
 
-class OstatniaJednostkaIDyscyplinaView(LoginRequiredMixin, View):
+@method_decorator(csrf_exempt, name="dispatch")
+class OstatniaJednostkaIDyscyplinaView(View):
     """Zwraca jako JSON ostatnią jednostkę danego autora oraz ewentualnie jego
     dyscyplinę naukową, w sytuacji gdy jest ona jedna i określona na dany rok.
 
-    ŚWIADOMIE ``LoginRequiredMixin``, a NIE
-    ``WprowadzanieDanychRequiredMixin``: widok niczego nie mutuje — czyta
-    ``Autor``/``Autor_Dyscyplina`` i zwraca JSON. Konsumuje go
-    ``autorform_dependant.js``, ładowany także do PUBLICZNEGO formularza
-    ``zglos_publikacje`` (patrz ``zglos_publikacje.forms``), więc bramka
-    redaktorska odcinała zwykłych zgłaszających od podpowiedzi jednostki
-    i dyscypliny — po cichu, bo to AJAX.
+    Widok jest ŚWIADOMIE w pełni publiczny — bez bramki uprawnień, bez bramki
+    logowania i bez CSRF. Każda z nich była tu osobnym błędem:
 
-    Anonim NADAL dostaje 302 na login (kontrakt ``LoginRequiredMixin``), więc
-    dla niezalogowanych zgłaszających podpowiedź nie działa — tak samo jak
-    przed ``e892142ff``. Poluzowanie tego to osobna decyzja: endpoint jest
-    oraklem istnienia autora dla całej przestrzeni PK i nie ma rate-limitu.
+    - ``WprowadzanieDanychRequiredMixin`` (``e892142ff``) → 403 dla każdego
+      zgłaszającego bez roli redaktora (Rollbar #4283-4294 i ~19 bliźniaczych),
+    - ``LoginRequiredMixin`` (``84673573c``) → 302 na login dla anonimów,
+    - CSRF → wymóg świeżego tokenu z formularza.
+
+    Konsumentem jest ``autorform_dependant.js``, ładowany do PUBLICZNEGO
+    formularza ``zglos_publikacje`` (patrz ``zglos_publikacje.forms``), którego
+    ``Zgloszenie_PublikacjiWizard`` nie ma żadnej bramki logowania. Odcięci
+    użytkownicy tracili podpowiedź jednostki i dyscypliny PO CICHU, bo to AJAX
+    — ``.done()`` po prostu się nie wykonywał.
+
+    Dlaczego poluzowanie jest bezpieczne:
+
+    - widok niczego nie MUTUJE — czyta ``Autor``/``Autor_Dyscyplina`` i zwraca
+      JSON; CSRF chroni wyłącznie przed wymuszoną zmianą stanu, więc na
+      czystym odczycie nie wnosi ochrony, a psuje konsumenta,
+    - nie ujawnia niczego nowego: te same dane (istnienie autora, jego aktualna
+      jednostka) anonim dostaje z publicznej, cache'owanej ``AutorView``
+      pod ``/bpp/autor/<pk>/``,
+    - podpowiadanie dyscypliny i tak pozostaje pod kontrolą wdrożenia przez
+      ``Uczelnia.podpowiadaj_dyscypliny`` (patrz :func:`ostatnia_dyscyplina`).
+
+    Bramki redaktorskie zostają na widokach MUTUJĄCYCH obok — pilnuje tego
+    ``test_pozostale_api_nadal_wymagaja_uprawnien_redaktorskich``.
     """
 
     def post(self, request, *args, **kw):


### PR DESCRIPTION
## Problem

Rollbar #4283–4294 (2 sierpnia, `publikacje.up.lublin.pl`): `PermissionDenied: Brak uprawnień do wprowadzania danych.`, context `api_ostatnia_jednostka_i_dyscyplina`, Referer `/zglos_publikacje/nowe_zgloszenie/`. Poszkodowani: zwykli zgłaszający bez roli redaktora.

Na widok **tylko-do-odczytu** nałożyły się z czasem **trzy** niezależne bramki:

| Bramka | Skąd | Efekt |
|---|---|---|
| `WprowadzanieDanychRequiredMixin` | `e892142ff` | 403 dla nie-redaktorów |
| `LoginRequiredMixin` | `84673573c` (#673) | 302 na login dla anonimów |
| CSRF | middleware | wymóg świeżego tokenu z formularza |

Środkową #673 już poluzował, ale **świadomie** zostawił otwartą kwestię anonimów — wprost w docstringu: *„Poluzowanie tego to osobna decyzja"*. To jest ta decyzja.

Konsumentem jest `autorform_dependant.js` ładowany do **publicznego** formularza `zglos_publikacje`, którego `Zgloszenie_PublikacjiWizard` nie ma żadnej bramki logowania — anonimowi zgłaszający to jego najliczniejsza grupa. Odcięci tracili podpowiedź jednostki i dyscypliny **po cichu**, bo to AJAX.

Warto odnotować, **dlaczego przypadku anonimowego nie było w Rollbarze**: `LoginRequiredMixin` dla anonima nie rzuca wyjątku, tylko zwraca 302 — poprawną odpowiedź HTTP. Monitoring pokazywał więc wyłącznie mniejszą, zalogowaną grupę poszkodowanych.

## Rozwiązanie

`OstatniaJednostkaIDyscyplinaView` → w pełni publiczny: zdjęty `LoginRequiredMixin`, dodany `@csrf_exempt`.

Dlaczego to bezpieczne:

- widok niczego **nie mutuje** — czyta `Autor`/`Autor_Dyscyplina` i zwraca JSON; CSRF chroni wyłącznie przed wymuszoną **zmianą stanu**;
- nie ujawnia niczego nowego — te same dane (istnienie autora, jego aktualna jednostka) anonim dostaje z publicznej, cache'owanej `AutorView` pod `/bpp/autor/<pk>/`, co unieważnia zastrzeżenie „oracle istnienia autora" z #673;
- podpowiadanie dyscypliny nadal zależy od `Uczelnia.podpowiadaj_dyscypliny`.

Bramki redaktorskie na sąsiednich widokach **mutujących** zostają nietknięte — pilnuje tego `test_pozostale_api_nadal_wymagaja_uprawnien_redaktorskich`.

## Testy

TDD, RED potwierdzony **osobno dla każdej bramki** (302 na login / „CSRF cookie not set"):

- `test_ostatnia_jednostka_dostepna_dla_anonima` — anonim → 200,
- `test_ostatnia_jednostka_nie_wymaga_tokenu_csrf` — `Client(enforce_csrf_checks=True)` → 200,
- endpoint zdjęty z listy „anonim → 302" w `test_authz_views.py`.

Lokalnie: 537 passed (`zglos_publikacje` + `bpp/tests/test_views` + authz), 18 passed Playwright — w tym `test_zglos_publikacje_drugi_autor_dyscyplina` i `test_procent_odpowiedzialnosci`, czyli realna ścieżka AJAX-a w przeglądarce. `ruff format`/`check` czyste.

## Uwaga wdrożeniowa

Ten PR **nie zamknie sam zgłoszeń Rollbara**. Produkcja stoi na `202607.1398` odciętej 22 lipca, a #673 powstał 26 lipca — prod nie ma nawet tamtej poprawki. Potrzebne jest wydanie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)