### PR TITLE
docs(liveops): uratuj plany migracji na django-liveops z worktree

### DIFF
--- a/docs/deweloper/plan-import-list-if-liveops.md
+++ b/docs/deweloper/plan-import-list-if-liveops.md
@@ -1,0 +1,616 @@
+# Plan migracji `import_list_if` na django-liveops 0.4
+
+Status: PLAN (do wykonania). Ten dokument NIE zmienia kodu — opisuje
+uporządkowaną, TDD-ową ścieżkę przeniesienia aplikacji `import_list_if`
+z legacy stacku `long_running` na `django-liveops` 0.4, wzorowaną 1:1 na
+już-scalonym, najbliższym kształtem `import_punktacji_zrodel`.
+
+Worktree: `~/Programowanie/bpp-import-list-if-liveops`
+(gałąź `worktree-import-list-if-liveops`, od `dev`).
+
+> **Zmiany po recenzji (execute-with-fixes).** Decyzje architektoniczne
+> (RETIRE `ImportOperation`, zostaw `ImportRowMixin`, delta `0005`, cutover)
+> — potwierdzone poprawne. Uściślenia po adversarialnej recenzji, każde
+> zweryfikowane w kodzie:
+> - **PRIMARY reference = `import_punktacji_zrodel`** (nie `import_pracownikow`).
+>   Ta apka jest **już na liveops 0.4** (`models.py:9`
+>   `ImportPunktacjiZrodel(LiveOperation)`) i to najbliższy 1:1 kształt
+>   `import_list_if`: jeden XLS → `index`/`new`/`results`, `run(self,p)`,
+>   `on_restart`, `ResultsView(GroupRequiredMixin, ListView)` z `paginate_by=25`
+>   i `object=self.parent_object` (`views.py:45-86`), auto-nazwane szablony
+>   (`import_punktacji_zrodel_result.html`). `import_pracownikow` pozostaje
+>   referencją dla wrappera `hx-headers` i group-gated restart mixinu.
+> - **Bramka grupy = 302 redirect_to_login, NIE 403** (braces
+>   `AccessMixin.raise_exception=False` domyślnie, `_access.py:27,81` →
+>   `redirect_to_login`). Testy asertują side-effect (stan/utworzenie), nie
+>   status. (Uwaga: 403 z CSRF to co innego i zostaje.)
+> - **Post-Faza-1 nie jest deployowalny** (aplikacja runtime-broken do Fazy 2);
+>   Faza 0 kończy RED (merge z Fazą 1 lub `xfail`). Doprecyzowane niżej.
+> - **Atomic ↔ cancel:** owinięcie `run()` w `transaction.atomic()` sprawia,
+>   że `OperationCancelled` cofa wiersze → test anulowania asertuje
+>   `pytest.raises(OperationCancelled)` + **0 wierszy**. `WebProgress.result/error`
+>   i tak defer push przez `transaction.on_commit` (`progress.py:263-289`), więc
+>   owinięcie jest oficjalnie wspierane. Świadome odejście od wzorca punktacji
+>   (ta NIE owija — pisze przyrostowo); owijamy dla parytetu z legacy
+>   `task_perform`.
+> - **App-level restart URL (`regen/`) — DROP** (precedens punktacji: brak
+>   `regen` w urls; „Ponów" idzie na centralny `liveops:restart`).
+> - Poprawione line-refy, literał grupy → `bpp.const.GR_WPROWADZANIE_DANYCH`
+>   (`const.py:20`), martwy `{% load render_table %}` do usunięcia, zanotowany
+>   (już naprawiony na dev, commit 7eed62a2a) latentny bug CSRF.
+
+---
+
+## 1. Streszczenie
+
+`import_list_if` to najprostszy z importerów BPP: jeden upload XLS
+(`plik_xls` + `rok`), synchroniczne przetworzenie wierszy (dopasowanie
+źródła + zapis `Punktacja_Zrodla.impact_factor` dla danego roku), lista
+importów i tabela wyników. Dziś operacja dziedziczy po abstrakcyjnym
+`import_common.models.ImportOperation` (`ASGINotificationMixin, Operation`
+z `long_running`), a widoki to rodzina `LongRunning*View`.
+
+Migracja: `ImportListIf` ma dziedziczyć **wprost po
+`liveops.models.LiveOperation`**, a logika `ImportOperation` (pole
+`plik_xls`, `get_xls_import_file`, `validation_form_class` /
+`get_validation_form_class`, pętla `perform`) zostaje **wchłonięta do
+`ImportListIf`** i przepisana na `run(self, p)`. Abstrakcyjny
+`ImportOperation` **znika** (jedyny użytkownik). `ImportRowMixin` z tego
+samego pliku **zostaje** — używa go też `import_pracownikow`.
+
+Skala zmiany jest mała (model ~75 linii, 6 widoków, 4 szablony, 1 nowa
+migracja delta). Rekomendacja: **cutover model+widoki w jednym kroku**
+(bez mostka kompatybilności z §Fazy) — aplikacja jest jednofazowa, nie ma
+osobnego etapu „emisja progresu" do zainscenizowania.
+
+Referencje (źródła prawdy, już na 0.4):
+- **PRIMARY — `src/import_punktacji_zrodel/`** (najbliższy 1:1 kształt):
+  `models.py:9` `ImportPunktacjiZrodel(LiveOperation)`, `run(self,p)`
+  (`:29`), `on_restart` (`:52`), `get_details_set`; `views.py:45-86`
+  `ResultsView(GroupRequiredMixin, ListView)` z `paginate_by=25` +
+  `object=self.parent_object`; `urls.py` (index/new/results/zatwierdz, brak
+  routera/detali/regen); `import_punktacji_zrodel_result.html`.
+- **SECONDARY — `src/import_pracownikow/`** (dla dwóch wzorców):
+  `templates/import_pracownikow/import_pracownikow.html:27` wrapper
+  `hx-headers` (CSRF), `views.py:1386` group-gated `_PkOwnerRestartMixin`.
+  Reszta (`models.py:72`, `migrations/0010_liveops.py`) — pomocniczo.
+
+---
+
+## 2. Stan obecny (legacy wiring)
+
+### Model — dziedziczenie abstrakcyjne (kluczowy fakt strukturalny)
+
+- `src/import_list_if/models.py:23` — `class ImportListIf(ImportOperation)`;
+  dokłada `rok`, `try_names`, `banned_names`, `min_points`,
+  `validation_form_class = ImportListRowValidationForm`,
+  `import_single_row()`, `on_reset()`, `get_details_set()`.
+- `src/import_common/models.py:11` — `class ImportOperation(
+  ASGINotificationMixin, Operation)`, `class Meta: abstract = True`.
+  Dostarcza: `plik_xls = FileField(upload_to="protected/import_common/")`,
+  `get_validation_form_class()`, `get_xls_import_file()` (buduje
+  `XLSImportFile`), `perform()` (pętla po wierszach XLS z walidacją formularza
+  i `self.send_progress(...)` co 2%), `ignore_bad_rows = False`.
+- `src/import_common/models.py:60` — `class ImportRowMixin` (`nr_arkusza`,
+  `nr_wiersza`) — **współdzielony**: `import_pracownikow/models.py:720`
+  (`ImportPracownikowRow(ImportRowMixin, models.Model)`).
+- `src/long_running/models.py:17` — `Operation(NullNotificationMixin,
+  models.Model)`: `id` UUID, `owner` FK (bez `related_name`), `created_on`,
+  `last_updated_on` (auto_now), `started_on`, `finished_on`,
+  `finished_successfully`, `traceback`; `Meta.ordering = ["-last_updated_on"]`;
+  `task_perform()` (`long_running/models.py:99`) owija `perform()` w
+  `transaction.atomic()` (`:108`).
+
+**POTWIERDZONE (grep repo-wide):** `ImportOperation` importuje/dziedziczy
+**wyłącznie** `import_list_if` (`grep -rn ImportOperation src` → tylko
+`import_common/models.py` definicja + `import_list_if/models.py:13,23`).
+Pozostałe importery na legacy stacku (`import_list_ministerialnych`,
+`import_polon`, `importer_autorow_pbn`, `raport_slotow`) używają `long_running`
+**bezpośrednio**, nie przez `ImportOperation`. Dlatego retire `ImportOperation`
+jest czysty. Natomiast `long_running` jako aplikacja **zostaje** (7+ innych
+użytkowników — `grep -rln long_running src`).
+
+**UWAGA (korekta po recenzji):** `import_punktacji_zrodel` **NIE jest** już na
+`long_running` — jest **już zmigrowany na liveops 0.4**
+(`src/import_punktacji_zrodel/models.py:9` `ImportPunktacjiZrodel(LiveOperation)`;
+`urls.py` bez routera/detali; auto-nazwane szablony). To najbliższy 1:1
+kształt `import_list_if` i **główna referencja** tego planu (patrz §3, §nota
+u góry). `import_pracownikow` to referencja dla wrappera `hx-headers` i
+group-gated restart mixinu.
+
+### Widoki (`src/import_list_if/views.py`)
+
+Wszystkie w `BaseImportListIfMixin(GroupRequiredMixin)`,
+`group_required = "wprowadzanie danych"`, `model = ImportListIf`:
+
+- `ListaImportowView(LongRunningOperationsView)` — owner-scoped ListView.
+- `NowyImportView(CreateLongRunningOperationView)`, `form_class =
+  NowyImportForm`.
+- `ImportListIfRouterView(LongRunningRouterView)`, `redirect_prefix =
+  "import_list_if:import_list_if"` — routuje po stanie na `-details`/`-results`.
+- `ImportListIfDetailsView(LongRunningDetailsView)` — strona z paskiem postępu.
+- `ImportListIfResultsView(LongRunningResultsView)` — `paginate_by = 25`
+  (dziedziczone z `long_running/views.py:89`).
+- `RestartImportView(RestartLongRunningOperationView)` — restart, group-gated
+  przez mixin.
+
+### URL-e (`src/import_list_if/urls.py`)
+
+`index`, `new`, `importlistif-router` (`<uuid:pk>/`), `importlistif-details`,
+`importlistif-results`, `restart` (`<uuid:pk>/regen/`). Wszystkie `<uuid:pk>`.
+
+### Szablony (`src/import_list_if/templates/import_list_if/`)
+
+- `importlistif_list.html` — lista; link `import_list_if:importlistif-router
+  object.pk`; **UWAGA: breadcrumb i nagłówek błędnie linkują
+  `import_pracownikow:index`** („import list IF") — bug do naprawienia przy
+  okazji.
+- `importlistif_form.html` — formularz (`CreateView` default:
+  `<app>/<model>_form.html`).
+- `importlistif_detail.html` — `{% include "long_running/operation_details.html" %}`.
+- `importlistifrow_list.html` — tabela wyników; `{% include "pagination.html" %}`
+  + iteruje `object_list`; używa `object.plik_xls.name`, `object.pk`
+  (kontekst `object` = rodzic!), `{% include "long_running/operation_details.html" %}`.
+
+### Testy
+
+- `tests/test_models.py` — `test_ImportListIF_perform` woła
+  `import_list_if.perform()` i sprawdza 4 wiersze + `impact_factor==70.67`;
+  `test_ImportListIF_on_reset`, `test_ImportListIF_get_details_set`.
+- `tests/test_views.py` — webtest: `index`/`new` GET + klik „pobierz plik
+  wzorcowy".
+
+### Odniesienia zewnętrzne (muszą przeżyć)
+
+- `src/django_bpp/templates/top_bar.html:190` → `{% url "import_list_if:index" %}`.
+- `src/bpp/templates/browse/uczelnia.html:706` → `link: "/import_list_if/"`.
+- `src/django_bpp/urls.py:183` mount `^import_list_if/`.
+- `src/django_bpp/urls.py:286` — centralny `path("live/", include("liveops.urls"))`
+  już zamontowany.
+- `admin.py` pusty (brak rejestracji ModelAdmin — zero pracy).
+
+---
+
+## 3. Docelowy stan (liveops)
+
+### Model `ImportListIf(LiveOperation)`
+
+Pola liveops (`.venv/.../liveops/models.py:27`): `id` UUID, `owner`
+(`related_name="+"`), `created_on`, `started_on`, `finished_on`,
+`finished_successfully`, `cancel_requested`, `cancelled`, `traceback`,
+`result_context`, `language`, `status_text`, `percent`, `log`, `log_seq`,
+`current_stage`, `stage_states`; `Meta.abstract`, `ordering = ["-created_on"]`.
+Wchłonięte z `ImportOperation`: `plik_xls`, `try_names`/`banned_names`/
+`min_points`, `validation_form_class` + `get_validation_form_class()`,
+`get_xls_import_file()`, `ignore_bad_rows`.
+
+Kontrakt liveops, który realizujemy:
+
+- `run(self, p)` — logika operacji (dawne `perform()`), progres/anulowanie
+  przez obiekt `p` (`liveops.progress.Progress`: `p.percent(int)`,
+  `p.track(iterable)`, `p.log(str)`, `p.stage(name)` [ctx-manager],
+  `p.check_cancelled()`, `p.result(ctx)`, `p.error(msg)`).
+- `on_restart(self)` — hook `RestartView` (kasuje wiersze; dawne `on_reset`).
+- `get_absolute_url()` — z bazy: reverse `liveops:live`
+  (`op_type=<app>.<model>`, pk). Zastępuje router+details.
+- template naming (auto, `liveops/naming.py`): `class_to_snake("ImportListIf")
+  = "import_list_if"` → host `import_list_if/import_list_if.html`,
+  wynik `import_list_if/import_list_if_result.html`. **ZWERYFIKOWANO**
+  uruchamiając `class_to_snake`.
+
+### Widoki (mapowanie legacy → liveops)
+
+| legacy `LongRunning*View` | zamiennik liveops |
+|---|---|
+| `LongRunningOperationsView` (lista) | zwykły owner-scoped `ListView` (wzór `import_punktacji_zrodel/views.py:14`), własny `template_name`, `order_by("-created_on")` |
+| `CreateLongRunningOperationView` | `liveops.views.CreateLiveOperationView` (`liveops/views.py:98`) — ustawia owner, `save()`, `enqueue()`, redirect na `get_absolute_url()`; group-gate przez braces (wzór `import_punktacji_zrodel/views.py:31`) |
+| `LongRunningRouterView` | **usunięty** — `get_absolute_url()` → `liveops:live` robi to samo |
+| `LongRunningDetailsView` | **usunięty** — strona live (`LiveOperationView`, centralny URL) renderuje host template `import_list_if.html` |
+| `LongRunningResultsView` | app-specific owner-scoped `ListView` **near-copy-paste z `import_punktacji_zrodel/views.py:45-86`** — `parent_object` (cached_property, owner→`Http404`), `get_details_set()`, `paginate_by=25`, `object=self.parent_object` w kontekście |
+| `RestartLongRunningOperationView` | **usunięty jako app-level URL** (patrz §URL-e docelowe). „Ponów" na stronie live idzie na centralny `liveops:restart` (owner-scoped). Gdyby jednak zostawić app-level restart: `_PkOwnerRestartMixin`-style (braces `GroupRequiredMixin + liveops.views.RestartView`, wzór `import_pracownikow/views.py:1386`) |
+
+Bramka grupy: `liveops.BaseLiveOperationMixin` gejtuje tylko gdy
+`LIVEOPS["REQUIRED_GROUP"]` ustawione — w BPP `LIVEOPS`
+(`settings/base.py:1049`) tego **nie ma**, więc dokładamy braces
+`GroupRequiredMixin` (jak `import_pracownikow`) na Create/List/Results/Restart,
+inaczej dowolny zalogowany user odpaliłby import.
+
+### URL-e docelowe
+
+`index` (`""`), `new` (`new/`), `importlistif-results`
+(`<uuid:pk>/rezultaty/`). **Usuwamy** `importlistif-router`,
+`importlistif-details` **oraz `restart` (`<uuid:pk>/regen/`)**. Strona live
+idzie przez centralny `liveops:live` (`live/<op_type>/<uuid:pk>/`).
+
+**Decyzja o app-level restart (`regen/`) — DROP.** Po usunięciu include
+`operation_details.html` nic już nie linkuje `<uuid:pk>/regen/`. Przycisk
+„Ponów" na stronie live POST-uje na centralny `liveops:restart`
+(owner-scoped, ale **NIE** group-gated — liveops gejtuje tylko przy
+`REQUIRED_GROUP`, którego BPP nie ustawia). Ekspozycja ~zerowa: user bez
+grupy „wprowadzanie danych" i tak nie stworzy importu (create jest
+group-gated), więc nie ma własnej operacji do restartu. To dokładnie
+precedens `import_punktacji_zrodel` (jego `urls.py` nie ma `regen`) i
+`import_pracownikow`. Jeśli w trakcie realizacji okaże się, że potrzebny jest
+jawny app-level restart (np. z listy importów), przywróć go jako
+`_PkOwnerRestartMixin` (group-gated) — ale domyślnie NIE dodajemy.
+
+### Szablony docelowe
+
+- **Nowy** `import_list_if/import_list_if.html` (host live) — `extends
+  base.html`, `{% load static liveops %}`, wrapper `hx-headers` z CSRF (patrz
+  §Gotchas) wokół `{% live_operation object %}`, plus 3 skrypty (`htmx.min.js`,
+  `channels_broadcast/js/notifications.js`, `liveops/liveops.js`) — kopia
+  `import_pracownikow/import_pracownikow.html`.
+- **Nowy** `import_list_if/import_list_if_result.html` (fragment wyniku) —
+  panel „import zakończony" + link do `importlistif-results`, kontekst z
+  `result_context` (np. `total`, `zintegrowano`, ...). Wzór:
+  `import_punktacji_zrodel/import_punktacji_zrodel_result.html` (near-copy-paste).
+- `importlistif_list.html` — link zamień na `object.get_absolute_url`
+  (liveops:live); **napraw** breadcrumb `import_pracownikow:index` →
+  `import_list_if:index`; usuń auto-redirect JS jak przeszkadza.
+- `importlistifrow_list.html` — usuń `{% include "long_running/
+  operation_details.html" %}`; reszta działa, o ile results view poda
+  `object=parent_object` i `paginate_by` (patrz §Gotchas).
+- **Usuń** `importlistif_detail.html` (zastąpiony host template).
+- `importlistif_form.html` — bez zmian (`CreateView` nadal go szuka jako
+  `import_list_if/importlistif_form.html`).
+
+---
+
+## 4. Decyzja o `ImportOperation`: RETIRE (uzasadnienie)
+
+**Decyzja: skasować abstrakcyjny `ImportOperation`, a jego zawartość
+wchłonąć do `ImportListIf(LiveOperation)`.** NIE migrujemy bazy
+abstrakcyjnej na `LiveOperation`.
+
+Uzasadnienie:
+
+1. **Jedyny użytkownik.** `grep -rn ImportOperation src` = definicja +
+   `import_list_if`. Utrzymywanie warstwy abstrakcji dla jednej podklasy to
+   martwy koszt; po migracji `import_pracownikow` (który nigdy nie dziedziczył
+   po `ImportOperation`) baza ta straciła rację bytu.
+2. **`LiveOperation` już jest bazą abstrakcyjną.** Wstawienie pośredniego
+   `ImportOperation(LiveOperation)` dodałoby drugi poziom MRO bez żadnego
+   drugiego konsumenta — antywzorzec „abstrakcja spekulacyjna".
+3. **Zawartość jest trywialna do inline'u** (~30 linii: `plik_xls`,
+   `get_xls_import_file`, `get_validation_form_class`, pętla walidacji).
+   `import_pracownikow` sam trzyma swój `plik_xls` i logikę — spójność
+   ze wzorcem referencyjnym.
+4. **`ImportRowMixin` NIE jest częścią tej decyzji** — to osobna klasa w tym
+   samym pliku, współdzielona z `import_pracownikow/models.py:720`. **Zostaje
+   w `import_common/models.py`.** Kasujemy z tego pliku **tylko** klasę
+   `ImportOperation` oraz nieużywane po niej importy (`ceil`,
+   `XLSParseError`, `XLSImportFile`, `Operation`, `ASGINotificationMixin`) —
+   o ile `ImportRowMixin` ich nie potrzebuje (nie potrzebuje).
+
+Konsekwencja czyszcząca: po przeniesieniu `import_common/models.py` zostaje
+praktycznie z samym `ImportRowMixin`. To OK — plik pozostaje (import ścieżki
+`from import_common.models import ImportRowMixin` używany przez
+`import_pracownikow`).
+
+---
+
+## 5. Migracja modelu (nowa migracja delta)
+
+Nowa migracja `src/import_list_if/migrations/0005_liveops.py`, mirror
+`import_pracownikow/migrations/0010_liveops.py`, **bez** `stan` i **bez**
+`RunPython` (import_list_if nie ma pól `performed`/`integrated` do
+przemapowania).
+
+- `dependencies`: `("import_list_if", "0004_alter_importlistif_plik_xls")`
+  + `migrations.swappable_dependency(settings.AUTH_USER_MODEL)`.
+- `operations`:
+  - `AlterModelOptions("importlistif", options={"ordering": ["-created_on"]})`
+    (dziś `options={}` po `0002`; nowa baza wnosi `-created_on`).
+  - `RemoveField("importlistif", "last_updated_on")`.
+  - `AddField` ×10 (identyczne definicje jak w 0010): `cancel_requested`
+    `BooleanField(default=False)`, `cancelled` `BooleanField(default=False)`,
+    `current_stage` `IntegerField(default=-1)`, `language`
+    `CharField(blank=True, default="", max_length=20)`, `log`
+    `JSONField(default=list)`, `log_seq` `PositiveIntegerField(default=0)`,
+    `percent` `PositiveSmallIntegerField(default=0)`, `result_context`
+    `JSONField(blank=True, null=True)`, `stage_states` `JSONField(default=dict)`,
+    `status_text` `CharField(blank=True, default="", max_length=255)`.
+  - `AlterField("importlistif", "owner", ForeignKey(on_delete=CASCADE,
+    related_name="+", to=AUTH_USER_MODEL))`.
+
+Pola niezmienne (już kolumny w tabeli po spłaszczeniu dziedziczenia): `id`,
+`created_on`, `started_on`, `finished_on`, `finished_successfully`,
+`traceback`, `plik_xls`, `rok` — **redeklaracja z bazy `LiveOperation` nie
+generuje operacji**. Zmiana `bases` w `CreateModel` NIE jest emitowana przez
+`makemigrations` (bases nie wpływają na schemat) — nie potrzeba `AlterModelBases`.
+
+### PK / FK / related_name
+
+- **PK zostaje UUID** — `LiveOperation.id = UUIDField(default=uuid4)` jest
+  identyczne z obecnym `Operation.id`; URL-e `<uuid:pk>` bez zmian.
+- `ImportListIfRow.parent` (FK do `ImportListIf`, `models.py:68`) —
+  **bez zmian** (nadal wskazuje ten sam model, `on_delete=CASCADE`,
+  `related_name` domyślny `importlistifrow_set`). Brak migracji na `Row`.
+- `owner` → `related_name="+"` (jak liveops) — pojedyncza `AlterField`.
+
+### Data concerns
+
+- Brak migracji danych. Istniejące ukończone importy: `finished_on` +
+  `finished_successfully` → `LiveOperation.get_state()` daje `FINISHED_OK`
+  poprawnie; `cancelled=False` (default). Utrata `last_updated_on` (sortowanie)
+  nieistotna — sortujemy po `-created_on`.
+- **Baseline:** migracja zmienia schemat → przy scalaniu do `dev` trzeba
+  `make baseline-update` (delta). **NIE** robić w tym worktree/branchu
+  (reguła: baseline raz, przy merge; równoległe branche = nierozwiązywalny
+  konflikt na jednym pliku). Odnotować w PR.
+- `makemigrations --check --dry-run` musi być czysty po napisaniu migracji
+  (walidacja zgodności model↔migracja).
+
+---
+
+## 6. Fazy (uporządkowane, każda niezależnie zielona, TDD)
+
+Rekomendacja: **cutover w jednej gałęzi, ale w 3 commitach-fazach**. Bez
+mostka kompatybilności — aplikacja jednofazowa, split emisji nic nie daje.
+(Mostek — patrz §Gotchas — trzymamy jako awaryjny fallback, gdyby ktoś chciał
+pośredni zielony stan między modelem a widokami; wtedy MUSI to być lokalny
+`Progress` forwardujący do legacy `send_progress`/`send_notification` z
+`check_cancelled` = no-op, NIGDY `TextProgress` na legacy modelu.)
+
+### Faza 0 — testy charakteryzujące (kończy RED — commituj RAZEM z Fazą 1)
+
+**WAŻNE:** Faza 0 z definicji kończy się **czerwono** (produkcja jeszcze nie
+ma `run()`). Nie jest to „niezależnie zielona" faza — albo **scal jej commit
+z Fazą 1** (jeden zielony commit model+testy), albo oznacz nowe testy
+`@pytest.mark.xfail(reason="run() dopiero w Fazie 1", strict=True)` i zdejmij
+xfail w Fazie 1. Nie zostawiaj czerwonego commitu jako osobnego kroku.
+
+- Przepisz `test_models.py`: zamiast `import_list_if.perform()` wołaj
+  `import_list_if.run(p)` z `liveops.testing.MockProgress(import_list_if)`
+  (`.venv/.../liveops/testing.py:43` klasa, `__init__` z `cancel_after` na `:46`;
+  docstring `test_my_import_run` na :27). Asercje bez zmian (4 wiersze,
+  `impact_factor == Decimal("70.67")`). `on_reset`→`on_restart`,
+  `get_details_set` — analogicznie.
+- Test anulowania **musi być zgodny z decyzją o atomicity** (patrz §9 ryzyko 1):
+  jeśli `run()` owinięte w `transaction.atomic()`, `p.check_cancelled()` rzuca
+  `liveops.progress.OperationCancelled`, które **cofa** zapisane wiersze →
+  asercja: `with pytest.raises(OperationCancelled): op.run(MockProgress(op,
+  cancel_after=1))` **oraz** `op.importlistifrow_set.count() == 0`. (Bez atomic
+  byłby 1 zapisany wiersz — nie tego chcemy.) `MockProgress.check_cancelled`
+  rzuca `OperationCancelled` po `cancel_after` wywołaniach.
+
+### Faza 1 — model + migracja (zielona po sobie)
+
+1. `import_list_if/models.py`: `class ImportListIf(LiveOperation)`; wchłoń
+   `plik_xls`, `get_xls_import_file`, `get_validation_form_class`,
+   `ignore_bad_rows`; przepisz `perform()` → `run(self, p)` (owinięte w
+   `transaction.atomic()` dla parytetu z legacy `task_perform` — patrz §9):
+   ```
+   def run(self, p):
+       from django.db import transaction
+       with transaction.atomic():
+           x = self.get_xls_import_file()
+           total = x.count()
+           form_class = self.get_validation_form_class()
+           for no, elem in enumerate(x.data()):
+               p.check_cancelled()  # OperationCancelled → rollback wierszy
+               cleaned = None
+               if form_class:
+                   form = form_class(elem)
+                   if not form.is_valid():
+                       if self.ignore_bad_rows:
+                           continue
+                       raise XLSParseError(
+                           elem, form, "wstępna weryfikacja danych"
+                       )
+                   cleaned = form.cleaned_data
+               self.import_single_row(xls_data=elem, cleaned_data=cleaned)
+               if total:
+                   p.percent(int((no + 1) * 100 / total))
+       p.result({"total": total})  # WebProgress.result deferuje push on_commit
+   ```
+   (importy przenieś do `import_list_if/models.py`: `ceil` niepotrzebny;
+   `XLSParseError` z `import_common.exceptions`, `XLSImportFile` z
+   `import_common.util`.) `on_reset`→`on_restart` (kasuje
+   `get_details_set().delete()`). `p.result(...)` **poza** blokiem atomic
+   (i tak defer przez `on_commit` — `progress.py:263-289`).
+2. `import_common/models.py`: usuń `class ImportOperation` + osierocone
+   importy; **zostaw `ImportRowMixin`**.
+3. Napisz `0005_liveops.py` (§5).
+4. Zielone: `uv run pytest src/import_list_if/tests/test_models.py`
+   + `uv run python src/manage.py makemigrations --check --dry-run`
+   (brak driftu).
+
+> **Post-Faza-1 NIE jest deployowalny.** Testy modelu są zielone, ale
+> aplikacja jest runtime-broken do końca Fazy 2: stare `views.py` nadal
+> importuje `LongRunning*View` i woła metody, których model już nie ma
+> (`RouterView.get` → `object.get_url()`/`get_state()` int-vs-str;
+> create → `task_perform` `AttributeError`; restart → `mark_reset`
+> `AttributeError`). To OK w obrębie jednej gałęzi (cutover), ale **nie
+> mergować/deployować między Fazą 1 a 2** — dopiero po Fazie 2 apka działa.
+
+### Faza 2 — widoki + URL-e + szablony (domyka cutover — dopiero tu apka działa)
+
+1. `views.py`: przepisz na liveops (tabela §3). `BaseImportListIfMixin`
+   (braces `GroupRequiredMixin`, `group_required = GR_WPROWADZANIE_DANYCH`
+   z `bpp.const` — **nie literał** `"wprowadzanie danych"`) zostaje jako miks
+   na Create/List/Results. Restart app-level: **nie dodajemy** (§3).
+2. `urls.py`: usuń `importlistif-router`, `importlistif-details` **oraz
+   `restart`**; zostaw `index`, `new`, `importlistif-results`.
+3. Szablony: nowy `import_list_if.html` (host, hx-headers + live_operation),
+   nowy `import_list_if_result.html`, napraw `importlistif_list.html`
+   (link + breadcrumb), oczyść `importlistifrow_list.html`, skasuj
+   `importlistif_detail.html`. **Usuń martwy `{% load render_table from
+   django_tables2 %}`** z każdego szablonu, który go trzyma bez użycia
+   (`importlistif_list.html`, `importlistif_form.html`,
+   `importlistifrow_list.html`, `importlistif_detail.html` — ten ostatni i tak
+   kasujemy).
+4. `test_views.py`: istniejące GET-y `index`/`new` przechodzą; dodaj:
+   - create POST → redirect na `liveops:live` (RUNNER=eager w
+     `settings/test.py` wykona import synchronicznie); wiersze zapisane;
+   - results view renderuje wiersze (owner-scoped; cudzy import → `Http404`);
+   - **group-gating (create):** zalogowany user **bez** grupy
+     „wprowadzanie danych" → **302 redirect_to_login** (braces
+     `raise_exception=False` domyślnie — NIE 403) **i brak side-effectu**
+     (import nie powstał). Asertuj po side-effekcie + `status_code == 302` /
+     `"/login" in resp.url`, wzorem `import_pracownikow/tests/test_auth_gate.py`
+     (który asertuje przez niezmieniony stan operacji). Superuser i user w
+     grupie → przechodzą.
+5. Zielone: `uv run pytest src/import_list_if/`.
+
+### Faza 3 — sprzątanie + newsfragment
+
+1. `grep -rn "ImportOperation\|long_running" src/import_list_if src/import_common`
+   = czysto (poza `ImportRowMixin`). Potwierdź, że `long_running` **nie** jest
+   usuwany globalnie (dalej używany przez 7+ apek).
+2. Newsfragment `src/bpp/newsfragments/<slug>.feature.rst` (PL, zwięźle) —
+   np. „Import list IF przeniesiony na django-liveops (live progress przez
+   WebSocket)".
+3. Zielone: `make tests-without-playwright` (albo pełne `make tests`).
+
+---
+
+## 7. Zachowanie do utrzymania (+ testy strażnicze)
+
+| Zachowanie | Strażnik |
+|---|---|
+| Dopasowanie źródła + zapis `Punktacja_Zrodla.impact_factor` per rok; flaga `zintegrowano` | `test_models.py::test_ImportListIF_run` (dawne `_perform`) |
+| Reset kasuje wiersze podglądu | `test_ImportListIF_on_restart` (dawne `_on_reset`) |
+| `get_details_set()` (select_related zrodlo) | `test_ImportListIF_get_details_set` |
+| Anulowanie przerywa pętlę **i cofa wiersze** (atomic) | nowy test `MockProgress(cancel_after=1)` → `pytest.raises(OperationCancelled)` + `count()==0` |
+| Owner-scoping list/results (brak wycieku cudzych importów) | nowy test widoku (dwóch userów; cudzy → `Http404`) |
+| Group-gating create (`GR_WPROWADZANIE_DANYCH`) | nowy test widoku: user bez grupy → **302 redirect_to_login + brak side-effectu** (NIE 403); superuser/w-grupie → OK |
+| Linki „pobierz plik wzorcowy" na index/new | istniejące `test_views.py` (zostają) |
+| Paginacja tabeli wyników + kontekst `object`=rodzic | test renderu `importlistif-results` |
+| Redirect po create na stronę live | test create POST → `liveops:live` |
+
+---
+
+## 8. Strategia testów
+
+- **Jednostkowe modelu:** `liveops.testing.MockProgress` (nagrywa
+  `percent`/`log`/`result`, wspiera `cancel_after`) — bez Redis/WebSocket.
+  `@pytest.mark.django_db`, `baker.make`/istniejące fixtury (`zrodlo`, `rok`,
+  `admin_user`), plik `testdata1.xlsx`.
+- **Widoki:** webtest (`admin_app`) jak dziś + `django_webtest`/`client`
+  dla POST-ów. `settings/test.py:73` ma `LIVEOPS = {**LIVEOPS,
+  "RUNNER": "eager"}` — create/restart uruchamiają `run()` synchronicznie,
+  więc po POST można od razu asertować wiersze i stan `FINISHED_OK`.
+- **Bramka grupy:** utwórz usera w grupie `GR_WPROWADZANIE_DANYCH` vs bez;
+  user bez grupy → **302 redirect_to_login** (braces `raise_exception=False`),
+  asertuj też brak side-effectu. Superuser exempt (semantyka braces).
+- **Lokalnie (reguła projektu):** odpal `uv run pytest src/import_list_if/`
+  po każdej fazie; przed PR `make tests-without-playwright`. Wymaga Dockera
+  (testcontainers PG/Redis) — jeśli brak, powiedz wprost.
+- **`makemigrations --check`** jako część CI/lokalnej walidacji Fazy 1.
+
+---
+
+## 9. Ryzyka i pytania otwarte
+
+**Top 3 ryzyka:**
+
+1. **Brak zewnętrznej transakcji wokół `run()`.** Legacy `task_perform`
+   (`long_running/models.py:99`) owijał `perform()` w `transaction.atomic()`
+   (`:108`); `liveops.runner._task_run` **nie owija** `operation.run(progress)`
+   (`runner.py:143`). Częściowy import przy błędzie w połowie pliku zostawiłby
+   część wierszy zapisanych + stan `FINISHED_ERROR`. **Mitygacja
+   (rekomendowana): owinąć ciało `run()` w `transaction.atomic()`** — przywraca
+   dawne all-or-nothing. Jest to **oficjalnie wspierane** przez liveops:
+   `WebProgress.result`/`error` deferują push terminalny przez
+   `transaction.on_commit` (`progress.py:263-289`, konkretnie `:302`/`:332`),
+   więc push nie odpala się dopóki transakcja się nie zacommituje.
+   **Świadome odejście od wzorca PRIMARY:** `import_punktacji_zrodel` **NIE**
+   owija (pisze wiersze przyrostowo w `analyze_jcr_file`); my owijamy dla
+   parytetu z legacy `task_perform` (dawne zachowanie import_list_if było
+   atomowe). Konsekwencja dla testu anulowania: `OperationCancelled` cofa
+   wiersze → asercja `raises + count()==0` (§Faza 0). Uwaga na `enqueue()`
+   gotcha §Gotchas (poza `run()`).
+2. **Nazwy szablonów.** Host MUSI być `import_list_if/import_list_if.html`,
+   wynik `import_list_if/import_list_if_result.html` (auto z `class_to_snake`).
+   Stary `importlistif_detail.html` NIE jest już rozpoznawany przez liveops —
+   łatwo zostawić martwy plik i dostać goły `liveops/operation.html`.
+3. **CSRF + `hx-headers`.** Bez wrappera `<div hx-headers=...>` przyciski
+   Anuluj/Ponów dają 403 (BPP `CSRF_COOKIE_HTTPONLY=True`,
+   `settings/base.py:1596`) — patrz §Gotchas.
+
+**Pozostałe ryzyka:** results view bez `paginate_by`/`object` łamie
+`importlistifrow_list.html` (§Gotchas); baseline drift jeśli ktoś odświeży
+baseline w tym branchu; `run()` importuje `XLSParseError`/`XLSImportFile` —
+pilnować, by przeniesione importy nie zostawiły cyklu.
+
+**Pytania otwarte:**
+
+- Czy `import_list_if` potrzebuje własnego `result_context` bogatszego niż
+  `{"total": ...}` (liczba zintegrowanych, niedopasowanych źródeł)? Wpływa na
+  treść `import_list_if_result.html`. Domyślnie: minimalny panel + link.
+- Czy zachować auto-redirect z pustej listy na `./new`
+  (`importlistif_list.html:36`)? Można zostawić.
+- Restart: app-level `regen/` **zdjęty** (§3) — „Ponów" idzie na centralny
+  `liveops:restart`, który `RestartView.post` robi pełny reset stanu sam
+  (nie potrzeba `reset_liveops_state` jak w wielofazowym
+  `import_pracownikow/models.py:326`). Otwarte tylko: czy UX wymaga jawnego
+  restartu z listy importów (wtedy przywróć group-gated `_PkOwnerRestartMixin`).
+
+---
+
+## 10. Czego NIE robić
+
+- **NIE** modyfikować istniejących migracji `import_list_if/migrations/
+  0001..0004` — tylko dodać `0005_liveops.py`.
+- **NIE** kasować `ImportRowMixin` z `import_common/models.py` (używa
+  `import_pracownikow`).
+- **NIE** usuwać aplikacji `long_running` ani jej z `INSTALLED_APPS`
+  (`settings/base.py:407`) — 7+ innych importerów na niej stoi.
+- **NIE** odświeżać baseline (`make baseline-update`/`rebuild-baseline`) w tym
+  branchu — robi się to raz, przy scalaniu do `dev`.
+- **NIE** montować nowych URL-i live w `import_list_if/urls.py` — centralny
+  router `liveops:live` już jest (`django_bpp/urls.py:286`).
+- **NIE** używać `TextProgress` na legacy modelu (brak pola `cancel_requested`
+  → `check_cancelled().refresh_from_db` wywali) — dotyczy tylko awaryjnego
+  mostka §Gotchas.
+- **NIE** dodawać `LIVEOPS["REQUIRED_GROUP"]` globalnie zamiast braces
+  `GroupRequiredMixin` — reszta liveopsów w BPP polega na braku tej bramki.
+- **NIE** wołać `enqueue()` wewnątrz `transaction.atomic()` bez
+  `transaction.on_commit` (§Gotchas).
+
+---
+
+## Załącznik — wbudowane gotchas (żeby wykonawca nie odkrywał od nowa)
+
+- **CSRF (`CSRF_COOKIE_HTTPONLY=True`, `settings/base.py:1596`):** host
+  template MUSI owinąć `{% live_operation object %}` w
+  `<div hx-headers='{"X-CSRFToken":"{{ csrf_token }}"}'>` — inaczej POST
+  Anuluj/Ponów = **403** (to prawdziwe 403 z CSRF, nie mylić z 302 bramki
+  grupy). Wzór: `import_pracownikow/import_pracownikow.html:27`. **NIE**
+  kopiować z `import_punktacji_zrodel/import_punktacji_zrodel.html:21` —
+  ten host template **nie miał** wrappera (latentny bug CSRF; analogicznie
+  `deduplikator_zrodel`). **Oba naprawione na `dev` (commit 7eed62a2a)** —
+  po rebase na `dev` można wzorować się i na punktacji, ale weź wrapper
+  świadomie.
+- **Results view:** `importlistifrow_list.html` używa `object.plik_xls.name`/
+  `object.pk` i `{% include "pagination.html" %}` → results view MUSI ustawić
+  `paginate_by = 25` i podać `object=self.parent_object` w kontekście (oprócz
+  `object_list`). Near-copy-paste z `import_punktacji_zrodel/views.py:45-86`
+  (`ResultsView.get_context_data` woła `super().get_context_data(
+  object=self.parent_object, ...)`).
+- **Bramka grupy = 302, nie 403.** Braces `GroupRequiredMixin`
+  (`AccessMixin.raise_exception=False`, `_access.py:27,81`) przy braku grupy
+  robi `redirect_to_login` → **302**, nie 403. Testy asertują przez
+  side-effect (op nie powstał/nie zresetowany), nie po statusie. Chcieć 403
+  = ustawić `raise_exception=True` (zmiana zachowania — NIE rekomendowane).
+- **Restart NIE jest group-gated** (świadomie). App-level `regen/` zdjęty;
+  centralny `liveops:restart` jest owner-scoped, ale liveops gejtuje grupą
+  tylko przy `REQUIRED_GROUP` (BPP nie ustawia). Ekspozycja ~zero: create jest
+  group-gated, więc user bez grupy nie ma własnego importu do restartu.
+  Precedens `import_punktacji_zrodel`/`import_pracownikow`.
+- **`enqueue()` → celery `.delay()` bez `on_commit`.** Bezpośredni enqueue
+  w create jest OK (brak `ATOMIC_REQUESTS`). Enqueue wewnątrz
+  `@transaction.atomic` wymaga `transaction.on_commit(...)`.
+- **Nazwy szablonów:** `class_to_snake("ImportListIf") = "import_list_if"`
+  (ZWERYFIKOWANO) → host `import_list_if/import_list_if.html`, wynik
+  `..._result.html`. Zgadza się z app_label — brak potrzeby jawnych
+  `host_template_name`/`result_template_name`.
+- **Mostek Fazy 1 (tylko jeśli split emisji ≠ cutover):** lokalny `Progress`
+  FORWARDUJĄCY do legacy `send_progress`/`send_notification`, z `check_cancelled`
+  nadpisanym na no-op (legacy `Operation` nie ma `cancel_requested` →
+  `refresh_from_db` by się wywalił). NIGDY `TextProgress` na legacy modelu.
+  Dla `import_list_if` rekomendacja: **pomiń mostek**, rób cutover.
+- **Istniejące migracje nietykalne; nie odświeżać baseline (odnotować przy
+  merge); newsfragment wymagany.**

