### PR TITLE
fix(rollbar): zwiń szum Http404 przez jawny fingerprint per widok

### DIFF
--- a/src/bpp/newsfragments/+rollbar-404-fingerprint.bugfix.rst
+++ b/src/bpp/newsfragments/+rollbar-404-fingerprint.bugfix.rst
@@ -1,0 +1,5 @@
+Rollbar: błędy "nie znaleziono strony" (``Http404``) są teraz grupowane w jedno
+zgłoszenie per serwer i widok, zamiast zakładać osobne zgłoszenie dla każdego
+nieistniejącego adresu odwiedzonego przez roboty indeksujące. Przy okazji
+zgłoszenia rozróżniają teraz uczelnie po adresie, pod którym faktycznie
+wystąpiły — istotne przy instalacjach obsługujących wiele uczelni naraz.

--- a/src/bpp/rollbar_config.py
+++ b/src/bpp/rollbar_config.py
@@ -9,6 +9,14 @@ from rollbar.lib.transforms.scruburl import ScrubUrlTransform
 # stały fingerprint — patrz collapse_noisy_fingerprints.
 NOISY_FINGERPRINT_EXC = {
     "DocxConversionError",
+    "Http404",
+}
+
+#: Podzbiór NOISY_FINGERPRINT_EXC, dla którego do fingerprintu dokładamy nazwę
+#: widoku. Bez tego 404 z przeglądania nieistniejących slugów zlałoby się z 404
+#: sygnalizującym realny brak danych (np. definicji raportu).
+FINGERPRINT_PO_WIDOKU = {
+    "Http404",
 }
 
 #: Domyślne `url_fields` pyrollbara — klucze, pod którymi spodziewa się URL-i.
