### PR TITLE
feat(import_polon): tabela ze statystykami na liście importów POLON

### DIFF
--- a/docs/superpowers/specs/2026-08-03-import-polon-statystyki-listy-design.md
+++ b/docs/superpowers/specs/2026-08-03-import-polon-statystyki-listy-design.md
@@ -1,0 +1,363 @@
+# Statystyki importów na liście `/import_polon/dane/`
+
+Data: 2026-08-03
+Status: zaakceptowany projekt po self-review, gotowy do implementacji
+
+## Problem
+
+Strona `/import_polon/dane/` („Ostatnio importowane dane") renderuje listę
+importów jako `<ul>` z jednym zdaniem na import
+(`src/import_polon/templates/import_polon/importplikupolon_list.html:19-28`):
+
+```
+plik protected/import_polon/rozszerzone_zestawienie_pracownikow_podmiotu_na_dzien_wygenerowania_raportu_2026-01-15.xlsx:
+import utworzono 15 stycznia 2026 09:12, ukończono 15 stycznia 2026 09:14, zakończono pomyślnie
+```
+
+Trzy wady:
+
+1. Prefiks `protected/import_polon/` to szczegół implementacyjny `upload_to` —
+   nie niesie informacji dla użytkownika, a zjada szerokość wiersza.
+2. Nazwa pliku z POLON-u („rozszerzone zestawienie pracowników podmiotu na
+   dzień wygenerowania raportu…") jest tak długa, że część odróżniająca
+   kolejne importy — data na końcu — ginie z pola widzenia.
+3. Nie widać nic o zawartości importu. Żeby dowiedzieć się, ilu autorów plik
+   obejmował i ile zmian wprowadził, trzeba wejść w każdy import osobno. Nie
+   widać też roku importu (`ImportPlikuPolon.rok`), który rozstrzyga, których
+   wpisów `Autor_Dyscyplina` import dotyczy.
+
+## Zakres
+
+Wyłącznie lista importów POLON (`/import_polon/dane/`). Lista importów
+absencji (`/import_polon/absencje/`) pozostaje bez zmian — świadoma decyzja,
+nie przeoczenie.
+
+## Cel
+
+Zamienić listę na tabelę pokazującą per import: skróconą nazwę pliku, rok,
+status i tryb, oraz sześć liczb opisujących zawartość i skutek importu.
+
+## Kluczowe odkrycie: część liczb nie jest odtwarzalna z bazy
+
+`WierszImportuPlikuPolon` nie jest wiernym odbiciem pliku. W
+`src/import_polon/core/import_polon.py:548-549` jest:
+
+```python
+if autor is None and parent_model.ukryj_niezmatchowanych_autorow:
+    continue
+```
+
+Przy domyślnym `ukryj_niezmatchowanych_autorow=True` wiersz z niedopasowanym
+autorem nie trafia do bazy w ogóle. Zatem `get_details_set().count()` ≠ liczba
+wierszy w pliku, a różnicy nie da się odzyskać po zakończeniu importu.
+
+Wniosek: liczby muszą być zapamiętane w trakcie importu, nie liczone przy
+wyświetlaniu listy. To zresztą korzystne wydajnościowo — metryka
+`do_odpiecia` to `autorzy_niezmatchowani()`, czyli `Autor_Dyscyplina` ×
+`kiedykolwiek_zatrudnieni()` × `annotate(Count(prace))`. Liczona na żywo dla
+10 importów oznaczałaby 10 ciężkich zapytań przy każdym wejściu na stronę.
+
+## Pułapka: dwa różne komunikaty „bez zmian"
+
+Kuszące jest policzenie zmian zapytaniem
+`exclude(rezultat__startswith="W BPP jest identycznie jak w XLSX")` — tak
+działa filtr „pokaż tylko różnice" w
+`src/import_polon/views/plik_polon.py:197-199`. Dla statystyk to nie wystarczy,
+i to z dwóch niezależnych powodów.
+
+**Powód pierwszy — ORCID doklejany po sentinelu.** `_sync_autor_dyscyplina`
+dokłada sentinel w `core/import_polon.py:431`, ale główna pętla dokłada potem
+operacje ORCID (`core/import_polon.py:597-598`):
+
+```python
+orcid_ops = _update_autor_orcid(autor, orcid, parent_model)
+ops.extend(orcid_ops)
+rezultat = ", ".join(ops)
+```
+
+Wiersz, który realnie ustawił autorowi ORCID, ma
+`rezultat == "W BPP jest identycznie jak w XLSX, Ustawiam ORCID. "` — czyli
+zaczyna się od sentinela, a mimo to jest zmianą.
+
+**Powód drugi — sentinel ma wariant z sufiksem.** W `core/import_polon.py:253`
+(gałąź „autor nie ma wpisu za ten rok, a plik nie niesie dyscyplin"):
+
+```python
+ops.append("W BPP jest identycznie jak w XLSX (brak danych o dyscyplinach).")
+```
+
+To również „bez zmian", ale tekst jest inny. Naiwne `op != SENTINEL`
+policzyłoby taki wiersz jako zmianę i systematycznie zawyżało metrykę.
+
+**Rozwiązanie.** Jawny zbiór komunikatów oznaczających brak zmian, sprawdzany
+przez dokładne dopasowanie — nie przez `startswith`:
+
+```python
+KOMUNIKAT_BEZ_ZMIAN = "W BPP jest identycznie jak w XLSX"
+KOMUNIKAT_BEZ_ZMIAN_BRAK_DYSCYPLIN = (
+    f"{KOMUNIKAT_BEZ_ZMIAN} (brak danych o dyscyplinach)."
+)
+KOMUNIKATY_BEZ_ZMIAN = frozenset(
+    {KOMUNIKAT_BEZ_ZMIAN, KOMUNIKAT_BEZ_ZMIAN_BRAK_DYSCYPLIN}
+)
+
+zmieniono = any(op not in KOMUNIKATY_BEZ_ZMIAN for op in ops)
+```
+
+`startswith` byłby tą samą krchą klasą rozwiązania, co pierwotny błąd:
+działałby przypadkiem, dopóki ktoś nie doda trzeciego komunikatu zaczynającego
+się tak samo, ale znaczącego zmianę. Zbiór dokładnych dopasowań **wymusza**
+rejestrację każdego nowego komunikatu „bez zmian" — nowy tekst spoza zbioru
+domyślnie liczy się jako zmiana, co jest bezpieczną stroną pomyłki.
+
+## Architektura
+
+### 1. Stałe komunikatów
+
+Tekst sentinela żyje dziś w trzech miejscach niezależnie
+(`core/import_polon.py:253`, `core/import_polon.py:431`,
+`views/plik_polon.py:198`). Wyciągamy stałe do `core/import_polon.py`,
+budując wariant z sufiksem z bazowego przez f-string, i importujemy
+`KOMUNIKAT_BEZ_ZMIAN` w widoku (filtr `startswith` w widoku pozostaje
+poprawny — oba komunikaty zaczynają się od bazowego).
+
+To celowana poprawka w obrębie zmienianego obszaru, nie refaktor przy okazji:
+bez niej statystyki dołożyłyby czwartą kopię tego samego napisu.
+
+### 2. Statystyki jako podział zupełny i rozłączny
+
+`analyze_file_import_polon()` prowadzi licznik inkrementowany w tych samych
+gałęziach, które już decydują o losie wiersza, i zwraca słownik (dziś funkcja
+nie ma `return`, więc zwraca `None`).
+
+Rdzeniem projektu jest **partycja**: każdy wiersz pliku wpada do dokładnie
+jednego z sześciu koszyków, a ich suma równa się `wierszy_w_pliku`. To nie
+jest kosmetyka — daje asercję możliwą do sprawdzenia w teście, która wychwyci
+każdą przyszłą gałąź `continue` dodaną bez aktualizacji liczników.
+
+| Koszyk | Kiedy | Miejsce w kodzie |
+|---|---|---|
+| `odrzuconych_zatrudnienie` | `ZATRUDNIENIE` nie zaczyna się od nazwy uczelni | `core/import_polon.py:497-509` |
+| `odrzuconych_obca_uczelnia` | dopasowany autor należy do innej uczelni | `core/import_polon.py:530-545` |
+| `ukrytych_niedopasowanych` | autor niedopasowany + `ukryj_niezmatchowanych_autorow` | `core/import_polon.py:548-549` |
+| `z_bledem` | `bledy` niepuste → nic nie synchronizowano | `core/import_polon.py:578-579` |
+| `ze_zmianami` | brak `bledy`, `ops` zawiera cokolwiek spoza `KOMUNIKATY_BEZ_ZMIAN` | `core/import_polon.py:580-600` |
+| `bez_zmian` | brak `bledy`, wszystkie `ops` w `KOMUNIKATY_BEZ_ZMIAN` | jw. |
+
+Partycja jest szczelna, bo w pętli istnieje dokładnie ta rozłączna kaskada:
+trzy `continue`, a potem gałąź `if bledy: … else: …` — wiersz albo ma błędy
+(i wtedy nic nie synchronizuje), albo produkuje `ops`.
+
+Ponadto dwa liczniki **ortogonalne** do partycji (celowo przecinające
+koszyki, więc nie sumujące się z nimi):
+
+| Licznik | Znaczenie |
+|---|---|
+| `dopasowanych` | `matchuj_autora()` znalazł Autora — niezależnie od tego, czy wiersz skończył w `z_bledem`, `ze_zmianami` czy `bez_zmian` |
+| `do_odpiecia` | `parent_model.autorzy_niezmatchowani().count()`, liczone raz po pętli |
+
+### 3. Wartości pochodne i świadome ustalenia
+
+- **`z_uczelni`** nie jest przechowywane — liczone w szablonie jako
+  `wierszy_w_pliku − odrzuconych_zatrudnienie`.
+- **Przy `ignoruj_miejsce_pracy=True`** `odrzuconych_zatrudnienie` wynosi
+  `None`, a kolumna „z uczelni" pokazuje **„n/d"**. Walidacja `ZATRUDNIENIE`
+  była wtedy wyłączona (`core/import_polon.py:492`), więc każda liczba w tej
+  kolumnie byłaby zmyślona. Lepiej powiedzieć „nie wiem" niż podać
+  `wierszy_w_pliku` udające pomiar.
+- **`ze_zmianami` w trybie podglądu** (`zapisz_zmiany_do_bazy=False`) znaczy
+  „ile zmian **zostałoby** wprowadzonych". Ta sama liczba, inne znaczenie —
+  rozróżnienie niesie badge trybu w kolumnie statusu oraz `title=` na
+  nagłówku kolumny.
+- **Kolumny się nie sumują.** `dopasowanych` przecina `z_bledem`,
+  `ze_zmianami` i `bez_zmian`; `w pliku` obejmuje wiersze, których w bazie nie
+  ma. Każdy nagłówek liczbowy dostaje `title=` z jednozdaniową definicją —
+  bez tego użytkownik będzie próbował te liczby dodawać.
+- **`do_odpiecia` to migawka z chwili importu**, podczas gdy
+  `ImportPolonResultsView` liczy `unmatched_count` na żywo
+  (`views/plik_polon.py:231-234`). Po późniejszych zmianach w bazie lista i
+  strona wyników mogą pokazać różne wartości. Akceptujemy to świadomie:
+  liczenie na żywo dla 10 importów kosztuje 10 ciężkich zapytań na każde
+  wejście na listę, a liczba na liście ma odpowiadać na pytanie „co ten
+  import zastał", nie „jaki jest stan teraz".
+
+### 4. Zapis do `result_context`
+
+Bez migracji — `LiveOperation.result_context` to istniejące pole `JSONField`
+(`liveops/models.py:47`), zapisywane przez `p.result()`. Zweryfikowane:
+`p.result()` **nadpisuje** `result_context` w całości, więc musi dostać
+komplet danych w jednym wywołaniu.
+
+`_uruchom_import()` (`src/import_polon/models.py:53-73`) jest współdzielony z
+importem absencji, którego rdzeń nadal nie zwraca nic — scalanie musi być
+odporne na `None`:
+
+```python
+def _uruchom_import(parent, p, analyze):
+    try:
+        wynik = analyze(parent.plik.path, parent, p)
+    except Exception:
+        ...  # bez zmian
+    p.result({"total": parent.get_details_set().count(), **(wynik or {})})
+```
+
+Kształt — statystyki **zagnieżdżone** pod jednym kluczem, żeby nie mieszały
+się z polami wyniku liveops:
+
+```python
+{"total": 1156,
+ "statystyki": {"wierszy_w_pliku": 1284,
+                "odrzuconych_zatrudnienie": 94,
+                "odrzuconych_obca_uczelnia": 0,
+                "ukrytych_niedopasowanych": 0,
+                "z_bledem": 34,
+                "ze_zmianami": 87,
+                "bez_zmian": 1069,
+                "dopasowanych": 1156,
+                "do_odpiecia": 12}}
+```
+
+(94 + 0 + 0 + 34 + 87 + 1069 = 1284 — partycja się domyka.)
+
+`analyze_file_import_polon` zwraca `{"statystyki": {...}}`, `_uruchom_import`
+tylko scala. Klucz `total` zostaje nietknięty.
+
+### 5. Skracanie nazwy pliku
+
+Czysta funkcja w `src/import_polon/utils.py`:
+
+```python
+def skroc_nazwe_pliku(sciezka, limit=36):
+    """'protected/import_polon/rozszerzone_….xlsx' → 'rozszerzone_zestawie…_2026-01-15.xlsx'"""
+```
+
+- Katalog obcinany przez `os.path.basename`, nie przez usunięcie
+  zahardkodowanego `protected/import_polon/` — działa dla dowolnego
+  `upload_to` i nie psuje się przy jego zmianie.
+- Wycinany jest **środek**, nie koniec: ogon nazwy zawiera datę i rozszerzenie,
+  czyli jedyną część odróżniającą kolejne raporty POLON.
+- Nazwa nie dłuższa niż `limit` wraca bez zmian (brak `…`).
+- Pusta nazwa (`plik` niewypełniony) wraca jako pusty napis.
+- Funkcja czysta, bez Django — testowalna bez bazy.
+
+Model `ImportPlikuPolon` dostaje dwie właściwości:
+
+- `nazwa_pliku_skrocona` → `skroc_nazwe_pliku(self.plik.name)`,
+- `statystyki` → `(self.result_context or {}).get("statystyki")`, żeby szablon
+  nie łańcuchował `result_context.statystyki` po polu, które bywa `None`.
+
+### 6. Szablon
+
+`importplikupolon_list.html`: `<ul>` → `<table class="compact-table">`.
+
+Klasa `compact-table` jest już definiowana w tym appie inline
+(`wierszimportuplikupolon_list.html:16-39`) — nowy szablon idzie tą samą
+konwencją. Nie dotykamy SCSS-a, więc `grunt build` nie jest potrzebny.
+
+```
+                                    │        z pliku POLON         │  wynik
+Plik                     Rok Status │  w pliku  z uczelni  dopasow.│ zmian  błędów  do odpięcia
+────────────────────────────────────┼──────────────────────────────┼──────────────────────────
+rozszerzone_zestaw…15.xlsx  2025  ✓ │   1 284      1 190     1 156 │    87      34          12
+  utworzono 15.01 09:12               podgląd
+```
+
+- **Plik** — `nazwa_pliku_skrocona` jako link do `get_absolute_url`, `title` z
+  pełną ścieżką (`object.plik.name`); badge uczelni gdy `object.uczelnia` (jak
+  dziś, `importplikupolon_list.html:22`); pod spodem daty utworzenia i
+  ukończenia mniejszym drukiem.
+- **Rok** — `object.rok`; nowa informacja, dziś nigdzie na liście niewidoczna.
+- **Status** — badge `w trakcie` / `✓ pomyślnie` / `✗ błąd` z `finished_on` +
+  `finished_successfully`, pod nim badge trybu `podgląd` (secondary) /
+  `zapisany do bazy` (success).
+- Sześć kolumn liczbowych, każda z `title=` (patrz „kolumny się nie sumują").
+- Ikony: Foundation-Icons (`fi-*`), zgodnie z regułą dla frontendu publicznego.
+- Komentarze Django: każdy `{# … #}` w jednej linii.
+
+**Trzy różne stany pustki**, rozróżniane jawnie:
+
+| Stan | Warunek w szablonie | Wyświetlenie |
+|---|---|---|
+| brak statystyk (import stary, w trakcie, anulowany lub zakończony błędem) | `{% if object.statystyki %}` fałsz | `—` we wszystkich kolumnach |
+| `odrzuconych_zatrudnienie is None` (walidacja wyłączona) | `\|default_if_none:"n/d"` | `n/d` w kolumnie „z uczelni" |
+| liczba zerowa | — | `0` |
+
+`default_if_none` jest tu istotny: zwykły `default` potraktowałby `0` jak brak
+wartości i pokazał `n/d` zamiast prawdziwego zera.
+
+Tabela w `<div style="overflow-x:auto">` — dziewięć kolumn nie zmieści się na
+wąskim ekranie. Klas gridu Foundation (`medium-*`, `large-*`) nie ruszamy.
+
+Zachowujemy istniejące przekierowanie na `./nowy`, gdy lista jest pusta
+(`importplikupolon_list.html:30-34`).
+
+## Zgodność wsteczna
+
+- Brak migracji — wykorzystujemy istniejące `JSONField`.
+- Stare importy renderują się z `—` w kolumnach liczbowych.
+- Restart importu oraz akcja „zapisz do bazy" idą przez ten sam
+  `analyze_file_import_polon`, więc przeliczają statystyki bez dodatkowej
+  ścieżki kodu.
+- Import absencji: `analyze_file_import_absencji` nadal zwraca `None`, więc
+  jego `result_context` pozostaje dokładnie `{"total": n}`.
+
+## Testy
+
+Konwencja repo: pytest, funkcje bez klas, `model_bakery.baker.make`,
+`@pytest.mark.django_db` tam, gdzie baza jest potrzebna.
+
+**`src/import_polon/tests/test_liveops.py` — aktualizacja istniejącego testu.**
+`test_run_finalizuje_polon` (linia 40) asertuje dziś
+`imp.result_context == {"total": n}` — ścisła równość, którą ta zmiana łamie.
+Zmieniamy na sprawdzenie `result_context["total"] == n` plus obecności i
+kształtu `result_context["statystyki"]`. `test_run_finalizuje_absencji`
+(linia 55) zostaje bez zmian — i to jest celowe: pilnuje, że import absencji
+nie dostał statystyk przypadkiem.
+
+**`src/import_polon/tests/test_utils.py` — rozszerzenie istniejącego pliku**
+(zawiera już testy `read_excel_or_csv_dataframe_guess_encoding`). Bez bazy:
+- nazwa krótsza niż limit wraca bez zmian, bez `…`,
+- nazwa dokładnie na granicy limitu wraca bez zmian,
+- nazwa dłuższa niż limit zachowuje rozszerzenie i ogon z datą oraz mieści się
+  w limicie,
+- ścieżka z katalogiem gubi katalog,
+- pusty napis wraca jako pusty napis.
+
+**`src/import_polon/tests/test_import_polon_core.py`:**
+- partycja się domyka: suma sześciu koszyków `== wierszy_w_pliku`,
+- **regresja na sentinel z sufiksem**: wiersz kończący się komunikatem
+  `KOMUNIKAT_BEZ_ZMIAN_BRAK_DYSCYPLIN` liczy się do `bez_zmian`, nie do
+  `ze_zmianami`,
+- **regresja na pułapkę ORCID**: wiersz zmieniający wyłącznie ORCID liczy się
+  do `ze_zmianami`, mimo że jego `rezultat` zaczyna się od
+  `KOMUNIKAT_BEZ_ZMIAN`,
+- `ignoruj_miejsce_pracy=True` → `odrzuconych_zatrudnienie is None`,
+- wiersz odrzucony przez walidację `ZATRUDNIENIE` wchodzi do
+  `odrzuconych_zatrudnienie`, a nie do `z_bledem`,
+- `ukryj_niezmatchowanych_autorow=True`: `wierszy_w_pliku` > liczba
+  `WierszImportuPlikuPolon`, a różnicę widać w `ukrytych_niedopasowanych`,
+- nakładanie się liczników ortogonalnych: wiersz z dopasowanym autorem, ale
+  błędem dyscypliny, wchodzi jednocześnie do `dopasowanych` i `z_bledem`,
+- plik o zerowej liczbie wierszy danych: same zera, `do_odpiecia` policzone,
+- plik o błędnym formacie: wyjątek przed pętlą, `p.result` się nie woła,
+  `result_context` pozostaje `None` (statystyki nie powstają).
+
+**Test widoku `PokazImporty`:**
+- lista renderuje się dla importu bez `statystyki` (stary import) i pokazuje `—`,
+- lista renderuje się dla importu ze `statystyki` i pokazuje liczby,
+- `odrzuconych_zatrudnienie=None` → „n/d"; `0` → `0`, nie „n/d",
+- skrócona nazwa pliku w treści, pełna ścieżka w `title`.
+
+## Newsfragment
+
+`src/bpp/newsfragments/import-polon-statystyki-listy.feature.rst` — lista
+importów POLON pokazuje teraz tabelę ze statystykami i skróconą nazwą pliku.
+
+## Poza zakresem
+
+- Lista importów absencji — bez zmian.
+- Sortowanie i filtrowanie tabeli importów — nie było o to prośby, a lista
+  jest ograniczona do 10 pozycji (`PokazImporty.max_previous_ops`).
+- Doliczanie statystyk dla starych importów wstecz — pokazują `—`.
+- Rozbicie zmian na typy operacji (osobno dyscyplina / procent / ORCID /
+  rodzaj autora) — odrzucone jako zbyt drobiazgowe na listę zbiorczą.

--- a/docs/superpowers/specs/2026-08-03-import-polon-statystyki-listy-design.md
+++ b/docs/superpowers/specs/2026-08-03-import-polon-statystyki-listy-design.md
@@ -124,6 +124,23 @@ poprawny — oba komunikaty zaczynają się od bazowego).
 To celowana poprawka w obrębie zmienianego obszaru, nie refaktor przy okazji:
 bez niej statystyki dołożyłyby czwartą kopię tego samego napisu.
 
+### 1a. Ujednolicenie filtru „pokaż tylko różnice" (wynik self-review PR-a)
+
+Filtr w `views/plik_polon.py` wycinał wiersze przez
+`exclude(rezultat__startswith=KOMUNIKAT_BEZ_ZMIAN)`. Po dołożeniu licznika
+„zmian" obie strony zaczęłyby sobie przeczyć: wiersz ustawiający wyłącznie
+ORCID jest liczony jako zmiana (bo `ops` zawiera operację ORCID), ale jego
+`rezultat` zaczyna się od sentinela — więc filtr by go **ukrył**. Import
+ustawiający ORCID trzem autorom pokazywałby na liście „zmian: 3", a po
+wejściu w szczegóły i włączeniu filtru — zero wierszy.
+
+Filtr przechodzi więc na dokładne dopasowanie
+`exclude(rezultat__in=KOMUNIKATY_BEZ_ZMIAN)`, czyli tę samą semantykę, co
+licznik. Skutek uboczny: to naprawia istniejącą wadę — zmiany samego ORCID-a
+były dotąd niewidoczne w „pokaż tylko różnice". Filtr nie miał żadnego
+pokrycia testowego; dostaje dwa testy (wiersz ORCID-owy widoczny, wiersz bez
+zmian nadal ukryty).
+
 ### 2. Statystyki jako podział zupełny i rozłączny
 
 `analyze_file_import_polon()` prowadzi licznik inkrementowany w tych samych
@@ -241,6 +258,9 @@ def skroc_nazwe_pliku(sciezka, limit=36):
   czyli jedyną część odróżniającą kolejne raporty POLON.
 - Nazwa nie dłuższa niż `limit` wraca bez zmian (brak `…`).
 - Pusta nazwa (`plik` niewypełniony) wraca jako pusty napis.
+- Ogon składany jawnym warunkiem, nie ujemnym indeksem: `nazwa[-0:]` zwraca
+  w Pythonie **cały** napis, więc przy bardzo małym limicie naiwna wersja
+  oddawała wynik dłuższy od wejścia (złapane w self-review PR-a).
 - Funkcja czysta, bez Django — testowalna bez bazy.
 
 Model `ImportPlikuPolon` dostaje dwie właściwości:

--- a/docs/superpowers/specs/2026-08-03-import-polon-statystyki-listy-design.md
+++ b/docs/superpowers/specs/2026-08-03-import-polon-statystyki-listy-design.md
@@ -158,8 +158,11 @@ koszyki, więc nie sumujące się z nimi):
 
 ### 3. Wartości pochodne i świadome ustalenia
 
-- **`z_uczelni`** nie jest przechowywane — liczone w szablonie jako
-  `wierszy_w_pliku − odrzuconych_zatrudnienie`.
+- **`z_uczelni`** nie jest przechowywane — liczone jako
+  `wierszy_w_pliku − odrzuconych_zatrudnienie` we właściwości
+  `ImportPlikuPolon.statystyki` (nie w szablonie: szablon Django nie ma
+  arytmetyki, a wartość pochodna utrwalona obok składników by się z nimi
+  rozjechała).
 - **Przy `ignoruj_miejsce_pracy=True`** `odrzuconych_zatrudnienie` wynosi
   `None`, a kolumna „z uczelni" pokazuje **„n/d"**. Walidacja `ZATRUDNIENIE`
   była wtedy wyłączona (`core/import_polon.py:492`), więc każda liczba w tej

--- a/src/bpp/newsfragments/import-polon-statystyki-listy.feature.rst
+++ b/src/bpp/newsfragments/import-polon-statystyki-listy.feature.rst
@@ -1,0 +1,5 @@
+Lista importów POLON pokazuje teraz tabelę ze statystykami każdego importu:
+ile wierszy miał plik, ilu autorów dotyczyło uczelni, ilu dopasowano do bazy,
+ile wierszy zmieniono, ile zakończyło się błędem oraz ilu autorów kwalifikuje
+się do odpięcia. Nazwa pliku jest skracana (pełna widoczna w dymku), a rok
+importu widoczny wprost na liście.

--- a/src/import_polon/core/import_polon.py
+++ b/src/import_polon/core/import_polon.py
@@ -15,6 +15,40 @@ from import_common.core import matchuj_autora, matchuj_dyscypline, normalize_dat
 from import_polon.models import ImportPlikuPolon, WierszImportuPlikuPolon
 from import_polon.utils import read_excel_or_csv_dataframe_guess_encoding
 
+# Komunikaty oznaczające „w bazie jest już to samo, co w pliku".
+#
+# Zbiór sprawdzamy DOKŁADNYM dopasowaniem, nie ``startswith``. Powód: gdyby
+# ktoś dopisał kiedyś trzeci komunikat zaczynający się tak samo, ale ZNACZĄCY
+# zmianę, prefiksowe dopasowanie po cichu zaliczyłoby go do „bez zmian".
+# Przy dokładnym dopasowaniu nowy tekst spoza zbioru domyślnie liczy się jako
+# zmiana — to bezpieczniejsza strona pomyłki, a dopisanie go do zbioru jest
+# świadomą decyzją.
+#
+# ``views.plik_polon`` filtruje wiersze po PREFIKSIE ``KOMUNIKAT_BEZ_ZMIAN``
+# i pozostaje poprawny, bo oba warianty się od niego zaczynają.
+KOMUNIKAT_BEZ_ZMIAN = "W BPP jest identycznie jak w XLSX"
+KOMUNIKAT_BEZ_ZMIAN_BRAK_DYSCYPLIN = (
+    f"{KOMUNIKAT_BEZ_ZMIAN} (brak danych o dyscyplinach)."
+)
+KOMUNIKATY_BEZ_ZMIAN = frozenset(
+    {KOMUNIKAT_BEZ_ZMIAN, KOMUNIKAT_BEZ_ZMIAN_BRAK_DYSCYPLIN}
+)
+
+# Liczniki tworzące PODZIAŁ ZUPEŁNY I ROZŁĄCZNY wierszy pliku: każdy wiersz
+# wpada do dokładnie jednego koszyka, a ich suma == ``wierszy_w_pliku``.
+# Gwarantuje to kaskada w ``analyze_file_import_polon``: trzy ``continue``,
+# a potem rozłączne ``if bledy: … else: …``. Test pilnuje, że suma się domyka —
+# dzięki temu dołożenie w przyszłości kolejnej gałęzi ``continue`` bez
+# aktualizacji licznika zapali się na czerwono, zamiast po cichu zgubić wiersze.
+KLUCZE_PARTYCJI = (
+    "odrzuconych_zatrudnienie",
+    "odrzuconych_obca_uczelnia",
+    "ukrytych_niedopasowanych",
+    "z_bledem",
+    "ze_zmianami",
+    "bez_zmian",
+)
+
 
 def _normalize_zatrudnienie_date(value):
     dt = normalize_date(value)
@@ -250,7 +284,7 @@ def _create_new_autor_dyscyplina(
             )
         ops.append("Brak wpisu dla tego roku, utworzono zgodnie z XLSX")
     else:
-        ops.append("W BPP jest identycznie jak w XLSX (brak danych o dyscyplinach).")
+        ops.append(KOMUNIKAT_BEZ_ZMIAN_BRAK_DYSCYPLIN)
     return ops
 
 
@@ -428,7 +462,7 @@ def _sync_autor_dyscyplina(
                     autor_id=ad.autor_id, rok=ad.rok
                 )
     else:
-        ops.append("W BPP jest identycznie jak w XLSX")
+        ops.append(KOMUNIKAT_BEZ_ZMIAN)
 
     return ops
 
@@ -445,6 +479,22 @@ def _update_autor_orcid(autor, orcid, parent_model):
         if parent_model.zapisz_zmiany_do_bazy:
             autor.save()
     return ops
+
+
+def _domknij_statystyki(parent_model, statystyki):
+    """Uzupełnia liczniki o to, co da się ustalić dopiero po całej pętli."""
+    if parent_model.ignoruj_miejsce_pracy:
+        # Walidacja ZATRUDNIENIE była wyłączona, więc licznik nie jest „zero" —
+        # jest „nie mierzono". Zero sugerowałoby, że sprawdzono i nikt nie
+        # odpadł. ``None`` przechodzi przez JSON, a szablon pokaże „n/d".
+        statystyki["odrzuconych_zatrudnienie"] = None
+
+    # Jedno ciężkie zapytanie (Autor_Dyscyplina × kiedykolwiek_zatrudnieni ×
+    # Count prac) — raz, tutaj. Liczone przy renderowaniu listy kosztowałoby
+    # tyle zapytań, ile importów na stronie.
+    statystyki["do_odpiecia"] = parent_model.autorzy_niezmatchowani().count()
+
+    return statystyki
 
 
 def analyze_file_import_polon(fn, parent_model: ImportPlikuPolon, p):
@@ -483,6 +533,16 @@ def analyze_file_import_polon(fn, parent_model: ImportPlikuPolon, p):
 
     records = data.to_dict("records")
     total = len(records)
+
+    # Liczniki do ``result_context`` — pokazywane na liście importów. Część z
+    # nich (ile wierszy miał plik, ilu autorów przepadło po cichu) NIE JEST
+    # odtwarzalna z bazy po zakończeniu importu, bo wiersze niedopasowane przy
+    # ``ukryj_niezmatchowanych_autorow`` w ogóle nie trafiają do
+    # ``WierszImportuPlikuPolon`` — stąd liczenie w locie, a nie zapytaniem.
+    statystyki = dict.fromkeys(KLUCZE_PARTYCJI, 0)
+    statystyki["wierszy_w_pliku"] = total
+    statystyki["dopasowanych"] = 0
+
     # ``p.track`` aktualizuje pasek postępu (throttlowany) i sprawdza anulowanie
     # przed każdym wierszem — zastępuje ręczne ``send_progress`` z każdej gałęzi.
     for n_row, row in p.track(
@@ -506,6 +566,7 @@ def analyze_file_import_polon(fn, parent_model: ImportPlikuPolon, p):
                         zatrudnienie, parent_model.uczelnia
                     ),
                 )
+                statystyki["odrzuconych_zatrudnienie"] += 1
                 continue
 
         # Match author
@@ -542,11 +603,19 @@ def analyze_file_import_polon(fn, parent_model: ImportPlikuPolon, p):
                     f"modyfikować danych obcej uczelni."
                 ),
             )
