### PR TITLE
feat(admin): ogranicz wyliczankę obiektów na stronie kasowania (delete_confirmation_max_display, Django 6.1)

### DIFF
--- a/src/bpp/admin/core.py
+++ b/src/bpp/admin/core.py
@@ -104,6 +104,42 @@ class DynamicAdminFilterMixin:
             return HttpResponse("-", content_type="text/html; charset=utf-8")
 
 
+MAKSYMALNA_LICZBA_OBIEKTOW_NA_STRONIE_KASOWANIA = 100
+"""Ile obiektów wypisać na stronie potwierdzenia kasowania w adminie.
+
+Trafia do ``ModelAdmin.delete_confirmation_max_display`` (Django >= 6.1).
+
+DLACZEGO w ogóle: strona potwierdzenia kasowania enumeruje KAŻDY obiekt,
+który poleci kaskadą. Dla ``Autor``, ``Zrodlo`` czy dowolnego masowego
+``delete_selected`` na przefiltrowanej changeliście to dziesiątki tysięcy
+``<li>`` z linkiem do zmiany — kilkanaście MB HTML-a, którego przeglądarka
+i tak nie jest w stanie sensownie pokazać, a człowiek przeczytać.
+
+DLACZEGO akurat 100:
+
+* to wartość z przykładu w docstringu samego filtra Django
+  (``{{ deleted_objects|truncated_unordered_list:100 }}``) — nie wymyślamy
+  własnego standardu tam, gdzie upstream ma swój,
+* to 2× ``list_per_page`` (50) — cała strona changelisty zaznaczona do
+  kasowania nadal wypisuje się co do sztuki,
+* powyżej ~100 pozycji lista i tak przestaje być narzędziem weryfikacji,
+  a staje się ścianą tekstu.
+
+CZEGO NIE TRACIMY: sekcja „Podsumowanie" (``object_delete_summary.html``)
+renderuje PEŁNE liczniki per model (``model_count``) i jest ponad listą.
+Obcięcie zabiera więc tylko wyliczankę pojedynczych obiektów — informacja
+o SKALI kasowania zostaje nienaruszona. Dodatkowo filtr sam dopisuje na
+końcu „…i N innych obiektów".
+
+CZEGO TO NIE ZAŁATWIA (żeby nie było złudzeń): opcja działa WYŁĄCZNIE na
+etapie renderowania. ``get_deleted_objects`` nadal zbiera i formatuje
+komplet obiektów (``NestedObjects.collect`` + ``format_callback`` z
+``reverse()`` per obiekt), więc zapytań do bazy ani szczytowego zużycia
+pamięci po stronie Pythona to nie zmniejsza. Zyskiem jest rozmiar
+odpowiedzi i to, że przeglądarka nie umiera na renderowaniu listy.
+"""
+
+
 class BaseBppAdminMixin(DynamicAdminFilterMixin):
     """Ta klasa jest potrzebna, (XXXżeby działały sygnały post_commit.XXX)
 
@@ -117,6 +153,26 @@ class BaseBppAdminMixin(DynamicAdminFilterMixin):
 
     # ograniczenie wielkosci listy
     list_per_page = 50
+
+    # Limit wyliczanki obiektów na stronie potwierdzenia kasowania.
+    #
+    # Ustawiamy GLOBALNIE (tu, a nie punktowo na paru „ciężkich" adminach),
+    # bo eksplozja listy nie bierze się z samego modelu, tylko z jego
+    # ogona kaskad — a ten potrafi urosnąć w dowolnym adminie po dodaniu
+    # jednego FK w zupełnie innej aplikacji. Limit punktowy z definicji
+    # nie chroni tam, gdzie nikt nie przewidział problemu, a nie ma
+    # w BPP modelu, dla którego wypisanie >100 obiektów co do sztuki
+    # niosłoby wartość (patrz argumentacja przy stałej wyżej).
+    #
+    # UWAGA: sama ta wartość NIE wystarczy. Aktywna skórka admina to
+    # grappelli, a jej ``admin/delete_confirmation.html`` i
+    # ``admin/delete_selected_confirmation.html`` renderują listę filtrem
+    # ``|unordered_list`` (bez obcinania). Dlatego BPP nadpisuje blok
+    # ``content`` obu tych szablonów w ``src/django_bpp/templates/admin/``
+    # i woła tam ``|truncated_unordered_list:delete_confirmation_max_display``.
+    # Jeżeli kiedyś znika grappelli — te nadpisania można skasować,
+    # bo szablony samego Django honorują opcję z automatu.
+    delete_confirmation_max_display = MAKSYMALNA_LICZBA_OBIEKTOW_NA_STRONIE_KASOWANIA
 
     def get_queryset(self, request):
         """Włącz ``FETCH_PEERS`` (Django 6.1) dla querysetów tego admina.

