### PR TITLE
fix(cerif): pusty <PartOf/> wywracał harvest całego setu jednostek

### DIFF
--- a/src/bpp/newsfragments/cerif-pusty-partof.bugfix.rst
+++ b/src/bpp/newsfragments/cerif-pusty-partof.bugfix.rst
@@ -1,0 +1,9 @@
+Eksport CERIF/OpenAIRE: jednostka, której jednostka nadrzędna jest wyłączona
+z eksportu (``widoczna=False`` albo ``nie_eksportuj_przez_api``), nie zostawia
+już pustego elementu ``PartOf``. Pusty ``PartOf`` jest niepoprawny wobec
+schematu profilu, a walidator euroCRIS przerywał na nim harvest całego zestawu
+``openaire_cris_orgunits`` — przez co kolejne jednostki nie trafiały do indeksu
+i ich powiązania z publikacji wyglądały na wiszące (dwa błędy walidatora
+z jednej przyczyny). Taka jednostka jest teraz podpinana pod uczelnię, więc
+drzewo organizacyjne pozostaje spójne, a o ukrytej jednostce nadrzędnej nadal
+nic nie wychodzi na zewnątrz.

--- a/src/cerif_export/cerif/orgunit.py
+++ b/src/cerif_export/cerif/orgunit.py
@@ -28,7 +28,7 @@ import re
 from bpp.models.projekt import Instytucja_Finansujaca
 from bpp.util import ror
 from cerif_export.cerif import wspolne
-from cerif_export.cerif.wspolne import dodaj, dodaj_kontener, element, tekst
+from cerif_export.cerif.wspolne import dodaj, element, tekst
 
 TYP_ID_ROR = "https://w3id.org/cerif/vocab/IdentifierTypes#RORID"
 TYP_ID_PBN_INSTYTUCJA = "https://pbn.nauka.gov.pl/core/#/institution"
@@ -108,27 +108,43 @@ def dodaj_adresy(el, jednostka):
     dodaj(el, "ElectronicAddress", tekst(getattr(jednostka, "www", None)))
 
 
-def _nadrzedna(jednostka):
+def _nadrzedna(jednostka, ctx):
     """Jednostka nadrzędna: rodzic w drzewie MPTT, a w korzeniu — uczelnia.
 
     Bez podpięcia korzeni pod uczelnię drzewo organizacyjne w OpenAIRE
     rozpadłoby się na niepowiązane wydziały.
+
+    Rodzic **poza eksportem** (``widoczna=False``, ``nie_eksportuj_przez_api``
+    albo cudzy tenant) jest traktowany jak jego brak: schodzimy na uczelnię,
+    zamiast zostawiać jednostkę bez ``PartOf``. Oderwana jednostka to ta sama
+    fragmentacja drzewa, przed którą broni akapit wyżej, a podpięcie pod
+    uczelnię jest prawdziwe (``Jednostka.uczelnia`` to FK) i nie zdradza
+    o ukrytym rodzicu niczego — nawet tego, że istnieje.
+
+    Rozstrzygnięcie widoczności musi być tutaj, a nie w miejscu osadzenia:
+    inaczej nie da się odróżnić „rodzica nie ma" od „rodzica nie wolno
+    pokazać", a to drugie wymaga zejścia o poziom wyżej.
     """
-    if getattr(jednostka, "parent_id", None):
-        return jednostka.parent
+    rodzic = jednostka.parent if getattr(jednostka, "parent_id", None) else None
+    if wspolne.jednostka_ujawnialna(rodzic, ctx):
+        return rodzic
     if getattr(jednostka, "uczelnia_id", None):
         return jednostka.uczelnia
     return None
 
 
 def dodaj_part_of(el, jednostka, ctx):
