### PR TITLE
Testy kolejki PBN nie zostawiają już content_type losowi

### DIFF
--- a/src/pbn_export_queue/tests/test_admin.py
+++ b/src/pbn_export_queue/tests/test_admin.py
@@ -6,6 +6,7 @@ from django import forms
 from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils import timezone
 from model_bakery import baker
@@ -277,6 +278,7 @@ def test_pbn_export_queue_admin_save_model(admin_user, rf):
     queue_item = baker.make(
         PBN_Export_Queue,
         zamowil=admin_user,
+        content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
     )
 
     class MockForm(forms.ModelForm):

--- a/src/pbn_export_queue/tests/test_pbn_queue_send.py
+++ b/src/pbn_export_queue/tests/test_pbn_queue_send.py
@@ -10,9 +10,11 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.contrib.contenttypes.models import ContentType
 from django.utils import timezone
 from model_bakery import baker
 
+from bpp.models import Wydawnictwo_Ciagle
 from pbn_api.exceptions import (
     CharakterFormalnyMissingPBNUID,
     CharakterFormalnyNieobslugiwanyError,
@@ -38,6 +40,7 @@ class TestSendToPbn:
                     PBN_Export_Queue,
                     zamowil=admin_user,
                     wysylke_zakonczono=None,
+                    content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
                 )
 
                 result = queue_item.send_to_pbn()

--- a/src/pbn_export_queue/tests/test_pbn_queue_status.py
+++ b/src/pbn_export_queue/tests/test_pbn_queue_status.py
@@ -85,7 +85,11 @@ class TestCheckIfRecordStillExists:
 
     def test_check_if_record_still_exists_when_no_content_type_id(self, admin_user):
         """Test that method returns False when content_type_id is missing"""
-        queue_item = baker.make(PBN_Export_Queue, zamowil=admin_user)
+        queue_item = baker.make(
+            PBN_Export_Queue,
+            zamowil=admin_user,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
+        )
         # Manually set content_type_id to None
         queue_item.content_type_id = None
         assert queue_item.check_if_record_still_exists() is False

--- a/src/pbn_export_queue/tests/test_pbn_validation_error_queue.py
+++ b/src/pbn_export_queue/tests/test_pbn_validation_error_queue.py
@@ -1,7 +1,9 @@
 import pytest
+from django.contrib.contenttypes.models import ContentType
 from model_bakery import baker
-
 from pbn_client.exceptions import PBNValidationError
+
+from bpp.models import Wydawnictwo_Ciagle
 from pbn_export_queue.models import PBN_Export_Queue, RodzajBledu
 from pbn_export_queue.views.utils import parse_pbn_api_error
 
@@ -13,7 +15,10 @@ VALIDATION_BODY = (
 
 @pytest.mark.django_db
 def test_queue_classifies_pbnvalidationerror_as_merytoryczny():
-    rec = baker.make(PBN_Export_Queue)
+    rec = baker.make(
+        PBN_Export_Queue,
+        content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
+    )
     exc = PBNValidationError(400, "/api/v1/publications", VALIDATION_BODY)
 
     rec._handle_pbn_exception(exc)

--- a/src/pbn_export_queue/tests/test_tasks.py
+++ b/src/pbn_export_queue/tests/test_tasks.py
@@ -163,7 +163,9 @@ def test_task_sprobuj_wyslac_do_pbn_raises(mocker):
 def test_task_sprobuj_wyslac_do_pbn_lock_already_acquired(mocker):
     """Test that task skips processing when lock is already acquired"""
     # Mock cache.add to return False (lock already exists)
-    mock_cache_add = mocker.patch("pbn_export_queue.tasks.cache.add", return_value=False)
+    mock_cache_add = mocker.patch(
+        "pbn_export_queue.tasks.cache.add", return_value=False
+    )
     mock_cache_delete = mocker.patch("pbn_export_queue.tasks.cache.delete")
 
     wait_for_object = mocker.patch("pbn_export_queue.tasks.wait_for_object")
@@ -385,6 +387,7 @@ def test_check_and_send_next_in_queue_with_locks(mocker):
                 PBN_Export_Queue,
                 wysylke_podjeto=None,
                 wysylke_zakonczono=None,
+                content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
             )
         )
 
@@ -394,8 +397,12 @@ def test_check_and_send_next_in_queue_with_locks(mocker):
             return "locked"
         return None
 
-    mock_cache = mocker.patch("pbn_export_queue.tasks.cache.get", side_effect=mock_cache_get)
-    mock_task_delay = mocker.patch("pbn_export_queue.tasks.task_sprobuj_wyslac_do_pbn.delay")
+    mock_cache = mocker.patch(
+        "pbn_export_queue.tasks.cache.get", side_effect=mock_cache_get
+    )
+    mock_task_delay = mocker.patch(
+        "pbn_export_queue.tasks.task_sprobuj_wyslac_do_pbn.delay"
+    )
 
     result = check_and_send_next_in_queue()
 
