### PR TITLE
chore(lint): zsynchronizuj pin ruff w pre-commit z pyproject (0.16.1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       # A lower pin here caused pre-commit to accept an I001 layout that
       # ruff 0.15.x (used by CI) rejected — the diff was invisible
       # locally until GitHub Actions failed.
-      rev: v0.15.12
+      rev: v0.16.1
       hooks:
         - id: ruff
           args: ["--fix", "--exit-non-zero-on-fix"]


### PR DESCRIPTION
`pyproject.toml` pinuje `ruff==0.16.1` (przyszło z grupy dependabota #694),
a `.pre-commit-config.yaml` trzymał `rev: v0.15.12`.

Komentarz nad tym pinem ostrzega, że taki rozjazd już raz przepuścił lokalnie
layout I001, który CI odrzucił. Dependabot nie połączy tych dwóch sam —
ekosystem `uv` nie zna hooków pre-commit.

## Weryfikacja

`ruff 0.15.12` i `0.16.1` dają identyczny wynik na repo:

- 131 błędów, 57 fixable — w obu wersjach
- `diff` wyników `--output-format=concise`: **0 różnic**

Bump nie odsłania nowych naruszeń. `pre-commit` z nowym hookiem przechodzi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)