### PR TITLE
fix(release): uv.lock został z wersją 202607.1398 po wydaniu 1399

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -80,9 +80,11 @@ jobs:
 
           git switch -C "$RELEASE_REF" "origin/$RELEASE_REF"
           RC_TAG=$(./bin/bpp-version.py)        # np. 202606.1392rc2 (immutable docker-tag źródłowy)
-          echo "release_ref=${RELEASE_REF}" >> "$GITHUB_OUTPUT"
-          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
-          echo "rc_tag=${RC_TAG}" >> "$GITHUB_OUTPUT"
+          {
+            echo "release_ref=${RELEASE_REF}"
+            echo "base=${BASE}"
+            echo "rc_tag=${RC_TAG}"
+          } >> "$GITHUB_OUTPUT"
           echo "::notice::Promuję ${RELEASE_REF}: obraz :${RC_TAG} → :${BASE} + :latest"
 
       - name: Log in to Docker Hub
@@ -137,6 +139,25 @@ jobs:
           uvx bumpver@2026.1132 update --no-fetch --commit --no-push \
             --set-version "v${BASE}"
           uvx towncrier@25.8.0 build --yes || echo "towncrier: brak newsfragmentów."
+
+          # uv.lock trzyma wersje root-pakietu we wlasnym wpisie `[[package]]
+          # bpp-iplweb`, a bumpver go NIE patchuje (file_patterns obejmuja
+          # pyproject.toml, version.py, package.json i Makefile). Bez tego
+          # kroku lock zostaje z poprzednia wersja i po merge'u do dev bramka
+          # `lockfile` (tests.yml -> `uv lock --check`) pada na kazdym wydaniu.
+          #
+          # To NIE jest to samo, co usuniete `uv lock` z release-candidate.yml.
+          # Tamto RE-RESOLVOWALO zaleznosci przy kazdym RC i mogło wciagnac
+          # deps, ktorych dev nigdy nie testowal. Tutaj `uv lock` (bez
+          # `--upgrade`) zachowuje istniejace piny, a dev jest juz bramkowany
+          # na spojnosc locka z pyproject.toml — wiec jedyna zmiana, jaka
+          # moze wniesc, to ta jedna linia z wersja root-pakietu.
+          #
+          # uv jest przypiete na 0.11.29 w kroku setup-uv wyzej. Wersja ma
+          # znaczenie: `uv lock --check` na dev biegnie na tym samym pinie,
+          # a rozne uv potrafia wygenerowac rozny (choc rownowazny) lock.
+          uv lock
+
           git add -A
           git commit -m "Changelog dla v${BASE}" || echo "Brak zmian changelogu."
 

--- a/uv.lock
+++ b/uv.lock
@@ -363,7 +363,7 @@ wheels = [
 
 [[package]]
 name = "bpp-iplweb"
-version = "202607.1398"
+version = "202608.1399"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
Dwa commity: pierwszy naprawia **skutek**, drugi usuwa **przyczynę**. Można
wziąć sam pierwszy.

## Co się stało

`bumpver` patchuje `pyproject.toml`, `version.py`, `package.json` i `Makefile`
(`[tool.bumpver.file_patterns]`) — ale **nie `uv.lock`**. A lock trzyma wersję
root-pakietu we własnym wpisie:

```toml
[[package]]
name = "bpp-iplweb"
version = "202607.1398"   # ← po wydaniu v202608.1399
```

Zostało tak i na `dev`, i na `master`.

## Dlaczego to nie jest kosmetyka

`dev` ma bramkę `lockfile` (`tests.yml` → `uv lock --check`), która na taki
rozjazd pada. Sprawdzone na przypiętym uv 0.11.29:

```
$ uv lock --check
Resolved 367 packages in 2.11s
error: The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
```

Nie wyszło dotąd tylko dlatego, że commity po promote były dokumentacją
z `[ci skip]`, więc pełna suita nie ruszyła. Pierwszy PR dotykający
`pyproject.toml` — albo pierwszy zwykły push na `dev` — zapaliłby to na
czerwono.

## Commit 1 — przelockowanie (1 linia)

```diff
 name = "bpp-iplweb"
-version = "202607.1398"
+version = "202608.1399"
```

Zrobione **uv 0.11.29**, tą samą wersją, którą przypinają workflow-y. Ma to
znaczenie: lokalne uv 0.11.14 przy okazji przeformatowuje 689 linii markerów
środowiskowych i zamazuje faktyczną zmianę. Po zmianie `uv lock --check`
przechodzi.

## Commit 2 — żeby nie wracało

`promote.yml` dostaje `uv lock` po `bumpver`, przed commitem changelogu.

**To nie jest przywrócenie `uv lock` usuniętego z `release-candidate.yml`** —
tamten komentarz (linie 230–242) jest nadal słuszny i zostaje w mocy. Tamto
`uv lock` **re-resolvowało zależności** przy każdym RC i mogło wciągnąć deps,
których `dev` nigdy nie testował; dlatego RC nie mógł pomijać re-testu.

Tutaj jest inaczej:

- `uv lock` bez `--upgrade` zachowuje istniejące piny;
- `dev` jest już bramkowany na spójność locka z `pyproject.toml`;
- więc **jedyną** zmianą, jaką ten krok może wnieść, jest ta jedna linia
  z wersją root-pakietu.

Ten komentarz w `release-candidate.yml` sam zresztą wskazał tę lukę: *„jedyną
zmianą, jaką `uv lock` by tu jeszcze wniósł, jest bump wersji root-pakietu
w locku"*. Dla obrazu RC pominięcie faktycznie jest bezpieczne (`uv sync
--frozen` to pole ignoruje) — ale dla bramki na `dev` już nie, i tego nikt
wtedy nie domknął.

uv jest już przypięte na **0.11.29** w kroku `setup-uv` tego joba, więc lock
powstaje tą samą wersją, która go potem sprawdza. To nie jest szczegół: ten
sam bit-w-bit lock przechodził na 0.11.29 i padał na 0.11.31 (opisane
w `tests.yml`).

Przy okazji **SC2129** w kroku `detect` — trzy kolejne przekierowania do
`$GITHUB_OUTPUT` zwinięte w jedną klamrę. Błąd był tam wcześniej, ale
`actionlint` sprawdza cały plik, więc blokował commit dotykający tego pliku.
`actionlint` i `zizmor` przechodzą.

## Czego NIE zmieniałem

Samo wydanie v202608.1399 jest **kompletne** — sprawdziłem, zanim cokolwiek
ruszyłem: `master` ma `Release v202608.1399`, tag `v202608.1399` istnieje,
nie ma otwartej gałęzi `release/*`, a `version.py` zgadza się na obu
gałęziach. Nieudany push z pierwszej próby promocji doszedł do skutku przy
ponowieniu. Jedyną pozostałością był lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)