### PR TITLE
cerif-validate pobiera gotowego JAR-a zamiast budować mavenem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,13 @@ tests-with-microsoft-auth: enable-microsoft-auth tests-without-playwright-with-m
 #
 # Wymagania: JRE 17+ ALBO Docker. Mavena i JDK nie trzeba.
 #
+# Oba tory uruchamiają walidator z katalogiem roboczym ustawionym na cache,
+# NIE na korzeń repo: walidator zapisuje pobrane odpowiedzi OAI-PMH do
+# WZGLĘDNEGO katalogu data/ (CRISValidator:
+# `new FileLoggingConnectionStreamFactory("data")`), więc uruchomiony stąd
+# zasypałby repo setkami nieśledzonych plików. Tor javowy dostaje `cd`,
+# dockerowy — montowanie tej samej ścieżki na /work/data.
+#
 # Użycie:  make cerif-validate URL=https://twoja-instancja/cerif-oai/
 CERIF_VALIDATOR_VERSION ?= v2.1.1-iplweb.1
 # Poza drzewem repo celowo: `make clean` robi `rm -rf .cache` (patrz
@@ -453,23 +460,45 @@ cerif-validate: ## Waliduj endpoint CERIF (URL=...) walidatorem euroCRIS
 	fi; \
 	if [ "$$java_ok" = 1 ]; then \
 	  $(MAKE) --no-print-directory "$(_cerif_jar)" && \
-	  java -jar "$(_cerif_jar)" "$(URL)"; \
+	  ( cd "$(CERIF_VALIDATOR_CACHE)" && java -jar "$(_cerif_jar)" "$(URL)" ); \
 	elif command -v docker >/dev/null 2>&1; then \
 	  echo "Używam obrazu $(CERIF_VALIDATOR_IMAGE):$(_cerif_image_tag)"; \
-	  url="$(URL)"; \
-	  host=$$(printf '%s' "$$url" | sed -E 's#^[a-zA-Z]+://([^/:]+).*#\1#'); \
-	  case "$$host" in \
-	    localhost|127.0.0.1|0.0.0.0|::1|"$$(hostname)"|"$$(hostname -s)") \
-	      url=$$(printf '%s' "$$url" | sed -e "s#//$$host#//host.docker.internal#"); \
-	      echo "UWAGA: kontener nie ma dostępu do '$$host' — podmieniam na $$url"; \
-	      echo "       Django musi mieć host.docker.internal w ALLOWED_HOSTS,"; \
-	      echo "       a na Linuksie serwer musi słuchać na 0.0.0.0, nie 127.0.0.1."; \
+	  host=$$(printf '%s' "$(URL)" | sed -E 's#^[a-zA-Z]+://([^/:]+).*#\1#'); \
+	  addhost=""; \
+	  lc() { printf '%s' "$$1" | tr 'A-Z' 'a-z'; }; \
+	  host_lc=$$(lc "$$host"); \
+	  self_lc=$$(lc "$$(hostname)"); \
+	  self_short_lc=$$(lc "$$(hostname -s)"); \
+	  case "$$host_lc" in \
+	    localhost|127.0.0.1|0.0.0.0|::1) \
+	      addhost="--add-host=$$host:host-gateway"; \
+	      echo "UWAGA: '$$host' w kontenerze wskazuje na sam kontener —"; \
+	      echo "       mapuję na bramę hosta. Serwer MUSI słuchać na 0.0.0.0;"; \
+	      echo "       przy bindzie tylko na 127.0.0.1 połączenie będzie odrzucone."; \
+	      ;; \
+	    "$$self_lc"|"$$self_short_lc") \
+	      ip=$$(getent hosts "$$host" 2>/dev/null | awk '{print $$1; exit}'); \
+	      [ -n "$$ip" ] || ip=$$(dscacheutil -q host -a name "$$host" 2>/dev/null \
+	                             | awk '/^ip_address:/{print $$2; exit}'); \
+	      [ -n "$$ip" ] || ip=$$(ping -c1 -t1 "$$host" 2>/dev/null \
+	                             | sed -n '1s/.*(\([0-9.]*\)).*/\1/p'); \
+	      case "$$ip" in \
+	        ""|127.*) \
+	          addhost="--add-host=$$host:host-gateway"; \
+	          echo "UWAGA: '$$host' nie rozwiązuje się na adres widoczny z kontenera"; \
+	          echo "       — mapuję na bramę hosta."; \
+	          ;; \
+	        *) \
+	          addhost="--add-host=$$host:$$ip"; \
+	          echo "Mapuję '$$host' -> $$ip w kontenerze."; \
+	          ;; \
+	      esac; \
 	      ;; \
 	  esac; \
 	  mkdir -p "$(CERIF_VALIDATOR_CACHE)/data"; \
-	  docker run --rm --add-host=host.docker.internal:host-gateway \
+	  docker run --rm $$addhost \
 	    -v "$(CERIF_VALIDATOR_CACHE)/data:/work/data" \
-	    "$(CERIF_VALIDATOR_IMAGE):$(_cerif_image_tag)" "$$url"; \
+	    "$(CERIF_VALIDATOR_IMAGE):$(_cerif_image_tag)" "$(URL)"; \
 	else \
 	  echo "Potrzebny JRE 17+ albo Docker. Zainstaluj jedno z:"; \
 	  echo "  brew install openjdk@17          # macOS"; \

--- a/Makefile
+++ b/Makefile
@@ -382,7 +382,9 @@ CERIF_VALIDATOR_CACHE ?= $(HOME)/.cache/bpp/cerif-validator
 CERIF_VALIDATOR_IMAGE ?= iplweb/cerif-validator
 # Przypięta suma pobieranego JAR-a. Pusta = weryfikacja spada na .sha256
 # z release'u (słabsza, patrz komentarz przy regule pobierania).
-CERIF_VALIDATOR_SHA256 ?=
+# Przy podbiciu CERIF_VALIDATOR_VERSION trzeba podbić RÓWNIEŻ to — inaczej
+# pobranie nowej wersji zostanie odrzucone jako niezgodne z sumą.
+CERIF_VALIDATOR_SHA256 ?= e077bb69007b7b45020b652d0d8040a26b5879198adfa2bac74eabe01f13cc28
 
 _cerif_asset = openaire-cris-validator-$(CERIF_VALIDATOR_VERSION)-jar-with-dependencies.jar
 _cerif_jar = $(CERIF_VALIDATOR_CACHE)/$(_cerif_asset)
@@ -397,7 +399,8 @@ _cerif_image_tag = $(patsubst v%,%,$(CERIF_VALIDATOR_VERSION))
 $(_cerif_jar):
 	@mkdir -p "$(CERIF_VALIDATOR_CACHE)"
 	@echo "Pobieram walidator euroCRIS $(CERIF_VALIDATOR_VERSION)..."
