### PR TITLE
docs(eurocris): oddziel zrobione od otwartego i popraw stan walidacji

### DIFF
--- a/docs/deweloper/eurocris-co-jeszcze.md
+++ b/docs/deweloper/eurocris-co-jeszcze.md
@@ -4,25 +4,47 @@
 > Ten dokument opisuje **dlaczego** jest jak jest; issues opisują **co i kto**.
 > Konfigurację i uruchomienie eksportu na instancji opisuje
 > [Eksport CERIF / OpenAIRE — dla administratora](../administrator/eksport-cerif.md).
-> Poszczególne sekcje mają odpowiadające im issues: A1 → #701, A2 → #702,
-> A3 → #703, A4 → #704, B → #705 i #706, D → #707, F1 → #708.
+> Otwarte sekcje mają odpowiadające im issues: A3 → #703, A4 → #704,
+> B → #705 i #706, D → #707, F1 → #708. Zrobione: A1 → #701, A2 → #702
+> (opisane w sekcji G).
 
-Data: 2026-08-04, aktualizacja 2026-08-05 (sekcje A1 i A2 — zrobione).
+Data: 2026-08-04. Aktualizacje: 2026-08-05 — sekcje A1 i A2 zrobione
+(przeniesione do G); 2026-08-05 — poprawka pustego `PartOf` (#724).
 Kontekst: po wdrożeniu aplikacji `cerif_export` (wariant A).
 
 ## Stan wyjściowy
 
 Endpoint `/cerif-oai/` wystawia CERIF-XML zgodny z **OpenAIRE Guidelines for
-CRIS Managers 1.2.0**. `openaire-cris-validator` 2.1.1 przechodzi w całości
-(`OK (13 tests)`) na żywym endpoincie z bazą produkcyjną.
+CRIS Managers 1.2.0**. Zaimplementowane encje: `Publication` (wydawnictwa
+ciągłe i zwarte, prace doktorskie i habilitacyjne, źródła jako kanały
+wydawnicze), `Person`, `OrgUnit`, `Patent`, `Event`, `Service`, `Project`
+i `Funding`.
 
-Zaimplementowane encje: `Publication` (wydawnictwa ciągłe i zwarte, prace
-doktorskie i habilitacyjne, źródła jako kanały wydawnicze), `Person`,
-`OrgUnit`, `Patent`, `Event`, `Service`, a od #701/#702 również `Project`
-i `Funding` (sekcje A1 i A2).
-
-**Zgodność formalna jest osiągnięta.** Wszystko poniżej to różnica między
+**Zgodność formalna jest osiągnięta** — w tym sensie, że wszystkie wymagane
+elementy profilu są zaimplementowane. Wszystko poniżej to różnica między
 „przechodzi walidator" a „daje uczelni to, po co się w to wchodzi".
+
+### Stan walidacji
+
+| Data | Wynik `openaire-cris-validator` 2.1.1 |
+|---|---|
+| 2026-08-04 | `OK (13 tests)` na żywym endpoincie z bazą produkcyjną |
+| 2026-08-05 | **2 błędy na 13** — `check500_CheckOrgUnits` i `check990` |
+| po #724 | do potwierdzenia ponownym przebiegiem po wdrożeniu |
+
+Błąd z 2026-08-05: jednostka, której jednostka nadrzędna jest wyłączona
+z eksportu, dostawała pusty `<PartOf/>` — element niepoprawny wobec XSD.
+Walidator **przerywa harvest setu na pierwszym złym rekordzie**, więc
+kolejne jednostki nie trafiały do jego indeksu i ich referencje wyglądały
+na wiszące. Stąd dwa błędy z jednej przyczyny (drugi był kaskadą).
+
+Wniosek na przyszłość, ważniejszy niż sama poprawka: **zielony wynik
+walidatora zależy od danych, nie tylko od kodu.** Przypadek wyszedł dopiero
+na bazie, w której ktoś ukrył jednostkę nadrzędną — na danych testowych
+i na bazie z 2026-08-04 nie występował. Po każdej zmianie w serializerach
+i po większych zmianach w danych warto przepuścić endpoint przez
+`make cerif-validate` (sekcja D, punkt 2), zamiast zakładać, że raz zielony
+został zielony.
 
 ---
 
@@ -33,86 +55,11 @@ nie jego zapełnienia), więc walidator przechodzi. Natomiast OpenAIRE nie
 zobaczy przez to najważniejszego, co CRIS ma do pokazania: **powiązań
 publikacja ↔ projekt ↔ finansowanie**.
 
