### PR TITLE
fix(powiazania_autorow): komunikat zamiast wyjątku, gdy brak WebGL-a (Rollbar #4006)

### DIFF
--- a/src/bpp/newsfragments/rollbar4006.bugfix.rst
+++ b/src/bpp/newsfragments/rollbar4006.bugfix.rst
@@ -1,0 +1,6 @@
+Widok 3D sieci powiązań autorów nie wywala się już na przeglądarkach bez
+WebGL-a: zamiast czarnego prostokąta i błędu w konsoli pokazuje komunikat
+z wyjaśnieniem i odsyłaczem do widoku 2D. Sieci powiązań (2D, 3D oraz
+zasilające je pliki JSON) zostały dodatkowo wyłączone spod indeksowania
+w ``robots.txt`` — dla robotów wyszukiwarek to sam koszt zapytań, bez
+żadnej treści do zaindeksowania.

--- a/src/bpp/static/robots.txt
+++ b/src/bpp/static/robots.txt
@@ -11,3 +11,7 @@ Disallow: /logout/
 Disallow: /admin/
 Disallow: /integrator2/
 Disallow: /password_change/
+# Sieci powiazan autorow (2D, 3D oraz zasilajace je *.json): cala tresc to
+# canvas rysowany JS-em, wiec crawler nie wyciaga stad ani znaku tekstu,
+# a kazde wejscie odpala BFS po wspolautorstwach z sumowaniem IF/PK.
+Disallow: /bpp/autor/*/powiazania/

--- a/src/bpp/tests/test_views/test_seo_metadata.py
+++ b/src/bpp/tests/test_views/test_seo_metadata.py
@@ -156,6 +156,29 @@ def test_robots_txt_wskazuje_sitemap(client):
     assert "Disallow:" in body
 
 
+@pytest.mark.django_db
+def test_robots_txt_blokuje_widoki_sieci_powiazan(client, settings, tmp_path):
+    """Sieci powiązań autorów muszą być wyłączone spod indeksowania.
+
+    Cała treść tych stron to canvas rysowany JS-em — crawler nie wyciąga
+    z nich ani znaku tekstu, a każde wejście odpala ``siec.json``, czyli
+    BFS po współautorstwach z sumowaniem IF/PK. Rollbar #4006: crawler
+    ``meta-externalagent`` przemiatał ``/powiazania/3d/`` autor po autorze,
+    generując wyłącznie koszt bazy i błędy WebGL-a.
+
+    ``STATIC_ROOT`` celuje w pusty katalog, żeby ``_read_static_robots``
+    poszło ścieżką staticfiles finders do ``src/bpp/static/robots.txt``.
+    Bez tego test czytałby to, co akurat zostało po ostatnim
+    ``collectstatic`` — a `staticroot/` jest gitignorowanym artefaktem
+    builda i lokalnie bywa nieaktualny.
+    """
+    settings.STATIC_ROOT = str(tmp_path)
+
+    res = client.get(reverse("robots_txt"))
+    body = res.content.decode("utf-8")
+    assert "Disallow: /bpp/autor/*/powiazania/" in body
+
+
 # ``robots_txt`` jest owinięty w ``cache_page(24h)`` (django_bpp/urls.py).
 # W ``settings/test.py`` CACHES["default"] to DummyCache — nic nie
 # zapamiętuje, więc bez podmiany na LocMem cache_page renderowałby wszystko

--- a/src/integration_tests/test_siec3d_bez_webgl.py
+++ b/src/integration_tests/test_siec3d_bez_webgl.py
@@ -1,0 +1,76 @@
+"""Widok 3D sieci powiązań na przeglądarce BEZ WebGL-a (Rollbar #4006).
+
+Przed poprawką ``new THREE.WebGLRenderer`` rzucał "Error creating WebGL
+context." jako nieobsłużony wyjątek, a użytkownik dostawał czarny prostokąt
+bez słowa wyjaśnienia. Zgłoszenia szły z crawlera ``meta-externalagent``
+(headless Chrome bez GPU), ale ta sama ścieżka dotyczy sesji zdalnego
+pulpitu, maszyn wirtualnych i przeglądarek z wyłączoną akceleracją.
+
+Test celowo idzie przez PRAWDZIWĄ przeglądarkę i PRAWDZIWY bundle
+(``dist/three-bundle.js``), bo testy jednostkowe w ``tests/js/`` importują
+moduły ze źródła i nie widzą ani kroku esbuilda, ani sklejenia z szablonem
+Django. Dwa błędy w tej poprawce — niedokończony refaktor w bundlu oraz
+atrybut ``data-url-2d``, który nie mapuje się na ``dataset.url2d`` — były
+niewidoczne dla vitesta i wyszły dopiero tutaj.
+
+WYMAGANIE WSTĘPNE: ``make assets`` (bez zbudowanego bundla strona nie ma
+czego wykonać i test padnie na braku komunikatu).
+"""
+
+import pytest
+from django.urls import reverse
+from model_bakery import baker
+from playwright.sync_api import Page, expect
+
+from bpp.models import Autor
+
+# Zdejmujemy WebGL-a ZANIM wystartują skrypty strony — `add_init_script`
+# wykonuje się przed każdym skryptem dokumentu, więc `three-entry.js` widzi
+# już spreparowane `getContext`. Robimy to zamiast flag startowych
+# przeglądarki (`--disable-webgl`), żeby nie dotykać współdzielonej w sesji
+# instancji Chromium: inne testy Playwrighta w tym samym przebiegu mają
+# dostać przeglądarkę nietkniętą.
+BEZ_WEBGL = """
+    const oryginalny = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function (nazwa) {
+        if (nazwa === "webgl" || nazwa === "webgl2"
+                || nazwa === "experimental-webgl") {
+            return null;
+        }
+        return oryginalny.apply(this, arguments);
+    };
+"""
+
+
+@pytest.mark.django_db(transaction=True)
+def test_widok_3d_bez_webgl_pokazuje_komunikat_zamiast_wyjatku(
+    channels_live_server,
+    page: Page,
+    transactional_db,
+):
+    autor = baker.make(Autor, imiona="Jan", nazwisko="Kowalski", pokazuj=True)
+
+    bledy_strony = []
+    page.on("pageerror", lambda e: bledy_strony.append(str(e)))
+
+    page.add_init_script(BEZ_WEBGL)
+    url = reverse("bpp:browse_autor_powiazania_3d", args=[autor.pk])
+    page.goto(f"{channels_live_server.url}{url}", wait_until="domcontentloaded")
+
+    kontener = page.locator("#siec3d-container")
+
+    # 1. Użytkownik dostaje wyjaśnienie, a nie czarny prostokąt.
+    expect(kontener).to_contain_text("Widok 3D jest niedostępny", timeout=15000)
+
+    # 2. …oraz działające wyjście awaryjne do widoku 2D.
+    link = kontener.locator("a")
+    expect(link).to_have_attribute(
+        "href", reverse("bpp:browse_autor_powiazania", args=[autor.pk])
+    )
+
+    # 3. Sedno zgłoszenia #4006: żaden wyjątek nie ucieka do window.onerror,
+    #    więc Rollbar nie dostaje już nic z tej ścieżki.
+    assert bledy_strony == [], f"nieobsłużone wyjątki na stronie: {bledy_strony}"
+
+    # 4. Renderer w ogóle nie powstał — sonda ubiegła Three.js.
+    assert kontener.locator("canvas").count() == 0

--- a/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/index.js
@@ -17,6 +17,8 @@
 
 import SpriteText from "three-spritetext";
 
+import { czyWebglDostepny, pokazBrakWebgl } from "./webgl.js";
+
 // Kolory wg poziomu: centrum złote, dalej chłodna paleta (dobre na ciemnym tle).
 const PALETA = [
     "#ffd54a", "#4ea1ff", "#36c9c0", "#7ed957",
@@ -76,6 +78,15 @@ export function init(ForceGraph3D) {
     const autorId = String(el.dataset.autorId);
     const siecTpl = el.dataset.siecUrlTemplate;
     const graf3dTpl = el.dataset.graf3dUrlTemplate;
+    const url2d = el.dataset.url2d;
+
+    // Bez WebGL-a nie ma po co budować renderera — Three.js rzuciłby wyjątek,
+    // a użytkownik dostałby czarny prostokąt bez wyjaśnienia (Rollbar #4006).
+    // Zamiast tego komunikat i wyjście awaryjne do widoku 2D.
+    if (!czyWebglDostepny(document)) {
+        pokazBrakWebgl(el, { url2d: url2d });
+        return;
+    }
 
     // --- kontrolki podstawowe ---
     const sliderGleb = document.getElementById("siec3d-glebokosc");
@@ -102,7 +113,20 @@ export function init(ForceGraph3D) {
     // linków przy zmianie opcji "powiązania w grupie" bez ponownego fetcha.
     let rawData = { nodes: [], edges: [], extra_edges: [] };
 
-    const Graph = ForceGraph3D()(el)
+    // Druga linia obrony: sonda wyżej mogła przejść, a renderer i tak paść.
+    // Kontekst bywa tracony między sondą a konstrukcją, karta ma twardy limit
+    // ~16 żywych kontekstów, a sterownik potrafi wysypać się w trakcie
+    // inicjalizacji. Nie wyciszamy — logujemy i informujemy użytkownika.
+    let Graph;
+    try {
+        Graph = ForceGraph3D()(el);
+    } catch (e) {
+        console.warn("Widok 3D: nie udało się utworzyć renderera WebGL.", e);
+        pokazBrakWebgl(el, { url2d: url2d, szczegoly: e && e.message });
+        return;
+    }
+
+    Graph
         .backgroundColor("#0b1020")
         .nodeRelSize(4)
         .nodeVal(function (n) { return wartoscMetryki(n, metryka); })

--- a/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/webgl.js
+++ b/src/powiazania_autorow/static/powiazania_autorow/js/siec3d/webgl.js
@@ -1,0 +1,128 @@
+// Wykrywanie WebGL-a i komunikat zastępczy dla widoku 3D sieci powiązań.
+//
+// Rollbar #4006: `new THREE.WebGLRenderer` rzuca "Error creating WebGL
+// context." u klientów bez działającego GPU. W praktyce trafia to w:
+//   * crawlery renderujące JS w headless Chrome bez GPU (meta-externalagent
+//     — źródło wszystkich 70 zgłoszeń, "Sandboxed = yes"),
+//   * sesje zdalnego pulpitu i maszyny wirtualne,
+//   * przeglądarki z wyłączoną akceleracją sprzętową lub GPU na liście blokad,
+//   * karty, które wyczerpały limit żywych kontekstów WebGL (~16).
+//
+// Bez tego modułu wyjątek szedł w górę jako uncaught, a użytkownik dostawał
+// czarny prostokąt bez wyjaśnienia. Testy: tests/js/siec3d-webgl.test.js.
+
+// Kolejność prób: WebGL 2 (tego używa Three.js r15x), potem WebGL 1.
+const KONTEKSTY = ["webgl2", "webgl"];
+
+// Czy da się w ogóle utworzyć kontekst WebGL.
+//
+// Sonda jest jednorazowa: kontekst od razu oddajemy przez WEBGL_lose_context,
+// bo karta ma twardy limit żywych kontekstów i szkoda zabierać slot
+// rendererowi, który powstanie sekundę później.
+//
+// `dok` wstrzykiwany zamiast globalnego `document` — dzięki temu funkcja jest
+// testowalna i nie zakłada środowiska przeglądarki w momencie importu.
+export function czyWebglDostepny(dok) {
+    let canvas;
+    try {
+        canvas = dok.createElement("canvas");
+    } catch (e) {
+        // Dokument bez createElement (nie-przeglądarka) — nie ma czym rysować.
+        return false;
+    }
+
+    for (let i = 0; i < KONTEKSTY.length; i++) {
+        let ctx = null;
+        try {
+            ctx = canvas.getContext(KONTEKSTY[i]);
+        } catch (e) {
+            // Część przeglądarek z twardo zablokowanym WebGL-em rzuca
+            // SecurityError zamiast zwrócić null. Próbujemy dalej.
+            continue;
+        }
+        if (ctx) {
+            zwolnijKontekst(ctx);
+            return true;
+        }
+    }
+    return false;
+}
+
+// Oddaj kontekst sondy. Rozszerzenie bywa niedostępne — wtedy nic nie robimy
+// (kontekst i tak zniknie z canvasem przy najbliższym GC).
+function zwolnijKontekst(ctx) {
+    if (typeof ctx.getExtension !== "function") { return; }
+    let ext = null;
+    try {
+        ext = ctx.getExtension("WEBGL_lose_context");
+    } catch (e) {
+        return;
+    }
+    if (ext && typeof ext.loseContext === "function") {
+        ext.loseContext();
+    }
+}
+
+function akapit(dok, tekst, style) {
+    const p = dok.createElement("p");
+    p.textContent = tekst;
+    p.style.cssText = style;
+    return p;
+}
+
+// Zastąp zawartość kontenera 3D czytelnym komunikatem o braku WebGL-a.
+//
+// Opcje:
+//   url2d     — adres widoku 2D tej samej sieci (wyjście awaryjne); bez niego
+//               link się nie renderuje,
+//   szczegoly — komunikat sterownika/przeglądarki; DANE NIEZAUFANE, wchodzą
+//               do DOM wyłącznie przez textContent.
+//
+// Wszystko budowane przez API DOM — zero innerHTML, tak jak reszta modułu 3D.
+export function pokazBrakWebgl(el, opcje) {
+    const opts = opcje || {};
+    // Ten sam dokument, w którym żyje kontener — spójnie z `czyWebglDostepny`
+    // nie sięgamy po globalne `document`.
+    const dok = el.ownerDocument;
+
+    el.textContent = "";
+
+    const box = dok.createElement("div");
+    box.style.cssText = "display: flex; flex-direction: column;"
+        + " align-items: center; justify-content: center; height: 100%;"
+        + " padding: 24px; text-align: center; color: #e8ecf5;"
+        + " font-size: 14px; line-height: 1.5;";
+
+    box.appendChild(akapit(
+        dok,
+        "Widok 3D jest niedostępny w tej przeglądarce.",
+        "margin: 0 0 8px; font-size: 17px; font-weight: bold; color: #fff;"
+    ));
+    box.appendChild(akapit(
+        dok,
+        "Rysowanie sieci w 3D wymaga WebGL-a, którego nie udało się tutaj"
+        + " uruchomić. Najczęstsze przyczyny to wyłączona akceleracja"
+        + " sprzętowa, praca przez zdalny pulpit albo starsza karta graficzna.",
+        "margin: 0 0 16px; max-width: 460px; color: #b9c3d6;"
+    ));
+
+    if (opts.url2d) {
+        const a = dok.createElement("a");
+        a.href = opts.url2d;
+        a.textContent = "Przejdź do widoku 2D";
+        a.className = "button small";
+        a.style.cssText = "margin: 0;";
+        box.appendChild(a);
+    }
+
+    if (opts.szczegoly) {
+        box.appendChild(akapit(
+            dok,
+            String(opts.szczegoly),
+            "margin: 16px 0 0; font-size: 11px; color: #7c879b;"
+            + " max-width: 460px; word-break: break-word;"
+        ));
+    }
+
+    el.appendChild(box);
+}

--- a/src/powiazania_autorow/templates/powiazania_autorow/graf3d.html
+++ b/src/powiazania_autorow/templates/powiazania_autorow/graf3d.html
@@ -130,6 +130,10 @@
              data-autor-id="{{ autor.pk }}"
              data-siec-url-template="{% url 'bpp:browse_autor_powiazania_siec' 0 %}"
              data-graf3d-url-template="{% url 'bpp:browse_autor_powiazania_3d' 0 %}"
+             {# wyjście awaryjne, gdy przeglądarka nie ma WebGL-a #}
+             {# UWAGA: bez myślnika przed "2d" — `data-url-2d` mapowałoby się #}
+             {# na dataset["url-2d"], bo po myślniku stoi cyfra, nie litera. #}
+             data-url2d="{% url 'bpp:browse_autor_powiazania' autor.pk %}"
              style="width: 100%; height: 78vh; border: 1px solid #ccc;
                     background: #0b1020;"></div>
         <div id="siec3d-info"

--- a/src/powiazania_autorow/test_views.py
+++ b/src/powiazania_autorow/test_views.py
@@ -467,6 +467,26 @@ def test_strona_grafu_3d_renderuje_kontener(client):
 
 
 @pytest.mark.django_db
+def test_strona_grafu_3d_podaje_link_awaryjny_do_2d(client):
+    """Kontener 3D musi nieść adres widoku 2D — to wyjście awaryjne, którym
+    JS ratuje użytkownika bez WebGL-a (Rollbar #4006).
+
+    Nazwa atrybutu jest tu istotna: ``data-url-2d`` NIE mapuje się na
+    ``dataset.url2d``. Konwersja atrybut→dataset skleja ``-x`` w ``X``
+    tylko wtedy, gdy ``x`` jest małą literą — a po myślniku stoi cyfra
+    ``2``, więc klucz wyszedłby ``dataset["url-2d"]`` i JS by go nie
+    znalazł. Test pilnuje obu stron tej pułapki.
+    """
+    autor = baker.make(Autor, imiona="Jan", nazwisko="Kowalski", pokazuj=True)
+    resp = client.get(reverse("bpp:browse_autor_powiazania_3d", args=[autor.pk]))
+    tresc = resp.content.decode("utf-8")
+
+    url_2d = reverse("bpp:browse_autor_powiazania", args=[autor.pk])
+    assert f'data-url2d="{url_2d}"' in tresc
+    assert "data-url-2d=" not in tresc
+
+
+@pytest.mark.django_db
 def test_strona_grafu_3d_404_gdy_siec_wylaczona(client, uczelnia):
     uczelnia.pokazuj_siec_powiazan = False
     uczelnia.save()

--- a/tests/js/siec3d-webgl.test.js
+++ b/tests/js/siec3d-webgl.test.js
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+//
+// Wykrywanie WebGL-a i komunikat zastępczy dla widoku 3D sieci powiązań.
+//
+// Kontekst: Rollbar #4006 — `new THREE.WebGLRenderer` rzuca "Error creating
+// WebGL context." u klientów bez GPU (crawlery w headless Chrome, sesje
+// zdalnego pulpitu, maszyny z zablokowaną akceleracją). Nieobsłużony wyjątek
+// zostawiał użytkownikowi czarny prostokąt bez słowa wyjaśnienia.
+//
+// jsdom NIE implementuje WebGL-a — `getContext("webgl")` zwraca tam `null`.
+// To wygodne: przypadek negatywny testujemy na PRAWDZIWYM dokumencie, bez
+// żadnej atrapy. Dla przypadków pozytywnych podmieniamy
+// `HTMLCanvasElement.prototype.getContext` — to jedyny sposób, bo w jsdom
+// nie da się uzyskać prawdziwego kontekstu WebGL.
+import { describe, test, expect, afterEach, vi } from "vitest";
+import {
+    czyWebglDostepny,
+    pokazBrakWebgl,
+} from "../../src/powiazania_autorow/static/powiazania_autorow/js/siec3d/webgl.js";
+
+const oryginalnyGetContext = HTMLCanvasElement.prototype.getContext;
+
+afterEach(() => {
+    HTMLCanvasElement.prototype.getContext = oryginalnyGetContext;
+});
+
+// Podmienia getContext na funkcję sterowaną mapą {nazwa: kontekst|null}.
+// Zwraca listę zapytanych nazw — do sprawdzenia kolejności prób.
+function zasymulujKonteksty(mapa) {
+    const zapytania = [];
+    HTMLCanvasElement.prototype.getContext = function (nazwa) {
+        zapytania.push(nazwa);
+        return Object.prototype.hasOwnProperty.call(mapa, nazwa)
+            ? mapa[nazwa]
+            : null;
+    };
+    return zapytania;
+}
+
+describe("czyWebglDostepny", () => {
+    test("jsdom bez WebGL-a (getContext → null) → false", () => {
+        // Bez żadnej atrapy: to realne zachowanie środowiska bez WebGL-a.
+        // jsdom przy okazji woła console.error("Not implemented: ...") —
+        // wyciszamy TEN JEDEN znany komunikat, żeby log testów został czysty.
+        const cichy = vi.spyOn(console, "error").mockImplementation(() => {});
+        try {
+            expect(czyWebglDostepny(document)).toBe(false);
+        } finally {
+            cichy.mockRestore();
+        }
+    });
+
+    test("dostępny webgl2 → true", () => {
+        zasymulujKonteksty({ webgl2: {} });
+        expect(czyWebglDostepny(document)).toBe(true);
+    });
+
+    test("brak webgl2, jest webgl → true (fallback na WebGL 1)", () => {
+        zasymulujKonteksty({ webgl: {} });
+        expect(czyWebglDostepny(document)).toBe(true);
+    });
+
+    test("getContext rzuca wyjątek → false, wyjątek nie ucieka", () => {
+        // Przeglądarki z twardo zablokowanym WebGL-em potrafią rzucić
+        // SecurityError zamiast zwrócić null.
+        HTMLCanvasElement.prototype.getContext = function () {
+            throw new Error("SecurityError: WebGL is disabled");
+        };
+        expect(czyWebglDostepny(document)).toBe(false);
+    });
+
+    test("probe zwalnia kontekst przez WEBGL_lose_context", () => {
+        // Karta ma twardy limit ~16 żywych kontekstów WebGL; kontekst
+        // testowy MUSI zostać oddany, inaczej sami odbieramy slot
+        // rendererowi, który za chwilę powstanie.
+        let zwolniony = false;
+        const ctx = {
+            getExtension(nazwa) {
+                if (nazwa !== "WEBGL_lose_context") { return null; }
+                return { loseContext() { zwolniony = true; } };
+            },
+        };
+        zasymulujKonteksty({ webgl2: ctx });
+
+        czyWebglDostepny(document);
+
+        expect(zwolniony).toBe(true);
+    });
+
+    test("brak rozszerzenia WEBGL_lose_context → nadal true, bez wyjątku", () => {
+        zasymulujKonteksty({ webgl2: { getExtension: () => null } });
+        expect(czyWebglDostepny(document)).toBe(true);
+    });
+});
+
+describe("pokazBrakWebgl", () => {
+    function kontener() {
+        const el = document.createElement("div");
+        el.textContent = "resztki poprzedniej sceny";
+        document.body.appendChild(el);
+        return el;
+    }
+
+    test("czyści kontener i wstawia komunikat o braku WebGL-a", () => {
+        const el = kontener();
+
+        pokazBrakWebgl(el, { url2d: "/bpp/autor/7/powiazania/" });
+
+        expect(el.textContent).not.toContain("resztki poprzedniej sceny");
+        expect(el.textContent).toContain("WebGL");
+    });
+
+    test("daje wyjście awaryjne: link do widoku 2D", () => {
+        const el = kontener();
+
+        pokazBrakWebgl(el, { url2d: "/bpp/autor/7/powiazania/" });
+
+        const link = el.querySelector("a");
+        expect(link).not.toBeNull();
+        expect(link.getAttribute("href")).toBe("/bpp/autor/7/powiazania/");
+    });
+
+    test("bez url2d nie renderuje linku (ale komunikat zostaje)", () => {
+        const el = kontener();
+
+        pokazBrakWebgl(el, {});
+
+        expect(el.querySelector("a")).toBeNull();
+        expect(el.textContent).toContain("WebGL");
+    });
+
+    test("szczegóły techniczne trafiają do DOM jako tekst, nie jako HTML", () => {
+        // Komunikat sterownika idzie prosto z przeglądarki — traktujemy go
+        // jak dane niezaufane (reszta modułu 3D trzyma ten sam standard).
+        const el = kontener();
+
+        pokazBrakWebgl(el, { szczegoly: "<img src=x onerror=alert(1)>" });
+
+        expect(el.querySelector("img")).toBeNull();
+        expect(el.textContent).toContain("<img src=x onerror=alert(1)>");
+    });
+});


### PR DESCRIPTION
## Problem

Rollbar #4006 — `Uncaught Error: Error creating WebGL context.`, 70 wystąpień.

Widok 3D sieci powiązań budował `THREE.WebGLRenderer` bez żadnego zabezpieczenia:

```js
const Graph = ForceGraph3D()(el)   // ← synchronicznie tworzy WebGLRenderer
```

Na kliencie bez działającego GPU konstruktor rzucał wyjątek, który nikt nie łapał.
Użytkownik dostawał **czarny prostokąt bez słowa wyjaśnienia**.

Wszystkie sprawdzone wystąpienia pochodzą z crawlera `meta-externalagent`
(Meta AI, blok IP 57.141.18.x). Telemetria Three.js: `Sandboxed = yes,
ErrorMessage = BindToCurrentSequence failed` — headless Chrome bez GPU
i bez SwiftShadera. Ta sama ścieżka dotyczy jednak realnych użytkowników:
sesji zdalnego pulpitu, maszyn wirtualnych, przeglądarek z wyłączoną
akceleracją oraz kart, które wyczerpały limit ~16 kontekstów WebGL.

Istniejący `rollbar-filters.js` słusznie tego nie wyciszał — wszystkie ramki
stosu pochodzą z naszego `three-bundle.js`, więc to nasz błąd, nie szum
obcego skryptu.

## Rozwiązanie

**1. Sonda WebGL przed budową renderera** (`siec3d/webgl.js`)
Gdy kontekstu nie da się utworzyć, renderer w ogóle nie powstaje — zamiast
niego komunikat z odsyłaczem do widoku 2D. Sonda oddaje kontekst przez
`WEBGL_lose_context`, żeby nie zabierać slotu rendererowi.

**2. `try/catch` wokół konstrukcji** (druga linia obrony)
Sonda może przejść, a renderer i tak paść: utrata kontekstu między sondą
a konstrukcją, limit kontekstów, crash sterownika. Nie wyciszamy — `console.warn`
plus ten sam komunikat dla użytkownika.

**3. `robots.txt`: `Disallow: /bpp/autor/*/powiazania/`**
Największy realny zysk i nie chodzi o Rollbara: cała treść tych stron to canvas
rysowany JS-em, więc crawler nie wyciąga stąd ani znaku tekstu, a każde wejście
odpala `siec.json`, czyli BFS po współautorstwach z sumowaniem IF/PK.

## Testy

| Zakres | Plik |
|---|---|
| Sonda + komunikat (10 testów, vitest) | `tests/js/siec3d-webgl.test.js` |
| Atrybut wyjścia awaryjnego | `powiazania_autorow/test_views.py` |
| Odtworzenie sytuacji crawlera (Playwright) | `integration_tests/test_siec3d_bez_webgl.py` |
| `robots.txt` | `bpp/tests/test_views/test_seo_metadata.py` |

Wszystkie sprawdzone mutacją — na kodzie sprzed poprawki test integracyjny pada
dokładnie tym, co widać w Rollbarze: `bledy_strony = ['Error creating WebGL context.']`.

Zweryfikowane też ręcznie w prawdziwym Chromium na dumpie produkcyjnej bazy:
z WebGL-em scena renderuje się jak dotąd (brak regresji), bez WebGL-a pojawia się
komunikat i działający przycisk „Przejdź do widoku 2D", zero nieobsłużonych wyjątków.

## Dwie pułapki warte odnotowania

* **`data-url-2d` NIE mapuje się na `dataset.url2d`** — konwersja atrybut→dataset
  skleja `-x` w `X` tylko dla małych liter, a po myślniku stoi cyfra. Atrybut
  nazywa się więc `data-url2d`; pilnuje tego osobny test.
* **Vitest i przeglądarka uruchamiają dwa różne programy** — vitest importuje
  moduły ze źródła, przeglądarka ładuje bundle esbuilda. Niedokończony refaktor
  przeszedł przez zielony vitest i wyszedł dopiero w przeglądarce; stąd test
  Playwrighta w tym PR-ze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)