+            statystyki["odrzuconych_obca_uczelnia"] += 1
             continue
 
         # Skip unmatched authors if configured
         if autor is None and parent_model.ukryj_niezmatchowanych_autorow:
+            statystyki["ukrytych_niedopasowanych"] += 1
             continue
+
+        # Licznik ORTOGONALNY do partycji — przecina koszyki ``z_bledem``,
+        # ``ze_zmianami`` i ``bez_zmian``, więc NIE sumuje się z nimi. Liczymy
+        # go dopiero tutaj, po guardzie obcej uczelni: „dopasowany" znaczy
+        # „rozpoznany jako NASZ autor", a nie „gdziekolwiek trafiony".
+        statystyki["dopasowanych"] += int(autor is not None)
 
         # Process disciplines
         bledy = []
@@ -577,6 +646,7 @@ def analyze_file_import_polon(fn, parent_model: ImportPlikuPolon, p):
         # Generate result
         if bledy:
             rezultat = ". ".join(bledy)
+            statystyki["z_bledem"] += 1
         else:
             # Sync author discipline data
             ops = _sync_autor_dyscyplina(
@@ -597,6 +667,13 @@ def analyze_file_import_polon(fn, parent_model: ImportPlikuPolon, p):
             orcid_ops = _update_autor_orcid(autor, orcid, parent_model)
             ops.extend(orcid_ops)
 
+            # Klasyfikujemy po STRUKTURZE ``ops``, nie po sklejonym ``rezultat``.
+            # Parsowanie tekstu dałoby tu błąd: operacja ORCID doklejana jest PO
+            # sentinelu, więc wiersz zmieniający wyłącznie ORCID ma ``rezultat``
+            # zaczynający się od „W BPP jest identycznie…", choć jest zmianą.
+            zmieniono = any(op not in KOMUNIKATY_BEZ_ZMIAN for op in ops)
+            statystyki["ze_zmianami" if zmieniono else "bez_zmian"] += 1
+
             rezultat = ", ".join(ops)
 
         # Create result record
@@ -609,3 +686,5 @@ def analyze_file_import_polon(fn, parent_model: ImportPlikuPolon, p):
             subdyscyplina_naukowa=subdyscyplina_xlsx,
             rezultat=rezultat,
         )