--- a/docs/deweloper/plan-import-polon-liveops.md
+++ b/docs/deweloper/plan-import-polon-liveops.md
@@ -1,0 +1,592 @@
+# Plan: migracja importera POLON z `long_running` na `django-liveops` (v3)
+
+> Status: PLAN (do wykonania). Wersja 3 — poprawiona po dwóch rundach
+> adversarialnego review (defekty zweryfikowane w kodzie tego worktree; patrz
+> „Zmiany względem v2" i „Zmiany względem v1" na końcu). Ten dokument NIE zmienia
+> kodu.
+
+## Streszczenie
+
+Importer POLON (`ImportPlikuPolon`) oraz importer absencji
+(`ImportPlikuAbsencji`) nadal dziedziczą po `long_running.models.Operation`
++ `ASGINotificationMixin` (postęp przez `channels_broadcast`,
+`?extraChannels=[pk]`). Migrujemy je na `liveops.LiveOperation` (kanały
+`liveop.<pk>`, podpisany `subscription_token`, snapshot-on-connect,
+throttlowany progress, runner celery). Zadanie jest **niepilne**: świeżo scalona
+łatka (`long_running/authorizers.py` + `CHANNELS_BROADCAST_SUBSCRIPTION_AUTHORIZER`)
+przywróciła live-progress na STAREJ ścieżce — to modernizacja spójnościowa, nie
+naprawa awarii.
+
+## Kontekst infrastrukturalny — CO JUŻ JEST (nie ruszać)
+
+Infrastruktura liveops jest już wpięta na `dev` (i w tym worktree). Migracja
+POLON to **wyłącznie zmiany w aplikacji** `import_polon` — bez plumbingu
+ASGI/URL/settings:
+
+- `pyproject.toml:160` — `django-liveops[celery]>=0.4.0,<0.5` (zainstalowane).
+- `src/django_bpp/settings/base.py:455` — `"liveops"` w `INSTALLED_APPS`.
+- `src/django_bpp/settings/base.py:1049` — `LIVEOPS = {BASE_TEMPLATE, RUNNER:
+  "celery", THROTTLE_HZ: 10}`. **Brak `REQUIRED_GROUP`** (świadomie — bramkuje
+  globalnie WSZYSTKIE liveopsy, w tym deduplikator).
+- `src/django_bpp/settings/test.py:73` — `LIVEOPS = {**LIVEOPS, "RUNNER":
+  "eager"}` — w testach dispatch jest SYNCHRONICZNY (bez Redis/workera).
+- `src/django_bpp/asgi.py:13,23` — `liveops.routing`
+  (`LiveOperationConsumer` = nadzbiór `NotificationsConsumer` + snapshot).
+- `src/django_bpp/urls.py:286` — `path("live/", include("liveops.urls"))`
+  (centralny `liveops:live` / `:cancel` / `:restart` po `op_type`).
+- `src/django_bpp/settings/base.py:1596` — **`CSRF_COOKIE_HTTPONLY = True`**
+  → `liveops.js` NIE odczyta tokenu z ciasteczka; host-template MUSI wstrzyknąć
+  `X-CSRFToken` (patrz Faza 2, wzór `import_pracownikow.html:27`).
+- `src/django_bpp/settings/base.py:1077` —
+  `CHANNELS_BROADCAST_SUBSCRIPTION_AUTHORIZER =
+  "long_running.authorizers.authorize_operation_channel"` — STARA ścieżka.
+  **Zostaje** (inne importery nadal używają `extraChannels`); POLON „wypadnie"
+  z autoryzatora sam, przestając być podklasą `Operation`.
+
+### Referencje (co JEST i czego NIE MA na tym branchu)
+
+Zweryfikowane w kodzie tego worktree — **rzeczywiście zmigrowane są TRZY
+importery**: `import_pracownikow`, `import_punktacji_zrodel`,
+`deduplikator_zrodel`.
+
+- **KANONICZNY wzór = `import_pracownikow`** (najbliższy POLON-owi: dry-run→
+  zapis, dzieci, uczelnia, grupa „wprowadzanie danych"):
+  - migracja: `src/import_pracownikow/migrations/0010_liveops.py` — zawiera
+    DOKŁADNIE naszą deltę: `AlterModelOptions ordering=["-created_on"]`,
+    `RemoveField last_updated_on`, `AddField` ×10 (cancel_requested, cancelled,
+    current_stage, language, log, log_seq, percent, result_context,
+    stage_states, status_text), `AlterField owner related_name="+"`.
+  - model: `src/import_pracownikow/models.py:72,251-345` — `run(self,p)` z
+    obudową rollbar+re-raise, `on_restart()`, `reset_liveops_state()`.
+  - host template: `src/import_pracownikow/templates/import_pracownikow/
+    import_pracownikow.html` (z wrapperem CSRF, kolejnością skryptów).
+  - widoki: `src/import_pracownikow/views.py:118-174` (ListView + Create),
+    `1386-1455` (`_PkOwnerRestartMixin(GroupRequiredMixin, RestartView)`).
+  - testy bramki: `src/import_pracownikow/tests/test_auth_gate.py`.
+- **`import_list_ministerialnych` — NIE scalony na dev.** Zweryfikowane:
+  `src/import_list_ministerialnych/models.py:10` to nadal
+  `ASGINotificationMixin, Operation`; migracje kończą się na `0008_*`;
+  `feat/liveops-import-list-ministerialnych` **NIE jest** przodkiem `dev`
+  (`git merge-base --is-ancestor … → NOT-ancestor`). Jego diff
+  (`origin/feat/liveops-import-list-ministerialnych`) można oglądać jako
+  ilustrację, ale NIE traktować jako „w drzewie". (Patrz też „Ryzyka" —
+  konflikt baseline przy scalaniu tych dwóch gałęzi.)
+
+---
+
+## Stan obecny (mapa legacy POLON)
+
+### Modele — `src/import_polon/models.py`
+
+- `ImportPlikuPolon(ASGINotificationMixin, Operation)` — pola: `rok`, `plik`,
+  `ukryj_niezmatchowanych_autorow`, `zapisz_zmiany_do_bazy`,
+  `ignoruj_miejsce_pracy`, `uczelnia` (FK `bpp.Uczelnia`). `perform()` →
+  `analyze_file_import_polon(self.plik.path, self)`; `on_reset()` kasuje dzieci;
+  `get_details_set()`; `autorzy_niezmatchowani()` (multi-hosted).
+- `ImportPlikuAbsencji(ASGINotificationMixin, Operation)` — `plik`,
+  `zapisz_zmiany_do_bazy`; `perform()` → `analyze_file_import_absencji`;
+  `on_reset()`.
+- Dzieci: `WierszImportuPlikuPolon`, `WierszImportuPlikuAbsencji` (FK `parent`).
+- `ImportPolonOverride` — słownik.
+
+`Operation` (`src/long_running/models.py:17`) daje: `id` (UUID pk), `owner`
+(FK, **bez** `related_name`), `created_on`, `last_updated_on` (auto_now),
+`started_on`, `finished_on`, `finished_successfully`, `traceback`,
+`get_state`, `mark_*`, `mark_reset`, `task_perform`, `get_url`,
+`get_absolute_url`→`get_url("router")`. **Brak** `cancel_requested`.
+
+### Ścieżka postępu (legacy)
+
+`ASGINotificationMixin`: `send_progress(pct)` (3× w `core/import_polon.py`:
+505,542,611; 1× w `core/import_absencji.py:130`), `send_notification` (2× w
+każdym rdzeniu), `send_processing_finished`. Widoki subskrybują
+`extraChannels=[pk]`. Autoryzacja: `authorize_operation_channel`.
+
+### Widoki — `views/plik_polon.py` + `plik_absencji.py`
+
+- `PokazImporty(BaseImportPlikuPolonMixin, LongRunningOperationsView)` —
+  zawężenie multi-hosted (`Q(uczelnia==current)|Q(uczelnia__isnull=True)`),
+  per-uczelnia trim `max_previous_ops`, order_by `-last_updated_on`.
+- `UtworzImportPlikuPolon(…, CreateLongRunningOperationView)` — `form_valid`
+  ustawia `uczelnia = Uczelnia.get_for_request(request)`.
+- `ImportPolonRouterView` / `…DetailsView` / `RestartImportView`.
+- `ImportPolonResultsView(…, LongRunningResultsView)` — filtry + kontekst
+  `unmatched_autor_dyscyplina`.
+- `ZapiszDoBazyMixin(RestrictToOwnerMixin, LongRunningTaskCallerMixin,
+  DetailView)` (`plik_polon.py:21-48`) — **owner-scope z
+  `RestrictToOwnerMixin`** (import z `long_running.views`); POST
+  (`@transaction.atomic` + `select_for_update`) → guard → flip flagi →
+  `self.object.mark_reset()` (linia 46) → `self.task_on_commit(pk)` (linia 47)
+  → `HttpResponseRedirect("..")` (linia 48).
+- `views/__init__.py` — star-importuje oba moduły (`from .plik_absencji import *`
+  + `from .plik_polon import *`).
+
+### URL-e — `src/import_polon/urls.py`
+
+`index`, `utworz-import`, `importplikupolon-router|details|restart|
+zapisz-do-bazy|results`; lustrzane `importplikuabsencji-*`; `index-absencji`
+(linia 35 — mapuje na `views.PokazImporty`, czyli listę POLON, **nie**
+absencji), `utworz-import-absencji`.
+
+### Szablony
+
+- `importplikupolon_detail.html`, `importplikuabsencji_detail.html` — include
+  `long_running/operation_details.html`. **Do usunięcia.**
+- `importplikupolon_list.html` — link `…importplikupolon-router` + label
+  `{{ object.uczelnia }}`.
+- `wierszimportuplikupolon_list.html` / `…absencji_list.html` — strona wyników;
+  include `operation_details.html` + przycisk „zapisz do bazy".
+- `potwierdz_zapis_do_bazy.html` — form `action="."` (POST OK) + link Anuluj
+  `href=".."` (**→ router URL, do naprawy w Fazie 2**).
+
+### Testy
+
+- `test_multi_uczelnia_scoping.py` — Finding 1-4; woła rdzeń (2×) i
+  `PokazImporty().get_queryset()`.
+- `test_zapisz_do_bazy.py` — **11 testów** (`grep -c '^def test'` = 11); liczą
+  callbacki `on_commit` po `task_on_commit` (`_reimport_scheduled`). **Wymaga
+  przepisania — patrz Faza 2.**
+- Call-site’y rdzenia bez `p`: `test_import_polon_core.py` (**6×**: linie
+  33,45,112,160,206,241), `test_import_polon_override.py` (4×),
+  `test_import_polon_ignoruj.py` (3×), `test_import_absencji_core.py` (2×),
+  `test_multi_uczelnia_scoping.py` (2×).
+
+---
+
+## Docelowy stan (liveops)
+
+### API liveops (zweryfikowane, wersja 0.4)
+
+`LiveOperation` (`liveops/models.py`): pk UUID; `owner` (`related_name="+"`);
+`created_on/started_on/finished_on`; `finished_successfully`,
+`cancel_requested`, `cancelled`, `traceback`, `result_context`, `language`,
+`status_text`, `percent`, `log`, `log_seq`, `current_stage`, `stage_states`;
+klasowe `stages`, override `host_template_name`/`result_template_name`.
+Kontrakt: `run(self,p)`, `on_restart()`. Kanał `liveop.<pk>`, `op_type_key()`
+= `<app_label>.<model_name>`. `get_absolute_url()` → `liveops:live`.
+`enqueue()` przy `RUNNER="celery"` → `_celery_task.delay(...)` **bez**
+`transaction.on_commit`.
+
+`Progress` (`liveops/progress.py`): `status`, `percent` (throttle),
+`track(iterable, total, label)` (throttle + `check_cancelled` per item), `log`,
+`stage(name)`, `result(ctx, **extra)`, `error(msg)`. **`check_cancelled()`
+(linia 154) woła `refresh_from_db(fields=["cancel_requested"])`** — istotne dla
+Fazy 1 (legacy `Operation` nie ma tego pola). `MockProgress`
+(`liveops/testing.py`) — nagrywa, finalizuje, bez throttle, `check_cancelled`
+no-op.
+
+Runner (`liveops/runner.py`): `task_run` ustawia `started_on`, woła `run(p)`,
+auto-finalizuje, łapie `OperationCancelled`/wyjątki (zapis `traceback`).
+
+Widoki (`liveops/views.py`): `CreateLiveOperationView`, `LiveOperationListView`,
+generyczne `LiveOperationView`/`CancelView`/`RestartView` (owner-scope, bramka
+`REQUIRED_GROUP` = no-op gdy nieustawione). Consumer robi `send_snapshot()`
+na connect.
+
+---
+
+## Migracja modelu
+
+Oba modele przechodzą z `Operation` na `LiveOperation`. **NIE modyfikujemy
+migracji 0001-0016** — nowa `0017_*`, POWIELAJĄCA na dwa modele deltę z
+`import_pracownikow/migrations/0010_liveops.py`:
+
+- `AlterModelOptions`: `ordering` `["-last_updated_on"]` → `["-created_on"]`.
+- `RemoveField last_updated_on` (jedyny konsument to sortowanie listy —
+  `PokazImporty` przechodzi na `-created_on`; **zweryfikowano grepem: żaden kod
+  nie czyta `user.importplikupolon_set` / `importplikuabsencji_set` ani
+  `.last_updated_on` POLON-a poza `plik_polon.py:69`**).
+- `AddField` ×10 (pola liveops z defaultami).
+- `AlterField owner` → `related_name="+"` (tylko stan migracji, bez SQL).
+
+Pola wspólne (`id`, `created_on`, `started_on`, `finished_on`,
+`finished_successfully`, `traceback`) mają identyczne definicje → brak operacji.
+pk zostaje UUID → URL-e `<uuid:pk>` bez zmian. Po zmianie modeli uruchomić
+`uv run python src/manage.py makemigrations --check`. **Baseline: NIE odświeżać
+w tym branchu** (dopiero przy scalaniu).
+
+---
+
+## Fazy (przyrostowe, TDD) — 4 fazy
+
+> Atomowość: `ImportPlikuPolon` i `ImportPlikuAbsencji` dzielą klasę bazową,
+> jedną migrację, wspólny plik widoków ORAZ wspólny `ZapiszDoBazyMixin`.
+> Cutover bazy modelu USUWA z użycia `mark_reset`/`task_perform`/`get_url`, więc
+> **cała warstwa widoków + `ZapiszDoBazyMixin` + jego testy muszą przejść w
+> TYM SAMYM commicie/PR** co model — inaczej `test_zapisz_do_bazy.py` (11
+> testów) jest czerwony między fazami. Dlatego Faza 2 to JEDEN zielony cutover
+> obejmujący również dry-run→zapisz.
+
+### Faza 1 — rdzeń przyjmuje `Progress` (stary model działa dalej)
+
+- `core/import_polon.py::analyze_file_import_polon(fn, parent_model, p)` —
+  dodać wymagany `p`. `send_progress(...)` → pętla
+  `for … in p.track(list(enumerate(records)), total=total, label="Import
+  POLON")`; `send_notification(err,"error")` → `p.log(err)` (potem `raise`).
+- `core/import_absencji.py::analyze_file_import_absencji(fn, parent_model, p)` —
+  analogicznie.
+- **Most zgodności = LOKALNA podklasa `Progress` FORWARDUJĄCA do legacy API,
+  NIE `TextProgress` i NIE pusty no-op.** Legacy `Operation` nie ma pola
+  `cancel_requested`, a `Progress.track` woła `check_cancelled()` →
+  `refresh_from_db(fields=["cancel_requested"])` (`liveops/progress.py:154`) → w
+  realnej ścieżce celery byłby `ValueError` (unit-testy z `MockProgress` by to
+  przegapiły) — dlatego `check_cancelled` nadpisujemy na **no-op** (fix awarii
+  zostaje). Ale pozostałych emiterów NIE zerujemy: skoro Fazy 1 i 2 mogą trafić
+  osobno, czysty no-op wygasiłby pasek postępu na starej stronie details między
+  nimi (zielone testy, regresja behawioralna). Most FORWARDUJE do legacy:
+  `_emit_percent(v) → parent_model.send_progress(v)`,
+  `log(line) → parent_model.send_notification(line, "info")`
+  (i `status`/`error` analogicznie). Cała klasa oraz linia w `perform()` znikają
+  w Fazie 2.
+- Zaktualizować test-call-site’y rdzenia na `MockProgress(model)`:
+  `test_import_polon_core.py` (6×), `test_import_polon_override.py` (4×),
+  `test_import_polon_ignoruj.py` (3×), `test_import_absencji_core.py` (2×),
+  `test_multi_uczelnia_scoping.py` (2×).
+
+Gate Fazy 1 (zielone): `uv run pytest
+src/import_polon/tests/test_import_polon_core.py
+src/import_polon/tests/test_import_polon_override.py
+src/import_polon/tests/test_import_polon_ignoruj.py
+src/import_polon/tests/test_import_absencji_core.py
+src/import_polon/tests/test_multi_uczelnia_scoping.py`.
+
+### Faza 2 — atomowy cutover (model + widoki + URL + szablony + zapisz-do-bazy)
+
+Model (`models.py`) — wzór `import_pracownikow/models.py:72,251-345`:
+- `ImportPlikuPolon(LiveOperation)`, `ImportPlikuAbsencji(LiveOperation)` —
+  usunąć importy `Operation`/`ASGINotificationMixin` + lokalny most z Fazy 1.
+- `perform()`→`run(self, p)`: woła rdzeń z `p`, finalizuje
+  `p.result({"total": self.get_details_set().count()})`; obudowa
+  `try/except: traceback.print_exc(); rollbar.report_exc_info(); raise`.
+- `on_reset()`→`on_restart()`.
+- Dodać `reset_liveops_state()` + `_POLA_LIVEOPS_RESET`
+  (kopia `import_pracownikow/models.py:306-345`).
+- Nazwy szablonów: `class_to_snake("ImportPlikuPolon") = "import_pliku_polon"`
+  (nie `importplikupolon`!). **Ustawić jawne `host_template_name` /
+  `result_template_name`** albo utworzyć pliki pod auto-nazwą — byle spójnie.
+- Migracja `0017_*` (patrz „Migracja modelu"); `makemigrations --check`.
+
+Widoki (`views/plik_polon.py`, `plik_absencji.py`):
+- Usunąć importy `long_running.views`.
+- `PokazImporty(GroupRequiredMixin, ListView)` — `model=ImportPlikuPolon`,
+  `group_required="wprowadzanie danych"`; `get_queryset` = owner-scope +
+  `order_by("-created_on")` + **zachować** zawężenie multi-hosted + per-uczelnia
+  trim (wzór ListView `import_pracownikow/views.py:118-133`). Analogiczny
+  `PokazImportyAbsencji`; **przy okazji naprawić `index-absencji`** (patrz Faza 4
+  — bugfix + newsfragment).
+- `UtworzImportPlikuPolon(GroupRequiredMixin, CreateLiveOperationView)` —
+  `form_valid` ustawia TYLKO `form.instance.uczelnia =
+  Uczelnia.get_for_request(request)` i woła `return super().form_valid(form)`;
+  reszta (owner + `form.save()` + `enqueue()` + redirect na `get_absolute_url`)
+  robi bazowe `CreateLiveOperationView.form_valid` (`liveops/views.py:101-105`).
+  **Uwaga o cytacie**: `import_pracownikow.NowyImportView.form_valid`
+  (`views.py:160-174`) świadomie NIE wywołuje `super()`/`enqueue()` — przekierowuje
+  na krok mapowania — więc to NIE jest wzór na enqueue; wzorem enqueue jest
+  bazowa metoda liveops. `UtworzImportPlikuAbsencji` bez `uczelnia` — może użyć
+  gołego `CreateLiveOperationView`.
+- `ImportPolonResultsView(GroupRequiredMixin, ListView)` — owner-scope przez
+  `parent_object` (`get_object_or_404(..., owner=request.user)`). **Ostrożnie z
+  wzorem `import_pracownikow/views.py:650-667`**: on podaje w kontekst
+  `parent_object=` (NIE `object=`) i NIE ma `paginate_by`. POLON-owy
+  `wierszimportuplikupolon_list.html` renderuje `{% url … object.pk %}` (~176)
+  i stronicowanie (~339,394), więc widok MUSI mieć:
+  - `paginate_by = 25` (inaczej cicha utrata paginacji — tysiące wierszy na
+    jednej stronie; testy tego NIE łapią),
+  - `get_context_data(object=self.parent_object, …)` (inaczej `NoReverseMatch`
+    na `object.pk` — testy łapią),
+  - zachowany dotychczasowy `filter_form` + kontekst `unmatched_autor_dyscyplina`
+    (`unmatched_count`), które obecny `ImportPolonResultsView` już buduje.
+  Absencji analogicznie (`object=self.parent_object` + `paginate_by=25` pod
+  `wierszimportuplikuabsencji_list.html`).
+- **Usunąć** `ImportPolonRouterView`, `ImportPolonDetailsView` + absencyjne
+  odpowiedniki. `RestartImportView` (POLON + absencji) NIE usuwać ślepo —
+  **zastąpić** gejtowanym wariantem opartym na liveops `RestartView` (patrz
+  „Restart" niżej).
+- **`ZapiszDoBazyMixin` — przepisać (owner-scope BEZ `long_running`)**:
+  - dziedziczenie: `LoginRequiredMixin` + `DetailView`/`SingleObjectMixin`;
+    owner-scope przez własny `get_queryset` = `self.model.objects.filter(
+    owner=self.request.user)` (zastępuje `RestrictToOwnerMixin` z
+    `long_running.views`) — po to, by Faza 4 „brak importów long_running"
+    przeszła.
+  - GET bez zmian (`potwierdz_zapis_do_bazy.html`).
+  - POST (`@transaction.atomic` + `select_for_update`) — guard bez zmian
+    (`finished_successfully and not zapisz_zmiany_do_bazy`), ale zamiast
+    `mark_reset()` + `task_on_commit`:
+    ```
+    self.object.zapisz_zmiany_do_bazy = True
+    self.object.on_restart()                      # kasuje wiersze-dzieci
+    pola = self.object.reset_liveops_state()
+    self.object.save(update_fields=["zapisz_zmiany_do_bazy", *pola])
+    transaction.on_commit(self.object.enqueue)     # patrz Ryzyko #2
+    ```
+  - **`HttpResponseRedirect("..")` (obecnie linia 48) → `HttpResponseRedirect(
+    self.object.get_absolute_url())`** (stary „.." = router URL kasowany w tej
+    fazie → 404).
+  - `ZapiszDoBazyImportView`/`ZapiszDoBazyImportAbsencjiView` zostają z
+    `GroupRequiredMixin` (bramka grupy).
+
+URL-e (`urls.py`): usunąć `*-router|details` (POLON + absencji); **zostawić
+`*-restart`** (teraz celuje w gejtowany `_PkOwnerRestartMixin`, POST); zostawić
+`index`, `utworz-import`, `*-results`, `*-zapisz-do-bazy`, `index-absencji`,
+`utworz-import-absencji`.
+
+`views/__init__.py`: nadal star-import obu modułów (bez zmiany struktury), ale
+zweryfikować, że nic z zewnątrz nie importuje po imieniu usuniętych klas
+(router/details/restart) — gwiazdka podąża za zawartością modułów, więc
+usunięcie klas wystarcza; sprawdzić importy w innych appach/urls.
+
+Szablony:
+- Host `import_polon/import_pliku_polon.html` (+ absencji) — wzór DOSŁOWNY
+  `import_pracownikow/templates/import_pracownikow/import_pracownikow.html`:
+  `{% extends "base.html" %}`, `{% load static liveops %}`, breadcrumbs, i
+  **OBOWIĄZKOWO wrapper CSRF** (bo `CSRF_COOKIE_HTTPONLY=True`):
+  ```
+  <div hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+      {% live_operation object %}
+  </div>
+  <script src="{% static 'liveops/vendor/htmx.min.js' %}"></script>
+  <script src="{% static 'channels_broadcast/js/notifications.js' %}"></script>
+  <script src="{% static 'liveops/liveops.js' %}"></script>
+  ```
+  (kolejność skryptów istotna).
+- Result `import_polon/import_pliku_polon_result.html` (+ absencji) — panel
+  „zakończono" + link `{% url "import_polon:importplikupolon-results"
+  operation.pk %}`. **Liczniki z `operation.get_details_set()`**, NIE tylko z
+  `result_context` (stare importy mają `result_context=NULL` — patrz Ryzyko #3).
+- `importplikupolon_list.html`: link → `{{ object.get_absolute_url }}`,
+  zachować `{{ object.uczelnia }}`.
+- **NOWY** `import_polon/importplikuabsencji_list.html` — dziś `index-absencji`
+  pożycza `importplikupolon_list.html` (bo mapuje na `PokazImporty`); po
+  wydzieleniu `PokazImportyAbsencji(ListView)` nie ma szablonu listy absencji →
+  `TemplateDoesNotExist`. Utworzyć osobny szablon: link wiersza →
+  `{{ object.get_absolute_url }}`, przycisk „utwórz nowy import" →
+  `{% url "import_polon:utworz-import-absencji" %}` (bez pola `uczelnia`).
+- `wierszimportuplikupolon_list.html` / `…absencji_list.html`: usunąć
+  `{% include "long_running/operation_details.html" %}` + toggle JS. Zachować
+  przycisk „zapisz do bazy".
+- `potwierdz_zapis_do_bazy.html`: **link Anuluj `href=".."` →
+  `href="{{ object.get_absolute_url }}"`** (stary „.." = router URL → 404).
+- Usunąć `importplikupolon_detail.html`, `importplikuabsencji_detail.html`.
+
+Restart — **gejtowany grupą** (precedens #508 F4). Centralny `liveops:restart`
+gejtuje tylko gdy `LIVEOPS["REQUIRED_GROUP"]` ustawione — w BPP NIE jest
+(`liveops/views.py:50-59` → no-op), a legacy `RestartImportView` siedział za
+grupą „wprowadzanie danych" (`plik_polon.py:104`). Restart z
+`zapisz_zmiany_do_bazy=True` PONOWNIE zapisuje do bazy, więc nie zostawiamy go
+owner-only. Dodać (wzór `import_pracownikow/views.py:1386-1404`) mały
+`_PkOwnerRestartMixin(GroupRequiredMixin, RestartView)` (owner-scope +
+`group_required="wprowadzanie danych"`) i gejtowane widoki restartu POLON +
+absencji, wpięte pod własne URL-e restartu (przywrócić `*-restart`), a przycisk
+restartu na host-page kierować na nie (a nie na centralny `liveops:restart`).
+Dodać test bramki (wzór `import_pracownikow/tests/test_auth_gate.py`): user bez
+grupy → POST restart nie zmienia stanu; z grupą → przechodzi.
+
+Testy Fazy 2 (nowe + przepisane, wszystko zielone na koniec):
+- `test_run_finalizuje_polon` / `…_absencji` — `op.run(MockProgress(op))` na
+  fixture-pliku: `finished_successfully`, `result_context`, wiersze utworzone.
+- `test_liveops_live_view_renderuje_host` — `op.get_absolute_url() ==
+  "/live/import_polon.importplikupolon/<pk>/"`; GET (admin) 200; treść zawiera
+  `data-liveop-channel`, `data-liveop-token` ORAZ `X-CSRFToken` (wrapper).
+- **Przepisany `test_zapisz_do_bazy.py` (11 testów)** — patrz „Strategia testów".
+- `test_restart_bez_grupy_nie_zmienia_stanu` / `…_z_grupa_przechodzi` (wzór
+  `import_pracownikow/tests/test_auth_gate.py`) — bramka grupy na restarcie.
+  **Asercja przez EFEKT UBOCZNY, NIE po kodzie 403**: braces
+  `GroupRequiredMixin` ma domyślnie `raise_exception=False` (żaden widok BPP nie
+  ustawia inaczej), więc zalogowany user bez grupy dostaje **302 →
+  redirect_to_login**, a nie 403. Sprawdzać: operacja NIE została zresetowana /
+  re-run (stan bez zmian, wiersze-dzieci nietknięte) — ewentualnie dodatkowo
+  `status_code == 302`; NIGDY nie asertować 403 (strażnik #508 F4 też idzie po
+  efekcie ubocznym, nie po kodzie).
+- Zielone bez zmian merytorycznych: całe `test_multi_uczelnia_scoping.py`
+  (get_queryset po `-created_on`; membership bez zmian),
+  `test_widok_tworzacy_przypina_uczelnie` (POST create — `enqueue()` w
+  `form_valid` jest SYNCHRONICZNE przy eager, więc import realnie biegnie;
+  sprawdzić że `run()` domyka na fixture-danych).
+
+### Faza 3 — polish live UI (opcjonalnie)
+
+- `stages` + `with p.stage(...)` (stepper; wzór
+  `import_pracownikow/models.py:270-284`). Niewymagane funkcjonalnie.
+- `get_success_url()` — domyślnie None (zostaje na stronie live z wynikiem).
+
+### Faza 4 — sprzątanie + newsfragmenty
+
+- Grep: `import_polon` nie importuje `long_running` ani `ASGINotificationMixin`;
+  brak martwych URL-name.
+- **NIE** usuwać `long_running`, autoryzatora, `CHANNELS_BROADCAST_*`.
+- **`admin.py` / `apps.py` — bez zmian** (`admin.py` rejestruje tylko
+  `ImportPolonOverride`; nie dotyka Operation/liveops) — executor nie musi ich
+  ruszać.
+- **DWA newsfragmenty** w `src/bpp/newsfragments/`:
+  - `<slug>.feature.rst` — „Import POLON i absencji na django-liveops
+    (live-progress WebSocket + HTMX)".
+  - `<slug2>.bugfix.rst` — **naprawa `index-absencji`**: dziś strona „absencje"
+    (`urls.py:35`) pokazuje listę importów POLON zamiast absencji; Faza 2
+    przepina `index-absencji` na `PokazImportyAbsencji`. To osobna,
+    user-widoczna poprawka → osobny fragment.
+
+---
+
+## Zachowanie do utrzymania (checklista + strażnicy)
+
+| Zachowanie | Gdzie | Test-strażnik |
+|-----------|-------|---------------|
+| Multi-hosted: raport niezmatchowanych | `ImportPlikuPolon.autorzy_niezmatchowani` (bez zmian) | `test_multi_uczelnia_scoping.py::test_autorzy_niezmatchowani_*` |
+| Multi-hosted: walidacja ZATRUDNIENIE | `core/import_polon.py::validate_zatrudnienie_...` | `..::test_walidacja_zatrudnienia_zawezona_do_uczelni_importu` |
+| Multi-hosted: guard mutacji obcej uczelni | `core/import_polon.py::autor_z_innej_uczelni` | `..::test_import_nie_modyfikuje_autora_innej_uczelni` |
+| Lista zawężona do uczelni + `uczelnia=None` wstecz | `PokazImporty.get_queryset` (ListView) | `..::test_lista_importow_zawezona_*`, `_bez_rozstrzygnietej_*` |
+| Create przypina `uczelnia` | `UtworzImportPlikuPolon.form_valid` | `..::test_widok_tworzacy_przypina_uczelnie_z_requestu` |
+| Label uczelni na liście | `importplikupolon_list.html` | (wizualny) |
+| Dry-run → zapisz (flip + reset + re-run) | `ZapiszDoBazyMixin.post` | `test_zapisz_do_bazy.py` (przepisany) |
+| Guardy zapisu (zapisany/błąd/w-trakcie/404) | `ZapiszDoBazyMixin.post` | `test_zapisz_do_bazy.py::*guard*`, `*other_user_404` |
+| Reset kasuje wiersze-dzieci | `on_restart()` | `..::test_zapisz_do_bazy_polon_post_deletes_child_rows` |
+| Przycisk „zapisz" tylko dla dry-run | `wierszimportuplikupolon_list.html` + results | `..::test_results_page_shows_button`, `_hides_button` |
+| Routing details/results/restart | `liveops:live/restart` + `*-results` | nowy `test_liveops_live_view_*` |
+
+Bramka grupy: `LIVEOPS` **nie ma** `REQUIRED_GROUP`, więc centralne
+`liveops:live`/`:cancel` są tylko owner-scoped. Grupa „wprowadzanie danych"
+nadal bramkuje create/list/results/zapisz (`GroupRequiredMixin`) ORAZ **restart**
+(gejtowany `_PkOwnerRestartMixin`, patrz Ryzyko #5 — restart jest destrukcyjny).
+Utworzyć import może tylko członek grupy, a live/wynik widzi tylko właściciel →
+brak regresji. **Nie** ustawiać `REQUIRED_GROUP` globalnie (zbramkowałoby
+deduplikator i inne liveopsy).
+
+---
+
+## Strategia testów
+
+- **`transaction.on_commit` w testach pytest-django NIE odpala się** (test biegnie
+  w rollbackowanej transakcji), chyba że użyjesz
+  `django_capture_on_commit_callbacks(execute=True)`. Wcześniejsze (v1)
+  stwierdzenie „eager + on_commit → import biegnie w teście" było BŁĘDNE dla
+  ścieżki zapisz-do-bazy (tam enqueue jest w `on_commit`).
+  - Ścieżka **create** (`enqueue()` wołane wprost w `form_valid`, poza
+    `on_commit`) JEST synchroniczna przy eager — `test_widok_tworzacy_*` realnie
+    uruchamia import.
+  - Ścieżka **zapisz-do-bazy** (`transaction.on_commit(enqueue)`):
+    - guard-testy (stan bez zmian) → `django_capture_on_commit_callbacks()`
+      BEZ `execute` i asercja, że lista callbacków enqueue jest pusta / że stan
+      nie ruszył;
+    - „re-run faktycznie przetworzył wiersze" → `…(execute=True)` żeby
+      wymusić enqueue (przy eager wykona się synchronicznie po commicie);
+    - flip-flag + reset stanu (`zapisz_zmiany_do_bazy=True`, `started_on`/
+      `finished_on` None, dzieci skasowane) sprawdzać PRZED wykonaniem enqueue
+      (capture bez execute) — inaczej re-run znów je ustawi.
+- Faza 1: rdzeń zielony z `MockProgress` (gate: core+override+ignoruj+absencji+
+  multi_uczelnia).
+- Faza 2: nowe `test_run_finalizuje_*`, `test_liveops_live_view_*`; regresja:
+  `test_multi_uczelnia_scoping.py`, `test_widok_tworzacy_*`; przepisany
+  `test_zapisz_do_bazy.py`.
+- Zielone bez zmian merytorycznych (poza `p`): `test_update_rodzaj_autora.py`,
+  `test_import_polon_validation.py`, `test_utils.py`.
+- Komendy: `uv run pytest src/import_polon/tests/ -q` (Docker daemon dla
+  testcontainers; RUNNER=eager z `settings/test.py`).
+
+---
+
+## Ryzyka i pytania otwarte
+
+1. **Migracja 0017 (oba modele naraz).** `owner related_name="+"` (AlterField
+   bez SQL) — zgrepowano, brak użyć reverse accessora. `last_updated_on` znika
+   (jedyny konsument: sortowanie listy → `-created_on`). `makemigrations
+   --check` po zmianie. Baseline dopiero przy scalaniu.
+2. **Celery enqueue w bloku `@transaction.atomic` (zapisz-do-bazy).**
+   `enqueue()` przy `RUNNER="celery"` woła `.delay()` bez `on_commit` — w bloku
+   atomic worker mógłby czytać stan sprzed commitu. Rozwiązanie:
+   `transaction.on_commit(self.object.enqueue)`. Konsekwencja: przepisanie
+   `test_zapisz_do_bazy.py` (patrz „Strategia testów").
+3. **Snapshot/result dla STARYCH importów (`result_context=NULL`).** Result-
+   template musi liczyć z `operation.get_details_set()`. Nazewnictwo:
+   `class_to_snake("ImportPlikuPolon")="import_pliku_polon"` — pliki host/result
+   pod tą nazwą albo jawne `host_template_name`/`result_template_name`.
+4. **CSRF.** `CSRF_COOKIE_HTTPONLY=True` (base.py:1596) → bez wrappera
+   `hx-headers` przyciski Anuluj/Ponów na host-page dają 403. Wrapper
+   obowiązkowy (wzór `import_pracownikow.html:27`).
+5. **Bramka grupy na restarcie — GEJTUJEMY (nie owner-only).** Centralny
+   `liveops:restart` gejtuje tylko przy ustawionym `REQUIRED_GROUP`
+   (`liveops/views.py:50-59`), którego BPP nie ustawia → owner-only. Ale restart
+   z `zapisz_zmiany_do_bazy=True` PONOWNIE zapisuje do bazy, a legacy
+   `RestartImportView` był za grupą „wprowadzanie danych" (`plik_polon.py:104`).
+   Projekt uznał to już za dziurę przy `import_pracownikow` (#508 F4:
+   `_PkOwnerRestartMixin(GroupRequiredMixin, RestartView)`,
+   `views.py:1386` + `test_auth_gate.py`). **Decyzja: powielić ten wzór dla
+   POLON + absencji** (własny gejtowany widok restartu pod `*-restart`, przycisk
+   host-page celuje w niego) zamiast akceptować owner-only. `cancel` (nie-
+   destrukcyjny) może zostać owner-only na centralnym `liveops:cancel`.
+6. **`notify_list_changed` / auto-refresh listy.** Własna `PokazImporty` nie ma
+   liveops-owego JS list-live → lista nie odświeży się sama (jak dziś). Bez
+   regresji.
+7. **Token TTL 24h** — POLON mieści się; snapshot-on-connect pokrywa reconnect.
+   Niskie ryzyko.
+8. **Faza 1 most zgodności.** Musi być LOKALNY no-op `Progress` (nie
+   `TextProgress`) — inaczej `check_cancelled → refresh_from_db(["cancel_
+   requested"])` na legacy `Operation` rzuci `ValueError` w realnej ścieżce
+   celery (unit-testy z `MockProgress` by to przegapiły).
+9. **Koordynacja z gałęzią `feat/liveops-import-list-ministerialnych`.** Jest
+   otwarta i też migruje importer na liveops. Przy scalaniu OBU:
+   (a) potencjalny konflikt baseline (`baseline-sql/baseline.sql` — jeden wielki
+   plik, odświeżać raz, przy merge); (b) obie dodają migracje/newsfragmenty —
+   niezależne katalogi, więc same fragmenty nie kolidują, ale baseline tak.
+   Uzgodnić kolejność scalania.
+10. **`index-absencji` (urls.py:35).** Dziś mapuje na listę POLON — user-
+    widoczny bug; Faza 2 naprawia (osobny newsfragment bugfix).
+
+---
+
+## Czego NIE robić
+
+- **NIE** modyfikować migracji `import_polon/0001-0016` — tylko `0017`.
+- **NIE** odświeżać baseline w tym branchu.
+- **NIE** usuwać `long_running`, `long_running/authorizers.py`,
+  `CHANNELS_BROADCAST_SUBSCRIPTION_AUTHORIZER`.
+- **NIE** ustawiać `LIVEOPS["REQUIRED_GROUP"]`.
+- **NIE** ruszać wspólnych plików `long_running/*`.
+- **NIE** cytować `import_list_ministerialnych` jako „w drzewie" — nie jest
+  scalony; wzór kanoniczny to `import_pracownikow`.
+
+---
+
+## Zmiany względem v2 (v3, dla recenzenta)
+
+- **Results views (MAJOR)**: jawny wymóg `paginate_by = 25` +
+  `get_context_data(object=self.parent_object, …)` dla POLON i absencji —
+  ślepe skopiowanie `import_pracownikow` (`parent_object=`, brak paginacji)
+  dałoby `NoReverseMatch` na `object.pk` (~176) i cichą utratę stronicowania.
+- **Bugfix `index-absencji` (MAJOR)**: dodano wymóg utworzenia NOWEGO
+  `importplikuabsencji_list.html` — bez niego wydzielony `PokazImportyAbsencji`
+  daje `TemplateDoesNotExist`.
+- **Restart gejtowany (MINOR 5)**: Ryzyko #5 zmienione z „owner-only OK" na
+  „GEJTUJEMY grupą" (`_PkOwnerRestartMixin` + auth-gate test; precedens #508 F4);
+  `*-restart` URL zostaje; zaktualizowano sekcje Widoki/URL/Zachowanie/Testy.
+- **Faza 1 most (MINOR 3)**: nie czysty no-op — forwarduje do legacy
+  `send_progress`/`send_notification` (żeby nie wygasić paska między fazami);
+  `check_cancelled` nadal no-op (fix awarii zostaje).
+- **Liczba testów (MINOR 4)**: `test_zapisz_do_bazy.py` = **11**, nie 13
+  (poprawione wszędzie).
+- **Cytat create (NIT 6)**: `UtworzImportPlikuPolon.form_valid` = ustaw
+  `uczelnia` + `super().form_valid()`; enqueue robi bazowe
+  `CreateLiveOperationView.form_valid` (`liveops/views.py:101-105`) — a nie
+  `NowyImportView` (`:160-174`), które celowo NIE enqueue’uje.
+
+## Zmiany względem v1 (dla recenzenta)
+
+- **Referencje**: `import_list_ministerialnych` przeniesiony do „NIE scalony"
+  (zweryfikowane: `models.py:10` = Operation, migracje do 0008, nie-przodek
+  dev); wzór kanoniczny → `import_pracownikow` (migracja `0010_liveops.py`,
+  host `import_pracownikow.html`).
+- **Fazy**: dry-run→zapisz (`ZapiszDoBazyMixin` + przepisanie
+  `test_zapisz_do_bazy.py`) wciągnięte do atomowej Fazy 2 (było osobną fazą, co
+  dawało 13 czerwonych testów między fazami). Fazy: 5 → **4**.
+- **Redirecty**: dopisany fix `HttpResponseRedirect("..")` → `get_absolute_url()`
+  (POST zapisu) i link Anuluj w `potwierdz_zapis_do_bazy.html`.
+- **CSRF**: dodany obowiązkowy wrapper `hx-headers` (CSRF_COOKIE_HTTPONLY).
+- **Faza 1 most**: `TextProgress` → LOKALNY no-op Progress (pole
+  `cancel_requested`).
+- **Strategia testów**: skorygowany błąd o `on_commit` w testach
+  (`django_capture_on_commit_callbacks(execute=True)`); poprawiona liczba
+  call-site’ów rdzenia (6, nie 3) i rozszerzony gate Fazy 1.
+- **ZapiszDoBazyMixin owner-scope**: dopisane, czym zastąpić
+  `RestrictToOwnerMixin` z `long_running`.
+- **Gapy**: drugi newsfragment (bugfix `index-absencji`), nota o
+  `views/__init__.py`, nota że `admin.py`/`apps.py` bez zmian, koordynacja z
+  otwartą gałęzią liveops-list-ministerialnych.

--- a/docs/deweloper/plan-raport-slotow-liveops.md
+++ b/docs/deweloper/plan-raport-slotow-liveops.md
@@ -1,0 +1,687 @@
+# Plan migracji `raport_slotow` (RaportSlotowUczelnia) na django-liveops 0.4
+
+Dokument planistyczny. NIE zawiera zmian w kodzie — opisuje docelowy stan,
+mapowania, fazy TDD, ryzyka i to, czego NIE robić. Referencja (jedyny
+zmigrowany, na 0.4): `src/import_pracownikow/` — ale to IMPORTER, nie Report,
+więc specyfikę „Report" trzeba wyprowadzić z API liveops + `long_running.models.Report`.
+
+Ścieżka dokumentu:
+- `/Users/mpasternak/Programowanie/bpp-raport-slotow-liveops/docs/deweloper/plan-raport-slotow-liveops.md`
+- file:///Volumes/mpasternak/Programowanie/bpp-raport-slotow-liveops/docs/deweloper/plan-raport-slotow-liveops.md
+
+---
+
+## 0. Zmiany po recenzji adwersarialnej (2026-07-15)
+
+Werdykt: „execute-with-fixes". Wszystkie file:line refs pierwotnego planu
+zweryfikowane jako poprawne; poniższe braki uzupełnione (każdy potwierdzony
+w kodzie przed edycją):
+
+- **HIGH — pominięta powierzchnia API v1** (nowy §4.5 + praca w Fazie 2 + szerszy
+  grep w Fazie 4 + ryzyko §11.9). `src/api_v1/serializers/raport_slotow_uczelnia.py`
+  wymienia `last_updated_on` (:25,38) i enqueue'uje przez
+  `perform_generic_long_running_task`→`task_perform()` (:66-76) — OBA pękają
+  natychmiast po migracji modelu. `create()` jest `@transaction.atomic`, więc to
+  REALNY (nie hipotetyczny) przypadek enqueue-inside-atomic z §7.4.
+- **MEDIUM — utracony guard „restart tylko gdy skończone"** (§8.4 + regen w
+  Fazie 3 + gotcha §7.9). Legacy resetuje tylko gdy `finished_on is not None`
+  (`long_running/views.py:125`); liveops `RestartView` resetuje BEZWARUNKOWO
+  (`liveops/views.py:175`). Pod celery regen w połowie runu = `on_restart`
+  kasuje wiersze piszące + drugi run. Decyzja: dodać guard (patrz §8.4).
+- **LOW — kolizja szablonów tylko HOST** (§7.5, §10 zmiękczone). `result` auto-name
+  ma sufiks `_result` i z niczym nie koliduje — `result_template_name` to „plik do
+  utworzenia", nie kwestia kolizji. `host_template_name` faktycznie koliduje.
+- **LOW — ścieżka API create NIE ustawia `uczelnia`** (§8.1 rozszerzone). To DRUGA
+  ścieżka zapisu (obok `form_valid`); świadoma decyzja: zostawić bez scope'u jak
+  dziś (test API to dokumentuje) czy dołożyć `uczelnia_dla_odczytu`.
+- **COSMETIC — zmiana `ordering`** (§5) `-last_updated_on`→`-created_on`: regenerowany
+  raport NIE wskakuje już na górę listy (zmiana UX), nie tylko sucha `AlterModelOptions`.
+
+---
+
+## 1. Streszczenie
+
+`RaportSlotowUczelnia` (`src/raport_slotow/models/uczelnia.py:31`) to jedyna
+long-running operacja w aplikacji `raport_slotow`. Dziedziczy po
+`long_running.models.Report` (via `ASGINotificationMixin`), który dokłada
+`create_report`/`task_create_report` nad `Operation.perform`. Widoki
+(`src/raport_slotow/views/uczelnia.py`) używają całej rodziny
+`LongRunning*View` (lista / router / details / results / restart) oraz taska
+`perform_generic_long_running_task`.
+
+Celem jest przeniesienie tej operacji na `liveops.models.LiveOperation`
+(`run(self, p)` + `WebProgress` po WebSocket/HTMX), tak jak zrobiono to dla
+`ImportPracownikow`. W odróżnieniu od importera to jest **Report**
+(generuje wyjście — wiersze `RaportSlotowUczelniaWiersz` w bazie), więc:
+- nie ma dry-run/commit, jest jeden przebieg generujący wiersze;
+- „wynik" to strona z wygenerowaną tabelą (`-results`), nie panel podsumowania;
+- postęp = pasek `p.percent(...)` w pętli po kombinacjach autor/dyscyplina/jednostka.
+
+**Kluczowe ułatwienie:** model już MA pk typu `UUIDField` (dziedziczony z
+`Operation`, `src/long_running/models.py:20`), a URL-e już są `<uuid:pk>`
+(`src/raport_slotow/urls.py:45-63`) — **żadna migracja pk nie jest potrzebna**.
+
+**Kluczowa pułapka nazewnictwa:** `class_to_snake("RaportSlotowUczelnia")` =
+`raport_slotow_uczelnia`, więc auto host-template = `raport_slotow/raport_slotow_uczelnia.html`
+— a to **istniejący plik szablonu wyników** (`src/raport_slotow/views/uczelnia.py:98`).
+Kolizja. Trzeba jawnie ustawić `host_template_name` (i `result_template_name`),
+NIE polegać na auto-nazwie. Szczegóły w §4 i §10.
+
+---
+
+## 2. Stan obecny (legacy wiring, Report specifics, uczelnia scoping)
+
+### 2.1 Model — `src/raport_slotow/models/uczelnia.py`
+
+- `class RaportSlotowUczelnia(ASGINotificationMixin, Report)` (:31). Pola
+  domenowe: `od_roku`, `do_roku`, `akcja`, `slot`, `minimalny_pk`,
+  `dziel_na_jednostki_i_wydzialy`, `pokazuj_zerowych` oraz **`uczelnia`**
+  (`FK bpp.Uczelnia, null=True, blank=True`, :55-57) — to nośnik scoping'u
+  per-uczelnia zapisany przy tworzeniu.
+- `clean()` (:76) — walidacja `od_roku<=do_roku` + reguły `akcja/slot`.
+- `on_reset()` (:73) — kasuje `raportslotowuczelniawiersz_set` (hook legacy
+  `Operation.mark_reset`, `src/long_running/models.py:72-80`).
+- **`create_report()`** (:108) — rdzeń generacji. Buduje `kombinacje` z
+  `Cache_Punktacja_Autora_Query`, **zawężone `if self.uczelnia_id is not None:
+  kombinacje.filter(jednostka__uczelnia_id=self.uczelnia_id)`** (:122-123),
+  pętla po kombinacjach woła `zbieraj_sloty(..., uczelnia_id=self.uczelnia_id)`
+  (:134-144), tworzy wiersze (:155), a postęp raportuje przez
+  `self.send_progress(n*100.0/total)` co 10 iteracji (:164-165). Gałąź
+  `pokazuj_zerowych` (:167) woła `autorzy_zerowi(..., uczelnia=self.uczelnia)`.
+- `get_details_set()` (:230) — queryset wierszy z `select_related` do tabeli
+  wyników.
+- Dziedziczone z `Report`/`Operation`: `perform()->create_report()`
+  (`src/long_running/models.py:164`), `task_create_report`,
+  `mark_started/mark_finished_okay/...`, `get_state()`, `get_url(suffix)`,
+  `get_absolute_url()->get_url("router")`.
+
+### 2.2 Base classes — `src/long_running/models.py`
+
+- `Operation` (:17): `id=UUIDField pk`, `owner=FK(AUTH_USER_MODEL, CASCADE)`
+  (domyślny related_name), `created_on`, **`last_updated_on` (auto_now)**,
+  `started_on`, `finished_on`, `finished_successfully`, `traceback`. Meta
+  `ordering=["-last_updated_on"]`.
+- `task_perform` (:99) owija `perform()` w **`with transaction.atomic()`**
+  (:108) — cały `create_report` jest transakcyjny (all-or-nothing).
+- `Report` (:163): `perform=create_report`.
+- `ASGINotificationMixin` (`src/long_running/notification_mixins.py`):
+  `send_notification`, `send_progress(percent)`, `send_processing_finished`
+  — pchają po `channels_broadcast` na kanał `str(self.pk)`. To warstwa
+  live-progress legacy, którą liveops zastępuje `WebProgress`.
+
+### 2.3 Widoki — `src/raport_slotow/views/uczelnia.py`
+
+| Klasa (linia) | Baza legacy | Rola |
+|---|---|---|
+| `ListaRaportSlotowUczelnia` (:35) | `LongRunningOperationsView` | lista raportów usera (owner-scoped, KASUJE stare >10) |
+| `UtworzRaportSlotowUczelnia` (:48) | `CreateLongRunningOperationView` | formularz + `form_valid` ustawia `uczelnia = uczelnia_dla_odczytu(request)` (:60-62) |
+| `RouterRaportuSlotowUczelnia` (:70) | `LongRunningRouterView` | routing NOT_STARTED→wait / STARTED→details / OK→results |
+| `SzczegolyRaportSlotowUczelnia` (:75) | `LongRunningDetailsView` | strona postępu (subskrypcja kanału pk) |
+| `WygenerujPonownieRaportSlotowUczelnia` (:83) | `RestartLongRunningOperationView` | **GET** regen: `mark_reset` + re-enqueue |
+| `SzczegolyRaportSlotowUczelniaListaRekordow` (:90) | `LongRunningResultsView` | filtrowalna tabela wyników + eksport XLSX |
+
+- Wszystkie (poza Utworz) mają `BaseRaportAuthMixin` (`src/nowe_raporty/views.py:76`)
+  = `UczelniaSettingRequiredMixin` + `group_required = GR_RAPORTY_WYSWIETLANIE`
+  (`src/bpp/const.py:22`) + `uczelnia_attr="pokazuj_raport_slotow_uczelnia"`.
+  To jest **bramka autoryzacji, którą trzeba utrzymać** (patrz §8).
+- `LongRunningResultsView` (`src/long_running/views.py:88`): `paginate_by=25`,
+  `parent_object` owner-scoped (`o.owner != request.user -> Http404`),
+  `get_queryset()->parent_object.get_details_set()`, przekazuje
+  `object=parent_object` do kontekstu (:103). **Results-view używa jednak
+  django_tables2 (`SingleTableMixin` + `RequestConfig`), więc realną
+  paginację robi tabela, nie `ListView.paginate_by`** — ważne przy odtworzeniu.
+
+### 2.4 URL-e — `src/raport_slotow/urls.py`
+
+`lista-…` (:35), `utworz-…/new` (:39), `…-router/<uuid:pk>/` (:44),
+`…-details` (:49), `…-regen` (:54), `…-results` (:59). Reverse'y tych nazw
+poza aplikacją / w testach:
+- `top_bar.html:123` → `lista-raport-slotow-uczelnia`.
+- `src/bpp/tests/.../test_uczelnia.py:321,326` → `lista-…`.
+- testy `raport_slotow` → `-details`, `-results`, `-regen`, `lista-…`.
+- szablony `-list.html:19` → `-router`; breadcrumbs → `lista-…`.
+
+### 2.5 Scoping per-uczelnia — jak nić przechodzi
+
+1. **Zapis (create):** `UtworzRaportSlotowUczelnia.form_valid`
+   (`views/uczelnia.py:60`) woła `uczelnia_dla_odczytu(self.request)`
+   (`src/raport_slotow/uczelnia_helper.py:10`) → hybryda: uczelnia z requestu
+   (host→Site→Uczelnia), a superuser może nadpisać `?uczelnia=<pk>`. Wynik
+   ląduje w `form.instance.uczelnia`.
+2. **Generacja (run):** `create_report` filtruje kombinacje i przekazuje
+   `uczelnia_id`/`uczelnia` do `zbieraj_sloty`/`autorzy_zerowi`
+   (`models/uczelnia.py:122-123,143,168-173`).
+3. **Odczyt (results/list):** owner-scoping (`owner=request.user`) izoluje
+   raporty per-użytkownik; sam raport niesie już zawężone dane (scoping
+   „wypalony" przy generacji). List/results nie filtrują ponownie po uczelni —
+   ich izolacja to owner + fakt, że wiersze są już per-uczelnia.
+
+Testy strażujące scoping:
+- `tests/test_uczelnia_helper.py` — reguły `uczelnia_dla_odczytu`
+  (nie-superuser nie nadpisze, superuser tak, złe pk → bazowa).
+- `tests/test_views/test_raport_slotow_zerowy_per_uczelnia.py` — zawężenie
+  „strony punktowej" do uczelni oglądającego (dotyczy raportu **zerowego**,
+  nie uczelnia-report, ale to ten sam mechanizm `uczelnia=` w `core.py`).
+- `tests/test_per_uczelnia_uczelnia.py`, `tests/tests_models/test_uczelnia.py`
+  — do przejrzenia pod kątem regresji generacji.
+
+---
+
+## 3. Docelowy stan (liveops 0.4)
+
+- `class RaportSlotowUczelnia(LiveOperation)` (`liveops.models.LiveOperation`,
+  pkg `.venv/.../liveops/models.py:27`). Znika `ASGINotificationMixin` i
+  `long_running.Report`.
+- `run(self, p)` zastępuje `create_report()`; postęp przez `p.percent(...)`
+  / `p.track(...)`; brak `send_progress`.
+- `on_restart()` zastępuje `on_reset()` (`liveops.models.LiveOperation.on_restart`,
+  pkg models.py:183).
+- Strona „live" = centralny `liveops:live` (`get_absolute_url()` zwraca
+  `reverse("liveops:live", op_type=<app.model>, pk=...)`, pkg models.py:155),
+  montowany raz w `src/django_bpp/urls.py:286` (`path("live/", include("liveops.urls"))`).
+  Znikają widoki router/details — ich rolę pełni host page liveops.
+- Widoki tworzenia/listy/wyników/restartu = cienkie podklasy owner-scoped
+  (wzór: `src/import_pracownikow/views.py`).
+- `LIVEOPS` już skonfigurowane globalnie (`src/django_bpp/settings/base.py:1049`):
+  `RUNNER="celery"` (prod), w testach `settings/test.py` nadpisuje na `"eager"`
+  (synchronicznie, bez Redis/workera). `liveops` jest w INSTALLED_APPS
+  (base.py:455).
+
+---
+
+## 4. Mapowanie `Report.create_report` → liveops `run(self, p)` + rendering raportu
+
+### 4.1 Sam przebieg
+
+Legacy `create_report()` (models/uczelnia.py:108) przenosimy 1:1 do
+`run(self, p)`, podmieniając TYLKO warstwę postępu i finalizację:
+
+- `total = kombinacje.count()`; pętla jak dotąd, ale zamiast
+  `if not n%10: self.send_progress(n*100.0/total)` używamy:
+  - albo `p.percent(int(n*100/total))` (throttling ma już `Progress.percent`,
+    pkg progress.py:52 — nie trzeba ręcznego `%10`),
+  - albo idiomatycznie `for res in p.track(kombinacje, total=total):` (pkg
+    progress.py:68) — dodatkowo woła `check_cancelled()` przed każdym elementem.
+    **Uwaga:** `p.track` liczy `total=len(...)` gdy `total=None`; podajemy
+    `total` jawnie, bo `kombinacje` to queryset (materializacja `list()` byłaby
+    kosztowna). `.count()` + iteracja queryset są OK.
+- **Scoping bez zmian:** `self.uczelnia_id` / `self.uczelnia` nadal filtrują
+  kombinacje (:122) i płyną do `zbieraj_sloty`/`autorzy_zerowi`. Migracja NIE
+  dotyka tej logiki — tylko warstwy postępu.
+- Anulowanie: `p.track` / okresowe `p.check_cancelled()` daje działający Anuluj
+  (którego legacy nie miało). Opcjonalne, ale „za darmo".
+
+### 4.2 Transakcyjność (różnica behawioralna — WAŻNE)
+
+Legacy owijało cały `create_report` w `transaction.atomic()`
+(`src/long_running/models.py:108`). liveops `task_run` woła `operation.run(p)`
+**bez** transakcji (pkg runner.py:143). Żeby zachować all-or-nothing generacji
+(inaczej błąd w połowie zostawia częściowe wiersze), **owijamy ciało `run` w
+`with transaction.atomic():`**. Konsekwencja: `p.result(...)` używa
+`transaction.on_commit` (pkg progress.py:302) — wewnątrz atomic odpali się przy
+commit (poprawnie); pushe `p.percent` są synchroniczne (group_send), więc pasek
+działa mimo otwartej transakcji.
+
+### 4.3 Finalizacja i rendering raportu (specyfika Report — brak wzorca)
+
+**Nie istnieje zmigrowany Report referencyjny** — `import_pracownikow` woła
+`p.result(context)` z bogatym słownikiem i renderuje panel inline. Dla Reportu
+wyjście (wiersze) jest w bazie, a „wynikiem" jest osobna strona tabeli
+(`-results`). Dwie ścieżki (do decyzji, patrz §9):
+
+- **Ścieżka A (rekomendowana): auto-redirect na results.** `run()` nie woła
+  `p.result()` (albo woła z pustym kontekstem). Definiujemy
+  `get_success_url(self)` (pkg models.py:169) → `reverse("raport_slotow:
+  raportslotowuczelnia-results", kwargs={"pk": self.pk})`. Po `FINISHED_OK`
+  `liveops.js` przenosi usera prosto na tabelę wyników (wzór:
+  `ImportPracownikow.get_success_url`, `src/import_pracownikow/models.py:224`).
+  Result-fragment (host page) pełni tylko rolę fallbacku no-JS.
+- **Ścieżka B: inline result-fragment.** `run()` woła `p.result(context)` z
+  minimalnym kontekstem (np. liczba wierszy), a `raport_slotow_uczelnia_result.html`
+  (nowy) renderuje krótkie podsumowanie + link „Zobacz wyniki". Więcej pracy,
+  bez wyraźnej korzyści dla Reportu.
+
+Auto-finalize: jeśli `run()` skończy bez `p.result()`, `task_run` sam ustawia
+`finished_successfully=True` i woła `push_finished` (pkg runner.py:145-151) →
+render `result_template_name`. Dlatego przy Ścieżce A i tak potrzebny jest
+**minimalny** `result_template_name` (patrz §10) — inaczej push wyrenderuje pustkę
+(bezpiecznie, ale brzydko dla no-JS).
+
+### 4.4 Host page (strona „live")
+
+Nowy szablon host (patrz §10) zawiera region `{% live_operation object %}`
+owinięty w `<div hx-headers='{"X-CSRFToken":"{{ csrf_token }}"}'>` (gotcha CSRF,
+§7). Wzór: `src/import_pracownikow/templates/import_pracownikow/import_pracownikow.html:27`.
+
+### 4.5 API v1 — DRUGA powierzchnia, pęka natychmiast po migracji (HIGH)
+
+`RaportSlotowUczelnia` ma REST-owy odpowiednik, którego pierwotny plan pominął.
+To NIE jest opcjonalne — serializer wywala się w momencie usunięcia pola.
+
+Pliki:
+- `src/api_v1/serializers/raport_slotow_uczelnia.py`
+- `src/api_v1/viewsets/` (viewset `RaportSlotowUczelniaViewSet` — owner-scoped)
+- `src/api_v1/tests/test_raport_slotow_uczelnia.py`
+
+Dwa twarde pęknięcia po Fazie 2 (migracja modelu):
+1. **`last_updated_on` w `fields`/`read_only_fields`** (`serializers/…:25,38`).
+   Po `RemoveField(last_updated_on)` KAŻDE żądanie do viewsetu (nawet
+   read-only GET listy) → DRF `ImproperlyConfigured` (pole w Meta nie istnieje
+   na modelu). **Fix:** usuń `last_updated_on` z obu list w Meta. Rozważ dodanie
+   `cancelled`/`finished_successfully` do read-only, jeśli chcesz je wystawić —
+   ale minimalny fix to samo usunięcie `last_updated_on`.
+2. **`create()` enqueue przez legacy task** (`serializers/…:66-76`):
+   `perform_generic_long_running_task(ct.app_label, ct.model, inst.pk)`
+   (`long_running/tasks.py:11`) na końcu woła `obj.task_perform()`
+   (tasks.py:32), którego `LiveOperation` NIE ma → `AttributeError` w tasku
+   celery (cichy — raport nigdy się nie wygeneruje). **Fix:** przepisz na
+   `transaction.on_commit(lambda: inst.enqueue())`.
+   **UWAGA — to REALNY przypadek enqueue-inside-atomic z §7.4:** `create()` jest
+   `@transaction.atomic` (`serializers/…:66`), więc NIE wolno wołać `inst.enqueue()`
+   bezpośrednio (task odpaliłby zanim wiersz się zacommituje → retry-loop
+   `perform_generic_long_running_task` był właśnie obejściem tego; `enqueue()`
+   przez runner NIE ma retry). MUSI być `transaction.on_commit`. Istniejący
+   `ContentType.get_for_model` + `perform_generic_long_running_task` znikają.
+3. **Test** `test_raport_slotow_uczelnia.py` — dziś tylko owner-scope na GET
+   (nie dotyka `last_updated_on` w asercjach, ale request przechodzi przez
+   serializer → padnie na (1)). Po fixie (1) testy GET powinny przejść. Dodaj
+   test POST create (enqueue przez `on_commit`, pod eager runner generuje
+   wiersze) — dziś BRAK testu ścieżki create (patrz §8.1 pkt LOW-4).
+
+Ta praca należy do **Fazy 2** (migracja modelu) — serializer pęka w tej samej
+chwili co pole. NIE odkładaj na Fazę 3.
+
+---
+
+## 5. Migracja modelu (nowa migracja, pk, FK/related_name, dane)
+
+Dodaj **nową** migrację `src/raport_slotow/migrations/0022_liveops.py`
+(nie edytuj istniejących; ostatnia to `0021_merge_20260604_1952.py`). Wzór:
+`src/import_pracownikow/migrations/0010_liveops.py`.
+
+Operacje (delta legacy `Operation` → `LiveOperation`):
+- `AlterModelOptions(ordering=["-created_on"])` — było `-last_updated_on`.
+  **Efekt UX (nie tylko sucha zmiana Meta):** lista sortuje po dacie
+  UTWORZENIA, nie ostatniej modyfikacji. Regenerowany (regen) raport NIE
+  wskakuje już na górę listy — zostaje w miejscu wg `created_on`. Legacy
+  `last_updated_on` (auto_now) wypychało świeżo-przeliczony raport na szczyt.
+  Akceptowalne (spójne z liveops i całą resztą operacji), ale odnotować.
+- `RemoveField last_updated_on` — łamie API v1 serializer (§4.5 pkt 1); fix
+  serializera należy do tej samej fazy.
+- `AddField`: `cancel_requested` (Bool default False), `cancelled` (Bool),
+  `current_stage` (Int -1), `language` (Char blank), `log` (JSON default list),
+  `log_seq` (PositiveInt 0), `percent` (PositiveSmallInt 0), `result_context`
+  (JSON null), `stage_states` (JSON default dict), `status_text` (Char blank).
+  **Uwaga:** `status_text` istnieje w `LiveOperation` (models.py:56) —
+  import_pracownikow ją dodał (0010:93); dodać też tu dla spójności stanu.
+- `AlterField owner` → `related_name="+"` (pkg models.py:31). To zmiana tylko
+  Django-level (reverse accessor), bez zmiany kolumny; makemigrations i tak
+  ją wygeneruje.
+
+**pk:** BEZ ZMIAN — już `UUIDField` z `default=uuid4` (legacy `Operation.id`,
+`src/long_running/models.py:20`; liveops `LiveOperation.id`, pkg models.py:30 —
+oba `uuid4`). URL-e już `<uuid:pk>`.
+
+**FK/related_name — świadoma decyzja:** zmiana `owner` na `related_name="+"`
+usuwa reverse accessor `user.raportslotowuczelnia_set`. Grep pokazał brak jego
+użycia — bezpieczne. `RaportSlotowUczelniaWiersz.parent`
+(`models/uczelnia.py:241`) zostaje bez zmian (`raportslotowuczelniawiersz_set`
+używane w `run`/`get_details_set`).
+
+**Dane:** raport_slotow NIE ma odpowiednika `performed/integrated→stan`
+(import miał, 0010:8-11). Nowe pola mają defaulty → `AddField` bez data-migracji.
+Usunięcie `last_updated_on` bez utraty istotnych danych (auto_now, pochodna).
+Istniejące raporty zachowują `finished_on/started_on/finished_successfully`
+(wspólne dla obu baz) — po migracji dalej otwierają się jako „skończone".
+
+**Baseline:** po dodaniu migracji baseline będzie nieaktualny — **NIE
+odświeżaj baseline w tym branchu** (reguła CLAUDE.md: baseline raz, przy
+scalaniu). Odnotuj w PR, że `make baseline-update` należy zrobić przy merge.
+
+---
+
+## 6. Fazy (uporządkowane, każda niezależnie „zielona", TDD)
+
+**Liczba faz: 5** (Faza 0 charakteryzacja → Faza 1 opcjonalny most zgodności →
+Faza 2 model+migracja+API v1 → Faza 3 widoki+URL+szablony → Faza 4 sprzątanie).
+Faza 1 jest opcjonalna (do pominięcia przy czystym cutover), więc ścieżka
+minimalna to 4 fazy wykonawcze + Faza 0.
+
+Kolejność minimalizuje okno niespójności. Każda faza kończy się przebiegiem
+`uv run pytest src/raport_slotow` (i, gdzie wskazano, `src/api_v1`,
+`src/import_pracownikow` oraz `src/long_running`).
+
+### Faza 0 — testy charakteryzujące (RED→GREEN baseline)
+Przed zmianami: uruchom istniejące testy raport_slotow, potwierdź zieleń
+(`uv run pytest src/raport_slotow`). Spisz oczekiwane zmiany kontraktu (patrz
+§8) — które testy MUSZĄ się zmienić (regen GET→POST, lista-delete, details).
+Nic nie zmieniaj w kodzie.
+
+### Faza 1 (opcjonalna) — most zgodności emisji (jeśli chcesz rozdzielić emisję od cutover)
+Tylko jeśli chcesz najpierw przełączyć `create_report` na API `Progress`
+zanim zmienisz bazę modelu. Wprowadź lokalny, minimalny `Progress`, który
+FORWARD-uje `percent/status` do legacy `send_progress`/`send_notification` i
+**nadpisuje `check_cancelled` na no-op** (legacy model NIE ma `cancel_requested`;
+`Progress.check_cancelled` robi `refresh_from_db(fields=["cancel_requested"])`,
+pkg progress.py:154 → wywaliłoby się `FieldError`). **NIE używaj `TextProgress`
+na modelu legacy** z tego samego powodu (jego `check_cancelled` też sięga pola).
+Ta faza jest zbędna, jeśli robisz czysty cutover (Faza 2+3 razem) — raport_slotow
+jest prosty, więc most prawdopodobnie pomijamy. Udokumentowane dla kompletności.
+
+### Faza 2 — model + migracja + API v1 (cutover bazy)
+Model i API v1 pękają razem (serializer wymienia `last_updated_on` i woła
+`task_perform`), więc idą w JEDNEJ fazie — inaczej po kroku 2 każdy request do
+viewsetu zwraca 500.
+1. Test (RED): `tests/tests_models/test_liveops_uczelnia.py` — instancja jest
+   `LiveOperation`, ma pola `cancel_requested/cancelled/result_context/...`,
+   `on_restart()` kasuje wiersze, `run(p)` generuje wiersze i respektuje
+   `self.uczelnia` (scoping!). Wzór: `import_pracownikow/tests/test_models/test_liveops_model.py`.
+2. Zmień bazę: `RaportSlotowUczelnia(LiveOperation)`; `create_report`→`run(self,p)`
+   (owinięte w `transaction.atomic()`, §4.2); `on_reset`→`on_restart`; usuń
+   `ASGINotificationMixin`; ustaw jawnie `host_template_name` (§10, kolizja) —
+   `result_template_name` też jawnie, ale to tylko wybór pliku, nie kolizja;
+   dodaj `get_success_url` (Ścieżka A, §4.3); zachowaj `clean()`,
+   `get_details_set()`, `uczelnia`, walidacje.
+3. `makemigrations raport_slotow` → nowa `0022_liveops.py` (§5). Zweryfikuj,
+   że to delta (nie churn), `--check` czysty po zastosowaniu.
+4. **API v1 (§4.5) — w tej samej fazie:** usuń `last_updated_on` z Meta
+   `fields`/`read_only_fields` (`api_v1/serializers/raport_slotow_uczelnia.py:25,38`);
+   przepisz `create()` (:66-76) z `perform_generic_long_running_task` na
+   `transaction.on_commit(lambda: inst.enqueue())` (create jest `@atomic` →
+   MUSI być on_commit). Zaktualizuj/rozszerz `api_v1/tests/test_raport_slotow_uczelnia.py`
+   (GET po fixie przechodzi; dodaj test create-enqueue pod eager runner).
+   Podejmij decyzję LOW-4 (§8.1): czy create ustawia `uczelnia`.
+5. GREEN: `uv run pytest src/raport_slotow/tests/tests_models src/api_v1/tests/test_raport_slotow_uczelnia.py`.
+
+### Faza 3 — widoki + URL-e + szablony (cutover UI)
+1. Testy (RED): zaktualizowane `test_views/test_uczelnia.py` — patrz §8:
+   - lista owner-scoped (decyzja o max-10, §8/§9),
+   - tworzenie ustawia `uczelnia` i redirectuje na `liveops:live`,
+   - results owner-scoped + eksport XLSX (istniejące testy w
+     `test_raport_slotow_uczelnia.py` MUSZĄ przejść bez zmian albo z minimalną
+     korektą fixture),
+   - regen jako **POST** resetuje i re-enqueue (GET→POST).
+2. Przepisz `views/uczelnia.py`:
+   - `UtworzRaportSlotowUczelnia(UczelniaSettingRequiredMixin, FormDefaultsMixin,
+     CreateLiveOperationView)` — nadpisz `form_valid`: ustaw `owner`,
+     `uczelnia=uczelnia_dla_odczytu(request)`, `self.object=form.save()`,
+     `self.object.enqueue()`, `redirect(self.object.get_absolute_url())`.
+     **enqueue bezpośrednio — bez `on_commit`** (brak ATOMIC_REQUESTS; gotcha §7).
+   - `ListaRaportSlotowUczelnia(BaseRaportAuthMixin, FormDefaultsMixin, ListView)`
+     — owner-scoped `get_queryset` (jak `ListaImportowView`,
+     `import_pracownikow/views.py:118`). Zachowaj custom szablon listy, ale
+     zmień link z `-router` na `object.get_absolute_url` (liveops:live).
+   - USUŃ `RouterRaportuSlotowUczelnia` i `SzczegolyRaportSlotowUczelnia`
+     (rolę przejmuje `liveops:live`). URL-e `-router`/`-details`: albo usuń,
+     albo zostaw jako cienki redirect na `liveops:live` (jeśli coś je reverse'uje
+     — patrz §8; `-router` używa tylko własny list-template, `-details` tylko test).
+   - `SzczegolyRaportSlotowUczelniaListaRekordow` — odetnij od
+     `LongRunningResultsView`; odtwórz `parent_object` (owner-scoped +
+     superuser-exempt, jak `ImportPracownikowResultsView.parent_object`,
+     `import_pracownikow/views.py:662`) i `get_queryset`. Zachowaj cały
+     `SingleTableMixin`/`FilterMixin`/`MyExportMixin`/eksport-XLSX. **Kontekst
+     musi dalej zawierać `object=parent_object`** (szablon czyta `object.od_roku`
+     itd., `raport_slotow_uczelnia.html:4,18`). Paginacja: robi ją django_tables2
+     (`RequestConfig`), nie `ListView.paginate_by` — ale ustaw i tak
+     `paginate_by` dla zgodności z gotchą, jeśli po odcięciu bazy `ListView`
+     zacznie wymagać (zweryfikuj testem eksportu).
+   - `WygenerujPonownieRaportSlotowUczelnia` — wzór `_PkOwnerRestartMixin`
+     (`import_pracownikow/views.py:1386`): `RestartView` + `BaseRaportAuthMixin`
+     (utrzymanie bramki grupy!) + `get_object` owner-scoped rozwiązujący model
+     wprost (URL ma tylko `pk`, bez `op_type`). POST-only. **Guard „tylko gdy
+     skończone" (§8.4):** nadpisz `post`, by resetował/re-enqueue'ował TYLKO gdy
+     `obj.get_state()` jest terminalny (finished OK/error/cancelled) — inaczej
+     regen w połowie runu skasuje wiersze piszące. Test: regen na
+     nie-skończonym raporcie NIE resetuje.
+3. Szablony (§10): nowy host `raport_slotow_uczelnia_live.html`; minimalny
+   `raport_slotow_uczelnia_result.html`; zaktualizuj `-list.html` (link na
+   `get_absolute_url`); zmień `<a href="../regen">` w `raport_slotow_uczelnia.html:27`
+   na **formularz POST** (regen jest POST) z `{% csrf_token %}`. Usuń martwe
+   `include "long_running/operation_details.html"` z `-detail.html` (jeśli
+   `-detail`/`-details` znika).
+4. GREEN: `uv run pytest src/raport_slotow`.
+
+### Faza 4 — sprzątanie + weryfikacja integracyjna
+- Usuń nieużywane szablony (`raportslotowuczelnia_detail.html`,
+  `raportslotowuczelniawiersz_list.html`, ewentualnie `-list` jeśli zastąpiony)
+  po potwierdzeniu braku referencji.
+- **Grep REPO-WIDE (nie tylko `src/raport_slotow`)** dla resztek legacy
+  powiązanych z tym modelem — pierwotny plan grepował tylko aplikację i przez
+  to zgubił `api_v1`:
+  ```
+  grep -rn "task_perform\|task_create_report\|perform_generic_long_running_task\|last_updated_on" src/ --include="*.py"
+  ```
+  Zweryfikuj, że żadne trafienie NIE dotyczy `RaportSlotowUczelnia`
+  (`raport_slotow`, `api_v1`). Potwierdź brak `import long_running` w
+  `raport_slotow` ORAZ w `api_v1/serializers/raport_slotow_uczelnia.py`.
+- `uv run pytest src/raport_slotow src/api_v1 src/import_pracownikow src/long_running`
+  (regresja sąsiadów + API).
+- Playwright (opcjonalnie, jeśli dotknięto UI live): `make assets` +
+  `src/raport_slotow/tests/test_playwright`.
+- Newsfragment `src/bpp/newsfragments/raport-slotow-liveops.feature.rst`.
+
+---
+
+## 7. Pre-loaded gotchas (wbudowane w plan)
+
+1. **CSRF_COOKIE_HTTPONLY=True** (`settings/base.py:1596` wg zadania). Host
+   template MUSI owinąć `{% live_operation object %}` w
+   `<div hx-headers='{"X-CSRFToken":"{{ csrf_token }}"}'>` — inaczej
+   Anuluj/Ponów liveops → 403. Wzór: `import_pracownikow.html:27`.
+2. **Results view / paginacja i `object`.** Szablon wyników
+   (`raport_slotow_uczelnia.html`) używa `{% url ... %}` z `lista-…` i
+   czyta `object.od_roku/…` → results-view MUSI przekazywać `object=parent_object`
+   (jak legacy, `views/uczelnia.py:148`). Realną paginację robi django_tables2;
+   `paginate_by` ustaw defensywnie i zweryfikuj testem XLSX.
+3. **Restart bramkowany grupą.** liveops gejtuje tylko gdy `LIVEOPS["REQUIRED_GROUP"]`
+   ustawione — w BPP NIE jest (`settings/base.py:1049`, brak klucza). Dlatego
+   restart/regen MUSI dostać `BaseRaportAuthMixin` (grupa `GR_RAPORTY_WYSWIETLANIE`
+   + owner-scope), tak jak legacy. Wzór `_PkOwnerRestartMixin`.
+4. **enqueue() → celery `.delay()`, BEZ on_commit.** Tworzenie nie jest w
+   `transaction.atomic` i brak `ATOMIC_REQUESTS` → bezpośredni `enqueue()` po
+   `save()` jest bezpieczny (wzór `CreateLiveOperationView.form_valid`, pkg
+   views.py:101). Gdybyś kiedyś owinął tworzenie w atomic — wtedy
+   `transaction.on_commit(lambda: op.enqueue())`.
+5. **Kolizja nazw szablonów — TYLKO host.** `class_to_snake("RaportSlotowUczelnia")`
+   = `raport_slotow_uczelnia` → auto **host** = `raport_slotow/raport_slotow_uczelnia.html`
+   = **istniejący szablon wyników** → prawdziwa kolizja. Ustaw JAWNIE
+   `host_template_name` (np. `raport_slotow/raport_slotow_uczelnia_live.html`).
+   Auto **result** = `raport_slotow/raport_slotow_uczelnia_result.html` (sufiks
+   `_result`) — z NICZYM nie koliduje. `result_template_name` ustawiamy jawnie
+   tylko dla czytelności / wyboru pliku, NIE z powodu kolizji.
+6. **Most fazy 1 (jeśli użyty).** Lokalny `Progress` forwardujący do legacy
+   `send_progress`/`send_notification` + `check_cancelled` jako no-op (legacy
+   model nie ma `cancel_requested` → `refresh_from_db` by wywaliło). NIE
+   `TextProgress` na modelu legacy.
+7. **Nie edytuj istniejących migracji**; dodaj `0022_liveops.py`. **Nie
+   odświeżaj baseline** w tym branchu (odnotuj potrzebę przy merge).
+8. **Transakcyjność generacji** — owiń `run()` w `transaction.atomic()` (§4.2),
+   bo `task_run` nie owija (legacy owijało).
+9. **liveops RestartView resetuje BEZWARUNKOWO** (`liveops/views.py:175`), legacy
+   tylko gdy skończone (`long_running/views.py:125`). Regen w połowie runu →
+   `on_restart` kasuje wiersze, które biegnący task jeszcze pisze + drugi run.
+   Guard w podklasie regenu (patrz §8.4).
+10. **API v1 create jest `@transaction.atomic`** (`serializers/…:66`) — enqueue
+    MUSI iść przez `transaction.on_commit` (§4.5). To jedyna ścieżka w kodzie,
+    gdzie „enqueue-inside-atomic" faktycznie występuje (§7.4 był hipotetyczny dla
+    widoku; API jest realny).
+
+---
+
+## 8. Zachowanie do utrzymania — ESPECIALLY per-uczelnia scoping + testy strażujące
+
+### 8.1 Scoping per-uczelnia (KRYTYCZNE — nie zgubić)
+- `uczelnia` FK na modelu ZOSTAJE (pole domenowe, nie liveops).
+- **DWIE ścieżki zapisu** — pierwotny plan wspominał tylko widok:
+  - **Widok:** `UtworzRaportSlotowUczelnia.form_valid` MUSI dalej ustawiać
+    `uczelnia = uczelnia_dla_odczytu(request)` PRZED `save()` (przenieś do
+    nadpisanego `form_valid` liveops).
+  - **API v1 (LOW-4):** `RaportSlotowUczelniaSerializer.create`
+    (`api_v1/serializers/…:66-76`) ustawia dziś tylko `owner`, NIE `uczelnia`
+    → raport tworzony przez API jest NIE-zawężony (kombinacje po wszystkich
+    uczelniach). To stan OBECNY (przed migracją), a `test_raport_slotow_uczelnia.py`
+    świadomie polega na owner-scope, nie uczelnia-scope. **Świadoma decyzja przy
+    realizacji:** (a) zostawić jak dziś (owner wystarcza do izolacji odczytu, a
+    generacja bez `uczelnia` = raport globalny — być może zamierzone dla API),
+    albo (b) dołożyć `uczelnia_dla_odczytu(request)` w `create()` dla parytetu z
+    widokiem. Domyślnie NIE zmieniać zachowania (a) — ale UDOKUMENTOWAĆ w PR, że
+    to celowe, nie przeoczenie.
+- `run()` MUSI zachować `if self.uczelnia_id is not None:
+  kombinacje.filter(jednostka__uczelnia_id=self.uczelnia_id)` oraz przekazywanie
+  `uczelnia_id=self.uczelnia_id` do `zbieraj_sloty` i `uczelnia=self.uczelnia`
+  do `autorzy_zerowi`. Migracja NIE dotyka tej logiki.
+- **Testy strażujące:** `tests/test_uczelnia_helper.py` (helper),
+  `tests/test_views/test_raport_slotow_zerowy_per_uczelnia.py` (mechanizm
+  `uczelnia=` w core), `tests/test_per_uczelnia_uczelnia.py`,
+  `tests/tests_models/test_uczelnia.py`. Dodaj test Fazy 2 sprawdzający, że
+  `run(p)` na raporcie z ustawioną `uczelnia` generuje wiersze tylko dla jej
+  jednostek (RED przed cutover jeśli dziś brak takiego testu na poziomie run()).
+
+### 8.2 Bramka autoryzacji
+`BaseRaportAuthMixin` (grupa `GR_RAPORTY_WYSWIETLANIE` + `uczelnia_attr` +
+`UczelniaSettingRequiredMixin`) na liście, results i regenie — utrzymać na
+wszystkich odpowiednikach. Tworzenie: `UczelniaSettingRequiredMixin` (jak dziś).
+
+### 8.3 Kontrakty testów, które MUSZĄ się zmienić (spisać w Fazie 0)
+- `test_RegenerujRaportuSlotowUczelnia` (`test_views/test_uczelnia.py:63`) —
+  dziś **GET** na regen, asercja że `finished_on` się zmienia. liveops
+  `RestartView` jest **POST-only** → przepisz na POST. Pod `RUNNER="eager"`
+  enqueue biegnie synchronicznie → run() wykona się → `finished_on` się zmieni.
+- `test_ListaRaportSlotowUczelnia` (:13) — dziś asercja, że lista KASUJE stare
+  (`count 20 → 10`). liveops list-view nie kasuje. Decyzja (§9): albo
+  odtworzyć „delete >N" w `get_queryset` (i test zostaje), albo porzucić tę
+  quirk i **zmienić test**. Rekomendacja: porzucić auto-delete (housekeeping
+  to nie zadanie list-view) i zaktualizować test.
+- `test_SzczegolyRaportuSlotowUczelnia` (:27) — hituje `-details`. Po usunięciu
+  details: repointuj na `liveops:live` (`get_absolute_url`) lub usuń test.
+- `test_form_formdefaults.py:17` — importuje `UtworzRaportSlotowUczelnia`
+  (klasa zostaje, tylko baza inna) — powinien przejść bez zmian.
+- **API v1 (§4.5):** `api_v1/tests/test_raport_slotow_uczelnia.py` — GET-y padną
+  na `last_updated_on` w Meta, dopóki serializer nie jest zfiksowany (Faza 2).
+  Po fixie przechodzą; dodać test create-enqueue.
+
+### 8.4 Guard restartu „tylko gdy skończone" (MEDIUM — nie zgubić)
+Legacy `RestartLongRunningOperationView.get` resetuje **tylko** gdy
+`self.object.finished_on is not None` (`long_running/views.py:125`). liveops
+`RestartView.post` resetuje **BEZWARUNKOWO** (`liveops/views.py:175-209`):
+woła `on_restart()` (kasuje wiersze) + zeruje stan + re-enqueue, niezależnie od
+tego, czy operacja właśnie biegnie. Pod `RUNNER="celery"` (prod) to realny
+wyścig: regen POST w połowie generacji → `on_restart` kasuje
+`raportslotowuczelniawiersz_set`, który biegnący task nadal wypełnia, i startuje
+drugi run równolegle.
+
+`import_pracownikow` **zaakceptował** bezwarunkowy restart — jego
+`_PkOwnerRestartMixin`/`ZatwierdzImportView` (`import_pracownikow/views.py:1386,1407`)
+NIE sprawdzają `finished_on` (grep potwierdza brak takiego guardu); tam bezpieczeństwo
+daje maszyna stanów `stan` (analiza vs integracja) i to, że akcje są bramkowane po
+`stan`. **Raport slotów NIE ma takiej maszyny stanów** — jego jedyny sygnał to
+`get_state()`. Dlatego: **dołóż guard** w podklasie regenu — nadpisz `post`, by
+resetował/re-enqueue'ował TYLKO gdy `obj.get_state()` jest terminalny
+(`FINISHED_OK`/`FINISHED_ERROR`/`CANCELLED`); dla `STARTED`/`NOT_STARTED` zwróć
+redirect na live bez resetu (jak legacy „nic nie rób gdy nieskończone"). Test:
+regen na nie-skończonym raporcie NIE zmienia `started_on`/nie kasuje wierszy.
+
+---
+
+## 9. Strategia testów
+
+- **TDD per faza** (§6): najpierw test opisujący docelowy kontrakt (RED),
+  potem implementacja (GREEN). Pytest-only, `@pytest.mark.django_db`,
+  `model_bakery.baker.make`, fixtures z `src/conftest.py` i
+  `src/raport_slotow/tests/conftest.py`.
+- **Model (Faza 2):** `test_liveops_uczelnia.py` — typ `LiveOperation`, nowe
+  pola, `on_restart` kasuje wiersze, `run(p)` generuje wiersze + respektuje
+  `uczelnia` scoping, atomic (błąd w połowie → brak częściowych wierszy).
+  Runner „eager" (test settings) → `run` synchronicznie, `WebProgress`
+  group_send trafia w pusty kanał (bez Redis) — OK, terminalny stan zapisany.
+- **Widoki (Faza 3):** owner-scope (obcy owner → 404), tworzenie ustawia
+  `uczelnia` + redirect na live, regen POST resetuje, results renderuje tabelę
+  + XLSX. Zachowaj istniejące `test_raport_slotow_uczelnia.py` (filtry + XLSX)
+  — mają przejść (ewentualnie fixture bez `started_on` wymaga korekty, bo
+  results-view liveops nie wymaga `finished`, więc powinno działać).
+- **Migracja:** `baseline-update` (przy merge, nie w branchu) waliduje
+  zastosowanie migracji na czystym kontenerze — tu tylko `makemigrations
+  --check` po dodaniu 0022.
+- **Regresja sąsiadów:** `uv run pytest src/import_pracownikow src/long_running`
+  (upewnić się, że `long_running` dalej działa dla pozostałych operacji).
+- **Uruchamiaj lokalnie** (reguła CLAUDE.md): `uv run pytest src/raport_slotow`
+  po każdej fazie; pełne `make tests-without-playwright` przed PR.
+
+---
+
+## 10. Szablony — konkretny plan
+
+| Szablon | Akcja | Uwaga |
+|---|---|---|
+| `raport_slotow_uczelnia_live.html` (NOWY) | host page liveops | jawny `host_template_name`; `{% load liveops %}`, `<div hx-headers=...>{% live_operation object %}</div>`, skrypty htmx/notifications/liveops (wzór `import_pracownikow.html`) |
+| `raport_slotow_uczelnia_result.html` (NOWY, minimalny) | result-fragment | jawny `result_template_name`; krótkie „raport gotowy" + link do `-results` (fallback no-JS; realny redirect robi `get_success_url`) |
+| `raport_slotow_uczelnia.html` (ISTNIEJE) | results-table — ZOSTAJE | tylko zmień `<a href="../regen">` (:27) na `<form method="post" action="../regen">{% csrf_token %}...</form>` |
+| `raportslotowuczelnia_list.html` | link `-router`→`object.get_absolute_url` | lub przejdź na liveops list-template |
+| `raportslotowuczelnia_detail.html` | USUŃ (po usunięciu `-details`) | zawiera `include long_running/operation_details.html` |
+| `raportslotowuczelniawiersz_list.html` | zweryfikuj/usuń | wygląda na martwy leftover |
+
+**Jawne nazwy na modelu (obowiązkowo, przez kolizję §7.5):**
+`host_template_name = "raport_slotow/raport_slotow_uczelnia_live.html"`,
+`result_template_name = "raport_slotow/raport_slotow_uczelnia_result.html"`.
+
+---
+
+## 11. Ryzyka i pytania otwarte
+
+1. **BRAK zmigrowanego Reportu jako wzorca (flaga).** `import_pracownikow` to
+   importer z bogatym `p.result()` inline; Report generuje wyjście do bazy i
+   pokazuje osobną tabelę. Mapowanie „run→rendering" (Ścieżka A vs B, §4.3) jest
+   wywnioskowane z API liveops + `long_running.Report`, nie z istniejącej
+   migracji. **Do decyzji przy realizacji.** Rekomendacja: Ścieżka A
+   (`get_success_url` → results) + minimalny result-fragment fallback.
+2. **Kolizja nazw szablonów** (§7.5) — najłatwiejsza do przeoczenia; auto-host
+   nadpisałby szablon wyników. Mitigacja: jawne nazwy.
+3. **regen GET→POST** — zmiana kontraktu URL (link w szablonie + test). Ktoś z
+   zabookmarkowanym GET `/regen` dostanie 405. Akceptowalne (akcja mutująca).
+4. **Auto-delete listy (>10)** — porzucenie zmienia zachowanie i test
+   (`test_ListaRaportSlotowUczelnia`). Alternatywa: odtworzyć w `get_queryset`.
+   Rekomendacja: porzucić (housekeeping poza list-view).
+5. **Transakcyjność** (§4.2) — jeśli NIE owiniemy `run` w atomic, błąd w połowie
+   zostawi częściowe wiersze (regresja vs legacy). Owinąć.
+6. **`WebProgress` w prod wymaga Redis channel-layer** (jest, `settings/base.py`)
+   — w testach eager+brak Redis → group_send trafia w pustkę, ale terminalny
+   stan i tak w bazie (results czyta z bazy). OK.
+7. **Router/details URL-e** — czy zostawić jako redirect-shim dla kompatybilności
+   linków, czy usunąć? `-router` referuje tylko własny list-template (do zmiany),
+   `-details` tylko test. Rekomendacja: usunąć, zaktualizować referencje.
+8. **Baseline** — trzeba odświeżyć przy merge (`make baseline-update`), nie w
+   branchu; łatwe do zapomnienia.
+9. **API v1 pęka natychmiast po migracji (HIGH, §4.5).** Usunięcie
+   `last_updated_on` → DRF `ImproperlyConfigured` na KAŻDYM żądaniu do viewsetu;
+   `create()` woła nieistniejący `task_perform` → cichy `AttributeError` w tasku
+   (raport się nie generuje). Musi być fiksowane w tej samej fazie co model
+   (Faza 2). Enqueue MUSI iść przez `transaction.on_commit` (create jest
+   `@atomic`). Pierwotny plan (grep tylko po aplikacji) tę powierzchnię zgubił.
+10. **Restart bez guardu wyścig z workerem (MEDIUM, §8.4).** liveops
+    `RestartView` resetuje bezwarunkowo; regen w połowie runu kasuje wiersze,
+    które task pisze. Rekomendacja: guard na `get_state()` terminalny (jak legacy
+    „reset tylko gdy finished"). `import_pracownikow` zaakceptował bezwarunkowość,
+    ale on ma maszynę stanów `stan` — raport slotów nie ma, więc guard potrzebny.
+11. **API v1 create NIE ustawia `uczelnia` (LOW, §8.1).** Raport z API jest
+    nie-zawężony (wszystkie uczelnie). Stan obecny; rekomendacja: zostawić jak
+    dziś, ale udokumentować że to celowe (owner-scope izoluje odczyt).
+
+---
+
+## 12. Czego NIE robić
+
+- **NIE** edytować istniejących migracji `src/raport_slotow/migrations/*`
+  (dodać `0022_liveops.py`).
+- **NIE** odświeżać baseline w tym branchu (raz, przy scalaniu).
+- **NIE** zmieniać typu pk (już UUID) ani schematu `RaportSlotowUczelniaWiersz`
+  (poza ewentualnym `related_name`, którego NIE ruszamy).
+- **NIE** dotykać logiki scoping per-uczelnia (`uczelnia` FK, filtry w `run`,
+  `uczelnia_dla_odczytu`) — przenieść 1:1.
+- **NIE** używać `TextProgress` ani `check_cancelled` na modelu legacy (Faza 1
+  most: `check_cancelled` no-op).
+- **NIE** polegać na auto-nazwie host-template (kolizja) — ustawić jawnie.
+- **NIE** owijać tworzenia w `transaction.atomic` bez `on_commit` przy enqueue;
+  domyślnie enqueue bezpośrednio (bez atomic).
+- **NIE** usuwać bramki grupowej `BaseRaportAuthMixin` na regenie/liście/results
+  (liveops `REQUIRED_GROUP` jest nieustawione → sam liveops NIE gejtuje).
+- **NIE** modyfikować kodu ani migracji w ramach tego zadania — to tylko plan.


### PR DESCRIPTION
Trzy dokumenty planistyczne powstały w worktree gałęzi `feat/import-list-if-liveops`,
`feat/import-polon-liveops` i `feat/raport-slotow-liveops`, ale **nigdy nie zostały
zacommitowane** — istniały wyłącznie jako pliki nieśledzone w tych katalogach
(0 commitów w całej historii repo).

PR-y #616, #617 i #618 są zmergowane, więc kod jest w `dev`. Przy sprzątaniu
gałęzi `[gone]` te plany zniknęłyby bezpowrotnie razem z worktree.

## Zawartość

| Plik | Rozmiar |
|---|---|
| `docs/deweloper/plan-import-list-if-liveops.md` | 35K |
| `docs/deweloper/plan-import-polon-liveops.md` | 34K |
| `docs/deweloper/plan-raport-slotow-liveops.md` | 43K |

Opisują przeniesienie `import_list_if`, importera POLON i `raport_slotow`
z legacy stacku `long_running` na `django-liveops` 0.4 — mapowania, fazy TDD,
ryzyka, czego nie robić.

Migracje są już wykonane. Dokumenty zostają jako zapis decyzji projektowych
i referencja dla kolejnych migracji `long_running` → `liveops`.

Sama dokumentacja — zero zmian w kodzie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)