### PR TITLE
feat(docker): prekompresja gzip plików statycznych

### DIFF
--- a/docker/appserver/entrypoint-appserver.sh
+++ b/docker/appserver/entrypoint-appserver.sh
@@ -53,6 +53,31 @@ echo "Starting background tasks..."
     python src/manage.py compress -v0 --force --traceback
     echo "  [bg] compress done."
 
+    # Prekompresja gzip wyjscia django-compressora ($STATIC_ROOT/CACHE,
+    # patrz COMPRESS_ROOT + COMPRESS_OUTPUT_DIR w settings/base.py).
+    # Reszta staticow ma `.gz` juz w obrazie (R16 w docker/bpp_base/Dockerfile),
+    # ale CACHE/ powstaje DOPIERO TERAZ, w runtime — build-time go nie widzial.
+    # To realny ruch: bare.html pakuje bundle.js (786 KB) w {% compress js %},
+    # wiec przegladarka pobiera CACHE/js/output.<hash>.js, a nie plik z .baked.
+    #
+    # Nieaktualny `.gz` nie grozi: compressor nazywa wyjscie content-hashem,
+    # wiec zmiana tresci = nowa nazwa pliku, a nie nadpisanie starej.
+    #
+    # Bledu NIE eskalujemy (skrypt leci z `sh -e`) — brak `.gz` degraduje sie
+    # miekko do `gzip on` w locie, a to nie powod, zeby nie wstal serwis.
+    # Logujemy za to glosno, bo inaczej regresja byla by niewidoczna.
+    if [ -d "$STATIC_ROOT/CACHE" ]; then
+        echo "  [bg] gzip CACHE..."
+        if find "$STATIC_ROOT/CACHE" -type f -size +1000c \
+                \( -name '*.js' -o -name '*.css' \) \
+                -exec gzip -9 -k -f {} +; then
+            echo "  [bg] gzip CACHE done."
+        else
+            echo "  [bg] UWAGA: prekompresja CACHE nie powiodla sie —"
+            echo "  [bg] nginx spadnie na gzip w locie (wolniej, ale dziala)."
+        fi
+    fi
+
     echo "  [bg] generate_500_page..."
     python src/manage.py generate_500_page
     echo "  [bg] generate_500_page done."

--- a/docker/bpp_base/Dockerfile
+++ b/docker/bpp_base/Dockerfile
@@ -174,6 +174,37 @@ RUN DJANGO_BPP_SECRET_KEY=build-time-only-not-used \
         --noinput -v0 --traceback \
         --ignore sinon --ignore qunit --ignore '*.map'
 
+# R16: prekompresja gzip dla `gzip_static on` po stronie nginksa (bpp-deploy,
+# defaults/webserver/_bpp-locations.conf). Ta dyrektywa jest tam wlaczona od
+# dawna, ale BEZ plikow `.gz` jest MARTWA i nie zglasza tego niczym — nginx
+# po prostu cicho spada na `gzip on` i kompresuje kazdy plik OD NOWA przy
+# kazdym cache-missie. Najwieksze assety to plotly.min.js (4.4 MB),
+# three-bundle.js (1.9 MB) i cytoscape-bundle.js (886 KB) — wszystkie trzy
+# ladowane w szablonach przez {% static %} POZA blokami {% compress %},
+# czyli serwowane wprost stad, a nie z CACHE/ compressora.
+#
+# Pomiar na 202608.1399rc5: 1813 plikow, 2 s buildu, +12.5 MB do obrazu.
+#
+# Dlaczego build-time, a nie runtime: entrypoint-appserver.sh robi `cp -rf`
+# z `.baked` do $STATIC_ROOT, wiec `.gz` powstaje w tym samym kroku co plik
+# zrodlowy i JEST Z NIM ZAWSZE ZGODNY. Gdyby generowac je pozniej, na
+# wolumenie, mielibysmy klasyczna pulapke `gzip_static`: nginx serwuje `x.js.gz`
+# NIE POROWNUJAC mtime z `x.js`, wiec nieaktualny `.gz` = wieczne serwowanie
+# starego JS-a, bez sladu w logach.
+#
+# `-size +1000c` odpowiada `gzip_min_length 1000` z konfiguracji nginksa.
+# Kompresujemy WYLACZNIE formaty tekstowe — woff/woff2/png/jpg/webp sa juz
+# skompresowane i `.gz` tylko zajalby miejsce nic nie dajac.
+# Drugi `find` kasuje `.gz`, ktory wyszedl nie mniejszy od oryginalu (nginx
+# serwowalby WIEKSZY plik klientom deklarujacym gzip). Na obecnym drzewie
+# takich przypadkow jest 0, ale to zabezpieczenie na przyszle assety.
+RUN find /app/staticroot.baked -type f -size +1000c \
+        \( -name '*.js' -o -name '*.css' -o -name '*.svg' -o -name '*.json' \
+           -o -name '*.xml' -o -name '*.txt' -o -name '*.html' \) \
+        -exec gzip -9 -k -f {} + && \
+    find /app/staticroot.baked -type f -name '*.gz' -exec sh -c \
+        'for g; do o="${g%.gz}"; if [ -f "$o" ] && [ "$(stat -c%s "$g")" -ge "$(stat -c%s "$o")" ]; then rm -f "$g"; fi; done' _ {} +
+
 RUN rm -rf /app/node_modules
 
 # R2: testy i pytest-only fixture package nie są potrzebne w produkcji.