@@ -419,6 +426,7 @@ def test_report_technical_errors_to_rollbar_with_errors(mocker, admin_user):
             rodzaj_bledu=RodzajBledu.TECHNICZNY,
             wysylke_zakonczono=timezone.now(),  # Must be finished
             zamowil=admin_user,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
         )
 
     # Create some MERYTORYCZNY errors (should not be counted)
@@ -427,6 +435,7 @@ def test_report_technical_errors_to_rollbar_with_errors(mocker, admin_user):
         rodzaj_bledu=RodzajBledu.MERYTORYCZNY,
         wysylke_zakonczono=timezone.now(),
         zamowil=admin_user,
+        content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
     )
 
     # Create an unfinished TECHNICZNY error (should not be counted)
@@ -435,6 +444,7 @@ def test_report_technical_errors_to_rollbar_with_errors(mocker, admin_user):
         rodzaj_bledu=RodzajBledu.TECHNICZNY,
         wysylke_zakonczono=None,
         zamowil=admin_user,
+        content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
     )
 
     mock_rollbar = mocker.patch("pbn_export_queue.tasks.rollbar.report_message")
@@ -512,6 +522,7 @@ def test_report_technical_errors_to_rollbar_no_errors(mocker, admin_user):
         rodzaj_bledu=RodzajBledu.MERYTORYCZNY,
         wysylke_zakonczono=timezone.now(),
         zamowil=admin_user,
+        content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
     )
 
     mock_rollbar = mocker.patch("pbn_export_queue.tasks.rollbar.report_message")

--- a/src/pbn_export_queue/tests/test_views_actions.py
+++ b/src/pbn_export_queue/tests/test_views_actions.py
@@ -4,9 +4,11 @@ from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from model_bakery import baker
 
+from bpp.models import Wydawnictwo_Ciagle
 from pbn_export_queue.models import PBN_Export_Queue
 
 User = get_user_model()
@@ -23,7 +25,10 @@ class TestResendToPbnView:
 
     def test_resend_to_pbn_requires_login(self, client):
         """Test that unauthenticated users are redirected"""
-        queue_item = baker.make(PBN_Export_Queue)
+        queue_item = baker.make(
+            PBN_Export_Queue,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
+        )
         url = reverse("pbn_export_queue:export-queue-resend", args=[queue_item.pk])
         response = client.post(url)
 
@@ -32,7 +37,10 @@ class TestResendToPbnView:
     def test_resend_to_pbn_requires_permission(self, client):
         """Test that users without permission get error"""
         user = baker.make(User)
-        queue_item = baker.make(PBN_Export_Queue)
+        queue_item = baker.make(
+            PBN_Export_Queue,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
+        )
 
         client.force_login(user)
         url = reverse("pbn_export_queue:export-queue-resend", args=[queue_item.pk])
@@ -46,6 +54,7 @@ class TestResendToPbnView:
             PBN_Export_Queue,
             zamowil=admin_user,
             wysylke_zakonczono=None,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
         )
 
         client.force_login(admin_user)
@@ -71,7 +80,10 @@ class TestPrepareForResendView:
     def test_prepare_for_resend_requires_permission(self, client):
         """Test that users without permission get error"""
         user = baker.make(User)
-        queue_item = baker.make(PBN_Export_Queue)
+        queue_item = baker.make(
+            PBN_Export_Queue,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
+        )
 
         client.force_login(user)
         url = reverse(
@@ -87,6 +99,7 @@ class TestPrepareForResendView:
             PBN_Export_Queue,
             zamowil=admin_user,
             wysylke_zakonczono=None,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
         )
 
         client.force_login(admin_user)
@@ -110,7 +123,10 @@ class TestTrySendToPbnView:
     def test_try_send_to_pbn_requires_permission(self, client):
         """Test that users without permission get error"""
         user = baker.make(User)
-        queue_item = baker.make(PBN_Export_Queue)
+        queue_item = baker.make(
+            PBN_Export_Queue,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
+        )
 
         client.force_login(user)
         url = reverse("pbn_export_queue:export-queue-try-send", args=[queue_item.pk])
@@ -120,7 +136,11 @@ class TestTrySendToPbnView:
 
     def test_try_send_to_pbn_success(self, client, admin_user):
         """Test successful try send"""
-        queue_item = baker.make(PBN_Export_Queue, zamowil=admin_user)
+        queue_item = baker.make(
+            PBN_Export_Queue,
+            zamowil=admin_user,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
+        )
 
         client.force_login(admin_user)
         url = reverse("pbn_export_queue:export-queue-try-send", args=[queue_item.pk])
@@ -165,12 +185,14 @@ class TestResendAllWaitingView:
             zamowil=admin_user,
             retry_after_user_authorised=True,
             wysylke_zakonczono=None,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
         )
         item2 = baker.make(
             PBN_Export_Queue,
             zamowil=admin_user,
             retry_after_user_authorised=True,
             wysylke_zakonczono=None,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
         )
 
         client.force_login(admin_user)