@@ -84,11 +92,15 @@ def add_hostname_to_payload(payload, **kw):
 def collapse_noisy_fingerprints(payload, **kw):
     """Narzuć stały fingerprint na zgłośne wyjątki (patrz NOISY_FINGERPRINT_EXC).
 
-    Rollbar domyślnie tworzy osobny item per raport, bo treść HTML z danymi
-    autora trafia do fingerprintu. Jawny ``data["fingerprint"]`` przejmuje
-    grupowanie: jeden serwer z zepsutą konwersją = dokładnie jeden item,
-    niezależnie od liczby autorów. Klucz ``(klasa, host)``, żeby dwa różne
-    serwery pozostały dwoma osobnymi itemami (dwa problemy do naprawy).
+    Rollbar domyślnie tworzy osobny item per zgłoszenie, bo zmienne lokalne
+    ramek (treść raportu, slug z URL-a) trafiają do fingerprintu. Jawny
+    ``data["fingerprint"]`` przejmuje grupowanie: klucz ``(klasa, host)``,
+    a dla klas z ``FINGERPRINT_PO_WIDOKU`` dodatkowo nazwa widoku.
+
+    Host bierzemy per-request (``request_host`` z middleware'u), bo canonical
+    ``DJANGO_BPP_HOSTNAME`` jest wspólny dla wszystkich uczelni w instalacji
+    multi-hosted. Zgłoszenia bez requestu (Celery, komendy) degradują do
+    canonical, potem do ``unknown``.
 
     Musi być zarejestrowany PO add_hostname_to_payload — czyta hosta z
     ``custom`` wypełnionego przez tamten handler.
@@ -102,9 +114,17 @@ def collapse_noisy_fingerprints(payload, **kw):
     if not trace:
         return payload
     exc_class = trace.get("exception", {}).get("class")
-    if exc_class in NOISY_FINGERPRINT_EXC:
-        host = data.get("custom", {}).get("DJANGO_BPP_HOSTNAME", "unknown")
-        data["fingerprint"] = f"{exc_class}:{host}"
+    if exc_class not in NOISY_FINGERPRINT_EXC:
+        return payload
+
+    custom = data.get("custom", {})
+    host = custom.get("request_host") or custom.get("DJANGO_BPP_HOSTNAME") or "unknown"
+    fingerprint = f"{exc_class}:{host}"
+    if exc_class in FINGERPRINT_PO_WIDOKU:
+        # `context` to url_name widoku — ustawia je BASE_DATA_HOOK
+        # django-rollbara, zanim odpalą się payload handlery.
+        fingerprint += f":{data.get('context') or 'unknown'}"
+    data["fingerprint"] = fingerprint
     return payload
 
 

--- a/src/bpp/tests/test_rollbar_config.py
+++ b/src/bpp/tests/test_rollbar_config.py
@@ -55,7 +55,9 @@ def test_niewymieniony_wyjatek_bez_fingerprintu():
         "data": {
             "custom": {"DJANGO_BPP_HOSTNAME": "x.pl"},
             "body": {
-                "trace_chain": [{"exception": {"class": "Http404", "message": "..."}}]
+                "trace_chain": [
+                    {"exception": {"class": "IntegrityError", "message": "..."}}
+                ]
             },
         }
     }
@@ -94,6 +96,70 @@ def test_payload_bez_body_nie_wybucha():
     result = collapse_noisy_fingerprints(payload)
 
     assert "fingerprint" not in result["data"]
+
+
+def _http404_payload(host="bpp.example.pl", widok="browse_autor"):
+    """Payload zbliżony do realnego Http404 z widoku publicznego."""
+    payload = {
+        "data": {
+            "custom": {"request_host": host},
+            "body": {"trace": {"exception": {"class": "Http404", "message": "..."}}},
+        }
+    }
+    if widok is not None:
+        payload["data"]["context"] = widok
+    return payload
+
+
+def test_http404_fingerprint_zawiera_widok():
+    """Http404 grupuje się po hoście I widoku, nie po samym haśle w URL-u."""
+    result = collapse_noisy_fingerprints(_http404_payload())
+
+    assert result["data"]["fingerprint"] == "Http404:bpp.example.pl:browse_autor"
+
+
+def test_rozne_widoki_daja_rozne_fingerprinty_http404():
+    """404 z przeglądania slugów nie może zlać się z 404 z raportów."""
+    a = collapse_noisy_fingerprints(_http404_payload(widok="browse_autor"))
+    b = collapse_noisy_fingerprints(_http404_payload(widok="raport_generuj"))
+
+    assert a["data"]["fingerprint"] != b["data"]["fingerprint"]
+
+
+def test_http404_bez_kontekstu_daje_unknown():
+    """Brak nazwy widoku degraduje człon widoku do :unknown."""
+    result = collapse_noisy_fingerprints(_http404_payload(widok=None))
+
+    assert result["data"]["fingerprint"] == "Http404:bpp.example.pl:unknown"
+
+
+def test_widok_nie_trafia_do_fingerprintu_pozostalych_wyjatkow():
+    """Tylko klasy z FINGERPRINT_PO_WIDOKU dostają człon widoku."""
+    payload = _docx_payload()
+    payload["data"]["context"] = "raport_generuj"
+
+    result = collapse_noisy_fingerprints(payload)
+
+    assert (
+        result["data"]["fingerprint"] == "DocxConversionError:publikacje.up.lublin.pl"
+    )
+
+
+def test_request_host_wygrywa_z_canonical_hostname():
+    """Na multi-hosted vhost per-request rozróżnia uczelnie, canonical nie."""
+    payload = _docx_payload()
+    payload["data"]["custom"]["request_host"] = "bpp.innauczelnia.pl"
+
+    result = collapse_noisy_fingerprints(payload)
+
+    assert result["data"]["fingerprint"] == "DocxConversionError:bpp.innauczelnia.pl"
+
+
+def test_brak_request_host_degraduje_do_canonical_hostname():
+    """Zgłoszenia z Celery / management commands nie mają vhosta."""
+    result = collapse_noisy_fingerprints(_docx_payload("celery.example.pl"))
+
+    assert result["data"]["fingerprint"] == "DocxConversionError:celery.example.pl"
 
 
 # --- Scrub pola `code`: sekret OAuth TAK, linia kodu w tracebacku NIE -------


### PR DESCRIPTION
## Problem

Rollbar grupuje itemy hashując traceback razem ze zmiennymi lokalnymi ramek.
Dla `Http404` z widoków przeglądania (`browse_autor`, `browse_jednostka`,
`browse_zrodlo`, `browse_praca_by_slug`) w tych zmiennych siedzi slug z URL-a,
więc **każdy** nieistniejący adres odwiedzony przez robota indeksującego zakłada
osobne zgłoszenie. Efekt: `Http404` zdominowało listę aktywnych itemów i przykrywa
realne błędy.

Drugi, mniejszy problem: dotychczasowy fingerprint `DocxConversionError` czytał
hosta wyłącznie z `custom["DJANGO_BPP_HOSTNAME"]`, a to jest
`DJANGO_BPP_HOSTNAMES[0]` (`src/django_bpp/settings/base.py`) — przy wdrożeniu
multi-hosted wszystkie uczelnie w jednym procesie mają tę samą wartość, więc
zgłoszenia z różnych uczelni zlewały się w jedno.

## Zmiana

`src/bpp/rollbar_config.py`:

1. `"Http404"` dopisane do `NOISY_FINGERPRINT_EXC` — dostaje jawny
   `data["fingerprint"]` zamiast natywnego grupowania.
2. Nowy zbiór `FINGERPRINT_PO_WIDOKU = {"Http404"}` — dla tych klas do
   fingerprintu dokładany jest człon z nazwą widoku (`data["context"]`, czyli
   `url_name` ustawiany przez `BASE_DATA_HOOK` django-rollbara w `_build_data`,
   a więc zanim odpalą się payload handlery). Bez tego członu 404 od botów
   indeksujących stare slugi wpadłoby do jednego wiaderka z 404 z
   `raport_generuj`, gdzie brak `DefinicjaRaportu` to realny problem wdrożenia.
   Brak `context` → człon `unknown`.
3. Host liczony jest teraz z per-requestowego `custom["request_host"]`
   (dokłada je `CustomRollbarNotifierMiddleware.get_extra_data` z
   `request.get_host()`), z fallbackiem na `DJANGO_BPP_HOSTNAME`, a potem na
   `"unknown"`. Naprawia przy okazji `DocxConversionError` na multi-hosted.
   Zgłoszenia z Celery / management commands nie mają `request_host` i
   zostają na fallbacku — tak ma być.

## Jak przetestowane

TDD: testy napisane i uruchomione przed implementacją (4 nowe padały —
`KeyError: 'fingerprint'` dla Http404, zły host dla `request_host`).

`src/bpp/tests/test_rollbar_config.py` — **24 passed**. Nowe przypadki:
fingerprint Http404 zawiera widok; różne widoki na tym samym hoście dają różne
fingerprinty; brak `context` → `unknown`; widok NIE trafia do fingerprintu klas
spoza `FINGERPRINT_PO_WIDOKU`; `request_host` wygrywa z `DJANGO_BPP_HOSTNAME`;
brak `request_host` degraduje do canonical.

Poprawiony `test_niewymieniony_wyjatek_bez_fingerprintu` — używał `Http404`
jako przykładu klasy spoza allowlisty, co po tej zmianie jest nieaktualne;
intencja testu zachowana, przykład zmieniony na `IntegrityError`.

Sąsiednie moduły rollbarowe (`test_rollbar_frontend`, `test_rollbar_filters`,
`test_rollbar_scrub`, `test_wyjatki`) — łącznie **56 passed**.
`ruff format --check` i `ruff check` czyste, `pre-commit` przechodzi.

## Zastrzeżenia operacyjne

**(a) Jawny fingerprint NIE scala wstecz.** Istniejące itemy `Http404` zostaną
aktywne dokładnie tak, jak są — grupowanie zadziała tylko dla zgłoszeń
przychodzących po wdrożeniu. Żeby odzyskać czytelną listę, trzeba je zamknąć
hurtem ręcznie w UI albo przez API Rollbara.

**(b) Jawny fingerprint wyłącza natywne grupowanie.** Jeśli realny bug zacznie
generować 404 w widoku, który ma już swoje wiaderko, wpadnie do niego: skoczy
licznik okurencji, ale **nowy item nie powstanie — a więc nie powstanie też
notyfikacja**. To świadomy trade-off (szum vs. czułość na nowe 404 w znanych
widokach); warto o tym pamiętać przy diagnozowaniu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)