--- a/src/bpp/newsfragments/prekompresja-gzip-staticow.feature.rst
+++ b/src/bpp/newsfragments/prekompresja-gzip-staticow.feature.rst
@@ -1,0 +1,6 @@
+Pliki statyczne są prekompresowane gzipem już w obrazie Dockera, a wyjście
+django-compressora (``CACHE/``) przy starcie kontenera. Nginx w ``bpp-deploy``
+ma ``gzip_static on`` włączone od dawna, ale bez plików ``.gz`` dyrektywa nic
+nie robiła — każde żądanie kompresowało plik od nowa. Największe assety
+(``plotly.min.js`` 4,4 MB, ``three-bundle.js`` 1,9 MB) schodzą teraz z dysku
+gotowe, mocniej skompresowane (poziom 9 zamiast 5) i bez narzutu CPU na brzegu.


### PR DESCRIPTION
## Problem

Nginx w `bpp-deploy` ma `gzip_static on` włączone od dawna. Ta dyrektywa **nie znaczy** „kompresuj statyki" — znaczy „wyślij `x.js.gz`, **jeśli istnieje**".

W obrazie nie było ani jednego `.gz` (zmierzone na `202608.1399rc5`: **3429 plików, 0 sztuk**). Nginx cicho spadał na `gzip on` i kompresował `plotly.min.js` (4,4 MB) od nowa przy każdym cache-missie.

Objawu nie ma żadnego: strona działa, `Content-Encoding` jest, różni się tylko CPU brzegu i poziom kompresji (w locie 5, offline 9).

## Rozwiązanie — dwa kroki, bo jeden nie wystarczał

**1. `R16` w `docker/bpp_base/Dockerfile`** — `gzip -9` na `staticroot.baked` zaraz po `collectstatic`.
Zmierzone: **1813 plików, 2 s buildu, +12,5 MB do obrazu**.

**2. `docker/appserver/entrypoint-appserver.sh`** — gzip na `$STATIC_ROOT/CACHE` po `manage.py compress`.

Drugi krok jest konieczny, bo `bare.html` pakuje `bundle.js` (786 KB) w `{% compress js %}` — przeglądarka pobiera `CACHE/js/output.<hash>.js`, plik, który **powstaje dopiero w runtime** i którego build-time nie widzi. Trzy największe assety są odwrotnie: `plotly.min.js` (4,4 MB), `three-bundle.js` (1,9 MB) i `cytoscape-bundle.js` (886 KB) są ładowane przez `{% static %}` **poza** blokami `{% compress %}`, czyli wprost z `.baked`.

## Dlaczego build-time, a nie krok po stronie wdrożenia

Nginx serwując `x.js.gz` **nie porównuje mtime z `x.js`**. Nieaktualny `.gz` = wieczne serwowanie starego JS-a wszystkim przeglądarkom, bez śladu w logach; operator zgłasza to jako „zaktualizowałem i nic się nie zmieniło".

Generowanie `.gz` w tym samym kroku co plik źródłowy usuwa problem z definicji — nie ma okna, w którym mogłyby się rozjechać. W `CACHE/` dodatkowo chroni content-hash w nazwie (zmiana treści = nowa nazwa, nie nadpisanie).

## Zabezpieczenia

- `-size +1000c` odpowiada `gzip_min_length 1000` z konfiguracji nginksa.
- Kompresujemy **wyłącznie formaty tekstowe** — `woff`/`png`/`webp` są już skompresowane, `.gz` tylko zajmowałby miejsce.
- Drugi `find` kasuje `.gz`, który wyszedł **nie mniejszy** od oryginału (nginx serwowałby większy plik klientom deklarującym gzip). Na obecnym drzewie takich przypadków jest 0 — to zabezpieczenie na przyszłe assety.
- Błąd w entrypoincie **nie eskaluje** (skrypt leci z `sh -e`) — degraduje się miękko do gzipu w locie, ale **loguje głośno**, żeby regresja nie była niewidoczna.

## Weryfikacja

Fragmenty wykonane na prawdziwym drzewie z opublikowanego obrazu, dokładnie w postaci, w jakiej wykona je Docker:

- `exit 0` pod `set -e`, **1813 plików** `.gz`;
- integralność: `gzip -dc | cmp` na losowej próbce — zgodne bajt w bajt;
- guard rozmiaru sprawdzony **podłożonym plikiem nieściśliwym** (usunięty poprawnie, `bundle.js.gz` nietknięty) — żeby nie był martwym kodem;
- entrypoint przetestowany w trzech ścieżkach: CACHE z plikami / brak CACHE / `find` z błędem — nigdzie nie wywraca startu.

Kompresja kluczowych assetów: `plotly.min.js` 4558732 → 1331125 B, `three-bundle.js` 1942818 → 424346 B, `bundle.js` 805055 → 226887 B.

**Nie budowałem pełnego obrazu** (kilkuminutowy build z yarn/uv) — pierwszy build w CI potwierdzi resztę.

Stage `testserver` (dev) celowo pominięty: `gzip_static` to funkcja nginksa, a dev serwuje statyki Django.

## Powiązane

Sparowany z iplweb/bpp-deploy#31, który zapisuje dowody i werdykt w sprawie brotli/zstd (odrzucone — trzy blokady po stronie obrazu CRS). Tamten PR nie zmienia zachowania; ten włącza `gzip_static` realnie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J35fM3toviqNDsGxRg6P1c