+
+    return {"statystyki": _domknij_statystyki(parent_model, statystyki)}

--- a/src/import_polon/models.py
+++ b/src/import_polon/models.py
@@ -52,7 +52,12 @@ class _LiveopsResetMixin:
 
 def _uruchom_import(parent, p, analyze):
     """Wspólny ``run`` dla obu importów: woła rdzeń z liveops ``Progress`` i
-    finalizuje wynikiem (``total`` z wierszy-dzieci).
+    finalizuje wynikiem (``total`` z wierszy-dzieci + to, co zwrócił rdzeń).
+
+    Rdzeń może zwrócić dodatkowy kontekst wyniku (import POLON zwraca
+    ``{"statystyki": {...}}``); import absencji nie zwraca nic, stąd ``or {}``.
+    ``p.result`` NADPISUJE ``result_context`` w całości, więc scalamy w jednym
+    wywołaniu.
 
     ``liveops.runner._handle_error`` zapisuje traceback WYŁĄCZNIE do pola
     ``traceback`` (bez śladu na konsoli workera i bez rollbara). Owijamy
@@ -60,7 +65,7 @@ def _uruchom_import(parent, p, analyze):
     (konsola celery/run-site) + rollbar (konwencja bg-tasków), po czym
     re-raise — liveops i tak zapisze traceback do bazy i pokaże błąd w UI."""
     try:
-        analyze(parent.plik.path, parent, p)
+        wynik = analyze(parent.plik.path, parent, p)
     except Exception:
         import sys
         import traceback as _traceback
@@ -70,7 +75,7 @@ def _uruchom_import(parent, p, analyze):
         _traceback.print_exc()
         rollbar.report_exc_info(sys.exc_info())
         raise
-    p.result({"total": parent.get_details_set().count()})
+    p.result({"total": parent.get_details_set().count(), **(wynik or {})})
 
 
 class ImportPlikuAbsencji(_LiveopsResetMixin, LiveOperation):
@@ -135,6 +140,40 @@ class ImportPlikuPolon(_LiveopsResetMixin, LiveOperation):
         from import_polon.core import analyze_file_import_polon
 
         _uruchom_import(self, p, analyze_file_import_polon)
+
+    @property
+    def nazwa_pliku_skrocona(self):
+        """Nazwa pliku bez katalogu i z wyciętym środkiem — do tabeli na liście."""
+        from import_polon.utils import skroc_nazwe_pliku
+
+        return skroc_nazwe_pliku(self.plik.name)
+
+    @property
+    def statystyki(self):
+        """Liczniki zapisane przez rdzeń importu (+ wartość pochodna), albo ``None``.
+
+        ``None`` dla importów sprzed wprowadzenia statystyk oraz dla tych, które
+        nie doszły do ``p.result`` (w trakcie, anulowane, zakończone błędem).
+        Osobna właściwość, bo szablon nie może bezpiecznie łańcuchować po
+        ``result_context``, które bywa ``None``.
+
+        ``z_uczelni`` liczymy TUTAJ, a nie w szablonie, bo szablon Django nie ma
+        arytmetyki; nie zapisujemy jej też do bazy, bo wartość pochodna
+        utrwalona obok składników prędzej czy później się z nimi rozjedzie.
+        """
+        dane = (self.result_context or {}).get("statystyki")
+        if dane is None:
+            return None
+
+        odrzuconych = dane.get("odrzuconych_zatrudnienie")
+        return {
+            **dane,
+            # ``None`` (walidacja ZATRUDNIENIE wyłączona) propaguje się dalej —
+            # szablon pokaże „n/d", a nie zmyśloną liczbę.
+            "z_uczelni": (
+                None if odrzuconych is None else dane["wierszy_w_pliku"] - odrzuconych
+            ),
+        }
 
     def get_details_set(self):
         return WierszImportuPlikuPolon.objects.filter(parent=self)

--- a/src/import_polon/models.py
+++ b/src/import_polon/models.py
@@ -166,12 +166,18 @@ class ImportPlikuPolon(_LiveopsResetMixin, LiveOperation):
             return None
 
         odrzuconych = dane.get("odrzuconych_zatrudnienie")
+        # ``.get``, nie ``[...]``: to dane z bazy, nie inwariant kodu. Niekompletny
+        # JSON (ręczna edycja, import z przyszłej wersji rdzenia) nie może wywalić
+        # 500 na CAŁEJ liście — property nie jest wyciszane przez resolver szablonu.
+        wierszy = dane.get("wierszy_w_pliku")
         return {
             **dane,
             # ``None`` (walidacja ZATRUDNIENIE wyłączona) propaguje się dalej —
             # szablon pokaże „n/d", a nie zmyśloną liczbę.
             "z_uczelni": (
-                None if odrzuconych is None else dane["wierszy_w_pliku"] - odrzuconych
+                None
+                if odrzuconych is None or wierszy is None
+                else wierszy - odrzuconych
             ),
         }
 

--- a/src/import_polon/templates/import_polon/importplikupolon_list.html
+++ b/src/import_polon/templates/import_polon/importplikupolon_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}{% load render_table from django_tables2 %}
+{% extends "base.html" %}
 
 {% block extratitle %}
     Import z POLON
@@ -9,27 +9,152 @@
     <li><a href="{% url "import_polon:index" %}">import POLON</a></li>
 {% endblock %}
 
-{% block content %}{% load static %}
+{% block content %}
+    <style>
+        /* Konwencja tego appu: styl inline przy szablonie, jak w */
+        /* wierszimportuplikupolon_list.html — bez dotykania SCSS-a. */
+        .importy-table {
+            font-size: 0.85rem;
+            margin-bottom: 0.5rem;
+            width: 100%;
+        }
+        .importy-table th,
+        .importy-table td {
+            padding: 0.4rem 0.5rem !important;
+            line-height: 1.3;
+            vertical-align: top;
+        }
+        .importy-table th {
+            font-weight: 600;
+            font-size: 0.8rem;
+            white-space: nowrap;
+        }
+        .importy-table .liczba {
+            text-align: right;
+            white-space: nowrap;
+            font-variant-numeric: tabular-nums;
+        }
+        .importy-table .grupa-lewa {
+            border-left: 1px solid #ddd !important;
+        }
+        .importy-table .meta {
+            font-size: 0.75rem;
+            color: #6c757d;
+            display: block;
+            margin-top: 0.15rem;
+        }
+        .importy-table .brak {
+            color: #6c757d;
+            font-style: italic;
+        }
+        .importy-table .label {
+            margin-bottom: 0.1rem;
+        }
+        /* Dziewięć kolumn nie mieści się na wąskim ekranie. Przewijamy sam */
+        /* kontener tabeli — klas gridu Foundation NIE nadpisujemy. */
+        .importy-scroll {
+            overflow-x: auto;
+        }
+        .importy-legenda {
+            font-size: 0.75rem;
+            color: #6c757d;
+            margin-bottom: 1.5rem;
+        }
+    </style>
+
     <h1>Ostatnio importowane dane:
-    <a class="button success" id="add-new-file" href="./nowy">
+        <a class="button success" id="add-new-file" href="{% url "import_polon:utworz-import" %}">
             <i class="fi-page-add"></i>
             utwórz nowy import
         </a>
     </h1>
