### PR TITLE
Testy cerif_export nie zakładają już, że Typ_Odpowiedzialnosci jest w bazie

### DIFF
--- a/src/cerif_export/tests/conftest.py
+++ b/src/cerif_export/tests/conftest.py
@@ -50,12 +50,21 @@ def status_ok(db):
 
 
 @pytest.fixture
-def fabryka_autorow(jednostka):
+def fabryka_autorow(jednostka, typ_autor):
     """Autor powiązany z jednostką uczelni — czyli kandydat do eksportu.
 
     Samo ``pokazuj=True`` nie wystarcza: reguła widoczności wymaga też
     powiązania ``Autor_Jednostka`` z jednostką TEJ uczelni, inaczej każdy
     tenant eksportowałby cudzych autorów.
+
+    Zależność od ``typ_autor`` jest celowa, mimo że sam ``Autor`` jej nie
+    potrzebuje: każdy konsument tej fabryki podpina autora do rekordu przez
+    ``dodaj_autora()``, a to robi ``Typ_Odpowiedzialnosci.objects.get(
+    skrot="aut.")``. Wiersz ten pochodzi z baseline'u, więc *zwykle* jest
+    w bazie — ale test transakcyjny truncate'uje tabele i kolejne testy
+    tego samego workera zastają je puste. Test, który liczy na dane
+    referencyjne zamiast je stworzyć, jest wtedy zielony albo czerwony
+    zależnie od tego, co się przed nim wykonało.
     """
 
     def zbuduj(nazwisko="Kowalski", pokazuj=True, powiaz=True, **kwargs):


### PR DESCRIPTION
## Objaw

`src/cerif_export/tests/test_serializery.py::test_patent_zgodne_z_xsd` padał
w shardzie 0 na CI (`Typ_Odpowiedzialnosci.DoesNotExist`), a lokalnie
w izolacji przechodził.

## Przyczyna

Trzy testy w `cerif_export` wołają `dodaj_autora()`, które robi
`Typ_Odpowiedzialnosci.objects.get(skrot="aut.")` — ale żaden z nich tego
wiersza nie tworzy. Liczyły na to, że przyjdzie z baseline'u (`id=1`,
`aut.`, jest w `baseline-sql/baseline.sql`).

Zwykle przychodzi. Ale test transakcyjny truncate'uje tabele, więc kolejne
testy tego samego workera zastają je puste. Wynik zależy więc od tego, co
wykonało się wcześniej w tym samym shardzie — klasyczne „u mnie działa".

CI zgłosiło jeden test, bo tylko on trafił w feralną kolejność. Pozostałe
dwa mają identyczną wadę i czekały na swoją kolej:

* `test_znak_towarowy_i_ror_modelu.py::test_znak_towarowy_nie_wychodzi_w_eksporcie`
* `test_znak_towarowy_i_ror_modelu.py::test_patent_bez_rodzaju_prawa_nadal_wychodzi`

## Poprawka

`fabryka_autorow` zależy teraz od `typ_autor` (istniejący fixture,
`get_or_create`, więc idempotentny). To wspólne źródło wszystkich trzech
przypadków — jedna zmiana naprawia je razem i zamyka drogę następnym,
bo każdy przyszły test budujący autora tą fabryką dostanie typ
odpowiedzialności utworzony, a nie założony.

## Weryfikacja

Reprodukcja przez fixture kasujący `Typ_Odpowiedzialnosci` przed każdym
testem — symuluje stan po teście transakcyjnym:

| | przed poprawką | po poprawce |
|---|---|---|
| `pytest src/cerif_export/` z wyczyszczonymi danymi referencyjnymi | **3 failed**, 310 passed | **313 passed** |
| `pytest src/cerif_export/` normalnie | 313 passed | 313 passed |

Bez newsfragmentu — zmiana dotyczy wyłącznie testów, nie ma nic do pokazania
użytkownikowi w `HISTORY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)