@@ -219,11 +241,13 @@ class TestResendAllErrorsView:
             PBN_Export_Queue,
             zamowil=admin_user,
             zakonczono_pomyslnie=False,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
         )
         item2 = baker.make(
             PBN_Export_Queue,
             zamowil=admin_user,
             zakonczono_pomyslnie=False,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
         )
 
         client.force_login(admin_user)
@@ -269,16 +293,19 @@ class TestPBNExportQueueCountsView:
             PBN_Export_Queue,
             zamowil=admin_user,
             zakonczono_pomyslnie=True,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
         )
         baker.make(
             PBN_Export_Queue,
             zamowil=admin_user,
             zakonczono_pomyslnie=False,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
         )
         baker.make(
             PBN_Export_Queue,
             zamowil=admin_user,
             zakonczono_pomyslnie=None,
+            content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
         )
 
         client.force_login(admin_user)

--- a/src/pbn_export_queue/tests/test_views_detail.py
+++ b/src/pbn_export_queue/tests/test_views_detail.py
@@ -7,6 +7,7 @@ from django.test import RequestFactory
 from django.urls import reverse
 from model_bakery import baker
 
+from bpp.models import Wydawnictwo_Ciagle
 from pbn_export_queue.models import PBN_Export_Queue
 from pbn_export_queue.views import PBNExportQueueDetailView
 
@@ -21,7 +22,10 @@ User = get_user_model()
 @pytest.mark.django_db
 def test_pbnexportqueuedetailview_requires_login(client):
     """Test that unauthenticated users are redirected"""
-    queue_item = baker.make(PBN_Export_Queue)
+    queue_item = baker.make(
+        PBN_Export_Queue,
+        content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
+    )
     url = reverse("pbn_export_queue:export-queue-detail", args=[queue_item.pk])
     response = client.get(url)
 
@@ -32,7 +36,10 @@ def test_pbnexportqueuedetailview_requires_login(client):
 def test_pbnexportqueuedetailview_requires_permission(client):
     """Test that users without permission get 403"""
     user = baker.make(User)
-    queue_item = baker.make(PBN_Export_Queue)
+    queue_item = baker.make(
+        PBN_Export_Queue,
+        content_type=ContentType.objects.get_for_model(Wydawnictwo_Ciagle),
+    )
 
     client.force_login(user)
     url = reverse("pbn_export_queue:export-queue-detail", args=[queue_item.pk])


### PR DESCRIPTION
## Objaw

`test_report_technical_errors_to_rollbar_with_errors` padał w pełnym
przebiegu suity, a w izolacji przechodził — klasyczny flake.

```
psycopg2.errors.CannotCoerce: nie można rzutować typu integer na integer[]
src/pbn_export_queue/tasks.py:301
```

## Przyczyna

`baker.make(PBN_Export_Queue, ...)` bez `content_type` każe model_bakery
**wylosować** typ zawartości spośród ~200 istniejących. Dwa z nich to miny:

* `bpp.rekord`
* `bpp.autorzy`

To zdenormalizowane widoki, których klucz główny jest typu `integer[]`.
`check_if_record_still_exists()` woła `get_object_for_this_type(pk=...)`,
co generuje `WHERE id = 1` — a Postgres nie rzutuje `integer` na `integer[]`.

Test był więc ruletką: trafiał w minę raz na kilkadziesiąt przebiegów.

Znalezione empirycznie — przejściem po wszystkich `ContentType` z osobnym
savepointem na każdy (bez tego pierwszy błąd przerywa transakcję i widać
tylko kaskadę).

## Poprawka

Wzorzec obrony **był już w tym pliku znany i opisany komentarzem**
(`test_tasks.py:21-23`), tylko stosowany niekonsekwentnie. Rozciągam go na
wszystkie **25 miejsc w 7 plikach**, które zostawiały `content_type` losowi.
Każde z nich było tą samą miną, tylko jeszcze nie wybuchło.

## Czego świadomie NIE zrobiłem

Nie łagodzę tego w `check_if_record_still_exists()`. Połknięcie tam
`ProgrammingError` byłoby groźne: `kolejka_wyczysc_wpisy_bez_rekordow`
**kasuje** wpisy, dla których ta metoda zwróci `False`. Zamiana błędu bazy
na „rekordu nie ma" oznaczałaby usuwanie poprawnych wpisów przy przejściowej
awarii bazy.

W produkcji `content_type` wskazuje na `Wydawnictwo_*`/`Patent`, nigdy na
widok — to wada testów, nie kodu produkcyjnego.

## Weryfikacja

* `pytest src/pbn_export_queue/` → 169 passed
* `pytest -n auto -m "not playwright"` → **9264 passed**, 4 skipped, 1 xfailed
* skan potwierdza zero pozostałych losowych `content_type`
* linter: 6 zgłoszeń `F841`/`B007` w `test_tasks.py` jest **sprzed** tej zmiany
  (zweryfikowane na `HEAD`), nie ruszam ich jako spoza zakresu

Bez newsfragmentu — zmiana wyłącznie w testach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)