-    """Dopisz ``PartOf`` wskazujące na jednostkę nadrzędną."""
-    nadrzedna = _nadrzedna(jednostka)
-    if nadrzedna is None:
-        return None
-    part_of = dodaj_kontener(el, "PartOf")
-    wspolne.osadz_orgunit(part_of, nadrzedna, ctx)
-    return part_of
+    """Dopisz ``PartOf`` wskazujące na jednostkę nadrzędną.
+
+    Kontener powstaje **wyłącznie** razem z treścią — tym zajmuje się
+    :func:`cerif_export.cerif.wspolne.dodaj_link_do_orgunit`, bo ``PartOf``
+    ma tę samą sekwencję ``DisplayName? | OrgUnit`` co ``Funding/Funder``
+    i ``Project/Funded/By``. Wcześniej ta funkcja tworzyła ``PartOf``
+    samodzielnie, przed sprawdzeniem widoczności, i przy rodzicu spoza
+    eksportu zostawiała pusty ``<PartOf/>`` — element niepoprawny wobec XSD,
+    na którym walidator euroCRIS przerywał harvest całego setu.
+    """
+    return wspolne.dodaj_link_do_orgunit(el, "PartOf", _nadrzedna(jednostka, ctx), ctx)
 
 
 def serializuj_grantodawce(instytucja, ctx):