-Łańcuch publikacja ↔ projekt ↔ finansowanie jest już zamknięty (A1 i A2);
-otwarte zostają `Product` i `Equipment`.
-
-### A1. `Project` — set `openaire_cris_projects` ✅ ZROBIONE (#701)
-
-Model `Grant` (`src/bpp/models/grant.py`) pozostał tym, czym był: etykietą
-numeru grantu przypinaną do publikacji. Obok niego stanął **`Projekt`**
-(`src/bpp/models/projekt.py`) — pełna encja projektu badawczego, a `Grant`
-dostał do niego FK. Dzięki temu istniejące numery grantów nie wymagają
-migracji: redakcja podpina je do projektów stopniowo, a rekordy bez projektu
-działają dalej po staremu.
-
-Zaimplementowane:
-
-- **model + admin** — `Projekt` (tytuł PL/EN, akronim, daty rozpoczęcia
-  i zakończenia, status, abstrakt PL/EN, dyscypliny, słowa kluczowe,
-  jednostka realizująca), `Projekt_Autor` (zespół: kierownik / wykonawca /
-  współwykonawca);
-- **eksport** — `src/cerif_export/cerif/project.py`,
-  `src/cerif_export/providers/projekty.py`: `Acronym`, `Title` (PL i EN),
-  `StartDate`, `EndDate`, `Consortium/Coordinator`, `Team/PrincipalInvestigator`
-  i `Team/Member`, `Funded/By` + `Funded/As`, `Subject`, `Keyword`, `Abstract`,
-  `Status`;
-- **powiązanie z dorobkiem** — `Publication/OriginatesFrom`
-  i `Patent/OriginatesFrom` osadzają pełny `<Project>`. To ogniwo, dla którego
-  cała sekcja A w ogóle ma sens: bez niego agregator dostaje dwie rozłączne
-  listy.
-
-Świadomie pominięte:
-
-| Element | Dlaczego |
-|---|---|
-| `Project/Type` | Profil oczekuje `cfGenericURIClassification__Type` ze schematem typologii projektów (badawczy / wdrożeniowy / infrastrukturalny). BPP takiej typologii nie prowadzi, a wpisanie wszystkim tej samej wartości byłoby twierdzeniem bez pokrycia w danych. |
-| `Projekt.strona_www` | Sekwencja `Project` nie ma elementu na adres strony. Wciśnięcie URL-a do generycznego `Identifier` mówiłoby, że to identyfikator projektu — czym adres strony nie jest. |
-| `Team/*/Affiliation` | `Projekt_Autor` nie niesie jednostki, a podstawienie `Projekt.jednostka` twierdziłoby, że każdy członek zespołu pracuje w jednostce realizującej. Bywa nieprawdą przy projektach międzyjednostkowych. |
-| `Consortium/Partner`, `Consortium/Contractor` | Wymagają encji instytucji zewnętrznej (partner spoza uczelni), której BPP nie ma. `Jednostka` opisuje wyłącznie strukturę własnej uczelni. |
-| Front publiczny i API dla projektów | Poza zakresem: zmiana miała domknąć eksport CERIF, a nie wprowadzić projekty do serwisu i do `/api/v1/`. |
-
-Uwaga o schematach klasyfikacji: `Status` i `Subject` używają **własnych**
-przestrzeni nazw (`const.SCHEMAT_STATUSU_PROJEKTU`, `const.SCHEMAT_DYSCYPLIN`),
-bo profil nie dostarcza słownika ani dla statusu projektu, ani dla polskiej
-klasyfikacji dyscyplin naukowych — a mapowanie dyscyplin na Fields of Science
-jest osobną decyzją merytoryczną, nie techniczną. Własny schemat jawnie nazywa
-pochodzenie wartości; to lepsze i od pominięcia danych, i od podszycia się pod
-cudzy słownik.
-
-### A2. `Funding` — set `openaire_cris_funding` ✅ ZROBIONE (#702)
-
-Zaimplementowane:
-
-- **`Instytucja_Finansujaca`** — słownik grantodawców z `ror_id`
-  i `fundref_id` (Crossref Funder ID), zaseedowany siedmioma pozycjami (NCN,
-  NCBiR, MNiSW/MEiN, FNP, NAWA, NPRH, ABM);
-- **`Finansowanie`** — typ (obowiązkowy, ze słownika OpenAIRE Funding Types),
-  nazwa programu, numer umowy, `GrantDOI`, kwota + waluta, FK do projektu
-  i do instytucji;
-- **eksport** — `src/cerif_export/cerif/funding.py`,
-  `src/cerif_export/providers/finansowanie.py`. `Funding/Funder` to
-  **referencja** do `OrgUnit`; grantodawcy wychodzą w secie
-  `openaire_cris_orgunits`, bo profil nie ma osobnej encji finansującego.
-  Ta sama funkcja serializująca obsługuje rekord setu i element osadzony
-  w `Project/Funded/As` — kontrola 5b walidatora (encja osadzona jest
-  podzbiorem pełnego rekordu) jest wtedy spełniona trywialnie.
-
-Świadomie pominięte:
-
-| Element | Dlaczego |
-|---|---|
-| `Funding/Amount` domyślnie | Kwoty grantów bywają objęte klauzulą poufności, więc wychodzą dopiero po włączeniu `Uczelnia.eksport_cerif_kwoty` (domyślnie wyłączone). |
-| `Funding/Acronym` | BPP nie ma osobnego pola na skrót finansowania, a wpisanie tam nazwy programu dublowałoby `Name`. |
-| `Funding/PartOf`, `Duration`, `OAMandate` | Brak odpowiadających danych w modelu. |
-| Numer umowy jako typowany identyfikator | Numer umowy grantowej nie ma w CERIF-ie własnego typu, a atrybut `type` jest obowiązkowy — stąd własny URI (`funding.TYP_ID_NUMER_UMOWY`), zamiast podszycia się pod cudzy słownik. |
-| Front publiczny i API dla finansowania | Jak wyżej: zmiana domykała eksport, nie serwis. |
-
-Integralność referencyjna całości (`Consortium/Coordinator`,
-`Team/PrincipalInvestigator`, `Team/Member`, `Funded/By`, `Funding/Funder`)
-jest pilnowana automatycznie —
-`src/cerif_export/tests/test_integralnosc_projektow.py` harvestuje wszystkie
-sety przez `ListRecords` i sprawdza, że każdy `@id` z encji osadzonej ma
-rekord we właściwym secie, w obu stanach obu przełączników uczelni.
+Łańcuch publikacja ↔ projekt ↔ finansowanie jest już **zamknięty po stronie
+kodu** (sekcja G) — otwarte zostają `Product` i `Equipment`. Uwaga: zamknięty
+łańcuch nie znaczy wypełniony. Dopóki redakcja nie wprowadzi projektów
+i nie podepnie do nich numerów grantów, sety `projects` i `funding` są puste
+tak samo jak przed zmianą.
 
 ### A3. `Product` — set `openaire_cris_products`
 
