### PR TITLE
fix(oidc): logowanie przez Keycloak na istniejące konto — zaufanie po domenie instytucjonalnej

### DIFF
--- a/src/django_bpp/settings/base.py
+++ b/src/django_bpp/settings/base.py
@@ -1411,6 +1411,16 @@ if "oidc_integration" not in INSTALLED_APPS:
 # Defaulty bezpieczne również dla instalacji bez OIDC.
 OIDC_REQUIRE_EMAIL_VERIFIED = (_OIDC_CONFIG or {}).get("require_email_verified", True)
 OIDC_GRACE_BIND_ENABLED = (_OIDC_CONFIG or {}).get("grace_bind", False)
+# Domeny, dla których adres z instytucjonalnego claimu (`mail`) jest wiarygodny
+# bez oglądania się na `email_verified` — ten flag dotyczy claimu `email`, a ten
+# w realmach LDAP-owych bywa adresem PRYWATNYM (patrz a2124bf34). Pusta lista =
+# bramka wyłączona, zachowanie jak dotąd.
+OIDC_TRUSTED_EMAIL_DOMAINS = (_OIDC_CONFIG or {}).get("trusted_email_domains", ())
+# Pozwól grace-bindowi związać konto Z UPRAWNIENIAMI (is_staff/superuser, grupy,
+# uprawnienia, token PBN, hasło lokalne). Działa WYŁĄCZNIE dla adresu zaufanego
+# po domenie — sam ten flag, bez OIDC_TRUSTED_EMAIL_DOMAINS, jest no-opem
+# (blokada wzajemna, żeby nie dało się tego otworzyć przez przypadek).
+OIDC_GRACE_BIND_PRIVILEGED = (_OIDC_CONFIG or {}).get("grace_bind_privileged", False)
 
 if _OIDC_CONFIG:
     OIDC_OP_ISSUER = _OIDC_CONFIG["issuer"]

--- a/src/oidc_integration/backends.py
+++ b/src/oidc_integration/backends.py
@@ -34,6 +34,16 @@ def _username_claim_keys():
     )
 
 
+def _trusted_email_domains():
+    """Domeny uznane za instytucjonalne (settings → pusta krotka).
+
+    Pusta krotka = bramka wyłączona: żaden adres nie dostaje zaufania tą
+    drogą i obowiązuje wyłącznie reguła historyczna (``email_verified``).
+    """
+    raw = getattr(settings, "OIDC_TRUSTED_EMAIL_DOMAINS", None) or ()
+    return tuple(str(d).strip().lstrip("@").lower() for d in raw if str(d).strip())
+
+
 def _first_claim(claims, keys):
     """Pierwsza niepusta wartość claimu z ``keys`` (albo ``None``)."""
     for key in keys:
@@ -176,6 +186,22 @@ class BppOIDCBackend(OIDCAuthenticationBackend):
         """Cienki wrapper (wsteczna zgodność) — sam adres, bez źródła."""
         return cls._resolve_email_with_source(claims)[0]
 