--- a/src/cerif_export/tests/test_widocznosc.py
+++ b/src/cerif_export/tests/test_widocznosc.py
@@ -443,6 +443,169 @@ def test_wylaczenie_osob_odbiera_orcid_i_identyfikator_w_publikacji(
     assert "Jednostka CERIF" in xml
 
 
+# -- JEDNOSTKI: ukryty rodzic a `PartOf` ---------------------------------
+
+
+def zserializuj_jednostke(uczelnia, jednostka):
+    """Zserializuj jednostkę w kontekście zbudowanym przez jej provider."""
+    from cerif_export.cerif import orgunit
+
+    provider = provider_dla_setu(const.SET_ORGUNITS)
+    obiekty, _ = provider.strona(uczelnia, rozmiar=1000)
+    swiezy = next(o for o in obiekty if o.pk == jednostka.pk and type(o) is Jednostka)
+    kontekst = KontekstSerializacji(
+        namespace=NAMESPACE,
+        uczelnia=uczelnia,
+        widoczne=provider.zbiory_widocznosci(uczelnia, obiekty),
+    )
+    return orgunit.serializuj(swiezy, kontekst)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "ukrycie",
+    [
+        {"widoczna": False},
+        {"nie_eksportuj_przez_api": True},
+    ],
+    ids=["niewidoczna", "opt-out-api"],
+)
+def test_ukryty_rodzic_nie_zostawia_pustego_part_of(uczelnia, jednostka, ukrycie):
+    """Rodzic poza eksportem nie może zostawić po sobie pustego ``PartOf``.
+
+    ``PartOf`` wymaga w XSD dziecka (``DisplayName`` albo ``OrgUnit``), więc
+    pusty kontener unieważnia **cały** rekord jednostki. Skutek jest dużo
+    gorszy niż jeden zły rekord: walidator euroCRIS przerywa na nim harvest
+    setu ``openaire_cris_orgunits``, przez co żadna kolejna jednostka nie
+    trafia do indeksu i jej referencje z publikacji wyglądają na wiszące
+    (kontrola 5a). Jeden niepoprawny element wywraca więc dwa testy naraz.
+    """
+    rodzic = Jednostka.objects.create(
+        nazwa="Rodzic poza eksportem", skrot="RPE", uczelnia=uczelnia, **ukrycie
+    )
+    jednostka.parent = rodzic
+    jednostka.save()
+
+    el = zserializuj_jednostke(uczelnia, jednostka)
+
+    part_of = el.findall(f"{{{const.NS_CERIF}}}PartOf")
+    assert all(len(kontener) for kontener in part_of), (
+        "pusty <PartOf/> — kontener powstał, mimo że rodzica nie wolno pokazać"
+    )
+    # Samo „brak pustego kontenera" spełniłoby też pominięcie ``PartOf`` w
+    # ogóle (``all()`` po pustej liście jest prawdziwe), a to inne — i gorsze
+    # — zachowanie: jednostka zostaje oderwanym korzeniem. Dlatego wprost
+    # wymagamy zejścia na uczelnię.
+    osadzony = el.find(f"{{{const.NS_CERIF}}}PartOf/{{{const.NS_CERIF}}}OrgUnit")
+    assert osadzony is not None, "jednostka bez PartOf = oderwany korzeń drzewa"
+    assert osadzony.get("id") == f"OrgUnits/uc-{uczelnia.pk}"
+    # Nazwa ukrytego rodzica nie ma prawa wyciec także jako sam tekst.
+    assert "Rodzic poza eksportem" not in etree.tostring(el).decode()
+
+
+@pytest.mark.django_db
+def test_rodzic_z_cudzego_tenanta_nie_wychodzi_w_part_of(uczelnia, jednostka):
+    """Rodzic z innej uczelni to ten sam przypadek co rodzic ukryty.
+
+    W instalacji multi-hosted ``Jednostka.parent`` nie jest niczym ograniczony
+    do własnego tenanta, więc bez tego członu eksport uczelni A wystawiałby
+    nazwę jednostki uczelni B — i to jako ``@id``, którego w tym harveście
+    nie da się rozwiązać na żaden rekord (kontrola 5a walidatora).
+    """
+    obca_uczelnia = Uczelnia.objects.create(
+        nazwa="Uczelnia obca",
+        skrot="UOB",
+        site=Site.objects.create(domain="obca.example.org", name="obca.example.org"),
+    )
+    obcy_rodzic = Jednostka.objects.create(
+        nazwa="Jednostka obcej uczelni", skrot="JOU", uczelnia=obca_uczelnia
+    )
+    jednostka.parent = obcy_rodzic
+    jednostka.save()
+
+    el = zserializuj_jednostke(uczelnia, jednostka)
+
+    xml = etree.tostring(el).decode()
+    assert "Jednostka obcej uczelni" not in xml, (
+        "wyciek nazwy jednostki z cudzego tenanta"
+    )
+    assert f"OrgUnits/je-{obcy_rodzic.pk}" not in xml, "referencja nie do rozwiązania"
+
+    osadzony = el.find(f"{{{const.NS_CERIF}}}PartOf/{{{const.NS_CERIF}}}OrgUnit")
+    assert osadzony.get("id") == f"OrgUnits/uc-{uczelnia.pk}"
+
+
+@pytest.mark.django_db
+def test_ukryty_rodzic_takze_przez_get_record(uczelnia, jednostka):
+    """Ta sama reguła musi działać na ścieżce ``GetRecord``, nie tylko listowej.
+
+    ``GetRecord`` buduje kontekst z jednoelementowej listy, więc gdyby
+    prekomputacja widoczności zależała od tego, co jeszcze jest na stronie,
+    pojedynczy rekord wychodziłby inaczej niż ten sam rekord w ``ListRecords``.
+    """
+    from cerif_export.cerif import orgunit
+
+    rodzic = Jednostka.objects.create(
+        nazwa="Rodzic poza eksportem", skrot="RPE", uczelnia=uczelnia, widoczna=False
+    )
+    jednostka.parent = rodzic
+    jednostka.save()
+
+    provider = provider_dla_setu(const.SET_ORGUNITS)
+    obiekt = provider.pojedynczy(uczelnia, Jednostka, jednostka.pk)
+    kontekst = KontekstSerializacji(
+        namespace=NAMESPACE,
+        uczelnia=uczelnia,
+        widoczne=provider.zbiory_widocznosci(uczelnia, [obiekt]),
+    )
+
+    el = orgunit.serializuj(obiekt, kontekst)
+
+    osadzony = el.find(f"{{{const.NS_CERIF}}}PartOf/{{{const.NS_CERIF}}}OrgUnit")
+    assert osadzony is not None, "pusty albo brakujący PartOf na ścieżce GetRecord"
+    assert osadzony.get("id") == f"OrgUnits/uc-{uczelnia.pk}"
+
+
+@pytest.mark.django_db
+def test_jednostka_z_ukrytym_rodzicem_przechodzi_xsd(uczelnia, jednostka):
+    """Ten sam przypadek, ale sprawdzony tym, co orzeka walidator: XSD."""
+    from cerif_export.tests.test_serializery import sprawdz, zbuduj_schemat
+
+    rodzic = Jednostka.objects.create(
+        nazwa="Rodzic poza eksportem", skrot="RPE", uczelnia=uczelnia, widoczna=False
+    )
+    jednostka.parent = rodzic
+    jednostka.save()
+
+    sprawdz(zbuduj_schemat(), zserializuj_jednostke(uczelnia, jednostka))
+
+
+@pytest.mark.django_db
+def test_widoczny_rodzic_nadal_wychodzi_w_part_of(uczelnia, jednostka):
+    """Kontrola negatywna — poprawka nie może zjeść normalnego ``PartOf``."""
+    rodzic = Jednostka.objects.create(
+        nazwa="Rodzic widoczny", skrot="RW", uczelnia=uczelnia
+    )
+    jednostka.parent = rodzic
+    jednostka.save()
+
+    el = zserializuj_jednostke(uczelnia, jednostka)
+
+    osadzony = el.find(f"{{{const.NS_CERIF}}}PartOf/{{{const.NS_CERIF}}}OrgUnit")
+    assert osadzony is not None
+    assert osadzony.get("id") == f"OrgUnits/je-{rodzic.pk}"
+
+
+@pytest.mark.django_db
+def test_korzen_podpiety_pod_uczelnie(uczelnia, jednostka):
+    """Jednostka bez rodzica trafia pod uczelnię — drzewo zostaje spójne."""
+    el = zserializuj_jednostke(uczelnia, jednostka)
+
+    osadzony = el.find(f"{{{const.NS_CERIF}}}PartOf/{{{const.NS_CERIF}}}OrgUnit")
+    assert osadzony is not None
+    assert osadzony.get("id") == f"OrgUnits/uc-{uczelnia.pk}"
+
+
 @pytest.mark.django_db
 def test_set_persons_istnieje_mimo_wylaczenia(uczelnia):
     """Profil wymaga wszystkich dziewięciu zestawów, także pustych."""