@@ -213,13 +160,16 @@ zombie w indeksie.
 
 1. **B (ROR + mapowania COAR)** — dni robocze redakcji, nie programisty,
    a bez tego eksport jest formalnie poprawny i merytorycznie ubogi.
-2. **D (rejestracja + decyzja RODO)** — odblokowuje jakikolwiek efekt.
-3. **C (nagrobki)** — im wcześniej, tym mniej śmieci w indeksie.
-4. ~~**A1 + A2 (Project + Funding)**~~ — zrobione (#701, #702). Zostaje
-   robota redakcji: wprowadzenie projektów i podpięcie do nich numerów
-   grantów, bo bez danych sety są puste tak samo jak przed zmianą.
-5. **A3, A4 (Product, Equipment)** — gdy uczelnia zacznie je rejestrować.
-6. **E** — przy okazji, pojedynczo.
+2. **Wprowadzenie projektów przez redakcję** — kod z A1/A2 jest gotowy
+   (sekcja G), ale bez danych sety `projects` i `funding` są puste tak samo
+   jak przed zmianą. To jedyna pozycja z sekcji G, która jeszcze coś wymaga.
+3. **D (rejestracja + decyzja RODO)** — odblokowuje jakikolwiek efekt.
+4. **C (nagrobki)** — im wcześniej, tym mniej śmieci w indeksie.
+5. **F1 (`FileLocations`)** — dziś eksport nie podaje lokalizacji pełnych
+   tekstów, a to jest główna rzecz, po którą przychodzi OpenAIRE. Wysoko jak
+   na „znane ograniczenie".
+6. **A3, A4 (Product, Equipment)** — gdy uczelnia zacznie je rejestrować.
+7. **E** — przy okazji, pojedynczo.
 
 ---
 
@@ -272,3 +222,89 @@ ustawienie.
   zamiast `badResumptionToken`.
 
 Oba są odstępstwami od litery OAI-PMH, których walidator nie sprawdza.
+
+---
+
+## G. Zrobione — dla kontekstu, nie do roboty
+
+Sekcje A1 i A2 były kiedyś największą pozycją tej listy. Zostają tutaj, bo
+dokument opisuje **dlaczego jest jak jest**, a decyzje o świadomych
+pominięciach nadal obowiązują i nadal bywa, że ktoś o nie pyta.
+
+### A1. `Project` — set `openaire_cris_projects` (#701)
+
+Model `Grant` (`src/bpp/models/grant.py`) pozostał tym, czym był: etykietą
+numeru grantu przypinaną do publikacji. Obok niego stanął **`Projekt`**
+(`src/bpp/models/projekt.py`) — pełna encja projektu badawczego, a `Grant`
+dostał do niego FK. Dzięki temu istniejące numery grantów nie wymagają
+migracji: redakcja podpina je do projektów stopniowo, a rekordy bez projektu
+działają dalej po staremu.
+
+Zaimplementowane:
+
+- **model + admin** — `Projekt` (tytuł PL/EN, akronim, daty rozpoczęcia
+  i zakończenia, status, abstrakt PL/EN, dyscypliny, słowa kluczowe,
+  jednostka realizująca), `Projekt_Autor` (zespół: kierownik / wykonawca /
+  współwykonawca);
+- **eksport** — `src/cerif_export/cerif/project.py`,
+  `src/cerif_export/providers/projekty.py`: `Acronym`, `Title` (PL i EN),
+  `StartDate`, `EndDate`, `Consortium/Coordinator`, `Team/PrincipalInvestigator`
+  i `Team/Member`, `Funded/By` + `Funded/As`, `Subject`, `Keyword`, `Abstract`,
+  `Status`;
+- **powiązanie z dorobkiem** — `Publication/OriginatesFrom`
+  i `Patent/OriginatesFrom` osadzają pełny `<Project>`. To ogniwo, dla którego
+  cała sekcja A w ogóle ma sens: bez niego agregator dostaje dwie rozłączne
+  listy.
+
+Świadomie pominięte:
+
+| Element | Dlaczego |
+|---|---|
+| `Project/Type` | Profil oczekuje `cfGenericURIClassification__Type` ze schematem typologii projektów (badawczy / wdrożeniowy / infrastrukturalny). BPP takiej typologii nie prowadzi, a wpisanie wszystkim tej samej wartości byłoby twierdzeniem bez pokrycia w danych. |
+| `Projekt.strona_www` | Sekwencja `Project` nie ma elementu na adres strony. Wciśnięcie URL-a do generycznego `Identifier` mówiłoby, że to identyfikator projektu — czym adres strony nie jest. |
+| `Team/*/Affiliation` | `Projekt_Autor` nie niesie jednostki, a podstawienie `Projekt.jednostka` twierdziłoby, że każdy członek zespołu pracuje w jednostce realizującej. Bywa nieprawdą przy projektach międzyjednostkowych. |
+| `Consortium/Partner`, `Consortium/Contractor` | Wymagają encji instytucji zewnętrznej (partner spoza uczelni), której BPP nie ma. `Jednostka` opisuje wyłącznie strukturę własnej uczelni. |
+| Front publiczny i API dla projektów | Poza zakresem: zmiana miała domknąć eksport CERIF, a nie wprowadzić projekty do serwisu i do `/api/v1/`. |
+
+Uwaga o schematach klasyfikacji: `Status` i `Subject` używają **własnych**
+przestrzeni nazw (`const.SCHEMAT_STATUSU_PROJEKTU`, `const.SCHEMAT_DYSCYPLIN`),
+bo profil nie dostarcza słownika ani dla statusu projektu, ani dla polskiej
+klasyfikacji dyscyplin naukowych — a mapowanie dyscyplin na Fields of Science
+jest osobną decyzją merytoryczną, nie techniczną. Własny schemat jawnie nazywa
+pochodzenie wartości; to lepsze i od pominięcia danych, i od podszycia się pod
+cudzy słownik.
+
+### A2. `Funding` — set `openaire_cris_funding` (#702)
+
+Zaimplementowane:
+
+- **`Instytucja_Finansujaca`** — słownik grantodawców z `ror_id`
+  i `fundref_id` (Crossref Funder ID), zaseedowany siedmioma pozycjami (NCN,
+  NCBiR, MNiSW/MEiN, FNP, NAWA, NPRH, ABM);
+- **`Finansowanie`** — typ (obowiązkowy, ze słownika OpenAIRE Funding Types),
+  nazwa programu, numer umowy, `GrantDOI`, kwota + waluta, FK do projektu
+  i do instytucji;
+- **eksport** — `src/cerif_export/cerif/funding.py`,
+  `src/cerif_export/providers/finansowanie.py`. `Funding/Funder` to
+  **referencja** do `OrgUnit`; grantodawcy wychodzą w secie
+  `openaire_cris_orgunits`, bo profil nie ma osobnej encji finansującego.
+  Ta sama funkcja serializująca obsługuje rekord setu i element osadzony
+  w `Project/Funded/As` — kontrola 5b walidatora (encja osadzona jest
+  podzbiorem pełnego rekordu) jest wtedy spełniona trywialnie.
+
+Świadomie pominięte:
+
+| Element | Dlaczego |
+|---|---|
+| `Funding/Amount` domyślnie | Kwoty grantów bywają objęte klauzulą poufności, więc wychodzą dopiero po włączeniu `Uczelnia.eksport_cerif_kwoty` (domyślnie wyłączone). |
+| `Funding/Acronym` | BPP nie ma osobnego pola na skrót finansowania, a wpisanie tam nazwy programu dublowałoby `Name`. |
+| `Funding/PartOf`, `Duration`, `OAMandate` | Brak odpowiadających danych w modelu. |
+| Numer umowy jako typowany identyfikator | Numer umowy grantowej nie ma w CERIF-ie własnego typu, a atrybut `type` jest obowiązkowy — stąd własny URI (`funding.TYP_ID_NUMER_UMOWY`), zamiast podszycia się pod cudzy słownik. |
+| Front publiczny i API dla finansowania | Jak wyżej: zmiana domykała eksport, nie serwis. |
+
+Integralność referencyjna całości (`Consortium/Coordinator`,
+`Team/PrincipalInvestigator`, `Team/Member`, `Funded/By`, `Funding/Funder`)
+jest pilnowana automatycznie —
+`src/cerif_export/tests/test_integralnosc_projektow.py` harvestuje wszystkie
+sety przez `ListRecords` i sprawdza, że każdy `@id` z encji osadzonej ma
+rekord we właściwym secie, w obu stanach obu przełączników uczelni.


### PR DESCRIPTION
Porządki w `docs/deweloper/eurocris-co-jeszcze.md` po zamknięciu #701 i #702
oraz po dzisiejszym przebiegu walidatora.

## Co się zmieniło

**1. Zrobione oddzielone od otwartego.** Dokument nazywa się „co jeszcze
zostało do zrobienia", a sekcje A1 i A2 (`Project`, `Funding`) siedziały
w środku listy zadań z dopiskiem „✅ ZROBIONE" — 80 linii opisu rzeczy
gotowych na drodze kogoś, kto szuka roboty. Trafiły do nowej sekcji **G**.

Nie do kosza, bo dokument opisuje **dlaczego jest jak jest**: tabele
„świadomie pominięte" (`Project/Type`, `Consortium/Partner`,
`Funding/Amount`, `Funding/Acronym`…) nadal opisują obowiązujące decyzje
i nadal ktoś o nie pyta.

