### PR TITLE
chore(deps): pytest-testcontainers{,-django} 0.3.1 — kontenery niszczone od reki przy SIGTERM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -524,8 +524,15 @@ dev = [
     # przestaje byc potrzebne. Konfiguracja w [tool.pytest-testcontainers-django].
     # 0.2.2 / 0.2.5: from_env() honoruje aktywny `docker context`, wiec stack
     # startuje na OrbStack / colima / Docker Desktop bez recznego DOCKER_HOST.
-    "pytest-testcontainers>=0.2.2",
-    "pytest-testcontainers-django>=0.2.5",
+    # 0.3.0: kontenery sa niszczone od reki takze przy SIGTERM/SIGHUP (wczesniej
+    # tylko pytest_unconfigure + atexit, wiec ubicie zawieszonego pytesta
+    # zostawialo je Ryukowi na ~10 s — albo na zawsze, gdy w miedzyczasie
+    # restartowal sie demon Dockera). Ryuk jest teraz zamykany razem z sesja
+    # zamiast wisiec ~60 s po niej, a `--testcontainers-clean` szuka po etykiecie
+    # org.testcontainers=true, wiec zastepuje `make clean-testcontainers`.
+    # SIGKILL nadal spada na Ryuka — tego nie da sie przechwycic.
+    "pytest-testcontainers>=0.3.1",
+    "pytest-testcontainers-django>=0.3.1",
     # django-run-site: CLI orchestrator dev stack-u. Dawniej `manage.py run_site`
     # + helpery w `_run_site_helpers/`. Instalowany w dev-deps zeby `uv run run-site`
     # mialo dostep do CLI bez globalnego `uv tool install`. Konfiguracja: runsite.toml.

--- a/uv.lock
+++ b/uv.lock
@@ -713,8 +713,8 @@ dev = [
     { name = "pytest-repeat", specifier = ">=0.9.4" },
     { name = "pytest-rerunfailures", specifier = ">=16.4" },
     { name = "pytest-split", specifier = ">=0.9.0" },
-    { name = "pytest-testcontainers", specifier = ">=0.2.2" },
-    { name = "pytest-testcontainers-django", specifier = ">=0.2.5" },
+    { name = "pytest-testcontainers", specifier = ">=0.3.1" },
+    { name = "pytest-testcontainers-django", specifier = ">=0.3.1" },
     { name = "pytest-timeout", specifier = ">=2.1.0" },
     { name = "pytest-tqdm", specifier = ">=0.4.0" },
     { name = "pytest-xdist", specifier = ">=2.3.0" },
@@ -4761,21 +4761,21 @@ wheels = [
 
 [[package]]
 name = "pytest-testcontainers"
-version = "0.2.2"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docker", marker = "platform_python_implementation != 'PyPy'" },
     { name = "pytest", marker = "platform_python_implementation != 'PyPy'" },
     { name = "testcontainers", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/ab/e71331e7ed6ecfd87755bd17c0b79462ca50f5e6b52592432b47d1fd9cfc/pytest_testcontainers-0.2.2.tar.gz", hash = "sha256:8df25594dc022773d4cbb4ee78f99810b0b3ae1ad9b5c0dea731e45ac85311db", size = 37465, upload-time = "2026-06-29T14:29:04.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/ba/ed37243f066980a11621094553f68bb0999ad7717a04d670b918a0d4b0be/pytest_testcontainers-0.3.1.tar.gz", hash = "sha256:23ca03a4549144e0c58d4027ad31d54aac2662d9f243717b25a477b975296031", size = 56642, upload-time = "2026-08-07T14:44:26.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/20/f26e05d45ef12fc00ee03b3df37d73579cb6ec2c1b971abf950bb028e1cd/pytest_testcontainers-0.2.2-py3-none-any.whl", hash = "sha256:055eb2f76b74fd4ddd0a2acfb866eb07e7373cc79c8025b7cd88b6dec70cce2e", size = 33922, upload-time = "2026-06-29T14:29:03.181Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/885bd7afd0fff12d77a15609c03a0f0a36bf9d2dfe4edda7efcabcfb4517/pytest_testcontainers-0.3.1-py3-none-any.whl", hash = "sha256:b9ef03e8f86296b8c51d7b9f4b749fec45f26f897490f6226a36564c42e86a14", size = 38244, upload-time = "2026-08-07T14:44:25.536Z" },
 ]
 
 [[package]]
 name = "pytest-testcontainers-django"
-version = "0.2.5"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest", marker = "platform_python_implementation != 'PyPy'" },
@@ -4783,9 +4783,9 @@ dependencies = [
     { name = "pytest-testcontainers", marker = "platform_python_implementation != 'PyPy'" },
     { name = "testcontainers", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/1d/f4ab596c6ec7606dcfb2ad6a27e2ff18044ff7beabef48cf88610df4d42d/pytest_testcontainers_django-0.2.5.tar.gz", hash = "sha256:f4d20576ea0826224307e06b102b44d504881eef65acbacc3ac2a50328625e4f", size = 30776, upload-time = "2026-06-29T14:32:45.311Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/71/72c7531f55eacf4289d4697335218d84d6cdaba95d6ebf4046ecc5dcf3f3/pytest_testcontainers_django-0.3.1.tar.gz", hash = "sha256:a4a9cdc2fe6aa92eee939edf2cfa3a0f927ff890a8a91e0140ad70d33cf6da6c", size = 34891, upload-time = "2026-08-07T14:45:40.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/8d/bfb0ab62e418ec2b6e48ebaf517b6d0617554e79f3b64a550c4a9231c323/pytest_testcontainers_django-0.2.5-py3-none-any.whl", hash = "sha256:db3087bca07d9b3dfd7df53776aabd8b6ebc7e1eb3cae936e0b850e10523dcc9", size = 23697, upload-time = "2026-06-29T14:32:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ce/cd297aef437af881e0c32e91abe43f20ac63b4714173da3c186b803ea3c2/pytest_testcontainers_django-0.3.1-py3-none-any.whl", hash = "sha256:91c322b52631350ee524abbf7678f4d314c8b0d5d195002be8974946caa43a2d", size = 24993, upload-time = "2026-08-07T14:45:39.615Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Po co

Kontenery testcontainers regularnie przezywaly przebieg pytesta i wisialy godzinami, obciazajac maszyne deweloperska. Sprzatal je dopiero Ryuk — albo nikt, gdy w miedzyczasie zrestartowal sie demon Dockera. Stad kontenery `bpp_iplweb-tc-*` w stanie `Exited (255)` sprzed tygodni.

Przyczyna byla w pluginach: teardown wisial wylacznie na `pytest_unconfigure` + `atexit`, a zaden z nich nie odpala sie na `SIGTERM`/`SIGHUP`. Ubicie zawieszonego pytesta zostawialo Postgresa Ryukowi.

## Co daje 0.3.1

* **Teardown na SIGTERM/SIGHUP**, uzbrajany *przed* startem kontenera — a nie po powrocie z `.start()`. To istotne wlasnie tutaj: `.start()` blokuje do konca ladowania `baseline.sql`, czyli kilkanascie sekund, i to jest dokladnie ten moment, w ktorym siega sie po `kill`.
* **Ryuk zamykany razem z sesja** zamiast wisiec ~60 s po niej.
* **Kontenery efemeryczne maja nazwy** `bpp_iplweb-tc-<serwis>-<branch>-<hash>-<worker>-<rand>` zamiast losowych dockerowych (`goofy_torvalds`) — widac, z ktorego przebiegu pochodza.
* **`pytest --testcontainers-clean`** szuka po etykiecie `org.testcontainers=true`, nie tylko po prefiksie nazwy, wiec zastepuje `make clean-testcontainers`. Wariant `--testcontainers-clean-project` ogranicza sie do tego projektu — uzywaj go, gdy na maszynie moze biec rownolegly przebieg.

## Weryfikacja

* Pelny `src/bpp/tests`: **3040 passed, 2 skipped** (9:47).
* SIGTERM w trakcie ladowania `baseline.sql` na tej suicie: Postgres i Ryuk znikaja w **2 s**, przy `RYUK_RECONNECTION_TIMEOUT=120s` — wiec sprzatal plugin, nie Ryuk. Przed zmiana kontener przezywal 20+ s.

## Czego to NIE naprawia

* `kill -9` — nieprzechwytywalny z procesu, nadal spada na Ryuka (~10 s).
* Tryb reuse (`PYTEST_TESTCONTAINERS_REUSE=1`) — nadal zostawia pare PG+Redis na kazdy branch i worktree, bez wygasania i z wylaczonym Ryukiem. To osobny temat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wyCfXDnQykz9BoAXvNTfj