-	@curl -fL --retry 3 --proto '=https' --tlsv1.2 -o "$@.tmp" "$(_cerif_url)" || { \
+	@curl -fL --retry 3 --progress-bar --proto '=https' --tlsv1.2 \
+	  -o "$@.tmp" "$(_cerif_url)" || { \
 	  rm -f "$@.tmp"; \
 	  echo ""; \
 	  echo "Nie udało się pobrać walidatora z:"; \

--- a/Makefile
+++ b/Makefile
@@ -357,26 +357,123 @@ tests-with-microsoft-auth: enable-microsoft-auth tests-without-playwright-with-m
 
 # Walidacja endpointu CERIF względem openaire-cris-validator (euroCRIS).
 #
-# Celowo POZA domyślną suitą: wymaga JVM, Mavena i DZIAŁAJĄCEGO endpointu
-# pod adresem URL. Testy w src/cerif_export/tests/test_serializery.py
-# walidują ładunek względem vendorowanych XSD i biegną offline — ten target
-# jest krokiem dodatkowym, sprawdzającym całość protokołu tak, jak zrobi to
-# zespół agregacji OpenAIRE przy rejestracji.
+# Celowo POZA domyślną suitą: wymaga DZIAŁAJĄCEGO endpointu pod adresem URL.
+# Testy w src/cerif_export/tests/test_serializery.py walidują ładunek
+# względem vendorowanych XSD i biegną offline — ten target jest krokiem
+# dodatkowym, sprawdzającym całość protokołu tak, jak zrobi to zespół
+# agregacji OpenAIRE przy rejestracji.
+#
+# Wcześniej target budował walidator mavenem przy KAŻDYM wywołaniu: upstream
+# (EuroCRIS) nie publikuje binariów, więc trzeba było mieć u siebie JDK,
+# Mavena, cache ~/.m2 i dwa klony — ~550 MB narzędzi, żeby wyprodukować
+# 4,7 MB JAR-a, a `mvn clean` kasował gotowy artefakt przed każdym buildem.
+# Teraz artefakt pobieramy z forka, który buduje go raz, na CI:
+# https://github.com/iplweb/openaire-cris-validator
+#
+# Wymagania: JRE 17+ ALBO Docker. Mavena i JDK nie trzeba.
 #
 # Użycie:  make cerif-validate URL=https://twoja-instancja/cerif-oai/
-CERIF_VALIDATOR_DIR ?= $(HOME)/Programowanie/openaire-cris-validator
+CERIF_VALIDATOR_VERSION ?= v2.1.1-iplweb.1
+# Poza drzewem repo celowo: `make clean` robi `rm -rf .cache` (patrz
+# clean-pycache), więc cache w .cache/ znikałby przy każdym sprzątaniu.
+# W $(HOME) przeżywa clean i jest współdzielony między worktree — na tym
+# hoście zwykle biega ich kilka naraz.
+CERIF_VALIDATOR_CACHE ?= $(HOME)/.cache/bpp/cerif-validator
+CERIF_VALIDATOR_IMAGE ?= iplweb/cerif-validator
+# Przypięta suma pobieranego JAR-a. Pusta = weryfikacja spada na .sha256
+# z release'u (słabsza, patrz komentarz przy regule pobierania).
+CERIF_VALIDATOR_SHA256 ?=
+
+_cerif_asset = openaire-cris-validator-$(CERIF_VALIDATOR_VERSION)-jar-with-dependencies.jar
+_cerif_jar = $(CERIF_VALIDATOR_CACHE)/$(_cerif_asset)
+_cerif_url = https://github.com/iplweb/openaire-cris-validator/releases/download/$(CERIF_VALIDATOR_VERSION)/$(_cerif_asset)
+# Tag obrazu = tag gita bez wiodącego "v" (Docker nie dopuszcza go w naszej
+# konwencji nazewniczej); v2.1.1-iplweb.1 -> 2.1.1-iplweb.1
+_cerif_image_tag = $(patsubst v%,%,$(CERIF_VALIDATOR_VERSION))
+
+# Pobranie do pliku tymczasowego + mv, żeby przerwany transfer nie zostawił
+# w cache'u obciętego JAR-a, który przy kolejnym wywołaniu wyglądałby na
+# gotowy artefakt i wywalał się dopiero w JVM.
+$(_cerif_jar):
+	@mkdir -p "$(CERIF_VALIDATOR_CACHE)"
+	@echo "Pobieram walidator euroCRIS $(CERIF_VALIDATOR_VERSION)..."
+	@curl -fL --retry 3 --proto '=https' --tlsv1.2 -o "$@.tmp" "$(_cerif_url)" || { \
+	  rm -f "$@.tmp"; \
+	  echo ""; \
+	  echo "Nie udało się pobrać walidatora z:"; \
+	  echo "  $(_cerif_url)"; \
+	  echo "Sprawdź, czy release $(CERIF_VALIDATOR_VERSION) istnieje:"; \
+	  echo "  https://github.com/iplweb/openaire-cris-validator/releases"; \
+	  exit 1; }
+	@# Sumę pobieramy z tego samego release'u, więc NIE jest to kotwica
+	@# zaufania — łapie obcięty transfer i przypadkowo podmieniony asset,
+	@# nie skompromitowane wydanie. Realny gate to CERIF_VALIDATOR_SHA256
+	@# (przypięty w gicie, przechodzi przez code review) — jeśli ustawiony,
+	@# ma pierwszeństwo.
+	@expected="$(CERIF_VALIDATOR_SHA256)"; \
+	if [ -z "$$expected" ]; then \
+	  expected=$$(curl -fsL --retry 3 --proto '=https' "$(_cerif_url).sha256" \
+	              2>/dev/null | cut -d' ' -f1); \
+	fi; \
+	if [ -n "$$expected" ]; then \
+	  actual=$$(shasum -a 256 "$@.tmp" 2>/dev/null | cut -d' ' -f1); \
+	  if [ "$$actual" != "$$expected" ]; then \
+	    rm -f "$@.tmp"; \
+	    echo "Suma SHA-256 się nie zgadza — pobrany plik odrzucony."; \
+	    echo "  oczekiwano: $$expected"; \
+	    echo "  otrzymano:  $$actual"; \
+	    exit 1; \
+	  fi; \
+	else \
+	  echo "OSTRZEŻENIE: brak sumy SHA-256 do weryfikacji artefaktu."; \
+	fi
+	@mv "$@.tmp" "$@"
 
 cerif-validate: ## Waliduj endpoint CERIF (URL=...) walidatorem euroCRIS
 	@test -n "$(URL)" || { \
 	  echo "Podaj URL, np. make cerif-validate URL=https://host/cerif-oai/"; \
 	  exit 1; }
-	@command -v mvn >/dev/null || { \
-	  echo "Brak mavena. Zainstaluj: brew install maven"; exit 1; }
-	@test -d "$(CERIF_VALIDATOR_DIR)" || git clone \
-	  https://github.com/EuroCRIS/openaire-cris-validator.git \
-	  "$(CERIF_VALIDATOR_DIR)"
-	cd "$(CERIF_VALIDATOR_DIR)" && mvn clean package -DskipTests && \
-	  java -jar target/openaire-cris-validator-*-jar-with-dependencies.jar "$(URL)"
+	@# Sama obecność `java` w PATH nie wystarcza: JAR ma target 17, więc na
+	@# JRE 8/11 (wciąż typowe) wywali się UnsupportedClassVersionError —
+	@# komunikatem, którego nikt nie mapuje na "zainstaluj nowszą Javę".
+	@# Za stara java jest traktowana jak jej brak i spada na Dockera.
+	@java_ok=0; \
+	if command -v java >/dev/null 2>&1; then \
+	  v=$$(java -version 2>&1 | sed -n '1s/.*version "\([0-9]*\).*/\1/p'); \
+	  if [ -n "$$v" ] && [ "$$v" -ge 17 ] 2>/dev/null; then \
+	    java_ok=1; \
+	  elif [ -n "$$v" ]; then \
+	    echo "Znaleziono Javę $$v, walidator wymaga 17+ — próbuję Dockera."; \
+	  else \
+	    echo "java jest w PATH, ale nie działa (stub macOS?) — próbuję Dockera."; \
+	  fi; \
+	fi; \
+	if [ "$$java_ok" = 1 ]; then \
+	  $(MAKE) --no-print-directory "$(_cerif_jar)" && \
+	  java -jar "$(_cerif_jar)" "$(URL)"; \
+	elif command -v docker >/dev/null 2>&1; then \
+	  echo "Używam obrazu $(CERIF_VALIDATOR_IMAGE):$(_cerif_image_tag)"; \
+	  url="$(URL)"; \
+	  host=$$(printf '%s' "$$url" | sed -E 's#^[a-zA-Z]+://([^/:]+).*#\1#'); \
+	  case "$$host" in \
+	    localhost|127.0.0.1|0.0.0.0|::1|"$$(hostname)"|"$$(hostname -s)") \
+	      url=$$(printf '%s' "$$url" | sed -e "s#//$$host#//host.docker.internal#"); \
+	      echo "UWAGA: kontener nie ma dostępu do '$$host' — podmieniam na $$url"; \
+	      echo "       Django musi mieć host.docker.internal w ALLOWED_HOSTS,"; \
+	      echo "       a na Linuksie serwer musi słuchać na 0.0.0.0, nie 127.0.0.1."; \
+	      ;; \
+	  esac; \
+	  mkdir -p "$(CERIF_VALIDATOR_CACHE)/data"; \
+	  docker run --rm --add-host=host.docker.internal:host-gateway \
+	    -v "$(CERIF_VALIDATOR_CACHE)/data:/work/data" \
+	    "$(CERIF_VALIDATOR_IMAGE):$(_cerif_image_tag)" "$$url"; \
+	else \
+	  echo "Potrzebny JRE 17+ albo Docker. Zainstaluj jedno z:"; \
+	  echo "  brew install openjdk@17          # macOS"; \
+	  echo "  brew install --cask docker       # macOS, wariant kontenerowy"; \
+	  echo "  apt install openjdk-17-jre       # Debian/Ubuntu"; \
+	  exit 1; \
+	fi
 
 # Chromium i Daphne konkuruja o zasoby przy `-n auto`, ktore bierze WSZYSTKIE
 # rdzenie logiczne. Na Apple Silicon oznacza to doliczenie rdzeni

--- a/docs/deweloper/eurocris-co-jeszcze.md
+++ b/docs/deweloper/eurocris-co-jeszcze.md
@@ -115,6 +115,8 @@ zombie w indeksie.
 2. **Uruchomić walidator na docelowym, publicznym adresie**:
    `make cerif-validate URL=https://<instancja>/cerif-oai/`.
    Walidacja lokalna nie sprawdzi HTTPS, przekierowań ani nagłówków proxy.
+   Target wymaga JRE 17+ **albo** Dockera — nie wymaga już Mavena ani JDK,
+   bo pobiera gotowego JAR-a z <https://github.com/iplweb/openaire-cris-validator>.
 3. **Zarejestrować CRIS w DRIS** (euroCRIS): <https://dspacecris.eurocris.org/cris/explore/dris>.
 4. **Zarejestrować endpoint w OpenAIRE Provide**:
    <https://provide.openaire.eu/>. Zespół agregacji OpenAIRE robi własną

--- a/docs/superpowers/specs/2026-08-05-cerif-validator-fork-design.md
+++ b/docs/superpowers/specs/2026-08-05-cerif-validator-fork-design.md
@@ -1,0 +1,442 @@
+# Spec: fork `openaire-cris-validator` z publikacją JAR-a i obrazu Dockera
+
+Data: 2026-08-05
+Autor: sesja Claude Code (na podstawie `HANDOFF-cerif-validator-fork.md`)
+Status: zatwierdzony do wdrożenia
+
+---
+
+## 1. Problem
+
+Żeby zweryfikować endpoint CERIF BPP (`/cerif-oai/`) walidatorem euroCRIS,
+trzeba dziś mieć lokalnie JDK (380 MB) + Maven (11 MB) + cache `~/.m2`
+(52 MB) + klon walidatora (89 MB) + klon `guidelines-cris-managers` (21 MB)
+— razem ~550 MB narzędzi, żeby wyprodukować **4,7 MB** samowystarczalnego
+JAR-a. Target `make cerif-validate` (`Makefile:369-379`) dodatkowo robi
+`mvn clean package` przy **każdym** wywołaniu, czyli kasuje gotowy artefakt,
+żeby zbudować identyczny.
+
+Upstream (`EuroCRIS/openaire-cris-validator`) nie publikuje binariów:
+release'y istnieją, ale **wszystkie mają zero assetów**, projektu nie ma
+na Maven Central, nie ma `Dockerfile`. Jedyna droga to zbudować raz
+i rozdystrybuować samodzielnie.
+
+## 2. Cel
+
+Fork `iplweb/openaire-cris-validator`, który przy tagu `v*` buduje JAR-a,
+publikuje go jako asset release'u **oraz** jako obraz
+`iplweb/cerif-validator` na Docker Hubie. BPP-owy `make cerif-validate`
+przestaje wymagać Mavena — pobiera gotowy artefakt.
+
+### Poza zakresem (świadome decyzje, nie przeoczenia)
+
+- **GitHub Packages / Maven registry forka** — walidator uruchamiamy jako
+  CLI, nie linkujemy jako zależność. Publikacja do rejestru Mavena nie ma
+  dla nas wartości.
+- **Automatyczna synchronizacja z upstreamem** (`repo-sync` itp.) —
+  upstream wydaje release ~raz na rok. Ręczny merge przy nowym tagu
+  wystarcza i jest mniej ruchomych części.
+- **Zmiany w kodzie walidatora** — fork ma być czysto dystrybucyjny.
+
+## 3. Fakty zweryfikowane pomiarem
+
+| Ustalenie | Wartość | Skąd |
+|---|---|---|
+| Wymagany JDK | **17** | `pom.xml:17` — `<maven.compiler.version>17</maven.compiler.version>`, użyte w `maven-compiler-plugin` jako `<source>`/`<target>` |
+| Testy upstreamu | **43, wszystkie przechodzą, wszystkie offline** | `mvn -B clean package` → `Tests run: 43, Failures: 0, Errors: 0`; fixture'y to zapisane odpowiedzi OAI-PMH w `src/test/java/.../check_*/` |
+| Czas ciepłego rebuildu | 3,5 s (`-o -DskipTests`) | pomiar w sesji źródłowej |
+| Rozmiar JAR-a | 4 721 874 B (~4,7 MB) | `target/openaire-cris-validator-2.1.1-SNAPSHOT-jar-with-dependencies.jar` |
+| Schematy w JAR-ze | **tak** — `schemas/original/cerif_profile_1_1/**` | `unzip -l` na zbudowanym JAR-ze |
+| `NOTICE` w upstreamie | **nie istnieje** (jest tylko `LICENSE`) | `ls` w klonie |
+| Tag schematów | `v1.2.0` istnieje w `openaire/guidelines-cris-managers` | `git tag` w klonie |
+| Wersja w `pom.xml` | `2.1.1-SNAPSHOT` (przed ostatnim tagiem `v2.1.0`) | `pom.xml:5` |
+
+### 3.1. Krytyczne: build NIE jest reprodukowalny
+
+`pom.xml` używa **zakresów wersji** zależności:
+
+```xml
+<version>[1.3.1,2)</version>   <!-- linia 23 -->
+<version>[4.13.1,)</version>   <!-- linia 28 -->
+```
+
+Maven rozwiązuje je **w czasie builda**. Rebuild z tego samego tagu za pół
+roku może wciągnąć inne wersje zależności. Konsekwencje dla designu:
+
+1. **Asset release'u jest jedynym źródłem prawdy.** Nigdy „odtwórz artefakt
+   z taga" — pobierz opublikowany plik.
+2. **Obraz Dockera musi zawierać dokładnie ten sam JAR co release**, więc
+   `Dockerfile` *kopiuje* artefakt z kroku Mavena, zamiast budować drugi raz.
+
+### 3.2. Schematy muszą leżeć jako katalog-rodzeństwo, nie byle gdzie
+
+`pom.xml:14` deklaruje `<guidelines.project.dir>../guidelines-cris-managers</guidelines.project.dir>`,
+używane w liniach 162, 175, 229, 241 (m.in. `${guidelines.project.dir}/schemas/catalog.xml`).
+Bez tego build pada na `That catalog does not exist`.
+
+Property **da się** nadpisać (`-Dguidelines.project.dir=/dowolna/sciezka`)
+i sam build wtedy przechodzi — ale **to nie wystarcza**. Pliki w `samples/`
+są dowiązaniami symbolicznymi do `../../guidelines-cris-managers/samples/*`,
+więc smoke test na `file:samples/` wymaga repo schematów pod **dokładnie tą
+nazwą, jako katalogu-rodzeństwa** korzenia repo. Zweryfikowane: przy
+nadpisanej property smoke test pada z
+`java.io.FileNotFoundException: samples/_verb=Identify.xml`.
+
+Dlatego CI robi to samo, co upstreamowy `maven.yml`: checkout do
+`guidelines-cris-managers`, potem `mv guidelines-cris-managers ..`.
+Zaspokaja to naraz symlinki i domyślną wartość property, więc żadne
+`-D` nie jest potrzebne. **Nie „upraszczać" tego z powrotem do `-D`.**
+
+## 4. Licencje
+
+- **Walidator: Apache License 2.0.** Redystrybucja binariów wprost dozwolona.
+  Warunki, które nas dotyczą: zachować `LICENSE`, dołączyć `NOTICE`
+  i **zaznaczyć, że wprowadzono zmiany** (§4b — fork dokłada CI i Dockerfile,
+  więc jest to „modified work").
+- **`guidelines-cris-managers` nie ma pliku `LICENSE`**, ale same wytyczne są
+  **CC BY 4.0** (nagłówek `schemas/openaire-cerif-profile.xsd`). Schematy
+  **fizycznie trafiają do JAR-a** (potwierdzone `unzip -l`), więc atrybucja
+  OpenAIRE/euroCRIS w `NOTICE` jest obowiązkowa, nie kurtuazyjna.
+
+## 5. Architektura
+
+### 5.1. Wersjonowanie
+
+Schemat tagów forka: **`v2.1.1-iplweb.N`**.
+
+- `2.1.1` — wersja z `pom.xml` upstreamu (baza forka to `main`, który jest
+  przed ostatnim releasem `v2.1.0`)
+- `iplweb.N` — inkrementowane przy zmianach **w samym forku** (CI, Dockerfile,
+  NOTICE), bez ruchu upstreamu
+
+Pierwszy tag: `v2.1.1-iplweb.1`.
+
+`N` liczy się **w obrębie danej bazy upstreamu** i resetuje do 1, gdy baza
+się zmienia. Tag wydajemy tylko wtedy, gdy zmienia się publikowany artefakt
+albo obraz — sama poprawka w `README.md` nowego tagu nie wymaga.
+
+**Gdy upstream wyda `v2.1.1`** i przestawi `pom.xml` na `2.1.2-SNAPSHOT`,
+nasze tagi `v2.1.1-iplweb.N` zaczęłyby kłamać (wskazywałyby na kod już po
+2.1.1). Procedura synchronizacji: `git fetch upstream && git merge
+upstream/main`, odczytaj `pom.xml:5`, nowy tag =
+`v<wersja-z-pom-bez-SNAPSHOT>-iplweb.1`, podbij `CERIF_VALIDATOR_VERSION`
+w BPP.
+
+**`pom.xml` pozostaje NIETKNIĘTY.** Nie podbijamy w nim wersji na
+`2.1.1-iplweb.1`, bo każdy diff w `pom.xml` to konflikt przy każdej
+synchronizacji z upstreamem. Artefakt buduje się pod nazwą
+`openaire-cris-validator-2.1.1-SNAPSHOT-jar-with-dependencies.jar`,
+a workflow przemianowuje go przy publikacji.
+
+### 5.2. Pliki dodane w forku
+
+Fork **dodaje** pliki, których upstream nie ma; jedyny plik współdzielony
+to `README.md`:
+
+| Plik | Rola |
+|---|---|
+| `.github/workflows/release.yml` | build + testy + release + obraz |
+| `Dockerfile` | runtime na JRE, kopiuje gotowy JAR |
+| `.dockerignore` | kontekst budowy = `dist/validator.jar` + `LICENSE` + `NOTICE` |
+| `NOTICE` | Apache §4b + atrybucja CC BY 4.0 dla schematów |
+| `README.md` (sekcja „Changes in this fork") | Apache §4b — jawna nota o modyfikacji |
+
+Sekcja w `README.md` dopisywana na końcu, żeby minimalizować ryzyko
+konfliktu przy synchronizacji.
+
+**Upstreamowy `.github/workflows/maven.yml` zostaje nietknięty.** Odpala się
+na push do `main` i na PR-y, przypina schematy do `ref: main` (niepinowane),
+więc może się kiedyś zaczerwienić z powodów niezależnych od nas. Zostawiamy
+go świadomie: to niezależny build check, minuty na repo publicznym są
+darmowe, a każda zmiana w nim to niepotrzebny konflikt przy merge'u
+upstreamu. To z niego pochodzi smoke test `java -jar … file:samples/`,
+przeniesiony do `release.yml`.
+
+### 5.3. Workflow `release.yml`
+
+Wyzwalacze: `push: tags: ['v*']` oraz `workflow_dispatch`.
+Uprawnienia: `contents: write` (tworzenie release'u).
+
+`concurrency: release-${{ github.ref }}` z `cancel-in-progress: false` —
+półopublikowane wydanie (asset jest, obrazu nie ma) jest gorsze niż
+zakolejkowane.
+
+Jeden job na `ubuntu-latest`:
+
+1. **Ustal tag.** Wartość wchodzi do shella przez `env:`, **nigdy** przez
+   bezpośrednią interpolację `${{ }}` do `run:` — inaczej spreparowany input
+   `workflow_dispatch` wykonałby się jako polecenie. Druga linia obrony:
+   wzorzec `^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.]*)?$`, bo ta
+   sama wartość trafia potem do `actions/checkout` jako `ref:`.
+   Bez tego kroku `workflow_dispatch` nie miałby skąd wziąć tagu
+   (`github.ref_name` na gałęzi = `main`, a `action-gh-release` bez tagu
+   kończy się błędem).
+2. **Odmów nadpisania.** `gh release view "$TAG"` → jeśli istnieje, twardy
+   fail. Uzasadnienie w §3.1: re-run wyprodukowałby inny artefakt pod
+   opublikowanym tagiem. Poprawki dostają nowe `iplweb.N`.
+3. `actions/checkout` forka na `ref: <TAG>`
+4. `actions/checkout` `openaire/guidelines-cris-managers` @ `v1.2.0` →
+   `path: guidelines-cris-managers`, potem `mv guidelines-cris-managers ..`
+   (uzasadnienie: §3.2 — symlinki w `samples/`)
+5. `actions/setup-java` — `distribution: temurin`, `java-version: 17`,
+   `cache: maven` (wbudowany cache `~/.m2`; osobny `actions/cache` zbędny)
+6. `mvn -B -V clean package -Dmaven.javadoc.skip=true` — **bez
+   `-DskipTests`**. 43 testy są offline i przechodzą, więc są darmowym
+   sanity checkiem na sensowność builda.
+7. **Smoke test:** `java -jar target/…-jar-with-dependencies.jar file:samples/`
+   → oczekiwane `OK (13 tests)`. Dowodzi, że złożony JAR faktycznie startuje
+   i waliduje, a nie tylko że się skompilował.
+8. Staging artefaktu do `dist/`: `validator.jar` (nazwa stała — dla `COPY`
+   w `Dockerfile`), `openaire-cris-validator-<TAG>-jar-with-dependencies.jar`
+   (nazwa z wersją — asset) oraz `<…>.sha256`. Oba JAR-y to **ta sama**
+   kopia jednego builda.
+9. `softprops/action-gh-release` — **jawnie wymienione** dwa pliki (asset
+   + `.sha256`), nie `dist/*`; `dist/validator.jar` nie jest publikowany.
+   Release idzie **przed** obrazem, żeby problem z poświadczeniami Docker
+   Huba nie kosztował JAR-a.
+10. `docker/setup-buildx-action` + `docker/login-action` +
+    `docker/build-push-action` z **`context: .`** → `iplweb/cerif-validator:<TAG-bez-v>`
+    oraz `:latest`, platformy `linux/amd64,linux/arm64`
+
+**`context: .` jest wymagane, nie domyślne.** `docker/build-push-action` bez
+niego używa kontekstu **gitowego** (pobiera repo z GitHuba), a `dist/` powstaje
+dopiero w kroku 8 i jest w `.gitignore` — build padłby na
+`COPY dist/validator.jar: not found`.
+
+Multi-arch jest tani, bo obraz nic nie kompiluje — to JRE + `COPY`.
+
+Akcje trzecich stron (`softprops/*`, `docker/*`) przypięte do SHA. Repo
+publikuje binarium uruchamiane u odbiorców; przejęty ruchomy tag akcji
+oznaczałby podmieniony artefakt. `actions/*` zostają na tagach głównych,
+zgodnie z konwencją `iplweb/bpp`.
+
+**Poświadczenia Docker Huba:** `vars.DOCKER_USER` (zmienna) +
+`secrets.DOCKER_PAT` (sekret) — te same nazwy, co w `iplweb/bpp`. Zmienna
+jest ustawiona; sekret trzeba dodać temu repo osobno (nie da się go odczytać
+z innego repo).
+
+### 5.4. `Dockerfile`
+
+```dockerfile
+FROM eclipse-temurin:17-jre
+LABEL org.opencontainers.image.* ...
+COPY LICENSE NOTICE /opt/
+COPY dist/validator.jar /opt/validator.jar
+WORKDIR /work
+ENTRYPOINT ["java", "-jar", "/opt/validator.jar"]
+```
+
+Świadomie **nie** multi-stage: build ma się zdarzyć raz, w kroku 6 workflow.
+Drugi przebieg Mavena wewnątrz obrazu mógłby — przez zakresy wersji z §3.1 —
+dać inny artefakt niż ten w release'ie.
+
+`COPY` używa stałej nazwy `dist/validator.jar` zamiast glob-a
+`target/*-jar-with-dependencies.jar`, bo `COPY` z wildcardem do ścieżki
+nie-katalogowej jest kruchy (w `target/` leżą dwa JAR-y).
+
+**`LICENSE` i `NOTICE` jadą razem z binarium**, bo obraz jest redystrybucją
+w rozumieniu Apache-2.0 §4. Sam JAR ma `META-INF/NOTICE`, ale to zmerdżowane
+NOTICE **zależności** — nie ma tam ani noty o modyfikacji, ani atrybucji
+CC BY 4.0 dla schematów, które fizycznie są w obrazie.
+
+**`WORKDIR /work`**, bo walidator zapisuje pobrane odpowiedzi OAI-PMH do
+**względnego** katalogu `data/` (`CRISValidator.java`:
+`new FileLoggingConnectionStreamFactory("data")`). Bez `WORKDIR` trafiałoby
+to do `/` i ginęło po `--rm`, czyli ścieżka dockerowa po cichu gubiłaby
+materiał diagnostyczny, który ścieżka javowa zostawia w katalogu roboczym.
+
+**`Dockerfile` nie może zawierać `RUN`.** Multi-arch działa bez
+`docker/setup-qemu-action` wyłącznie dlatego, że sam `FROM` + `COPY` +
+`WORKDIR` nie wykonuje kodu. Pierwsze `RUN apt-get …` da `exec format error`
+na obcej architekturze.
+
+`.dockerignore` (negacja zweryfikowana empirycznie — BuildKit schodzi do
+wykluczonego katalogu, gdy istnieją wyjątki):
+
+```
+*
+!dist/validator.jar
+!LICENSE
+!NOTICE
+```
+
+### 5.5. Zmiana w `iplweb/bpp`
+
+Osobny, mały PR. `Makefile:358-379` zastąpione w całości — **łącznie
+z blokiem komentarza**, który dziś mówi „wymaga JVM, Mavena i DZIAŁAJĄCEGO
+endpointu" i po zmianie kłamałby dokładnie w tym, czego dotyczy PR.
+
+Zmienne:
+
+```make
+CERIF_VALIDATOR_VERSION ?= v2.1.1-iplweb.1
+CERIF_VALIDATOR_CACHE   ?= $(HOME)/.cache/bpp/cerif-validator
+CERIF_VALIDATOR_IMAGE   ?= iplweb/cerif-validator
+CERIF_VALIDATOR_SHA256  ?=
+```
+
+Cache **poza drzewem repo**: `make clean` zależy od `clean-pycache`, który
+robi `rm -rf .cache` (`Makefile:206-209`), więc artefakt znikałby przy każdym
+sprzątaniu. W `$(HOME)` przeżywa `clean` i jest współdzielony między worktree
+— na tym hoście zwykle biega ich kilka naraz.
+
+Nazwa pliku w cache **zawiera wersję**, więc podbicie
+`CERIF_VALIDATOR_VERSION` wymusza pobranie; stały `validator.jar`
+w nieskończoność serwowałby starą wersję.
+
+Logika targetu `cerif-validate`:
+
+1. Brak `URL=` → komunikat z przykładem, `exit 1` (zachowanie jak dziś)
+2. JAR-a nie ma w cache → `curl -fL --retry 3 --proto '=https' --tlsv1.2`
+   do pliku tymczasowego, weryfikacja SHA-256, potem `mv` na docelowy
+   (atomowo — przerwany download nie zostawia uszkodzonego cache'u).
+   Błąd `curl` → komunikat z wersją, URL-em i linkiem do listy wydań.
+3. Jest `java` **w wersji ≥ 17** → `java -jar <cache>/… "$(URL)"`
+4. Brak javy albo za stara, jest `docker` → `docker run --rm` z obrazem
+   `iplweb/cerif-validator:<wersja-bez-v>`
+5. Nie ma ani `java`, ani `docker` → błąd z konkretnymi poleceniami
+   instalacji (`brew install openjdk@17`, `brew install --cask docker`,
+   `apt install openjdk-17-jre`)
+
+Znika: `mvn`, `git clone`, `mvn clean`, zmienna `CERIF_VALIDATOR_DIR`.
+
+#### Wersja javy, nie sama jej obecność
+
+JAR ma target 17. Na JRE 8/11 (wciąż typowe na macOS i w korporacyjnych
+Linuksach) `java -jar` wywala `UnsupportedClassVersionError` — komunikat,
+którego odbiorca nie zmapuje na „zainstaluj nowszą Javę". Target parsuje
+`java -version`; za stara albo niedziałająca java (macOS-owy stub w
+`/usr/bin/java`) jest traktowana jak jej brak i spada na Dockera.
+
+#### Weryfikacja integralności
+
+Suma pobierana z tego samego release'u co JAR **nie jest kotwicą zaufania**
+— łapie obcięty transfer i przypadkowo podmieniony asset, nie skompromitowane
+wydanie. Realnym gatem jest `CERIF_VALIDATOR_SHA256` przypięte w gicie
+(przechodzi przez code review); gdy ustawione, ma pierwszeństwo. Do
+uzupełnienia po opublikowaniu pierwszego release'u.
+
+Ma to znaczenie właśnie dlatego, że §3.1 wyklucza odtworzenie artefaktu:
+sumy nie da się zweryfikować przez rebuild, więc musi być zapisana.
+
+#### Pułapka: `docker run` + adres lokalny
+
+Kontener ma własny network namespace, więc lokalny endpoint jest z niego
+niedostępny. Detekcja **nie może** opierać się na samym `localhost`:
+`run-site` binduje się na **nazwę hosta** (`mac-mini`), więc typowy lokalny
+przepływ nie zawiera wcale słowa „localhost" — dokładnie ten przypadek
+umknąłby heurystyce. Target wyciąga host z URL-a i porównuje z:
+`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, `$(hostname)`, `$(hostname -s)`.
+
+Przy trafieniu: `--add-host=host.docker.internal:host-gateway` i podmiana
+hosta w URL-u, plus ostrzeżenie o dwóch warunkach, bez których i tak nie
+zadziała:
+
+- **`ALLOWED_HOSTS`** — kontener wyśle `Host: host.docker.internal`, a Django
+  odrzuci to `DisallowedHost` (HTTP 400). Walidator zobaczy 400 zamiast
+  OAI-PMH i wypluje mylący błąd protokołu.
+- **bind na Linuksie** — `host-gateway` mapuje na IP bridge'a (`172.17.0.1`),
+  więc serwer słuchający tylko na `127.0.0.1` odrzuci połączenie mimo
+  poprawnego DNS-u. Na Docker Desktop (macOS) ruch idzie przez VM i działa
+  niezależnie od bindu — stąd klasyczne „u mnie działa".
+
+Katalog `data/` z kontenera montowany do cache'u, żeby ścieżka dockerowa
+zostawiała ten sam materiał diagnostyczny, co javowa (patrz §5.4).
+
+#### Dokumentacja i newsfragment
+
+- `src/bpp/newsfragments/cerif-validator-artefakt.doc.rst`
+- `docs/deweloper/eurocris-co-jeszcze.md:116` — wymienia `make cerif-validate`
+  w kroku rejestracyjnym; dopisać, że wymaga JRE 17+ **albo** Dockera
+
+## 6. Kolejność wdrożenia
+
+1. ✅ **Fork** — `gh repo fork EuroCRIS/openaire-cris-validator --org iplweb
+   --clone=false`, potem osobny `git clone` po SSH do
+   `~/Programowanie/openaire-cris-validator-iplweb`. Osobny klon, bo
+   `gh repo fork --clone` nie przyjmuje ścieżki docelowej — sklonowałby do
+   `./openaire-cris-validator` i zderzył się z istniejącym klonem upstreamu.
+2. ✅ **`NOTICE` + sekcja w `README.md`** — commit, push
+3. ✅ **`Dockerfile` + `.dockerignore`** — commit, push
+4. ✅ **`.github/workflows/release.yml`** — commit, push. Hipoteza o SSH
+   potwierdzona (§7)
+5. ✅ **Merge do `main`** — workflow rejestruje się dopiero z gałęzi
+   domyślnej; oba workflow mają stan `active` (nie `disabled_fork`)
+6. ⏳ **Sekret `DOCKER_PAT`** w repo forka — wymaga człowieka, wartości
+   sekretu nie da się odczytać z `iplweb/bpp`. Zmienna `DOCKER_USER`
+   ustawiona.
+7. ⏳ **Tag `v2.1.1-iplweb.1`** + push → workflow buduje i publikuje.
+   **Dopiero po kroku 6** — release powstaje przed logowaniem do Docker
+   Huba, więc przy braku sekretu zostałby opublikowany JAR bez obrazu,
+   a blokada z §5.3 krok 2 uniemożliwiłaby poprawkę bez podbicia `iplweb.N`.
+8. ⏳ **Weryfikacja artefaktów** — pobrany JAR i obraz dają ten sam wynik;
+   uzupełnić `CERIF_VALIDATOR_SHA256` w BPP
+9. ⏳ **PR do `iplweb/bpp`** — `Makefile` + newsfragment + `eurocris-co-jeszcze.md`
+
+## 7. Scope `workflow` tokena `gh` — hipoteza POTWIERDZONA
+
+Token `gh` na hoście `mac-mini` ma scope'y `admin:public_key`, `gist`,
+`read:org`, `repo` — **bez `workflow`** (zweryfikowane przez
+`gh api -i user` → `X-Oauth-Scopes`, nie tylko przez odczyt konfiguracji).
+
+Handoff zakładał, że to twardy blocker. **Nie jest** — zweryfikowane
+empirycznie w kroku 4: commit z `.github/workflows/release.yml` przeszedł
+po SSH bez odświeżania tokena.
+
+Mechanizm: ograniczenie „refusing to allow an OAuth App to create or update
+workflow" jest przypięte do **uwierzytelnienia tokenem** (Contents API oraz
+push po HTTPS z `gho_*`/PAT). Push po SSH uwierzytelnia się kluczem, żaden
+token OAuth nie bierze udziału, więc nie ma czego sprawdzać pod kątem
+scope'ów.
+
+⚠️ **Pułapka przy weryfikacji:** `gh config get git_protocol` (bez `--host`)
+zwraca `https`, a `gh config get git_protocol --host github.com` zwraca `ssh`
+— i to ta druga wartość obowiązuje. Kto sprawdzi tę pierwszą, wyciągnie
+odwrotny wniosek. Twardy warunek jest inny i deterministyczny: po klonie
+`git remote get-url origin` musi zwracać `git@github.com:…`. Jeśli zwraca
+`https://` — `git remote set-url origin git@github.com:iplweb/openaire-cris-validator.git`
+przed pushem workflow.
+
+Gdyby mimo wszystko odbiło: `gh auth refresh -s workflow` **na tym hoście**
+(interaktywne, otwiera przeglądarkę).
+
+## 8. Kryteria akceptacji
+
+1. Release `v2.1.1-iplweb.1` w `iplweb/openaire-cris-validator` ma dwa assety:
+   `openaire-cris-validator-v2.1.1-iplweb.1-jar-with-dependencies.jar`
+   (~4,7 MB) oraz `<…>.sha256`
+2. `docker run --rm iplweb/cerif-validator:2.1.1-iplweb.1 <URL>` uruchamia
+   walidację i kończy się kodem 0. **Wywołanie bez argumentu kończy się
+   kodem niezerowym, nie komunikatem usage** — `CRISValidator.main()` robi
+   `args.length > 0 ? args[0] : null`, a potem bezwarunkowo
+   `URI.create(...)`, więc leci `NullPointerException`. Usage istnieje tylko
+   w konstruktorze, do którego `main` nigdy nie dochodzi. Zmiana tego
+   wymagałaby patcha w kodzie walidatora, co §2 wyklucza.
+3. Workflow przechodzi z **43 testami** (nie `-DskipTests`) **i** smoke
+   testem `file:samples/` → `OK (13 tests)`
+4. `docker run --rm --entrypoint ls iplweb/cerif-validator:… /opt` pokazuje
+   `LICENSE` i `NOTICE`
+5. Obraz zawiera JAR o **tym samym SHA-256**, co asset release'u
+6. `make cerif-validate URL=…` działa na maszynie **bez Mavena**
+7. `make cerif-validate URL=…` na maszynie **bez `java` w PATH** kończy się
+   tym samym wynikiem, przez ścieżkę dockerową
+8. Wynik walidacji tego samego endpointu przez stary tor (`mvn`) i nowy
+   (pobrany asset) jest **identyczny** — sprawdzalne, dopóki Maven jest
+   jeszcze na hoście
+9. `NOTICE` zawiera notę o modyfikacji (Apache §4b) i atrybucję CC BY 4.0
+   dla schematów
+
+## 9. Weryfikacja końcowa
+
+```bash
+# .dump, NIE .pg_dump — run-site rozpoznaje .sql/.sql.gz/.dump, a obok
+# leży identyczny plik (ten sam rozmiar) z akceptowanym rozszerzeniem
+uv run run-site run --from-dump /Volumes/SSD/db-backup-20260428-093811.dump \
+    --no-browser --no-celery
+# adres z bannera "run-site is running" — run-site bindował się na hostname
+# (mac-mini), NIE na localhost; nie bierz portu z .dev_helpers_port w oderwaniu
+make cerif-validate URL=http://<host>:<port>/cerif-oai/
+```
+
+Oczekiwane: `OK (13 tests)`. Powtórzyć z wymuszoną ścieżką dockerową
+(np. tymczasowo ukrywając `java` w `PATH`), żeby sprawdzić oba warianty.

--- a/docs/superpowers/specs/2026-08-05-cerif-validator-fork-design.md
+++ b/docs/superpowers/specs/2026-08-05-cerif-validator-fork-design.md
@@ -328,20 +328,46 @@ przepływ nie zawiera wcale słowa „localhost" — dokładnie ten przypadek
 umknąłby heurystyce. Target wyciąga host z URL-a i porównuje z:
 `localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, `$(hostname)`, `$(hostname -s)`.
 
-Przy trafieniu: `--add-host=host.docker.internal:host-gateway` i podmiana
-hosta w URL-u, plus ostrzeżenie o dwóch warunkach, bez których i tak nie
-zadziała:
+**Podmiana hosta w URL-u to złe rozwiązanie** — zweryfikowane empirycznie
+na `run-site` z prawdziwą bazą. Pierwotny wariant (przepisz host na
+`host.docker.internal`) padał z dwóch niezależnych powodów naraz:
 
-- **`ALLOWED_HOSTS`** — kontener wyśle `Host: host.docker.internal`, a Django
-  odrzuci to `DisallowedHost` (HTTP 400). Walidator zobaczy 400 zamiast
-  OAI-PMH i wypluje mylący błąd protokołu.
-- **bind na Linuksie** — `host-gateway` mapuje na IP bridge'a (`172.17.0.1`),
-  więc serwer słuchający tylko na `127.0.0.1` odrzuci połączenie mimo
-  poprawnego DNS-u. Na Docker Desktop (macOS) ruch idzie przez VM i działa
-  niezależnie od bindu — stąd klasyczne „u mnie działa".
+1. **`connection refused`** — Daphne słucha na **jednym interfejsie**
+   (`100.107.38.27:51656`), nie na `0.0.0.0`. Brama Dockera trafia w inny
+   adres hosta, na którym nic nie nasłuchuje.
+2. **HTTP 400 `DisallowedHost`** — po podmianie kontener wysyła
+   `Host: host.docker.internal`, którego Django nie zna. Walidator widzi 400
+   zamiast OAI-PMH i zgłasza mylący błąd protokołu. Drugi błąd był maskowany
+   przez pierwszy.
 
-Katalog `data/` z kontenera montowany do cache'u, żeby ścieżka dockerowa
-zostawiała ten sam materiał diagnostyczny, co javowa (patrz §5.4).
+Rozwiązanie odwraca problem: **nie ruszamy URL-a, mapujemy nazwę.**
+`--add-host=<host>:<IP hosta>` sprawia, że TCP idzie na realny adres, a
+nagłówek `Host` zostaje ten, którego Django oczekuje. IP rozwiązujemy na
+hoście: `getent hosts`, `dscacheutil` (macOS), `ping` jako ostatnia deska.
+
+⚠️ Porównanie nazw **musi być case-insensitive**: `hostname -s` zwraca
+`Mac-mini`, a banner `run-site` podaje `mac-mini`. Nazwy hostów są
+case-insensitive, więc naiwne `case` je rozjeżdża i gałąź w ogóle się nie
+odpala — objaw wygląda wtedy jak problem sieciowy, nie jak literówka.
+
+Dla `localhost`/`127.0.0.1`/`::1`/`0.0.0.0` nie ma dobrego mapowania: zostaje
+`host-gateway` plus ostrzeżenie, że serwer musi słuchać na `0.0.0.0`. Tego
+ograniczenia nie da się obejść po stronie klienta.
+
+#### Katalog roboczy: cache, nie repo
+
+Walidator zapisuje pobrane odpowiedzi do **względnego** `data/`. Stary target
+uruchamiał `java` w katalogu klonu walidatora, więc śmieci lądowały tam.
+Naiwne przeniesienie na `java -jar <cache>/…` z korzenia repo zasypuje BPP
+setkami nieśledzonych plików (zmierzone: 157 po jednym przebiegu; `data/`
+nie jest w `.gitignore`). Oba tory dostają więc katalog roboczy w cache'u:
+javowy przez `cd`, dockerowy przez montowanie na `/work/data`.
+
+Efekt uboczny, o którym warto wiedzieć: `data/` przeżywa między przebiegami,
+a walidator czyta stamtąd. Po serii nieudanych przebiegów potrafi to dać
+fałszywe błędy — jeden przebieg pokazał 2 błędy zaraz po serii zepsutych,
+a trzy kolejne czyste `OK (13 tests)`. Przy niewyjaśnionych błędach:
+wyczyścić `data/`.
 
 #### Dokumentacja i newsfragment
 

--- a/src/bpp/newsfragments/cerif-validator-artefakt.doc.rst
+++ b/src/bpp/newsfragments/cerif-validator-artefakt.doc.rst
@@ -1,0 +1,4 @@
+``make cerif-validate`` nie wymaga już Mavena ani JDK — pobiera gotowego
+JAR-a walidatora euroCRIS z wydań https://github.com/iplweb/openaire-cris-validator
+albo uruchamia go z obrazu ``iplweb/cerif-validator``. Wystarczy JRE 17+
+lub Docker.


### PR DESCRIPTION
## Co i po co

`make cerif-validate` budował walidator euroCRIS mavenem przy **każdym**
wywołaniu. Upstream (EuroCRIS) nie publikuje binariów — każdy release ma zero
assetów, projektu nie ma na Maven Central, nie ma `Dockerfile` — więc trzeba
było mieć u siebie JDK, Mavena, cache `~/.m2` i dwa klony. Około **550 MB
narzędzi, żeby wyprodukować 4,7 MB JAR-a**, a `mvn clean` kasował gotowy
artefakt przed każdym buildem.

Teraz artefakt pochodzi z forka, który buduje go raz, na CI:
https://github.com/iplweb/openaire-cris-validator

Wymagania spadają do **JRE 17+ albo Docker**.

Fork jest czysto dystrybucyjny — zero zmian w kodzie walidatora, testach czy
`pom.xml`. Dokłada wyłącznie `release.yml`, `Dockerfile`, `NOTICE` i sekcję
w `README.md` (Apache-2.0 §4(b) wymaga jawnej noty o modyfikacji).

## Weryfikacja

Przeciw prawdziwemu endpointowi (`run-site` z dumpu produkcyjnego), **oba
tory**:

| tor | wynik |
|---|---|
| `java -jar` z pobranego assetu | `OK (13 tests)` |
| `docker run` z `iplweb/cerif-validator` | `OK (13 tests)` |

To ten sam wynik, co przy starym torze mavenowym — punkt odniesienia się
zgadza.

Po stronie forka: workflow przechodzi z **43 testami** upstreamu (bez
`-DskipTests`) plus smoke testem `file:samples/`. Suma SHA-256 JAR-a w obrazie
jest identyczna z sumą assetu wydania.

## Rzeczy nieoczywiste

* **Sprawdzamy wersję javy, nie samą obecność.** JAR ma target 17, więc na
  JRE 8/11 poleciałby `UnsupportedClassVersionError` — komunikat, którego
  nikt nie mapuje na „zainstaluj nowszą Javę". Za stara java = spadamy na
  Dockera.

* **Cache poza drzewem repo** (`$HOME/.cache/bpp/`). `make clean` robi
  `rm -rf .cache`, więc artefakt znikałby przy każdym sprzątaniu. Przy okazji
  jest współdzielony między worktree.

* **Wariant dockerowy mapuje nazwę hosta, nie podmienia jej w URL-u.**
  Podmiana wyglądała rozsądnie i nie działała: `run-site` binduje się na
  jednym interfejsie (nie `0.0.0.0`), więc `host.docker.internal` dawało
  `connection refused`, a połączenie wprost na IP wracało jako
  `DisallowedHost`. `--add-host=<host>:<IP>` rozwiązuje oba naraz —
  nagłówek `Host` zostaje ten, którego Django oczekuje.

* **Oba tory uruchamiają walidator z katalogiem roboczym w cache'u**, bo
  pisze on do względnego `data/` i z korzenia repo zasypywał BPP setkami
  nieśledzonych plików.

* **Suma SHA-256 przypięta w `Makefile`.** Build walidatora nie jest
  odtwarzalny (`pom.xml` deklaruje zakresy wersji zależności, rozwiązywane
  w czasie builda), więc nie da się zweryfikować artefaktu przez rebuild —
  suma zapisana w gicie jest jedyną kotwicą, która przechodzi przez code
  review. Widać to zresztą w liczbach: ten sam commit dał lokalnie 4 721 874 B,
  a na CI 4 720 967 B.

Spec: `docs/superpowers/specs/2026-08-05-cerif-validator-fork-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)