--- a/src/bpp/newsfragments/delete-confirmation-max-display.feature.rst
+++ b/src/bpp/newsfragments/delete-confirmation-max-display.feature.rst
@@ -1,0 +1,6 @@
+Strona potwierdzenia kasowania w module redagowania nie wypisuje już
+wszystkich obiektów, które zostaną usunięte kaskadą — pokazuje pierwszych 100
+i informację, ile pozycji ukryto. Pełne liczniki (ile obiektów każdego rodzaju
+zniknie) nadal są widoczne w sekcji „Podsumowanie". Wcześniej kasowanie autora,
+źródła albo masowe kasowanie z listy potrafiło wygenerować wielomegabajtową
+stronę, której przeglądarka nie była w stanie wyświetlić.

--- a/src/bpp/tests/test_admin/test_delete_confirmation_max_display.py
+++ b/src/bpp/tests/test_admin/test_delete_confirmation_max_display.py
@@ -1,0 +1,230 @@
+"""Kontrakt: strona potwierdzenia kasowania NIE wypisuje wszystkiego, co
+poleci kaskadą.
+
+``BaseBppAdminMixin.delete_confirmation_max_display`` (Django >= 6.1) tnie
+wyliczankę obiektów zależnych do 100 pozycji i dokleja na końcu „…i N innych
+obiektów". Dla ``Autor``, ``Zrodlo`` czy masowego ``delete_selected`` na
+przefiltrowanej changeliście różnica to kilkanaście MB HTML-a, którego
+przeglądarka i tak nie renderuje sensownie.
+
+Testy tutaj pilnują rzeczy, których łatwo NIE zauważyć:
+
+1. sama wartość jest sensowna z punktu widzenia Django (``admin.E041``),
+2. obcinanie NAPRAWDĘ się dzieje na wyrenderowanej stronie — a to wcale nie
+   wynika z ustawienia atrybutu. Aktywną skórką admina jest grappelli, której
+   szablony renderują listę filtrem ``|unordered_list`` (bez obcinania).
+   Gdyby ktoś skasował nadpisania z ``src/django_bpp/templates/admin/``,
+   atrybut zostałby ustawiony, checki Django przeszłyby — a strona dalej
+   wypisywałaby wszystko. Dlatego testujemy przez klienta HTTP, na realnym
+   łańcuchu szablonów, a nie przez ``assert admin.delete_confirmation_max_display``,
+3. obcinana jest WYŁĄCZNIE wyliczanka obiektów. Sekcja „Podsumowanie"
+   (pełne liczniki per model) i lista blokad ``protected`` (w BPP niosąca
+   ręcznie pisane komunikaty ``JednostkaAdmin.get_deleted_objects``) muszą
+   zostać nietknięte — inaczej obcinanie ukrywałoby informacje, po które
+   użytkownik na tę stronę przyszedł.
+"""
+
+import re
+from unittest import mock
+
+import pytest
+from django.contrib import admin as dj_admin
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from django.utils.translation import ngettext
+from model_bakery import baker
+
+from bpp.admin.core import MAKSYMALNA_LICZBA_OBIEKTOW_NA_STRONIE_KASOWANIA
+from bpp.admin.jednostka import JednostkaAdmin
+from bpp.admin.wydawnictwo_ciagle import Wydawnictwo_CiagleAdmin
+from bpp.models import (
+    Autor,
+    BppUser,
+    Jednostka,
+    Wydawnictwo_Ciagle,
+    Wydawnictwo_Zwarte,
+)
+
+LICZBA_AUTOROW = 6
+"""Ilu autorów doczepiamy do rekordu w testach obcinania.
+
+Musi być zauważalnie większa od podstawianego limitu (2), żeby różnica
+„z limitem / bez limitu" była jednoznaczna, i na tyle mała, żeby test nie
+kosztował sekundy na samym zapisie do bazy.
+"""
+
+LIMIT_TESTOWY = 2
+"""Limit podstawiany na czas testu. Produkcyjnych 100 nie da się sensownie
+sprawdzić bez tworzenia >100 obiektów — a testujemy MECHANIZM, nie liczbę
+(liczbę pilnuje ``test_wartosc_limitu_jest_ta_udokumentowana``)."""
+
+
+@pytest.fixture
+def administracja_client(client, db):
+    """Zalogowany superuser w grupie ``administracja`` — obie przesłanki
+    ``has_delete_permission`` w adminach BPP spełnione naraz."""
+    grupa, _ = Group.objects.get_or_create(name="administracja")
+    user = baker.make(BppUser, is_superuser=True, is_staff=True)
+    user.groups.add(grupa)
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def ciagle_z_autorami(wydawnictwo_ciagle, jednostka) -> tuple[Wydawnictwo_Ciagle, list]:
+    """Rekord z ``LICZBA_AUTOROW`` powiązaniami autorów.
+
+    Nazwiska są unikalne i „nieżyciowe", żeby dało się je jednoznacznie
+    wyszukać w HTML-u strony potwierdzenia (``Wydawnictwo_Ciagle_Autor.__str__``
+    zaczyna się od ``str(autor)``)."""
+    nazwiska = []
+    for i in range(LICZBA_AUTOROW):
+        nazwisko = f"Obcinalski{i:02d}"
+        autor = baker.make(Autor, nazwisko=nazwisko, imiona="Test")
+        wydawnictwo_ciagle.dodaj_autora(autor, jednostka)
+        nazwiska.append(nazwisko)
+    return wydawnictwo_ciagle, nazwiska
+
+
+def _widoczne(nazwiska: list[str], html: str) -> list[str]:
+    return [nazwisko for nazwisko in nazwiska if nazwisko in html]
+
+
+def _komunikat_o_ukrytych(html: str) -> int | None:
+    """Zwraca liczbę obiektów zgłoszonych jako ukryte, albo ``None``.
+
+    Wzorzec budujemy z ``ngettext`` zamiast wpisywać tekst na sztywno — dzięki
+    temu test nie pęknie, gdy Django dorzuci polskie tłumaczenie tego (nowego
+    w 6.1) komunikatu."""
+    szablon = ngettext(
+        "…and %(count)d more object.",
+        "…and %(count)d more objects.",
+        LICZBA_AUTOROW,
+    )
+    wzorzec = re.escape(szablon).replace(re.escape("%(count)d"), r"(\d+)")
+    dopasowanie = re.search(wzorzec, html)
+    return int(dopasowanie.group(1)) if dopasowanie else None
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "model", [Autor, Jednostka, Wydawnictwo_Ciagle, Wydawnictwo_Zwarte]
+)
+def test_opcja_przechodzi_walidacje_django(model):
+    """Django waliduje tę opcję własnym checkiem (``admin.E041``: musi być
+    nieujemnym intem albo ``None``). Odpalamy checki admina w całości, więc
+    test złapie też przypadek, w którym ktoś wpisze tam np. string albo -1.
+
+    Sięgamy po ZAREJESTROWANĄ instancję admina, a nie po klasę — dopiero ona
+    ma podpięty model i realny ``admin_site``."""
+    bledy = [b.id for b in dj_admin.site.get_model_admin(model).check()]
+    assert "admin.E041" not in bledy, bledy
+
+
+def test_wartosc_limitu_jest_ta_udokumentowana():
+    """Wartość jest uzasadniona (2× ``list_per_page``, przykład z docstringu
+    filtra Django) — jeżeli ktoś ją zmienia, ma zaktualizować uzasadnienie
+    przy stałej w ``bpp/admin/core.py``, a nie tylko liczbę."""
+    assert MAKSYMALNA_LICZBA_OBIEKTOW_NA_STRONIE_KASOWANIA == 100
+    assert Wydawnictwo_CiagleAdmin.delete_confirmation_max_display == (
+        MAKSYMALNA_LICZBA_OBIEKTOW_NA_STRONIE_KASOWANIA
+    )
+
+
+@pytest.mark.django_db
+def test_lista_obiektow_zaleznych_jest_obcinana(
+    administracja_client, ciagle_z_autorami
+):
+    """Realna strona potwierdzenia (szablon grappelli + nadpisanie BPP)
+    pokazuje MNIEJ obiektów, niż jest do skasowania, i mówi ile ukryła."""
+    wydawnictwo, nazwiska = ciagle_z_autorami
+    url = reverse("admin:bpp_wydawnictwo_ciagle_delete", args=(wydawnictwo.pk,))
+
+    with mock.patch.object(
+        Wydawnictwo_CiagleAdmin, "delete_confirmation_max_display", LIMIT_TESTOWY
+    ):
+        html = administracja_client.get(url).content.decode()
+
+    widoczne = _widoczne(nazwiska, html)
+    assert len(widoczne) < LICZBA_AUTOROW, (
+        "Lista nie została obcięta — sprawdź, czy nadpisania szablonów w "
+        "src/django_bpp/templates/admin/ nadal używają "
+        "|truncated_unordered_list:delete_confirmation_max_display"
+    )
+
+    ukryte = _komunikat_o_ukrytych(html)
+    assert ukryte, "Brak informacji o tym, ile obiektów ukryto"
+
+
+@pytest.mark.django_db
+def test_bez_limitu_lista_jest_pelna(administracja_client, ciagle_z_autorami):
+    """Kontrola negatywna: ``None`` = „bez ograniczeń" (zachowanie sprzed
+    Django 6.1). Bez tego testu poprzedni przechodziłby również wtedy, gdyby
+    szablon gubił obiekty z zupełnie innego powodu."""
+    wydawnictwo, nazwiska = ciagle_z_autorami
+    url = reverse("admin:bpp_wydawnictwo_ciagle_delete", args=(wydawnictwo.pk,))
+
+    with mock.patch.object(
+        Wydawnictwo_CiagleAdmin, "delete_confirmation_max_display", None
+    ):
+        html = administracja_client.get(url).content.decode()
+
+    assert _widoczne(nazwiska, html) == nazwiska
+    assert _komunikat_o_ukrytych(html) is None
+
+
+@pytest.mark.django_db
+def test_podsumowanie_pokazuje_pelne_liczniki(administracja_client, ciagle_z_autorami):
+    """Obcinamy wyliczankę, ale NIE liczniki.
+
+    To jest cała przesłanka, dla której obcinanie jest bezpieczne: sekcja
+    „Podsumowanie" nad listą (``model_count``) nadal podaje dokładnie, ile
+    obiektów każdego typu zniknie."""
+    wydawnictwo, nazwiska = ciagle_z_autorami
+    url = reverse("admin:bpp_wydawnictwo_ciagle_delete", args=(wydawnictwo.pk,))
+
+    with mock.patch.object(
+        Wydawnictwo_CiagleAdmin, "delete_confirmation_max_display", LIMIT_TESTOWY
+    ):
+        html = administracja_client.get(url).content.decode()
+
+    etykieta = str(wydawnictwo.autorzy_set.model._meta.verbose_name_plural).capitalize()
+    assert f"{etykieta}: {LICZBA_AUTOROW}" in html
+
+
+@pytest.mark.django_db
+def test_kasowanie_masowe_tez_obcina(administracja_client, ciagle_z_autorami):
+    """``delete_selected`` renderuje INNY szablon
+    (``admin/delete_selected_confirmation.html``) i to tam obcinanie boli
+    najbardziej — zaznaczenie całej changelisty wciąga wszystkie kaskady
+    naraz. Osobny szablon = osobny test."""
+    wydawnictwo, nazwiska = ciagle_z_autorami
+
+    with mock.patch.object(
+        Wydawnictwo_CiagleAdmin, "delete_confirmation_max_display", LIMIT_TESTOWY
+    ):
+        html = administracja_client.post(
+            reverse("admin:bpp_wydawnictwo_ciagle_changelist"),
+            {"action": "delete_selected", "_selected_action": [wydawnictwo.pk]},
+        ).content.decode()
+
+    assert len(_widoczne(nazwiska, html)) < LICZBA_AUTOROW
+    assert _komunikat_o_ukrytych(html)
+
+
+@pytest.mark.django_db
+def test_lista_blokad_nie_jest_obcinana(administracja_client, jednostka: Jednostka):
+    """``protected`` renderujemy BEZ obcinania — świadomie.
+
+    ``JednostkaAdmin.get_deleted_objects`` dokłada tam własny komunikat
+    („nie można usunąć, bo są przypięte…") na KOŃCU listy. Gdyby obcinanie
+    objęło też ``protected``, przy dłuższej liście blokad zniknąłby dokładnie
+    ten komunikat, który tłumaczy użytkownikowi, co ma zrobić."""
+    jednostka.dodaj_autora(baker.make(Autor))
+    url = reverse("admin:bpp_jednostka_delete", args=(jednostka.pk,))
+
+    # Limit 1 — gdyby dotyczył ``protected``, komunikat BPP wypadłby z listy.
+    with mock.patch.object(JednostkaAdmin, "delete_confirmation_max_display", 1):
+        html = administracja_client.get(url).content.decode()
+
+    assert "nie można usunąć" in html

