### PR TITLE
fix(pbn): 423 z PBN ponawiaj zamiast zapisywać jako błąd techniczny

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,11 +316,6 @@ default = true
 # WYCOFAĆ gdy upstream wyda release z #2156 → wróć na PyPI `>=4.5`. Tracking: #280.
 [tool.uv.sources]
 django-import-export = { git = "https://github.com/mpasternak/django-import-export.git", rev = "d6ee0d39194fee31437affbdc6fee5ce549b4b8f" }
-# TYMCZASOWO: pbn-client 0.2.2 (ErrorRecord, 423→ResourceLockedException) nie
-# jest jeszcze na PyPI. Pin do commita gałęzi feat/error-record, żeby
-# CI/lokalnie rozwiązać zależność.
-# USUŃ po wydaniu pbn-client 0.2.2 na PyPI (wtedy sam pin >=0.2.2,<0.3 wystarczy).
-pbn-client = { git = "https://github.com/iplweb/pbn-client.git", rev = "787e65c0dcda14ff52e67b7259ab4856ac805f68" }
 # TYMCZASOWO: django-pbn-client 0.2.2 (sync_dictionary D3 + with_deleted_marker
 # A2) nie jest jeszcze na PyPI. Pin do commita gałęzi feat/deleted-marker
 # (stacked na feat/sync-dictionary). USUŃ po wydaniu 0.2.2 na PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "Django>=5.2.16,<5.3",
     # Reużywalne pakiety PBN wydzielone na PyPI (github.com/iplweb/*).
     "django-pbn-client>=0.2,<0.3",
-    "pbn-client>=0.2.1,<0.3",
+    "pbn-client>=0.2.2,<0.3",
     "django-polish-inflection>=0.1,<0.2",
     "django-axes>=7.0,<9",
     "arrow>=1.3,<2",
@@ -316,10 +316,11 @@ default = true
 # WYCOFAĆ gdy upstream wyda release z #2156 → wróć na PyPI `>=4.5`. Tracking: #280.
 [tool.uv.sources]
 django-import-export = { git = "https://github.com/mpasternak/django-import-export.git", rev = "d6ee0d39194fee31437affbdc6fee5ce549b4b8f" }
-# TYMCZASOWO: pbn-client 0.2.1 (ErrorRecord) nie jest jeszcze na PyPI. Pin do
-# commita gałęzi feat/error-record, żeby CI/lokalnie rozwiązać zależność.
-# USUŃ po wydaniu pbn-client 0.2.1 na PyPI (wtedy sam pin >=0.2.1,<0.3 wystarczy).
-pbn-client = { git = "https://github.com/iplweb/pbn-client.git", rev = "84503cf41b308bc86edc6f8709b71383a8676cac" }
+# TYMCZASOWO: pbn-client 0.2.2 (ErrorRecord, 423→ResourceLockedException) nie
+# jest jeszcze na PyPI. Pin do commita gałęzi feat/error-record, żeby
+# CI/lokalnie rozwiązać zależność.
+# USUŃ po wydaniu pbn-client 0.2.2 na PyPI (wtedy sam pin >=0.2.2,<0.3 wystarczy).
+pbn-client = { git = "https://github.com/iplweb/pbn-client.git", rev = "787e65c0dcda14ff52e67b7259ab4856ac805f68" }
 # TYMCZASOWO: django-pbn-client 0.2.2 (sync_dictionary D3 + with_deleted_marker
 # A2) nie jest jeszcze na PyPI. Pin do commita gałęzi feat/deleted-marker
 # (stacked na feat/sync-dictionary). USUŃ po wydaniu 0.2.2 na PyPI.

--- a/src/bpp/newsfragments/pbn-423-ponawianie.bugfix.rst
+++ b/src/bpp/newsfragments/pbn-423-ponawianie.bugfix.rst
@@ -1,0 +1,4 @@
+Blokada zasobu po stronie PBN (HTTP 423) jest ponawiana, zamiast kończyć
+wysyłkę terminalnym błędem technicznym. Dotyczy też odpowiedzi 423 z ciałem
+w formacie JSON, których poprzednia wersja klienta nie rozpoznawała jako
+blokady.