-    <ul>
-        {% for object in object_list %}
-            <li>
-                <a href="{{ object.get_absolute_url }}">plik {{ object.plik.name }}</a>{% if object.uczelnia %} <span class="label secondary">{{ object.uczelnia }}</span>{% endif %}:
-                import utworzono {{ object.created_on }}{% if object.finished_on %}, ukończono {{ object.finished_on }}
-                {% if object.finished_successfully %}, zakończono pomyślnie{% else %}, zakończono z błędem{% endif %}
-            {% endif %}
-            </li>
-        {% endfor %}
-    </ul>
+
+    <div class="importy-scroll">
+        <table class="importy-table">
+            <thead>
+                <tr>
+                    <th rowspan="2">Plik</th>
+                    <th rowspan="2">Rok</th>
+                    <th rowspan="2">Status</th>
+                    <th colspan="3" class="grupa-lewa">z pliku POLON</th>
+                    <th colspan="3" class="grupa-lewa">wynik importu</th>
+                </tr>
+                <tr>
+                    <th class="liczba grupa-lewa"
+                        title="Liczba wierszy danych w pliku POLON">w pliku</th>
+                    <th class="liczba"
+                        title="Wiersze, których pole ZATRUDNIENIE zaczyna się od nazwy uczelni. „n/d" gdy walidacja miejsca pracy była wyłączona.">z uczelni</th>
+                    <th class="liczba"
+                        title="Wiersze, dla których udało się wskazać autora w bazie BPP">dopasowanych</th>
+                    <th class="liczba grupa-lewa"
+                        title="Wiersze, dla których import coś zmienił. Przy imporcie w trybie podglądu: ile zmian zostałoby wprowadzonych.">zmian</th>
+                    <th class="liczba"
+                        title="Wiersze pominięte z powodu błędu — np. nierozpoznana dyscyplina, brak wymiaru etatu, niedopasowany autor">błędów</th>
+                    <th class="liczba"
+                        title="Autorzy z przypisaną dyscypliną na rok importu, których nie było w pliku. Stan z chwili importu.">do odpięcia</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for object in object_list %}
+                    <tr>
+                        <td>
+                            <a href="{{ object.get_absolute_url }}"
+                               title="{{ object.plik.name }}">{{ object.nazwa_pliku_skrocona }}</a>
+                            {% if object.uczelnia %}
+                                <span class="label secondary">{{ object.uczelnia }}</span>
+                            {% endif %}
+                            <span class="meta">
+                                utworzono {{ object.created_on }}{% if object.finished_on %}, ukończono {{ object.finished_on }}{% endif %}
+                            </span>
+                        </td>
+
+                        <td>{{ object.rok }}</td>
+
+                        <td>
+                            {% if not object.finished_on %}
+                                <span class="label secondary"><i class="fi-clock"></i> w trakcie</span>
+                            {% elif object.finished_successfully %}
+                                <span class="label success"><i class="fi-check"></i> pomyślnie</span>
+                            {% else %}
+                                <span class="label alert"><i class="fi-x"></i> błąd</span>
+                            {% endif %}
+                            <span class="meta">
+                                {% if object.zapisz_zmiany_do_bazy %}zapisany do bazy{% else %}podgląd{% endif %}
+                            </span>
+                        </td>
+
+                        {% with s=object.statystyki %}
+                            {% if s %}
+                                <td class="liczba grupa-lewa">{{ s.wierszy_w_pliku }}</td>
+                                {# default_if_none, NIE default — „0" to prawdziwy pomiar, nie brak danych #}
+                                <td class="liczba">{{ s.z_uczelni|default_if_none:"n/d" }}</td>
+                                <td class="liczba">{{ s.dopasowanych }}</td>
+                                <td class="liczba grupa-lewa">{{ s.ze_zmianami }}</td>
+                                <td class="liczba">{{ s.z_bledem }}</td>
+                                <td class="liczba">{{ s.do_odpiecia }}</td>
+                            {% else %}
+                                <td colspan="6" class="brak grupa-lewa"
+                                    title="Import sprzed wprowadzenia statystyk albo niezakończony (w trakcie, anulowany, zakończony błędem)">
+                                    brak statystyk
+                                </td>
+                            {% endif %}
+                        {% endwith %}
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <p class="importy-legenda">
+        Liczby w kolumnach opisują różne przekroje i <strong>nie sumują się</strong>:
+        wiersz z dopasowanym autorem może jednocześnie zakończyć się błędem, a wiersze
+        z niedopasowanym autorem nie są zapisywane i widać je tylko jako różnicę między
+        kolumnami. Najedź na nagłówek kolumny, żeby zobaczyć jej definicję.
+    </p>
 
     {% if object_list.count == 0 %}
         <script>
-            location.href = "./nowy";
+            location.href = "{% url "import_polon:utworz-import" %}";
         </script>
     {% endif %}
 

--- a/src/import_polon/templates/import_polon/importplikupolon_list.html
+++ b/src/import_polon/templates/import_polon/importplikupolon_list.html
@@ -83,9 +83,9 @@
                     <th class="liczba grupa-lewa"
                         title="Liczba wierszy danych w pliku POLON">w pliku</th>
                     <th class="liczba"
-                        title="Wiersze, których pole ZATRUDNIENIE zaczyna się od nazwy uczelni. „n/d" gdy walidacja miejsca pracy była wyłączona.">z uczelni</th>
+                        title="Wiersze, których pole ZATRUDNIENIE zaczyna się od nazwy uczelni. &quot;n/d&quot; gdy walidacja miejsca pracy była wyłączona.">z uczelni</th>
                     <th class="liczba"
-                        title="Wiersze, dla których udało się wskazać autora w bazie BPP">dopasowanych</th>
+                        title="Wiersze, dla których udało się wskazać autora w bazie BPP należącego do uczelni tego importu">dopasowanych</th>
                     <th class="liczba grupa-lewa"
                         title="Wiersze, dla których import coś zmienił. Przy imporcie w trybie podglądu: ile zmian zostałoby wprowadzonych.">zmian</th>
                     <th class="liczba"

--- a/src/import_polon/tests/test_liveops.py
+++ b/src/import_polon/tests/test_liveops.py
@@ -37,7 +37,9 @@ def test_run_finalizuje_polon(admin_user, fn_test_import_polon):
     assert imp.finished_successfully is True
     n = imp.get_details_set().count()
     assert n > 0, "run() musi utworzyć wiersze-dzieci"
-    assert imp.result_context == {"total": n}
+    assert imp.result_context["total"] == n
+    # Rdzeń POLON dokłada do wyniku statystyki pokazywane na liście importów.
+    assert imp.statystyki["wierszy_w_pliku"] > 0
 
 
 @pytest.mark.django_db
@@ -52,6 +54,9 @@ def test_run_finalizuje_absencji(admin_user, fn_test_import_absencji):
     assert imp.finished_successfully is True
     n = imp.get_details_set().count()
     assert n > 0
+    # Ścisła równość CELOWO: import absencji nie ma dostać statystyk przypadkiem
+    # (rdzeń absencji nadal nie zwraca nic, więc ``or {}`` w _uruchom_import
+    # musi zadziałać).
     assert imp.result_context == {"total": n}
 
 

--- a/src/import_polon/tests/test_statystyki.py
+++ b/src/import_polon/tests/test_statystyki.py
@@ -1,0 +1,371 @@
+"""Testy liczników importu POLON pokazywanych na liście ``/import_polon/dane/``.
+
+Liczniki powstają w locie, w pętli importu, bo część z nich NIE JEST odtwarzalna
+z bazy po fakcie: wiersze z niedopasowanym autorem przy
+``ukryj_niezmatchowanych_autorow`` nie trafiają do ``WierszImportuPlikuPolon``
+w ogóle (pilnuje tego ``test_ukryci_niedopasowani_nie_trafiaja_do_bazy``).
+"""
+
+import pandas as pd
+import pytest
+from django.contrib.auth.models import Group
+from django.core.files import File
+from django.urls import reverse
+from django.utils import timezone
+from liveops.testing import MockProgress
+from model_bakery import baker
+
+from bpp.models import Autor
+from import_polon.core.import_polon import (
+    KLUCZE_PARTYCJI,
+    KOMUNIKAT_BEZ_ZMIAN,
+    KOMUNIKAT_BEZ_ZMIAN_BRAK_DYSCYPLIN,
+    analyze_file_import_polon,
+)
+from import_polon.models import ImportPlikuPolon, WierszImportuPlikuPolon
+
+
+def _wiersz(uczelnia, **nadpisania):
+    """Minimalny wiersz POLON przechodzący walidację dla danej uczelni.
+
+    Bez dyscyplin (``OSWIADCZENIE_* = nie``), więc dopasowany autor wpada w
+    gałąź „brak danych o dyscyplinach" — czyli w komunikat bez zmian z sufiksem.
+    """
+    dane = {
+        "IMIE": "Jan",
+        "NAZWISKO": "Kowalski",
+        "ZATRUDNIENIE": f"{uczelnia.nazwa} (Nauczyciel akademicki)",
+        "ORCID": "",
+        "OSWIADCZENIE_N": "nie",
+        "OSWIADCZENIE_O_DYSCYPLINACH": "nie",
+        "WIELKOSC_ETATU_PREZENTACJA_DZIESIETNA": "1.0",
+    }
+    dane.update(nadpisania)
+    return dane
+
+
+def _uruchom(tmp_path, wiersze, **kwargs_importu):
+    """Zapisuje wiersze do xlsx-a i puszcza import. Zwraca (import, statystyki)."""
+    plik = tmp_path / "polon.xlsx"
+    pd.DataFrame(wiersze).to_excel(plik, index=False)
+
+    kwargs_importu.setdefault("zapisz_zmiany_do_bazy", False)
+    imp = baker.make(ImportPlikuPolon, rok=2023, **kwargs_importu)
+    with open(plik, "rb") as f:
+        imp.plik.save("polon.xlsx", File(f))
+
+    wynik = analyze_file_import_polon(str(plik), imp, MockProgress(imp))
+    return imp, wynik["statystyki"]
+
+
+@pytest.mark.django_db
+def test_partycja_sie_domyka(tmp_path, uczelnia):
+    """Suma sześciu koszyków == liczba wierszy pliku.
+
+    To asercja strukturalna, nie kosmetyczna: gdy ktoś doda w pętli kolejną
+    gałąź ``continue`` bez inkrementacji licznika, wiersze przestaną się
+    bilansować i ten test zapali się na czerwono.
+    """
+    wiersze = [
+        _wiersz(uczelnia),  # autor niedopasowany → ukryty
+        _wiersz(uczelnia, ZATRUDNIENIE="Zupełnie Inna Uczelnia"),  # odrzucony
+    ]
+    _, statystyki = _uruchom(tmp_path, wiersze)
+
+    assert statystyki["wierszy_w_pliku"] == 2
+    assert sum(statystyki[k] or 0 for k in KLUCZE_PARTYCJI) == 2
+
+
+@pytest.mark.django_db
+def test_odrzucenie_zatrudnienia_nie_jest_bledem(tmp_path, uczelnia):
+    """Wiersz obcej uczelni to nie „błąd importu" — to wiersz spoza zakresu."""
+    _, statystyki = _uruchom(
+        tmp_path, [_wiersz(uczelnia, ZATRUDNIENIE="Zupełnie Inna Uczelnia")]
+    )
+
+    assert statystyki["odrzuconych_zatrudnienie"] == 1
+    assert statystyki["z_bledem"] == 0
+    assert statystyki["dopasowanych"] == 0
+
+
+@pytest.mark.django_db
+def test_ignoruj_miejsce_pracy_daje_none_a_nie_zero(tmp_path, uczelnia):
+    """Wyłączona walidacja to „nie mierzono", nie „nikt nie odpadł"."""
+    _, statystyki = _uruchom(
+        tmp_path,
+        [_wiersz(uczelnia, ZATRUDNIENIE="Zupełnie Inna Uczelnia")],
+        ignoruj_miejsce_pracy=True,
+    )
+
+    assert statystyki["odrzuconych_zatrudnienie"] is None
+
+
+@pytest.mark.django_db
+def test_ukryci_niedopasowani_nie_trafiaja_do_bazy(tmp_path, uczelnia):
+    """Uzasadnienie całego projektu: tych wierszy NIE DA SIĘ policzyć po fakcie."""
+    imp, statystyki = _uruchom(tmp_path, [_wiersz(uczelnia)])
+
+    assert statystyki["wierszy_w_pliku"] == 1
+    assert statystyki["ukrytych_niedopasowanych"] == 1
+    assert WierszImportuPlikuPolon.objects.filter(parent=imp).count() == 0
+
+
+@pytest.mark.django_db
+def test_brak_dyscyplin_liczy_sie_jako_bez_zmian(tmp_path, uczelnia):
+    """REGRESJA: sentinel ma wariant z sufiksem.
+
+    ``"W BPP jest identycznie jak w XLSX (brak danych o dyscyplinach)."`` też
+    znaczy „nic się nie zmieniło". Porównanie ``op != KOMUNIKAT_BEZ_ZMIAN``
+    policzyłoby ten wiersz jako zmianę i zawyżało metrykę przy każdym imporcie.
+    """
+    baker.make(Autor, imiona="Jan", nazwisko="Kowalski")
+
+    imp, statystyki = _uruchom(
+        tmp_path, [_wiersz(uczelnia)], ukryj_niezmatchowanych_autorow=False
+    )
+
+    wiersz = WierszImportuPlikuPolon.objects.get(parent=imp)
+    assert wiersz.rezultat == KOMUNIKAT_BEZ_ZMIAN_BRAK_DYSCYPLIN
+    assert statystyki["bez_zmian"] == 1
+    assert statystyki["ze_zmianami"] == 0
+    assert statystyki["dopasowanych"] == 1
+
+
+@pytest.mark.django_db
+def test_sam_orcid_liczy_sie_jako_zmiana(tmp_path, uczelnia):
+    """REGRESJA: operacja ORCID jest doklejana PO sentinelu.
+
+    ``rezultat`` takiego wiersza zaczyna się od „W BPP jest identycznie…",
+    choć autorowi realnie ustawiono ORCID. Klasyfikowanie po sklejonym tekście
+    (``startswith``) zgubiłoby tę zmianę — dlatego liczymy po strukturze ``ops``.
+    """
+    baker.make(Autor, imiona="Jan", nazwisko="Kowalski", orcid=None)
+
+    imp, statystyki = _uruchom(
+        tmp_path,
+        [_wiersz(uczelnia, ORCID="0000-0002-1825-0097")],
+        ukryj_niezmatchowanych_autorow=False,
+    )
+
+    wiersz = WierszImportuPlikuPolon.objects.get(parent=imp)
+    assert wiersz.rezultat.startswith(KOMUNIKAT_BEZ_ZMIAN), (
+        "warunek wstępny testu: bez tego test nie pilnuje opisanej pułapki"
+    )
+    assert statystyki["ze_zmianami"] == 1
+    assert statystyki["bez_zmian"] == 0
+
+
+@pytest.mark.django_db
+def test_dopasowany_z_bledem_wchodzi_do_obu_licznikow(tmp_path, uczelnia):
+    """``dopasowanych`` jest ORTOGONALNY do partycji — kolumny się nie sumują."""
+    baker.make(Autor, imiona="Jan", nazwisko="Kowalski")
+
+    _, statystyki = _uruchom(
+        tmp_path,
+        [_wiersz(uczelnia, WIELKOSC_ETATU_PREZENTACJA_DZIESIETNA=None)],
+        ukryj_niezmatchowanych_autorow=False,
+    )
+
+    assert statystyki["dopasowanych"] == 1
+    assert statystyki["z_bledem"] == 1
+    assert statystyki["ze_zmianami"] == 0
+
+
+@pytest.mark.django_db
+def test_pusty_plik_daje_same_zera(tmp_path, uczelnia):
+    plik = tmp_path / "pusty.xlsx"
+    pd.DataFrame(columns=list(_wiersz(uczelnia).keys())).to_excel(plik, index=False)
+
+    imp = baker.make(ImportPlikuPolon, rok=2023, zapisz_zmiany_do_bazy=False)
+    wynik = analyze_file_import_polon(str(plik), imp, MockProgress(imp))
+    statystyki = wynik["statystyki"]
+
+    assert statystyki["wierszy_w_pliku"] == 0
+    assert all(statystyki[k] == 0 for k in KLUCZE_PARTYCJI)
+    assert statystyki["do_odpiecia"] == 0
+
+
+@pytest.mark.django_db
+def test_nieczytelny_plik_nie_zostawia_statystyk(tmp_path, uczelnia):
+    """Wyjątek leci PRZED pętlą, więc ``p.result`` się nie woła — lista pokaże „—"."""
+    plik = tmp_path / "zly.txt"
+    plik.write_text("to nie jest arkusz")
+
+    imp = baker.make(ImportPlikuPolon, rok=2023, zapisz_zmiany_do_bazy=False)
+
+    with pytest.raises(ValueError):
+        analyze_file_import_polon(str(plik), imp, MockProgress(imp))
+
+    assert imp.statystyki is None
+
+
+# --- lista importów: renderowanie tabeli -------------------------------------
+
+NAZWA_POLON = (
+    "protected/import_polon/rozszerzone_zestawienie_pracownikow_podmiotu_"
+    "na_dzien_wygenerowania_raportu_2026-01-15.xlsx"
+)
+
+
+@pytest.fixture
+def klient_wprowadzajacy(client, django_user_model):
+    """Zalogowany użytkownik w grupie wymaganej przez ``PokazImporty``."""
+    user = django_user_model.objects.create_user(username="wprowadzajacy", password="x")
+    user.groups.add(Group.objects.get_or_create(name="wprowadzanie danych")[0])
+    client.force_login(user)
+    return client, user
+
+
+def _import_na_liscie(owner, statystyki=None, **nadpisania):
+    kontekst = None if statystyki is None else {"total": 1, "statystyki": statystyki}
+    # ``finished_on`` OBOWIĄZKOWE: badge statusu kluczuje po nim, a nie po
+    # ``finished_successfully``. Liveops zawsze ustawia oba naraz — samo
+    # ``finished_successfully=True`` dałoby nierealny obiekt „ukończony, ale
+    # bez daty ukończenia" i test renderowałby badge „w trakcie".
+    nadpisania.setdefault("finished_on", timezone.now())
+    nadpisania.setdefault("finished_successfully", True)
+    return baker.make(
+        ImportPlikuPolon,
+        owner=owner,
+        rok=2023,
+        plik=NAZWA_POLON,
+        result_context=kontekst,
+        **nadpisania,
+    )
+
+
+@pytest.mark.django_db
+def test_lista_pokazuje_statystyki(klient_wprowadzajacy):
+    client, user = klient_wprowadzajacy
+    _import_na_liscie(
+        user,
+        {
+            "wierszy_w_pliku": 41,
+            "odrzuconych_zatrudnienie": 4,
+            "odrzuconych_obca_uczelnia": 0,
+            "ukrytych_niedopasowanych": 0,
+            "z_bledem": 7,
+            "ze_zmianami": 13,
+            "bez_zmian": 17,
+            "dopasowanych": 37,
+            "do_odpiecia": 5,
+        },
+    )
+
+    tresc = client.get(reverse("import_polon:index")).content.decode()
+
+    assert ">41<" in tresc, "liczba wierszy w pliku"
+    assert ">37<" in tresc, "dopasowanych"
+    assert ">13<" in tresc, "ze zmianami"
+    assert ">5<" in tresc, "do odpięcia"
+    # z_uczelni jest pochodną: 41 − 4
+    assert ">37<" in tresc
+
+
+@pytest.mark.django_db
+def test_lista_bez_statystyk_nie_sypie(klient_wprowadzajacy):
+    """Import sprzed wprowadzenia statystyk — tabela ma się wyrenderować."""
+    client, user = klient_wprowadzajacy
+    _import_na_liscie(user, statystyki=None)
+
+    response = client.get(reverse("import_polon:index"))
+
+    assert response.status_code == 200
+    assert "brak statystyk" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_lista_skraca_nazwe_pliku_zachowujac_pelna_w_tytule(klient_wprowadzajacy):
+    client, user = klient_wprowadzajacy
+    _import_na_liscie(user, statystyki=None)
+
+    tresc = client.get(reverse("import_polon:index")).content.decode()
+
+    assert "protected/import_polon" not in tresc.split('title="')[0]
+    assert f'title="{NAZWA_POLON}"' in tresc, "pełna ścieżka zostaje w tooltipie"
+    assert "…" in tresc, "nazwa skrócona wielokropkiem"
+
+
+@pytest.mark.django_db
+def test_lista_pokazuje_nd_gdy_walidacja_wylaczona(klient_wprowadzajacy):
+    client, user = klient_wprowadzajacy
+    _import_na_liscie(
+        user,
+        {
+            "wierszy_w_pliku": 41,
+            "odrzuconych_zatrudnienie": None,
+            "odrzuconych_obca_uczelnia": 0,
+            "ukrytych_niedopasowanych": 4,
+            "z_bledem": 0,
+            "ze_zmianami": 20,
+            "bez_zmian": 17,
+            "dopasowanych": 37,
+            "do_odpiecia": 5,
+        },
+    )
+
+    tresc = client.get(reverse("import_polon:index")).content.decode()
+
+    # ">n/d<" celuje w KOMÓRKĘ; samo "n/d" trafiłoby też w tooltip nagłówka.
+    assert ">n/d<" in tresc
+
+
+@pytest.mark.django_db
+def test_lista_pokazuje_zero_a_nie_nd(klient_wprowadzajacy):
+    """``default_if_none``, nie ``default`` — zero to pomiar, nie brak danych."""
+    client, user = klient_wprowadzajacy
+    _import_na_liscie(
+        user,
+        {
+            "wierszy_w_pliku": 41,
+            "odrzuconych_zatrudnienie": 41,
+            "odrzuconych_obca_uczelnia": 0,
+            "ukrytych_niedopasowanych": 0,
+            "z_bledem": 0,
+            "ze_zmianami": 0,
+            "bez_zmian": 0,
+            "dopasowanych": 0,
+            "do_odpiecia": 5,
+        },
+    )
+
+    tresc = client.get(reverse("import_polon:index")).content.decode()
+
+    assert ">n/d<" not in tresc, "z_uczelni == 0 musi się pokazać jako 0"
+    assert ">0<" in tresc
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "pola,oczekiwany_badge",
+    [
+        ({"finished_on": None, "finished_successfully": False}, "w trakcie"),
+        ({"finished_successfully": True}, "pomyślnie"),
+        ({"finished_successfully": False}, "błąd"),
+    ],
+)
+def test_lista_pokazuje_badge_statusu(klient_wprowadzajacy, pola, oczekiwany_badge):
+    """Badge kluczuje po ``finished_on``, nie po ``finished_successfully``.
+
+    Bez ``finished_on`` operacja jest „w trakcie" — nawet gdy flaga sukcesu
+    jest podniesiona. Ten test pilnuje obu wymiarów naraz.
+    """
+    client, user = klient_wprowadzajacy
+    _import_na_liscie(user, statystyki=None, **pola)
+
+    tresc = client.get(reverse("import_polon:index")).content.decode()
+
+    assert oczekiwany_badge in tresc
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "zapisz,oczekiwany_tryb",
+    [(True, "zapisany do bazy"), (False, "podgląd")],
+)
+def test_lista_pokazuje_tryb_importu(klient_wprowadzajacy, zapisz, oczekiwany_tryb):
+    """Tryb rozstrzyga, czy „zmian" znaczy „wprowadzono", czy „wprowadzono by"."""
+    client, user = klient_wprowadzajacy
+    _import_na_liscie(user, statystyki=None, zapisz_zmiany_do_bazy=zapisz)
+
+    assert oczekiwany_tryb in client.get(reverse("import_polon:index")).content.decode()

