### PR TITLE
fix(importer): rozpoznawaj nazwy pól BibTeX niezależnie od wielkości liter

### DIFF
--- a/src/bpp/newsfragments/bibtex-wielkosc-liter-pol.bugfix.rst
+++ b/src/bpp/newsfragments/bibtex-wielkosc-liter-pol.bugfix.rst
@@ -1,0 +1,6 @@
+Importer publikacji: rekordy BibTeX wyeksportowane z Web of Science i Scopusa
+(nazwy pól pisane wielką literą — ``Author``, ``Title``, ``Journal``, ``Year``)
+nie były rozpoznawane. Wpis pokazywał się na liście bez tytułu, a pobranie
+danych kończyło się komunikatem, że dostawca nic nie zwrócił. Nazwy pól BibTeX
+są zgodnie ze specyfikacją niewrażliwe na wielkość liter i tak są teraz
+traktowane.

--- a/src/importer_publikacji/providers/bibtex.py
+++ b/src/importer_publikacji/providers/bibtex.py
@@ -2,6 +2,7 @@ import logging
 import re
 
 import bibtexparser
+from bibtexparser.middlewares import NormalizeFieldKeys
 from bibtexparser.model import Entry, ParsingFailedBlock
 
 from bpp.util import zaloguj_polkniety_wyjatek
@@ -39,6 +40,30 @@ BIBTEX_TYPE_MAP = {
     # dalszym potoku importera (normalized_data["publication_type"]).
     "patent": "patent",
 }
+
+
+def _parse(text: str):
+    """Sparsuj BibTeX, normalizujac nazwy pol do malych liter.
+
+    Nazwy pol sa w BibTeX niewrazliwe na wielkosc liter — ``Title``,
+    ``title`` i ``TITLE`` oznaczaja to samo pole. ``bibtexparser`` 2.x
+    zachowuje jednak w ``entry.fields_dict`` oryginalna pisownie i wynosi
+    normalizacje do opcjonalnego middleware'u, ktorego domyslnie NIE
+    stosuje (w 1.x dzialo sie to samo z siebie).
+
+    Web of Science i Scopus eksportuja pola kapitalizowane
+    (``Author``, ``Title``, ``Journal``, ``Year``), wiec bez tego kroku
+    ``_get_field(fields, "title")`` nie widzialo zadnego pola: ``fetch()``
+    zwracalo ``None`` ("dostawca nic nie zwrocil"), a lista rekordow do
+    zaimportowania pokazywala wpis z pustym tytulem. Parsowanie samo w
+    sobie sie udawalo, wiec ``validate_identifier()`` przepuszczalo taki
+    wpis do kolejki i blad wychodzil dopiero w tasku Celery.
+
+    Middleware dziala na modelu, nie na tekscie zrodlowym — ``block.raw``
+    (uzywany przez ``split_input()`` i podawany potem do ``fetch()``)
+    pozostaje surowym, parsowalnym BibTeX-em.
+    """
+    return bibtexparser.parse_string(text, append_middleware=[NormalizeFieldKeys()])
 
 
 @register_provider
@@ -85,7 +110,7 @@ class BibTeXProvider(DataProvider):
         if not identifier or not identifier.strip():
             return None
         try:
-            library = bibtexparser.parse_string(identifier)
+            library = _parse(identifier)
         except Exception:
             zaloguj_polkniety_wyjatek(
                 "Walidacja identyfikatora BibTeX (bibtexparser)",
@@ -112,7 +137,7 @@ class BibTeXProvider(DataProvider):
         znikałby po cichu (dokładnie bug, który naprawiamy). Kolejność
         źródłowa zachowana przez iterację po ``library.blocks``.
         """
-        library = bibtexparser.parse_string(text)
+        library = _parse(text)
         records: list[SplitRecord] = []
         for block in library.blocks:
             if isinstance(block, Entry):
@@ -135,7 +160,7 @@ class BibTeXProvider(DataProvider):
         # a nie zniknac jako "dostawca nic nie zwrocil". validate_identifier
         # juz potwierdzil parsowalnosc synchronicznie przed kolejka.
         try:
-            library = bibtexparser.parse_string(identifier)
+            library = _parse(identifier)
         except Exception:
             logger.exception("Nieoczekiwany blad parsowania BibTeX w fetch()")
             raise

--- a/src/importer_publikacji/tests/test_bibtex_provider.py
+++ b/src/importer_publikacji/tests/test_bibtex_provider.py
@@ -446,3 +446,103 @@ def test_patent_date_only_year_left_unset():
     pub = p.fetch(bibtex)
     assert pub is not None
     assert pub.filing_date is None
+
+
+# --- wielkosc liter w nazwach pol (eksport z Web of Science) ---
+
+# Nazwy pol w BibTeX sa case-insensitive (spec), a Web of Science i Scopus
+# eksportuja je kapitalizowane: Author/Title/Journal/Year. bibtexparser 2.x
+# zachowuje oryginalna wielkosc liter w fields_dict, wiec bez normalizacji
+# _get_field(fields, "title") nie widzialo NICZEGO: fetch() zwracal None
+# ("dostawca nic nie zwrocil"), a lista rekordow pokazywala pusty tytul.
+# Ponizsze rekordy to verbatim eksport z WOS zgloszony przez uzytkownika.
+
+WOS_ARTICLE = (
+    "@article{ WOS:000448237400001, Author = {Nowak, Jacek}, Title = "
+    "{Human major histocompatibility complex (MHC)-region gene and "
+    "haplotype polymorphisms in non-Hodgkin's lymphoma}, Journal = "
+    "{ONCOLOGY IN CLINICAL PRACTICE}, Year = {2008}, Volume = {4}, "
+    "Number = {D}, Pages = {D1-D28}, ISSN = {2450-1654}, EISSN = "
+    "{2450-6478}, ResearcherID-Numbers = {Nowak, Jacek/X-3477-2018}, "
+    "Unique-ID = {WOS:000448237400001}, }"
+)
+
+WOS_ARTICLE_MANY_AUTHORS = (
+    "@article{ WOS:000258575800005, Author = {Nowak, Jacek and "
+    "Mika-Witkowska, Renata and Polak, Malgorzata and Zajko, Malgorzata "
+    "and Rogatko-Koros, Marta and Graczyk-Pol, Elzbieta and Stepkowski, "
+    "Tomasz and Lange, Andrzej}, Title = {Road-like pattern of "
+    "HLA-ABDR-based genetic distances between populations}, Journal = "
+    "{CENTRAL EUROPEAN JOURNAL OF IMMUNOLOGY}, Year = {2008}, Volume = "
+    "{33}, Number = {3}, Pages = {114-119}, ISSN = {1426-3912}, EISSN = "
+    "{1644-4124}, Unique-ID = {WOS:000258575800005}, }"
+)
+
+
+def test_fetch_wos_capitalized_field_names():
+    """Eksport z WOS (Author/Title/Journal/Year) musi sie zaciagnac."""
+    p = BibTeXProvider()
+    pub = p.fetch(WOS_ARTICLE)
+    assert pub is not None
+    assert pub.title == (
+        "Human major histocompatibility complex (MHC)-region gene and "
+        "haplotype polymorphisms in non-Hodgkin's lymphoma"
+    )
+    assert pub.year == 2008
+    assert pub.source_title == "ONCOLOGY IN CLINICAL PRACTICE"
+    assert pub.volume == "4"
+    assert pub.issue == "D"
+    assert pub.pages == "D1-D28"
+    assert pub.issn == "2450-1654"
+    assert pub.authors == [{"family": "Nowak", "given": "Jacek"}]
+    assert pub.publication_type == "journal-article"
+
+
+def test_fetch_wos_all_authors_parsed():
+    """Osmiu autorow z WOS trafia na liste, nie tylko pierwszy."""
+    p = BibTeXProvider()
+    pub = p.fetch(WOS_ARTICLE_MANY_AUTHORS)
+    assert pub is not None
+    assert len(pub.authors) == 8
+    assert pub.authors[0] == {"family": "Nowak", "given": "Jacek"}
+    assert pub.authors[-1] == {"family": "Lange", "given": "Andrzej"}
+
+
+def test_split_input_wos_shows_titles():
+    """Lista rekordow do zaimportowania pokazuje tytuly, nie puste pola."""
+    p = BibTeXProvider()
+    records = p.split_input(WOS_ARTICLE + "\n\n" + WOS_ARTICLE_MANY_AUTHORS)
+    assert len(records) == 2
+    assert all(r.ok for r in records)
+    assert records[0].title.startswith("Human major histocompatibility")
+    assert records[1].title.startswith("Road-like pattern")
+
+
+def test_split_input_raw_stays_reparsable():
+    """``raw`` z split_input() trafia potem do fetch() — musi zostac
+    surowym, parsowalnym BibTeX-em (normalizacja nazw pol dziala na
+    modelu, nie na tekscie zrodlowym)."""
+    p = BibTeXProvider()
+    records = p.split_input(WOS_ARTICLE)
+    assert "Title = {" in records[0].raw
+    pub = p.fetch(records[0].raw)
+    assert pub is not None
+    assert pub.title.startswith("Human major histocompatibility")
+
+
+def test_fetch_uppercase_field_names():
+    """Skrajny przypadek: pola KRZYCZANE w calosci (spec dopuszcza)."""
+    bibtex = """
+@ARTICLE{screaming2024,
+  TITLE = {Loud Title},
+  AUTHOR = {Kowalski, Jan},
+  JOURNAL = {Journal of Caps},
+  YEAR = {2024},
+}
+"""
+    p = BibTeXProvider()
+    pub = p.fetch(bibtex)
+    assert pub is not None
+    assert pub.title == "Loud Title"
+    assert pub.year == 2024
+    assert pub.source_title == "Journal of Caps"


### PR DESCRIPTION
## Problem

Rekordy BibTeX wyeksportowane z **Web of Science** (i Scopusa) nie dawały się
zaimportować. Wpis pojawiał się na liście do zaimportowania **bez tytułu**,
a pobranie danych kończyło się komunikatem, że dostawca nic nie zwrócił.

Zgłoszone na rzeczywistych rekordach, np.:

```bibtex
@article{ WOS:000448237400001, Author = {Nowak, Jacek}, Title = {Human major
histocompatibility complex (MHC)-region gene and haplotype polymorphisms in
non-Hodgkin's lymphoma}, Journal = {ONCOLOGY IN CLINICAL PRACTICE}, ... }
```

## Przyczyna

Nazwy pól są w BibTeX **niewrażliwe na wielkość liter** — `Title`, `title`
i `TITLE` oznaczają to samo pole. `bibtexparser` 2.x zachowuje jednak
w `entry.fields_dict` oryginalną pisownię i wynosi normalizację do
opcjonalnego middleware'u `NormalizeFieldKeys`, którego domyślnie **nie**
stosuje (w 1.x działo się to samo z siebie — klasyczny cichy regres przy
podbiciu major wersji).

WOS eksportuje pola kapitalizowane, więc `_get_field(fields, "title")` nie
widziało **żadnego** pola: ani tytułu, ani autorów, ani roku, ani czasopisma.

Bug był podstępny, bo samo parsowanie się udawało — `validate_identifier()`
przepuszczało wpis do kolejki, a błąd wychodził dopiero w tasku Celery, bez
wskazania przyczyny.

## Rozwiązanie

Wszystkie trzy ścieżki parsujące (`validate_identifier`, `split_input`,
`fetch`) idą przez wspólny `_parse()` z `NormalizeFieldKeys` — zamiast
trzech gołych `bibtexparser.parse_string()`.

Świadomie **nie** poszła wersja „uodpornij `_get_field` na wielkość liter":
normalizacja przy parsowaniu naprawia cały model naraz, w tym `peek_title()`
(pusty tytuł na liście) i każde przyszłe pole, zamiast rozsiewać `.lower()`.

Middleware działa na modelu, nie na tekście źródłowym, więc `block.raw`
zwracany przez `split_input()` pozostaje surowym, parsowalnym BibTeX-em
i nadal poprawnie wraca do `fetch()`. Ta zależność jest niewidoczna przy
czytaniu kodu, więc dostała osobny test.

## Testy

Nowe testy regresyjne (5) — wszystkie **czerwone przed poprawką**:

- `test_fetch_wos_capitalized_field_names` — rekord WOS verbatim ze zgłoszenia
- `test_fetch_wos_all_authors_parsed` — 8 autorów, nie tylko pierwszy
- `test_split_input_wos_shows_titles` — lista pokazuje tytuły, nie puste pola
- `test_split_input_raw_stays_reparsable` — `raw` → `fetch()` nadal działa
- `test_fetch_uppercase_field_names` — pola w całości wielkimi literami

Lokalnie: `src/importer_publikacji/tests/` → **805 passed, 1 skipped**.
`ruff format` / `ruff check` / `pre-commit` — czysto.

## Zakres

Parsowanie BibTeX-a występuje w repo **tylko** w tym providerze
(`grep parse_string` poza testami), więc poprawka zamyka temat w całości.
Eksport BibTeX-a (`src/bpp/.../export_bibtex.py`) jest nietknięty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPGuzMUWhUHESw6DZTtZkS