+    @staticmethod
+    def _domain_trusted(email):
+        """Czy domena adresu jest na liście ``OIDC_TRUSTED_EMAIL_DOMAINS``.
+
+        Dopasowanie DOKŁADNE (case-insensitive), bez wieloznaczników i bez
+        obejmowania subdomen: ``student-afm.edu.pl`` trzeba wypisać osobno,
+        obok ``uafm.edu.pl``. Świadomie — lista domen jest jedyną bramką
+        chroniącą wiązanie kont uprzywilejowanych, więc nie chcemy w niej
+        reguł, które łatwo napisać szerzej, niż się zamierzało.
+        """
+        domains = _trusted_email_domains()
+        if not domains:
+            return False
+        _, _, domain = (email or "").rpartition("@")
+        return bool(domain) and domain.lower() in domains
+
     @classmethod
     def _normalized(cls, claims):
         """Zwróć claimy z kanonicznym ``email`` + anotacją zaufania i ``iss``.
@@ -187,20 +213,33 @@ class BppOIDCBackend(OIDCAuthenticationBackend):
 
         * ``email`` — kanoniczny adres (patrz ``_resolve_email_with_source``),
         * ``email_verified`` — znormalizowany bool z payloadu/userinfo,
-        * ``_bpp_email_trusted`` — czy adresowi wolno ufać przy fail-closed:
+        * ``_bpp_email_domain_trusted`` — adres pochodzi z właściwego claimu
+          (nie z fallbacku ``preferred_username``), a jego domena jest na liście
+          ``OIDC_TRUSTED_EMAIL_DOMAINS``. Zaufanie płynie wtedy z katalogu
+          instytucji, nie z ``email_verified``,
+        * ``_bpp_email_trusted`` — czy adresowi wolno ufać przy fail-closed.
+          Prawda, gdy zachodzi zaufanie po domenie ALBO (reguła historyczna)
           ``email_verified is True`` ORAZ adres pochodzi z właściwego claimu
-          (nie z fallbacku ``preferred_username``) ORAZ równa się poświadczonemu
-          claimowi ``email`` (``email_verified`` dotyczy tego właśnie claimu),
+          ORAZ równa się poświadczonemu claimowi ``email``.
+
+          Reguła historyczna sama w sobie jest niespełnialna w realmie, dla
+          którego ustawiono mail-first (``a2124bf34``): wymaga równości adresu
+          instytucjonalnego (``mail``) z prywatnym (``email``). Dlatego
+          instalacje takie jak UAFM muszą wskazać domeny jawnie,
         * ``iss`` — issuer bez końcowego ``/`` (do dopasowania po ``(iss, sub)``).
         """
         email, from_fallback = cls._resolve_email_with_source(claims)
         verified = bool(claims.get("email_verified") is True)
         payload_email = (claims.get("email") or "").lower()
-        trusted = verified and not from_fallback and email.lower() == payload_email
+        domain_trusted = not from_fallback and cls._domain_trusted(email)
+        trusted = domain_trusted or (
+            verified and not from_fallback and email.lower() == payload_email
+        )
         iss = (claims.get("iss") or "").rstrip("/")
         out = dict(claims)
         out["email"] = email
         out["email_verified"] = verified
+        out["_bpp_email_domain_trusted"] = domain_trusted
         out["_bpp_email_trusted"] = trusted
         out["iss"] = iss
         return out
@@ -439,7 +478,8 @@ class BppOIDCBackend(OIDCAuthenticationBackend):
         adresie może zostać JEDNORAZOWO związane z ``sub`` — ale tylko gdy jest
         „czysto-OIDC" i niskiego ryzyka:
 
-        * ``_bpp_email_trusted`` (email_verified + zgodny adres),
+        * ``_bpp_email_trusted`` (email_verified + zgodny adres ALBO zaufana
+          domena instytucjonalna),
         * dokładnie jedno konto z tym adresem,
         * bez ``is_staff``/``is_superuser``, aktywne,
         * bez używalnego hasła lokalnego (logowanie tylko przez OIDC),
@@ -449,6 +489,19 @@ class BppOIDCBackend(OIDCAuthenticationBackend):
         Każdy z tych warunków chroni przed przejęciem konta o realnych
         uprawnieniach. Zwraca związane konto albo ``None`` (→ normalny tor
         create_user / fail-closed). Domyślnie wyłączone.