--- a/src/import_polon/tests/test_statystyki.py
+++ b/src/import_polon/tests/test_statystyki.py
@@ -23,6 +23,7 @@ from import_polon.core.import_polon import (
     analyze_file_import_polon,
 )
 from import_polon.models import ImportPlikuPolon, WierszImportuPlikuPolon
+from import_polon.utils import skroc_nazwe_pliku
 
 
 def _wiersz(uczelnia, **nadpisania):
@@ -60,20 +61,54 @@ def _uruchom(tmp_path, wiersze, **kwargs_importu):
 
 @pytest.mark.django_db
 def test_partycja_sie_domyka(tmp_path, uczelnia):
-    """Suma sześciu koszyków == liczba wierszy pliku.
+    """Suma koszyków == liczba wierszy pliku, przy KAŻDYM koszyku niepustym.
 
-    To asercja strukturalna, nie kosmetyczna: gdy ktoś doda w pętli kolejną
-    gałąź ``continue`` bez inkrementacji licznika, wiersze przestaną się
-    bilansować i ten test zapali się na czerwono.
+    Asercja strukturalna, nie kosmetyczna: gdy ktoś doda w pętli kolejną gałąź
+    ``continue`` bez inkrementacji licznika, wiersze przestaną się bilansować.
+    Scenariusz celowo aktywuje wszystkie gałęzie naraz — test na dwóch
+    koszykach dawałby fałszywe poczucie pokrycia.
     """
+    baker.make(Autor, imiona="Jan", nazwisko="Kowalski")
+    baker.make(Autor, imiona="Maria", nazwisko="Zmieniona", orcid=None)
+    baker.make(Autor, imiona="Piotr", nazwisko="Bledny")
+
     wiersze = [
-        _wiersz(uczelnia),  # autor niedopasowany → ukryty
-        _wiersz(uczelnia, ZATRUDNIENIE="Zupełnie Inna Uczelnia"),  # odrzucony
+        # → odrzuconych_zatrudnienie
+        _wiersz(uczelnia, ZATRUDNIENIE="Zupełnie Inna Uczelnia"),
+        # → ukrytych_niedopasowanych (autora nie ma w bazie)
+        _wiersz(uczelnia, NAZWISKO="Nieistniejacy"),
+        # → bez_zmian (dopasowany, brak dyscyplin w pliku)
+        _wiersz(uczelnia),
+        # → ze_zmianami (dopasowany, ustawiany ORCID)
+        _wiersz(
+            uczelnia, NAZWISKO="Zmieniona", IMIE="Maria", ORCID="0000-0002-1825-0097"
+        ),
+        # → z_bledem (dopasowany, brak wymiaru etatu)
+        _wiersz(
+            uczelnia,
+            NAZWISKO="Bledny",
+            IMIE="Piotr",
+            WIELKOSC_ETATU_PREZENTACJA_DZIESIETNA=None,
+        ),
     ]
+    # ``ukryj_niezmatchowanych_autorow`` domyślnie włączone — dzięki temu wiersz
+    # z nieistniejącym autorem trafia do ``ukrytych_niedopasowanych``, a nie do
+    # ``z_bledem``. Wiersze z dopasowanym autorem przechodzą normalnie.
     _, statystyki = _uruchom(tmp_path, wiersze)
 
-    assert statystyki["wierszy_w_pliku"] == 2
-    assert sum(statystyki[k] or 0 for k in KLUCZE_PARTYCJI) == 2
+    assert statystyki["wierszy_w_pliku"] == 5
+    assert sum(statystyki[k] or 0 for k in KLUCZE_PARTYCJI) == 5
+
+    # Każdy z aktywowanych koszyków musi być niepusty — inaczej test bilansuje
+    # sumę zer i nie pilnuje niczego.
+    for koszyk in (
+        "odrzuconych_zatrudnienie",
+        "ukrytych_niedopasowanych",
+        "z_bledem",
+        "ze_zmianami",
+        "bez_zmian",
+    ):
+        assert statystyki[koszyk] > 0, f"scenariusz nie aktywował koszyka {koszyk}"
 
 
 @pytest.mark.django_db
@@ -237,6 +272,8 @@ def _import_na_liscie(owner, statystyki=None, **nadpisania):
 @pytest.mark.django_db
 def test_lista_pokazuje_statystyki(klient_wprowadzajacy):
     client, user = klient_wprowadzajacy
+    # Każda metryka MUSI mieć inną wartość — gdy dwie się pokrywają, asercja
+    # podłańcuchowa trafia w pierwszą z brzegu i nie odróżnia ich od siebie.
     _import_na_liscie(
         user,
         {
@@ -247,19 +284,19 @@ def test_lista_pokazuje_statystyki(klient_wprowadzajacy):
             "z_bledem": 7,
             "ze_zmianami": 13,
             "bez_zmian": 17,
-            "dopasowanych": 37,
+            "dopasowanych": 30,
             "do_odpiecia": 5,
         },
     )
 
     tresc = client.get(reverse("import_polon:index")).content.decode()
 
-    assert ">41<" in tresc, "liczba wierszy w pliku"
-    assert ">37<" in tresc, "dopasowanych"
+    assert ">41<" in tresc, "wierszy w pliku"
+    assert ">37<" in tresc, "z uczelni — pochodna: 41 − 4"
+    assert ">30<" in tresc, "dopasowanych"
     assert ">13<" in tresc, "ze zmianami"
+    assert ">7<" in tresc, "z błędem"
     assert ">5<" in tresc, "do odpięcia"
-    # z_uczelni jest pochodną: 41 − 4
-    assert ">37<" in tresc
 
 
 @pytest.mark.django_db
@@ -281,9 +318,12 @@ def test_lista_skraca_nazwe_pliku_zachowujac_pelna_w_tytule(klient_wprowadzajacy
 
     tresc = client.get(reverse("import_polon:index")).content.decode()
 
-    assert "protected/import_polon" not in tresc.split('title="')[0]
+    # Asercja na TREŚĆ LINKU, nie na „tekst przed pierwszym title=" — pierwszy
+    # title= jest w <thead> (tooltipy nagłówków), więc taki prefiks nigdy nie
+    # obejmowałby wiersza tabeli i nie sprawdzałby niczego.
+    assert f">{skroc_nazwe_pliku(NAZWA_POLON)}</a>" in tresc
+    assert "protected/import_polon" not in skroc_nazwe_pliku(NAZWA_POLON)
     assert f'title="{NAZWA_POLON}"' in tresc, "pełna ścieżka zostaje w tooltipie"
-    assert "…" in tresc, "nazwa skrócona wielokropkiem"
 
 
 @pytest.mark.django_db
@@ -369,3 +409,89 @@ def test_lista_pokazuje_tryb_importu(klient_wprowadzajacy, zapisz, oczekiwany_tr
     _import_na_liscie(user, statystyki=None, zapisz_zmiany_do_bazy=zapisz)
 
     assert oczekiwany_tryb in client.get(reverse("import_polon:index")).content.decode()
+
+
+# --- property ImportPlikuPolon.statystyki ------------------------------------
+
+
+def _z_kontekstem(statystyki):
+    """Instancja bez zapisu do bazy — property jest czysta, baza niepotrzebna."""
+    return ImportPlikuPolon(result_context={"statystyki": statystyki})
+
+
+def test_property_statystyki_liczy_z_uczelni():
+    """Wprost na property — test przez HTML nie odróżniał odejmowania od dodawania."""
+    imp = _z_kontekstem({"wierszy_w_pliku": 41, "odrzuconych_zatrudnienie": 4})
+
+    assert imp.statystyki["z_uczelni"] == 37
+
+
+def test_property_statystyki_z_uczelni_none_gdy_nie_mierzono():
+    imp = _z_kontekstem({"wierszy_w_pliku": 41, "odrzuconych_zatrudnienie": None})
+
+    assert imp.statystyki["z_uczelni"] is None
+
+
+def test_property_statystyki_znosi_niekompletny_json():
+    """Dane z bazy, nie inwariant kodu — brak klucza nie może wywalić listy."""
+    imp = _z_kontekstem({"odrzuconych_zatrudnienie": 4})
+
+    assert imp.statystyki["z_uczelni"] is None
+
+
+def test_property_statystyki_bez_kontekstu():
+    assert ImportPlikuPolon(result_context=None).statystyki is None
+    assert ImportPlikuPolon(result_context={"total": 5}).statystyki is None
+
+
+# --- spójność licznika „zmian" z filtrem „pokaż tylko różnice" ---------------
+
+
+@pytest.mark.django_db
+def test_filtr_roznic_pokazuje_wiersz_zmieniajacy_sam_orcid(
+    tmp_path, uczelnia, klient_wprowadzajacy
+):
+    """REGRESJA: filtr i licznik muszą mówić to samo.
+
+    Wiersz ustawiający wyłącznie ORCID jest zmianą (liczy go ``ze_zmianami``),
+    ale jego ``rezultat`` zaczyna się od sentinela. Dawny filtr prefiksowy
+    ukrywał go — lista pokazywałaby „zmian: 1", a strona wyników po włączeniu
+    „pokaż tylko różnice" świeciłaby pustką.
+    """
+    client, user = klient_wprowadzajacy
+    baker.make(Autor, imiona="Jan", nazwisko="Kowalski", orcid=None)
+
+    imp, statystyki = _uruchom(
+        tmp_path,
+        [_wiersz(uczelnia, ORCID="0000-0002-1825-0097")],
+        owner=user,
+        ukryj_niezmatchowanych_autorow=False,
+        finished_successfully=True,
+    )
+    assert statystyki["ze_zmianami"] == 1, "warunek wstępny testu"
+
+    url = reverse("import_polon:importplikupolon-results", kwargs={"pk": imp.pk})
+    response = client.get(url, {"pokaz_tylko_roznice": "1"})
+
+    assert len(response.context["object_list"]) == 1
+
+
+@pytest.mark.django_db
+def test_filtr_roznic_ukrywa_wiersz_bez_zmian(tmp_path, uczelnia, klient_wprowadzajacy):
+    """Druga strona medalu: oba warianty komunikatu „bez zmian" nadal znikają."""
+    client, user = klient_wprowadzajacy
+    baker.make(Autor, imiona="Jan", nazwisko="Kowalski")
+
+    imp, statystyki = _uruchom(
+        tmp_path,
+        [_wiersz(uczelnia)],
+        owner=user,
+        ukryj_niezmatchowanych_autorow=False,
+        finished_successfully=True,
+    )
+    assert statystyki["bez_zmian"] == 1, "warunek wstępny testu"
+
+    url = reverse("import_polon:importplikupolon-results", kwargs={"pk": imp.pk})
+    response = client.get(url, {"pokaz_tylko_roznice": "1"})
+
+    assert len(response.context["object_list"]) == 0