--- a/src/django_bpp/templates/admin/delete_confirmation.html
+++ b/src/django_bpp/templates/admin/delete_confirmation.html
@@ -1,5 +1,5 @@
 {% extends "admin/delete_confirmation.html" %}
-{% load i18n admin_urls %}
+{% load i18n admin_urls admin_filters %}
 
 <!-- BREADCRUMBS -->
 {% block breadcrumbs %}
@@ -9,7 +9,71 @@
         {% url opts|admin_urlname:'changelist' as changelist_url %}
         <li><a href="{% add_preserved_filters changelist_url %}">{{ opts.verbose_name_plural|capfirst|escape }}</a></li>
         {% url opts|admin_urlname:'change' object.pk|admin_urlquote as object_url %}
-        <li><a href="{% add_preserved_filters object_url %}">{{ object|truncatewords:"18" }}</a></lI>
+        <li><a href="{% add_preserved_filters object_url %}">{{ object|truncatewords:"18" }}</a></li>
         <li>{% trans 'Delete' %}</li>
     </ul>
+{% endblock %}
+
+{# Blok `content` jest skopiowany z grappelli 5.0.0 (admin/delete_confirmation.html) #}
+{# z JEDNĄ różnicą: lista kasowanych obiektów idzie przez #}
+{# `truncated_unordered_list:delete_confirmation_max_display` zamiast `unordered_list`. #}
+{# #}
+{# DLACZEGO kopiujemy cały blok: grappelli trzyma całą treść strony w jednym #}
+{# bloku `content` i nie wystawia mniejszego bloku, w który dałoby się wejść #}
+{# punktowo. Bez tego nadpisania `ModelAdmin.delete_confirmation_max_display` #}
+{# (Django >= 6.1) NIE MA ŻADNEGO EFEKTU w BPP — Django wstawia tę wartość do #}
+{# kontekstu, ale to szablon decyduje, czy w ogóle obetnie listę, a grappelli #}
+{# jej nie obcina. Patrz komentarz przy `BaseBppAdminMixin`. #}
+{# #}
+{# PRZY PODBIJANIU GRAPPELLI: porównaj ten blok z oryginałem — jeżeli upstream #}
+{# zmienił markup, przenieś zmiany tutaj (albo skasuj to nadpisanie, gdy #}
+{# grappelli zacznie samo używać filtra obcinającego). #}
+{# #}
+{# `perms_lacking` i `protected` renderujemy ŚWIADOMIE bez obcinania: to krótkie #}
+{# listy blokad, a w BPP niosą dopisywane ręcznie komunikaty (patrz #}
+{# `JednostkaAdmin.get_deleted_objects`, które dokłada je na KOŃCU listy). #}
+{# Obcięcie ukryłoby dokładnie tę informację, po którą użytkownik tu przyszedł. #}
+{% block content %}
+    <div class="g-d-c">
+        {% if perms_lacking or protected %}
+            <div class="grp-group">
+                {% if perms_lacking %}
+                    <h2>{% blocktrans with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktrans %}</h2>
+                    <ul class="grp-nested-list">
+                        {% for obj in perms_lacking %}
+                            <li>{{ obj }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                {% if protected %}
+                    <h2>{% blocktrans with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would require deleting the following protected related objects:{% endblocktrans %}</h2>
+                    <ul class="grp-nested-list">
+                        {% for obj in protected %}
+                            <li>{{ obj }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </div>
+        {% else %}
+            <div class="grp-group">
+                <h2>{% blocktrans with escaped_object=object %}Are you sure you want to delete the {{ object_name }} "{{ escaped_object }}"? All of the following related items will be deleted:{% endblocktrans %}</h2>
+                {% include "admin/includes/object_delete_summary.html" %}
+                {% if delete_confirmation_max_display is None or delete_confirmation_max_display > 0 %}
+                    <ul class="grp-nested-list">{{ deleted_objects|truncated_unordered_list:delete_confirmation_max_display }}</ul>
+                {% endif %}
+            </div>
+            <form action="" method="post" novalidate>{% csrf_token %}
+                <div class="grp-module grp-submit-row grp-fixed-footer">
+                    <ul>
+                        {% url opts|admin_urlname:'change' object.pk|admin_urlquote as object_url %}
+                        <li class="grp-float-left"><a href="{% add_preserved_filters object_url %}" class="grp-button grp-cancel-link">{% trans "No, take me back" %}</a></li>
+                        <li><input type="submit" value="{% trans "Yes, I’m sure" %}" class="grp-button grp-default" /></li>
+                    </ul>
+                    <input type="hidden" name="post" value="yes" />
+                    {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}
+                    {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}" />{% endif %}
+                </div>
+            </form>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/src/django_bpp/templates/admin/delete_selected_confirmation.html
+++ b/src/django_bpp/templates/admin/delete_selected_confirmation.html
@@ -1,5 +1,5 @@
 {% extends "admin/delete_selected_confirmation.html" %}
-{% load i18n admin_urls %}
+{% load i18n l10n admin_urls admin_filters %}
 
 <!-- BREADCRUMBS -->
 {% block breadcrumbs %}
@@ -9,4 +9,61 @@
         <li><a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a></li>
         <li>{% trans 'Delete multiple objects' %}</li>
     </ul>
+{% endblock %}
+
+{# Blok `content` skopiowany z grappelli 5.0.0 #}
+{# (admin/delete_selected_confirmation.html) z JEDNĄ różnicą: lista kasowanych #}
+{# obiektów idzie przez `truncated_unordered_list:delete_confirmation_max_display` #}
+{# zamiast `unordered_list`. Pełne uzasadnienie — patrz bliźniaczy komentarz #}
+{# w admin/delete_confirmation.html oraz `BaseBppAdminMixin` w bpp/admin/core.py. #}
+{# #}
+{# Tu obcinanie boli najbardziej: `delete_selected` na przefiltrowanej #}
+{# changeliście potrafi wciągnąć dziesiątki tysięcy obiektów zależnych. #}
+{% block content %}
+    <div class="g-d-c">
+        {% if perms_lacking or protected %}
+            <div class="grp-group">
+                {% if perms_lacking %}
+                    <h2>{% blocktrans %}Deleting the selected {{ objects_name }} would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktrans %}</h2>
+                    <ul class="grp-nested-list">
+                        {% for obj in perms_lacking %}
+                            <li>{{ obj }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                {% if protected %}
+                    <h2>{% blocktrans %}Deleting the selected {{ objects_name }} would require deleting the following protected related objects:{% endblocktrans %}</h2>
+                    <ul class="grp-nested-list">
+                        {% for obj in protected %}
+                            <li>{{ obj }}</li>
+                        {% endfor %}
+                     </ul>
+                {% endif %}
+            </div>
+        {% else %}
+            <div class="grp-group">
+                <h2>{% blocktrans %}Are you sure you want to delete the selected {{ objects_name }}? All of the following objects and their related items will be deleted:{% endblocktrans %}</h2>
+                {% include "admin/includes/object_delete_summary.html" %}
+                {% if delete_confirmation_max_display is None or delete_confirmation_max_display > 0 %}
+                    {% for deleteable_object in deletable_objects %}
+                        <ul class="grp-nested-list">{{ deleteable_object|truncated_unordered_list:delete_confirmation_max_display }}</ul>
+                    {% endfor %}
+                {% endif %}
+            </div>
+            <form action="" method="post" novalidate>{% csrf_token %}
+                <div id="submit" class="grp-module grp-submit-row grp-fixed-footer">
+                    {% for obj in queryset %}
+                        <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}" />
+                    {% endfor %}
+                    <input type="hidden" name="action" value="delete_selected" />
+                    <input type="hidden" name="post" value="yes" />
+                    <ul>
+                        <li class="grp-float-left"><a href="." class="grp-button grp-cancel-link">{% trans "Cancel" %}</a></li>
+                        <li><input type="submit" value="{% trans "Yes, I’m sure" %}" class="grp-button grp-default" /></li>
+                    </ul>
+                    <input type="hidden" name="post" value="yes" />
+                </div>
+            </form>
+        {% endif %}
+    </div>
 {% endblock %}


### PR DESCRIPTION
## Co i po co

Strona potwierdzenia kasowania w adminie enumeruje **każdy** obiekt, który
poleci kaskadą — jeden `<li>` z linkiem do zmiany na sztukę. Dla `Autor`,
`Zrodlo` czy masowego `delete_selected` na przefiltrowanej changeliście to
dziesiątki tysięcy pozycji: kilkanaście MB HTML-a, którego przeglądarka nie
renderuje sensownie, a człowiek i tak nie czyta.

Django 6.1 dorzuciło na to `ModelAdmin.delete_confirmation_max_display`.

## Co zbadałem w API Django 6.1 (zainstalowany kod, nie dokumentacja)

| Miejsce | Co robi |
|---|---|
| `admin/options.py:200` | `delete_confirmation_max_display = None` na `BaseModelAdmin` (czyli dotyczy też `InlineModelAdmin`). Domyślnie = bez limitu |
| `admin/options.py:2547` | `_delete_view` wkłada wartość do kontekstu strony pojedynczego kasowania |
| `admin/actions.py:73` | `delete_selected` wkłada ją do kontekstu strony akcji masowej — **tak, dotyczy `delete_selected`** |
| `admin/options.py:2765–2802` | inline'y: `hand_clean_DELETE` tnie listę `collector.protected` w komunikacie `ValidationError` (`islice` + „…and N more objects”); `None` → `sys.maxsize` |
| `admin/checks.py:828` | check `admin.E041`: musi być nieujemnym `int` albo `None` |
| `admin/templatetags/admin_filters.py:19` | **cała logika obcinania** siedzi w filtrze `truncated_unordered_list`. Idzie po zagnieżdżonej liście, renderuje pierwsze `max_items` pozycji i dokleja `<li>` „…and N more objects.”. `max_items=None` → bez limitu, `<= 0` → pusty string |
| szablony `admin/delete_confirmation.html`, `admin/delete_selected_confirmation.html` | wołają `\|truncated_unordered_list:delete_confirmation_max_display` na `deleted_objects`, `perms_lacking` i `protected`; sekcja „Objects” chowa się w całości przy wartości `0` |

**Wniosek, który zmienił kształt tej zmiany:** Django **tylko wkłada tę
wartość do kontekstu**. O obcięciu decyduje szablon. Sam atrybut jest
bezczynny, jeśli szablon nie zawoła filtra.

**Czego opcja NIE robi (istotne, żeby nie sprzedawać jej jako lekarstwa na
timeouty):** działa wyłącznie na etapie renderowania. `get_deleted_objects`
nadal zbiera i formatuje komplet obiektów — `NestedObjects.collect()`
+ `format_callback` z `reverse()` **per obiekt**. Zapytań do bazy ani
szczytowego zużycia pamięci po stronie Pythona to nie zmniejsza. Zyskiem jest
rozmiar odpowiedzi i to, że przeglądarka nie umiera na renderowaniu listy.

## Gdzie i dlaczego ustawiłem opcję

`BaseBppAdminMixin.delete_confirmation_max_display = 100` — **globalnie**, nie
punktowo na paru „ciężkich” adminach. Eksplozja listy nie bierze się z samego
modelu, tylko z ogona jego kaskad, a ten potrafi urosnąć po dodaniu jednego FK
w zupełnie innej aplikacji. Limit punktowy z definicji nie chroni tam, gdzie
nikt problemu nie przewidział. Mixin pokrywa adminy autora, jednostki, obu
wydawnictw, źródła, konferencji, serii, projektu, pracy doktorskiej.

Dlaczego 100:

* to wartość z przykładu w docstringu samego filtra Django
  (`{{ deleted_objects|truncated_unordered_list:100 }}`) — nie wymyślamy
  własnego standardu tam, gdzie upstream ma swój,
* to 2× `list_per_page` (50), więc cała strona changelisty zaznaczona do
  kasowania nadal wypisuje się co do sztuki,
* powyżej ~100 pozycji lista przestaje być narzędziem weryfikacji.

## Dlaczego trzeba było ruszyć szablony (sedno PR-a)

Aktywną skórką admina jest **grappelli**, i to ona — nie Django — wygrywa
rozwiązywanie nazwy szablonu. Sprawdzone na realnym łańcuchu loaderów:

```
admin/delete_confirmation.html
  1: src/django_bpp/templates/admin/delete_confirmation.html   (nadpisanie BPP)
  2: grappelli/templates/admin/delete_confirmation.html        ← ta renderuje
  3: django/contrib/admin/templates/admin/delete_confirmation.html
```

Szablony grappelli 5.0.0 renderują listę przez `|unordered_list` (bez
obcinania). **Sam atrybut nie zmieniłby w BPP niczego.** Dlatego oba
nadpisania BPP przejmują blok `content` (grappelli trzyma tam całą treść
i nie wystawia mniejszego bloku, w który dałoby się wejść punktowo) i wołają
filtr obcinający. Blok jest skopiowany z grappelli 5.0.0 z **jedną** różnicą —
zamianą filtra; komentarz w szablonie mówi, żeby przy podbijaniu grappelli
porównać go z oryginałem (albo skasować nadpisanie, gdy grappelli samo zacznie
obcinać).

Świadome odstępstwa od szablonów upstreamu:

* **`protected` i `perms_lacking` renderujemy BEZ obcinania.** W BPP ta lista
  niesie ręcznie pisane komunikaty (`JednostkaAdmin.get_deleted_objects`
  dokłada je na **końcu**), więc obcięcie ukryłoby dokładnie tę informację, po
  którą użytkownik na tę stronę przyszedł.
* Sekcja „Podsumowanie” (`model_count`) zostaje nietknięta — pełne liczniki per
  model są **nad** listą, więc obcięcie zabiera tylko wyliczankę pojedynczych
  obiektów, a nie wiedzę o skali kasowania. To jest cała przesłanka, dla której
  obcinanie jest bezpieczne.

## Jak to się ma do `JednostkaAdmin.get_deleted_objects`

**Nie koliduje.** Nadpisanie w `jednostka.py` woła `super().get_deleted_objects()`
i dokłada wpisy do listy `protected` — działa więc po stronie **danych**, przed
renderowaniem. Nowa opcja żyje wyłącznie po stronie **szablonu**. Nie ma
ścieżki, którą jedno omijałoby drugie.

Co więcej, obcinanie i tak by tej bramki nie tknęło: gdy jednostka jest
niepusta, szablon idzie gałęzią `protected` (której nie obcinamy), a gdy jest
pusta — lista obiektów zależnych jest z definicji krótka. Test
`test_lista_blokad_nie_jest_obcinana` przybija to gwoździem (limit ustawiony
na 1, komunikat BPP nadal widoczny).

## Testy

Nowy plik `src/bpp/tests/test_admin/test_delete_confirmation_max_display.py`
(10 testów, wzorowany na `test_fetch_peers.py`). Testy idą **przez klienta
HTTP, na realnym łańcuchu szablonów** — asercja na samym atrybucie
przechodziłaby również wtedy, gdyby ktoś skasował nadpisania szablonów, a
strona dalej wypisywałaby wszystko.

* `test_opcja_przechodzi_walidacje_django` (×4 modele) — checki admina, brak `admin.E041`
* `test_wartosc_limitu_jest_ta_udokumentowana` — 100 i propagacja przez mixin
* `test_lista_obiektow_zaleznych_jest_obcinana` — realna strona pokazuje mniej
  obiektów, niż jest do skasowania, i mówi ile ukryła
* `test_bez_limitu_lista_jest_pelna` — kontrola negatywna (`None` = zachowanie sprzed 6.1)
* `test_podsumowanie_pokazuje_pelne_liczniki` — `model_count` nietknięty
* `test_kasowanie_masowe_tez_obcina` — drugi, osobny szablon (`delete_selected`)
* `test_lista_blokad_nie_jest_obcinana` — `protected` z komunikatem BPP przeżywa limit 1

Komunikat „…i N innych obiektów” wykrywam wzorcem zbudowanym z `ngettext`, a
nie tekstem na sztywno — test nie pęknie, gdy Django dorzuci polskie
tłumaczenie tego (nowego w 6.1) stringa.

**Wyniki lokalnie:**

* nowy plik: **10 passed**
* `src/bpp/tests/test_admin/`: **653 passed**
* `-k "jednostka or kasowanie or delete"`: **311 passed**
* pełna suita (bez `src/integration_tests`): **9442 passed, 5 skipped** (6:29)
* `pre-commit` (bez argumentów): zielony

Przy okazji: djLint wywalił się na odziedziczonym po grappelli literówkowym
`</lI>` w breadcrumbach `delete_confirmation.html` — poprawione na `</li>`.

## Newsfragment

`src/bpp/newsfragments/delete-confirmation-max-display.feature.rst`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F134BWb3YoYPQ6zjzqoqds