+
+        **Tryb uprzywilejowany** (``OIDC_GRACE_BIND_PRIVILEGED``): powyższe
+        warunki „niskiego ryzyka" ustępują, gdy adres jest zaufany PO DOMENIE
+        (``_bpp_email_domain_trusted``) — wtedy wolno związać także konto
+        ``is_staff``/superusera, z grupami, uprawnieniami, tokenem PBN i
+        hasłem lokalnym. Rolę zabezpieczenia przejmuje wtedy w całości lista
+        ``OIDC_TRUSTED_EMAIL_DOMAINS`` plus założenie, że użytkownik nie może
+        samodzielnie zmienić sobie adresu w katalogu instytucji. Bez listy
+        domen flag jest no-opem. Zostaje wymóg pojedynczego konta z danym
+        adresem, aktywności oraz braku tożsamości W TYM SAMYM realmie — konto
+        związane już z innym ``sub`` tego issuera nie da się „przejąć",
+        natomiast powiązanie z innego realmu nie przeszkadza (świadomie: pod
+        wiele realmów można dołożyć kolejne powiązanie, tak jak w profilu).
         """
         if not getattr(settings, "OIDC_GRACE_BIND_ENABLED", False):
             return None
@@ -463,16 +516,25 @@ class BppOIDCBackend(OIDCAuthenticationBackend):
         if qs.count() != 1:
             return None
         user = qs.first()
-        eligible = (
-            not user.is_staff
-            and not user.is_superuser
-            and user.is_active
-            and not user.has_usable_password()
-            and not user.groups.exists()
-            and not user.user_permissions.exists()
-            and not (user.pbn_token or "")
-            and not user.oidc_identities.exists()
-        )
+        privileged = getattr(
+            settings, "OIDC_GRACE_BIND_PRIVILEGED", False
+        ) and claims.get("_bpp_email_domain_trusted")
+        if privileged:
+            eligible = (
+                user.is_active
+                and not user.oidc_identities.filter(issuer=issuer).exists()
+            )
+        else:
+            eligible = (
+                not user.is_staff
+                and not user.is_superuser
+                and user.is_active
+                and not user.has_usable_password()
+                and not user.groups.exists()
+                and not user.user_permissions.exists()
+                and not (user.pbn_token or "")
+                and not user.oidc_identities.exists()
+            )
         if not eligible:
             return None
         try:

--- a/src/oidc_integration/conf.py
+++ b/src/oidc_integration/conf.py
@@ -87,6 +87,23 @@ def _get_claim_list(environ, field, skrot, default):
     return items or tuple(default)
 
 
+def _get_domain_list(environ, field, skrot):
+    """Rozwiąż listę domen e-mail (CSV) wg precedencji prefiks-skrót > bare.
+
+    Normalizuje wpisy operatora: obcina białe znaki, wiodącą ``@`` (naturalne
+    jest wpisać ``@uafm.edu.pl``) i sprowadza do małych liter — porównanie
+    domen jest case-insensitive. Brak/pusto → pusta krotka (bramka wyłączona).
+    """
+    raw = _get(environ, field, skrot)
+    if not raw:
+        return ()
+    return tuple(
+        part.strip().lstrip("@").lower()
+        for part in raw.split(",")
+        if part.strip().lstrip("@")
+    )
+
+
 def _keycloak_endpoints(issuer):
     """Wyprowadź endpointy z URL issuera konwencją Keycloaka.
 
@@ -151,9 +168,10 @@ def discover_oidc_config(environ=None):
     Zwracany słownik: ``client_id``, ``client_secret``, ``issuer``, ``skrot``
     (może być ``None``), ``endpoints`` (dict z 4 adresami), ``email_claims`` i
     ``username_claims`` (krotki nazw claimów wg preferencji),