--- a/src/import_polon/tests/test_utils.py
+++ b/src/import_polon/tests/test_utils.py
@@ -65,3 +65,18 @@ def test_skroc_nazwe_pliku_pusta():
     """``plik`` niewypełniony (FileField bez pliku) → pusty napis, nie wyjątek."""
     assert skroc_nazwe_pliku("") == ""
     assert skroc_nazwe_pliku(None) == ""
+
+
+@pytest.mark.parametrize("limit", [0, 1, 2, 3, 4, 10, 36])
+def test_skroc_nazwe_pliku_nigdy_nie_wydluza(limit):
+    """REGRESJA: ``nazwa[-0:]`` zwraca CAŁY napis, nie pusty.
+
+    Przy limicie 1 i 2 długość ogona wychodziła zerowa, a ujemny indeks
+    ``nazwa[-0:]`` wklejał z powrotem całą nazwę — wynik był DŁUŻSZY niż
+    wejście, czyli skracanie działało odwrotnie do zamierzenia.
+    """
+    wynik = skroc_nazwe_pliku(NAZWA_POLON, limit=limit)
+
+    assert len(wynik) <= len(NAZWA_POLON)
+    # Wielokropka nie da się zmieścić poniżej jednego znaku — poza tym limit trzyma.
+    assert len(wynik) <= max(limit, 1)

--- a/src/import_polon/tests/test_utils.py
+++ b/src/import_polon/tests/test_utils.py
@@ -2,7 +2,16 @@ from pathlib import Path
 
 import pytest
 
