### PR TITLE
fix(dostępność): nadmiarowy nawias w adresie deklaracji dostępności

### DIFF
--- a/src/bpp/newsfragments/deklaracja-dostepnosci-meta-url.bugfix.rst
+++ b/src/bpp/newsfragments/deklaracja-dostepnosci-meta-url.bugfix.rst
@@ -1,0 +1,4 @@
+Metadana wskazująca deklarację dostępności zawierała adres z doklejonym
+nawiasem klamrowym (``...deklaracja-dostepnosci/}``), przez co wskazywała
+nieistniejącą stronę. Dotyczyło to instalacji, w których deklaracja jest
+serwowana przez BPP (opcja „tekst", nie zewnętrzny adres).

--- a/src/bpp/tests/test_models/test_uczelnia.py
+++ b/src/bpp/tests/test_models/test_uczelnia.py
@@ -122,3 +122,23 @@ def test_uczelnia_deklaracja_dostepnosci_url(uczelnia, client):
 
     res = client.get("/", follow=True)
     assert b"https://onet.pl" in res.content
+
+
+@pytest.mark.django_db
+def test_uczelnia_deklaracja_dostepnosci_meta_adres_dokladny(uczelnia, client):
+    # Metadana z adresem deklaracji musi zawierać sam adres -- bez
+    # doklejonych znaków. Testy powyżej sprawdzają `adres in content`,
+    # a przy takiej asercji śmieć doklejony do adresu przechodzi
+    # niezauważony: adres pozostaje podciągiem. Stąd asercja na pełny
+    # atrybut, wraz z zamykającym cudzysłowem.
+    uczelnia.pokazuj_deklaracje_dostepnosci = (
+        Uczelnia.DeklaracjaDostepnosciChoices.TEKST
+    )
+    uczelnia.deklaracja_dostepnosci_tekst = "<h1>TEST</h1>"
+    uczelnia.save()
+
+    url = reverse("bpp:browse_deklaracja_dostepnosci")
+
+    res = client.get("/", follow=True)
+
+    assert f'content="{url}"'.encode() in res.content

--- a/src/django_bpp/templates/bare.html
+++ b/src/django_bpp/templates/bare.html
@@ -47,7 +47,7 @@
     {% endif %}
 
     {% if uczelnia.pokazuj_deklaracje_dostepnosci == 2 %}
-        <meta name="deklaracja-dostępności" content="{% url "bpp:browse_deklaracja_dostepnosci" %}}"/>
+        <meta name="deklaracja-dostępności" content="{% url "bpp:browse_deklaracja_dostepnosci" %}"/>
     {% endif %}
 
     {# bare.html - FOUC prevention #}
@@ -144,7 +144,9 @@
         {% place_favicon %}
     {% endcache %}
 </head>
+{# djlint:off H025 #}
 <body class="fouc-hidden">
+{# djlint:on H025 #}
 {% block skip_link %}<a href="#main-content" class="skip-link">Przejdź do głównej zawartości</a>{% endblock %}
 {% block body %}
 {% endblock %}


### PR DESCRIPTION
## Problem

`bare.html` składał metadaną wskazującą deklarację dostępności jako:

```django
content="{% url "bpp:browse_deklaracja_dostepnosci" %}}"
```

Nadmiarowy `}` trafiał do atrybutu, więc metadana wskazywała `/bpp/deklaracja-dostepnosci/}` — adres nieistniejący. Dotyczy instalacji serwujących deklarację przez BPP (opcja „tekst"), nie tych z zewnętrznym adresem.

Znalezione przy okazji analizy dostępności — ironicznie, dotyczy metadanej wskazującej deklarację dostępności.

## Dlaczego testy tego nie widziały

`test_uczelnia_deklaracja_dostepnosci_tekst` asertuje:

```python
assert bytes(url_deklaracji_bpp, "ascii") in res.content
```

Przy asercji podciągowej doklejony znak przechodzi niezauważony — adres pozostaje podciągiem `/bpp/deklaracja-dostepnosci/}`. Nowy test asertuje pełny atrybut wraz z zamykającym cudzysłowem i **przed poprawką pada** (zweryfikowane — RED przed GREEN).

## Zmiany

- `bare.html` — usunięty nadmiarowy `}`
- nowy test `test_uczelnia_deklaracja_dostepnosci_meta_adres_dokladny`
- newsfragment

## Uwaga o djlint

To pierwsza zmiana w `bare.html` od czasu dodania hooka djlint, więc ujawniła zastany **fałszywy alarm** H025 („orphan `<body>`") w pinowanej wersji 1.36.4. Tagi są sparowane (`<body>` 147, `</body>` 179), a djlint 1.43.2 nie zgłasza problemu.

Podbicie pinu **odpada w tym PR** — nowsza wersja znajduje 68 błędów w 405 plikach i zablokowałaby commity w całym repo (osobne zadanie). Zamiast dopisywać plik do listy wykluczeń (istniejący wzorzec w konfiguracji, ale wyłącza cały szablon z lintowania) wyciszam punktowo H025 w miejscu wystąpienia — pozostałe reguły nadal obowiązują.

## Weryfikacja

- `src/bpp/tests/test_models/test_uczelnia.py` — 8 passed
- `src/bpp/tests/test_views/` — 371 passed, 1 skipped (zmiana dotyka szablonu bazowego całego serwisu)
- `pre-commit` — 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)