--- a/src/bpp/newsfragments/pbn-kolejka-alarm-wpisy.feature.rst
+++ b/src/bpp/newsfragments/pbn-kolejka-alarm-wpisy.feature.rst
@@ -1,0 +1,3 @@
+Codzienny alarm o błędach technicznych w kolejce eksportu do PBN wskazuje
+konkretne wpisy — numer, rekord, powód zatrzymania i link do panelu
+administracyjnego — zamiast samego licznika.

--- a/src/pbn_export_queue/models.py
+++ b/src/pbn_export_queue/models.py
@@ -301,6 +301,16 @@ class PBN_Export_Queue(models.Model):
             self.save()
             return SendStatus.RETRY_LATER
 
+        if isinstance(exc, HttpException) and exc.status_code == 423:
+            # 423 = Locked (RFC 4918), blokada przejściowa — zawsze ponawiamy.
+            # Pas bezpieczeństwa na wypadek, gdy pbn-client nie rozpozna
+            # kształtu odpowiedzi i nie podniesie ResourceLockedException.
+            self.dopisz_komunikat(
+                "Zasób zablokowany w PBN (HTTP 423), ponawiam wysyłkę za kilka minut..."
+            )
+            self.save()
+            return SendStatus.RETRY_LATER
+
         if isinstance(exc, StatementsResendFailedException):
             # Publikacja została wysłana do PBN (POST /repositorium OK),
             # ale synchronizacja oświadczeń (GET/DELETE/POST /v2) wyczerpała

--- a/src/pbn_export_queue/tasks.py
+++ b/src/pbn_export_queue/tasks.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import rollbar
 from django.apps import apps
 from django.core.cache import cache
+from django.urls import reverse
 from django.utils import timezone
 
 from django_bpp.celery_tasks import app
@@ -242,30 +243,86 @@ def queue_watchdog():
     return woken
 
 
+#: Ile wpisów wyliczyć imiennie; resztę sygnalizuje ``wpisy_pominieto``.
+LIMIT_WPISOW_W_ALARMIE = 10
+
+
+def _najnowszy_komunikat(komunikat):
+    """Najświeższy powód zatrzymania wpisu, bez daty i separatora.
+
+    ``dopisz_komunikat`` doszywa wpisy na początku pola, w formacie
+    ``<data>\\n===…===\\n<treść>``; bez separatora bierzemy pierwszą
+    niepustą linię.
+    """
+    linie = [linia.strip() for linia in (komunikat or "").splitlines()]
+    po_separatorze = False
+    for linia in linie:
+        if linia.startswith("====="):
+            po_separatorze = True
+            continue
+        if po_separatorze and linia:
+            return linia[:200]
+
+    for linia in linie:
+        if linia:
+            return linia[:200]
+    return ""
+
+
 @app.task
 def report_technical_errors_to_rollbar():
     """
-    Raportuje do Rollbar liczbę błędów technicznych w kolejce PBN.
+    Raportuje do Rollbar błędy techniczne w kolejce PBN.
     Uruchamiane przez Celery Beat raz dziennie.
 
     Raportuje jedynie jeśli liczba błędów jest większa niż 0.
-    """
-    technical_errors_count = PBN_Export_Queue.objects.filter(
-        rodzaj_bledu=RodzajBledu.TECHNICZNY, wysylke_zakonczono__isnull=False
-    ).count()
 