### PR DESCRIPTION
## Objaw

`openaire-cris-validator` 2.1.1 na żywym endpoincie `publikacje-test`:
**13 testów, 2 błędy.**

```
1) check500_CheckOrgUnits
   While validating element OrgUnit[@id="OrgUnits/je-1"]:
   cvc-complex-type.2.4.b: The content of element 'PartOf' is not complete.
   One of '{...:DisplayName, ...:OrgUnit}' is expected.

2) check990_CheckReferentialIntegrityAndFunctionalDependency
   Record for OrgUnit[@id="OrgUnits/je-3"] not found, referential integrity
   violated in oai:publikacje.up.lublin.pl:Publications/wz-12310 (5a)
```

## Przyczyna — jedna, nie dwie

`dodaj_part_of` (`src/cerif_export/cerif/orgunit.py`) tworzyła kontener
`<PartOf>` **zanim** sprawdziła, czy jednostkę nadrzędną wolno pokazać.
`osadz_orgunit` — słusznie — odmawiała osadzenia rodzica spoza eksportu
(`widoczna=False`, `nie_eksportuj_przez_api=True`, cudzy tenant). Kontener
zostawał pusty.

Pusty `<PartOf/>` jest niepoprawny wobec XSD, a walidator **przerywa harvest
setu na pierwszym złym rekordzie**. Dlatego drugi błąd jest kaskadą: po
przerwaniu na `je-1` żadna kolejna jednostka nie trafiła do indeksu
walidatora, więc `je-3` wyglądał na referencję wiszącą — choć jest poprawny
i siedzi w secie (`GetRecord` go zwraca).

## Poprawka

