### PR TITLE
Podnieś floor h2 do >=4.4.1 (CVE-2026-71554)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,9 +253,12 @@ environments = ["python_version >= '3.10' and python_version < '3.15' and platfo
 #                     CVE-2026-54531, GHSA-jm82-fx9c-mx94
 #   pyasn1  >=0.6.4  (via pyasn1-modules/python-ldap) - PYSEC-2026-3455,
 #                     PYSEC-2026-3456, PYSEC-2026-3457 (audyt: lipiec 2026)
+#   h2      >=4.4.1  (via twisted[http2]/daphne)      - CVE-2026-71554
+#                     (audyt: sierpien 2026)
 constraint-dependencies = [
     "bleach>=6.4.0",
     "daphne>=4.2.2",
+    "h2>=4.4.1",
     "pyasn1>=0.6.4",
     "pypdf>=6.13.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,7 @@ supported-markers = [
 constraints = [
     { name = "bleach", specifier = ">=6.4.0" },
     { name = "daphne", specifier = ">=4.2.2" },
+    { name = "h2", specifier = ">=4.4.1" },
     { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pypdf", specifier = ">=6.13.3" },
 ]
@@ -2828,24 +2829,24 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.3.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack", marker = "platform_python_implementation != 'PyPy'" },
     { name = "hyperframe", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]
 name = "hpack"
-version = "4.1.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Co i dlaczego

`h2` 4.3.0 ma **CVE-2026-71554**, poprawione w 4.4.1. Pakiet przychodzi tranzytywnie przez `twisted[http2]`/`daphne`, więc floor trafia do istniejącej sekcji `constraint-dependencies` — tej samej, która trzyma już minima dla `bleach`, `daphne`, `pyasn1` i `pypdf`.

## Skąd to wyszło

Podatność wykryta przy pracach nad gałęzią `django-6.1`: tam `pip-audit` na PR-ze ją zgłosił i floor już wszedł. Na `dev` siedzi od publikacji CVE i jest niewidoczna **wyłącznie dlatego, że `dev` nie miał od tego czasu przebiegu `pip-audit`** — pierwszy taki przebieg by ją zatrzymał. Ten PR go zresztą wywoła.

## Zakres zmiany w locku

Audytowalny co do pakietu:

| Pakiet | Było | Jest |
|---|---|---|
| `h2` | 4.3.0 | 4.4.1 |
| `hpack` | 4.1.0 | 4.2.0 |

Żadnego innego pakietu diff nie dotyka — sprawdzone porównaniem wpisów `version` w `uv.lock`.

## Weryfikacja

`uv lock` rozwiązuje czysto (367 pakietów), `pre-commit` zielony. Testów nie uruchamiałem lokalnie — to floor zależności tranzytywnej, a pełną suitę i tak przepuści CI tego PR-a.