### PR TITLE
chore(security): js-yaml ^4.3.1 (2× HIGH, algorithmic complexity DoS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "resolutions": {
         "jquery": "^3.7.1",
         "minimatch": "^3.1.2",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.1",
         "esbuild": "^0.28.1"
     },
     "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,6 +255,17 @@ environments = ["python_version >= '3.10' and python_version < '3.15' and platfo
 #                     PYSEC-2026-3456, PYSEC-2026-3457 (audyt: lipiec 2026)
 #   h2      >=4.4.1  (via twisted[http2]/daphne)      - CVE-2026-71554
 #                     (audyt: sierpien 2026)
+#
+# CELOWO NIEPODNIESIONE (nie dopisuj bez przeczytania tego):
+#   setuptools >=83.0.0 - CVE-2026-59890 (dependabot alert #326, medium).
+#     Bump JEST BREAKING: setuptools 83 usunal `pkg_resources`, a `pyoai`
+#     (direct dep, ==2.5.0) importuje go na poziomie modulu w oaipmh/common.py
+#     -> `manage.py check` sie wywala. Sprawdzone empirycznie: sierpien 2026.
+#     Jednoczesnie ekspozycja jest zerowa: CVE dotyczy WYLACZNIE budowania
+#     sdist z regulami MANIFEST.in, a sdist buduje sie w izolowanym srodowisku
+#     PEP 517 z `[build-system].requires`, gdzie mamy juz setuptools>=83.0.0.
+#     Alert wisi na uv.lock, czyli na setuptools *runtime*, ktory nigdy nic
+#     nie buduje. Odblokowanie wymaga wymiany/zalatania pyoai (nieutrzymywany).
 constraint-dependencies = [
     "bleach>=6.4.0",
     "daphne>=4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2739,10 +2739,10 @@ js-tokens@^9.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.1.tgz#2ec43964658435296f6761b34e10671c2d9527f4"
   integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
 
-js-yaml@^4.2.0, js-yaml@~3.14.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+js-yaml@^4.3.1, js-yaml@~3.14.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Zamyka dwa alerty dependabota klasy **HIGH** (oba CVSS 7.5) i dokumentuje, dlaczego trzeci **nie** zostaje naprawiony.

## Naprawione: js-yaml 4.2.0 → 4.3.1

| alert | GHSA | problem |
|---|---|---|
| #330 | `GHSA-52cp-r559-cp3m` (CVE-2026-59869) | łańcuch merge-keys (`<<: *anchor`) wymusza kwadratowe zużycie CPU przy liniowo rosnącym wejściu |
| #343 | `GHSA-5p4m-2wfm-xmqj` | `resolveYamlOmap()` sprawdza unikalność kluczy przez `objectKeys.indexOf()` wewnątrz pętli po elementach → `!!omap` jest O(n²); fix z 3.x nie został zbackportowany do 4.x |

To podatności typu *algorithmic complexity* — nie wykonanie kodu, tylko czysty wektor DoS. Stąd CVSS 7.5 mimo braku RCE.

Pakiet jest tranzytywny (`grunt`, `foundation-sites`, `jsdom`), ale `package.json` ma już sekcję `resolutions` z pinem `js-yaml` — podniesienie `^4.2.0` → `^4.3.1` wystarcza. Zostajemy na linii 4.x (npm ma już 5.2.3), bo advisory wskazuje 4.3.1 jako wersję załataną, a bump majora ruszyłby toolchain builda.

## Świadomie NIE naprawione: setuptools (#326, CVE-2026-59890, medium)

Bump do 83.0.0 **jest breaking**: setuptools 83 usunął `pkg_resources`, a `pyoai` (zależność bezpośrednia, `==2.5.0`) importuje go na poziomie modułu w `oaipmh/common.py`. Sprawdzone empirycznie — `manage.py check` przestaje przechodzić:

```
File ".../oaipmh/common.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Jednocześnie **ekspozycja jest zerowa**: CVE dotyczy wyłącznie budowania sdist z regułami `MANIFEST.in`, a sdist buduje się w izolowanym środowisku PEP 517 z `[build-system].requires`, gdzie `pyproject.toml` **już** ma `setuptools>=83.0.0`. Alert wisi na `uv.lock`, czyli na setuptools *runtime*, który nigdy niczego nie buduje.

Powód zapisany w `pyproject.toml` obok `constraint-dependencies`, żeby następna osoba nie dopisała tego floora w dobrej wierze i nie zepsuła aplikacji. Odblokowanie wymaga wymiany albo załatania `pyoai` (nieutrzymywany).

## Weryfikacja lokalna

- `make assets` → exit 0
- `yarn test:js` → **81/81 passed** (8 plików)
- `manage.py check` → *System check identified no issues (4 silenced)*
- `pre-commit` → wszystko Passed (w tym `uv-lock`, więc `uv.lock` jest spójny — zmiana w `pyproject.toml` to sam komentarz)

Bez newsfragmentu, zgodnie z precedensem `9b2fabd0e` (floor bumpy bezpieczeństwa nie są widoczne dla użytkownika).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vjeDgH27F3x6qv4kbcDN9