### PR TITLE
fix(docs): wlasne ograniczniki include-markdown zamiast kolidujacych z Django

### DIFF
--- a/docs/o-projekcie/historia.md
+++ b/docs/o-projekcie/historia.md
@@ -1,3 +1,3 @@
-{%
+{!
    include-markdown "../../HISTORY.md"
-%}
+!}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,17 @@ plugins:
         - en
   - autorefs
   - glightbox
-  - include-markdown
+  # Wlasne ograniczniki zamiast domyslnych `{% %}`. Domyslne sa DOKLADNIE
+  # te same, ktorych uzywa Django, a dokumentacja BPP cytuje szablony Django
+  # w kolko (np. `{% include "long_running/operation_details.html" %}`
+  # w planach liveops). Wtyczka brala taki cytat za polecenie i probowala
+  # wciagnac plik, ktorego w `docs/` nie ma -- build padal z BuildError,
+  # a autor dokumentu nie mial powodu podejrzewac, ze opisanie szablonu
+  # Django psuje strone. Rozdzielenie skladni likwiduje cala te klase
+  # bledow; escape'owanie pojedynczych wystapien tylko odsuwa nastepne.
+  - include-markdown:
+      opening_tag: "{!"
+      closing_tag: "!}"
 
 exclude_docs: |
   superpowers/


### PR DESCRIPTION
`mkdocs build --strict` padał na `dev` — wyszło przy okazji #719.

## Przyczyna

Wtyczka `include-markdown` używa domyślnie ograniczników `{% %}` — **dokładnie tych samych, co Django**. Dokument `deweloper/plan-import-list-if-liveops.md` (z #717) cytuje szablon:

```
{% include "long_running/operation_details.html" %}
```

Wtyczka wzięła cytat za polecenie i spróbowała wciągnąć plik, którego w `docs/` nie ma — leży w `src/long_running/templates/`. Build kończył się `BuildError`.

Takich cytatów jest w `docs/deweloper/` sześć. Build przewracał się na pierwszym alfabetycznie i nie pokazywał reszty.

## Dlaczego nie escape

Escape'owanie sześciu wystąpień odsunęłoby tylko następne: dokumentacja BPP z natury cytuje szablony Django, a autor planu nie ma powodu podejrzewać, że opisanie szablonu psuje stronę dokumentacji. Wtyczka dostaje więc własne ograniczniki `{! !}`, które z niczym nie kolidują.

Jedyne prawdziwe użycie wtyczki w całej dokumentacji (`o-projekcie/historia.md`, wciągające `HISTORY.md`) przepisane na nową składnię.

## Weryfikacja

Lokalnie, dokładnie tak jak CI (`uv run --with-requirements docs/requirements.txt --no-project mkdocs build --strict`):

- przed: `Aborted with a BuildError!`
- po: `Documentation built in 1.34 seconds`, exit 0
- `site/o-projekcie/historia/index.html` ma 738 KB i pełną treść `HISTORY.md` — czyli dyrektywa nadal działa, a nie została po cichu zignorowana

Bez newsfragmentu: to naprawa konfiguracji budowania dokumentacji, nie zmiana widoczna dla użytkownika BPP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)