Budowa kontenera oddana do `wspolne.dodaj_link_do_orgunit`, która tworzy go
wyłącznie razem z treścią i obsługuje tę samą sekwencję
`DisplayName? | OrgUnit`. Trzy z czterech miejsc osadzających OrgUnit-a już
tego pilnowały, a docstring tej funkcji wprost ostrzega przed „stworzeniem
kontenera na wszelki wypadek" — `dodaj_part_of` była jedynym miejscem, które
tego nie robiło. Poprawka usuwa więc duplikat logiki, który pozwolił na
rozjazd.

**Decyzja projektowa:** rodzic poza eksportem jest traktowany jak jego brak —
jednostka trafia pod uczelnię. Samo pominięcie `PartOf` zostawiłoby ją
oderwanym korzeniem, czyli tą samą fragmentacją drzewa organizacyjnego,
przed którą broni podpinanie korzeni pod uczelnię. Podpięcie jest prawdziwe
(`Jednostka.uczelnia` to FK) i nie zdradza o ukrytej jednostce nadrzędnej
niczego — nawet tego, że istnieje.

Świadomy trade-off: przy wielopoziomowym drzewie (rodzic ukryty, dziadek
widoczny) jednostka idzie pod uczelnię, nie pod dziadka. Wspinaczka po
`parent.parent` wymagałaby zapytań, których serializerowi nie wolno robić
(reguła „serializer nie dotyka bazy" z `kontekst.py`).

## Weryfikacja

Na **danych produkcyjnych** (pełny harvest `publikacje-test`), nie tylko na
fixture'ach:

| Sprawdzenie | Wynik |
|---|---|
| Rekordy OrgUnit wobec vendorowanego XSD | przed: **7 ze 110** niepoprawnych (wszystkie ten sam błąd); po: **110/110** poprawnych |
| Integralność referencyjna całego harvestu | **0 wiszących referencji** na 71 503 rekordach |
| `src/cerif_export/` | 404 testy zielone |
| `ruff` + `pre-commit` | czysto |

Że za przerwanym harvestem nie chowało się nic innego, potwierdza pierwszy
wiersz: po usunięciu pustych `PartOf` **wszystkie** 110 rekordów przechodzi
schemat.

## Testy

Siedem nowych przypadków w `test_widocznosc.py` — `PartOf` nie miało wcześniej
**żadnego** testu, stąd luka:

- `test_ukryty_rodzic_nie_zostawia_pustego_part_of` — parametryzowany
  (`widoczna=False`, `nie_eksportuj_przez_api=True`), plus asercja, że nazwa
  ukrytego rodzica nie wycieka jako tekst,
- `test_rodzic_z_cudzego_tenanta_nie_wychodzi_w_part_of` — wielotenantowość,
- `test_ukryty_rodzic_takze_przez_get_record` — ścieżka `GetRecord`, nie tylko
  listowa,
- `test_jednostka_z_ukrytym_rodzicem_przechodzi_xsd` — sprawdzone tym, czym
  orzeka walidator,
- `test_widoczny_rodzic_nadal_wychodzi_w_part_of` — kontrola negatywna,
- `test_korzen_podpiety_pod_uczelnie` — regresja na spójność drzewa.

Asercje wymagają **wprost** zejścia na uczelnię, bo sam brak pustego kontenera
spełniłoby też pominięcie `PartOf` w ogóle (`all()` po pustej liście jest
prawdziwe) — a to inne i gorsze zachowanie. Sprawdzone symulacją takiej
regresji: 4 z 5 testów wtedy padają.

## Przejrzane przy okazji

Pozostałe siedem miejsc tworzących kontenery (`Authors`, `Editors`,
`Inventors`, `PublishedIn`, `Publication/PartOf`, `OriginatesFrom`,
`FileLocations`) — każde albo ma gate na pustą listę, albo osadza
bezwarunkowo. Bez zmian.

## Do potwierdzenia po wdrożeniu

Ostateczny dowód to ponowny przebieg walidatora na `publikacje-test` po
deployu. Sprawdzenia XSD i integralności są mocną przesłanką, ale nie
zastępują przebiegu end-to-end.

Refs #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)