**2. Poprawiony stan walidacji — to była nieprawda.** Nagłówek twierdził, że
`openaire-cris-validator` „przechodzi w całości (`OK (13 tests)`)". Przebieg
z 2026-08-05 dał **2 błędy na 13**: pusty `<PartOf/>` przy jednostce, której
jednostka nadrzędna jest wyłączona z eksportu (poprawka w #724).

Zamiast podmienić jedno twierdzenie na drugie, doszła tabelka ze stanem
walidacji w czasie plus wniosek, który z tej wpadki płynie:

> **Zielony wynik walidatora zależy od danych, nie tylko od kodu.**

Przypadek nie występował ani na fixture'ach, ani na bazie z 2026-08-04 —
wyszedł dopiero tam, gdzie ktoś faktycznie ukrył jednostkę nadrzędną. Stąd
zalecenie przepuszczania endpointu przez `make cerif-validate` po zmianach
w serializerach, zamiast zakładania, że raz zielony został zielony.

**3. Poprawiona „sugerowana kolejność":**

- **wprowadzenie projektów przez redakcję** dostało własną pozycję — kod
  z A1/A2 jest gotowy, ale bez danych sety `projects` i `funding` są puste
  tak samo jak przed zmianą. Czytając samo „zrobione" łatwo to przeoczyć
  i zdziwić się pustym setem;
- doszło **F1 (`FileLocations`)** — dziś eksport nie podaje lokalizacji
  pełnych tekstów, a to główna rzecz, po którą przychodzi OpenAIRE. Za
  wysoka stawka, żeby zostawiać to wyłącznie na liście „znanych ograniczeń".

**4. Skasowany `AUDYT-EUROCRIS-2026-08-03.md`** z korzenia repo (nigdy nie
był w gicie, więc nie ma go w diffie). Powstał **przed** wdrożeniem
`cerif_export`, twierdził „Ekspozycja CERIF-XML: 0%" i wyceniał na 27–36 dni
robotę, która jest zrobiona — a jego „najsłabsze punkty" (`Project`,
`Funding`) zamknięte w #701/#702. Trwała treść żyje w tym dokumencie
i w dokumentacji administratora.

## Czego NIE zmieniałem

Sekcje B, C, D, E i F sprawdziłem względem kodu — nadal są aktualne:
`Element_Repozytorium` wciąż nie ma `GenericRelation` (F1),
`wspolne.ATRYBUT_PLIKI` jest tylko odczytywany i nikt go nie ustawia,
`adminEmail` nadal pochodzi z globalnego `settings.ADMINS` (F4), a `Subject`
i `FileLocations` nie występują w serializerze publikacji. Issues #703–#708
są otwarte i sekcje im odpowiadają.

`mkdocs build --strict` przechodzi.

Refs #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)