-    if technical_errors_count > 0:
-        rollbar.report_message(
-            (
-                f"PBN Export Queue contains {technical_errors_count} "
-                "TECHNICAL errors that require investigation"
+    Poza licznikiem wysyła listę wpisów (PK, rekord, powód, link do admina) —
+    sam licznik nie pozwala dojść do konkretnego wiersza. ``rodzaj_bledu``
+    czyści wyłącznie ``ponow_wysylke()``, więc wpis alarmuje codziennie, aż
+    ktoś go ręcznie ponowi.
+    """
+    qset = PBN_Export_Queue.objects.filter(
+        rodzaj_bledu=RodzajBledu.TECHNICZNY, wysylke_zakonczono__isnull=False
+    )
+    technical_errors_count = qset.count()
+
+    if not technical_errors_count:
+        return technical_errors_count
+
+    wpisy = [
+        {
+            "pk": wpis.pk,
+            # Rekordu może już nie być; sięganie po GenericFK bez tego
+            # sprawdzenia wywala się na nieistniejącej tabeli (ProgrammingError)
+            # i zabiłoby cały alarm.
+            "rekord": (
+                str(wpis.rekord_do_wysylki)
+                if wpis.check_if_record_still_exists()
+                else "<rekord usunięty>"
             ),
-            level="warning",
-            extra_data={
-                "technical_errors_count": technical_errors_count,
-                "queue_name": "pbn_export_queue",
-                "error_type": "TECHNICZNY",
-            },
-        )
+            "zakonczono": wpis.wysylke_zakonczono.isoformat(),
+            "komunikat": _najnowszy_komunikat(wpis.komunikat),
+            "admin_url": reverse(
+                "admin:pbn_export_queue_pbn_export_queue_change", args=[wpis.pk]
+            ),
+        }
+        for wpis in qset.order_by("-wysylke_zakonczono")[:LIMIT_WPISOW_W_ALARMIE]
+    ]
+
+    rollbar.report_message(
+        (
+            f"PBN Export Queue contains {technical_errors_count} "
+            "TECHNICAL errors that require investigation"
+        ),
+        level="warning",
+        extra_data={
+            "technical_errors_count": technical_errors_count,
+            "queue_name": "pbn_export_queue",
+            "error_type": "TECHNICZNY",
+            "wpisy": wpisy,
+            "wpisy_pominieto": technical_errors_count - len(wpisy),
+        },
+    )
 
     return technical_errors_count

--- a/src/pbn_export_queue/tests/test_pbn_queue_send.py
+++ b/src/pbn_export_queue/tests/test_pbn_queue_send.py
@@ -125,6 +125,37 @@ class TestSendToPbn:
             assert "abc-123" in queue_item.komunikat
             assert "Ponowię" in queue_item.komunikat
 
+    def test_send_to_pbn_http_423_ponawia_zamiast_bledu_technicznego(
+        self, wydawnictwo_ciagle, admin_user
+    ):
+        """423 to blokada przejściowa — ponawiamy, nie zamykamy błędem.
+
+        Dotyczy też 423 z JSON-owym body, którego pbn-client nie rozpozna
+        jako ``ResourceLockedException``.
+        """
+        queue_item = baker.make(
+            PBN_Export_Queue,
+            rekord_do_wysylki=wydawnictwo_ciagle,
+            zamowil=admin_user,
+        )
+
+        with patch(
+            "bpp.admin.helpers.pbn_api.cli.sprobuj_wyslac_do_pbn_celery"
+        ) as mock_send:
+            mock_send.side_effect = HttpException(
+                423,
+                "/api/v2/institution-profile/statements",
+                '{"message": "Locked", "description": "Publikacja zostało '
+                'tymczasowo zablokowane z uwagi na równoległą operację."}',
+            )
+
+            result = queue_item.send_to_pbn()
+
+            assert result == SendStatus.RETRY_LATER
+            queue_item.refresh_from_db()
+            assert queue_item.rodzaj_bledu is None
+            assert "zablokowany" in queue_item.komunikat.lower()
+
     def test_send_to_pbn_prace_serwisowe_exception(
         self, wydawnictwo_ciagle, admin_user
     ):

--- a/src/pbn_export_queue/tests/test_tasks.py
+++ b/src/pbn_export_queue/tests/test_tasks.py
@@ -450,6 +450,60 @@ def test_report_technical_errors_to_rollbar_with_errors(mocker, admin_user):
 
 
 @pytest.mark.django_db
+def test_report_technical_errors_wskazuje_konkretne_wpisy(
+    mocker, admin_user, wydawnictwo_ciagle
+):
+    """Alarm niesie PK, rekord, powód i link do admina — nie sam licznik."""
+    wpis = baker.make(
+        PBN_Export_Queue,
+        rekord_do_wysylki=wydawnictwo_ciagle,
+        rodzaj_bledu=RodzajBledu.TECHNICZNY,
+        wysylke_zakonczono=timezone.now(),
+        zamowil=admin_user,
+    )
+    wpis.dopisz_komunikat(
+        "Wystąpił błąd HTTP z PBN, załączam traceback:\n"
+        "Traceback (most recent call last):\n  File ..."
+    )
+    wpis.save()
+
+    mock_rollbar = mocker.patch("pbn_export_queue.tasks.rollbar.report_message")
+
+    report_technical_errors_to_rollbar()
+
+    wpisy = mock_rollbar.call_args[1]["extra_data"]["wpisy"]
+    assert [w["pk"] for w in wpisy] == [wpis.pk]
+    assert wpisy[0]["rekord"] == str(wydawnictwo_ciagle)
+    assert wpisy[0]["komunikat"].startswith("Wystąpił błąd HTTP z PBN")
+    assert str(wpis.pk) in wpisy[0]["admin_url"]
+
+
+@pytest.mark.django_db
+def test_report_technical_errors_mowi_ile_wpisow_pominieto(mocker, admin_user):
+    """Przycięcie listy jest widoczne w payloadzie, nie milczące."""
+    for _ in range(12):
+        baker.make(
+            PBN_Export_Queue,
+            rodzaj_bledu=RodzajBledu.TECHNICZNY,
+            wysylke_zakonczono=timezone.now(),
+            zamowil=admin_user,
+            # bez tego baker losuje content_type — trafia np. w tabelę
+            # tymczasową cache, której nie ma w bazie
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
+            object_id=0xBEEF,
+        )
+
+    mock_rollbar = mocker.patch("pbn_export_queue.tasks.rollbar.report_message")
+
+    report_technical_errors_to_rollbar()
+
+    extra = mock_rollbar.call_args[1]["extra_data"]
+    assert extra["technical_errors_count"] == 12
+    assert len(extra["wpisy"]) == 10
+    assert extra["wpisy_pominieto"] == 2
+
+
+@pytest.mark.django_db
 def test_report_technical_errors_to_rollbar_no_errors(mocker, admin_user):
     """Test that nothing is reported when there are no technical errors."""
     # Create only MERYTORYCZNY errors

--- a/uv.lock
+++ b/uv.lock
@@ -651,7 +651,7 @@ requires-dist = [
     { name = "ortools", specifier = ">=9.15.6755" },
     { name = "pandas", specifier = ">=3.0.3" },
     { name = "pathspec", specifier = ">=1.1.1" },
-    { name = "pbn-client", git = "https://github.com/iplweb/pbn-client.git?rev=787e65c0dcda14ff52e67b7259ab4856ac805f68" },
+    { name = "pbn-client", specifier = ">=0.2.2,<0.3" },
     { name = "pillow", specifier = ">=12.2,<14" },
     { name = "psycopg2-binary", specifier = ">=2.9.12" },
     { name = "pygad", specifier = ">=3.7.0" },
@@ -4007,10 +4007,14 @@ wheels = [
 [[package]]
 name = "pbn-client"
 version = "0.2.2"
-source = { git = "https://github.com/iplweb/pbn-client.git?rev=787e65c0dcda14ff52e67b7259ab4856ac805f68#787e65c0dcda14ff52e67b7259ab4856ac805f68" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests", marker = "platform_python_implementation != 'PyPy'" },
     { name = "simplejson", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/53/ef61b6f58592eef44a27a216e9a7687a782a09f5e3f2d499860e59bd9c0d/pbn_client-0.2.2.tar.gz", hash = "sha256:21b78873fbea40c4e13cee39c75ea3e1411429dd21a9c772c2fac83963e3f6c4", size = 64750, upload-time = "2026-08-05T07:27:16.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ce/b8549f6fe70cd5965c161d0a2c6cd92ee6d65d3a5d818ec4904d8efdfdf6/pbn_client-0.2.2-py3-none-any.whl", hash = "sha256:07dc76a80bbc4c94f7b1a6d96ce9c42391b85cdbd4ef22ae36aec2eb67f386a7", size = 36044, upload-time = "2026-08-05T07:27:15.367Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -651,7 +651,7 @@ requires-dist = [
     { name = "ortools", specifier = ">=9.15.6755" },
     { name = "pandas", specifier = ">=3.0.3" },
     { name = "pathspec", specifier = ">=1.1.1" },
-    { name = "pbn-client", git = "https://github.com/iplweb/pbn-client.git?rev=84503cf41b308bc86edc6f8709b71383a8676cac" },
+    { name = "pbn-client", git = "https://github.com/iplweb/pbn-client.git?rev=787e65c0dcda14ff52e67b7259ab4856ac805f68" },
     { name = "pillow", specifier = ">=12.2,<14" },
     { name = "psycopg2-binary", specifier = ">=2.9.12" },
     { name = "pygad", specifier = ">=3.7.0" },
@@ -4006,8 +4006,8 @@ wheels = [
 
 [[package]]
 name = "pbn-client"
-version = "0.2.1"
-source = { git = "https://github.com/iplweb/pbn-client.git?rev=84503cf41b308bc86edc6f8709b71383a8676cac#84503cf41b308bc86edc6f8709b71383a8676cac" }
+version = "0.2.2"
+source = { git = "https://github.com/iplweb/pbn-client.git?rev=787e65c0dcda14ff52e67b7259ab4856ac805f68#787e65c0dcda14ff52e67b7259ab4856ac805f68" }
 dependencies = [
     { name = "requests", marker = "platform_python_implementation != 'PyPy'" },
     { name = "simplejson", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
## Problem

Blokada zasobu po stronie PBN (HTTP 423) była rozpoznawana wyłącznie wtedy,
gdy ciało odpowiedzi równało się dosłownie `Locked`. PBN zwraca 423 także
z JSON-em — wtedy leciał goły `HttpException`, a `PBN_Export_Queue`
klasyfikowała go w gałęzi „inny HttpException" jako `TECHNICZNY`, czyli
terminalnie i bez ani jednego ponowienia. Blokada jest z definicji przejściowa.

Osobno: codzienny alarm o błędach technicznych w kolejce wysyłał sam licznik,
bez identyfikatorów — z takiego zgłoszenia nie da się dojść do konkretnego
wpisu w adminie.

## Zmiany

- **pbn-client 0.2.2** (osobne repo, wydane na PyPI): 423 zawsze →
  `ResourceLockedException`, bez raportu do Rollbara.
- **Kolejka**: pas bezpieczeństwa `HttpException(423)` → `RETRY_LATER`,
  niezależny od wersji klienta w środowisku (`ResourceLockedException`
  dziedziczy po `HttpException`, więc gałęzie się nie wykluczają).
- **Alarm**: obok licznika lista wpisów (`pk`, rekord, powód, `admin_url`),
  limit 10 + jawny `wpisy_pominieto`. Rekord czytany przez
  `check_if_record_still_exists()` — sięgnięcie po GenericFK wskazujący na
  nieistniejącą tabelę wywala się `ProgrammingError` i zabiłoby cały alarm.
- `pyproject.toml`: `pbn-client>=0.2.2,<0.3` z PyPI, bez tymczasowego pinu po SHA.

## Testy

- `src/pbn_export_queue/` + `src/pbn_api/tests`: 626 passed.
- Nowe: 423→RETRY_LATER, zawartość listy wpisów w alarmie, widoczność przycięcia.
- pbn-client: 142 passed (test parametryzowany po trzech kształtach ciała 423).

🤖 Generated with [Claude Code](https://claude.com/claude-code)