-from import_polon.utils import read_excel_or_csv_dataframe_guess_encoding
+from import_polon.utils import (
+    read_excel_or_csv_dataframe_guess_encoding,
+    skroc_nazwe_pliku,
+)
+
+# Realna nazwa eksportu z POLON-u — 84 znaki, część odróżniająca (data) na końcu.
+NAZWA_POLON = (
+    "rozszerzone_zestawienie_pracownikow_podmiotu_"
+    "na_dzien_wygenerowania_raportu_2026-01-15.xlsx"
+)
 
 
 @pytest.mark.parametrize(
@@ -15,3 +24,44 @@ from import_polon.utils import read_excel_or_csv_dataframe_guess_encoding
 def test_read_excel_or_csv_dataframe_guess_encoding(fn):
     res = read_excel_or_csv_dataframe_guess_encoding(fn)
     assert len(res) > 1
+
+
+def test_skroc_nazwe_pliku_krotka_bez_zmian():
+    assert skroc_nazwe_pliku("krotka.xlsx") == "krotka.xlsx"
+
+
+def test_skroc_nazwe_pliku_na_granicy_limitu():
+    """Nazwa dokładnie długości limitu NIE jest skracana (brak wielokropka)."""
+    nazwa = "a" * 32 + ".xls"  # dokładnie 36 znaków
+    assert len(nazwa) == 36
+    assert skroc_nazwe_pliku(nazwa, limit=36) == nazwa
+
+
+def test_skroc_nazwe_pliku_gubi_katalog():
+    """Prefiks z ``upload_to`` to szczegół implementacyjny — nie pokazujemy go."""
+    assert skroc_nazwe_pliku("protected/import_polon/krotka.xlsx") == "krotka.xlsx"
+
+
+def test_skroc_nazwe_pliku_dluga_miesci_sie_w_limicie():
+    wynik = skroc_nazwe_pliku(NAZWA_POLON, limit=36)
+    assert len(wynik) <= 36
+    assert "…" in wynik
+
+
+def test_skroc_nazwe_pliku_dluga_zachowuje_ogon_z_data():
+    """Ogon niesie datę i rozszerzenie — jedyne, co odróżnia kolejne raporty."""
+    wynik = skroc_nazwe_pliku(NAZWA_POLON, limit=36)
+    assert wynik.endswith("2026-01-15.xlsx")
+    assert wynik.startswith("rozszerzone")
+
+
+def test_skroc_nazwe_pliku_dluga_ze_sciezka():
+    wynik = skroc_nazwe_pliku(f"protected/import_polon/{NAZWA_POLON}", limit=36)
+    assert wynik.endswith("2026-01-15.xlsx")
+    assert "protected" not in wynik
+
+
+def test_skroc_nazwe_pliku_pusta():
+    """``plik`` niewypełniony (FileField bez pliku) → pusty napis, nie wyjątek."""
+    assert skroc_nazwe_pliku("") == ""
+    assert skroc_nazwe_pliku(None) == ""

--- a/src/import_polon/utils.py
+++ b/src/import_polon/utils.py
@@ -34,11 +34,15 @@ def skroc_nazwe_pliku(sciezka, limit=36):
     # Budżet znaków po odjęciu wielokropka, dzielony między początek i koniec.
     # Reszta z dzielenia idzie do początku — koniec ma zmieścić datę i
     # rozszerzenie, więc lepiej mu dać stabilną, przewidywalną długość.
-    budzet = limit - len(WIELOKROPEK)
+    budzet = max(limit - len(WIELOKROPEK), 0)
     dlugosc_ogona = budzet // 2
     dlugosc_glowy = budzet - dlugosc_ogona
 
-    return f"{nazwa[:dlugosc_glowy]}{WIELOKROPEK}{nazwa[-dlugosc_ogona:]}"
+    # ``nazwa[-0:]`` zwraca CAŁY napis, nie pusty — bez tego warunku skracanie
+    # do bardzo małego limitu dawało wynik DŁUŻSZY od wejścia.
+    ogon = nazwa[len(nazwa) - dlugosc_ogona :] if dlugosc_ogona else ""
+
+    return f"{nazwa[:dlugosc_glowy]}{WIELOKROPEK}{ogon}"
 
 
 def read_excel_or_csv_dataframe_guess_encoding(fn, header=0, nrows=None):

--- a/src/import_polon/utils.py
+++ b/src/import_polon/utils.py
@@ -1,8 +1,44 @@
+import os.path
 import sys
 
 import numpy as np
 import pandas as pd
 import rollbar
+
+# Znak wstawiany w miejsce wyciętego środka nazwy pliku.
+WIELOKROPEK = "…"
+
+
+def skroc_nazwe_pliku(sciezka, limit=36):
+    """Skraca nazwę pliku do wyświetlenia w tabeli, wycinając ŚRODEK.
+
+    Eksporty z POLON-u nazywają się np. ``rozszerzone_zestawienie_pracownikow_
+    podmiotu_na_dzien_wygenerowania_raportu_2026-01-15.xlsx`` — 90 znaków, z
+    czego odróżnia je wyłącznie data na końcu. Obcięcie od końca (``truncatechars``,
+    ``text-overflow: ellipsis``) zjadłoby właśnie tę datę, więc wycinamy środek
+    i zachowujemy oba końce.
+
+    Katalog gubimy przez ``basename``, a nie przez usunięcie zahardkodowanego
+    ``protected/import_polon/`` — dzięki temu funkcja przeżyje zmianę
+    ``upload_to`` w modelu.
+
+    Zwraca pusty napis dla pustej ścieżki (``FileField`` bez pliku).
+    """
+    if not sciezka:
+        return ""
+
+    nazwa = os.path.basename(str(sciezka))
+    if len(nazwa) <= limit:
+        return nazwa
+
+    # Budżet znaków po odjęciu wielokropka, dzielony między początek i koniec.
+    # Reszta z dzielenia idzie do początku — koniec ma zmieścić datę i
+    # rozszerzenie, więc lepiej mu dać stabilną, przewidywalną długość.
+    budzet = limit - len(WIELOKROPEK)
+    dlugosc_ogona = budzet // 2
+    dlugosc_glowy = budzet - dlugosc_ogona
+
+    return f"{nazwa[:dlugosc_glowy]}{WIELOKROPEK}{nazwa[-dlugosc_ogona:]}"
 
 
 def read_excel_or_csv_dataframe_guess_encoding(fn, header=0, nrows=None):

--- a/src/import_polon/views/plik_polon.py
+++ b/src/import_polon/views/plik_polon.py
@@ -8,6 +8,7 @@ from django.utils.functional import cached_property
 from django.views.generic import DetailView, ListView
 from liveops.views import CreateLiveOperationView, RestartView
 
+from import_polon.core.import_polon import KOMUNIKAT_BEZ_ZMIAN
 from import_polon.forms import NowyImportForm, WierszImportuPlikuPolonFilterForm
 from import_polon.models import ImportPlikuPolon
 
@@ -194,9 +195,10 @@ class ImportPolonResultsView(BaseImportPlikuPolonMixin, ListView):
 
         # Apply "show only differences" filter
         if pokaz_tylko_roznice:
-            queryset = queryset.exclude(
-                rezultat__startswith="W BPP jest identycznie jak w XLSX"
-            )
+            # Prefiks, nie równość: sentinel ma wariant z sufiksem
+            # (KOMUNIKAT_BEZ_ZMIAN_BRAK_DYSCYPLIN), a do wiersza bywa doklejana
+            # operacja ORCID. Oba warianty zaczynają się od tej stałej.
+            queryset = queryset.exclude(rezultat__startswith=KOMUNIKAT_BEZ_ZMIAN)
 
         return queryset
 

--- a/src/import_polon/views/plik_polon.py
+++ b/src/import_polon/views/plik_polon.py
@@ -8,7 +8,7 @@ from django.utils.functional import cached_property
 from django.views.generic import DetailView, ListView
 from liveops.views import CreateLiveOperationView, RestartView
 
-from import_polon.core.import_polon import KOMUNIKAT_BEZ_ZMIAN
+from import_polon.core.import_polon import KOMUNIKATY_BEZ_ZMIAN
 from import_polon.forms import NowyImportForm, WierszImportuPlikuPolonFilterForm
 from import_polon.models import ImportPlikuPolon
 
@@ -84,8 +84,12 @@ class PokazImporty(BaseImportPlikuPolonMixin, ListView):
         # importy uczelni Y właściciela.
         from bpp.models import Uczelnia
 
-        qset = self.model.objects.filter(owner=self.request.user).order_by(
-            "-created_on"
+        # select_related: szablon pokazuje badge uczelni przy KAŻDYM wierszu
+        # tabeli, więc bez tego wychodzi N+1 (do max_previous_ops zapytań).
+        qset = (
+            self.model.objects.filter(owner=self.request.user)
+            .select_related("uczelnia")
+            .order_by("-created_on")
         )
 
         uczelnia = Uczelnia.objects.get_for_request(self.request)
@@ -195,10 +199,13 @@ class ImportPolonResultsView(BaseImportPlikuPolonMixin, ListView):
 
         # Apply "show only differences" filter
         if pokaz_tylko_roznice:
-            # Prefiks, nie równość: sentinel ma wariant z sufiksem
-            # (KOMUNIKAT_BEZ_ZMIAN_BRAK_DYSCYPLIN), a do wiersza bywa doklejana
-            # operacja ORCID. Oba warianty zaczynają się od tej stałej.
-            queryset = queryset.exclude(rezultat__startswith=KOMUNIKAT_BEZ_ZMIAN)
+            # DOKŁADNE dopasowanie do zbioru komunikatów „bez zmian", nie prefiks.
+            # Prefiks (poprzednia wersja) ukrywał wiersz, któremu import ustawił
+            # WYŁĄCZNIE ORCID: operacja ORCID doklejana jest PO sentinelu, więc
+            # rezultat zaczyna się od „W BPP jest identycznie…", choć jest zmianą.
+            # Licznik „zmian" na liście importów liczy taki wiersz jako zmianę —
+            # bez tej poprawki obie strony przeczyłyby sobie nawzajem.
+            queryset = queryset.exclude(rezultat__in=KOMUNIKATY_BEZ_ZMIAN)
 
         return queryset
 


### PR DESCRIPTION
## Problem

`/import_polon/dane/` renderowała listę importów jako `<ul>`, jedno zdanie na import:

```
plik protected/import_polon/rozszerzone_zestawienie_pracownikow_podmiotu_na_dzien_wygenerowania_raportu_2026-01-15.xlsx:
import utworzono 15 stycznia 2026 09:12, ukończono …, zakończono pomyślnie
```

Prefiks `protected/import_polon/` to szczegół `upload_to`, nazwa eksportu z POLON-u
ma ~90 znaków (a odróżnia je wyłącznie data na końcu), i nie widać nic o zawartości
pliku ani nawet roku importu.

## Rozwiązanie

Tabela z sześcioma licznikami. Nazwa pliku skracana **wycięciem środka**, nie końca —
ogon niesie datę i rozszerzenie, więc `truncatechars`/`text-overflow` zjadłoby właśnie
część odróżniającą. Pełna ścieżka zostaje w `title=`.

| Plik | Rok | Status | w pliku | z uczelni | dopasow. | zmian | błędów | do odpięcia |
|---|---|---|---|---|---|---|---|---|
| `rozszerzone_zestaw…u_2026-01-15.xlsx` | 2025 | ✓ pomyślnie / podgląd | 1284 | 1190 | 1156 | 87 | 34 | 12 |

## Dlaczego liczniki, a nie zapytania

Części z tych liczb **nie da się policzyć po fakcie**: przy
`ukryj_niezmatchowanych_autorow` (domyślnie włączone) wiersz z niedopasowanym autorem
nie trafia do `WierszImportuPlikuPolon` w ogóle — `get_details_set().count()` ≠ liczba
wierszy pliku. Liczenie na żywo byłoby też drogie: `autorzy_niezmatchowani()` to
`Autor_Dyscyplina` × `kiedykolwiek_zatrudnieni()` × `annotate(Count(prace))`, razy
liczba importów na stronie.

Liczniki lądują w istniejącym `result_context` (`JSONField` z liveops) — **bez migracji**.

## Dwie pułapki, które to zmieniło w nietrywialne

Naturalny odruch to policzyć zmiany przez `exclude(rezultat__startswith="W BPP jest
identycznie jak w XLSX")` — tak działa istniejący filtr „pokaż tylko różnice". Dla
statystyk daje to **błędny wynik na dwa niezależne sposoby**:

1. **Operacja ORCID doklejana jest PO sentinelu.** Wiersz, który realnie ustawił
   autorowi ORCID, ma `rezultat` zaczynający się od „W BPP jest identycznie…".
2. **Sentinel ma wariant z sufiksem** — `"… (brak danych o dyscyplinach)."`. Naiwne
   `op != SENTINEL` policzyłoby go jako zmianę i systematycznie zawyżało metrykę.

Klasyfikujemy więc po **strukturze** listy `ops`, a nie po sklejonym tekście, przez
jawny `frozenset` komunikatów „bez zmian" (dokładne dopasowanie, nie `startswith` —
nowy komunikat spoza zbioru domyślnie liczy się jako zmiana, co jest bezpieczną stroną
pomyłki). Oba przypadki mają test regresji; sprawdziłem mutacyjnie, że test
`test_brak_dyscyplin_liczy_sie_jako_bez_zmian` faktycznie pada przy naiwnej implementacji.

Przy okazji: tekst sentinela żył w **trzech kopiach w dwóch plikach** — wyciągnięty
do stałych.

## Podział zupełny i rozłączny

Sześć liczników (`odrzuconych_zatrudnienie`, `odrzuconych_obca_uczelnia`,
`ukrytych_niedopasowanych`, `z_bledem`, `ze_zmianami`, `bez_zmian`) tworzy partycję —
`test_partycja_sie_domyka` sprawdza, że ich suma równa się liczbie wierszy pliku.
Dołożenie w przyszłości gałęzi `continue` bez aktualizacji licznika zapali się na
czerwono, zamiast po cichu gubić wiersze.

`dopasowanych` i `do_odpiecia` są **ortogonalne** do partycji (przecinają koszyki),
więc kolumny się nie sumują — mówi o tym legenda pod tabelą i `title=` na każdym
nagłówku.

## Świadome ustalenia

- **`z_uczelni` = „n/d" przy `ignoruj_miejsce_pracy=True`**, nie zero. Walidacja
  ZATRUDNIENIE była wtedy wyłączona, więc każda liczba byłaby zmyślona. W szablonie
  `default_if_none`, nie `default` — zero to prawdziwy pomiar, nie brak danych
  (jest na to test).
- **`do_odpiecia` to migawka z chwili importu**, podczas gdy strona wyników liczy to
  na żywo. Po późniejszych zmianach w bazie mogą się różnić. Liczba na liście
  odpowiada na pytanie „co ten import zastał", nie „jaki jest stan teraz".
- **Stare importy pokazują „brak statystyk"** — nie ma ścieżki doliczania wstecz.
- **Lista importów absencji nietknięta** (zgodnie z ustaleniem).

## Testy

`src/import_polon/tests/test_statystyki.py` — 19 testów: partycja, obie regresje,
`None` vs `0`, ukryci niedopasowani, pusty plik, nieczytelny plik, badge statusu
i trybu, skracanie nazwy. Plus rozszerzone `test_utils.py` (funkcja czysta, bez bazy).

`test_liveops.py::test_run_finalizuje_polon` asertował `result_context == {"total": n}`
— zaktualizowany. Bliźniaczy test dla absencji **celowo zostaje ze ścisłą równością**:
pilnuje, że import absencji nie dostał statystyk przypadkiem.

Lokalnie: `8869 passed, 5 skipped, 1 xfailed` (11:52, z Playwrightem). `ruff check`,
`ruff format`, `pre-commit` (w tym `djLint` i hook `Django {#`) — czysto.

Spec: `docs/superpowers/specs/2026-08-03-import-polon-statystyki-listy-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)