-    ``require_email_verified`` (bool, default ``True``) oraz ``grace_bind``
-    (bool, default ``False``). ``None`` oznacza brak kompletu — aplikacja OIDC
-    ma się wtedy w ogóle nie aktywować.
+    ``require_email_verified`` (bool, default ``True``), ``grace_bind``
+    (bool, default ``False``), ``trusted_email_domains`` (krotka domen, default
+    pusta) oraz ``grace_bind_privileged`` (bool, default ``False``). ``None``
+    oznacza brak kompletu — aplikacja OIDC ma się wtedy w ogóle nie aktywować.
     """
     environ = os.environ if environ is None else environ
     skrot = _detect_skrot(environ)
@@ -175,4 +193,10 @@ def discover_oidc_config(environ=None):
         environ, "REQUIRE_EMAIL_VERIFIED", skrot, default=True
     )
     config["grace_bind"] = _get_bool(environ, "GRACE_BIND", skrot, default=False)
+    config["trusted_email_domains"] = _get_domain_list(
+        environ, "TRUSTED_EMAIL_DOMAINS", skrot
+    )
+    config["grace_bind_privileged"] = _get_bool(
+        environ, "GRACE_BIND_PRIVILEGED", skrot, default=False
+    )
     return config

--- a/src/oidc_integration/tests/test_backends.py
+++ b/src/oidc_integration/tests/test_backends.py
@@ -951,3 +951,182 @@ def test_filter_excludes_inactive_account(db):
     b = _backend()
     claims = {"sub": "S1", "iss": "https://kc", "email": "jan@x.pl"}
     assert list(b.filter_users_by_claims(claims)) == []
+
+
+# --- Zaufanie po domenie instytucjonalnej (realm UAFM) ---
+#
+# Realm UAFM trzyma adres instytucjonalny w `mail`, a PRYWATNY w `email`
+# (patrz a2124bf34). Stara reguła zaufania wymagała `email == payload_email`,
+# czyli równości instytucjonalnego z prywatnym — w tym realmie niespełnialnej.
+
+UAFM_ISS = "https://auth.uafm.edu.pl/auth/realms/KA"
+
+
+def _uafm_claims(**extra):
+    claims = {
+        "sub": "P1",
+        "iss": UAFM_ISS,
+        "mail": "profesor@uafm.edu.pl",
+        "email": "prywatny@gmail.com",
+        "email_verified": True,
+        "preferred_username": "profesor",
+    }
+    claims.update(extra)
+    return claims
+
+
+@override_settings(OIDC_TRUSTED_EMAIL_DOMAINS=["uafm.edu.pl"])
+def test_domena_czyni_email_zaufanym_mimo_prywatnego_email_claimu():
+    out = _backend()._normalized(_uafm_claims())
+    assert out["email"] == "profesor@uafm.edu.pl"
+    assert out["_bpp_email_domain_trusted"] is True
+    assert out["_bpp_email_trusted"] is True
+
+
+def test_bez_listy_domen_realm_uafm_nie_jest_zaufany():
+    # Regresja: udokumentowanie stanu sprzed poprawki.
+    out = _backend()._normalized(_uafm_claims())
+    assert out["_bpp_email_trusted"] is False
+
+
+@override_settings(OIDC_TRUSTED_EMAIL_DOMAINS=["uafm.edu.pl"])
+def test_domena_spoza_listy_nie_daje_zaufania():
+    out = _backend()._normalized(_uafm_claims(mail="ktos@obca.pl"))
+    assert out["_bpp_email_domain_trusted"] is False
+    assert out["_bpp_email_trusted"] is False
+
+
+@override_settings(OIDC_TRUSTED_EMAIL_DOMAINS=["uafm.edu.pl"])
+def test_domena_porownywana_bez_wzgledu_na_wielkosc_liter():
+    out = _backend()._normalized(_uafm_claims(mail="Profesor@UAFM.Edu.PL"))
+    assert out["_bpp_email_domain_trusted"] is True
+
+
+@override_settings(OIDC_TRUSTED_EMAIL_DOMAINS=["student-afm.edu.pl"])
+def test_domena_nie_ufa_adresowi_z_preferred_username():
+    # Adres z fallbacku (UPN) pozostaje niezaufany — niezmiennik sprzed zmiany.
+    claims = {
+        "sub": "S1",
+        "iss": UAFM_ISS,
+        "preferred_username": "99999@student-afm.edu.pl",
+    }
+    out = _backend()._normalized(claims)
+    assert out["email"] == "99999@student-afm.edu.pl"
+    assert out["_bpp_email_domain_trusted"] is False
+    assert out["_bpp_email_trusted"] is False
+
+
+@override_settings(OIDC_TRUSTED_EMAIL_DOMAINS=["uafm.edu.pl"])
+def test_domena_zaufana_nie_wymaga_email_verified():
+    # `email_verified` dotyczy prywatnego claimu `email` — dla adresu z
+    # katalogu instytucjonalnego jest nieadekwatne, więc nie blokuje.
+    out = _backend()._normalized(_uafm_claims(email_verified=False))
+    assert out["_bpp_email_trusted"] is True
+
+
+# --- Wiązanie kont uprzywilejowanych (grace bind privileged) ---
+
+
+def _privileged_settings(settings):
+    settings.OIDC_GRACE_BIND_ENABLED = True
+    settings.OIDC_GRACE_BIND_PRIVILEGED = True
+    settings.OIDC_TRUSTED_EMAIL_DOMAINS = ["uafm.edu.pl"]
+
+
+def test_grace_wiaze_konto_staff_gdy_domena_zaufana(db, settings):
+    _privileged_settings(settings)
+    u = baker.make("bpp.BppUser", email="profesor@uafm.edu.pl", is_staff=True)
+    u.set_unusable_password()
+    u.save()
+    b = _backend()
+    out = b._try_grace_bind(b._normalized(_uafm_claims()))
+    assert out == u
+    assert u.oidc_identities.filter(issuer=UAFM_ISS, sub="P1").exists()
+
+
+def test_grace_wiaze_superusera_z_grupami_uprawnieniami_i_pbn(db, settings):
+    _privileged_settings(settings)
+    u = baker.make(
+        "bpp.BppUser",
+        email="profesor@uafm.edu.pl",
+        is_staff=True,
+        is_superuser=True,
+        # Wartości bez znaczenia — liczy się tylko to, że pola są NIEPUSTE
+        # (w torze bez trybu uprzywilejowanego każde z nich dyskwalifikuje
+        # konto). Celowo placeholdery, nie ciągi wyglądające na poświadczenia.
+        pbn_token="dummy",
+    )
+    u.set_password("secret")
+    u.groups.add(baker.make("auth.Group"))
+    u.save()
+    b = _backend()
+    assert b._try_grace_bind(b._normalized(_uafm_claims())) == u
+
+
+def test_create_user_wiaze_staff_zamiast_odmawiac(db, settings):
+    # Właściwy bug: create_user odmawiał ("konto z tym adresem już istnieje"),
+    # bo grace bind odpadał na is_staff i na niezaufanej domenie.
+    _privileged_settings(settings)
+    u = baker.make("bpp.BppUser", email="profesor@uafm.edu.pl", is_staff=True)
+    u.set_unusable_password()
+    u.save()
+    b = _backend()
+    assert b.create_user(b._normalized(_uafm_claims())) == u
+
+
+def test_grace_nie_wiaze_staff_gdy_privileged_wylaczony(db, settings):
+    _privileged_settings(settings)
+    settings.OIDC_GRACE_BIND_PRIVILEGED = False
+    u = baker.make("bpp.BppUser", email="profesor@uafm.edu.pl", is_staff=True)
+    u.set_unusable_password()
+    u.save()
+    b = _backend()
+    assert b._try_grace_bind(b._normalized(_uafm_claims())) is None
+
+
+def test_grace_nie_wiaze_staff_bez_listy_domen(db, settings):
+    # Blokada wzajemna: sam PRIVILEGED, bez bramki domenowej, nic nie otwiera.
+    settings.OIDC_GRACE_BIND_ENABLED = True
+    settings.OIDC_GRACE_BIND_PRIVILEGED = True
+    settings.OIDC_TRUSTED_EMAIL_DOMAINS = []
+    u = baker.make("bpp.BppUser", email="profesor@uafm.edu.pl", is_staff=True)
+    u.set_unusable_password()
+    u.save()
+    b = _backend()
+    assert b._try_grace_bind(b._normalized(_uafm_claims())) is None
+
+
+def test_grace_privileged_odmawia_gdy_konto_ma_tozsamosc_w_tym_realmie(db, settings):
+    from oidc_integration.models import OIDCIdentity
+
+    _privileged_settings(settings)
+    u = baker.make("bpp.BppUser", email="profesor@uafm.edu.pl", is_staff=True)
+    u.set_unusable_password()
+    u.save()
+    OIDCIdentity.objects.create(user=u, issuer=UAFM_ISS, sub="INNY-SUB")
+    b = _backend()
+    assert b._try_grace_bind(b._normalized(_uafm_claims())) is None
+
+
+def test_grace_privileged_pozwala_gdy_tozsamosc_w_innym_realmie(db, settings):
+    from oidc_integration.models import OIDCIdentity
+
+    _privileged_settings(settings)
+    u = baker.make("bpp.BppUser", email="profesor@uafm.edu.pl", is_staff=True)
+    u.set_unusable_password()
+    u.save()
+    OIDCIdentity.objects.create(user=u, issuer="https://inny-realm", sub="Z")
+    b = _backend()
+    assert b._try_grace_bind(b._normalized(_uafm_claims())) == u
+
+
+def test_grace_privileged_odmawia_gdy_dwa_konta_z_tym_adresem(db, settings):
+    _privileged_settings(settings)
+    for i in range(2):
+        u = baker.make(
+            "bpp.BppUser", username=f"u{i}", email="profesor@uafm.edu.pl", is_staff=True
+        )
+        u.set_unusable_password()
+        u.save()
+    b = _backend()
+    assert b._try_grace_bind(b._normalized(_uafm_claims())) is None

--- a/src/oidc_integration/tests/test_conf.py
+++ b/src/oidc_integration/tests/test_conf.py
@@ -193,3 +193,58 @@ def test_get_bool_prefers_skrot_variant():
 
 def test_get_bool_default_when_absent():
     assert _get_bool({}, "REQUIRE_EMAIL_VERIFIED", None, default=True) is True
+
+
+# --- Zaufane domeny instytucjonalne + wiązanie kont uprzywilejowanych ---
+
+
+def _base_env(**extra):
+    env = {
+        "DJANGO_BPP_OIDC_CLIENT_ID": "abc",
+        "DJANGO_BPP_OIDC_CLIENT_SECRET": "sekret",
+        "DJANGO_BPP_OIDC_ISSUER": ISSUER,
+    }
+    env.update(extra)
+    return env
+
+
+def test_trusted_email_domains_domyslnie_puste():
+    cfg = discover_oidc_config(_base_env())
+    assert cfg["trusted_email_domains"] == ()
+
+
+def test_trusted_email_domains_z_csv():
+    cfg = discover_oidc_config(
+        _base_env(
+            DJANGO_BPP_OIDC_TRUSTED_EMAIL_DOMAINS="uafm.edu.pl, student-afm.edu.pl"
+        )
+    )
+    assert cfg["trusted_email_domains"] == ("uafm.edu.pl", "student-afm.edu.pl")
+
+
+def test_trusted_email_domains_normalizuje_malpe_i_wielkosc():
+    # Operator równie dobrze wpisze "@UAFM.edu.pl" — ma zadziałać tak samo.
+    cfg = discover_oidc_config(
+        _base_env(DJANGO_BPP_OIDC_TRUSTED_EMAIL_DOMAINS="@UAFM.edu.pl")
+    )
+    assert cfg["trusted_email_domains"] == ("uafm.edu.pl",)
+
+
+def test_trusted_email_domains_prefiks_ma_pierwszenstwo():
+    env = {
+        "DJANGO_BPP_OIDC_UAFM_CLIENT_ID": "abc",
+        "DJANGO_BPP_OIDC_UAFM_CLIENT_SECRET": "sekret",
+        "DJANGO_BPP_OIDC_UAFM_ISSUER": ISSUER,
+        "DJANGO_BPP_OIDC_UAFM_TRUSTED_EMAIL_DOMAINS": "uafm.edu.pl",
+        "DJANGO_BPP_OIDC_TRUSTED_EMAIL_DOMAINS": "inna.edu.pl",
+    }
+    assert discover_oidc_config(env)["trusted_email_domains"] == ("uafm.edu.pl",)
+
+
+def test_grace_bind_privileged_domyslnie_false():
+    assert discover_oidc_config(_base_env())["grace_bind_privileged"] is False
+
+
+def test_grace_bind_privileged_z_env():
+    cfg = discover_oidc_config(_base_env(DJANGO_BPP_OIDC_GRACE_BIND_PRIVILEGED="1"))
+    assert cfg["grace_bind_privileged"] is True


### PR DESCRIPTION
## Objaw

Użytkownik z realmu UAFM nie mógł wejść do BPP przez Keycloak. Cały flow OIDC
przechodził poprawnie (302 → 302 → 200, żadnego 403 — WAF niewinny), a logowanie
kończyło się w `appserver` na:

```
failed to get or create user: OIDC: konto z tym adresem już istnieje —
połącz je z SSO przez profil (re-auth hasłem), nie tworzę konta.
AXES: Repeated login failure ... path_info: "/oidc/callback/"
```

Wszystkie trzy drogi wejścia były zamknięte jednocześnie:

1. `create_user` → fail-closed na kolizję e-maila,
2. `_try_grace_bind` → odpadał na pierwszym warunku (`_bpp_email_trusted`),
3. linkowanie przez profil (`SSOLinkInitView`) → wymaga hasła lokalnego,
   którego konto czysto-SSO z definicji nie ma.

## Przyczyna — kolizja dwóch zmergowanych PR-ów

| PR | Zmergowany | Co wniósł |
|---|---|---|
| #189 `feat(multi-hosted)` | 2026-07-04 | `a2124bf34` — `mail` przed `email`, bo w realmie UAFM `email` to adres **prywatny**, a instytucjonalny siedzi pod `mail` |
| #555 `fix(oidc): wiązanie po (issuer, sub)` | 2026-07-12 | `d989ae692` + `a6a84e65e` — `_bpp_email_trusted` z regułą `email == payload_email` oraz fail-closed w `create_user` |

`_normalized` liczyło zaufanie jako:

```python
trusted = verified and not from_fallback and email.lower() == payload_email
```

czyli wymagało równości adresu **instytucjonalnego** (`mail`) z **prywatnym**
(`email`) — w realmie, dla którego mail-first wprowadzono, warunek jest
z definicji niespełnialny. `_bpp_email_trusted` było więc trwale `False`.

Żaden z tych PR-ów nie jest błędny osobno. #555 był PR-em bezpieczeństwa
i poprawnie zamykał przejęcie konta przez wpisanie cudzego adresu w realmie —
tyle że oparł zaufanie na claimie, o którym #189 tydzień wcześniej świadomie
zdecydował, że go nie używamy. Objaw wyszedł dopiero teraz, bo potrzebny był
użytkownik z kontem założonym jeszcze na prywatnym adresie sprzed #189.

## Rozwiązanie

Dwa niezależne przełączniki, **oba domyślnie wyłączone** — instalacja bez
konfiguracji zachowuje się bit-w-bit jak dotąd, bez migracji.

### `DJANGO_BPP_OIDC[_<SKROT>]_TRUSTED_EMAIL_DOMAINS` (CSV)

Adres z właściwego claimu w wypisanej domenie jest wiarygodny **niezależnie od
`email_verified`** — bo ten flag opisuje claim `email`, czyli akurat ten
prywatny, i dla adresu pochodzącego z katalogu instytucji jest nieadekwatny.

Adres z fallbacku `preferred_username` (UPN) pozostaje niezaufany — niezmiennik
bez zmian. Dopasowanie domen dokładne, case-insensitive, bez subdomen
i wieloznaczników (lista domen jest jedyną bramką chroniącą wiązanie kont
uprzywilejowanych, więc nie chcemy w niej reguł łatwych do napisania szerzej,
niż się zamierzało).

### `DJANGO_BPP_OIDC[_<SKROT>]_GRACE_BIND_PRIVILEGED` (bool)

Grace-bind wiąże także konto `is_staff`/superusera, z grupami, uprawnieniami,
tokenem PBN i hasłem lokalnym. Zabezpieczenie przenosi się w całości na listę
domen plus założenie, że użytkownik nie zmieni sobie adresu w katalogu instytucji.

**Blokada wzajemna:** bez `TRUSTED_EMAIL_DOMAINS` ten flag jest no-opem — nie da
się go otworzyć przez przypadek.

Zachowane bezpieczniki: dokładnie jedno konto z danym adresem, konto aktywne,
brak tożsamości **w tym samym realmie** (konto związane z innym `sub` tego
issuera jest nie do przejęcia). Powiązanie z innego realmu nie przeszkadza —
zgodnie z logiką linkowania w profilu, gdzie pod wiele realmów można dołożyć
kolejne powiązanie.

## Konfiguracja (nic w Compose — zmienne jadą hurtowym `env_file`)

```bash
DJANGO_BPP_OIDC_GRACE_BIND=1              # nadal bramka wejściowa grace-bindu
DJANGO_BPP_OIDC_TRUSTED_EMAIL_DOMAINS=uafm.edu.pl,student-afm.edu.pl
DJANGO_BPP_OIDC_GRACE_BIND_PRIVILEGED=1
```

## Testy

TDD, RED→GREEN. 21 nowych testów; 9 backendowych padało bez implementacji,
reszta to strażnicy blokad wzajemnych i przypadków negatywnych (zweryfikowane
przez `git stash` implementacji i ponowny przebieg).

- `oidc_integration` + `test_profile_sso` — 138 passed
- `test_dopasowanie_autora` + `django_bpp/tests` — 127 passed
- `manage.py check` — czysty, ruff + pre-commit przechodzą

## Poza zakresem

Studenci logujący się samym UPN-em (`preferred_username` bez claimu `mail`)
nadal nie dostają zaufania — świadomie, żeby nie rozszerzać zmiany na tor
zakładania nowych kont bez dowodów, że tam też coś nie działa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175jeAqUnobDP5rz1waUAow
